### PR TITLE
RS-353: Move roxctl tests to tests/roxctl and reimplement with BATS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3494,6 +3494,12 @@ jobs:
             cci-export "SERVICE_KEY_FILE" "$SERVICE_KEY_FILE"
 
       - run:
+          name: Setup prerequisites for Bats tests
+          command: |
+            source tests/e2e/run.sh
+            install_yq
+
+      - run:
           name: Run roxctl tests
           command: |
             source tests/e2e/run.sh

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -115,9 +115,26 @@ prepare_for_endpoints_test() {
     start_port_forwards_for_test
 }
 
+install_yq() {
+  # Intstall yq to allow more precise test cases
+  if is_CI; then
+    if ! command -v yq >/dev/null 2>&1; then
+        sudo wget https://github.com/mikefarah/yq/releases/download/v4.15.1/yq_linux_amd64 -O /usr/bin/yq
+        sudo chmod 0755 /usr/bin/yq
+    fi
+  else
+      require_executable yq
+  fi
+}
+
 run_roxctl_tests() {
     info "Run roxctl tests"
 
+    # TODO(PR): Move this to the bottom after finishing the experiments
+    info "Running roxctl BATS tests"
+    "$TEST_ROOT/tests/roxctl/bats-wrapper.sh" "$TEST_ROOT/tests/roxctl/bats-tests"
+
+    info "Running the regular roxctl tests"
     "$TEST_ROOT/tests/roxctl/token-file.sh"
     "$TEST_ROOT/tests/roxctl/slim-collector.sh"
     "$TEST_ROOT/tests/roxctl/authz-trace.sh"

--- a/tests/roxctl/bats-tests/roxctl-central-generate.bats
+++ b/tests/roxctl/bats-tests/roxctl-central-generate.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+# TODO(do-not-merge): required for local and remote runs of the tests - remove before merging
+test -f "/usr/lib/node_modules/bats-support/load.bash" && load "/usr/lib/node_modules/bats-support/load.bash"
+test -f "/usr/lib/node_modules/bats-assert/load.bash" && load "/usr/lib/node_modules/bats-assert/load.bash"
+
+test -f "${HOME}/bats-core/bats-support/load.bash" && load "${HOME}/bats-core/bats-support/load.bash"
+test -f "${HOME}/bats-core/bats-assert/load.bash" && load "${HOME}/bats-core/bats-assert/load.bash"
+
+# TODO(do-not-merge): uncomment before merging
+# load "/usr/lib/node_modules/bats-support/load.bash"
+# load "/usr/lib/node_modules/bats-assert/load.bash"
+
+out_dir=""
+
+setup_file() {
+  echo "Testing roxctl version: '$(roxctl version)'" >&3
+  command -v yq || skip "Tests in this file require yq"
+}
+
+setup() {
+  out_dir="$(mktemp -d -u)"
+  # TODO(PR): all tests are currrently skipped here to focus on helm-output first
+  skip "Tests in this file are not ready yet"
+}
+
+teardown() {
+  rm -rf "$out_dir"
+}
+
+@test "(devel) roxctl central generate k8s should use development registry" {
+  run roxctl central generate k8s hostpath --output-dir $out_dir
+  assert_success
+
+  run yq e '.spec.template.spec.containers[] | select(.name == "central").image' "$out_dir/central/01-central-12-deployment.yaml"
+  assert_output --regexp 'docker.io/stackrox/main:[0-9]+\.[0-9]+\.'
+
+  run yq e 'select(documentIndex == 0) | .spec.template.spec.containers[] | select(.name == "scanner").image' "$out_dir/scanner/02-scanner-06-deployment.yaml"
+  assert_output --regexp 'docker.io/stackrox/scanner:[0-9]+\.[0-9]+\.'
+
+  run yq e 'select(documentIndex == 1) | .spec.template.spec.containers[] | select(.name == "db").image' "$out_dir/scanner/02-scanner-06-deployment.yaml"
+  assert_output --regexp 'docker.io/stackrox/scanner-db:[0-9]+\.[0-9]+\.'
+}
+
+@test "(devel) roxctl central generate k8s should respect customly-provided images" {
+  # Ensure that custom images are respected
+  # TODO(PR): check how to set collector immage (here or somewhere else)
+  run roxctl central generate k8s \
+    --main-image example.com/main:1.2.3 \
+    --scanner-image example.com/scanner:1.2.3 \
+    --scanner-db-image example.com/scanner-db:1.2.3 \
+    hostpath \
+    --output-dir $out_dir
+  assert_success
+  run yq e '.spec.template.spec.containers[] | select(.name == "central").image' "$out_dir/central/01-central-12-deployment.yaml"
+  assert_output 'example.com/main:1.2.3'
+  run yq e 'select(documentIndex == 0) | .spec.template.spec.containers[] | select(.name == "scanner").image' "$out_dir/scanner/02-scanner-06-deployment.yaml"
+  assert_output 'example.com/scanner:1.2.3'
+  run yq e 'select(documentIndex == 1) | .spec.template.spec.containers[] |  select(.name == "db").image' "$out_dir/scanner/02-scanner-06-deployment.yaml"
+  assert_output 'example.com/scanner-db:1.2.3'
+}
+
+@test "(devel) roxctl central generate k8s --rhacs should use redhat.io registry" {
+  grep "\-\-rhacs" <(roxctl central generate -h) || skip "because roxctl generate does not support --rhacs flag yet"
+  run roxctl central generate --rhacs k8s hostpath --output-dir $out_dir
+  assert_success
+
+  run yq e '.spec.template.spec.containers[] | select(.name == "central").image' "$out_dir/central/01-central-12-deployment.yaml"
+  assert_output --regexp 'registry.redhat.io/advanced-cluster-security/rhacs-rhel8-main:[0-9]+\.[0-9]+\.'
+
+  run yq e 'select(documentIndex == 0) | .spec.template.spec.containers[] | select(.name == "scanner").image' "$out_dir/scanner/02-scanner-06-deployment.yaml"
+  assert_output --regexp 'registry.redhat.io/advanced-cluster-security/rhacs-rhel8-scanner:[0-9]+\.[0-9]+\.'
+
+  run yq e 'select(documentIndex == 1) | .spec.template.spec.containers[] | select(.name == "db").image' "$out_dir/scanner/02-scanner-06-deployment.yaml"
+  assert_output --regexp 'registry.redhat.io/advanced-cluster-security/rhacs-rhel8-scanner-db:[0-9]+\.[0-9]+\.'
+}
+
+@test "(release) roxctl central generate k8s should use stackrox.io registry" {
+  skip "Unimplemented yet"
+}
+
+@test "(release) roxctl central generate k8s --rhacs should use redhat.io registry" {
+  skip "Unimplemented yet"
+}

--- a/tests/roxctl/bats-tests/roxctl-helm-output.bats
+++ b/tests/roxctl/bats-tests/roxctl-helm-output.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+
+# TODO(do-not-merge): required for local and remote runs of the tests - remove before merging
+test -f "/usr/lib/node_modules/bats-support/load.bash" && load "/usr/lib/node_modules/bats-support/load.bash"
+test -f "/usr/lib/node_modules/bats-assert/load.bash" && load "/usr/lib/node_modules/bats-assert/load.bash"
+
+test -f "${HOME}/bats-core/bats-support/load.bash" && load "${HOME}/bats-core/bats-support/load.bash"
+test -f "${HOME}/bats-core/bats-assert/load.bash" && load "${HOME}/bats-core/bats-assert/load.bash"
+
+# TODO(do-not-merge): uncomment before merging
+# load "/usr/lib/node_modules/bats-support/load.bash"
+# load "/usr/lib/node_modules/bats-assert/load.bash"
+
+out_dir=""
+setup() {
+  out_dir="$(mktemp -d -u)"
+  command -v yq || skip "Tests in this file require yq"
+}
+
+teardown() {
+  rm -rf "$out_dir"
+}
+
+@test "roxctl helm output central-services should use docker.io registry" {
+  run roxctl helm output central-services --output-dir "$out_dir"
+  assert_success
+  assert_output --partial "Written Helm chart central-services to directory"
+
+  run helm template stackrox-central-services "$out_dir" \
+    -n stackrox \
+    --set imagePullSecrets.allowNone=true \
+    --output-dir="$out_dir/rendered"
+
+  run yq e '.spec.template.spec.containers[] | select(.name == "central").image' "$out_dir/rendered/stackrox-central-services/templates/01-central-12-deployment.yaml"
+  assert_output --regexp 'docker.io/stackrox/main:[0-9]+\.[0-9]+\.'
+
+  run yq e 'select(documentIndex == 0) | .spec.template.spec.containers[] | select(.name == "scanner").image' "$out_dir/rendered/stackrox-central-services/templates/02-scanner-06-deployment.yaml"
+  assert_output --regexp 'docker.io/stackrox/scanner:[0-9]+\.[0-9]+\.'
+
+  run yq e 'select(documentIndex == 1) | .spec.template.spec.containers[] | select(.name == "db").image' "$out_dir/rendered/stackrox-central-services/templates/02-scanner-06-deployment.yaml"
+  assert_output --regexp 'docker.io/stackrox/scanner-db:[0-9]+\.[0-9]+\.'
+}
+
+@test "roxctl helm output central-services --rhacs should use redhat.io registry" {
+  grep "\-\-rhacs" <(roxctl helm output central-services -h) || skip "because roxctl generate does not support --rhacs flag yet"
+  run roxctl helm output central-services --rhacs --output-dir "$out_dir"
+  assert_success
+  assert_output --partial "Written Helm chart central-services to directory"
+
+  run helm template stackrox-central-services "$out_dir" \
+    -n stackrox \
+    --set imagePullSecrets.allowNone=true \
+    --output-dir="$out_dir/rendered"
+  assert_success
+  assert_output --partial "wrote $out_dir/rendered/stackrox-central-services/templates/01-central-12-deployment.yaml"
+  assert_output --partial "wrote $out_dir/rendered/stackrox-central-services/templates/02-scanner-06-deployment.yaml"
+
+  run yq e '.spec.template.spec.containers[] | select(.name == "central").image' "$out_dir/rendered/stackrox-central-services/templates/01-central-12-deployment.yaml"
+  assert_output --regexp 'registry.redhat.io/advanced-cluster-security/rhacs-rhel8-main:[0-9]+\.[0-9]+\.'
+
+  run yq e 'select(documentIndex == 0) | .spec.template.spec.containers[] | select(.name == "scanner").image' "$out_dir/rendered/stackrox-central-services/templates/02-scanner-06-deployment.yaml"
+  assert_output --regexp 'registry.redhat.io/advanced-cluster-security/rhacs-rhel8-scanner:[0-9]+\.[0-9]+\.'
+
+  run yq e 'select(documentIndex == 1) | .spec.template.spec.containers[] | select(.name == "db").image' "$out_dir/rendered/stackrox-central-services/templates/02-scanner-06-deployment.yaml"
+  assert_output --regexp 'registry.redhat.io/advanced-cluster-security/rhacs-rhel8-scanner-db:[0-9]+\.[0-9]+\.'
+}
+
+@test "roxctl helm output secured-cluster-services should use docker.io registry" {
+  run roxctl helm output secured-cluster-services --ca /dev/null --output-dir "$out_dir"
+  assert_success
+  assert_output --partial "Written Helm chart secured-cluster-services to directory"
+
+  run helm template stackrox-secured-cluster-services "$out_dir" \
+    -n stackrox \
+    --set clusterName=clusterUnderTest \
+    --set imagePullSecrets.allowNone=true \
+    --output-dir="$out_dir/rendered"
+  assert_success
+
+  run yq e '.spec.template.spec.containers[] | select(.name == "central").image' "$out_dir/rendered/stackrox-central-services/templates/01-central-12-deployment.yaml"
+  assert_output --regexp 'docker.io/stackrox/main:[0-9]+\.[0-9]+\.'
+
+  run yq e 'select(documentIndex == 0) | .spec.template.spec.containers[] | select(.name == "scanner").image' "$out_dir/rendered/stackrox-central-services/templates/02-scanner-06-deployment.yaml"
+  assert_output --regexp 'docker.io/stackrox/scanner:[0-9]+\.[0-9]+\.'
+
+  run yq e 'select(documentIndex == 1) | .spec.template.spec.containers[] | select(.name == "db").image' "$out_dir/rendered/stackrox-central-services/templates/02-scanner-06-deployment.yaml"
+  assert_output --regexp 'docker.io/stackrox/scanner-db:[0-9]+\.[0-9]+\.'
+}
+
+@test "roxctl helm output secured-cluster-services --rhacs should use redhat.io registry" {
+  skip "Unimplemented yet. TODO: test helm-charts and K8s manifests"
+  # Helm charts and yaml manifests are generated independently, so testing helm charts is not enough and we should also test the yaml manifests
+  # I should get the sam results as in CircleCI, unless I run with go tag release!
+}

--- a/tests/roxctl/bats-wrapper.sh
+++ b/tests/roxctl/bats-wrapper.sh
@@ -1,0 +1,35 @@
+#! /usr/bin/env bash
+
+set -uo pipefail
+
+FAILURES=0
+BATS_TESTS_DIR="${1:-tests/roxctl/bats-tests}"
+
+BATS_VERSION="$(bats --version)"
+echo "Using Bats version: $BATS_VERSION"
+echo "Testing roxctl version: '$(roxctl version)'"
+
+BATS_FLAGS=( "--tap" )
+# poor-mans semver compare
+if [[ $BATS_VERSION =~ ^Bats\ ([0-9]).([0-9]).([0-9])?$ ]]; then
+  if (( "${BASH_REMATCH[1]}" == 1 && "${BASH_REMATCH[2]}" >= 5 )); then
+    # Useful flags introduced in v1.5.0
+    BATS_FLAGS+=( "--print-output-on-failure" "--verbose-run" "--show-output-of-passing-tests" ) # TODO(PR): consider removing --show-output-of-passing-tests before merging
+  fi
+fi
+
+# Running all bats test suites found in the directory
+echo "Running Bats with parameters: " "${BATS_FLAGS[@]}"
+BATS_OUT="$(bats "${BATS_FLAGS[@]}" "${BATS_TESTS_DIR}")"
+NUM_FAILED="$(grep -c "^not ok " <<< "$BATS_OUT")"
+FAILURES=$((FAILURES + NUM_FAILED))
+
+if (( ! FAILURES )); then
+  echo "All tests passed"
+  printf "Bats output:\n%s" "$BATS_OUT" # TODO(PR): remove before merging
+else
+  echo "$FAILURES test failed"
+  printf >&2 "Bats output:\n%s" "$BATS_OUT"  # TODO(PR): remove before merging
+  exit 1
+fi
+printf "\nBats testing done.\n"


### PR DESCRIPTION
## Description

⚠️ ⚠️  This is still work-in-progress - please do not invest too much time in a review as long as this is a draft-PR ⚠️ ⚠️

This PR implements e2e tests for `roxctl` features (planned to be) introduced in RS-317.

This is a continuation of https://github.com/stackrox/rox/pull/9947 in rox.

## Decisions

I decided to go with Bats for implementing the tests to improve readability of the test cases and assertions.
I based my decision on my own experience and on reading [this Slack thread](https://srox.slack.com/archives/CELUQKESC/p1637164240150900).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed


