### PR TITLE
ci: fallback to  goproxy.io on proxy.golang.org error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -507,8 +507,6 @@ executors:
     resource_class: << parameters.resource_class >>
     docker:
       - image: quay.io/rhacs-eng/apollo-ci:0.3.21
-        environment:
-          GOPROXY: 'https://proxy.golang.org|https://goproxy.io|direct'
         auth:
           username: $QUAY_RHACS_ENG_RO_USERNAME
           password: $QUAY_RHACS_ENG_RO_PASSWORD

--- a/make/env.mk
+++ b/make/env.mk
@@ -11,7 +11,7 @@ ifeq ($(findstring :, $(GOPATH)), $(colon))
 GOPATH := $(patsubst :%,,$(GOPATH))
 endif
 
-export CGO_ENABLED DEFAULT_GOOS GOARCH GOTAGS GO111MODULE GOPRIVATE GOBIN
+export CGO_ENABLED DEFAULT_GOOS GOARCH GOTAGS GO111MODULE GOPRIVATE GOBIN GOPROXY
 CGO_ENABLED := 1
 
 # Update the arch to arm64 but only for Macs running on Apple Silicon (M1)
@@ -24,6 +24,7 @@ endif
 DEFAULT_GOOS := linux
 GO111MODULE := on
 GOPRIVATE := github.com/stackrox
+GOPROXY := https://proxy.golang.org|https://goproxy.io|direct
 
 ifeq ($(GOBIN),)
 GOBIN := $(GOPATH)/bin


### PR DESCRIPTION
## Description

Try to solve issues with proxy.golang.org with fallback to goproxy.io.

```
go: cloud.google.com/go@v0.94.1: Get "https://proxy.golang.org/cloud.google.com/go/@v/v0.94.1.mod": net/http: TLS handshake timeout
go: cloud.google.com/go/storage@v1.12.0: Get "https://proxy.golang.org/cloud.google.com/go/storage/@v/v1.12.0.mod": net/http: TLS handshake timeout
```

> The GOPROXY environment variable now supports skipping proxies that return errors. Proxy URLs may now be separated with either commas (,) or pipe characters (|). If a proxy URL is followed by a comma, the go command will only try the next proxy in the list after a 404 or 410 HTTP response. If a proxy URL is followed by a pipe character, the go command will try the next proxy in the list after any error. Note that the default value of GOPROXY remains https://proxy.golang.org,direct, which does not fall back to direct in case of errors. [Go 1.15](https://go.dev/doc/go1.15#:~:text=Tools-,Go%20command,-The%20GOPROXY%20environment)

See: https://app.circleci.com/pipelines/github/stackrox/stackrox/928/workflows/088fddc5-1e08-4ace-a2ff-7d670b012220/jobs/39597
Refs: https://github.com/golang/go/issues/37367

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

CI