### PR TITLE
Fix E2E test's proto-generated-srcs when running on M1 Macs

### DIFF
--- a/qa-tests-backend/README.md
+++ b/qa-tests-backend/README.md
@@ -32,8 +32,8 @@ are inferred from the `central-deploy` directory.
 - If you have deployed the cluster differently or need to use a custom environment variable configuration:
 - Go to `Run > Edit Configurations`
 - Select Gradle, add a new configuration
-  - Script path : `github.com/stackrox/rox/qa-tests-backend/src/test/groovy/<Groovy class name>.groovy`
-  - Working Directory : `github.com/stackrox/rox/qa-tests-backend`
+  - Script path : `github.com/stackrox/stackrox/qa-tests-backend/src/test/groovy/<Groovy class name>.groovy`
+  - Working Directory : `github.com/stackrox/stackrox/qa-tests-backend`
   - Environment Variables:
     - `CLUSTER`: Either `OPENSHIFT` or `K8S`
     - `API_HOSTNAME`: hostname central is running; default `localhost`
@@ -88,8 +88,8 @@ of kubernetes code for example. One way to do that is to use a
 standalone gradle task.
 
 See for example: 
-[build.gradle](https://github.com/stackrox/rox/blob/2995f06927248966665a546881db2e4d233bf487/qa-tests-backend/build.gradle#L145)
-the task `checkSensorCollectorHealth` corresponds to [checkSensorCollectorHealth.groovy](https://github.com/stackrox/rox/blob/2995f06927248966665a546881db2e4d233bf487/qa-tests-backend/src/main/groovy/checkSensorCollectorHealth.groovy). This can be executed with: 
+[build.gradle](https://github.com/stackrox/stackrox/blob/391a08e18b7386cb6ce2ec205b6489a20df0e61c/qa-tests-backend/build.gradle#L145)
+the task `checkSensorCollectorHealth` corresponds to [checkSensorCollectorHealth.groovy](https://github.com/stackrox/stackrox/blob/391a08e18b7386cb6ce2ec205b6489a20df0e61c/qa-tests-backend/src/main/groovy/checkSensorCollectorHealth.groovy). This can be executed with:
 ```
 ./gradlew checkSensorCollectorHealth
 ```

--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -22,9 +22,16 @@ def nettyTcNativeVersion = '2.0.45.Final'
 def fabric8Version = '5.7.0'
 
 protobuf {
+    // There is no protoc-grpc-gen for Apple Silicon (M1), so if you are running on it, force the osx-x86_64 version
+    // See https://github.com/grpc/grpc-java/issues/7690
+    def protocGenArch = ''
+    if (System.getProperty("os.arch") == "aarch64" && System.getProperty("os.name").toLowerCase().contains("mac")) {
+        protocGenArch = ':osx-x86_64'
+    }
+
     protoc { artifact = "com.google.protobuf:protoc:${protocVersion}" }
     plugins {
-        grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
+        grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}${protocGenArch}" }
     }
     generateProtoTasks {
         all()*.plugins {


### PR DESCRIPTION
## Description

Also update README to reflect new repo

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

I tried on M1.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
