### PR TITLE
ROX-8608: Remove SAC-disabled code paths

### DIFF
--- a/central/compliance/datastore/datastore_impl.go
+++ b/central/compliance/datastore/datastore_impl.go
@@ -181,8 +181,8 @@ func (ds *datastoreImpl) StoreComplianceDomain(ctx context.Context, domain *stor
 }
 
 func (ds *datastoreImpl) PerformStoredAggregation(ctx context.Context, args *StoredAggregationArgs) ([]*storage.ComplianceAggregation_Result, []*storage.ComplianceAggregation_Source, map[*storage.ComplianceAggregation_Result]*storage.ComplianceDomain, error) {
-	// Using stored aggregation results is not allowed when SAC is enabled
-	if sac.IsContextSACEnabled(ctx) {
+	// TODO(ROX-9134): consider storing compliance results for Unrestricted scope
+	if true {
 		return args.AggregationFunc()
 	}
 

--- a/central/compliance/datastore/test/datastore_test.go
+++ b/central/compliance/datastore/test/datastore_test.go
@@ -235,7 +235,6 @@ func (s *complianceDataStoreWithSACTestSuite) TestEnforceStoreFailure() {
 }
 
 func (s *complianceDataStoreWithSACTestSuite) TestDoesNotUseStoredAggregationsWithSAC() {
-	ctx := sac.SetContextSACEnabled(context.Background())
 	noop := func() ([]*storage.ComplianceAggregation_Result, []*storage.ComplianceAggregation_Source, map[*storage.ComplianceAggregation_Result]*storage.ComplianceDomain, error) {
 		return nil, nil, nil, nil
 	}
@@ -245,11 +244,13 @@ func (s *complianceDataStoreWithSACTestSuite) TestDoesNotUseStoredAggregationsWi
 		Unit:            storage.ComplianceAggregation_CLUSTER,
 		AggregationFunc: noop,
 	}
-	_, _, _, err := s.dataStore.PerformStoredAggregation(ctx, aggArgs)
+	_, _, _, err := s.dataStore.PerformStoredAggregation(context.Background(), aggArgs)
 	s.Require().NoError(err)
 }
 
 func (s *complianceDataStoreWithSACTestSuite) TestUsesStoredAggregationsWithoutSAC() {
+	s.T().Skip("ROX-9134: Re-enable or delete")
+
 	queryString := "query"
 	testUnit := storage.ComplianceAggregation_CLUSTER
 	results := []*storage.ComplianceAggregation_Result{}

--- a/central/cve/service/service_impl.go
+++ b/central/cve/service/service_impl.go
@@ -27,7 +27,6 @@ import (
 )
 
 var (
-	// TODO: Change the resource to CVE once SAC is in place
 	authorizer = func() authz.Authorizer {
 		if features.VulnRiskManagement.Enabled() {
 			return perrpc.FromMap(map[authz.Authorizer][]string{

--- a/central/cve/suppress/reprocessor_test.go
+++ b/central/cve/suppress/reprocessor_test.go
@@ -97,12 +97,13 @@ func TestUnsuppressCVEs(t *testing.T) {
 
 	cveDataStore, edgeDataStore := createDataStore(t, dacky, bleveIndex)
 
+	cveClusters := []*storage.Cluster{{Id: "id"}}
 	parts := make([]converter.ClusterCVEParts, 0, len(expiredCVEs)+len(unexpiredCVEs))
 	for _, expiredCVE := range expiredCVEs {
-		parts = append(parts, converter.ClusterCVEParts{CVE: expiredCVE})
+		parts = append(parts, converter.NewClusterCVEParts(expiredCVE, cveClusters, "fixVersions"))
 	}
 	for _, unexpiredCVE := range unexpiredCVEs {
-		parts = append(parts, converter.ClusterCVEParts{CVE: unexpiredCVE})
+		parts = append(parts, converter.NewClusterCVEParts(unexpiredCVE, cveClusters, "fixVersions"))
 	}
 	err = edgeDataStore.Upsert(reprocessorCtx, parts...)
 	require.NoError(t, err)

--- a/central/dackbox/shared_object_sac_filter.go
+++ b/central/dackbox/shared_object_sac_filter.go
@@ -196,7 +196,8 @@ func (f *combinedSAC) noSACApply(ctx context.Context, from ...string) ([]int, bo
 }
 
 func (f *combinedSAC) Apply(ctx context.Context, from ...string) ([]int, bool, error) {
-	if !sac.IsContextSACEnabled(ctx) {
+	// TODO(ROX-9134): consider re-enabling for Unrestricted scope
+	if false {
 		filteredIndices, all := f.noSACApply(ctx, from...)
 		return filteredIndices, all, nil
 	}

--- a/central/dackbox/shared_object_sac_filter_test.go
+++ b/central/dackbox/shared_object_sac_filter_test.go
@@ -14,14 +14,10 @@ import (
 	nodeDackBox "github.com/stackrox/rox/central/node/dackbox"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/dackbox"
 	"github.com/stackrox/rox/pkg/dackbox/graph/testutils"
-	"github.com/stackrox/rox/pkg/grpc/authn"
-	"github.com/stackrox/rox/pkg/grpc/authn/mocks"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sliceutils"
-	"github.com/stackrox/rox/pkg/testutils/roletest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -74,22 +70,6 @@ var (
 		),
 	)
 )
-
-func identity(readResources ...string) func(mockCtrl *gomock.Controller, t *testing.T) context.Context {
-	return func(mockCtrl *gomock.Controller, t *testing.T) context.Context {
-		identity := mocks.NewMockIdentity(mockCtrl)
-
-		resourceToAccess := make(map[string]storage.Access)
-		for _, resource := range readResources {
-			resourceToAccess[resource] = storage.Access_READ_ACCESS
-		}
-
-		dummyRole := roletest.NewResolvedRoleWithDenyAll("Dummy", nil)
-		identity.EXPECT().Roles().AnyTimes().Return([]permissions.ResolvedRole{dummyRole})
-		identity.EXPECT().Permissions().AnyTimes().Return(resourceToAccess)
-		return authn.ContextWithIdentity(context.Background(), identity, t)
-	}
-}
 
 func TestNoSACApplyWithoutIdentity(t *testing.T) {
 	filter, err := NewSharedObjectSACFilter(
@@ -159,75 +139,6 @@ func TestNoSACApplyWithoutIdentity(t *testing.T) {
 			defer mockCtrl.Finish()
 
 			testutils.DoWithGraph(c.ctx, testGraph, func(ctx context.Context) {
-				filteredIndices, all, err := filter.Apply(ctx, c.keys...)
-				require.NoError(t, err)
-				if all {
-					assert.Equal(t, c.expectedKeys, c.keys)
-				} else {
-					assert.Equal(t, c.expectedKeys, sliceutils.StringSelect(c.keys, filteredIndices...))
-				}
-			})
-		})
-	}
-}
-
-func TestNoSACApplyWithIdentity(t *testing.T) {
-	filter, err := NewSharedObjectSACFilter(
-		WithNode(nodeCVESAC, CVEToNodeBucketPath),
-		WithImage(imageCVESAC, CVEToImageBucketPath),
-		WithCluster(clusterCVESAC, CVEToClusterBucketPath),
-		WithSharedObjectAccess(storage.Access_READ_ACCESS))
-	require.NoError(t, err)
-
-	cases := []struct {
-		name               string
-		identityFunc       func(mockCtrl *gomock.Controller, t *testing.T) context.Context
-		keys, expectedKeys []string
-	}{
-		{
-			name:         "all access",
-			identityFunc: identity("Node", "Image", "Cluster"),
-			keys:         []string{"node", "image", "cluster", "node-image", "image-cluster"},
-			expectedKeys: []string{"node", "image", "cluster", "node-image", "image-cluster"},
-		},
-		{
-			name:         "no access",
-			identityFunc: identity(),
-			keys:         []string{"node", "image", "cluster", "node-image", "image-cluster"},
-			expectedKeys: nil,
-		},
-		{
-			name:         "node access",
-			identityFunc: identity("Node"),
-			keys:         []string{"node", "image", "cluster", "node-image", "image-cluster"},
-			expectedKeys: []string{"node", "node-image"},
-		},
-		{
-			name:         "image access",
-			identityFunc: identity("Image"),
-			keys:         []string{"node", "image", "cluster", "node-image", "image-cluster"},
-			expectedKeys: []string{"image", "node-image", "image-cluster"},
-		},
-		{
-			name:         "cluster access",
-			identityFunc: identity("Cluster"),
-			keys:         []string{"node", "image", "cluster", "node-image", "image-cluster"},
-			expectedKeys: []string{"cluster", "image-cluster"},
-		},
-		{
-			name:         "image and node access",
-			identityFunc: identity("Image", "Node"),
-			keys:         []string{"node", "image", "cluster", "node-image", "image-cluster"},
-			expectedKeys: []string{"node", "image", "node-image", "image-cluster"},
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
-
-			ctx := c.identityFunc(mockCtrl, t)
-			testutils.DoWithGraph(ctx, testGraph, func(ctx context.Context) {
 				filteredIndices, all, err := filter.Apply(ctx, c.keys...)
 				require.NoError(t, err)
 				if all {

--- a/central/imagecomponent/search/searcher_impl_test.go
+++ b/central/imagecomponent/search/searcher_impl_test.go
@@ -176,10 +176,10 @@ func (suite *ImageComponentSearchTestSuite) TestBasicSearchImage() {
 func (suite *ImageComponentSearchTestSuite) TestBasicSearchNode() {
 	node := getTestNode("id1")
 
-	ctx := sac.SetContextSACEnabled(sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowFixedScopes(
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowFixedScopes(
 		sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 		sac.ResourceScopeKeys(resources.Node),
-	)))
+	))
 
 	// Sanity search.
 	results, err := suite.searcher.Search(ctx, pkgSearch.EmptyQuery())

--- a/central/main.go
+++ b/central/main.go
@@ -484,14 +484,9 @@ func startGRPCServer() {
 	)
 	config.HTTPInterceptors = append(config.HTTPInterceptors, observe.AuthzTraceHTTPInterceptor(authzTraceSink))
 
-	// The below enrichers handle SAC being off or on.
 	// Before authorization is checked, we want to inject the sac client into the context.
 	config.PreAuthContextEnrichers = append(config.PreAuthContextEnrichers,
 		centralSAC.GetEnricher().GetPreAuthContextEnricher(authzTraceSink),
-	)
-	// After auth checks are run, we want to use the client (if available) to add scope checking.
-	config.PostAuthContextEnrichers = append(config.PostAuthContextEnrichers,
-		centralSAC.GetEnricher().PostAuthContextEnricher,
 	)
 
 	server := pkgGRPC.NewAPI(config)

--- a/central/sac/transitional/verifying_interceptor.go
+++ b/central/sac/transitional/verifying_interceptor.go
@@ -67,7 +67,7 @@ var (
 func VerifySACScopeChecksInterceptor(ctx context.Context, req interface{}, serverInfo *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	// We cannot validate the built-in scoped authorizer's permission checks
 	// because it does not check permissions via ScopeCheckerCore::TryAllowed().
-	if sac.IsContextBuiltinScopedAuthzEnabled(ctx) {
+	if !sac.IsContextPluginScopedAuthzEnabled(ctx) {
 		return handler(ctx, req)
 	}
 

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
@@ -12,11 +12,18 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/golang/mock/gomock"
 	clusterIndex "github.com/stackrox/rox/central/cluster/index"
+	clusterCVEEdgeDackBox "github.com/stackrox/rox/central/clustercveedge/dackbox"
+	clusterCVEEdgeDataStore "github.com/stackrox/rox/central/clustercveedge/datastore"
+	clusterCVEEdgeIndex "github.com/stackrox/rox/central/clustercveedge/index"
+	edgeIndexMocks "github.com/stackrox/rox/central/clustercveedge/index/mocks"
+	edgeSearchMocks "github.com/stackrox/rox/central/clustercveedge/search/mocks"
+	clusterCVEEdgeStore "github.com/stackrox/rox/central/clustercveedge/store/dackbox"
 	componentCVEEdgeDackBox "github.com/stackrox/rox/central/componentcveedge/dackbox"
 	componentCVEEdgeDS "github.com/stackrox/rox/central/componentcveedge/datastore"
 	componentCVEEdgeIndex "github.com/stackrox/rox/central/componentcveedge/index"
 	componentCVEEdgeSearcher "github.com/stackrox/rox/central/componentcveedge/search"
 	componentCVEEdgeStore "github.com/stackrox/rox/central/componentcveedge/store/dackbox"
+	"github.com/stackrox/rox/central/cve/converter"
 	cveDackBox "github.com/stackrox/rox/central/cve/dackbox"
 	cveDS "github.com/stackrox/rox/central/cve/datastore"
 	cveIndex "github.com/stackrox/rox/central/cve/index"
@@ -82,20 +89,21 @@ type VulnRequestManagerTestSuite struct {
 	suite.Suite
 	envIsolator *envisolator.EnvIsolator
 
-	db                    *rocksdb.RocksDB
-	indexQ                queue.WaitableQueue
-	bleveIndex            bleve.Index
-	vulnReqDataStore      vulnReqDS.DataStore
-	deployments           *deploymentMockDS.MockDataStore
-	cveDataStore          cveDS.DataStore
-	imageDataStore        imageDS.DataStore
-	componentCVEDataStore componentCVEEdgeDS.DataStore
-	imageCVEDataStore     imageCVEEdgeDS.DataStore
-	sensorConnMgrMocks    *sensorConnMgrMocks.MockManager
-	reprocessor           *reprocessorMocks.MockLoop
-	manager               *managerImpl
-	pendingReqCache       vulnReqCache.VulnReqCache
-	activeReqCache        vulnReqCache.VulnReqCache
+	db                      *rocksdb.RocksDB
+	indexQ                  queue.WaitableQueue
+	bleveIndex              bleve.Index
+	vulnReqDataStore        vulnReqDS.DataStore
+	deployments             *deploymentMockDS.MockDataStore
+	cveDataStore            cveDS.DataStore
+	imageDataStore          imageDS.DataStore
+	componentCVEDataStore   componentCVEEdgeDS.DataStore
+	imageCVEDataStore       imageCVEEdgeDS.DataStore
+	sensorConnMgrMocks      *sensorConnMgrMocks.MockManager
+	reprocessor             *reprocessorMocks.MockLoop
+	manager                 *managerImpl
+	pendingReqCache         vulnReqCache.VulnReqCache
+	activeReqCache          vulnReqCache.VulnReqCache
+	clusterCVEEdgeDataStore clusterCVEEdgeDataStore.DataStore
 }
 
 func (s *VulnRequestManagerTestSuite) TearDownTest() {
@@ -146,6 +154,12 @@ func (s *VulnRequestManagerTestSuite) SetupTest() {
 	reg.RegisterWrapper(imageDackBox.Bucket, imageIndex.Wrapper{})
 	reg.RegisterWrapper(imageComponentEdgeDackBox.Bucket, imageComponentEdgeIndex.Wrapper{})
 	reg.RegisterWrapper(imageCVEEdgeDackBox.Bucket, imageCVEEdgeIndex.Wrapper{})
+	reg.RegisterWrapper(clusterCVEEdgeDackBox.Bucket, clusterCVEEdgeIndex.Wrapper{})
+
+	clusterCVEEdgeStore, err := clusterCVEEdgeStore.New(dacky, concurrency.NewKeyFence())
+	s.Require().NoError(err)
+	s.clusterCVEEdgeDataStore, err = clusterCVEEdgeDataStore.New(dacky, clusterCVEEdgeStore, edgeIndexMocks.NewMockIndexer(s.mockCtrl), edgeSearchMocks.NewMockSearcher(s.mockCtrl))
+	s.Require().NoError(err)
 
 	s.pendingReqCache, s.activeReqCache = vulnReqCache.New(), vulnReqCache.New()
 	s.createImageDataStore(dacky)
@@ -262,6 +276,13 @@ func (s *VulnRequestManagerTestSuite) validateSnoozeAndUnsnoozeVulns(img *storag
 				allCVEs = append(allCVEs, vuln.GetCve())
 			}
 		}
+	}
+
+	// Insert cluster -> CVE edge so CVE will be returned from CVE datastore.
+	cveClusters := []*storage.Cluster{{Id: "id"}}
+	for _, cve := range allCVEs {
+		parts := converter.NewClusterCVEParts(&storage.CVE{Id: cve}, cveClusters, "fixVersions")
+		s.NoError(s.clusterCVEEdgeDataStore.Upsert(allAllowedCtx, parts))
 	}
 
 	err := s.imageDataStore.UpsertImage(allAllowedCtx, img)

--- a/pkg/grpc/authz/user/user_test.go
+++ b/pkg/grpc/authz/user/user_test.go
@@ -77,7 +77,7 @@ func Test_permissionChecker_Authorized(t *testing.T) {
 			}, {
 				Resource: nsScopedResource, Access: storage.Access_READ_ACCESS,
 			}},
-			ctx: sac.WithNoAccess(sac.SetContextBuiltinScopedAuthzEnabled(ctx)),
+			ctx: sac.WithNoAccess(ctx),
 			err: errorhelpers.ErrNotAuthorized,
 		},
 		{
@@ -85,14 +85,14 @@ func Test_permissionChecker_Authorized(t *testing.T) {
 			requiredPermissions: []permissions.ResourceWithAccess{{
 				Resource: clusterScopedResource, Access: storage.Access_READ_WRITE_ACCESS,
 			}},
-			ctx: sac.WithNoAccess(sac.SetContextBuiltinScopedAuthzEnabled(ctx)),
+			ctx: sac.WithNoAccess(ctx),
 		},
 		{
 			name: "built-in scoped authz check permissions but nil permissions in ID",
 			requiredPermissions: []permissions.ResourceWithAccess{{
 				Resource: clusterScopedResource, Access: storage.Access_READ_WRITE_ACCESS,
 			}},
-			ctx: sac.WithNoAccess(sac.SetContextBuiltinScopedAuthzEnabled(ctxWithNoPermissions)),
+			ctx: sac.WithNoAccess(ctxWithNoPermissions),
 			err: errorhelpers.ErrNoCredentials,
 		},
 		{
@@ -102,21 +102,21 @@ func Test_permissionChecker_Authorized(t *testing.T) {
 			}, {
 				Resource: nsScopedResource, Access: storage.Access_READ_ACCESS,
 			}},
-			ctx: sac.WithNoAccess(sac.SetContextSACEnabled(ctx)),
+			ctx: sac.WithNoAccess(sac.SetContextPluginScopedAuthzEnabled(ctx)),
 		},
 		{
 			name: "plugin SAC check only global permissions",
 			requiredPermissions: []permissions.ResourceWithAccess{{
 				Resource: clusterScopedResource, Access: storage.Access_READ_WRITE_ACCESS,
 			}},
-			ctx: sac.WithNoAccess(sac.SetContextSACEnabled(ctx)),
+			ctx: sac.WithNoAccess(sac.SetContextPluginScopedAuthzEnabled(ctx)),
 		},
 		{
 			name: "plugin SAC check only global permissions",
 			requiredPermissions: []permissions.ResourceWithAccess{{
 				Resource: globalScopedResource, Access: storage.Access_READ_WRITE_ACCESS,
 			}},
-			ctx: sac.WithNoAccess(sac.SetContextSACEnabled(ctx)),
+			ctx: sac.WithNoAccess(sac.SetContextPluginScopedAuthzEnabled(ctx)),
 			err: errorhelpers.ErrNotAuthorized,
 		},
 		{
@@ -124,14 +124,14 @@ func Test_permissionChecker_Authorized(t *testing.T) {
 			requiredPermissions: []permissions.ResourceWithAccess{{
 				Resource: globalScopedResource, Access: storage.Access_READ_WRITE_ACCESS,
 			}},
-			ctx: sac.WithAllAccess(sac.SetContextSACEnabled(ctx)),
+			ctx: sac.WithAllAccess(sac.SetContextPluginScopedAuthzEnabled(ctx)),
 		},
 		{
 			name: "plugin SAC check only global permissions with errored scope checker",
 			requiredPermissions: []permissions.ResourceWithAccess{{
 				Resource: globalScopedResource, Access: storage.Access_READ_WRITE_ACCESS,
 			}},
-			ctx: sac.WithGlobalAccessScopeChecker(sac.SetContextSACEnabled(ctx), sac.ErrorAccessScopeCheckerCore(err)),
+			ctx: sac.WithGlobalAccessScopeChecker(sac.SetContextPluginScopedAuthzEnabled(ctx), sac.ErrorAccessScopeCheckerCore(err)),
 			err: err,
 		},
 	}

--- a/pkg/sac/context.go
+++ b/pkg/sac/context.go
@@ -7,8 +7,7 @@ import (
 )
 
 type globalAccessScopeContextKey struct{}
-type sacEnabled struct{}
-type builtinScopedAuthzEnabled struct{}
+type pluginScopedAuthzEnabled struct{}
 
 // GlobalAccessScopeChecker retrieves the global access scope from the context.
 // This function is guaranteed to return a non-nil value.
@@ -20,47 +19,17 @@ func GlobalAccessScopeChecker(ctx context.Context) ScopeChecker {
 	return NewScopeChecker(core)
 }
 
-// GlobalAccessScopeCheckerOrNil retrieves the global access scope checker if it is stored in the context; otherwise,
-// it returns `nil`.
-func GlobalAccessScopeCheckerOrNil(ctx context.Context) *ScopeChecker {
-	core, _ := ctx.Value(globalAccessScopeContextKey{}).(ScopeCheckerCore)
-	if core == nil {
-		return nil
-	}
-	sc := NewScopeChecker(core)
-	return &sc
+// IsContextPluginScopedAuthzEnabled will return true if the auth plugin scoped
+// authorizer is enabled for a context and false otherwise.
+func IsContextPluginScopedAuthzEnabled(ctx context.Context) bool {
+	pluginScopedAuthz := ctx.Value(pluginScopedAuthzEnabled{})
+	return pluginScopedAuthz != nil
 }
 
-// IsContextSACEnabled will return true if SAC is enabled for a context and false if SAC has not been enabled for a
-// context
-func IsContextSACEnabled(ctx context.Context) bool {
-	if contextHasSAC := ctx.Value(sacEnabled{}); contextHasSAC != nil {
-		return true
-	}
-	return false
-}
-
-// SetContextSACEnabled enables SAC for a context.  Note, this must be done separately from setting a
-// GlobalAccessScopeChecker for a context.  All contexts must have a GlobalAccessScopeChecker but not all contexts must
-// have SAC enabled.
-func SetContextSACEnabled(ctx context.Context) context.Context {
-	return context.WithValue(ctx, sacEnabled{}, struct{}{})
-}
-
-// IsContextBuiltinScopedAuthzEnabled will return true if the built-in scoped
-// authorizer and SAC are enabled for a context and false otherwise.
-func IsContextBuiltinScopedAuthzEnabled(ctx context.Context) bool {
-	builtinScopedAuthz := ctx.Value(builtinScopedAuthzEnabled{})
-	return builtinScopedAuthz != nil && IsContextSACEnabled(ctx)
-}
-
-// SetContextBuiltinScopedAuthzEnabled indicates the built-in scoped authorizer
-// must be used in this context. This must be done separately from setting a
-// GlobalAccessScopeChecker for a context. All contexts must have a
-// GlobalAccessScopeChecker but not all contexts must use the built-in scoped
-// authorizer.
-func SetContextBuiltinScopedAuthzEnabled(ctx context.Context) context.Context {
-	return context.WithValue(SetContextSACEnabled(ctx), builtinScopedAuthzEnabled{}, struct{}{})
+// SetContextPluginScopedAuthzEnabled indicates the auth plugin scoped authorizer
+// must be used in this context.
+func SetContextPluginScopedAuthzEnabled(ctx context.Context) context.Context {
+	return context.WithValue(ctx, pluginScopedAuthzEnabled{}, struct{}{})
 }
 
 // WithGlobalAccessScopeChecker returns a context that is a child of the given context and contains

--- a/pkg/sac/context_test.go
+++ b/pkg/sac/context_test.go
@@ -11,26 +11,21 @@ import (
 func TestIsContextBuiltinScopedAuthzEnabled(t *testing.T) {
 	tests := []struct {
 		ctx                context.Context
-		sac                bool
 		builtinScopedAuthz bool
 	}{{
-		ctx: context.Background(),
-		sac: false, builtinScopedAuthz: false,
+		ctx:                context.Background(),
+		builtinScopedAuthz: false,
 	}, {
-		ctx: SetContextSACEnabled(context.Background()),
-		sac: true, builtinScopedAuthz: false,
+		ctx:                SetContextPluginScopedAuthzEnabled(context.Background()),
+		builtinScopedAuthz: true,
 	}, {
-		ctx: SetContextBuiltinScopedAuthzEnabled(context.Background()),
-		sac: true, builtinScopedAuthz: true,
-	}, {
-		ctx: context.WithValue(context.Background(), builtinScopedAuthzEnabled{}, struct{}{}),
-		sac: false, builtinScopedAuthz: false,
+		ctx:                context.WithValue(context.Background(), pluginScopedAuthzEnabled{}, struct{}{}),
+		builtinScopedAuthz: true,
 	},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%v", tt.ctx), func(t *testing.T) {
-			assert.Equal(t, tt.sac, IsContextSACEnabled(tt.ctx))
-			assert.Equal(t, tt.builtinScopedAuthz, IsContextBuiltinScopedAuthzEnabled(tt.ctx))
+			assert.Equal(t, tt.builtinScopedAuthz, IsContextPluginScopedAuthzEnabled(tt.ctx))
 		})
 	}
 }


### PR DESCRIPTION
## Description

SAC is enabled by default and we are never coming back. Let's kill the last pieces of unused code.

### Changes in this PR
* remove SAC-disabled code path from dackbox(see changes in shared_object_sac_filter.go) + corresponding changes in tests
* Stop storing compliance aggregation results as this was only possible without SAC enabled
* Remove IsContextSACEnabled/SetContextSACEnabled
* Remove GlobalAccessScopeCheckerOrNil
* Minor fixes(comments, broken tests etc.)

### Why do we need to add cluster->cve edge in some tests?
These tests use dackbox SAC filter. The same logic as described [here](https://github.com/stackrox/stackrox/blob/8d3f5419142829ecaeeae1153cc7508771defba2/central/dackbox/shared_object_sac_filter.go#L126-L127) is applied.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

1. CI