### PR TITLE
Remove recompile step from debug helm chart script

### DIFF
--- a/dev-tools/debug-helm-chart.sh
+++ b/dev-tools/debug-helm-chart.sh
@@ -1,19 +1,13 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Wrapper around helm but builds roxctl and generates new rox charts.
+# Wrapper around helm to sweeten the development experience by rendering both Helm charts before executing Helm
 # Example testing central-services-chart:
 # ./debug-helm-chart.sh upgrade --install --dry-run stackrox-central-services ./stackrox-central-services-chart -n stackrox --set imagePullSecrets.allowNone=true
 #
 # Usage: ./debug-helm-chart.sh [NAME] [CHART] [flags]
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-if [[ "$(uname)" == "Darwin"* ]]; then
-  make -C "$DIR/../" cli-darwin
-else
-  make -C "$DIR/../" cli-linux
-fi
 
 "$DIR/roxctl.sh" helm output central-services --remove --debug
 "$DIR/roxctl.sh" helm output secured-cluster-services --remove --debug


### PR DESCRIPTION
## Description

Remove roxctl compiliation from helper script because it is not necessary anymore

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

 - /