### PR TITLE
ROX-8784: Remove Helm release revision from configuration fingerprint

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -18,7 +18,7 @@
 {{/*
     Calculate the fingerprint of the input config.
    */}}
-{{ $configFP := printf "%s-%d" (.Values | toJson | sha256sum) .Release.Revision }}
+{{ $configFP := (.Values | toJson | sha256sum) }}
 
 {{/*
     Initial Setup


### PR DESCRIPTION
## Description

Remove Helm release revision from configuration fingerprint, so the Helm charts are idempotent again.  
This should not be merged before https://github.com/stackrox/stackrox/pull/163 to disable editing the cluster configuration in the web UI for Helm based installations.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
- [x] Evaluated and added CHANGELOG entry if required
-  ~~[ ] Determined and documented upgrade step~~


## Testing Performed

Manual testing in k8s on docker desktop:

```bash
kubectl -n stackrox port-forward svc/central 8443:443 &
sleep 1
rm cluster-init-bundle.yaml 
ADMIN_PWD=$(cat ./deploy/k8s/central-deploy/password)
./bin/darwin/roxctl central init-bundles generate init_bundle --output cluster-init-bundle.yaml  --insecure-skip-tls-verify -p ${ADMIN_PWD}
INIT_BUNDLE_PATH=cluster-init-bundle.yaml  

# Install secured cluster services
roxctl helm output secured-cluster-services --debug --remove
helm -n stackrox install stackrox-secured-cluster-services ./stackrox-secured-cluster-services-chart \
   --set clusterName=docker-desktop \
   -f ${INIT_BUNDLE_PATH} \
   --set mainImagePullSecrets.allowNone=true --set collectorImagePullSecrets.allowNone=true

# differences both in USER-SUPPLIED-VALUES, COMPUTED VALUES and secret effective-cluster-name
helm -n stackrox get all stackrox-secured-cluster-services > current.yaml
helm -n stackrox upgrade stackrox-secured-cluster-services stackrox-secured-cluster-services-chart --reuse-values --dry-run  > upgrade.yaml
diff current.yaml upgrade.yaml

helm -n stackrox upgrade stackrox-secured-cluster-services stackrox-secured-cluster-services-chart --reuse-values
# differences just in USER-SUPPLIED-VALUES and COMPUTED VALUES
helm -n stackrox get all stackrox-secured-cluster-services > current.yaml
helm -n stackrox upgrade stackrox-secured-cluster-services stackrox-secured-cluster-services-chart --reuse-values --dry-run  > upgrade.yaml
diff current.yaml upgrade.yaml
```
