### PR TITLE
Adding support to save the scope hierarchy in the Context object

### DIFF
--- a/central/graphql/resolvers/distroctx/distro_context.go
+++ b/central/graphql/resolvers/distroctx/distro_context.go
@@ -24,7 +24,7 @@ func IsImageScoped(ctx context.Context) bool {
 	return FromContext(ctx) != ""
 }
 
-// FromContext returns the distro from the input context as well as a boolean indicating if there was a distro attached.
+// FromContext returns the distro from the input context
 func FromContext(hasDistroContext context.Context) string {
 	if hasDistroContext == nil {
 		return ""

--- a/pkg/search/scoped/context.go
+++ b/pkg/search/scoped/context.go
@@ -8,8 +8,9 @@ import (
 
 // Scope hold an id and scope level for scoping searches.
 type Scope struct {
-	ID    string
-	Level v1.SearchCategory
+	ID     string
+	Level  v1.SearchCategory
+	Parent *Scope
 }
 
 // scopedContextKey is the key for the scope value in the context.
@@ -22,6 +23,10 @@ type scopedContextValue struct {
 
 // Context returns a new context with the scope attached.
 func Context(ctx context.Context, scope Scope) context.Context {
+	inner, ok := ctx.Value(scopedContextKey{}).(*scopedContextValue)
+	if ok {
+		scope.Parent = &inner.scope
+	}
 	return context.WithValue(ctx, scopedContextKey{}, &scopedContextValue{
 		scope: scope,
 	})
@@ -38,4 +43,27 @@ func GetScope(hasGraphContext context.Context) (Scope, bool) {
 	}
 	s := inter.(*scopedContextValue)
 	return s.scope, true
+}
+
+// GetScopeAtLevel returns the Scope from the input context with the given level, nil if that level doesn't exist in the scope hierarchy
+func GetScopeAtLevel(hasGraphContext context.Context, level v1.SearchCategory) (Scope, bool) {
+	if hasGraphContext == nil {
+		return Scope{}, false
+	}
+	inter := hasGraphContext.Value(scopedContextKey{})
+	if inter == nil {
+		return Scope{}, false
+	}
+	scope := inter.(*scopedContextValue).scope
+	return getScopeAtLevel(&scope, level)
+}
+
+func getScopeAtLevel(scope *Scope, level v1.SearchCategory) (Scope, bool) {
+	if scope == nil {
+		return Scope{}, false
+	}
+	if scope.Level == level {
+		return *scope, true
+	}
+	return getScopeAtLevel(scope.Parent, level)
 }

--- a/pkg/search/scoped/context_test.go
+++ b/pkg/search/scoped/context_test.go
@@ -1,0 +1,55 @@
+package scoped
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestContext(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(scopedContextTestSuite))
+}
+
+type scopedContextTestSuite struct {
+	suite.Suite
+}
+
+func (s *scopedContextTestSuite) TestGetScopeAtLevel() {
+	ctx := context.Background()
+	ctx = Context(ctx, Scope{
+		ID:    "image-1",
+		Level: v1.SearchCategory_IMAGES,
+	})
+
+	ctx = Context(ctx, Scope{
+		ID:    "component-1",
+		Level: v1.SearchCategory_IMAGE_COMPONENTS,
+	})
+
+	imageScope, hasImageScope := GetScopeAtLevel(ctx, v1.SearchCategory_IMAGES)
+	s.Equal(true, hasImageScope)
+	s.Equal(Scope{
+		ID:     "image-1",
+		Level:  v1.SearchCategory_IMAGES,
+		Parent: nil,
+	}, imageScope)
+
+	componentScope, hasCompScope := GetScopeAtLevel(ctx, v1.SearchCategory_IMAGE_COMPONENTS)
+	s.Equal(true, hasCompScope)
+	s.Equal(Scope{
+		ID:    "component-1",
+		Level: v1.SearchCategory_IMAGE_COMPONENTS,
+		Parent: &Scope{
+			ID:     "image-1",
+			Level:  v1.SearchCategory_IMAGES,
+			Parent: nil,
+		},
+	}, componentScope)
+
+	deploymentScope, hasDepScope := GetScopeAtLevel(ctx, v1.SearchCategory_DEPLOYMENTS)
+	s.Equal(false, hasDepScope)
+	s.Equal(Scope{}, deploymentScope)
+}


### PR DESCRIPTION

## Description
* Adding support to save the scope hierarchy in the Context object
* Adding a method to get the scope for a particular level
* Unit tests

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~

# Testing Performed
Unit tests only.

PR credits: @viswajithiii @theencee @md2119 , thanks folks.