### PR TITLE
[ROX-8930] Add sleep when vuln req are undone in tests

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/VulnRequestService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/VulnRequestService.groovy
@@ -4,6 +4,7 @@ import io.stackrox.proto.api.v1.Common
 import io.stackrox.proto.api.v1.VulnReqService
 import io.stackrox.proto.api.v1.VulnerabilityRequestServiceGrpc
 import io.stackrox.proto.storage.VulnRequests.VulnerabilityRequest
+import util.Helpers
 
 class VulnRequestService extends BaseService {
     static getVulnRequestClient() {
@@ -63,7 +64,10 @@ class VulnRequestService extends BaseService {
         def id = Common.ResourceByID.newBuilder()
                 .setId(reqID)
                 .build()
-        return getVulnRequestClient().undoVulnerabilityRequest(id)
+        def response = getVulnRequestClient().undoVulnerabilityRequest(id)
+        // Allow propagation of CVE suppression and invalidation of cache
+        Helpers.sleepWithRetryBackoff(15000 * (ClusterService.isOpenShift4() ? 4 : 1))
+        return response
     }
 
     static globalScope() {

--- a/qa-tests-backend/src/test/groovy/VulnMgmtWorkflowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtWorkflowTest.groovy
@@ -8,7 +8,6 @@ import org.junit.experimental.categories.Category
 import services.FeatureFlagService
 import services.VulnRequestService
 import spock.lang.Unroll
-import util.Helpers
 
 class VulnMgmtWorkflowTest extends BaseSpecification {
 
@@ -84,8 +83,6 @@ class VulnMgmtWorkflowTest extends BaseSpecification {
         cleanup:
         if (approve) {
             VulnRequestService.undoReq(id)
-             // Allow propagation of CVE suppression and invalidation of cache
-             Helpers.sleepWithRetryBackoff(15000 * (ClusterService.isOpenShift4() ? 4 : 1))
         }
 
         where:


### PR DESCRIPTION
## Description

Add sleep when vuln req are undone in tests. Whenever a request is undone, reprocessing happens. We move onto next test without waiting.  

## Checklist
- [ ] Investigated and inspected CI test results
- ~Unit test and regression tests added~
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed
CI