### PR TITLE
Move internal comment to meta template so it is not visible in charts

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/README.md.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/README.md.htpl
@@ -287,6 +287,11 @@ chart and their default values:
 |`createUpgraderServiceAccount`| Specify `true` to create the `sensor-upgrader` account. By default, the StackRox Kubernetes Security Platform creates a service account called `sensor-upgrader` in each secured cluster. This account is highly privileged but is only used during upgrades. If you don’t create this account, you will have to complete future upgrades manually if the Sensor doesn’t have enough permissions. See [Enable automatic upgrades for secured clusters](https://help.stackrox.com/docs/configure-stackrox/enable-automatic-upgrades/) for more information.|`false` |
 |`createSecrets`| Specify `false` to skip the orchestrator secret creation for the sensor, collector, and admission controller. | `true` |
 |`customize`|Modern interface for specifying custom metadata for resources, including labels, annotations and environment variables. See below for more information.|`{}`|
+[</*
+ROX-8778: workaround for single customer. These options are not publicly documented, and are not supported by our CRDs.
+|collector.disableSELinuxOptions|Set it to `true` to disable all SELinux options for the security context of Collector's Compliance container|`null`|
+|collector.seLinuxOptionsType| Value for `type` in the SELinux options for the security context of Collector's Compliance container. This has no effect if `collector.disableSELinuxOptions` is set to `true`. `|`container_runtime_t`|
+ */>]
 
 The following table lists some advanced parameters, and you'll only need them in
 non-standard environments:

--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -92,9 +92,7 @@ collector:
     key: null # string
   exposeMonitoring: null # bool
   nodeSelector: null # string | dict
-  # ROX-8778: workaround for single customer. This option is not publicly documented, and it is not supported by our CRDs.
   disableSELinuxOptions: null # bool
-  # ROX-8778: workaround for single customer. This option is not publicly documented, and it is not supported by our CRDs.
   seLinuxOptionsType: null # string
 auditLogs:
   disableCollection: null # bool


### PR DESCRIPTION
## Description

Move internal comment to meta template so it is not visible in charts, as it would be confusing to customers. 
Before this change a comment mentioning ROX-8778 is visible in the rendered charts. 

```bash
roxctl helm output secured-cluster-services --debug --remove
$ grep -rni ROX-8778 ./stackrox-secured-cluster-services-chart
./stackrox-secured-cluster-services-chart/internal/config-shape.yaml:95:  # ROX-8778: workaround for single customer. This option is not publicly documented, and it is not supported by our CRDs.
./stackrox-secured-cluster-services-chart/internal/config-shape.yaml:97:  # ROX-8778: workaround for single customer. This option is not publicly documented, and it is not supported by our CRDs.
```

After this change the comment is not visible anymore 

```bash
roxctl helm output secured-cluster-services --debug --remove
$ grep -rni ROX-8778 ./stackrox-secured-cluster-services-chart
$
```

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps

No additional instructions required .

## Testing Performed

Re-rendered the charts as seen in the description. 
Visually inspected the render of stackrox-secured-cluster-services-chart/README.md to check that the markdown is properly formatted. 
