### PR TITLE
ROX-8628: Show notifier name instead of id in policies table cell

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/PoliciesTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/PoliciesTablePage.tsx
@@ -19,9 +19,11 @@ import {
     exportPolicies,
     updatePoliciesDisabledState,
 } from 'services/PoliciesService';
+import { fetchNotifierIntegrations } from 'services/NotifierIntegrationsService';
 import useToasts from 'hooks/useToasts';
 import { getSearchOptionsForCategory } from 'services/SearchService';
 import { ListPolicy } from 'types/policy.proto';
+import { NotifierIntegration } from 'types/notifier.proto';
 import { SearchFilter } from 'types/search';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
@@ -42,6 +44,7 @@ function PoliciesTablePage({
 }: PoliciesTablePageProps): React.ReactElement {
     const history = useHistory();
 
+    const [notifiers, setNotifiers] = useState<NotifierIntegration[]>([]);
     const [isLoading, setIsLoading] = useState(false);
     const [policies, setPolicies] = useState<ListPolicy[]>([]);
     const [errorMessage, setErrorMessage] = useState('');
@@ -136,6 +139,16 @@ function PoliciesTablePage({
     }
 
     useEffect(() => {
+        fetchNotifierIntegrations()
+            .then((data) => {
+                setNotifiers(data as NotifierIntegration[]);
+            })
+            .catch(() => {
+                setNotifiers([]);
+            });
+    }, []);
+
+    useEffect(() => {
         getSearchOptionsForCategory('POLICIES')
             .then((options) => {
                 setSearchOptions(options);
@@ -162,6 +175,7 @@ function PoliciesTablePage({
                 </Bullseye>
             ) : (
                 <PoliciesTable
+                    notifiers={notifiers}
                     policies={policies}
                     hasWriteAccessForPolicy={hasWriteAccessForPolicy}
                     deletePoliciesHandler={deletePoliciesHandler}


### PR DESCRIPTION
## Description

1. PoliciesTable.tsx
    * Move `Cell` callback functions from `columns` to children of `Td` elements because **Notifiers** depends on `labelAndNotifierIdsForTypes` which is within component scope; also because initial attempt to move `columns` into component scope caused lint problems from `react-hooks` because of `columns[activeSortIndex]` in `useEffect` hook; by the way, the move lets us delete type casts because TypeScript knows the type of properties destructured from policy
    * Compute `labelAndNotifierIdsForTypes` whenever `notifiers` changes (for example, from initial empty array to response from request)

2. PoliciesTablePage.tsx
    * Add `useState` and `useEffect` for notifiers; omit error message because `formatNotifierCountsWithLabelStrings` falls back to **N notifiers** before response to request or if request fails

3. policies.utils.ts
    * Export `formatCountWithLabelStrings` function that returns array of strings to render in table cell
    * Export `getLabelAndNotifierIdsForTypes` function that returns data structure derived from notifiers

### Residue

* Delete `as NotifierIntegration[]` type case after change to return type of `fetchNotifierIntegrations` function

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### with notifiers request

* policy has no notifiers
* policy has 1 notifier
* policy has 2 notifiers with 2 different types
* policy has 2 notifiers with same type
* policy has 3 notifiers with 2 different types
* policy has 3 notifiers with 3 different types

![with-notifiers](https://user-images.githubusercontent.com/11862657/145052247-4de085b8-04dc-4387-8c9f-82d2568ad2da.png)

### without notifiers request

Temporarily comment out notifiers request

* policy has no notifiers
* policy has 1 notifier
* policy has 2 notifiers with 2 different types
* policy has 2 notifiers with same type
* policy has 3 notifiers with 2 different types
* policy has 3 notifiers with 3 different types

![without-notifiers](https://user-images.githubusercontent.com/11862657/145052303-7455379b-629f-41bf-ab1e-a41b0142d55b.png)