### PR TITLE
fix: making severity the default sorting for observed/deferred/false positive cve tables

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
@@ -21,7 +21,7 @@ function DeferredCVEs({ imageId }: DeferredCVEsProps): ReactElement {
             limit: perPage,
             offset: (page - 1) * perPage,
             sortOption: {
-                field: 'cve',
+                field: 'Severity',
                 reversed: true,
             },
         },

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
@@ -21,7 +21,7 @@ function FalsePositiveCVEs({ imageId }: FalsePositiveCVEsProps): ReactElement {
             limit: perPage,
             offset: (page - 1) * perPage,
             sortOption: {
-                field: 'cve',
+                field: 'Severity',
                 reversed: true,
             },
         },

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
@@ -21,7 +21,7 @@ function ObservedCVEs({ imageId }: ObservedCVEsProps): ReactElement {
             limit: perPage,
             offset: (page - 1) * perPage,
             sortOption: {
-                field: 'cve',
+                field: 'Severity',
                 reversed: true,
             },
         },


### PR DESCRIPTION
## Description

The sorting was not working properly before. This fixes it while also defaulting to `Severity` as it aligns with what the customer would want to sort by

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

<img width="1508" alt="Screen Shot 2022-01-25 at 9 00 39 AM" src="https://user-images.githubusercontent.com/4805485/151024420-7cfffc56-eba9-4888-b537-83f8eb60c018.png">
<img width="1552" alt="Screen Shot 2022-01-25 at 9 03 49 AM" src="https://user-images.githubusercontent.com/4805485/151024263-bcaa5147-63f0-4864-8552-781117363448.png">
<img width="1552" alt="Screen Shot 2022-01-25 at 9 04 16 AM" src="https://user-images.githubusercontent.com/4805485/151024284-cc5cfe77-6b37-4c2b-892e-8f6a820d4e04.png">
