### PR TITLE
Rely on operator to provision init bundle automatically in `securedcluster` e2e test.

### DIFF
--- a/operator/tests/securedcluster/basic-sc/07-fetch-bundle.yaml
+++ b/operator/tests/securedcluster/basic-sc/07-fetch-bundle.yaml
@@ -1,1 +1,0 @@
-../../common/fetch-bundle.yaml


### PR DESCRIPTION
## Description

Now that the operator auto-provisions the init bundle (#97 ) we can rely on and test that functionality, so drop our hacky script. For now just in the `securedcluster` test, not in the `upgrade` one. The latter will need to wait until we upgrade from a release which already has this functionality, tracked in https://issues.redhat.com/browse/ROX-8833

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~

## Testing Performed

Relying on CI.