### PR TITLE
ROX-8788: Fix Image Overview crash on browser back

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
@@ -33,11 +33,15 @@ const emptyImage = {
     lastUpdated: '',
     metadata: {
         layerShas: [],
-        v1: {},
+        v1: {
+            layers: [],
+        },
     },
     name: {},
     priority: 0,
-    scan: {},
+    scan: {
+        components: [],
+    },
     topVuln: {},
     vulnCount: 0,
 };


### PR DESCRIPTION
## Description

Something has changed in either the caching of the GraphQL library, or the speed of the API response, and now there seems to be a race condition that affects returning to the single image Overview after visiting it once,  and then going somewhere else.

The data is almost instantaneously available, but adding empty default properties prevents this new crash.

(I'm sure there is a mathematically provable better solution, if we had time to track it down, but I deem it's not worth re-deploying multiple times during a `git bisect` to find the breaking change.)

## Checklist
- [x] Investigated and inspected CI test results (failure is a flake)

## Testing Performed

Manually observed it NOT crashing. (Screenshots don't add anything to this description.)
