### PR TITLE
RS-380: set `ImagePullSecrets.AllowNone = true` for Operator

### DIFF
--- a/operator/pkg/reconciler/reconciler_factory.go
+++ b/operator/pkg/reconciler/reconciler_factory.go
@@ -41,6 +41,14 @@ func SetupReconcilerWithManager(mgr ctrl.Manager, gvk schema.GroupVersionKind, c
 		metaVals["CollectorRegistry"] = collectorRegistryOverride.Setting()
 	}
 	metaVals["Operator"] = true
+
+	// TODO: RS-379: Remove casting and simply override value:
+	// metaVals.ImagePullSecrets.AllowNone = true
+	if imagePullSecrets, ok := metaVals["ImagePullSecrets"].(defaults.ImagePullSecrets); ok {
+		imagePullSecrets.AllowNone = true
+		metaVals["ImagePullSecrets"] = imagePullSecrets
+	}
+
 	chart, err := image.GetDefaultImage().LoadChart(chartPrefix, metaVals)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

Operator should always have `ImagePullSecrets.AllowNone = true`, regardless of the flavor selected.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~~Unit test and regression tests added~~
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~

No need for changelog or upgrade steps.

## Testing Performed

- CI jobs with `ci-release-build` label should not fail on operator tests