### PR TITLE
Push k8s artifacts during upgrade tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3743,6 +3743,7 @@ jobs:
       - get-and-store-debug-dump
       - get-and-store-diagnostic-bundle
       - get-central-data
+      - store-k8s-logs
       - *storeQALogs
       - teardown-gke
 


### PR DESCRIPTION
## Description

This seems like it was forgotten previously, and now I have trouble investigating [failed upgrade tests](https://srox.slack.com/archives/CLUNQEEMA/p1639419400074300) without k8s artifacts.

All other instances of `collect-k8s-logs` seem to have corresponding `store-k8s-logs`.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~ - does not apply.
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ - not needed.
- ~~[ ] Determined and documented upgrade steps~~ - internal change.

If any of these don't apply, please comment below.

## Testing Performed

* CI will show if it works. Added corresponding label.