### PR TITLE
ROX-8745: Bump CSV patch timeout to help with flakes.

### DIFF
--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -97,7 +97,7 @@ function nurse_deployment_until_available() {
   local -r version_tag="$2"
 
   log "Patching image pull secret into ${version_tag} CSV..."
-  retry 20 5 kubectl -n "${operator_ns}" patch clusterserviceversions.operators.coreos.com \
+  retry 30 10 kubectl -n "${operator_ns}" patch clusterserviceversions.operators.coreos.com \
     "rhacs-operator.v${version_tag}" --type json \
     -p '[ { "op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/imagePullSecrets", "value": [{"name": "'"${pull_secret}"'"}] } ]'
 


### PR DESCRIPTION
## Description

Detailed timeline analysis in the ticket. In short, sometimes the underlying image(s) take just a tiny bit longer to pull than we allow the whole operation to take.
Bumping by just 1 more second would have been sufficient in the case I've analyzed, but it does not hurt if we take our time here.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~

## Testing Performed

Relying on CI.