### PR TITLE
Fix default Helm debug path

### DIFF
--- a/roxctl/helm/output/output.go
+++ b/roxctl/helm/output/output.go
@@ -99,7 +99,7 @@ func Command() *cobra.Command {
 	c.PersistentFlags().BoolVar(&rhacs, "rhacs", false, "render RHACS chart flavor")
 
 	if !buildinfo.ReleaseBuild {
-		defaultDebugPath := path.Join(os.Getenv("GOPATH"), "src/github.com/stackrox/rox/image/")
+		defaultDebugPath := path.Join(os.Getenv("GOPATH"), "src/github.com/stackrox/stackrox/image/")
 		c.PersistentFlags().BoolVar(&debug, "debug", false, "read templates from local filesystem")
 		c.PersistentFlags().StringVar(&debugChartPath, "debug-path", defaultDebugPath, "path to helm templates on your local filesystem")
 	}


### PR DESCRIPTION
## Description

Due to the repo change the path to the Helm path had changed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

 - run `roxctl helm output central-services --debug`