### PR TITLE
Allow filtering commits/PRs based on milestone in `sync-release-branch.sh`

### DIFF
--- a/scripts/sync-release-branch.sh
+++ b/scripts/sync-release-branch.sh
@@ -96,10 +96,16 @@ echo 'Fetching all recent commits from GitHub ...'
 git fetch
 echo
 
+arg_milestone="${1}"
+
 # For each milestone, find all PRs attached to it. Then, for each PR that is closed, find the "merge" event and
 # retrieve the associated commit hash. Then analyze whether this commit has already been cherry-picked or otherwise
 # made it onto the branch.
 for milestone in "${milestones[@]}"; do
+  if [[ -n "$arg_milestone" && "$milestone" != "$arg_milestone" ]]; then
+    echo "Skipping milestone ${milestone} ..."
+    continue
+  fi
   echo "Analyzing PRs/commits for milestone ${milestone} ..."
   milestone_prs="$(gh_curl '/search/issues?q=repo:stackrox/stackrox+is:pr+milestone:"'"$milestone"'"')"
 


### PR DESCRIPTION
## Description

Our [release documentation](https://stack-rox.atlassian.net/wiki/spaces/ENGKB/pages/2138832897/How+to+manage+a+release#Creating-new-RCs%3A) suggests a gap in the functionality of `sync-release-branch.sh` script (see the highlighted comment in confluence).

This change adds support for a parameter to the `sync-release-branch.sh` that allows to filter the commits/PRs for a single Github milestone.

## Checklist
- ~~[ ] Investigated and inspected CI test results~~
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~

## Testing Performed

- [x] by running the script locally


### Example runs

#### Milestone rc.3 is empty, but rc.2 has commits

```
$  ./scripts/sync-release-branch.sh 68.0-rc.3
Release family names: 3.68.x, 68.x
Searching GitHub milestones ...
Found milestones:
 - 68.0-rc.2
 - 68.0-rc.3
Fetching all recent commits from GitHub ...

Skipping milestone 68.0-rc.2 ...
Analyzing PRs/commits for milestone 68.0-rc.3 ...

No commits require cherry-picking at this point!
HOWEVER, there are still the following unclosed PRs:
 - #348 by vikin91: RS-419: Make rhacs default flavor for `roxctl helm output`
```

```
$ ./scripts/sync-release-branch.sh 68.0-rc.2
Release family names: 3.68.x, 68.x
Searching GitHub milestones ...
Found milestones:
 - 68.0-rc.2
 - 68.0-rc.3
Fetching all recent commits from GitHub ...

Analyzing PRs/commits for milestone 68.0-rc.2 ...
Skipping milestone 68.0-rc.3 ...


The following commits require cherry-picking:
 - ba64bb62fa309782947e1682ea3ba0d9ad7da58d (ROX-9016 Use kernel module on openshift 3.11 (#376))
 - 50a06a6afd304784c11855d57e56093ece6ea485 (Return nil vuln req instead of empty (#384))
 - bb6ee77055462ec2b702dd973b21a4a7c7848dc9 (Do not refetch image metadata unless the object has changed (#182))
 - 750601d18f6f24430da35c9d2c143b87acb1b74a (Ensure that states are set correctly based on remaining vuln reqs (#388))
 - cccf471f12545cf24602eebfd6ef37709c29fe4c (refactoring: using the new GraphQL resolver to get vuln requests for image vulns (#381))
 - 5230175726e852bd59887a9a10ba1a973a7b7369 (Update MaxParallelImageScanInternal default value to 30 (#390))
 - c029e82db7a1080d2bf5987e119aa5c795230312 (Fix report bugs for release (#389))
 - 437586eca7da93a8b2f6f7f2845b6e0b0d50ed6c (ROX-9072: Audit logs are not generated for vuln management mutation requests (#385))
 - 7e27db5fd54d64ba61769e68b7fd6a628be24e0d (ROX-9008,ROX-9050,ROX-9051: Vuln report query pagination, support multiple recipients for gmail server (#375))

Copy-pastable command:

  git cherry-pick -x \
    ba64bb62fa309782947e1682ea3ba0d9ad7da58d   `# ROX-9016 Use kernel module on openshift 3.11 (#376)` \
    50a06a6afd304784c11855d57e56093ece6ea485   `# Return nil vuln req instead of empty (#384)` \
    bb6ee77055462ec2b702dd973b21a4a7c7848dc9   `# Do not refetch image metadata unless the object has changed (#182)` \
    750601d18f6f24430da35c9d2c143b87acb1b74a   `# Ensure that states are set correctly based on remaining vuln reqs (#388)` \
    cccf471f12545cf24602eebfd6ef37709c29fe4c   `# refactoring: using the new GraphQL resolver to get vuln requests for image vulns (#381)` \
    5230175726e852bd59887a9a10ba1a973a7b7369   `# Update MaxParallelImageScanInternal default value to 30 (#390)` \
    c029e82db7a1080d2bf5987e119aa5c795230312   `# Fix report bugs for release (#389)` \
    437586eca7da93a8b2f6f7f2845b6e0b0d50ed6c   `# ROX-9072: Audit logs are not generated for vuln management mutation requests (#385)` \
    7e27db5fd54d64ba61769e68b7fd6a628be24e0d   `# ROX-9008,ROX-9050,ROX-9051: Vuln report query pagination, support multiple recipients for gmail server (#375)` \
    ;
```