### PR TITLE
Make sure inithooks script fails if realpath is not found

### DIFF
--- a/tools/githooks/install-hooks.sh
+++ b/tools/githooks/install-hooks.sh
@@ -27,7 +27,7 @@ function install_hook
     fi
   fi
 
-  command -v realpath || { echo "realpath not found"; exit 1; }
+  command -v realpath >/dev/null || { echo "realpath not found, please make sure it is installed (e.g. by installing GNU coreutils)"; exit 1; }
   ln -sf "$(realpath --relative-to "$hooks_path" "$hook_script")" "$hook_link"
 }
 


### PR DESCRIPTION
## Description

When `realpath` is not available on your system, the following happens:
```
➜  stackrox git:(master) ✗ make init-githooks
+ init-githooks
./tools/githooks/install-hooks.sh tools/githooks/pre-commit
./tools/githooks/install-hooks.sh: line 30: realpath: command not found
➜  stackrox git:(master) ✗ ls -l .git/hooks
total 120
-rwxr-xr-x  1 moritz  staff   478 Dec  7 09:11 applypatch-msg.sample
-rwxr-xr-x  1 moritz  staff   896 Dec  7 09:11 commit-msg.sample
-rwxr-xr-x  1 moritz  staff  4655 Dec  7 09:11 fsmonitor-watchman.sample
-rwxr-xr-x  1 moritz  staff   189 Dec  7 09:11 post-update.sample
-rwxr-xr-x  1 moritz  staff   424 Dec  7 09:11 pre-applypatch.sample
lrwxr-xr-x  1 moritz  staff     0 Jan  3 15:00 pre-commit ->
-rwxr-xr-x  1 moritz  staff  1643 Dec  7 09:11 pre-commit.sample
-rwxr-xr-x  1 moritz  staff   416 Dec  7 09:11 pre-merge-commit.sample
-rwxr-xr-x  1 moritz  staff  1374 Dec  7 09:11 pre-push.sample
-rwxr-xr-x  1 moritz  staff  4898 Dec  7 09:11 pre-rebase.sample
-rwxr-xr-x  1 moritz  staff   544 Dec  7 09:11 pre-receive.sample
-rwxr-xr-x  1 moritz  staff  1492 Dec  7 09:11 prepare-commit-msg.sample
-rwxr-xr-x  1 moritz  staff  2783 Dec  7 09:11 push-to-checkout.sample
-rwxr-xr-x  1 moritz  staff  3650 Dec  7 09:11 update.sample
➜  stackrox git:(master) ✗
```

In particular, the call to `make init-githooks` returned with a zero exit code even though it failed.

This PR makes sure that the script fails if realpath is not found instead of creating a bogus link and silently ignoring the failure.

## Checklist
- [x] ~~Investigated and inspected CI test results~~
- [x] ~~Unit test and regression tests added~~
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~

## Testing Performed

Just manual testing.
