### PR TITLE
ROX-8555: Add GraphQL mutation to re-observe CVE in False Positive CVEs table

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEActionsColumns.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEActionsColumns.tsx
@@ -1,0 +1,32 @@
+import React, { ReactElement } from 'react';
+import { ActionsColumn } from '@patternfly/react-table';
+import { FalsePositiveCVEsToBeAssessed } from './types';
+import { Vulnerability } from '../imageVulnerabilities.graphql';
+
+export type FalsePositiveCVEActionsColumnProps = {
+    row: Vulnerability;
+    setVulnsToBeAssessed: React.Dispatch<React.SetStateAction<FalsePositiveCVEsToBeAssessed>>;
+};
+
+function FalsePositiveCVEActionsColumn({
+    row,
+    setVulnsToBeAssessed,
+}: FalsePositiveCVEActionsColumnProps): ReactElement {
+    const items = [
+        {
+            title: 'Reobserve CVE',
+            onClick: (event) => {
+                event.preventDefault();
+                // @TODO: pass the vuln request id for this vuln in requestIDs
+                setVulnsToBeAssessed({
+                    type: 'FALSE_POSITIVE',
+                    action: 'UNDO',
+                    requestIDs: [row.id],
+                });
+            },
+        },
+    ];
+    return <ActionsColumn items={items} />;
+}
+
+export default FalsePositiveCVEActionsColumn;

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/types.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/types.ts
@@ -1,0 +1,5 @@
+export type FalsePositiveCVEsToBeAssessed = {
+    type: 'FALSE_POSITIVE';
+    action: 'UNDO';
+    requestIDs: string[];
+} | null;

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/UndoVulnRequestModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/UndoVulnRequestModal.tsx
@@ -3,6 +3,7 @@ import { Button, Modal, ModalVariant } from '@patternfly/react-core';
 
 import FormMessage, { FormResponseMessage } from 'Components/PatternFly/FormMessage';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import pluralize from 'pluralize';
 
 type AllowedType = 'DEFERRAL' | 'FALSE_POSITIVE';
 
@@ -51,7 +52,7 @@ function UndoVulnRequestModal({
         onCancel();
     }
 
-    const title = `Reobserve approved deferrals (${numRequestsToBeAssessed} )`;
+    const title = `Reobserve approved ${pluralize(typeLabel[type])} (${numRequestsToBeAssessed} )`;
 
     return (
         <Modal


### PR DESCRIPTION
## Description

* Added GraphQL mutation to re-observe CVE in False Positive CVEs table

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

<img width="1439" alt="Screen Shot 2021-12-20 at 1 10 45 PM" src="https://user-images.githubusercontent.com/4805485/146833222-f831a416-6352-44b6-8973-b3cc2af39edc.png">


