### PR TITLE
Lazily cache templates used in policy evaluation

### DIFF
--- a/pkg/booleanpolicy/violationmessages/printer/util.go
+++ b/pkg/booleanpolicy/violationmessages/printer/util.go
@@ -28,8 +28,8 @@ func (t *templateCache) Get(tpl string) *template.Template {
 }
 
 func (t *templateCache) Set(tpl string, tmpl *template.Template) {
-	t.lock.RLock()
-	defer t.lock.RUnlock()
+	t.lock.Lock()
+	defer t.lock.Unlock()
 
 	t.templates[tpl] = tmpl
 }


### PR DESCRIPTION
## Description

Lazily cache the parsed printer templates. It is thread safe to call the template.Execute multiple times

<img width="400" alt="Screen Shot 2022-01-24 at 7 22 59 PM" src="https://user-images.githubusercontent.com/2565181/150907332-1d21908e-aa11-456a-9ac3-cc5cb06735e9.png">

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

Straightforward