### PR TITLE
Fix monitoring deployment script

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -214,7 +214,7 @@ function launch_central {
     if [[ "$MONITORING_SUPPORT" == "true" || ( "${is_local_dev}" != "true" && -z "$MONITORING_SUPPORT" ) ]]; then
       needs_monitoring="true"
     fi
-    if [[ "${needs_monitoring}" == "true" ]];
+    if [[ "${needs_monitoring}" == "true" ]]; then
         echo "Deploying Monitoring..."
         helm_args=(
           -f "${COMMON_DIR}/monitoring-values.yaml"


### PR DESCRIPTION
## Description

Monitoring would be deployed on a GKE cluster without being able to pickup any metrics due to the lack of the patches in monitoring.sh

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

Works :) 