### PR TITLE
Add a minimal .editorconfig file for tabs in Makefiles.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[{Makefile,**.mk}]
+indent_style = tab


### PR DESCRIPTION
## Description

Hopefully decrease the likelihood of indenting rules with spaces, leading to issues like the one fixed in #161 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~

## Testing Performed

Tested in my goland, but it does not seem to have any effect if I create a dummy rule where actions are indented with spaces 🤷🏻 