### PR TITLE
Synchronously save images scanned internally

### DIFF
--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -215,8 +215,9 @@ func (s *serviceImpl) ScanImageInternal(ctx context.Context, request *v1.ScanIma
 		// even if we weren't able to enrich it
 	}
 
-	img.Id = utils.GetImageID(img)
-	if img.GetId() != "" {
+	// Due to discrepancies in digests retrieved from metadata pulls and k8s, only upsert if the request
+	// contained a digest
+	if request.GetImage().GetId() != "" {
 		if err := s.riskManager.CalculateRiskAndUpsertImage(img); err != nil {
 			log.Errorf("error upserting image %q: %v", img.GetName().GetFullName(), err)
 		}


### PR DESCRIPTION
## Description

Unless we are getting a large number of untagged images, saving images synchronously only adds potentially hundreds of ms after we already did an image scan which can take in the order of seconds. This helps reduce memory pressure by having fewer copies of images in mem

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

Testing and scale