### PR TITLE
Label PRs on more events via GitHub Actions

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
     types:
     - ready_for_review
+    - opened
+    - synchronize
 
 jobs:
   label-pr:


### PR DESCRIPTION
## Description

Add more events which trigger the workflow to label PRs.

Right now, the workflow would only be triggered if somebody opens a PR in draft state -> switches to "ready for review".
Biggest issue with this is that if a PR is opened and _already_ in review state, the "ready for review" event will not be emitted, thus the PR not labelled.

After the change, the workflow will be triggered after:
- opening the PR (irrespective of `draft` or `ready for review`)
- the PR is switched from `draft` to `ready for review`
- any changes are made to the HEAD of the source branch of the PR (i.e. you add code _after_ creating the PR)

