### PR TITLE
Only cache vuln requests that are approved and active on startup

### DIFF
--- a/central/vulnerabilityrequest/manager/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/manager_impl.go
@@ -426,7 +426,11 @@ func (m *managerImpl) runExpiredDeferralsProcessor() {
 }
 
 func (m *managerImpl) buildCache() error {
-	res, err := m.vulnReqs.Search(allAccessCtx, search.EmptyQuery())
+	q := search.ConjunctionQuery(
+		search.NewQueryBuilder().AddBools(search.ExpiredRequest, false).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.RequestStatus, storage.RequestStatus_APPROVED.String(), storage.RequestStatus_APPROVED_PENDING_UPDATE.String()).ProtoQuery(),
+	)
+	res, err := m.vulnReqs.Search(allAccessCtx, q)
 	if err != nil {
 		return errors.Wrap(err, "error retrieving keys from vuln request datastore")
 	}

--- a/central/vulnerabilityrequest/manager/manager_impl_test.go
+++ b/central/vulnerabilityrequest/manager/manager_impl_test.go
@@ -653,6 +653,31 @@ func (s *VulnRequestManagerTestSuite) TestProcessorDoesntExpireOnceStopped() {
 	s.False(r.Expired)
 }
 
+func (s *VulnRequestManagerTestSuite) TestBuildCacheOnlyCachesApprovedAndActiveRequests() {
+	reqs := []*storage.VulnerabilityRequest{
+		newFalsePositive("approved-fp", "cve-approved-fp", false, storage.RequestStatus_APPROVED, nil),
+		newFalsePositive("approved-pending-update-fp", "cve-approved-pending-update-fp", false, storage.RequestStatus_APPROVED_PENDING_UPDATE, nil),
+		newFalsePositive("expired-fp", "cve-expired-fp", true, storage.RequestStatus_APPROVED, nil),
+		newFalsePositive("denied-fp", "cve-denied-fp", false, storage.RequestStatus_DENIED, nil),
+		newFalsePositive("pending-fp", "cve-pending-fp", false, storage.RequestStatus_PENDING, nil),
+	}
+	for _, r := range reqs {
+		err := s.vulnReqDataStore.AddRequest(allAllowedCtx, r)
+		s.NoError(err)
+	}
+
+	s.forceIndexing()
+
+	s.NoError(s.manager.buildCache())
+	states, err := s.manager.VulnsWithState(allAllowedCtx, "registry", "remote", ".*")
+	s.NoError(err)
+
+	// Only two states (for the two approved reqs) should be in the cache
+	s.Len(states, 2)
+	s.Equal(states["cve-approved-fp"], storage.VulnerabilityState_FALSE_POSITIVE)
+	s.Equal(states["cve-approved-pending-update-fp"], storage.VulnerabilityState_FALSE_POSITIVE)
+}
+
 func newDeferral(id string, expired bool, status storage.RequestStatus, expiry *types.Timestamp) *storage.VulnerabilityRequest {
 	return &storage.VulnerabilityRequest{
 		Id:          id,


### PR DESCRIPTION
## Description

If you have a pending request or an expired one, on startup it used to get added to the request. Which is a problem as that cache is relied upon to show effective state and pending requests (or expired requests) are effectively OBSERVED.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed

Unit

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
