### PR TITLE
Add key prop in map for group in PolicyCriteriaFieldInput

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step3/PolicyCriteriaFieldInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step3/PolicyCriteriaFieldInput.tsx
@@ -141,7 +141,7 @@ function PolicyCriteriaFieldInput({
                     </Select>
                 </FormGroup>
             );
-        case 'group':
+        case 'group': {
             /* eslint-disable react/no-array-index-key */
             return (
                 <>
@@ -155,7 +155,8 @@ function PolicyCriteriaFieldInput({
                     ))}
                 </>
             );
-        /* eslint-enable react/no-array-index-key */
+            /* eslint-enable react/no-array-index-key */
+        }
     }
     /* eslint-enable default-case */
 }


### PR DESCRIPTION
## Description

I added a block to `case 'group'` because without it, prettier did not let the second `eslint-disable` comment align with the first.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Add **Container memory limit** policy field

Does have error in console without `key` prop
![PolicyCriteriaFieldInput-group-without-key](https://user-images.githubusercontent.com/11862657/150411212-08d76645-1c6f-46d6-be37-677b48f55671.png)

Does not have error in console with `key` prop
![PolicyCriteriaFieldInput-group-with-key](https://user-images.githubusercontent.com/11862657/150411187-ef288944-1406-4db3-a799-fccc5e653556.png)
