### PR TITLE
ROX-8130: Validation of operator-issued init bundle certs in Central.

### DIFF
--- a/pkg/grpc/authn/service/extractor.go
+++ b/pkg/grpc/authn/service/extractor.go
@@ -37,7 +37,6 @@ func (e extractor) IdentityForRequest(ctx context.Context, ri requestinfo.Reques
 	if e.validator != nil {
 		err := e.validator.ValidateClientCertificate(ctx, ri.VerifiedChains[0])
 		if err != nil {
-			log.Errorf("init bundle cert is revoked: %q", ri.VerifiedChains[0][0].Subject.Organization)
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Description

For operator-issued init bundle certs, we skip revocation validation [as designed](https://docs.google.com/document/d/1REVFwEU2OwdyIUdodgcG64VH7U1ogQN8Tqj86xR-Wpk/edit#heading=h.ccp8orkhrpa).

PR extracted from the rest of the code on @SimonBaeumer 's request.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~

## Testing Performed

Relying on CI.