### PR TITLE
ROX-9072: Audit logs are not generated for vuln management mutation requests

### DIFF
--- a/central/audit/audit.go
+++ b/central/audit/audit.go
@@ -55,6 +55,20 @@ func (a *audit) sendAuditMessage(ctx context.Context, req interface{}, grpcMetho
 	a.notifications.ProcessAuditMessage(ctx, am)
 }
 
+// SendAdhocAuditMessage will send an audit message for the specified request. It is done on an adhoc basis as opposed to via the unary interceptor
+// because GraphQL mutation apis won't get intercepted. This will be removed in the future once GraphQL also goes through the same pipeline as other APIs
+func (a *audit) SendAdhocAuditMessage(ctx context.Context, req interface{}, grpcMethod string, authError interceptor.AuthStatus, requestError error) {
+	if !a.notifications.HasEnabledAuditNotifiers() {
+		return
+	}
+
+	am := newAuditMessage(ctx, req, grpcMethod, authError, requestError)
+	if am == nil {
+		return
+	}
+	a.notifications.ProcessAuditMessage(ctx, am)
+}
+
 func requestToAny(req interface{}) *types.Any {
 	if req == nil {
 		return nil

--- a/central/cve/csv/handler_test.go
+++ b/central/cve/csv/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stackrox/rox/central/audit"
 	clusterMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	cveMocks "github.com/stackrox/rox/central/cve/datastore/mocks"
 	deploymentMocks "github.com/stackrox/rox/central/deployment/datastore/mocks"
@@ -13,6 +14,7 @@ import (
 	componentMocks "github.com/stackrox/rox/central/imagecomponent/datastore/mocks"
 	nsMocks "github.com/stackrox/rox/central/namespace/datastore/mocks"
 	nodeMocks "github.com/stackrox/rox/central/node/globaldatastore/mocks"
+	notifierMocks "github.com/stackrox/rox/central/notifier/processor/mocks"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
@@ -49,6 +51,9 @@ func (suite *CVEScopingTestSuite) SetupTest() {
 	suite.nodeDataStore = nodeMocks.NewMockGlobalDataStore(suite.mockCtrl)
 	suite.componentDataStore = componentMocks.NewMockDataStore(suite.mockCtrl)
 	suite.cveDataStore = cveMocks.NewMockDataStore(suite.mockCtrl)
+	notifierMock := notifierMocks.NewMockProcessor(suite.mockCtrl)
+
+	notifierMock.EXPECT().HasEnabledAuditNotifiers().Return(false).AnyTimes()
 
 	suite.resolver = &resolvers.Resolver{
 		ClusterDataStore:        suite.clusterDataStore,
@@ -58,6 +63,7 @@ func (suite *CVEScopingTestSuite) SetupTest() {
 		NodeGlobalDataStore:     suite.nodeDataStore,
 		ImageComponentDataStore: suite.componentDataStore,
 		CVEDataStore:            suite.cveDataStore,
+		AuditLogger:             audit.New(notifierMock),
 	}
 
 	suite.handler = newHandler(suite.resolver)

--- a/central/graphql/resolvers/resolver.go
+++ b/central/graphql/resolvers/resolver.go
@@ -10,6 +10,7 @@ import (
 	activeComponent "github.com/stackrox/rox/central/activecomponent/datastore"
 	violationsDatastore "github.com/stackrox/rox/central/alert/datastore"
 	"github.com/stackrox/rox/central/apitoken/backend"
+	"github.com/stackrox/rox/central/audit"
 	clusterDatastore "github.com/stackrox/rox/central/cluster/datastore"
 	clusterCVEEdgeDataStore "github.com/stackrox/rox/central/clustercveedge/datastore"
 	"github.com/stackrox/rox/central/compliance/aggregation"
@@ -35,6 +36,7 @@ import (
 	npDS "github.com/stackrox/rox/central/networkpolicies/datastore"
 	nodeDataStore "github.com/stackrox/rox/central/node/globaldatastore"
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
+	"github.com/stackrox/rox/central/notifier/processor"
 	podDatastore "github.com/stackrox/rox/central/pod/datastore"
 	policyDatastore "github.com/stackrox/rox/central/policy/datastore"
 	baselineStore "github.com/stackrox/rox/central/processbaseline/datastore"
@@ -51,6 +53,7 @@ import (
 	vulnReqService "github.com/stackrox/rox/central/vulnerabilityrequest/service"
 	watchedImageDataStore "github.com/stackrox/rox/central/watchedimage/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	auditPkg "github.com/stackrox/rox/pkg/audit"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/or"
@@ -101,6 +104,7 @@ type Resolver struct {
 	vulnReqMgr                  vulnReqManager.Manager
 	vulnReqService              vulnReqService.Service
 	vulnReqStore                vulnReqDataStore.DataStore
+	AuditLogger                 auditPkg.Auditor
 }
 
 // New returns a Resolver wired into the relevant data stores
@@ -148,6 +152,7 @@ func New() *Resolver {
 		vulnReqMgr:                  vulnReqManager.Singleton(),
 		vulnReqService:              vulnReqService.Singleton(),
 		vulnReqStore:                vulnReqDataStore.Singleton(),
+		AuditLogger:                 audit.New(processor.Singleton()),
 	}
 	return resolver
 }

--- a/central/graphql/resolvers/vulnerability_requests.go
+++ b/central/graphql/resolvers/vulnerability_requests.go
@@ -13,6 +13,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/grpc/authz/interceptor"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/paginated"
@@ -77,6 +78,19 @@ func init() {
 	)
 }
 
+// processWithAuditLog runs handler and logs to the audit log pipeline (assuming there is a notifier setup for audit logging).
+// It logs details of the request and if there was an error. processWithAuditLog will return the response and error directly
+// from handler. You may need to cast it back to your desired type.
+// This is required because currently audit logs are only automatically added for GRPC calls and not GraphQL.
+// However, mutating calls should also log. This is a workaround for this limitation.
+func (resolver *Resolver) processWithAuditLog(ctx context.Context, req interface{}, method string, handler func() (interface{}, error)) (interface{}, error) {
+	resp, err := handler()
+	if resolver.AuditLogger != nil {
+		go resolver.AuditLogger.SendAdhocAuditMessage(ctx, req, method, interceptor.AuthStatus{}, err)
+	}
+	return resp, err
+}
+
 // DeferVulnerability starts the  workflow to defer a vulnerability.
 func (resolver *Resolver) DeferVulnerability(
 	ctx context.Context,
@@ -87,14 +101,23 @@ func (resolver *Resolver) DeferVulnerability(
 	if !features.VulnRiskManagement.Enabled() {
 		return nil, errors.New("Vulnerability Risk Management is not enabled")
 	}
-	if err := writeVulnerabilityRequests(ctx); err != nil {
+
+	resp, err := resolver.processWithAuditLog(ctx, args.Request.AsV1DeferralRequest(), "DeferVulnerability", func() (interface{}, error) {
+		if err := writeVulnerabilityRequests(ctx); err != nil {
+			return nil, err
+		}
+		response, err := resolver.vulnReqService.DeferVulnerability(ctx, args.Request.AsV1DeferralRequest())
+		if err != nil {
+			return nil, err
+		}
+		return resolver.wrapVulnerabilityRequest(response.GetRequestInfo(), err)
+	})
+
+	if resp == nil {
 		return nil, err
 	}
-	response, err := resolver.vulnReqService.DeferVulnerability(ctx, args.Request.AsV1DeferralRequest())
-	if err != nil {
-		return nil, err
-	}
-	return resolver.wrapVulnerabilityRequest(response.GetRequestInfo(), err)
+
+	return resp.(*VulnerabilityRequestResolver), err
 }
 
 // MarkVulnerabilityFalsePositive starts the workflow to mark a vulnerability as false-positive.
@@ -108,14 +131,23 @@ func (resolver *Resolver) MarkVulnerabilityFalsePositive(
 	if !features.VulnRiskManagement.Enabled() {
 		return nil, errors.New("Vulnerability Risk Management is not enabled")
 	}
-	if err := writeVulnerabilityRequests(ctx); err != nil {
+
+	resp, err := resolver.processWithAuditLog(ctx, args.Request.AsV1FalsePositiveRequest(), "MarkVulnerabilityFalsePositive", func() (interface{}, error) {
+		if err := writeVulnerabilityRequests(ctx); err != nil {
+			return nil, err
+		}
+		response, err := resolver.vulnReqService.FalsePositiveVulnerability(ctx, args.Request.AsV1FalsePositiveRequest())
+		if err != nil {
+			return nil, err
+		}
+		return resolver.wrapVulnerabilityRequest(response.GetRequestInfo(), err)
+	})
+
+	if resp == nil {
 		return nil, err
 	}
-	response, err := resolver.vulnReqService.FalsePositiveVulnerability(ctx, args.Request.AsV1FalsePositiveRequest())
-	if err != nil {
-		return nil, err
-	}
-	return resolver.wrapVulnerabilityRequest(response.GetRequestInfo(), err)
+
+	return resp.(*VulnerabilityRequestResolver), err
 }
 
 // ApproveVulnerabilityRequest approves the vulnerability request with the specified ID.
@@ -131,19 +163,28 @@ func (resolver *Resolver) ApproveVulnerabilityRequest(
 	if !features.VulnRiskManagement.Enabled() {
 		return nil, errors.New("Vulnerability Risk Management is not enabled")
 	}
-	if err := writeVulnerabilityApprovals(ctx); err != nil {
+
+	approveReq := &v1.ApproveVulnRequest{
+		Id:      string(args.RequestID),
+		Comment: args.Comment,
+	}
+
+	resp, err := resolver.processWithAuditLog(ctx, approveReq, "ApproveVulnerabilityRequest", func() (interface{}, error) {
+		if err := writeVulnerabilityApprovals(ctx); err != nil {
+			return nil, err
+		}
+		response, err := resolver.vulnReqService.ApproveVulnerabilityRequest(ctx, approveReq)
+		if err != nil {
+			return nil, err
+		}
+		return resolver.wrapVulnerabilityRequest(response.GetRequestInfo(), err)
+	})
+
+	if resp == nil {
 		return nil, err
 	}
-	response, err := resolver.vulnReqService.ApproveVulnerabilityRequest(
-		ctx,
-		&v1.ApproveVulnRequest{
-			Id:      string(args.RequestID),
-			Comment: args.Comment,
-		})
-	if err != nil {
-		return nil, err
-	}
-	return resolver.wrapVulnerabilityRequest(response.GetRequestInfo(), err)
+
+	return resp.(*VulnerabilityRequestResolver), err
 }
 
 // DenyVulnerabilityRequest denies the vulnerability request with the specified ID.
@@ -159,19 +200,28 @@ func (resolver *Resolver) DenyVulnerabilityRequest(
 	if !features.VulnRiskManagement.Enabled() {
 		return nil, errors.New("Vulnerability Risk Management is not enabled")
 	}
-	if err := writeVulnerabilityApprovals(ctx); err != nil {
+
+	denyReq := &v1.DenyVulnRequest{
+		Id:      string(args.RequestID),
+		Comment: args.Comment,
+	}
+
+	resp, err := resolver.processWithAuditLog(ctx, denyReq, "DenyVulnerabilityRequest", func() (interface{}, error) {
+		if err := writeVulnerabilityApprovals(ctx); err != nil {
+			return nil, err
+		}
+		response, err := resolver.vulnReqService.DenyVulnerabilityRequest(ctx, denyReq)
+		if err != nil {
+			return nil, err
+		}
+		return resolver.wrapVulnerabilityRequest(response.GetRequestInfo(), err)
+	})
+
+	if resp == nil {
 		return nil, err
 	}
-	response, err := resolver.vulnReqService.DenyVulnerabilityRequest(
-		ctx,
-		&v1.DenyVulnRequest{
-			Id:      string(args.RequestID),
-			Comment: args.Comment,
-		})
-	if err != nil {
-		return nil, err
-	}
-	return resolver.wrapVulnerabilityRequest(response.GetRequestInfo(), err)
+
+	return resp.(*VulnerabilityRequestResolver), err
 }
 
 // UpdateVulnerabilityRequest updates the vulnerability request with specified ID. Currently, only the expiry of a deferral request can be updated.
@@ -188,20 +238,30 @@ func (resolver *Resolver) UpdateVulnerabilityRequest(
 	if !features.VulnRiskManagement.Enabled() {
 		return nil, errors.New("Vulnerability Risk Management is not enabled")
 	}
-	if err := writeVulnerabilityRequestsOrApprovals(ctx); err != nil {
-		return nil, err
-	}
 
 	updateReq := &v1.UpdateVulnRequest{
 		Id:      string(args.RequestID),
 		Comment: args.Comment,
 		Expiry:  args.Expiry.AsRequestExpiry(),
 	}
-	response, err := resolver.vulnReqService.UpdateVulnerabilityRequest(ctx, updateReq)
-	if err != nil {
+
+	resp, err := resolver.processWithAuditLog(ctx, updateReq, "UpdateVulnerabilityRequest", func() (interface{}, error) {
+		if err := writeVulnerabilityRequestsOrApprovals(ctx); err != nil {
+			return nil, err
+		}
+
+		response, err := resolver.vulnReqService.UpdateVulnerabilityRequest(ctx, updateReq)
+		if err != nil {
+			return nil, err
+		}
+		return resolver.wrapVulnerabilityRequest(response.GetRequestInfo(), err)
+	})
+
+	if resp == nil {
 		return nil, err
 	}
-	return resolver.wrapVulnerabilityRequest(response.GetRequestInfo(), err)
+
+	return resp.(*VulnerabilityRequestResolver), err
 }
 
 // UndoVulnerabilityRequest undoes/retires the vulnerability request with specified ID. This action does not delete the vulnerability request.
@@ -214,14 +274,24 @@ func (resolver *Resolver) UndoVulnerabilityRequest(
 	if !features.VulnRiskManagement.Enabled() {
 		return nil, errors.New("Vulnerability Risk Management is not enabled")
 	}
-	if err := writeVulnerabilityRequestsOrApprovals(ctx); err != nil {
+
+	resID := &v1.ResourceByID{Id: string(args.RequestID)}
+	resp, err := resolver.processWithAuditLog(ctx, resID, "UndoVulnerabilityRequest", func() (interface{}, error) {
+		if err := writeVulnerabilityRequestsOrApprovals(ctx); err != nil {
+			return nil, err
+		}
+		response, err := resolver.vulnReqService.UndoVulnerabilityRequest(ctx, resID)
+		if err != nil {
+			return nil, err
+		}
+		return resolver.wrapVulnerabilityRequest(response.GetRequestInfo(), err)
+	})
+
+	if resp == nil {
 		return nil, err
 	}
-	response, err := resolver.vulnReqService.UndoVulnerabilityRequest(ctx, &v1.ResourceByID{Id: string(args.RequestID)})
-	if err != nil {
-		return nil, err
-	}
-	return resolver.wrapVulnerabilityRequest(response.GetRequestInfo(), err)
+
+	return resp.(*VulnerabilityRequestResolver), err
 }
 
 // DeleteVulnerabilityRequest deletes the vulnerability request with specified ID.
@@ -234,14 +304,24 @@ func (resolver *Resolver) DeleteVulnerabilityRequest(
 	if !features.VulnRiskManagement.Enabled() {
 		return false, errors.New("Vulnerability Risk Management is not enabled")
 	}
-	if err := writeVulnerabilityRequests(ctx); err != nil {
+
+	resID := &v1.ResourceByID{Id: string(args.RequestID)}
+	resp, err := resolver.processWithAuditLog(ctx, resID, "DeleteVulnerabilityRequest", func() (interface{}, error) {
+		if err := writeVulnerabilityRequests(ctx); err != nil {
+			return false, err
+		}
+		_, err := resolver.vulnReqService.DeleteVulnerabilityRequest(ctx, resID)
+		if err != nil {
+			return false, err
+		}
+		return true, err
+	})
+
+	if resp == nil {
 		return false, err
 	}
-	_, err := resolver.vulnReqService.DeleteVulnerabilityRequest(ctx, &v1.ResourceByID{Id: string(args.RequestID)})
-	if err != nil {
-		return false, err
-	}
-	return true, err
+
+	return resp.(bool), err
 }
 
 // VulnerabilityRequest returns the vulnerability request with specified ID.

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -3,10 +3,12 @@ package audit
 import (
 	"context"
 
+	"github.com/stackrox/rox/pkg/grpc/authz/interceptor"
 	"google.golang.org/grpc"
 )
 
 // Auditor implements a unary server interceptor
 type Auditor interface {
 	UnaryServerInterceptor() func(context.Context, interface{}, *grpc.UnaryServerInfo, grpc.UnaryHandler) (interface{}, error)
+	SendAdhocAuditMessage(ctx context.Context, req interface{}, grpcMethod string, authError interceptor.AuthStatus, requestError error)
 }


### PR DESCRIPTION
## Description

A detailed explanation of the changes in your PR.

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

Manual:

Setup an echo server and use that as a generic webhook with audit logs enabled

Confirmed the following don't create logs:
* Unrelated mutations (used alert comment as a test)
* Non-mutations (getVulnerabilityRequests, getImageVulnerabilities, getImage)

Confirmed that regular REST API only logs one (i.e. this change isn't double logging)

Went through each mutating flow in VM and check if it logs:

Defer:
```
{
    "audit":
    {
        "time": "2022-01-20T22:58:28.589665107Z",
        "status": "REQUEST_SUCCEEDED",
        "user":
        {
            "friendlyName": "admin",
            [...]
        },
        "request":
        {
            "endpoint": "/api/graphql?opname=deferVulnerability",
            "method": "POST",
            "payload":
            {
                "@type": "v1.DeferVulnRequest",
                "cve": "CVE-2007-6755",
                "comment": "defer",
                "scope":
                {
                    "imageScope":
                    {
                        "registry": "docker.io",
                        "remote": "vulhub/log4j",
                        "tag": ".*"
                    }
                },
                "expiresWhenFixed": true
            }
        },
        "method": "UI",
        "interaction": "CREATE"
    }
}
```

Approve:
```
{
    "audit":
    {
        "time": "2022-01-20T23:39:54.522367764Z",
        "status": "REQUEST_SUCCEEDED",
        "user":
        {
            "friendlyName": "admin",
            "permissions":
            [...]
        },
        "request":
        {
            "endpoint": "/api/graphql?opname=approveVulnerabilityRequest",
            "method": "POST",
            "payload":
            {
                "@type": "v1.ApproveVulnRequest",
                "id": "2b6bd431-d5af-40d7-9de9-0d0ba9ecc866",
                "comment": "test approve"
            }
        },
        "method": "UI",
        "interaction": "CREATE"
    }
}
```

Create FP:
```
{
    "audit":
    {
        "time": "2022-01-20T23:42:01.846940973Z",
        "status": "REQUEST_SUCCEEDED",
        "user":
        {
            "friendlyName": "admin",
            [...]
        },
        "request":
        {
            "endpoint": "/api/graphql?opname=markVulnerabilityFalsePositive",
            "method": "POST",
            "payload":
            {
                "@type": "v1.FalsePositiveVulnRequest",
                "cve": "CVE-2010-0928",
                "scope":
                {
                    "imageScope":
                    {
                        "registry": "docker.io",
                        "remote": "vulhub/log4j",
                        "tag": "2.8.1"
                    }
                },
                "comment": "fp"
            }
        },
        "method": "UI",
        "interaction": "CREATE"
    }
}
```

Update deferral:

```
{
    "audit":
    {
        "time": "2022-01-20T23:55:28.648646866Z",
        "status": "REQUEST_SUCCEEDED",
        "user":
        {
            "friendlyName": "admin",
           [...]
        },
        "request":
        {
            "endpoint": "/api/graphql?opname=updateVulnerabilityRequest",
            "method": "POST",
            "payload":
            {
                "@type": "v1.UpdateVulnRequest",
                "id": "2b4f0075-55fd-47c6-b5cb-9484f437c350",
                "comment": "update to forever",
                "expiry":
                {
                    "expiresOn": "1970-01-01T00:00:00Z"
                }
            }
        },
        "method": "UI",
        "interaction": "CREATE"
    }
}
```

Cancel Req:
```
{
    "audit":
    {
        "time": "2022-01-21T03:36:47.534162113Z",
        "status": "REQUEST_SUCCEEDED",
        "user":
        {
            "friendlyName": "admin",
            [...]
        },
        "request":
        {
            "endpoint": "/api/graphql?opname=deleteVulnerabilityRequest",
            "method": "POST",
            "payload":
            {
                "@type": "v1.ResourceByID",
                "id": "2d812028-e669-4629-b0db-d43df10957b9"
            }
        },
        "method": "UI",
        "interaction": "CREATE"
    }
}
```

Deny Req:
```
{
    "audit":
    {
        "time": "2022-01-21T03:37:48.893317483Z",
        "status": "REQUEST_SUCCEEDED",
        "user":
        {
            "friendlyName": "admin",
            [...]
        },
        "request":
        {
            "endpoint": "/api/graphql?opname=denyVulnerabilityRequest",
            "method": "POST",
            "payload":
            {
                "@type": "v1.DenyVulnRequest",
                "id": "58741943-158c-449c-9252-e635e986e15b",
                "comment": "deny"
            }
        },
        "method": "UI",
        "interaction": "CREATE"
    }
}
```

Re-observe:
```
{
    "audit":
    {
        "time": "2022-01-21T03:39:14.977685685Z",
        "status": "REQUEST_SUCCEEDED",
        "user":
        {
            "friendlyName": "admin",
            [...]
        },
        "request":
        {
            "endpoint": "/api/graphql?opname=undoVulnerabilityRequest",
            "method": "POST",
            "payload":
            {
                "@type": "v1.ResourceByID",
                "id": "397b4303-1dcc-48ae-8826-e84ef38f725e"
            }
        },
        "method": "UI",
        "interaction": "CREATE"
    }
}
```
AuthN Error:
```
{
    "audit":
    {
        "time": "2022-01-21T03:53:37.521227597Z",
        "status": "AUTH_FAILED",
        "statusReason": "credentials not found: token validation failed",
        "request":
        {
            "endpoint": "/v1/cve/requests/defer",
            "method": "POST",
            "payload":
            {
                "@type": "v1.DeferVulnRequest",
                "cve": "CVE-2007-6755",
                "scope":
                {
                    "globalScope":
                    {}
                },
                "expiresWhenFixed": true
            }
        },
        "method": "API",
        "interaction": "CREATE"
    }
}
```

Permissions Error:
```
{
    "audit":
    {
        "time": "2022-01-21T03:50:00.898695908Z",
        "status": "AUTH_FAILED",
        "statusReason":"not authorized: \\"READ_WRITE_ACCESS\\" for \\"VulnerabilityManagementApprovals\\"",
        "user":
        {
            "username": "email@stackrox.com",
            "friendlyName": "First Last (email@stackrox.com)",
            "permissions":
            {
                "resourceToAccess":
                {
                    "VulnerabilityManagementRequests": "READ_WRITE_ACCESS"
                }
            },
            "roles":
            [
                {
                    "name": "Vulnerability Management Requester",
                    "resourceToAccess":
                    {
                        "VulnerabilityManagementRequests": "READ_WRITE_ACCESS"
                    }
                }
            ]
        },
        "request":
        {
            "endpoint": "/v1/cve/requests/1ebdf701-96a7-4428-9ef5-22462a299e85/approve",
            "method": "POST",
            "payload":
            {
                "@type": "v1.ApproveVulnRequest",
                "id": "1ebdf701-96a7-4428-9ef5-22462a299e85",
                "comment": "approved"
            }
        },
        "method": "API",
        "interaction": "CREATE"
    }
}
```

Other Error:
```
{
    "audit":
    {
        "time": "2022-01-21T03:55:16.357492648Z",
        "status": "REQUEST_FAILED",
        "statusReason": "approving vulnerability request 1ebdf701-96a7-4428-9ef5-22462a299e79: vulnerability request 1ebdf701-96a7-4428-9ef5-22462a299e79 not found",
        "user":
        {
            "friendlyName": "admin",
            [..]
        },
        "request":
        {
            "endpoint": "/v1/cve/requests/1ebdf701-96a7-4428-9ef5-22462a299e79/approve",
            "method": "POST",
            "payload":
            {
                "@type": "v1.ApproveVulnRequest",
                "id": "1ebdf701-96a7-4428-9ef5-22462a299e79",
                "comment": "approved"
            }
        },
        "method": "API",
        "interaction": "CREATE"
    }
}
```

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
