### PR TITLE
Revert "ROX-8961: Mention the automatic init bundle creation in operator docs."

### DIFF
--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -565,29 +565,26 @@ spec:
     \ For all customization options, please visit the RHACS documentation.\n\n###\
     \ SecuredCluster Custom Resource\n\nSecuredCluster is the configuration template\
     \ for the RHACS Secured Cluster services.\n\n#### Installation Prerequisites\n\
-    \nBefore deploying a SecuredCluster resource you need to make sure cluster init\
-    \ bundle secrets exist.\n\nFor convenience, when SecuredCluster resource is created\
-    \ in a namespace where a Central resource also exists, the operator will automatically\
-    \ provision init bundle secrets for you.\nHowever otherwise, you need to do it:\n\
-    \n- **Through the RHACS UI:** To create a cluster init bundle secret through the\
-    \ RHACS UI, navigate to `Platform Configuration > Clusters`, and then click `Manage\
-    \ Tokens` in the top-right corner. Select `Cluster Init Bundle`, and click `Generate\
-    \ Bundle`. Select `Download Kubernetes secrets file`, and store the file under\
-    \ a name of your choice (for example, `cluster-init-secrets.yaml`).\n- **Through\
-    \ the `roxctl` CLI:** To create a cluster init bundle secret through the `roxctl`\
-    \ command-line interface, run `roxctl central init-bundles generate <name> --output-secrets\
-    \ <file name>`. Choose any `name` and `file name` that you like.\n\nRun `oc project`\
-    \ and check that it reports the correct namespace where you intend to deploy SecuredCluster.\
-    \ In case you want to install SecuredCluster to a different namespace, select\
-    \ it by running `oc project <namespace>`.\nThen, run `oc create -f init-bundle.yaml`.\
-    \ If you have chosen a name other than `init-bundle.yaml`, specify that file name\
-    \ instead.\n\n#### Required Fields\n\nThe following attributes are required to\
-    \ be specified. For all customization options, please visit the RHACS documentation.\n\
-    \n| Parameter          | Description     |\n| :----------------- | :--------------\
-    \ |\n| `clusterName`      | The name given to this secured cluster. The cluster\
-    \ will appear with this name in RHACS user interface. |\n| `centralEndpoint` \
-    \ | This field should specify the address of the Central endpoint, including the\
-    \ port number. `centralEndpoint` may be omitted if this SecuredCluster Custom\
+    \nBefore deploying a SecuredCluster resource, you need to create a cluster init\
+    \ bundle secret.\n\n- **Through the RHACS UI:** To create a cluster init bundle\
+    \ secret through the RHACS UI, navigate to `Platform Configuration > Clusters`,\
+    \ and then click `Manage Tokens` in the top-right corner. Select `Cluster Init\
+    \ Bundle`, and click `Generate Bundle`. Select `Download Kubernetes secrets file`,\
+    \ and store the file under a name of your choice (for example, `cluster-init-secrets.yaml`).\n\
+    - **Through the `roxctl` CLI:** To create a cluster init bundle secret through\
+    \ the `roxctl` command-line interface, run `roxctl central init-bundles generate\
+    \ <name> --output-secrets <file name>`. Choose any `name` and `file name` that\
+    \ you like.\n\nRun `oc project` and check that it reports the correct namespace\
+    \ where you intend to deploy SecuredCluster. In case you want to install SecuredCluster\
+    \ to a different namespace, select it by running `oc project <namespace>`.\nThen,\
+    \ run `oc create -f init-bundle.yaml`. If you have chosen a name other than `init-bundle.yaml`,\
+    \ specify that file name instead.\n\n#### Required Fields\n\nThe following attributes\
+    \ are required to be specified. For all customization options, please visit the\
+    \ RHACS documentation.\n\n| Parameter          | Description     |\n| :-----------------\
+    \ | :-------------- |\n| `clusterName`      | The name given to this secured cluster.\
+    \ The cluster will appear with this name in RHACS user interface. |\n| `centralEndpoint`\
+    \  | This field should specify the address of the Central endpoint, including\
+    \ the port number. `centralEndpoint` may be omitted if this SecuredCluster Custom\
     \ Resource is in the same cluster and namespace as Central. |\n"
   displayName: Advanced Cluster Security for Kubernetes
   icon:

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -556,10 +556,7 @@ spec:
 
     #### Installation Prerequisites
 
-    Before deploying a SecuredCluster resource you need to make sure cluster init bundle secrets exist.
-
-    For convenience, when SecuredCluster resource is created in a namespace where a Central resource also exists, the operator will automatically provision init bundle secrets for you.
-    However otherwise, you need to do it:
+    Before deploying a SecuredCluster resource, you need to create a cluster init bundle secret.
 
     - **Through the RHACS UI:** To create a cluster init bundle secret through the RHACS UI, navigate to `Platform Configuration > Clusters`, and then click `Manage Tokens` in the top-right corner. Select `Cluster Init Bundle`, and click `Generate Bundle`. Select `Download Kubernetes secrets file`, and store the file under a name of your choice (for example, `cluster-init-secrets.yaml`).
     - **Through the `roxctl` CLI:** To create a cluster init bundle secret through the `roxctl` command-line interface, run `roxctl central init-bundles generate <name> --output-secrets <file name>`. Choose any `name` and `file name` that you like.


### PR DESCRIPTION
Reverts stackrox/stackrox#328

The autoprovisioned bundle is (for now) not re-issued automatically before expiration. This will be tackled by https://issues.redhat.com/browse/ROX-8131

As such, while useful to save some time during a quick installation demo, it's not ready to be publicly advertised yet.