### PR TITLE
[ROX-8767] Ensure that the correct image cache key is being used in sensor

### DIFF
--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/detector/unified"
 	"github.com/stackrox/rox/sensor/common/enforcer"
 	"github.com/stackrox/rox/sensor/common/externalsrcs"
+	"github.com/stackrox/rox/sensor/common/imagecacheutils"
 	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/common/updater"
 	"google.golang.org/grpc"
@@ -363,13 +364,13 @@ func (d *detectorImpl) ProcessDeployment(deployment *storage.Deployment, action 
 func (d *detectorImpl) ReprocessDeployments(deploymentIDs ...string) {
 	d.admCtrlSettingsMgr.FlushCache()
 
-	invalidatedImages := make(map[imageCacheKey]struct{})
+	invalidatedImages := make(map[imagecacheutils.ImageCacheKey]struct{})
 	for _, deploymentID := range deploymentIDs {
 		d.reprocessDeployment(deploymentID, invalidatedImages)
 	}
 }
 
-func (d *detectorImpl) reprocessDeployment(deploymentID string, invalidatedImages map[imageCacheKey]struct{}) {
+func (d *detectorImpl) reprocessDeployment(deploymentID string, invalidatedImages map[imagecacheutils.ImageCacheKey]struct{}) {
 	d.deploymentDetectionLock.Lock()
 	defer d.deploymentDetectionLock.Unlock()
 
@@ -379,7 +380,7 @@ func (d *detectorImpl) reprocessDeployment(deploymentID string, invalidatedImage
 	}
 
 	for _, container := range deployment.GetContainers() {
-		key := getImageCacheKey(container.GetImage())
+		key := imagecacheutils.GetImageCacheKey(container.GetImage())
 		if _, invalidated := invalidatedImages[key]; invalidated {
 			continue
 		}

--- a/sensor/common/image/service_impl.go
+++ b/sensor/common/image/service_impl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/expiringcache"
 	grpcPkg "github.com/stackrox/rox/pkg/grpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/idcheck"
+	"github.com/stackrox/rox/sensor/common/imagecacheutils"
 	"google.golang.org/grpc"
 )
 
@@ -41,7 +42,7 @@ func (s *serviceImpl) SetClient(conn grpc.ClientConnInterface) {
 
 func (s *serviceImpl) GetImage(ctx context.Context, req *sensor.GetImageRequest) (*sensor.GetImageResponse, error) {
 	if id := req.GetImage().GetId(); id != "" {
-		img, _ := s.imageCache.Get(id).(*storage.Image)
+		img, _ := s.imageCache.Get(imagecacheutils.GetImageCacheKey(req.GetImage())).(*storage.Image)
 		if img != nil && (!req.GetScanInline() || img.GetScan() != nil) {
 			return &sensor.GetImageResponse{
 				Image: img,

--- a/sensor/common/imagecacheutils/common.go
+++ b/sensor/common/imagecacheutils/common.go
@@ -1,0 +1,22 @@
+package imagecacheutils
+
+import "github.com/stackrox/rox/generated/storage"
+
+// ImageCacheKey represents the key by which images are keyed in image cache.
+type ImageCacheKey struct {
+	ID, Name string
+}
+
+// CacheKeyProvider represents an interface from which image cache can be generated.
+type CacheKeyProvider interface {
+	GetId() string
+	GetName() *storage.ImageName
+}
+
+// GetImageCacheKey generates image cache key from a cache key provider.
+func GetImageCacheKey(provider CacheKeyProvider) ImageCacheKey {
+	return ImageCacheKey{
+		ID:   provider.GetId(),
+		Name: provider.GetName().GetFullName(),
+	}
+}


### PR DESCRIPTION
## Description

The images are keyed by ID and name, however, the sensor image service tried to lookup images by id only.

## Checklist
- [ ] Investigated and inspected CI test results
- ~Unit test and regression tests added~
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed
CI