### PR TITLE
Respect MAIN_IMAGE_TAG in ensure-rox-image script

### DIFF
--- a/operator/hack/ensure-rox-image-exist.sh
+++ b/operator/hack/ensure-rox-image-exist.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -euo pipefail
 
 # Fetch latest tags etc
 git fetch origin


### PR DESCRIPTION
## Description

Use the `MAIN_IMAGE_TAG` env variable if is set, otherwise rely on the generated tag.

## Checklist
- [ ] ~~Investigated and inspected CI test results~~
- [ ] ~~Unit test and regression tests added~~
- [] ~~Evaluated and added CHANGELOG entry if required~~
- [] ~~Determined and documented upgrade steps~~

If any of these don't apply, please comment below.

## Testing Performed

 - CI
 - Set MAIN_IMAGE_TAG
 - Unset MAIN_IMAGE_TAG
