### PR TITLE
Just mark the deployment for reprocessing instead of forcing scan rightaway

### DIFF
--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -366,7 +366,6 @@ func (d *detectorImpl) ReprocessDeployments(deploymentIDs ...string) {
 
 	for _, deploymentID := range deploymentIDs {
 		d.deduper.removeDeployment(deploymentID)
-		d.markDeploymentForProcessing(deploymentID)
 	}
 }
 


### PR DESCRIPTION
## Description

Just mark the deployment for reprocessing instead of forcing scan rightaway. The next k8s client sync, which happens every 1 min, will push the deployment for processing. Therefore, [this code](https://github.com/stackrox/stackrox/blob/e43f2bd51aaad9498ee6652e94e20c3fe8825250/sensor/common/detector/detector.go#L396-L409) will now take care of processing deps.

Note that cache invalidation is already done before reprocessing deps, hence when the dep is reprocessed next time, new scan will be fetched from central.

## Checklist
- [ ] Investigated and inspected CI test results
- ~Unit test and regression tests added~
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed
CI (need to do manual testing)
