### PR TITLE
Add a check that prevents some targets from running in CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4145,6 +4145,7 @@ jobs:
     - ROX_OPERATOR_COLLECTOR_REGISTRY: "quay.io/rhacs-eng"
     - IMAGE_REPO: "quay.io/rhacs-eng"
     - IMAGE_TAG_BASE: "quay.io/rhacs-eng/stackrox-operator"
+    - INSTALL_OPERATOR_THROUGH_OLM: "true"
 
     steps:
     - checkout
@@ -4215,6 +4216,7 @@ jobs:
     - ROX_OPERATOR_COLLECTOR_REGISTRY: "quay.io/rhacs-eng"
     - IMAGE_REPO: "quay.io/rhacs-eng"
     - IMAGE_TAG_BASE: "quay.io/rhacs-eng/stackrox-operator"
+    - INSTALL_OPERATOR_THROUGH_OLM: "true"
 
     steps:
     - checkout

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -247,8 +247,12 @@ stackrox-image-pull-secret: ## Create default image pull secret for StackRox ima
 # Create stackrox image pull secret in stackrox namespace.
 	$(PROJECT_DIR)/../deploy/common/pull-secret.sh stackrox docker.io | kubectl -n stackrox apply -f -
 
+.PHONY: check-ci-setup
+check-ci-setup: ## Make sure this target is not started in CI environment.
+	@if [ -n "$$INSTALL_OPERATOR_THROUGH_OLM" ]; then echo "Setup error: operator should be installed and started by OLM." >&2; exit 1; fi
+
 .PHONY: run
-run: manifests generate ensure-rox-main-image-exists fmt vet ## Run operator from your host without deploying it to a cluster.
+run: check-ci-setup manifests generate ensure-rox-main-image-exists fmt vet ## Run operator from your host without deploying it to a cluster.
 	ENABLE_WEBHOOKS=$(ENABLE_WEBHOOKS) ../scripts/go-run.sh ./main.go
 
 .PHONY: ensure-rox-main-image-exists
@@ -286,15 +290,15 @@ docker-build: test ## Build docker image with the operator.
 ##@ Deployment
 
 .PHONY: install
-install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
+install: check-ci-setup manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -
 
 .PHONY: uninstall
-uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
+uninstall: check-ci-setup manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found -f -
 
 .PHONY: deploy
-deploy: manifests kustomize ## Deploy operator image to the K8s cluster specified in ~/.kube/config.
+deploy: check-ci-setup manifests kustomize ## Deploy operator image to the K8s cluster specified in ~/.kube/config.
 	rm -rf config/local-deploy-versioned && \
 		mkdir config/local-deploy-versioned && \
 		cd config/local-deploy-versioned && \
@@ -303,7 +307,7 @@ deploy: manifests kustomize ## Deploy operator image to the K8s cluster specifie
 	$(KUSTOMIZE) build config/local-deploy-versioned | kubectl create -f -
 
 .PHONY: undeploy
-undeploy: kustomize ## Undeploy operator image from the K8s cluster specified in ~/.kube/config.
+undeploy: check-ci-setup kustomize ## Undeploy operator image from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found -f -
 
 .PHONY: deploy-via-olm


### PR DESCRIPTION
## Description

The `install`, `run`, and `deploy` targets should not run in the scope of CI, since they would clobber the operator installed through OLM, and potentially prevent detection of an OLM-related bug.

To prevent accidentally adding a dependency on these targets, we:
- set an environment variable in our CI jobs (comments welcome if we can depend on another variable which is guaranteed to be present in the CI context but not on a developer workstation),
- adds a `check-ci-setup` target which just fails if the environment variable is set
- makes the forbidden targets depend on the new target

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~

## Testing Performed

Relying on CI, checked locally that the target fails when variable is set, and passes when it's empty.