### PR TITLE
Style fix.

### DIFF
--- a/pkg/images/defaults/flavor.go
+++ b/pkg/images/defaults/flavor.go
@@ -152,6 +152,6 @@ func (f *ImageFlavor) CollectorFullImageNoTag() string {
 }
 
 // CollectorImageNoTag is the container image repository (image name including registry, excluding tag) for the "collector" image.
-func (flavor *ImageFlavor) CollectorImageNoTag() string {
-	return fmt.Sprintf("%s/%s", flavor.CollectorRegistry, flavor.CollectorImageName)
+func (f *ImageFlavor) CollectorImageNoTag() string {
+	return fmt.Sprintf("%s/%s", f.CollectorRegistry, f.CollectorImageName)
 }


### PR DESCRIPTION
## Description

```
pkg/images/defaults/flavor.go:155:1: receiver-naming: receiver name flavor should be consistent with previous receiver name f for ImageFlavor (revive)
func (flavor *ImageFlavor) CollectorImageNoTag() string {
	return fmt.Sprintf("%s/%s", flavor.CollectorRegistry, flavor.CollectorImageName)
}
```