### PR TITLE
Race condition in datastore test.

### DIFF
--- a/central/networkgraph/entity/datastore/datastore_impl_test.go
+++ b/central/networkgraph/entity/datastore/datastore_impl_test.go
@@ -171,6 +171,7 @@ func (suite *NetworkEntityDataStoreTestSuite) TestNetworkEntities() {
 
 	// Test Upsert
 	for _, c := range cases {
+		c := c
 		cluster := c.entity.GetScope().GetClusterId()
 		pushSig := concurrency.NewSignal()
 		if c.pass {
@@ -206,7 +207,7 @@ func (suite *NetworkEntityDataStoreTestSuite) TestNetworkEntities() {
 		if c.skipGet {
 			continue
 		}
-
+		c := c
 		actual, found, err := suite.ds.GetEntity(suite.globalReadAccessCtx, c.entity.GetInfo().GetId())
 		if c.pass {
 			suite.NoError(err)
@@ -236,6 +237,7 @@ func (suite *NetworkEntityDataStoreTestSuite) TestNetworkEntities() {
 
 	// Test Delete
 	for _, c := range cases {
+		c := c
 		cluster := c.entity.GetScope().GetClusterId()
 		pushSig := concurrency.NewSignal()
 		if !c.pass {
@@ -644,6 +646,7 @@ func (suite *NetworkEntityDataStoreTestSuite) TestDefaultGraphSetting() {
 	}
 
 	for _, c := range cases {
+		c := c
 		suite.graphConfig.EXPECT().GetNetworkGraphConfig(gomock.Any()).Return(c.graphConfig, nil)
 		actual, err := suite.ds.GetAllEntities(suite.globalReadAccessCtx)
 		suite.NoError(err)


### PR DESCRIPTION
## Description

```
    --- FAIL: TestNetworkEntityDataStore/TestSAC (0.01s)
=== CONT  
    testing.go:1152: race detected during execution of test
FAIL
```

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

Unit tests.