### PR TITLE
Revert Bump fabric8Version from 5.10.1 to 5.11.2 in /qa-tests-backend

### DIFF
--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -19,7 +19,7 @@ def grpcVersion = '1.21.0'
 def protocVersion = '3.17.3'
 def protobufVersion = '3.18.1'
 def nettyTcNativeVersion = '2.0.45.Final'
-def fabric8Version = '5.11.2'
+def fabric8Version = '5.10.1'
 
 protobuf {
     // There is no protoc-grpc-gen for Apple Silicon (M1), so if you are running on it, force the osx-x86_64 version


### PR DESCRIPTION
## Description

This reverts commit 5b3c6fc8e10fc4fa62b92a29670bc3ae25433297, PR https://github.com/stackrox/stackrox/pull/271.

There seem to be groovy errors after this change.

See https://srox.slack.com/archives/CELUQKESC/p1642181523098600

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~

All with strikethrough do not apply.

## Testing Performed

* Only CI. Waiting to see e2e tests not fail due to `@Override` annotation.
