### PR TITLE
ROX-9016 Explicitly set kernel module on openshift 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3864,6 +3864,7 @@ jobs:
     executor: custom
     environment:
       - LOCAL_PORT: 8000
+      - COLLECTION_METHOD: kernel-module
       - MONITORING_SUPPORT: true
       - SCANNER_SUPPORT: true
       - ROX_BASELINE_GENERATION_DURATION: 1m
@@ -3889,6 +3890,7 @@ jobs:
     executor: custom
     environment:
       - LOCAL_PORT: 8000
+      - COLLECTION_METHOD: kernel-module
       - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - ROX_BASELINE_GENERATION_DURATION: 1m


### PR DESCRIPTION
## Description

eBPF support has been [re-enabled](https://stack-rox.atlassian.net/browse/ROX-3377) in collector version `3.6.0` for the kernel used by openshift 3.11, previously, we would fall back to kernel-module. However, SELinux must be configured to allow `bpf()` system call, which is not the case circle ci openshift cluster. 


## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed

Created and added labels `ci-openshift-crio-tests` and `ci-openshift-tests` to trigger the affected jobs. 
