### PR TITLE
ROX-8820: operator: bind pip and setuptools versions in Makefile

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -338,7 +338,7 @@ upgrade-via-olm: kuttl
 # Commands to enter local Python virtual environment and get needed dependencies there.
 ACTIVATE_PYTHON = python3 -m venv bundle_helpers/.venv ;\
 	. bundle_helpers/.venv/bin/activate ;\
-	pip3 install --upgrade pip setuptools ;\
+	pip3 install --upgrade pip==19.2 setuptools==59.6.0 ;\
 	pip3 install -r bundle_helpers/requirements.txt
 
 .PHONY: bundle


### PR DESCRIPTION
## Description

It looks like setuptools has introduced issue in latest release https://github.com/pypa/setuptools/issues/2940
Let's use frozen version to prevent this issues in the future and have more repeatable builds.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

CI