### PR TITLE
ROX-8750: Change VerifyServiceCert arguments to match its purpose.

### DIFF
--- a/operator/pkg/central/extensions/reconcile_tls.go
+++ b/operator/pkg/central/extensions/reconcile_tls.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/joelanford/helm-operator/pkg/extensions"
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
 	platform "github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"github.com/stackrox/rox/pkg/certgen"
 	"github.com/stackrox/rox/pkg/mtls"
@@ -69,7 +70,7 @@ func (r *createCentralTLSExtensionRun) validateAndConsumeCentralTLSData(fileMap 
 	if err := r.ca.CheckProperties(); err != nil {
 		return errors.Wrap(err, "loaded service CA certificate is invalid")
 	}
-	if err := certgen.VerifyServiceCert(fileMap, r.ca, mtls.CentralSubject, ""); err != nil {
+	if err := certgen.VerifyServiceCert(fileMap, r.ca, storage.ServiceType_CENTRAL_SERVICE, ""); err != nil {
 		return errors.Wrap(err, "verifying existing central CA")
 	}
 	return nil
@@ -98,8 +99,8 @@ func (r *createCentralTLSExtensionRun) generateCentralTLSData() (secretDataMap, 
 	return fileMap, nil
 }
 
-func (r *createCentralTLSExtensionRun) validateServiceTLSData(subj mtls.Subject, fileMap secretDataMap) error {
-	if err := certgen.VerifyServiceCert(fileMap, r.ca, subj, ""); err != nil {
+func (r *createCentralTLSExtensionRun) validateServiceTLSData(serviceType storage.ServiceType, fileMap secretDataMap) error {
+	if err := certgen.VerifyServiceCert(fileMap, r.ca, serviceType, ""); err != nil {
 		return err
 	}
 	if err := certgen.VerifyCACertInFileMap(fileMap, r.ca); err != nil {
@@ -117,7 +118,7 @@ func (r *createCentralTLSExtensionRun) generateServiceTLSData(subj mtls.Subject,
 }
 
 func (r *createCentralTLSExtensionRun) validateScannerTLSData(fileMap secretDataMap, _ bool) error {
-	return r.validateServiceTLSData(mtls.ScannerSubject, fileMap)
+	return r.validateServiceTLSData(storage.ServiceType_SCANNER_SERVICE, fileMap)
 }
 
 func (r *createCentralTLSExtensionRun) generateScannerTLSData() (secretDataMap, error) {
@@ -129,7 +130,7 @@ func (r *createCentralTLSExtensionRun) generateScannerTLSData() (secretDataMap, 
 }
 
 func (r *createCentralTLSExtensionRun) validateScannerDBTLSData(fileMap secretDataMap, _ bool) error {
-	return r.validateServiceTLSData(mtls.ScannerDBSubject, fileMap)
+	return r.validateServiceTLSData(storage.ServiceType_SCANNER_DB_SERVICE, fileMap)
 }
 
 func (r *createCentralTLSExtensionRun) generateScannerDBTLSData() (secretDataMap, error) {

--- a/pkg/certgen/certgen.go
+++ b/pkg/certgen/certgen.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/services"
 )
@@ -39,8 +40,8 @@ func IssueOtherServiceCerts(fileMap map[string][]byte, ca mtls.CA, subjs ...mtls
 }
 
 // VerifyServiceCert verifies that the service certificate (stored with the given fileNamePrefix in the file
-// map) is a valid service certificate relative to the given CA.
-func VerifyServiceCert(fileMap map[string][]byte, ca mtls.CA, subj mtls.Subject, fileNamePrefix string) error {
+// map) is a valid service certificate for the given serviceType, relative to the given CA.
+func VerifyServiceCert(fileMap map[string][]byte, ca mtls.CA, serviceType storage.ServiceType, fileNamePrefix string) error {
 	certPEM := fileMap[fileNamePrefix+mtls.ServiceCertFileName]
 	if len(certPEM) == 0 {
 		return errors.New("no service certificate in file map")
@@ -52,8 +53,8 @@ func VerifyServiceCert(fileMap map[string][]byte, ca mtls.CA, subj mtls.Subject,
 
 	if subjFromCert, err := ca.ValidateAndExtractSubject(cert); err != nil {
 		return errors.Wrap(err, "failed to validate certificate and extract subject")
-	} else if subjFromCert.ServiceType != subj.ServiceType {
-		return errors.Errorf("unexpected certificate service type: got %s, expected %s", subjFromCert.ServiceType, subj.ServiceType)
+	} else if subjFromCert.ServiceType != serviceType {
+		return errors.Errorf("unexpected certificate service type: got %s, expected %s", subjFromCert.ServiceType, serviceType)
 	}
 
 	keyPEM := fileMap[fileNamePrefix+mtls.ServiceKeyFileName]


### PR DESCRIPTION
## Description

No functional changes. Just a change in the signature which could mislead users that something apart from the service type in subject was being checked. This becomes more important when the init bundle type in the subject could vary.

Extracted from a bigger PR for simplicity.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~

## Testing Performed

Relying on CI.