### PR TITLE
ROX-8703: fixes 500 errors for missing kernel probes

### DIFF
--- a/pkg/kocache/entry.go
+++ b/pkg/kocache/entry.go
@@ -103,7 +103,9 @@ func (e *entry) doPopulate(client *http.Client, upstreamURL string, opts Options
 	// or 3xx status code.
 	// Note that Golang's HTTP client by default follows redirects.
 	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode == http.StatusNotFound {
+		// If the probe does not exist, we may receive 403 Forbidden due to security constraints
+		// on the storage. Convert this to errNotFound for better visibility of this scenario.
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
 			return errNotFound
 		}
 		return errors.Errorf("upstream HTTP request returned status %s", resp.Status)


### PR DESCRIPTION
## Description

When requesting a kernel probe from collector-modules.stackrox.io, if the probe does not exist a 403 Forbidden error is reported by the GCS bucket due to security constraints. Central and Sensor treat anything that isn't 200 or 404 as an internal server error (500), which is then reported to collector.

This PR translates 403 errors into 404 errors to better report the existence / non-existence of the probe.

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed

Largely relying on CI but testing locally to confirm that the 404 is reported correctly to collector.
