### PR TITLE
CI: reduce resource usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2900,7 +2900,7 @@ jobs:
 
   build-operator:
     executor: custom
-    resource_class: medium
+    resource_class: large
     steps:
       - checkout
 


### PR DESCRIPTION
## Description

We can claw back some more Circle CI time if we use smaller machines. This PR reduces executor size when prior runs show memory usage at approx <= 25% and CPU usage at approx <= 50%. I'm being conservative to avoid running into intermittent OOM flakes.

## Sizing Changes

- operator tests (4 & 4-6) 
  - medium -> small 
  - [looks good](https://app.circleci.com/pipelines/github/stackrox/stackrox/1015/workflows/090b00c6-bda5-4c9a-8dc9-e76157dbad95/jobs/43799/resources), run time is comparable
- build 
  - large -> medium 
  - [looks good](https://app.circleci.com/pipelines/github/stackrox/stackrox/1015/workflows/090b00c6-bda5-4c9a-8dc9-e76157dbad95/jobs/43736/resources), run time is comparable
- build-operator 
  - ~large -> medium~
  - TENTATIVE: based on memory usage but CPU may be pegged, so check for increase in duration which we do not want (current 18-19mins)
  - Run time increased to 23 mins. Memory might be an issue. Reverted back to large.
- build-scale-monitoring-and-mock-server
  - large -> medium
  - [looks good](https://app.circleci.com/pipelines/github/stackrox/stackrox/1015/workflows/090b00c6-bda5-4c9a-8dc9-e76157dbad95/jobs/43701/resources), run time is comparable
- check-generated-files-up-to-date
  - small -> medium
  - TENTATIVE upsizing, this required job is CPU pegged and takes 30 minutes so lets see if it can be reduced
  - [looks good](https://app.circleci.com/pipelines/github/stackrox/stackrox/1015/workflows/090b00c6-bda5-4c9a-8dc9-e76157dbad95/jobs/43712/resources)
  - Run time is reduced to 20 minutes
  - Keeping this as a QOL improvement. This will no longer be the slowest required job.
- style-checks gets close to 100% memory and largely pegs the CPU
  - large -> xlarge
  - TENTATIVE upsizing, current time 12 mins
  - With xlarge, takes 9 minutes, memory mostly below 50%, CPU still pegged
  - Keeping this to avoid style-check OOM flakes (though there is no evidence of them that I recall)
- go-unit-tests and go-unit-tests also get close to 100% memory and peg CPU
  - medium -> large.
  - TENTATIVE upsizing current time 20 mins
  - run time is now 16 minutes
  - Keeping to give unit tests comfortable headroom.
- pre-build-cli 
   - large -> medium
   - [looks good](https://app.circleci.com/pipelines/github/stackrox/stackrox/1015/workflows/090b00c6-bda5-4c9a-8dc9-e76157dbad95/jobs/43731/resources)
- provision-* 
   - medium -> small
   - Looks good!

## Options

OpenShift 3.11 and KOPS provisioning could change to a small docker image but they would need volume packing for the remote docker server so this is maybe something for next time.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient