### PR TITLE
ROX-8406: UI filter for Report table

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/SearchFilterResults.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/SearchFilterResults.tsx
@@ -1,0 +1,69 @@
+import { Button, Chip, ChipGroup, Flex, FlexItem } from '@patternfly/react-core';
+import React, { ReactElement } from 'react';
+
+import { SearchFilter } from 'types/search';
+
+export type SearchResultsProps = {
+    searchFilter: SearchFilter;
+    setSearchFilter: React.Dispatch<React.SetStateAction<SearchFilter>>;
+};
+
+function SearchResults({ searchFilter, setSearchFilter }: SearchResultsProps): ReactElement {
+    const attributes = Object.keys(searchFilter);
+
+    function deleteAll() {
+        setSearchFilter({});
+    }
+
+    function deleteChipGroup(attribute) {
+        const modifiedSearchFilter = { ...searchFilter };
+        delete modifiedSearchFilter[attribute];
+        setSearchFilter(modifiedSearchFilter);
+    }
+
+    function deleteChip(attribute, value) {
+        const modifiedSearchFilter = { ...searchFilter };
+        const attributeValue = searchFilter[attribute];
+        if (Array.isArray(attributeValue)) {
+            modifiedSearchFilter[attribute] = attributeValue.filter(
+                (filterValue) => filterValue === value
+            );
+        } else {
+            delete modifiedSearchFilter[attribute];
+        }
+        setSearchFilter(modifiedSearchFilter);
+    }
+
+    const chipGroups = attributes.map((attribute) => {
+        const attributeValue = searchFilter[attribute];
+        const values = !Array.isArray(attributeValue) ? [attributeValue] : attributeValue;
+        return (
+            <ChipGroup
+                categoryName={attribute}
+                isClosable
+                onClick={() => deleteChipGroup(attribute)}
+            >
+                {values.map((value) => (
+                    <Chip key={value} onClick={() => deleteChip(attribute, value)}>
+                        {value}
+                    </Chip>
+                ))}
+            </ChipGroup>
+        );
+    });
+
+    return (
+        <Flex>
+            {chipGroups.map((chipGroup) => {
+                return <FlexItem spacer={{ default: 'spacerMd' }}>{chipGroup}</FlexItem>;
+            })}
+            <FlexItem>
+                <Button type="button" variant="link" isInline onClick={() => deleteAll()}>
+                    Clear all filters
+                </Button>
+            </FlexItem>
+        </Flex>
+    );
+}
+
+export default SearchResults;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/Components/ReportsSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/Components/ReportsSearchFilter.tsx
@@ -20,8 +20,11 @@ function ReportsSearchFilter({
     searchFilter,
     setSearchFilter,
 }: ReportsSearchFilterProps): ReactElement {
-    const [selectedAttribute] = useState<string>('Report Name');
-    const [inputValue, setInputValue] = useState<string>('');
+    const [selectedAttribute] = useState('Report Name');
+
+    // TODO: hard-coding input value for now, because initially, only Report Name is searchable
+    const existingReportName = (searchFilter['Report Name'] as string) ?? '';
+    const [inputValue, setInputValue] = useState<string>(existingReportName);
 
     function handleSearchChange(value) {
         const modifiedSearchObject = { ...searchFilter };
@@ -47,6 +50,7 @@ function ReportsSearchFilter({
                             id="reportNameSearchInput"
                             type="search"
                             aria-label="Report name search input"
+                            placeholder="Filter by report name"
                             onChange={handleInputChange}
                             value={inputValue}
                         />

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePage.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React, { useEffect, useState, ReactElement } from 'react';
-import { Link } from 'react-router-dom';
-import { useQuery } from '@apollo/client';
+import React, { useState, ReactElement } from 'react';
+import { Link, useHistory } from 'react-router-dom';
 import {
     Alert,
     AlertVariant,
@@ -28,7 +27,9 @@ import useFetchReports from 'hooks/useFetchReports';
 import useTableSort from 'hooks/useTableSort';
 import { vulnManagementReportsPath } from 'routePaths';
 import { deleteReport, runReport } from 'services/ReportsService';
+import { SearchFilter } from 'types/search';
 import { filterAllowedSearch } from 'utils/searchUtils';
+import { getQueryString } from 'utils/queryStringUtils';
 import VulnMgmtReportTablePanel from './VulnMgmtReportTablePanel';
 import VulnMgmtReportTableColumnDescriptor from './VulnMgmtReportTableColumnDescriptor';
 import { VulnMgmtReportQueryObject } from './VulnMgmtReport.utils';
@@ -38,6 +39,8 @@ type ReportTablePageProps = {
 };
 
 function ReportTablePage({ query }: ReportTablePageProps): ReactElement {
+    const history = useHistory();
+
     const { hasReadWriteAccess } = usePermissions();
     const hasVulnReportWriteAccess = hasReadWriteAccess('VulnerabilityReports');
 
@@ -64,8 +67,14 @@ function ReportTablePage({ query }: ReportTablePageProps): ReactElement {
         sortOption,
     } = useTableSort(columns, defaultSort);
 
-    function setSearchFilter(filters: Record<string, string | string[]>) {
-        console.log({ filters });
+    function setSearchFilter(filters: SearchFilter) {
+        const newSearchString = getQueryString({
+            s: filters,
+        });
+
+        history.push({
+            search: newSearchString,
+        });
     }
 
     const { reports, reportCount, error, isLoading, triggerRefresh } = useFetchReports(

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePanel.tsx
@@ -23,6 +23,7 @@ import useTableSelection from 'hooks/useTableSelection';
 import { TableColumn, SortDirection } from 'hooks/useTableSort';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
+import SearchFilterResults from 'Components/PatternFly/SearchFilterResults';
 import TableCell from 'Components/PatternFly/TableCell';
 import { selectors } from 'reducers';
 import { getHasReadWritePermission } from 'reducers/roles';
@@ -243,6 +244,18 @@ function ReportingTablePanel({
                     </ToolbarItem>
                 </ToolbarContent>
             </Toolbar>
+            {Object.keys(searchFilter).length !== 0 && (
+                <Toolbar>
+                    <ToolbarContent>
+                        <ToolbarItem>
+                            <SearchFilterResults
+                                searchFilter={searchFilter}
+                                setSearchFilter={setSearchFilter}
+                            />
+                        </ToolbarItem>
+                    </ToolbarContent>
+                </Toolbar>
+            )}
             <Divider component="div" />
             <PageSection isFilled hasOverflowScroll>
                 <TableComposable variant="compact">


### PR DESCRIPTION
## Description

A MVP implementation for search filtering for launch of the VM reports feature

1. Only Report Name is searchable, so this requires some cuts to the standard PatternFly paradigm for choosing different search filters
2. I am reusing some paradigms that Saif pioneered with his in-progress feature, VM Deferral Workflow, but I had already implemented query string handling without his new hook. Also, I'm using the query param `s[<key>]` that we have used in other sections of the app.
3. This implementation does not supports arrays yet; a new search string replaces the existing one (and it's chip)


## Checklist
- [x] Investigated and inspected CI test results (failures are flakes)


## Testing Performed

Manual testing

No search
<img width="1552" alt="Screen Shot 2022-01-19 at 11 07 19 AM" src="https://user-images.githubusercontent.com/715729/150171551-65256479-bf37-460c-b11e-2b761c987339.png">

Basic search, multiple results
<img width="1552" alt="Screen Shot 2022-01-19 at 11 07 33 AM" src="https://user-images.githubusercontent.com/715729/150171605-909543fd-256d-4f84-8bbf-5f6097d6acc0.png">

Replacing with a new search
<img width="1552" alt="Screen Shot 2022-01-19 at 11 07 41 AM" src="https://user-images.githubusercontent.com/715729/150171652-0198cb0b-65d4-4f82-ba7f-4dde4e0550bc.png">

Replacing with a more discriminating search
<img width="1552" alt="Screen Shot 2022-01-19 at 11 07 47 AM" src="https://user-images.githubusercontent.com/715729/150171714-79a55af8-1497-4ab4-a38e-6b6507cb7319.png">
