### PR TITLE
Fix updating deferral requests in GraphQL API to and from indefinite expiry time

### DIFF
--- a/central/graphql/resolvers/inputtypes/vuln_req.go
+++ b/central/graphql/resolvers/inputtypes/vuln_req.go
@@ -16,10 +16,7 @@ type VulnReqExpiry struct {
 // AsRequestExpiry converts vulnerability request expiry to proto.
 func (re *VulnReqExpiry) AsRequestExpiry() *storage.RequestExpiry {
 	if re == nil {
-		return nil
-	}
-	if re.ExpiresWhenFixed == nil && re.ExpiresOn == nil {
-		return nil
+		return &storage.RequestExpiry{}
 	}
 
 	ret := &storage.RequestExpiry{}
@@ -27,13 +24,10 @@ func (re *VulnReqExpiry) AsRequestExpiry() *storage.RequestExpiry {
 		ret.Expiry = &storage.RequestExpiry_ExpiresWhenFixed{
 			ExpiresWhenFixed: true,
 		}
-	} else {
-		if re.ExpiresOn == nil {
-			return nil
-		}
+	} else if re.ExpiresOn != nil {
 		ts := protoconv.ConvertTimeToTimestampOrNil(re.ExpiresOn.Time)
 		if ts == nil {
-			return nil
+			return &storage.RequestExpiry{}
 		}
 		ret.Expiry = &storage.RequestExpiry_ExpiresOn{
 			ExpiresOn: ts,

--- a/central/graphql/resolvers/inputtypes/vuln_req_test.go
+++ b/central/graphql/resolvers/inputtypes/vuln_req_test.go
@@ -74,17 +74,17 @@ func (s *VulnReqInputResolversTestSuite) TestAsRequestExpiry() {
 				ExpiresWhenFixed: boolPtr(false),
 				ExpiresOn:        nil,
 			},
-			expectedExpiry: nil,
+			expectedExpiry: &storage.RequestExpiry{},
 		},
 		{
 			name:           "Never expiring with nil VulnReqExpiry",
 			input:          nil,
-			expectedExpiry: nil,
+			expectedExpiry: &storage.RequestExpiry{},
 		},
 		{
 			name:           "Never expiring with empty VulnReqExpiry",
 			input:          &VulnReqExpiry{},
-			expectedExpiry: nil,
+			expectedExpiry: &storage.RequestExpiry{},
 		},
 		{
 			name: "Expiring at zero time",

--- a/central/vulnerabilityrequest/service/service_impl.go
+++ b/central/vulnerabilityrequest/service/service_impl.go
@@ -201,6 +201,11 @@ func (s *serviceImpl) DenyVulnerabilityRequest(ctx context.Context, req *v1.Deny
 }
 
 func (s *serviceImpl) UpdateVulnerabilityRequest(ctx context.Context, req *v1.UpdateVulnRequest) (*v1.UpdateVulnRequestResponse, error) {
+	// Currently, only deferral requests can be updated
+	if req.GetExpiry() == nil {
+		return nil, errors.Wrap(errorhelpers.ErrInvalidArgs, "nothing to update for request - at least expiry must be provided")
+	}
+
 	requestInfo, err := s.datastore.UpdateRequestExpiry(ctx, req.GetId(), req.GetComment(), req.GetExpiry())
 	if err != nil {
 		return nil, errors.Wrapf(err, "updating vulnerability request %s", req.GetId())


### PR DESCRIPTION
## Description

Due to the fact that the UI passes in null/empty objects if expiry doesn't apply (indefinite or expires when fixed), the validation logic is incorrect. This prevents updating requests to and from indefinite expiry.  This only impacts the GraphQL APIs. 

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed

CI + Manual. For manual I stepped through each combination. Confirmed that the REST endpoint continues to work as it did before

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
