### PR TITLE
ROX-8901+ROX-8902+ROX-8903: Risk Acceptance bug fixes

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/CVSSScoreLabel/CVSSScoreLabel.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/CVSSScoreLabel/CVSSScoreLabel.tsx
@@ -6,20 +6,14 @@ import { getSeverityByCvss } from 'utils/vulnerabilityUtils';
 
 export type CVSSScoreLabelProps = {
     cvss: string;
-    scoreVersion?: string;
 };
 
-function CVSSScoreLabel({ cvss, scoreVersion }: CVSSScoreLabelProps) {
+function CVSSScoreLabel({ cvss }: CVSSScoreLabelProps) {
     const severity = getSeverityByCvss(cvss);
     const severityLabel = severityLabels[severity];
     const cvssNum = Number(cvss).toFixed(1);
 
-    return (
-        <>
-            <Label color={severityColorMapPF[severityLabel]}>{cvssNum}</Label>
-            {scoreVersion && <span className="pf-u-ml-sm">({scoreVersion})</span>}
-        </>
-    );
+    return <Label color={severityColorMapPF[severityLabel]}>{cvssNum}</Label>;
 }
 
 export default CVSSScoreLabel;

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
@@ -55,6 +55,7 @@ function AffectedComponentsModal({
                     <Thead>
                         <Tr>
                             <Th>Component</Th>
+                            <Th>Version</Th>
                             <Th>Fixed in</Th>
                         </Tr>
                     </Thead>
@@ -72,6 +73,7 @@ function AffectedComponentsModal({
                                             {component.name}
                                         </a>
                                     </Td>
+                                    <Td dataLabel="Version">{component.version}</Td>
                                     <Td dataLabel="Fixed in">{component.fixedIn || '-'}</Td>
                                 </Tr>
                             );

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferralsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferralsTable.tsx
@@ -151,9 +151,8 @@ function ApprovedDeferralsTable({
                         <Th>Requested Entity</Th>
                         <Th>Requested Action</Th>
                         <Th>Expires</Th>
-                        <Th>Scope</Th>
+                        <Th modifier="fitContent">Scope</Th>
                         <Th>Impacted Entities</Th>
-                        <Th>Apply to</Th>
                         <Th>Comments</Th>
                         <Th>Requestor</Th>
                     </Tr>
@@ -192,16 +191,13 @@ function ApprovedDeferralsTable({
                                     />
                                 </Td>
                                 <Td dataLabel="Scope">
-                                    {row.scope.imageScope ? 'image' : 'global'}
+                                    <VulnerabilityRequestScope scope={row.scope} />
                                 </Td>
                                 <Td dataLabel="Impacted entities">
                                     <ImpactedEntities
                                         deploymentCount={row.deploymentCount}
                                         imageCount={row.imageCount}
                                     />
-                                </Td>
-                                <Td dataLabel="Apply to">
-                                    <VulnerabilityRequestScope scope={row.scope} />
                                 </Td>
                                 <Td dataLabel="Comments">
                                     <RequestCommentsButton

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositivesTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositivesTable.tsx
@@ -125,9 +125,8 @@ function ApprovedFalsePositivesTable({
                         />
                         <Th>Requested Entity</Th>
                         <Th>Requested Action</Th>
-                        <Th>Scope</Th>
+                        <Th modifier="fitContent">Scope</Th>
                         <Th>Impacted Entities</Th>
-                        <Th>Apply to</Th>
                         <Th>Comments</Th>
                         <Th>Requestor</Th>
                     </Tr>
@@ -158,16 +157,13 @@ function ApprovedFalsePositivesTable({
                                     />
                                 </Td>
                                 <Td dataLabel="Scope">
-                                    {row.scope.imageScope ? 'image' : 'global'}
+                                    <VulnerabilityRequestScope scope={row.scope} />
                                 </Td>
                                 <Td dataLabel="Impacted entities">
                                     <ImpactedEntities
                                         deploymentCount={row.deploymentCount}
                                         imageCount={row.imageCount}
                                     />
-                                </Td>
-                                <Td dataLabel="Apply to">
-                                    <VulnerabilityRequestScope scope={row.scope} />
                                 </Td>
                                 <Td dataLabel="Comments">
                                     <RequestCommentsButton

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
@@ -150,10 +150,10 @@ function DeferredCVEsTable({
                         />
                         <Th>CVE</Th>
                         <Th>Severity</Th>
+                        <Th>Expires</Th>
+                        <Th modifier="fitContent">Scope</Th>
                         <Th>Affected Components</Th>
                         <Th>Comments</Th>
-                        <Th>Expires</Th>
-                        <Th>Apply to</Th>
                         <Th>Approver</Th>
                     </Tr>
                 </Thead>
@@ -177,15 +177,6 @@ function DeferredCVEsTable({
                                 <Td dataLabel="Severity">
                                     <VulnerabilitySeverityLabel severity={row.severity} />
                                 </Td>
-                                <Td dataLabel="Affected components">
-                                    <AffectedComponentsButton components={row.components} />
-                                </Td>
-                                <Td dataLabel="Comments">
-                                    <RequestCommentsButton
-                                        comments={row.vulnerabilityRequest.comments}
-                                        cve={row.vulnerabilityRequest.cves.ids[0]}
-                                    />
-                                </Td>
                                 <Td dataLabel="Expires">
                                     <DeferralExpirationDate
                                         targetState={row.vulnerabilityRequest.targetState}
@@ -193,9 +184,18 @@ function DeferredCVEsTable({
                                         deferralReq={row.vulnerabilityRequest.deferralReq.expiry}
                                     />
                                 </Td>
-                                <Td dataLabel="Apply to">
+                                <Td dataLabel="Scope">
                                     <VulnerabilityRequestScope
                                         scope={row.vulnerabilityRequest.scope}
+                                    />
+                                </Td>
+                                <Td dataLabel="Affected components">
+                                    <AffectedComponentsButton components={row.components} />
+                                </Td>
+                                <Td dataLabel="Comments">
+                                    <RequestCommentsButton
+                                        comments={row.vulnerabilityRequest.comments}
+                                        cve={row.vulnerabilityRequest.cves.ids[0]}
                                     />
                                 </Td>
                                 <Td dataLabel="Approver">

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
@@ -149,9 +149,9 @@ function FalsePositiveCVEsTable({
                         />
                         <Th>CVE</Th>
                         <Th>Severity</Th>
+                        <Th modifier="fitContent">Scope</Th>
                         <Th>Affected Components</Th>
                         <Th>Comments</Th>
-                        <Th>Apply to</Th>
                         <Th>Approver</Th>
                     </Tr>
                 </Thead>
@@ -175,6 +175,11 @@ function FalsePositiveCVEsTable({
                                 <Td dataLabel="Severity">
                                     <VulnerabilitySeverityLabel severity={row.severity} />
                                 </Td>
+                                <Td dataLabel="Scope">
+                                    <VulnerabilityRequestScope
+                                        scope={row.vulnerabilityRequest.scope}
+                                    />
+                                </Td>
                                 <Td dataLabel="Affected components">
                                     <AffectedComponentsButton components={row.components} />
                                 </Td>
@@ -182,11 +187,6 @@ function FalsePositiveCVEsTable({
                                     <RequestCommentsButton
                                         comments={row.vulnerabilityRequest.comments}
                                         cve={row.vulnerabilityRequest.cves.ids[0]}
-                                    />
-                                </Td>
-                                <Td dataLabel="Apply to">
-                                    <VulnerabilityRequestScope
-                                        scope={row.vulnerabilityRequest.scope}
                                     />
                                 </Td>
                                 <Td dataLabel="Approver">

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
@@ -224,10 +224,7 @@ function ObservedCVEsTable({
                                     <VulnerabilitySeverityLabel severity={row.severity} />
                                 </Td>
                                 <Td dataLabel="CVSS score">
-                                    <CVSSScoreLabel
-                                        cvss={row.cvss}
-                                        scoreVersion={row.scoreVersion}
-                                    />
+                                    <CVSSScoreLabel cvss={row.cvss} />
                                 </Td>
                                 <Td dataLabel="Affected components">
                                     <AffectedComponentsButton components={row.components} />

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovalsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovalsTable.tsx
@@ -220,9 +220,8 @@ function PendingApprovalsTable({
                         <Th>Requested Entity</Th>
                         <Th>Requested Action</Th>
                         <Th>Expires</Th>
-                        <Th>Scope</Th>
+                        <Th modifier="fitContent">Scope</Th>
                         <Th>Impacted Entities</Th>
-                        <Th>Apply to</Th>
                         <Th>Comments</Th>
                         <Th>Requestor</Th>
                     </Tr>
@@ -260,16 +259,13 @@ function PendingApprovalsTable({
                                     />
                                 </Td>
                                 <Td dataLabel="Scope">
-                                    {row.scope.imageScope ? 'image' : 'global'}
+                                    <VulnerabilityRequestScope scope={row.scope} />
                                 </Td>
                                 <Td dataLabel="Impacted entities">
                                     <ImpactedEntities
                                         deploymentCount={row.deploymentCount}
                                         imageCount={row.imageCount}
                                     />
-                                </Td>
-                                <Td dataLabel="Apply to">
-                                    <VulnerabilityRequestScope scope={row.scope} />
                                 </Td>
                                 <Td dataLabel="Comments">
                                     <RequestCommentsButton

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/VulnerabilityRequestScope.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/VulnerabilityRequestScope.tsx
@@ -7,13 +7,10 @@ export type VulnerabilityRequestScopeProps = {
 };
 
 function VulnerabilityRequestScope({ scope }: VulnerabilityRequestScopeProps): ReactElement {
-    let text = '-';
+    let text = 'N/A';
     if (scope.imageScope) {
-        if (scope.imageScope.tag === '.*') {
-            text = 'All image tags';
-        } else {
-            text = 'This image';
-        }
+        const { registry, remote, tag } = scope.imageScope;
+        text = `${registry}/${remote}:${tag}`;
     }
     return <div>{text}</div>;
 }

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/imageVulnerabilities.graphql.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/imageVulnerabilities.graphql.ts
@@ -21,7 +21,12 @@ export type VulnerabilityWithRequest = Vulnerability & {
 };
 
 // This type is specific to the way we query using GraphQL
-export type EmbeddedImageScanComponent = { id: string; name: string; fixedIn: string };
+export type EmbeddedImageScanComponent = {
+    id: string;
+    name: string;
+    version: string;
+    fixedIn: string;
+};
 
 export type GetImageVulnerabilitiesData = {
     image: {
@@ -69,6 +74,7 @@ export const GET_IMAGE_VULNERABILITIES = gql`
                 components {
                     id
                     name
+                    version
                     fixedIn
                 }
             }


### PR DESCRIPTION
## Description

* ROX-8901: Remove the cvss score version from image findings
* ROX-8902: Show component version in affected components window in image findings
* ROX-8903: Change "scope" column to show actual image and tag

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

The `Scope` column now displays the actual image registry+remote+tag and the `Applies To` column is removed
<img width="1552" alt="Screen Shot 2022-01-10 at 10 29 21 AM" src="https://user-images.githubusercontent.com/4805485/148819799-42e93c61-1eec-494d-899f-2dc4fede7042.png">
The `Scope` column now displays the actual image registry+remote+tag and the `Applies To` column is removed
<img width="1552" alt="Screen Shot 2022-01-10 at 10 29 24 AM" src="https://user-images.githubusercontent.com/4805485/148819812-b2a806dc-369c-4c82-9666-ae2f007ac2c5.png">
The `Scope` column now displays the actual image registry+remote+tag and the `Applies To` column is removed
<img width="1552" alt="Screen Shot 2022-01-10 at 10 29 26 AM" src="https://user-images.githubusercontent.com/4805485/148819820-b56fb70d-cb9e-4a3b-9fe4-a9b2b4428bb9.png">
The CVSS score version was removed
<img width="1552" alt="Screen Shot 2022-01-10 at 10 29 39 AM" src="https://user-images.githubusercontent.com/4805485/148819825-25bfdd25-bb61-4292-9948-7ab498b224e7.png">
The `Scope` column now displays the actual image registry+remote+tag and the `Applies To` column is removed
<img width="1552" alt="Screen Shot 2022-01-10 at 10 29 43 AM" src="https://user-images.githubusercontent.com/4805485/148819835-1b56cf08-2f33-4307-9339-c9b30bd02be1.png">
The `Scope` column now displays the actual image registry+remote+tag and the `Applies To` column is removed
<img width="1552" alt="Screen Shot 2022-01-10 at 10 29 45 AM" src="https://user-images.githubusercontent.com/4805485/148819847-e3305103-c7e7-4513-9309-833c3d27f1a5.png">
The table now show the component version 
<img width="1552" alt="Screen Shot 2022-01-10 at 10 37 48 AM" src="https://user-images.githubusercontent.com/4805485/148820499-b3c28e01-b768-4ae8-9ea9-9347d838d5b0.png">
