### PR TITLE
ROX-8983: Limit height of watched image list and add scrolling, review

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Images/WatchedImagesDialog.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Images/WatchedImagesDialog.tsx
@@ -197,7 +197,10 @@ const WatchedImagesDialog = ({ closeDialog }: WatchedImagesDialogProps): ReactEl
                         <Message type="error">{errorMessage}</Message>
                     </div>
                 )}
-                <div className="flex flex-col leading-normal p-4 text-base-600 w-full">
+                <div
+                    className="flex flex-col leading-normal p-4 text-base-600 w-full overflow-y-auto"
+                    style={{ maxHeight: '200px' }}
+                >
                     <h3 className="font-700 mb-2">Images Currently Being Watched</h3>
                     {currentWatchedImages.length > 0 ? (
                         <ol>{imageList}</ol>


### PR DESCRIPTION


## Description

If you add more than **~12 images** * to the image watch list (Vulnerability Management / Images / Manage Watches), the list is not scrollable and runs out of the box onscreen.  There is no way to see all watches or to edit any past the first dozen.

[* depends on height of window: This simple fix limits the height to work on windows even as small in height as a small laptop ] 


## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Manual testing

No scrolling with a few images
<img width="1604" alt="Screen Shot 2022-01-19 at 12 30 37 PM" src="https://user-images.githubusercontent.com/715729/150187290-df6ceabd-c281-41dd-85a8-c561902546d4.png">

Scrolling with many images
<img width="1604" alt="Screen Shot 2022-01-19 at 12 26 51 PM" src="https://user-images.githubusercontent.com/715729/150187303-9e75a454-be06-44b8-9a55-82fceb13e071.png">
