### PR TITLE
fix: TestErrorWriter

### DIFF
--- a/roxctl/maincommand/error_writer_test.go
+++ b/roxctl/maincommand/error_writer_test.go
@@ -15,15 +15,15 @@ func TestErrorWriter(t *testing.T) {
 	}{
 		{
 			in:  "\nError: rpc error: code = Unauthenticated desc =\n credentials not found\n",
-			out: "\nError: rpc error: code = Unauthenticated desc =\n credentials not found\n",
+			out: "ERROR:\t\nError: rpc error: code = Unauthenticated desc =\n credentials not found\n",
 		},
 		{
 			in:  "rpc error: code = Unauthenticated desc = credentials not found",
-			out: "rpc error: code = Unauthenticated desc = credentials not found\n",
+			out: "ERROR:\trpc error: code = Unauthenticated desc = credentials not found\n",
 		},
 		{
 			in:  "rpc error: code = Unauthenticated desc = credentials not found\n",
-			out: "rpc error: code = Unauthenticated desc = credentials not found\n",
+			out: "ERROR:\trpc error: code = Unauthenticated desc = credentials not found\n",
 		},
 		{
 			in:  "Error: rpc error: code = Unauthenticated desc = credentials not found",
@@ -39,6 +39,7 @@ func TestErrorWriter(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.in, func(t *testing.T) {
 			t.Parallel()
 			io, _, out, errorOut := environment.TestIO()


### PR DESCRIPTION
## Description

When using `t.Parallel()` we must remember that memory is reused inside `for := range`.
Maybe we should also enable linter for that like here https://github.com/pingcap/tidb/pull/28996

Refs: https://github.com/stackrox/stackrox/pull/48#issuecomment-989048448

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
