### PR TITLE
Fix `sed` expression in `roxctl-windows-test`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4380,7 +4380,7 @@ jobs:
             cd go/src/github.com/stackrox/rox
             version_from_yaml="$(grep -rnw -e 'image.*main' rox-k8s-bundle/central | sed -E 's/.*main.*:([^" ]+).*/\1/g')"
             version_from_roxctl="$(./bin/windows/roxctl.exe version)"
-            echo "Versions: from YAML ${version_from_yaml}; from roxctl ${version_from_roxctl}"
+            printf "Versions:\n  from YAML: %s\nfrom roxctl: %s\n" "${version_from_yaml}" "${version_from_roxctl}"
             test "${version_from_yaml}" = "${version_from_roxctl}"
 
   race-condition-tests:


### PR DESCRIPTION
## Description

The previous expression expected the image tag to immediately follow `main`:  `registry/main:<TAG>`.
This did not support our RH registries: `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.68.0-rc.2`.
This PR fixes the `sed` expression.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~

If any of these don't apply, please comment below.

## Testing Performed

- [x] CI
- [x] locally with:

```shell
# old expression
echo 'rox-k8s-bundle/central/01-central-12-deployment.yaml:64:        image: "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.68.0-rc.2"' | sed -E 's/.*main:([^" ]+).*/\1/g'
rox-k8s-bundle/central/01-central-12-deployment.yaml:64:        image: "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.68.0-rc.2"

# new expression
$ echo 'rox-k8s-bundle/central/01-central-12-deployment.yaml:64:        image: "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.68.0-rc.2"' | sed -E 's/.*main.*:([^" ]+).*/\1/g'
3.68.0-rc.2
```
