### PR TITLE
Add isSVG prop to occurrences of PatternFly Spinner element

### DIFF
--- a/ui/apps/platform/src/Components/CommentThread/CommentThread.js
+++ b/ui/apps/platform/src/Components/CommentThread/CommentThread.js
@@ -61,7 +61,7 @@ const CommentThread = ({
 
     let content = (
         <Bullseye>
-            <Spinner />
+            <Spinner isSVG />
         </Bullseye>
     );
     if (!isLoading) {

--- a/ui/apps/platform/src/Components/IconWithCount/IconWithCount.js
+++ b/ui/apps/platform/src/Components/IconWithCount/IconWithCount.js
@@ -7,7 +7,7 @@ function IconWithCount({ Icon, count, isLoading }) {
         <Flex alignItems={{ default: 'alignItemsCenter' }}>
             {isLoading ? (
                 <Bullseye>
-                    <Spinner size="lg" />
+                    <Spinner isSVG size="lg" />
                 </Bullseye>
             ) : (
                 <>

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
@@ -175,7 +175,7 @@ function AccessScopes(): ReactElement {
             {alertRoles}
             {counterFetching !== 0 ? (
                 <Bullseye>
-                    <Spinner />
+                    <Spinner isSVG />
                 </Bullseye>
             ) : isList ? (
                 <AccessScopesList

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -149,7 +149,7 @@ function AuthProviders(): ReactElement {
             </AccessControlDescription>
             {isFetchingAuthProviders || isFetchingRoles ? (
                 <Bullseye>
-                    <Spinner />
+                    <Spinner isSVG />
                 </Bullseye>
             ) : isList ? (
                 <>

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
@@ -191,7 +191,7 @@ function PermissionSets(): ReactElement {
             {alertRoles}
             {counterFetching !== 0 ? (
                 <Bullseye>
-                    <Spinner />
+                    <Spinner isSVG />
                 </Bullseye>
             ) : isList ? (
                 <PermissionSetsList

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
@@ -236,7 +236,7 @@ function Roles(): ReactElement {
             {alertGroups}
             {counterFetching !== 0 ? (
                 <Bullseye>
-                    <Spinner />
+                    <Spinner isSVG />
                 </Bullseye>
             ) : isList ? (
                 <RolesList

--- a/ui/apps/platform/src/Containers/AnalystNotes/AnalystTags/AnalystTags.js
+++ b/ui/apps/platform/src/Containers/AnalystNotes/AnalystTags/AnalystTags.js
@@ -103,7 +103,7 @@ const AnalystTags = ({ type, variables, autoComplete, autoCompleteVariables, onI
                 )}
                 {isLoading ? (
                     <Bullseye>
-                        <Spinner />
+                        <Spinner isSVG />
                     </Bullseye>
                 ) : (
                     <Select

--- a/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsView.tsx
+++ b/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsView.tsx
@@ -55,7 +55,7 @@ function MitreAttackVectorsView({ policyId }: MitreAttackVectorsViewProps): Reac
         return (
             <Flex className="pf-u-my-md" justifyContent={{ default: 'justifyContentCenter' }}>
                 <FlexItem>
-                    <Spinner />
+                    <Spinner isSVG />
                 </FlexItem>
             </Flex>
         );

--- a/ui/apps/platform/src/Containers/Policies/PatternFly/PolicyPage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/PolicyPage.tsx
@@ -140,7 +140,7 @@ function PolicyPage({
             <PageTitle title="Policies - Policy" />
             {isLoading ? (
                 <Bullseye>
-                    <Spinner />
+                    <Spinner isSVG />
                 </Bullseye>
             ) : (
                 policyError || // TODO ROX-8487: Improve PolicyPage when request fails

--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Table/PoliciesTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Table/PoliciesTablePage.tsx
@@ -166,7 +166,7 @@ function PoliciesTablePage({
         <PageSection variant="light" isFilled id="policies-table">
             {isLoading && (
                 <Bullseye>
-                    <Spinner />
+                    <Spinner isSVG />
                 </Bullseye>
             )}
             {errorMessage ? (

--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step2/DownloadCLIDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step2/DownloadCLIDropdown.tsx
@@ -30,7 +30,7 @@ function DownloadCLIDropdown({ hasBuild }) {
                 >
                     {isCLIDownloading ? (
                         <Bullseye>
-                            <Spinner size="md" />
+                            <Spinner isSVG size="md" />
                         </Bullseye>
                     ) : (
                         'Download CLI'

--- a/ui/apps/platform/src/Containers/Violations/PatternFly/Modals/TagConfirmation.tsx
+++ b/ui/apps/platform/src/Containers/Violations/PatternFly/Modals/TagConfirmation.tsx
@@ -85,7 +85,7 @@ function TagConfirmation({
             title={modalTitle}
             data-testid="tag-confirmation-modal"
         >
-            {isLoading && <Spinner />}
+            {isLoading && <Spinner isSVG />}
             {hasErrors && (
                 <Alert
                     variant="warning"

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportSinglePage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportSinglePage.tsx
@@ -29,7 +29,7 @@ function VulnMgmtReportPage(): ReactElement {
             {isLoading ? (
                 <PageSection isFilled id="report-page">
                     <Bullseye>
-                        <Spinner />
+                        <Spinner isSVG />
                     </Bullseye>
                 </PageSection>
             ) : error ? (

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferrals.tsx
@@ -22,7 +22,7 @@ function ApprovedDeferrals(): ReactElement {
     if (isLoading) {
         return (
             <Bullseye>
-                <Spinner size="sm" />
+                <Spinner isSVG size="sm" />
             </Bullseye>
         );
     }

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositives.tsx
@@ -22,7 +22,7 @@ function ApprovedFalsePositives(): ReactElement {
     if (isLoading) {
         return (
             <Bullseye>
-                <Spinner size="sm" />
+                <Spinner isSVG size="sm" />
             </Bullseye>
         );
     }

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
@@ -29,7 +29,7 @@ function DeferredCVEs({ imageId }: DeferredCVEsProps): ReactElement {
     if (isLoading) {
         return (
             <Bullseye>
-                <Spinner size="sm" />
+                <Spinner isSVG size="sm" />
             </Bullseye>
         );
     }

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
@@ -29,7 +29,7 @@ function FalsePositiveCVEs({ imageId }: FalsePositiveCVEsProps): ReactElement {
     if (isLoading) {
         return (
             <Bullseye>
-                <Spinner size="sm" />
+                <Spinner isSVG size="sm" />
             </Bullseye>
         );
     }

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
@@ -29,7 +29,7 @@ function ObservedCVEs({ imageId }: ObservedCVEsProps): ReactElement {
     if (isLoading) {
         return (
             <Bullseye>
-                <Spinner size="sm" />
+                <Spinner isSVG size="sm" />
             </Bullseye>
         );
     }

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovals.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovals.tsx
@@ -23,7 +23,7 @@ function PendingApprovals(): ReactElement {
     if (isLoading) {
         return (
             <Bullseye>
-                <Spinner size="sm" />
+                <Spinner isSVG size="sm" />
             </Bullseye>
         );
     }


### PR DESCRIPTION
## Description

The inconsistency appeared in search results for example to imitate in Step 5 of policy wizard

It seems worthwhile to render spinner as `svg` element consistently with `isSVG` prop:

> Whether to use an SVG (new) rather than a span (old)

https://www.patternfly.org/v4/components/spinner#spinner

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

CI will verify that change does not break selectors for any integration tests

Evidence that the two versions of spinner are interchangeable

Example of `Spinner` element which **did not have** `isSVG` prop
![spinner-span](https://user-images.githubusercontent.com/11862657/148556236-e6ce7bb4-1285-4e58-bdc0-d30086203e62.png)

Example of `Spinner` element which **already did have** `isSVG` prop
![spinner-svg](https://user-images.githubusercontent.com/11862657/148556214-bc0a3252-ac06-4b41-af2d-60951051a7be.png)

