### PR TITLE
Fix graphql query to get the image name unmarshalled correctly.

### DIFF
--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -44,7 +44,7 @@ var (
 								name
 								images {
 									name {
-										fullName
+										full_name:fullName
 									}
 									components {
 										name


### PR DESCRIPTION
## Description
The full name of the image was not being unmarshalled correctly due to the mismatch in output field name and expected json tag.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~

## Testing Performed
Manually verified correctness of image name in the vuln report generated.