### PR TITLE
Get rid of `buildConfigFileOverridesMap` as unused

### DIFF
--- a/pkg/renderer/kubernetes.go
+++ b/pkg/renderer/kubernetes.go
@@ -2,7 +2,6 @@ package renderer
 
 import (
 	"encoding/base64"
-	"io"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
@@ -81,22 +80,16 @@ func postProcessConfig(c *Config, mode mode) error {
 
 // Render renders a bunch of zip files based on the given config.
 func Render(c Config) ([]*zip.File, error) {
-	return render(c, renderAll, nil)
-}
-
-// RenderWithOverrides renders a bunch of zip files based on the given config, allowing to selectively override some of
-// the bundled files.
-func RenderWithOverrides(c Config, centralOverrides map[string]func() io.ReadCloser) ([]*zip.File, error) {
-	return render(c, renderAll, centralOverrides)
+	return render(c, renderAll)
 }
 
 // RenderScannerOnly renders the zip files for the scanner based on the given config.
 func RenderScannerOnly(c Config) ([]*zip.File, error) {
-	return render(c, scannerOnly, nil)
+	return render(c, scannerOnly)
 }
 
 func renderAndExtractSingleFileContents(c Config, mode mode) ([]byte, error) {
-	files, err := render(c, mode, nil)
+	files, err := render(c, mode)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +110,7 @@ func RenderScannerTLSSecretOnly(c Config) ([]byte, error) {
 	return renderAndExtractSingleFileContents(c, scannerTLSOnly)
 }
 
-func render(c Config, mode mode, centralOverrides map[string]func() io.ReadCloser) ([]*zip.File, error) {
+func render(c Config, mode mode) ([]*zip.File, error) {
 	err := postProcessConfig(&c, mode)
 	if err != nil {
 		return nil, err

--- a/pkg/renderer/render_test.go
+++ b/pkg/renderer/render_test.go
@@ -65,7 +65,7 @@ func TestRenderScannerOnly(t *testing.T) {
 		},
 	}
 
-	files, err := render(config, scannerOnly, nil)
+	files, err := render(config, scannerOnly)
 	assert.NoError(t, err)
 
 	for _, f := range files {

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -3,7 +3,6 @@ package generate
 import (
 	"encoding/pem"
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"strconv"
@@ -16,7 +15,6 @@ import (
 	"github.com/stackrox/rox/pkg/certgen"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
-	"github.com/stackrox/rox/pkg/ioutils"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/renderer"
 	"github.com/stackrox/rox/pkg/roxctl"
@@ -116,28 +114,6 @@ func populateMTLSFiles(fileMap map[string][]byte, backupBundle string) error {
 	return nil
 }
 
-func openFileFunc(path string) func() io.ReadCloser {
-	return func() io.ReadCloser {
-		f, err := os.Open(path)
-		if err != nil {
-			return io.NopCloser(ioutils.ErrorReader(err))
-		}
-		return f
-	}
-}
-
-func buildConfigFileOverridesMap(filePathMap map[string]string) map[string]func() io.ReadCloser {
-	if len(filePathMap) == 0 {
-		return nil
-	}
-
-	fileOverridesMap := make(map[string]func() io.ReadCloser, len(filePathMap))
-	for configFilePath, replacementFilePath := range filePathMap {
-		fileOverridesMap[path.Join("config", configFilePath)] = openFileFunc(replacementFilePath)
-	}
-	return fileOverridesMap
-}
-
 func createBundle(config renderer.Config) (*zip.Wrapper, error) {
 	wrapper := zip.NewWrapper()
 
@@ -199,7 +175,7 @@ func createBundle(config renderer.Config) (*zip.Wrapper, error) {
 		return nil, err
 	}
 
-	files, err := renderer.RenderWithOverrides(config, buildConfigFileOverridesMap(config.ConfigFileOverrides))
+	files, err := renderer.Render(config)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not render files")
 	}


### PR DESCRIPTION
## Description

GoLand showed that `centralOverrides` function argument is unused in https://github.com/stackrox/stackrox/blob/master/pkg/renderer/kubernetes.go#L120

![2021-12-15_19-41](https://user-images.githubusercontent.com/537715/146247897-820736b9-497e-4cc0-a02b-2c9895778dad.png)

Instead, there's `Config.GetConfigOverride()`
https://github.com/stackrox/stackrox/blob/9418c9612db6d8c1a772173de93fa0cea466b685/pkg/renderer/templater.go#L190-L191
that's used in templates here
https://github.com/stackrox/stackrox/blob/08cb1a4813effd47d7bcdd4bdbb0607cdabfaafb/pkg/renderer/helm_values.go#L48-L51

Therefore I went ahead and cleaned up `centralOverrides` from `kubernetes.go` and some other stuff that followed.

Originally, the usage was here https://github.com/stackrox/rox/pull/4824/files#diff-9ada4c8b1378c71b315581687ee84fe693c98f6587cbb5e8c8a0a81980ed37feR90-R106 but the approach got migrated to `Config.GetConfigOverride()` that I linked above.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~ no here and below.
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~

## Testing Performed

* CI will tell if I was wrong.