### PR TITLE
ROX-8529: Add validation for policy wizard step 3

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/policyValidationSchemas.ts
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/policyValidationSchemas.ts
@@ -17,7 +17,33 @@ const validationSchema2 = yup.object().shape({
         .min(1, 'At least one lifecycle state is required'), // TODO redundant? .required('Lifecycle stage is required'),
 });
 
-const validationSchema3 = yup.object().shape({}); // TODO
+const validationSchema3 = yup.object().shape({
+    policySections: yup
+        .array()
+        .of(
+            yup.object().shape({
+                policyGroups: yup
+                    .array()
+                    .of(
+                        yup.object().shape({
+                            fieldName: yup.string().trim().required(),
+                            booleanOperator: yup.string().trim().oneOf(['OR', 'AND']),
+                            negate: yup.boolean(),
+                            values: yup
+                                .array()
+                                .of(
+                                    yup.object().shape({
+                                        value: yup.string().trim().required(),
+                                    })
+                                )
+                                .min(1),
+                        })
+                    )
+                    .min(1),
+            })
+        )
+        .min(1),
+});
 
 const validationSchema4 = yup.object().shape({}); // TODO
 


### PR DESCRIPTION
## Description

Minimum validation to require at least one policy criterion

* `policySections` array has at least one item
* `policyGroups` array has at least one item
* `values` array has at least one item
* `value` property has non-empty string value

### Residue

* Validate temporary option `key` value for **Container memory limit** and so on?
* Is default `max = 10` correct for **Container memory limit** and so on?
* Validate `value` according to backend regexp? Or is input type for `type: "number"` like **Image age** enough?
* Delete `fieldKey` from policy group objects before request
* Merge `key` property into `value` at least before request
* Display backend validation error in preview panel if dry run request fails immediately

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### PatternFly

1. Start Platform UI

    * `export ROX_POLICIES_PATTERNFLY=true`
    * `yarn deploy-local`
    * `yarn start`

2. /main/policies-pf/?action=create, selected Deploy lifecycle stage, and then on step 3

3. **Next** button is disabled because `policySections` array has no items
    ![3-Next-disabled](https://user-images.githubusercontent.com/11862657/150541631-b52ee482-f740-4a05-9e98-16539d08f08e.png)

4. Click **Add new condition** and **Next** button is disabled because `policyGroups` has no items

5. Drop **Image registry** which has `type: 'text'` and **Next** button is disabled because `value` has empty string value

6. Type **docker.io** and **Next** button is enabled because `value` has non-empty string value
    ![6-Next-enabled](https://user-images.githubusercontent.com/11862657/150541679-3bc1c15e-c406-4e8b-ae03-dc64a984545c.png)

7. Click trash to delete **Image registry** group and **Next** is disabled because `policyGroups` has no items

8. Drop **Image age** which has `type: "number"` type **2** and **Next** button is enabled

9. Drop **Container memory limit** which has `type: 'group'` type a number but do not select and **Next** button is enabled

10. Click **Next** and click **Next** and see `value: "10"` in dry run request with no errors, therefore is equal a default option?

### classic

Verify in classic wizard for DEPLOY that the following require non-empty string for `value` property:

1. Image registry
    * Image registry
    * Image remote
    * Image tag
2. Image contents
    * Image age
    * Image scan age
    * Image user
    * Dockerfile line
    * Unscanned image: **success** with default value `"true"`
    * CVSS: failure with default value `"undefined "`
    * Severity: failure with default value `"undefined "`
    * Fixed by
    * CVE
    * Image component
    * Image OS
    * Require image label
    * Disallowed image label
3. Container configuration
    * Environment variable: **success** with default value `"=undefined="` but is it a bug?
    * Container CPU request: failure with default value `"undefined "`
    * Container CPU limit: failure with default value `"undefined "`
    * Container memory request: failure with default value `"undefined "`
    * Container memory limit: failure with default value `"undefined "`
    * Privileged container: **success** with default value `"true"`
    * Read-only root filesystem: **success** with default value `"false"`
    * Seccomp profile type
    * Drop capabilities
    * Add capabilities
    * Container name
    * AppArmor profile
4. Deployment metadata
    * Disallowed annotation
    * Required label
    * Required annotation
    * Runtime class
    * Host network: **success** with default value `"true"`
    * Host PID: **success** with default value `"true"`
    * Host IPC: **success** with default value `"true"`
    * Namespace
5. Storage
    * Volume name
    * Volume source
    * Volume destination
    * Volume type
    * Writable mounted volumn: **success** with default value `"false"`
    * Mount propagation
    * Writable host mount: **success** with default value `"false"`
6. Networking
    * Exposed port protocol
    * Exposed node port
    * Exposed port
    * Port exposure method
    * Unexpected network flow detected: TODO RUNTIME only
7. Process activity
    * Process name
    * Process ancestor
    * Process arguments
    * Process UID
    * Unexpected process executed: TODO RUNTIME only
8. Kubernetes access
    * Service account
    * Automount service account token: **success** with default value `"false"`
    * Minimum RBAC permissions
9. Kubernetes events
    * Kubernetes action
    * Kubernetes user name
    * Kubernetes user groups

Here is the failure in classic code:

```js
export function parseNumericComparisons(str) { // `"undefined "`
    const matches = str.match(numericCompRe);
    return [matches[1], matches[2]]; // TypeError: Cannot read properties of null
}
```