### PR TITLE
CI: Fix build for race-condition-debug tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2846,7 +2846,7 @@ jobs:
     executor: custom
     resource_class: large
     steps:
-      - checkout
+      - checkout-with-submodules
       - *checkToRunSeparateRaceConditionTestPipe
 
       - run:


### PR DESCRIPTION
## Description

submodule --init is required at least on branch builds.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient