### PR TITLE
RS-427: overidden images values without tag shouldn't be assumed as `latest`

### DIFF
--- a/pkg/renderer/images.go
+++ b/pkg/renderer/images.go
@@ -10,8 +10,8 @@ import (
 // ComputeImageOverrides takes in a full image reference as well as default registries, names,
 // and tags, and computes the components of the image which are different. I.e., if
 // `fullImageRef` is `<defRegistry>/<defName>:<defTag>`, an empty map is returned; if, for
-// example, only the tag is different, a map containing only the non-default "Tag" is returned
-// etc.
+// example, only the tag is different, a map containing only the non-default "Tag" is returned etc.
+// If the provided image doesn't have a tag, the tag won't show as overridden.
 func ComputeImageOverrides(fullImageRef, defRegistry, defName, defTag string) map[string]string {
 	var remoteAndRepo, tag string
 
@@ -35,10 +35,8 @@ func ComputeImageOverrides(fullImageRef, defRegistry, defName, defTag string) ma
 
 	overrides := map[string]string{}
 
-	if tag == "" {
-		tag = "latest"
-	}
-	if tag != defTag {
+	// Only compute tag override if provided
+	if tag != "" && tag != defTag {
 		overrides["Tag"] = tag
 	}
 	if stringutils.ConsumeSuffix(&remoteAndRepo, "/"+defName) {


### PR DESCRIPTION
## Description

This PR provides a simple fix for an issue I found during the testing of flavors. The following `roxctl` command generates images defaulted to tag `latest`: 

```
roxctl central generate k8s pvc --image-defaults="stackrox.io" --main-image="example.io/main" --scanner-image="example.io/scanner" --scanner-db-image="example.io/scanner-db" --output-dir /tmp/test/wrong-image-test
```

When an overridden image is provided without a tag, we should take the tag from the flavor instead of assuming `latest`. Running the command above should generate a bundle with images tagged with `STABLE_MAIN_VERSION` (e.g. `3.67.0`)

## Open points:

1. I wanted to address [RS-397](https://issues.redhat.com/browse/RS-397) here as well, but it seems like there are a lot of other cases not related to this change that I would have to cover.
2. I also wanted to enhance our bats suite to also test this change, but it requires a little refactor to allow assertions on scanner tag. 
3. Decide if we should allow tags in `roxctl central generate` overrides. It might make sense to allow tags for `main` override, but maybe not so much for `scanner` and `scanner-db`.

In order to try to get this in for the CPaaS release, I'll split (1) and (2) points above into separate PRs branching from this. 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~

Although unit tests were added, more tests will be added in the follow-up PRs.

## Testing Performed

- Enhanced `deployer_test.go@TestComputeOverrides` to assert that images without tags don't produce overrides
- Added a couple of tests in `deployer_test.go@TestConfigureImageOverrides` to assert this case won't happen again for main images.