### PR TITLE
fix: pending approvals page was crashing

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/VulnRequestedAction/VulnRequestedAction.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/VulnRequestedAction/VulnRequestedAction.tsx
@@ -7,7 +7,7 @@ import { getDistanceStrict } from 'utils/dateUtils';
 export type VulnRequestedActionProps = {
     targetState: VulnerabilityState;
     requestStatus: RequestStatus;
-    deferralReq: DeferralRequest;
+    deferralReq: DeferralRequest | null;
     updatedDeferralReq?: DeferralRequest;
     currentDate: Date;
 };
@@ -34,11 +34,13 @@ function VulnRequestedAction({
         type = 'Deferral';
     }
 
-    // if "updatedDeferralReq" is not passed then default to "deferralReq"
-    const { expiresWhenFixed, expiresOn } =
+    const chosenDeferralReq =
         requestStatus === 'APPROVED_PENDING_UPDATE' && updatedDeferralReq
             ? updatedDeferralReq
             : deferralReq;
+    const expiresWhenFixed = chosenDeferralReq?.expiresWhenFixed || false;
+    const expiresOn = chosenDeferralReq?.expiresOn || null;
+
     if (expiresWhenFixed) {
         action = '(until fixed)';
     } else if (expiresOn) {


### PR DESCRIPTION
## Description

The pending approvals tab should not break anymore when the `deferralReq` comes back as null

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

<img width="1552" alt="Screen Shot 2022-01-21 at 10 29 53 AM" src="https://user-images.githubusercontent.com/4805485/150581043-760fef01-f982-49dc-b966-fd79ef0d2520.png">
