### PR TITLE
Use correct syntax within CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,6 @@
 # This will automatically assign a team / people as reviewers for PRs based on the files changed within the PR.
 
 # Merlin's main responsibilities include roxctl, authN (authproviders), authZ (SAC).
-roxctl/**/* pkg/auth/**/* pkg/sac/**/* @stackrox/merlin
+roxctl/**/*     @stackrox/merlin
+pkg/auth/**/*   @stackrox/merlin
+pkg/sac/**/*    @stackrox/merlin


### PR DESCRIPTION
## Description

The CODEOWNERS syntax doesn't allow multiple matches in a single line, but rather requires a pair of match + team / person in a single line.
