### PR TITLE
ROX-9008,ROX-9050,ROX-9051: Vuln report query pagination, support multiple recipients for gmail server

### DIFF
--- a/central/notifiers/email/email_test.go
+++ b/central/notifiers/email/email_test.go
@@ -17,7 +17,7 @@ func TestEmailMsgWithAttachment(t *testing.T) {
 	assert.NoError(t, err)
 
 	msg := &message{
-		To:      "foo@stackrox.com, bar@stackrox.com",
+		To:      []string{"foo@stackrox.com", "bar@stackrox.com"},
 		From:    "xyz@stackrox.com",
 		Subject: "Test Email",
 		Body:    "How you doin'?",
@@ -31,7 +31,7 @@ func TestEmailMsgWithAttachment(t *testing.T) {
 	msgStr := string(msgBytes)
 
 	assert.Contains(t, msgStr, "From: xyz@stackrox.com\r\n")
-	assert.Contains(t, msgStr, "To: foo@stackrox.com, bar@stackrox.com\r\n")
+	assert.Contains(t, msgStr, "To: foo@stackrox.com,bar@stackrox.com\r\n")
 	assert.Contains(t, msgStr, "Subject: Test Email\r\n")
 	assert.Contains(t, msgStr, "MIME-Version: 1.0\r\n")
 	assert.Contains(t, msgStr, "Content-Type: multipart/mixed;")
@@ -52,7 +52,7 @@ func TestEmailMsgWithAttachment(t *testing.T) {
 
 func TestEmailMsgNoAttachments(t *testing.T) {
 	msg := &message{
-		To:        "foo@stackrox.com, bar@stackrox.com",
+		To:        []string{"foo@stackrox.com", "bar@stackrox.com"},
 		From:      "xyz@stackrox.com",
 		Subject:   "Test Email",
 		Body:      "How you doin'?",
@@ -63,12 +63,11 @@ func TestEmailMsgNoAttachments(t *testing.T) {
 	msgStr := string(msgBytes)
 
 	assert.Contains(t, msgStr, "From: xyz@stackrox.com\r\n")
-	assert.Contains(t, msgStr, "To: foo@stackrox.com, bar@stackrox.com\r\n")
+	assert.Contains(t, msgStr, "To: foo@stackrox.com,bar@stackrox.com\r\n")
 	assert.Contains(t, msgStr, "Subject: Test Email\r\n")
 	assert.Contains(t, msgStr, "MIME-Version: 1.0\r\n")
 	assert.Contains(t, msgStr, "Content-Type: text/plain; charset=\"utf-8\"\r\n\r\n")
 	assert.NotContains(t, msgStr, "Content-Type: multipart/mixed;")
-
 	assert.NotContains(t, msgStr, "Content-Type: application/zip\r\n")
 	assert.NotContains(t, msgStr, "Content-Transfer-Encoding: base64\r\n")
 	assert.NotContains(t, msgStr, "Content-Disposition: attachment;")

--- a/pkg/search/queryutils.go
+++ b/pkg/search/queryutils.go
@@ -87,10 +87,10 @@ func AddAsConjunction(toAdd *v1.Query, addTo *v1.Query) (*v1.Query, error) {
 	case *v1.Query_Conjunction:
 		typedQ.Conjunction.Queries = append(typedQ.Conjunction.Queries, toAdd)
 		return addTo, nil
-	case *v1.Query_BaseQuery:
+	case *v1.Query_BaseQuery, *v1.Query_Disjunction:
 		return ConjunctionQuery(toAdd, addTo), nil
 	default:
-		return nil, errors.New("cannot add to a non-nil, non-conjunction, non-base query")
+		return nil, errors.New("cannot add to a non-nil, non-conjunction/disjunction, non-base query")
 	}
 }
 

--- a/pkg/search/queryutils_test.go
+++ b/pkg/search/queryutils_test.go
@@ -332,5 +332,5 @@ func TestAddAsConjunction(t *testing.T) {
 	}
 
 	_, err = AddAsConjunction(toAdd, addTo)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Description
1. Paginate graphql query to get vuln report data
2. Fix 0 day in query infra to allow concatenation into a disjunction query
3. Fix email notifier to send multiple `RCPT TO` headers, one for each recipient, to be able to support `GMAIL SMTP` server.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~

## Testing Performed
Manual testing on GKE cluster