### PR TITLE
Fix make target for circleci validate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ ui-lint:
 .PHONY: ci-config-validate
 ci-config-validate:
 	@echo "+ $@"
-	circleci config validate
+	circleci config validate --org-slug gh/stackrox
 
 .PHONY: staticcheck
 staticcheck: $(STATICCHECK_BIN)


### PR DESCRIPTION
## Description

Handles the privateness of the ci-artifacts orb.

## Checklist
~- [ ] Investigated and inspected CI test results~
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~

## Testing Performed

$ make ci-config-validate 
+ ci-config-validate
circleci config validate --org-slug gh/stackrox
Config file at .circleci/config.yml is valid.
