### PR TITLE
ROX-8821: Fix upgrade tests

### DIFF
--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -370,10 +370,11 @@ test_upgrade_paths() {
 
 deploy_earlier_central() {
     info "Deploying: $EARLIER_TAG..."
-    # BASH_ENV contains already a variable called MAIN_IMAGE_TAG
+    # BASH_ENV already contains  a variable called MAIN_IMAGE_TAG
     ORIG_MAIN_IMAGE_TAG="$MAIN_IMAGE_TAG"
     cci-export MAIN_IMAGE_TAG "$EARLIER_TAG"
     MAIN_IMAGE_TAG="$EARLIER_TAG" ./deploy/k8s/central.sh
+    # restore the original value of MAIN_IMAGE_TAG
     cci-export MAIN_IMAGE_TAG "$ORIG_MAIN_IMAGE_TAG"
     get_central_basic_auth_creds
 }


### PR DESCRIPTION
The problem seems to be a bit trickier than I though. The real issue is described in https://github.com/stackrox/rox-ci-image/pull/99. I could also revert #84, but that would break other things that would block us in areas of e2e testing of roxctl.

While working on a proper fix in [rox-ci-image#99](https://github.com/stackrox/rox-ci-image/pull/99), I would like to propose a workaround, so that we can have a green master again.


How tested:
- CI: https://app.circleci.com/pipelines/github/stackrox/stackrox/1225/workflows/171a25ac-ecb3-4230-b20a-30ed7e72b718

Related PRs:
- #84 
- https://github.com/stackrox/rox-ci-image/pull/96