### PR TITLE
ROX-7807: Fix Anchore scanner test flakiness

### DIFF
--- a/scripts/ci/anchore/deploy.sh
+++ b/scripts/ci/anchore/deploy.sh
@@ -124,10 +124,10 @@ for deploy in ${others}; do
     kubectl -n "${namespace}" scale --replicas 1 deploy "${deploy}"
 done
 
+wait_for_anchore_to_start
+
 # More than a single analyzer is needed to bypass blocked analysis. See ROX-7807.
 kubectl -n "${namespace}" scale --replicas 3 "deploy/${app_name}-anchore-engine-analyzer"
-
-wait_for_anchore_to_start
 
 sleep 10 # required to let Anchore get ready
 


### PR DESCRIPTION
## Description

Anchore analyzer has only one pod and one thread per pod by default. If it starts to analyze an image before our test image and if that analysis blocks or takes a long time to complete then the test image will not get analyzed before the test gives up. One image in particular blocks: gke.gcr.io/gke-metrics-agent-windows:1.2.0-gke.0 and so depending on the order that images are sent to Anchore then ImageScanningTest failures are randomly hit.

The fix is to start a few more pods.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient