### PR TITLE
fix: don't show expired vuln requests in the image findings section

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/useImageVulnerabilities.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/useImageVulnerabilities.ts
@@ -1,6 +1,7 @@
 import { useApolloClient, useQuery } from '@apollo/client';
 import { useEffect, useState } from 'react';
 import { fetchVulnRequests } from 'services/VulnerabilityRequestsService';
+import queryService from 'utils/queryService';
 import {
     GetImageVulnerabilitiesData,
     GetImageVulnerabilitiesVars,
@@ -32,7 +33,16 @@ function useImageVulnerabilities({ imageId, vulnsQuery, pagination }) {
     useEffect(() => {
         if (vulnsData) {
             const cves = vulnsData.image.vulns.map((vuln) => vuln.cve).join(',');
-            const vulnRequestsQuery = vulnsData.image.vulns.length ? `CVE:${cves}` : '';
+            const queryObj = vulnsData.image.vulns.length
+                ? {
+                      CVE: cves,
+                      'Expired Request': 'false',
+                  }
+                : {};
+            const vulnRequestsQuery = queryService.objectToWhereClause(
+                queryObj,
+                encodeURIComponent('+')
+            );
             fetchVulnRequests({ query: vulnRequestsQuery })
                 .then((vulnRequests) => {
                     const { vulns } = vulnsData.image;

--- a/ui/apps/platform/src/utils/queryService.js
+++ b/ui/apps/platform/src/utils/queryService.js
@@ -44,7 +44,7 @@ function objectToWhereClause(query, delimiter = '+') {
             const queryValue = needsExactMatch ? `"${flatValue}"` : flatValue;
             return `${acc}${key}:${queryValue}${delimiter}`;
         }, '')
-        .slice(0, -1);
+        .slice(0, -delimiter.length);
 }
 
 function entityContextToQueryObject(entityContext) {


### PR DESCRIPTION
## Description

There was an issue with our query where we were showing expired vuln request data in the Image Findings section. This is the flow that yielded the bug:
1. Defer CVE
2. Approve it
3. Re-Observe it
4. Go to the images view. It shows that there is a pending request. But there shouldn't be a pending request

![Screen Shot 2022-01-11 at 5 11 25 PM](https://user-images.githubusercontent.com/4805485/149053220-2e687286-7726-471d-a919-2463ae4184fa.png)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

Do the steps mentioned above. We shouldn't see the pending request information anymore