### PR TITLE
Pin `pip` and `setuptools` to newer versions taken from pypi.org

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -333,7 +333,7 @@ upgrade-via-olm: kuttl
 # Commands to enter local Python virtual environment and get needed dependencies there.
 ACTIVATE_PYTHON = python3 -m venv bundle_helpers/.venv ;\
 	. bundle_helpers/.venv/bin/activate ;\
-	pip3 install --upgrade pip==19.2 setuptools==59.6.0 ;\
+	pip3 install --upgrade pip==21.3.1 setuptools==60.2.0 ;\
 	pip3 install -r bundle_helpers/requirements.txt
 
 .PHONY: bundle


### PR DESCRIPTION
## Description

This follows up on https://github.com/stackrox/stackrox/pull/169.

The existence of this line
```
pip3 install --upgrade pip setuptools
```
was due to `pip` complaining that it has an older version than needed. `pip` recommends to upgrade itself.

https://github.com/stackrox/stackrox/pull/169 pinned `pip` and `setuptools` versions to older ones due to some bug in `setuptools`.
(First reported in
* <https://github.com/stackrox/stackrox/pull/161#issuecomment-997784542>
* <https://srox.slack.com/archives/CELUQKESC/p1639998334383900>)

Now setuptools seems to be fixed and we can pin both dependencies to their recent versions.

Find them here:
1. https://pypi.org/project/pip/
2. https://pypi.org/project/setuptools/

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~ - not for this change.
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ - no needed.
- ~~[ ] Determined and documented upgrade steps~~ - not needed.

## Testing Performed

* Relying on CI.