### PR TITLE
dependabot: remove splunk image from updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -74,12 +74,3 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
     - "stackrox/backend-dep-updaters"
-
-  - package-ecosystem: 'docker'
-    directory: 'ci/splunk/'
-    schedule:
-      interval: 'weekly'
-      day: 'wednesday'
-    open-pull-requests-limit: 1
-    reviewers:
-    - "stackrox/backend-dep-updaters"


### PR DESCRIPTION
## Description

Do not check for updates on splunk image since it requires updates in more than one place.

Closes: #1 #119 #186 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

N/A