### PR TITLE
Fix roxctl bats output location

### DIFF
--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -129,7 +129,7 @@ install_yq() {
 
 run_roxctl_bats_tests() {
     info "Running Bats e2e tests on development roxctl"
-    "$TEST_ROOT/tests/roxctl/bats-runner.sh" ${1:-roxctl-test-output} "$TEST_ROOT/tests/roxctl/bats-tests/"
+    "$TEST_ROOT/tests/roxctl/bats-runner.sh" "${1:-roxctl-test-output}" "$TEST_ROOT/tests/roxctl/bats-tests/"
 }
 
 run_roxctl_tests() {


### PR DESCRIPTION
## Description

Previously, test results for the roxctl bats tests weren't properly uploaded (i.e. [see this link](https://app.circleci.com/pipelines/github/stackrox/stackrox/2057/workflows/daf0f549-063f-4af5-9c1a-c33e66346d2f/jobs/89723/parallel-runs/0/steps/0-135)).

Added the output location within the call of `run_roxctl_bats_tests`, as it previously wasn't propagated properly.

Now, the results will be [properly uploaded and archived](https://app.circleci.com/pipelines/github/stackrox/stackrox/2081/workflows/862d4bb5-9c8d-446c-bb90-14bb22015d70/jobs/90907/parallel-runs/0/steps/0-135).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
