### PR TITLE
Fix for build-race-condition-debug image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2803,7 +2803,7 @@ jobs:
     executor: custom
     resource_class: large
     steps:
-      - checkout
+      - checkout-with-submodules
       - *checkToRunSeparateRaceConditionTestPipe
 
       - run:


### PR DESCRIPTION
## Description

Submodule --init gets it built.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient (tagged to run the build-race-condition-debug job) https://app.circleci.com/pipelines/github/stackrox/stackrox/829/workflows/b4e0eae6-d064-42f6-8ea5-99b9e7c6b4c4