### PR TITLE
ROX-8963: Return 'central.stackrox:443' as the default central endpoint

### DIFF
--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -904,8 +904,11 @@ func addDefaults(cluster *storage.Cluster) error {
 	if cluster.CollectorImage == "" {
 		cluster.CollectorImage = flavor.CollectorImageNoTag()
 	}
-	if cluster.MainImage == "" {
+	if cluster.GetMainImage() == "" {
 		cluster.MainImage = flavor.MainImage()
+	}
+	if cluster.GetCentralApiEndpoint() == "" {
+		cluster.CentralApiEndpoint = "central.stackrox:443"
 	}
 	return nil
 }

--- a/central/cluster/datastore/datastore_impl_test.go
+++ b/central/cluster/datastore/datastore_impl_test.go
@@ -1290,3 +1290,9 @@ func (suite *ClusterDataStoreTestSuite) TestValidateCluster() {
 	}
 
 }
+
+func (suite *ClusterDataStoreTestSuite) TestGetClusterDefaults() {
+	defaults, err := suite.clusterDataStore.GetClusterDefaults(suite.hasWriteCtx)
+	suite.NoError(err)
+	suite.Equal(defaults.GetCentralApiEndpoint(), centralEndpoint)
+}


### PR DESCRIPTION
## Description

Return 'central.stackrox:443' as the default central endpoint.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed

```
$ roxcurl /v1/clusters-env/cluster-defaults -X GET | qyaml "cluster: centralApiEndpoint"
- central.stackrox:443
```

Unittest.