### PR TITLE
ROX-7855: Fix data race, use a lock for in memory timestamp map updates in the health reporter

### DIFF
--- a/central/integrationhealth/reporter/health_reporter_impl.go
+++ b/central/integrationhealth/reporter/health_reporter_impl.go
@@ -79,8 +79,12 @@ func (d *DatastoreBasedIntegrationHealthReporter) RemoveIntegrationHealth(id str
 	if err := d.integrationDS.RemoveIntegrationHealth(allAccessCtx, id); err != nil {
 		return errors.Wrapf(err, "Error removing health for integration %s", id)
 	}
-	d.healthRemoval <- id
-	return nil
+	select {
+	case d.healthRemoval <- id:
+		return nil
+	case <-d.stopSig.Done():
+		return nil
+	}
 }
 
 // UpdateIntegrationHealthAsync updates the health of the integration


### PR DESCRIPTION

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~


## Testing Performed
Automated and manual

On manual cluster, create new email integration with incorrect password, configure that as a notifier in a policy, generate a violation and see that the health status for that integration is unhealthy. Remove integration successfully. That action is reflected in the health reporting.