### PR TITLE
ROX-8449: Fix for CI Pipeline issue introduced in #73

### DIFF
--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -697,7 +697,7 @@ class IntegrationsTest extends BaseSpecification {
         "invalid endpoint"
 
         new ECRRegistryIntegration()    | { [registryId: '0123456789',]
-        }       | StatusRuntimeException | /InvalidParameterException/ | "incorrect registry ID"
+        }       | StatusRuntimeException | /INVALID_ARGUMENT/ | "incorrect registry ID"
         new ECRRegistryIntegration()    | { [region: 'nowhere',]
         }       | StatusRuntimeException | /valid region/ | "incorrect region"
         new ECRRegistryIntegration()    | { [accessKeyId: Env.mustGetAWSAccessKeyID() + "OOPS",]


### PR DESCRIPTION
## Description

This fixes an issue where changes introduced in #73 caused CI Pipeline failures due to the removal of a deprecated field causing an unexpected error return type.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Running the CI Pipeline on this PR with the `ci-kernel-module-tests` label to ensure that this code flow is tested.
