### PR TITLE
Assert os.ErrOut within roxctl tests for image check / scan & deployment check

### DIFF
--- a/roxctl/deployment/check/check_test.go
+++ b/roxctl/deployment/check/check_test.go
@@ -1159,9 +1159,7 @@ func (d *deployCheckTestSuite) runOutputTests(cases map[string]outputFormatTest,
 				d.Require().NoError(err)
 			}
 			d.Assert().Equal(c.expectedOutput, out.String())
-			if c.expectedErrOutput != "" {
-				d.Assert().Equal(c.expectedErrOutput, errOut.String())
-			}
+			d.Assert().Equal(c.expectedErrOutput, errOut.String())
 		})
 	}
 }

--- a/roxctl/image/check/check_test.go
+++ b/roxctl/image/check/check_test.go
@@ -1083,9 +1083,7 @@ func (suite *imageCheckTestSuite) runOutputTests(cases map[string]outputFormatTe
 
 			}
 			suite.Assert().Equal(c.expectedOutput, out.String())
-			if c.expectedErrOutput != "" {
-				suite.Assert().Equal(c.expectedErrOutput, errOut.String())
-			}
+			suite.Assert().Equal(c.expectedErrOutput, errOut.String())
 		})
 	}
 }

--- a/roxctl/image/scan/scan_test.go
+++ b/roxctl/image/scan/scan_test.go
@@ -969,9 +969,7 @@ func (s *imageScanTestSuite) runOutputTests(cases map[string]outputFormatTest, p
 			err := imgScanCmd.Scan()
 			s.Require().NoError(err)
 			s.Assert().Equal(c.expectedOutput, out.String())
-			if c.expectedErrorOutput != "" {
-				s.Assert().Equal(c.expectedErrorOutput, errOut.String())
-			}
+			s.Assert().Equal(c.expectedErrorOutput, errOut.String())
 		})
 	}
 }


### PR DESCRIPTION
Switched from muliline strings to double quoted, as multiline doesn't support identation with tabs.

Relevant PR: #75 

## Description

A detailed explanation of the changes in your PR.

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
