### PR TITLE
Allow users to cancel a pending update deferral request

### DIFF
--- a/central/vulnerabilityrequest/datastore/datastore_impl.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl.go
@@ -350,15 +350,26 @@ func (ds *datastoreImpl) RemoveRequest(ctx context.Context, id string) error {
 		return errors.Wrap(sac.ErrResourceAccessDenied, "requests can only be cancelled by the original requester")
 	}
 
-	if req.GetStatus() != storage.RequestStatus_PENDING {
-		return errors.New("only pending vulnerability requests can be cancelled")
-	}
+	switch req.GetStatus() {
+	case storage.RequestStatus_PENDING:
+		if err := ds.store.Delete(id); err != nil {
+			return err
+		}
+		if err := ds.index.DeleteVulnerabilityRequest(id); err != nil {
+			return err
+		}
 
-	if err := ds.store.Delete(id); err != nil {
-		return err
-	}
-	if err := ds.index.DeleteVulnerabilityRequest(id); err != nil {
-		return err
+	case storage.RequestStatus_APPROVED_PENDING_UPDATE:
+		// Removing a request should take it back to its previous state. In the case of a pending update, that means
+		// back to original deferral. Since the original request object maintains the original state, it can't be simply removed
+		req.Status = storage.RequestStatus_APPROVED
+		req.UpdatedReq = nil
+		if err := ds.store.Upsert(req); err != nil {
+			return err
+		}
+		if err := ds.index.AddVulnerabilityRequest(req); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/central/vulnerabilityrequest/datastore/datastore_impl_test.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl_test.go
@@ -498,3 +498,21 @@ func (s *VulnRequestDataStoreTestSuite) TestOnlyRequesterWithWriteCannotRemoveOt
 		s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	}
 }
+
+func (s *VulnRequestDataStoreTestSuite) TestRemoveRequestsPendingUpdate() {
+	req := &storage.VulnerabilityRequest{
+		Requestor:  &storage.SlimUser{Id: fakeUserID},
+		Expired:    false,
+		Status:     storage.RequestStatus_APPROVED_PENDING_UPDATE,
+		UpdatedReq: &storage.VulnerabilityRequest_UpdatedDeferralReq{},
+	}
+	s.mockStore.EXPECT().Get("id").Return(req, true, nil)
+	s.mockIndexer.EXPECT().AddVulnerabilityRequest(gomock.Any()).Return(nil)
+	s.mockStore.EXPECT().Upsert(gomock.Any()).Do(func(req *storage.VulnerabilityRequest) {
+		s.Equal(storage.RequestStatus_APPROVED, req.GetStatus())
+		s.Nil(req.UpdatedReq)
+	}).Return(nil)
+
+	err := s.datastore.RemoveRequest(authn.ContextWithIdentity(selfApproverAllSac, s.mockIdentity, s.T()), "id")
+	s.NoError(err)
+}

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -124,8 +124,8 @@ func (m *managerImpl) Delete(ctx context.Context, id string) error {
 		return err
 	}
 	m.pendingReqCache.Remove(id)
-	// Although we do not allow deleting active requests, it is safe to visit active cache. It is inexpensive.
-	m.activeReqCache.Remove(id)
+	// We do not allow deleting active requests. Only pending requests and pending request updates can be removed.
+	// Hence, skip the active cache.
 	return nil
 }
 

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_cache_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_cache_test.go
@@ -104,7 +104,6 @@ func TestVulnReqCacheUpdatesForDelete(t *testing.T) {
 	expected := fixtures.GetImageScopeDeferralRequest("r", "r", "g", "cve")
 	vulnReqDS.EXPECT().RemoveRequest(allAccessCtx, expected.GetId()).Return(nil)
 	pendingReqCache.EXPECT().Remove(expected.GetId())
-	activeReqCache.EXPECT().Remove(expected.GetId())
 
 	assert.NoError(t, manager.Delete(allAccessCtx, expected.GetId()))
 }


### PR DESCRIPTION
## Description

Currently cannot cancel a pending request. An approver has to Deny it instead which works but isn't ideal. This change will allow users to cancel, which will just remove the pending part and take it back to the previous state (an approved req).

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed

Unit test + Manual

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/9895898/154557826-7b180689-332a-4a96-acc1-fd7b9db38928.png">

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/9895898/154558448-8382ea2e-d730-4322-a655-349afee00589.png">

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/9895898/154558494-a81d3f5a-909a-469e-8b67-a993a700c1ca.png">

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/9895898/154558725-7f22def0-4197-4eb1-a43f-6a1085348bae.png">
