### PR TITLE
ROX-9022: add type to make requests to a retryable source with asynchronous interface

### DIFF
--- a/pkg/retry/retry_source.go
+++ b/pkg/retry/retry_source.go
@@ -16,7 +16,7 @@ import (
 // Retry() can be called several times to retry the result computation, the
 // RetryableSource is in charge of handling the cancellation of the computation if needed.
 type RetryableSource interface {
-	AskForResult() chan *Result
+	AskForResult(ctx context.Context) chan *Result
 	Retry()
 }
 
@@ -55,7 +55,7 @@ func NewRetryableSourceRetriever(backoff wait.Backoff, requestTimeout time.Durat
 func (r *RetryableSourceRetriever) Run(ctx context.Context, source RetryableSource) (interface{}, error) {
 	r.timeoutC = make(chan struct{})
 
-	resultC := source.AskForResult()
+	resultC := source.AskForResult(ctx)
 	r.setTimeoutTimer(r.RequestTimeout)
 	defer r.setTimeoutTimer(-1)
 	for {


### PR DESCRIPTION
## Description

Create type to make requests to a retryable source with asynchronous interface with timeout per request.  
This would be used by the CertManager (final name TBD) to reliably request the TLS certificates for a set of components

### Previous attempts

I started with this, but the problem is that this doesn't retries the timeouts, which is essentials for using this for fetching values through the `Communicate` RPC in central, that is bidirectional and has no timeouts or requests failures implemented:

```go
type result struct {
	v interface {}
	err error
}
type RetryableSource interface {
    // ask the source for a result, and assumes the source will perform the necessary 
    // cancellation procedure
	Request()
    // where the source puts the result: we only care about the first one
	ResponseC() chan result
}
type backoffRequesterImpl struct {
	source RetryableSource
	stopC concurrency.ErrorSignal
	backoff wait.Backoff
}

func (r *backoffRequesterImpl) Request(parentCtx context.Context, timeout time.Duration, errReporter errorReporter) (interface{}, error) {
	r.source.Request()
	ctx, cancel := context.WithTimeout(parentCtx, timeout)
	defer cancel()
	for {
		select {
		case <-r.stopC.Done():
			return nil, errors.New("request cancelled")
		case <-ctx.Done():
			// FIXME retry
			return nil, errors.New("timeout")
		case response := <-r.source.ResponseC():
			if response.err != nil {
				if errReporter != nil {
					errReporter.Report(response.err)
				}
				time.AfterFunc(r.backoff.Step(), func() {
					r.source.Request()
				})
			} else {
				return response.v, nil
			}
		}
	}
}
```

I tried retrying timeouts, but this doesn't reset the timeout timer when a new request is sent.

```go
// NOTE BLOCKING: loops forever or until you cancel
func (r *backoffRequesterImpl) Request(parentCtx context.Context, timeout time.Duration) (interface{}, error) {
	r.source.Request()
	cancelCtx, cancel := context.WithCancel(parentCtx)
	defer cancel()
	timeoutCtx, _ := context.WithTimeout(cancelCtx, timeout)
	for {
		select {
		case <-r.cancelC.Done():
			return nil, errors.New("request cancelled")
		case <-timeoutCtx.Done():
			r.handleError(errors.New("timeout"))
			timeoutCtx, _ = context.WithTimeout(cancelCtx, timeout)
		case response := <-r.source.ResponseC():
			err := response.err
			if err != nil {
				r.handleError(err)
			} else {
				return response.v, nil
			}
		}
	}
}

func (r *backoffRequesterImpl) handleError(err error) {
	time.AfterFunc(r.backoff.Step(), func() {
		r.source.Request()
	})
}

func (r *backoffRequesterImpl) Cancel() {
	r.cancelC.SignalWithError(errors.New("stop"))
}
```

This does reset the timeout timer on a new request, but I'm not sure it is safe to modify `r.timeoutCtx`, that is used in a `case` in the `select`, while the select is running. It doesn't look concurrently safe but I'm not sure, any insight is appreciated.

```go
type backoffRequesterImpl struct {
	source RetryableSource
	cancelC concurrency.ErrorSignal
	backoff wait.Backoff
	timeoutCtx context.Context
}

// NOTE BLOCKING: loops forever or until you cancel
func (r *backoffRequesterImpl) Request(parentCtx context.Context, timeout time.Duration) (interface{}, error) {
	r.source.Request()
	cancelCtx, cancel := context.WithCancel(parentCtx)
	defer cancel()
	r.timeoutCtx, _ = context.WithTimeout(cancelCtx, timeout)
	for {
		select {
		case <-r.cancelC.Done():
      // assume request will never come. We take first value in `r.source.ResponseC()` as
			// the response, assume `r.source.Request()` does any cancellation required.
			return nil, errors.New("request cancelled")
		case <-r.timeoutCtx.Done():
			r.handleError(cancelCtx, timeout, errors.New("timeout"))
			// r.timeoutCtx, _ = context.WithTimeout(cancelCtx, timeout)
		case response := <-r.source.ResponseC():
			err := response.err
			if err != nil {
				r.handleError(cancelCtx, timeout, err)
			} else {
				return response.v, nil
			}
		}
	}
    // TODO wait for parentCtx and Cancel if done: consider that the way to cancel instead,so no `cancelC concurrency.ErrorSignal`
}

func (r *backoffRequesterImpl) handleError(cancelCtx context.Context, timeout time.Duration, err error) {
	// BAD: starts timeout before request: `r.timeoutCtx, _ = context.WithTimeout(cancelCtx, timeout)`
    r.timeoutCtx = cancelCtx
	time.AfterFunc(r.backoff.Step(), func() {
		r.source.Request()
		// BAD: concurrently modifies timeout, Request loop might not catch it
		r.timeoutCtx, _ = context.WithTimeout(cancelCtx, timeout)
	})
}

func (r *backoffRequesterImpl) Cancel() {
	r.cancelC.SignalWithError(errors.New("stop"))
}
```

The current code uses a channel and a timer for timeouts instead of contexts. I also replaced the signal with a context for cancellation and a global timeout for the whole process.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
