### PR TITLE
CI: fix 4.6 provision for operator tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2138,7 +2138,7 @@ commands:
               gcr.io/stackrox-infra/automation-flavors/openshift-4:$OPENSHIFT_4_AUTOMATION_VERSION \
               create << parameters.cluster-name >>-"${CIRCLE_WORKFLOW_ID:0:7}" "${GCP_PROJECT}" openshift.ci.rox.systems
             docker cp openshift-4-automation:/data $PWD/<< parameters.cluster-name >>
-          no_output_timeout: 45m
+          no_output_timeout: 60m
 
 jobs:
   ###


### PR DESCRIPTION
## Description

My recent change to hide the kubeadmin password during OpenShift 4 installs broke the install for 4.6. The earlier change causes no output while the install is happening, OpenShift 4.6 installs have a [p95 install time](https://app.circleci.com/insights/github/stackrox/rox/workflows/build_all/jobs?branch=master&reporting-window=last-30-days) of 51 minutes and the step only allows for 45 minutes of no output. This change ups that to 60 minutes.

## Checklist
- [x] Investigated and inspected CI test results


## Testing Performed

CI is sufficient