### PR TITLE
Write importPolicy integration test for PatternFly

### DIFF
--- a/ui/apps/platform/cypress/constants/PoliciesPagePatternFly.js
+++ b/ui/apps/platform/cypress/constants/PoliciesPagePatternFly.js
@@ -2,14 +2,15 @@ export const url = '/main/policies-pf';
 
 export const selectors = {
     table: {
-        trFirst: 'tbody tr:nth-child(1)',
-        linkToPolicy: 'td[data-label="Policy"] a',
-        buttonForActionToggle: 'td.pf-c-table__action button.pf-c-dropdown__toggle',
-        buttonForActionItem: 'td.pf-c-table__action ul li[role="menuitem"] button',
+        createButton: 'button:contains("Create policy")',
+        importButton: 'button:contains("Import policy")',
+        policyLink: 'td[data-label="Policy"] a',
+        actionsToggleButton: 'td.pf-c-table__action button.pf-c-dropdown__toggle',
+        actionsItemButton: 'td.pf-c-table__action ul li[role="menuitem"] button',
     },
     page: {
-        buttonForActionToggle: 'button.pf-c-dropdown__toggle:contains("Actions")',
-        buttonForActionItem:
+        actionsToggleButton: 'button.pf-c-dropdown__toggle:contains("Actions")',
+        actionsItemButton:
             'button.pf-c-dropdown__toggle:contains("Actions") + ul li[role="menuitem"] button',
     },
     toast: {
@@ -17,4 +18,26 @@ export const selectors = {
         description: 'ul.pf-c-alert-group .pf-c-alert__description',
     },
     wizard: {},
+    importUploadModal: {
+        titleText: '.pf-c-modal-box__title-text:contains("Import policy JSON")',
+        fileInput: '.pf-c-file-upload input[type="file"]',
+        policyNames: '[data-testid="policies-to-import"] div',
+        beginButton: '.pf-c-modal-box__footer button:contains("Begin import")',
+        resumeButton: '.pf-c-modal-box__footer button:contains("Resume import")',
+        cancelButton: '.pf-c-modal-box__footer button:contains("Cancel")',
+        // Form for duplicate policy name
+        duplicateAlertTitle:
+            '.pf-c-modal-box__body .pf-c-alert__title:contains("Policies already exist")',
+        duplicateIdSubstring: '.pf-c-alert__description li:contains("has the same ID")',
+        duplicateNameSubstring: '.pf-c-alert__description li:contains("has the same name")',
+        keepBothRadioLabel: 'label[for="keep-both-radio"]:contains("Keep both policies")',
+        renameRadioLabel: 'label[for="policy-rename-radio"]:contains("Rename incoming policy")',
+        renameInput: 'input#policy-rename',
+        overwriteRadioLabel:
+            'label[for="policy-overwrite-radio-1"]:contains("Overwrite existing policy")',
+    },
+    importSuccessModal: {
+        titleText: '.pf-c-modal-box__title-text:contains("Import policy JSON")',
+        policyNames: '[data-testid="policies-imported"] div',
+    },
 };

--- a/ui/apps/platform/cypress/helpers/policiesPatternFly.js
+++ b/ui/apps/platform/cypress/helpers/policiesPatternFly.js
@@ -21,17 +21,17 @@ export function visitPolicy(policyId) {
 export function createPolicy() {}
 
 export function doPolicyRowAction(trSelector, titleOfActionItem) {
-    cy.get(`${trSelector} ${selectors.table.buttonForActionToggle}`).click();
+    cy.get(`${trSelector} ${selectors.table.actionsToggleButton}`).click();
     cy.get(
-        `${trSelector} ${selectors.table.buttonForActionItem}:contains("${titleOfActionItem}")`
+        `${trSelector} ${selectors.table.actionsItemButton}:contains("${titleOfActionItem}")`
     ).click();
 }
 
 // Actions on policy detail page
 
 export function doPolicyPageAction(titleOfActionItem) {
-    cy.get(selectors.page.buttonForActionToggle).click();
-    cy.get(`${selectors.page.buttonForActionItem}:contains("${titleOfActionItem}")`).click();
+    cy.get(selectors.page.actionsToggleButton).click();
+    cy.get(`${selectors.page.actionsItemButton}:contains("${titleOfActionItem}")`).click();
 }
 
 export function clonePolicy() {}

--- a/ui/apps/platform/cypress/integration/policies/PatternFly/exportPolicy.test.js
+++ b/ui/apps/platform/cypress/integration/policies/PatternFly/exportPolicy.test.js
@@ -23,7 +23,7 @@ describe('Export policy', () => {
             visitPolicies();
 
             const trSelector = 'tbody tr:nth-child(1)';
-            cy.get(`${trSelector} ${selectors.table.linkToPolicy}`).then(($a) => {
+            cy.get(`${trSelector} ${selectors.table.policyLink}`).then(($a) => {
                 const segments = $a.attr('href').split('/');
                 const policyId = segments[segments.length - 1];
 
@@ -91,7 +91,7 @@ describe('Export policy', () => {
             visitPolicies();
 
             const trSelector = 'tbody tr:nth-child(1)';
-            cy.get(`${trSelector} ${selectors.table.linkToPolicy}`).then(($a) => {
+            cy.get(`${trSelector} ${selectors.table.policyLink}`).then(($a) => {
                 const segments = $a.attr('href').split('/');
                 const policyId = segments[segments.length - 1];
 
@@ -121,7 +121,7 @@ describe('Export policy', () => {
             visitPolicies();
 
             const trSelector = 'tbody tr:nth-child(1)';
-            cy.get(`${trSelector} ${selectors.table.linkToPolicy}`).then(($a) => {
+            cy.get(`${trSelector} ${selectors.table.policyLink}`).then(($a) => {
                 const segments = $a.attr('href').split('/');
                 const policyId = segments[segments.length - 1];
 
@@ -147,7 +147,7 @@ describe('Export policy', () => {
             visitPolicies();
 
             const trSelector = 'tbody tr:nth-child(1)';
-            cy.get(`${trSelector} ${selectors.table.linkToPolicy}`).then(($a) => {
+            cy.get(`${trSelector} ${selectors.table.policyLink}`).then(($a) => {
                 const segments = $a.attr('href').split('/');
                 const policyId = segments[segments.length - 1];
 

--- a/ui/apps/platform/cypress/integration/policies/PatternFly/importPolicy.test.js
+++ b/ui/apps/platform/cypress/integration/policies/PatternFly/importPolicy.test.js
@@ -1,0 +1,256 @@
+import * as api from '../../../constants/apiEndpoints';
+import { selectors } from '../../../constants/PoliciesPagePatternFly';
+import withAuth from '../../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../../helpers/features';
+import { doPolicyRowAction, visitPolicies } from '../../../helpers/policiesPatternFly';
+
+describe('Import policy', () => {
+    withAuth();
+
+    before(function beforeHook() {
+        if (!hasFeatureFlag('ROX_POLICIES_PATTERNFLY')) {
+            this.skip();
+        }
+    });
+
+    it('should open and close dialog box', () => {
+        visitPolicies();
+
+        cy.get(selectors.table.importButton).click();
+
+        cy.get(selectors.importUploadModal.titleText);
+        cy.get(selectors.importUploadModal.beginButton).should('be.disabled');
+
+        cy.get(selectors.importUploadModal.cancelButton).click();
+        cy.get(selectors.importUploadModal.titleText).should('not.exist');
+    });
+
+    it('should import policy and then delete it', () => {
+        visitPolicies();
+
+        const fileName = 'policies/good_policy_to_import.json';
+        cy.fixture(fileName).then((fileContent) => {
+            const importedPolicyName = fileContent.policies[0].name;
+
+            cy.get(`${selectors.table.policyLink}:contains("${importedPolicyName}")`).should(
+                'not.exist'
+            );
+
+            cy.get(selectors.table.importButton).click();
+
+            cy.get(selectors.importUploadModal.fileInput).attachFile({
+                fileContent,
+                fileName,
+                mimeType: 'application/json',
+                encoding: 'utf8',
+            });
+            cy.get(
+                `${selectors.importUploadModal.policyNames}:nth-child(1):contains("${importedPolicyName}")`
+            );
+
+            cy.intercept('POST', api.policies.import).as('importPolicy');
+            cy.get(selectors.importUploadModal.beginButton).click();
+            cy.wait('@importPolicy');
+
+            cy.get(
+                `${selectors.importSuccessModal.policyNames}:nth-child(1):contains("${importedPolicyName}")`
+            );
+
+            // After 3 seconds, success modal closes, and then table displays imported policy.
+            cy.intercept('GET', `${api.policies.policies}?query=`).as('getPolicies');
+            cy.wait('@getPolicies');
+            cy.get(`${selectors.table.policyLink}:contains("${importedPolicyName}")`);
+
+            const trSelector = `tbody tr:contains("${importedPolicyName}")`;
+            doPolicyRowAction(trSelector, 'Delete policy');
+            cy.get(`${selectors.toast.title}:contains("Successfully deleted policy")`);
+        });
+    });
+
+    it('it should display options for policy which has duplicate name', () => {
+        visitPolicies();
+
+        cy.get(selectors.table.importButton).click();
+
+        const fileContent = {
+            policies: [
+                {
+                    name: 'Dupe Name Policy',
+                },
+            ],
+        };
+        cy.get(selectors.importUploadModal.fileInput).attachFile({
+            fileContent,
+            fileName: 'dummy.json',
+            mimeType: 'application/json',
+            encoding: 'utf8',
+        });
+
+        const body = {
+            responses: [
+                {
+                    succeeded: false,
+                    policy: {
+                        id: 'f09f8da1-6111-4ca0-8f49-294a76c65118',
+                        name: 'Dupe Name Policy',
+                        // Omit other policy properties.
+                    },
+                    errors: [
+                        {
+                            message: 'Could not add policy due to name validation',
+                            type: 'duplicate_name',
+                            duplicateName: 'Dupe Name Policy',
+                        },
+                    ],
+                },
+            ],
+            allSucceeded: false,
+        };
+        cy.intercept('POST', api.policies.import, { body }).as('importPolicy');
+        cy.get(selectors.importUploadModal.beginButton).click();
+        cy.wait('@importPolicy');
+
+        // Alert and disabled button.
+        cy.get(selectors.importUploadModal.duplicateAlertTitle);
+        cy.get(selectors.importUploadModal.duplicateNameSubstring);
+        cy.get(selectors.importUploadModal.resumeButton).should('be.disabled');
+
+        // Overwrite option enables the button.
+        cy.get(selectors.importUploadModal.overwriteRadioLabel).click();
+        cy.get(selectors.importUploadModal.resumeButton).should('be.enabled');
+
+        // Rename option requires a new name to enable the button.
+        cy.get(selectors.importUploadModal.renameRadioLabel).click();
+        cy.get(selectors.importUploadModal.resumeButton).should('be.disabled');
+
+        // Input a new name to enable the button (but cannot import the incomplete policy).
+        cy.get(selectors.importUploadModal.renameInput).click().type('A whole new world');
+        cy.get(selectors.importUploadModal.resumeButton).should('be.enabled');
+    });
+
+    it('should display options for policy which has duplicate id', () => {
+        visitPolicies();
+
+        cy.get(selectors.table.importButton).click();
+
+        const fileContent = {
+            policies: [
+                {
+                    name: 'Dupe ID Policy',
+                },
+            ],
+        };
+        cy.get(selectors.importUploadModal.fileInput).attachFile({
+            fileContent,
+            fileName: 'dummy.json',
+            mimeType: 'application/json',
+            encoding: 'utf8',
+        });
+
+        const body = {
+            responses: [
+                {
+                    succeeded: false,
+                    policy: {
+                        id: 'f09f8da1-6111-4ca0-8f49-294a76c65117',
+                        name: 'Fixable CVSS >= 9',
+                        // other policy properties omitted from mock
+                    },
+                    errors: [
+                        {
+                            message:
+                                'Policy Different than Fixable CVSS is >= 9 (f09f8da1-6111-4ca0-8f49-294a76c65117) cannot be added because it already exists',
+                            type: 'duplicate_id',
+                            duplicateName: 'Fixable CVSS >= 9',
+                        },
+                    ],
+                },
+            ],
+            allSucceeded: false,
+        };
+        cy.intercept('POST', api.policies.import, { body }).as('importPolicy');
+        cy.get(selectors.importUploadModal.beginButton).click();
+        cy.wait('@importPolicy');
+
+        // Alert and disabled button.
+        cy.get(selectors.importUploadModal.duplicateAlertTitle);
+        cy.get(selectors.importUploadModal.duplicateIdSubstring);
+        cy.get(selectors.importUploadModal.resumeButton).should('be.disabled');
+
+        // Overwrite option enables the button.
+        cy.get(selectors.importUploadModal.overwriteRadioLabel).click();
+        cy.get(selectors.importUploadModal.resumeButton).should('not.be.disabled');
+
+        // Keep both option enables the button
+        cy.get(selectors.importUploadModal.keepBothRadioLabel).click();
+        cy.get(selectors.importUploadModal.resumeButton).should('not.be.disabled');
+    });
+
+    it('should display options for policy which has duplicate name and id', () => {
+        visitPolicies();
+
+        cy.get(selectors.table.importButton).click();
+
+        const fileContent = {
+            policies: [
+                {
+                    name: 'Dupe Name and Dupe ID Policy',
+                },
+            ],
+        };
+        cy.get(selectors.importUploadModal.fileInput).attachFile({
+            fileContent,
+            fileName: 'dummy.json',
+            mimeType: 'application/json',
+            encoding: 'utf8',
+        });
+
+        const body = {
+            responses: [
+                {
+                    succeeded: false,
+                    policy: {
+                        id: '8ac93556-4ad4-4220-a275-3f518db0ceb9',
+                        name: 'Fixable CVSS >= 9',
+                        // other policy properties omitted from mock
+                    },
+                    errors: [
+                        {
+                            message:
+                                'Policy Fixable CVSS >= 9 (8ac93556-4ad4-4220-a275-3f518db0ceb9) cannot be added because it already exists',
+                            type: 'duplicate_id',
+                            duplicateName: 'Container using read-write root filesystem',
+                        },
+                        {
+                            message: 'Could not add policy due to name validation',
+                            type: 'duplicate_name',
+                            duplicateName: 'Fixable CVSS >= 9',
+                        },
+                    ],
+                },
+            ],
+            allSucceeded: false,
+        };
+        cy.intercept('POST', api.policies.import, { body }).as('importPolicy');
+        cy.get(selectors.importUploadModal.beginButton).click();
+        cy.wait('@importPolicy');
+
+        // Alert and disabled button.
+        cy.get(selectors.importUploadModal.duplicateAlertTitle);
+        cy.get(selectors.importUploadModal.duplicateIdSubstring);
+        cy.get(selectors.importUploadModal.duplicateNameSubstring);
+        cy.get(selectors.importUploadModal.resumeButton).should('be.disabled');
+
+        // Overwrite option enables the button.
+        cy.get(selectors.importUploadModal.overwriteRadioLabel).click();
+        cy.get(selectors.importUploadModal.resumeButton).should('be.enabled');
+
+        // Rename option requires a new name to enable the button.
+        cy.get(selectors.importUploadModal.renameRadioLabel).click();
+        cy.get(selectors.importUploadModal.resumeButton).should('be.disabled');
+
+        // Input a new name to enable the button (but cannot import the incomplete policy).
+        cy.get(selectors.importUploadModal.renameInput).click().type('Two are better than one');
+        cy.get(selectors.importUploadModal.resumeButton).should('be.enabled');
+    });
+});


### PR DESCRIPTION
## Description

1. Edit cypress/constants/PoliciesPagePatternFly.js
    * Add selectors
    * Delete obsolete selector
    * Rename a few keys

2. Edit cypress/helpers/policiesPatternFly.js
    * Rename a few keys

3. Edit cypress/integration/policies/PatternFly/exportPolicy.test.js
    * Rename a few keys

4. Add cypress/integration/policies/PatternFly/importPolicy.test.js
    * should open **and close** dialog box
    * should import policy **and then delete it**
    * should display options for policy which has duplicate name
    * should display options for policy which has duplicate id
    * should display options for policy which has duplicate name and id

## Checklist
- [x] Investigated and inspected CI test results
- [x] Added integration tests

## Testing Performed

1. Start Platform UI
    * `export ROX_POLICIES_PATTERNFLY=true`
    * `yarn deploy-local`
    * `yarn start`
2. Start Cypress
    * `export CYPRESS_ROX_POLICIES_PATTERNFLY=true`
    * `yarn cypress-open`
3. Run classic and PatternFly tests
    * cypress/integration/policies/policies-import-export.test.js
    * cypress/integration/policies/PatternFly/importPolicy.test.js