### PR TITLE
Automatically assign teams as reviewer based on files changed within a PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# For further documentation on CODEOWNERS, visit
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners
+# This will automatically assign a team / people as reviewers for PRs based on the files changed within the PR.
+
+# Merlin's main responsibilities include roxctl, authN (authproviders), authZ (SAC).
+roxctl/**/* pkg/auth/**/* pkg/sac/**/* @stackrox/merlin


### PR DESCRIPTION
# Description

Based on the discussion within #177 , this PR adds now the ability to assign teams / people as reviewers on PRs based on the files changed within the PR, leveraging [GitHub's CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) as suggested.

For the assignment to work, the team needs to have `write` access to the repository.