### PR TITLE
run diagnostic first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ ui-lint:
 .PHONY: ci-config-validate
 ci-config-validate:
 	@echo "+ $@"
-	circleci diagnostic > /dev/null 2>&1 # Must first set CIRCLECI_CLI_TOKEN or run circleci setup
+	@circleci diagnostic > /dev/null 2>&1 || (echo "Must first set CIRCLECI_CLI_TOKEN or run circleci setup"; exit 1)
 	circleci config validate --org-slug gh/stackrox
 
 .PHONY: staticcheck


### PR DESCRIPTION
## Description

cicrcleci config validate needs a tad more user help.

## Checklist
~- [ ] Investigated and inspected CI test results~
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~

## Testing Performed

$ make ci-config-validate
+ ci-config-validate
circleci config validate --org-slug gh/stackrox
Config file at .circleci/config.yml is valid.

(unset CIRCLECI_CLI_TOKEN; make ci-config-validate)
+ ci-config-validate
Must first set CIRCLECI_CLI_TOKEN or run circleci setup
make: *** [Makefile:192: ci-config-validate] Error 1

