### PR TITLE
ROX-8765: Bind Scanner to OpenShift system:image-puller ClusterRole

### DIFF
--- a/image/templates/helm/shared/templates/02-scanner-01-security.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-01-security.yaml
@@ -2,6 +2,25 @@
 
 {{- if not ._rox.scanner.disable -}}
 
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scanner-system-image-puller
+  labels:
+    {{- include "srox.labels" (list . "clusterrolebinding" "scanner-system-image-puller") | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "clusterrolebinding" "scanner-system-image-puller") | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:image-puller
+subjects:
+- kind: ServiceAccount
+  name: scanner
+  namespace: {{ .Release.Namespace }}
+
+---
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
@@ -1,3 +1,5 @@
+#.clusterrolebindings["scanner-system-image-puller"] | assertThat(. == null)
+
 values:
   ca:
     cert: ""
@@ -40,6 +42,26 @@ tests:
     .deployments["scanner"].spec.replicas | assertThat(. == 5)
     .horizontalpodautoscalers["scanner"].spec.minReplicas | assertThat(. == 50)
     .horizontalpodautoscalers["scanner"].spec.maxReplicas | assertThat(. == 100)
+
+- name: "scanner with OpenShift 3 has Image Puller ClusterRole"
+  server:
+    visibleSchemas:
+    - openshift-3.11.0
+  values:
+    env:
+      openshift: 3
+  expect: |
+    .clusterrolebindings["scanner-system-image-puller"] | assertThat(. != null)
+
+- name: "scanner with OpenShift 4 has Image Puller ClusterRole"
+  server:
+    visibleSchemas:
+    - openshift-4.1.0
+  values:
+    env:
+      openshift: 4
+  expect: |
+    .clusterrolebindings["scanner-system-image-puller"] | assertThat(. != null)
 
 - name: "scanner with OpenShift 3 and enabled SCCs"
   server:


### PR DESCRIPTION
## Description

This gives Scanner permission to pull images from the OpenShift Cluster's store.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
