### PR TITLE
ROX-8406: Getting pagination working for reports table

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTableColumnDescriptor.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTableColumnDescriptor.tsx
@@ -11,7 +11,7 @@ const VulnMgmtReportTableColumnDescriptor = [
     {
         Header: 'Report',
         accessor: 'report.name',
-        sortField: 'Report',
+        sortField: 'Report Name',
         Cell: ({ original }) => {
             const url = `${vulnManagementReportsPath}/${original.id as string}`;
             return (

--- a/ui/apps/platform/src/services/AlertsService.ts
+++ b/ui/apps/platform/src/services/AlertsService.ts
@@ -4,6 +4,7 @@ import { Alert, ListAlert } from 'Containers/Violations/PatternFly/types/violati
 
 import axios from './instance';
 import searchOptionsToQuery from './searchOptionsToQuery';
+import { RestSortOption } from './sortOption';
 
 const baseUrl = '/v1/alerts';
 const baseCountUrl = '/v1/alertscount';
@@ -13,11 +14,6 @@ export type RestSearchOption = {
     label?: string;
     type?: string; // for example, 'categoryOption'
     value: string | string[];
-};
-
-export type RestSortOption = {
-    field: string;
-    reversed: boolean;
 };
 
 // TODO import Severity from PoliciesService when it is TypeScript.

--- a/ui/apps/platform/src/services/sortOption.ts
+++ b/ui/apps/platform/src/services/sortOption.ts
@@ -1,0 +1,4 @@
+export type RestSortOption = {
+    field: string;
+    reversed: boolean;
+};


### PR DESCRIPTION
## Description

Pagination should work as intended for the VM Reports table. Sorting only currently works for name, however. 

![image](https://user-images.githubusercontent.com/10412893/149856902-d03c69a4-de1e-41a1-99d9-43f88d7a77df.png)
![image](https://user-images.githubusercontent.com/10412893/149856939-3bd86d39-4a40-4439-acb2-f29a000457da.png)
![image](https://user-images.githubusercontent.com/10412893/149856998-0f516134-9932-4b7b-9f03-63d8634af1f8.png)

## Checklist
- [x] Investigated and inspected CI test results (failure is flake)


## Testing Performed

Manual testing