### PR TITLE
dependabot: fix linters path

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -49,7 +49,7 @@ updates:
       - "stackrox/backend-dep-updaters"
 
   - package-ecosystem: 'gomod'
-    directory: '/tools/lint/'
+    directory: '/tools/linters/'
     schedule:
       interval: 'weekly'
       day: 'wednesday'


### PR DESCRIPTION
## Description

In #83 I moved tools to a separated go module but in dependabot configuration we have wrong path.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

