### PR TITLE
Ensure to images from cache having keys with no ID are also being flushed

### DIFF
--- a/sensor/common/reprocessor/handler.go
+++ b/sensor/common/reprocessor/handler.go
@@ -84,6 +84,11 @@ func (h *handlerImpl) invalidateImageCache(req *central.InvalidateImageCache) er
 	default:
 		h.admCtrlSettingsMgr.FlushCache()
 		for _, image := range req.GetImageKeys() {
+			// For new images the image ID may not be present since the image is not saved in Central DB.
+			// Hence, flush the entries having keys with no ID as well.
+			h.imageCache.Remove(imagecacheutils.ImageCacheKey{
+				Name: image.GetImageFullName(),
+			})
 			h.imageCache.Remove(imagecacheutils.ImageCacheKey{
 				ID:   image.GetImageId(),
 				Name: image.GetImageFullName(),


### PR DESCRIPTION
## Description

For new images the image ID may not be present since the image is not saved in Central DB. Hence, flush the entries having keys with no ID as well on snooze/unsnooze event.

## Checklist
- [ ] Investigated and inspected CI test results
- ~Unit test and regression tests added~
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed
CI