### PR TITLE
Write exportPolicy integration test for PatternFly

### DIFF
--- a/ui/apps/platform/cypress/constants/PoliciesPagePatternFly.js
+++ b/ui/apps/platform/cypress/constants/PoliciesPagePatternFly.js
@@ -1,3 +1,20 @@
 export const url = '/main/policies-pf';
 
-export const selectors = {};
+export const selectors = {
+    table: {
+        trFirst: 'tbody tr:nth-child(1)',
+        linkToPolicy: 'td[data-label="Policy"] a',
+        buttonForActionToggle: 'td.pf-c-table__action button.pf-c-dropdown__toggle',
+        buttonForActionItem: 'td.pf-c-table__action ul li[role="menuitem"] button',
+    },
+    page: {
+        buttonForActionToggle: 'button.pf-c-dropdown__toggle:contains("Actions")',
+        buttonForActionItem:
+            'button.pf-c-dropdown__toggle:contains("Actions") + ul li[role="menuitem"] button',
+    },
+    toast: {
+        title: 'ul.pf-c-alert-group .pf-c-alert__title',
+        description: 'ul.pf-c-alert-group .pf-c-alert__description',
+    },
+    wizard: {},
+};

--- a/ui/apps/platform/cypress/helpers/policiesPatternFly.js
+++ b/ui/apps/platform/cypress/helpers/policiesPatternFly.js
@@ -1,20 +1,38 @@
-// import * as api from '../constants/apiEndpoints';
-import { url as policiesUrl } from '../constants/PoliciesPagePatternFly';
+import * as api from '../constants/apiEndpoints';
+import { selectors, url as policiesUrl } from '../constants/PoliciesPagePatternFly';
 
 // Navigation
 
 export function visitPolicies() {
     // Include empty search query to distinguish from intercept with search query.
-    // cy.intercept('GET', `${api.policies.policies}?query=`).as('getPolicies');
+    cy.intercept('GET', `${api.policies.policies}?query=`).as('getPolicies');
     cy.visit(policiesUrl);
-    // cy.wait('@getPolicies');
+    cy.wait('@getPolicies');
+}
+
+export function visitPolicy(policyId) {
+    cy.intercept('GET', api.policies.policy).as('getPolicy');
+    cy.visit(`${policiesUrl}/${policyId}`);
+    cy.wait('@getPolicy');
 }
 
 // Actions on policy table
 
-export function addPolicy() {}
+export function createPolicy() {}
+
+export function doPolicyRowAction(trSelector, titleOfActionItem) {
+    cy.get(`${trSelector} ${selectors.table.buttonForActionToggle}`).click();
+    cy.get(
+        `${trSelector} ${selectors.table.buttonForActionItem}:contains("${titleOfActionItem}")`
+    ).click();
+}
 
 // Actions on policy detail page
+
+export function doPolicyPageAction(titleOfActionItem) {
+    cy.get(selectors.page.buttonForActionToggle).click();
+    cy.get(`${selectors.page.buttonForActionItem}:contains("${titleOfActionItem}")`).click();
+}
 
 export function clonePolicy() {}
 

--- a/ui/apps/platform/cypress/integration/policies/PatternFly/exportPolicy.test.js
+++ b/ui/apps/platform/cypress/integration/policies/PatternFly/exportPolicy.test.js
@@ -1,0 +1,172 @@
+import * as api from '../../../constants/apiEndpoints';
+import { selectors } from '../../../constants/PoliciesPagePatternFly';
+import withAuth from '../../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../../helpers/features';
+import {
+    doPolicyPageAction,
+    doPolicyRowAction,
+    visitPolicies,
+    visitPolicy,
+} from '../../../helpers/policiesPatternFly';
+
+describe('Export policy', () => {
+    withAuth();
+
+    before(function beforeHook() {
+        if (!hasFeatureFlag('ROX_POLICIES_PATTERNFLY')) {
+            this.skip();
+        }
+    });
+
+    describe('policies table', () => {
+        it('should export policy', () => {
+            visitPolicies();
+
+            const trSelector = 'tbody tr:nth-child(1)';
+            cy.get(`${trSelector} ${selectors.table.linkToPolicy}`).then(($a) => {
+                const segments = $a.attr('href').split('/');
+                const policyId = segments[segments.length - 1];
+
+                cy.intercept('POST', api.policies.export).as('exportPolicy');
+
+                doPolicyRowAction(trSelector, 'Export policy to JSON');
+
+                cy.wait('@exportPolicy').then(({ request, response }) => {
+                    // Request has expected policy id.
+                    expect(request.body).to.deep.equal({
+                        policyIds: [policyId],
+                    });
+
+                    // Response has expected policy id.
+                    expect(response.body.policies).to.have.length(1);
+                    expect(response.body.policies[0]).to.include({
+                        id: policyId,
+                    });
+                });
+                cy.get(`${selectors.toast.title}:contains("Successfully exported policy")`);
+            });
+        });
+
+        it('should display toast alert for export request failure', () => {
+            visitPolicies();
+
+            const trSelector = 'tbody tr:nth-child(1)';
+            const message = 'Some policies could not be retrieved.';
+            cy.intercept('POST', api.policies.export, {
+                statusCode: 400,
+                body: {
+                    message, // emulate request failure
+                },
+            }).as('exportPolicy');
+
+            doPolicyRowAction(trSelector, 'Export policy to JSON');
+
+            cy.wait('@exportPolicy');
+            cy.get(`${selectors.toast.title}:contains("Could not export the policy")`);
+            cy.get(`${selectors.toast.description}:contains("${message}")`);
+        });
+
+        it('should display toast alert for export service failure', () => {
+            visitPolicies();
+
+            const trSelector = 'tbody tr:nth-child(1)';
+            const message = 'Problem exporting policy data';
+            cy.intercept('POST', api.policies.export, {
+                statusCode: 400,
+                body: {
+                    message, // emulate error thrown by service call after request success
+                },
+            }).as('exportPolicy');
+
+            doPolicyRowAction(trSelector, 'Export policy to JSON');
+
+            cy.wait('@exportPolicy');
+            cy.get(`${selectors.toast.title}:contains("Could not export the policy")`);
+            cy.get(`${selectors.toast.description}:contains("${message}")`);
+        });
+    });
+
+    describe('policy page', () => {
+        it('should export policy', () => {
+            visitPolicies();
+
+            const trSelector = 'tbody tr:nth-child(1)';
+            cy.get(`${trSelector} ${selectors.table.linkToPolicy}`).then(($a) => {
+                const segments = $a.attr('href').split('/');
+                const policyId = segments[segments.length - 1];
+
+                visitPolicy(policyId);
+
+                cy.intercept('POST', api.policies.export).as('exportPolicy');
+
+                doPolicyPageAction('Export policy to JSON');
+
+                cy.wait('@exportPolicy').then(({ request, response }) => {
+                    // Request has expected policy id.
+                    expect(request.body).to.deep.equal({
+                        policyIds: [policyId],
+                    });
+
+                    // Response has expected policy id.
+                    expect(response.body.policies).to.have.length(1);
+                    expect(response.body.policies[0]).to.include({
+                        id: policyId,
+                    });
+                });
+                cy.get(`${selectors.toast.title}:contains("Successfully exported policy")`);
+            });
+        });
+
+        it('should display toast alert for export request failure', () => {
+            visitPolicies();
+
+            const trSelector = 'tbody tr:nth-child(1)';
+            cy.get(`${trSelector} ${selectors.table.linkToPolicy}`).then(($a) => {
+                const segments = $a.attr('href').split('/');
+                const policyId = segments[segments.length - 1];
+
+                visitPolicy(policyId);
+
+                const message = 'Some policies could not be retrieved.';
+                cy.intercept('POST', api.policies.export, {
+                    statusCode: 400,
+                    body: {
+                        message, // emulate request failure
+                    },
+                }).as('exportPolicy');
+
+                doPolicyPageAction('Export policy to JSON');
+
+                cy.wait('@exportPolicy');
+                cy.get(`${selectors.toast.title}:contains("Could not export the policy")`);
+                cy.get(`${selectors.toast.description}:contains("${message}")`);
+            });
+        });
+
+        it('should display toast alert for export service failure', () => {
+            visitPolicies();
+
+            const trSelector = 'tbody tr:nth-child(1)';
+            cy.get(`${trSelector} ${selectors.table.linkToPolicy}`).then(($a) => {
+                const segments = $a.attr('href').split('/');
+                const policyId = segments[segments.length - 1];
+
+                visitPolicy(policyId);
+
+                const message = 'Problem exporting policy data';
+                cy.intercept('POST', api.policies.export, {
+                    statusCode: 400,
+                    body: {
+                        message, // emulate error thrown by service call after request success
+                    },
+                }).as('exportPolicy');
+
+                doPolicyPageAction('Export policy to JSON');
+
+                cy.wait('@exportPolicy');
+                cy.get(`${selectors.toast.title}:contains("Could not export the policy")`);
+                cy.get(`${selectors.toast.description}:contains("${message}")`);
+            });
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Detail/PolicyDetail.tsx
@@ -21,7 +21,7 @@ import {
 import { CaretDownIcon } from '@patternfly/react-icons';
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
-import useToasts from 'hooks/useToasts';
+import useToasts, { Toast } from 'hooks/patternfly/useToasts';
 import { policiesBasePathPatternFly as policiesBasePath } from 'routePaths';
 import { deletePolicy, exportPolicies } from 'services/PoliciesService';
 import { Cluster } from 'types/cluster.proto';
@@ -88,8 +88,9 @@ function PolicyDetail({
             .then(() => {
                 addToast('Successfully exported policy', 'success');
             })
-            .catch(({ response }) => {
-                addToast('Could not export policy', 'danger', response.data.message);
+            .catch((error) => {
+                const message = getAxiosErrorMessage(error);
+                addToast('Could not export the policy', 'danger', message);
             })
             .finally(() => {
                 setIsRequesting(false);
@@ -242,7 +243,7 @@ function PolicyDetail({
             <Divider component="div" className="pf-u-pb-md" />
             <PolicyDetailContent clusters={clusters} policy={policy} notifiers={notifiers} />
             <AlertGroup isToast isLiveRegion>
-                {toasts.map(({ key, variant, title, children }) => (
+                {toasts.map(({ key, variant, title, children }: Toast) => (
                     <Alert
                         variant={AlertVariant[variant]}
                         title={title}
@@ -250,7 +251,7 @@ function PolicyDetail({
                         actionClose={
                             <AlertActionCloseButton
                                 title={title}
-                                variantLabel={`${variant as string} alert`}
+                                variantLabel={`${variant} alert`}
                                 onClose={() => removeToast(key)}
                             />
                         }

--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Table/PoliciesTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Table/PoliciesTablePage.tsx
@@ -20,7 +20,7 @@ import {
     updatePoliciesDisabledState,
 } from 'services/PoliciesService';
 import { fetchNotifierIntegrations } from 'services/NotifierIntegrationsService';
-import useToasts from 'hooks/useToasts';
+import useToasts, { Toast } from 'hooks/patternfly/useToasts';
 import { getSearchOptionsForCategory } from 'services/SearchService';
 import { ListPolicy } from 'types/policy.proto';
 import { NotifierIntegration } from 'types/notifier.proto';
@@ -109,8 +109,9 @@ function PoliciesTablePage({
                     onClearAll();
                 }
             })
-            .catch(({ response }) => {
-                addToast(`Could not export the ${policyText}`, 'danger', response.data.message);
+            .catch((error) => {
+                const message = getAxiosErrorMessage(error);
+                addToast(`Could not export the ${policyText}`, 'danger', message);
             });
     }
 
@@ -198,7 +199,7 @@ function PoliciesTablePage({
                 fetchPoliciesWithQuery={() => fetchPolicies(query)}
             />
             <AlertGroup isToast isLiveRegion>
-                {toasts.map(({ key, variant, title, children }) => (
+                {toasts.map(({ key, variant, title, children }: Toast) => (
                     <Alert
                         variant={AlertVariant[variant]}
                         title={title}
@@ -206,7 +207,7 @@ function PoliciesTablePage({
                         actionClose={
                             <AlertActionCloseButton
                                 title={title}
-                                variantLabel={`${variant as string} alert`}
+                                variantLabel={`${variant} alert`}
                                 onClose={() => removeToast(key)}
                             />
                         }

--- a/ui/apps/platform/src/hooks/patternfly/useToasts.tsx
+++ b/ui/apps/platform/src/hooks/patternfly/useToasts.tsx
@@ -1,17 +1,17 @@
-import { ReactElement, useState } from 'react';
+import { ReactNode, useState } from 'react';
 
 type AlertVariantType = 'default' | 'info' | 'success' | 'danger' | 'warning';
 
-type Toast = {
+export type Toast = {
     title: string;
     variant: AlertVariantType;
     key: number;
-    children?: ReactElement;
+    children?: ReactNode;
 };
 
 type UseToasts = {
     toasts: Toast[];
-    addToast: (title, variant?: AlertVariantType, children?: ReactElement) => void;
+    addToast: (title, variant?: AlertVariantType, children?: ReactNode) => void;
     removeToast: (key) => void;
 };
 


### PR DESCRIPTION
## Description

### cypress

1. Edit constants/PoliciesPagePatternFly.js
    * Add selectors

2. Edit helpers/policiesPatternFly.js
    * Add `visitPolicy` function
    * Add `doPolicyRowAction` function
    * Add `doPolicyPageAction` function

3. Add integration/policies/PatternFly/exportPolicy.test.js
    * Add 1 success and 2 failure tests for action in policies table row and on policy page

### Policies/PatternFly

1. Edit etail/PolicyDetail.tsx
    * Import `Toast` type and use in `map` method
    * Call `getAxiosErrorMessage` function for `error` in `onExportPolicy` function
    * Replace `${variant as string}` with `${variant}`

2. Edit Table/PoliciesTablePage.tsx
    * Import `Toast` type and use in `map` method
    * Call `getAxiosErrorMessage` function for `error` in `exportPoliciesHandler` function
    * Replace `${variant as string}` with `${variant}`

### hooks

1. Edit useToasts.tsx and move to patternfly subfoler
    * Export `Toast` type
    * Replace `ReactElement` with `ReactNode` so children can be string

## Checklist
- [x] Investigated and inspected CI test results
- [x] Added regression tests

## Testing Performed

1. Start Platform UI
    * `export ROX_POLICIES_PATTERNFLY=true`
    * `yarn deploy-local`
    * `yarn start`
2. Start Cypress
    * `export CYPRESS_ROX_POLICIES_PATTERNFLY=true`
    * `yarn cypress-open`
3. Run classic and PatternFly tests
    * cypress/integration/policies/policies-import-export.test.js
    * cypress/integration/policies/PatternFly/exportPolicy.test.js