### PR TITLE
ROX-8969: Add RetryTicker type for running a function periodically with retries

### DIFF
--- a/pkg/concurrency/retry_ticker_test.go
+++ b/pkg/concurrency/retry_ticker_test.go
@@ -61,7 +61,7 @@ func TestRetryTickerCallsTickFunction(t *testing.T) {
 			doneErrSig := NewErrorSignal()
 			mockFunc := &testTickFunc{}
 			schedulerSpy := &afterFuncSpy{}
-			ticker := newTestRetryTicker(t, mockFunc.doTick)
+			ticker := newRetryTicker(t, mockFunc.doTick)
 			defer ticker.Stop()
 			ticker.scheduler = schedulerSpy.afterFunc
 
@@ -77,7 +77,7 @@ func TestRetryTickerCallsTickFunction(t *testing.T) {
 				schedulerSpy.On("afterFunc", backoff.Duration, mock.Anything).Return(nil).Once()
 			}
 
-			ticker.start()
+			require.NoError(t, ticker.Start())
 
 			_, ok := doneErrSig.WaitWithTimeout(testTimeout)
 			require.True(t, ok, "timeout exceeded")
@@ -90,7 +90,7 @@ func TestRetryTickerCallsTickFunction(t *testing.T) {
 func TestRetryTickerStop(t *testing.T) {
 	firsTickErrSig := NewErrorSignal()
 	stopErrSig := NewErrorSignal()
-	ticker := newTestRetryTicker(t, func(ctx context.Context) (timeToNextTick time.Duration, err error) {
+	ticker := newRetryTicker(t, func(ctx context.Context) (timeToNextTick time.Duration, err error) {
 		firsTickErrSig.Signal()
 		_, ok := stopErrSig.WaitWithTimeout(testTimeout)
 		require.True(t, ok)
@@ -98,19 +98,40 @@ func TestRetryTickerStop(t *testing.T) {
 	})
 	defer ticker.Stop()
 
-	ticker.start()
+	require.NoError(t, ticker.Start())
 	_, ok := firsTickErrSig.WaitWithTimeout(testTimeout)
 	require.True(t, ok, "timeout exceeded")
 	ticker.Stop()
 	stopErrSig.Signal()
 
-	// ensure `ticker.scheduleTick` does not schedule a new timer after stopping the ticker.
+	// ensure `ticker.scheduleTick` does not schedule a new timer after stopping the ticker
 	time.Sleep(capTime)
 	assert.Nil(t, ticker.getTickTimer())
 }
 
-func newTestRetryTicker(t *testing.T, doFunc tickFunc) *retryTickerImpl {
-	ticker := newRetryTicker(doFunc, longTime, backoff, false)
+func TestRetryTickerStartWhileStarterFailure(t *testing.T) {
+	ticker := newRetryTicker(t, func(ctx context.Context) (timeToNextTick time.Duration, err error) {
+		return 0, nil
+	})
+	defer ticker.Stop()
+
+	require.NoError(t, ticker.Start())
+	assert.ErrorIs(t, ErrStartedTimer, ticker.Start())
+}
+
+func TestRetryTickerStartTwiceFailure(t *testing.T) {
+	ticker := newRetryTicker(t, func(ctx context.Context) (timeToNextTick time.Duration, err error) {
+		return 0, nil
+	})
+	defer ticker.Stop()
+
+	require.NoError(t, ticker.Start())
+	ticker.Stop()
+	require.ErrorIs(t, ErrStoppedTimer, ticker.Start())
+}
+
+func newRetryTicker(t *testing.T, doFunc tickFunc) *retryTickerImpl {
+	ticker := NewRetryTicker(doFunc, longTime, backoff)
 	require.IsType(t, &retryTickerImpl{}, ticker)
 	return ticker.(*retryTickerImpl)
 }


### PR DESCRIPTION
## Description

Create a `RetryTicker` type for running a function periodically with retries.
This is a part of ROX-8752 for the client side part of refreshing the local scanner certificates. 
This in concerned only with the retry and coordination logic.

This and subsequent PRs are replacing https://github.com/stackrox/stackrox/pull/278, as that PR was getting too long. This is a addressing some suggestions from the comments in that PR, as well as missing features in that PR:

- Creating a separate `CertManager` that is a generic component to handle refreshing certificates for any resource. I renamed this to  `RetryTicker` because the type was getting very generic. 
   - Determining whether or not the secrets should be refreshed is out of scope for `RetryTicker` and should be handled by the function that is called on each tick, as part of https://github.com/stackrox/stackrox/pull/400. Same for secret resource ownership and creation.
- Timeout when the certificate issue request is not responded on time.
- Retry errors with exponential backoff.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps

No CHANGELOG entry or upgrade instructions required.

## Testing Performed

Added unit test. Test passing running as `go test -count=500 -race -v -p=1 github.com/stackrox/rox/pkg/concurrency -run TestRetryTicker`
