### PR TITLE
ROX-7197: explicitly return nil and log when service account is missing for the deployment

### DIFF
--- a/central/graphql/resolvers/log.go
+++ b/central/graphql/resolvers/log.go
@@ -1,7 +1,0 @@
-package resolvers
-
-import "github.com/stackrox/rox/pkg/logging"
-
-var (
-	log = logging.LoggerForModule()
-)


### PR DESCRIPTION
## Description

`errors.Wrap` returns nil when wrapped error is nil, we never returned an error when results were empty.
Let's log warning and explicitly return `nil`

See: https://github.com/stackrox/rox/pull/8248

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

CI