### PR TITLE
RS-380: Leftover: enable tests to run on `rhacs` flavor

### DIFF
--- a/central/clusters/deployer_test.go
+++ b/central/clusters/deployer_test.go
@@ -144,15 +144,21 @@ func testMetaValueGenerationWithImageFlavor(s *deployerTestSuite, flavor default
 			expectedCollectorFullRef: defaultCollectorFullImage,
 			expectedCollectorSlimRef: defaultCollectorSlimImage,
 		},
+		"custom registry with default main image name / no collector": {
+			cluster:                  makeTestCluster("quay.io/rhacs/"+flavor.MainImageName, ""),
+			expectedMain:             fmt.Sprintf("quay.io/rhacs/%s:%s", flavor.MainImageName, flavor.MainImageTag),
+			expectedCollectorFullRef: fmt.Sprintf("quay.io/rhacs/%s:%s", flavor.CollectorImageName, flavor.CollectorImageTag),
+			expectedCollectorSlimRef: fmt.Sprintf("quay.io/rhacs/%s:%s", flavor.CollectorSlimImageName, flavor.CollectorSlimImageTag),
+		},
 		"custom main image (with namespace) / no collector": {
 			cluster:                  makeTestCluster("quay.io/rhacs/main", ""),
-			expectedMain:             fmt.Sprintf("quay.io/rhacs/%s:%s", flavor.MainImageName, flavor.MainImageTag),
+			expectedMain:             fmt.Sprintf("quay.io/rhacs/main:%s", flavor.MainImageTag),
 			expectedCollectorFullRef: fmt.Sprintf("quay.io/rhacs/%s:%s", flavor.CollectorImageName, flavor.CollectorImageTag),
 			expectedCollectorSlimRef: fmt.Sprintf("quay.io/rhacs/%s:%s", flavor.CollectorSlimImageName, flavor.CollectorSlimImageTag),
 		},
 		"custom main image (without namespace) / no collector": {
 			cluster:                  makeTestCluster("example.io/main", ""),
-			expectedMain:             fmt.Sprintf("example.io/%s:%s", flavor.MainImageName, flavor.MainImageTag),
+			expectedMain:             fmt.Sprintf("example.io/main:%s", flavor.MainImageTag),
 			expectedCollectorFullRef: fmt.Sprintf("example.io/%s:%s", flavor.CollectorImageName, flavor.CollectorImageTag),
 			expectedCollectorSlimRef: fmt.Sprintf("example.io/%s:%s", flavor.CollectorSlimImageName, flavor.CollectorSlimImageTag),
 		},
@@ -227,6 +233,7 @@ func (s *deployerTestSuite) TestFieldsFromClusterAndRenderOpts() {
 	flavorCases := map[string]defaults.ImageFlavor{
 		"development": defaults.DevelopmentBuildImageFlavor(),
 		"stackrox":    defaults.StackRoxIOReleaseImageFlavor(),
+		"rhacs":       defaults.RHACSReleaseImageFlavor(),
 	}
 
 	for name, flavor := range flavorCases {


### PR DESCRIPTION
## Description

There were two tests that were hardcoding `main` as image name so they initially failed when I simply added `rhacs` to the list of test cases. The pasts were passing before because both `development_build` and `stackrox.io` use the same `main` image name.  

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~


## Testing Performed
- Additional flavor being tested in `deployer_test.go`