### PR TITLE
ROX-8928: network graph quick fix for expanding/closing blue bar

### DIFF
--- a/ui/apps/platform/src/Components/DetailsOverlay/DetailsOverlay.tsx
+++ b/ui/apps/platform/src/Components/DetailsOverlay/DetailsOverlay.tsx
@@ -1,4 +1,7 @@
 import React, { ReactElement, ReactNode } from 'react';
+import * as Icon from 'react-feather';
+
+import useDetailsOverlayToggle from 'Containers/Network/SidePanel/useDetailsOverlayToggle';
 
 type DetailsOverlayProps = {
     headerText: string;
@@ -15,25 +18,45 @@ function DetailsOverlay({
     dataTestId = 'network-details-overlay',
     children,
 }: DetailsOverlayProps): ReactElement {
+    const { isContentHidden, toggleContentHidden } = useDetailsOverlayToggle();
+
     return (
         <div
             className="flex flex-1 flex-col text-sm max-h-minus-buttons rounded-bl-lg min-w-0"
             data-testid={dataTestId}
         >
-            <div className="bg-primary-800 flex items-center m-2 min-w-108 p-3 rounded-lg shadow text-primary-100">
-                <div className="flex flex-1 flex-col" data-testid={`${dataTestId}-header`}>
-                    <div className="text-base">{headerText}</div>
-                    <div className="italic text-primary-200 text-xs capitalize">
-                        {subHeaderText}
+            <div className="bg-primary-800 flex items-center m-2 min-w-108 rounded-lg shadow text-primary-100">
+                <div
+                    className="flex flex-1 items-center p-3 cursor-pointer"
+                    role="button"
+                    tabIndex={0}
+                    onKeyUp={toggleContentHidden}
+                    onClick={toggleContentHidden}
+                >
+                    <div className="mr-4">
+                        {isContentHidden ? (
+                            <Icon.ChevronRight className="h-4 w-4" />
+                        ) : (
+                            <Icon.ChevronDown className="h-4 w-4" />
+                        )}
+                    </div>
+                    <div className="flex flex-1 flex-col" data-testid={`${dataTestId}-header`}>
+                        <div className="text-base">{headerText}</div>
+                        <div className="italic text-primary-200 text-xs capitalize">
+                            {subHeaderText}
+                        </div>
                     </div>
                 </div>
+
                 {!!tabHeaderComponents.length && (
-                    <ul className="flex ml-8 items-center text-sm uppercase font-700">
+                    <ul className="flex ml-8 items-center text-sm uppercase font-700 p-3 ">
                         {tabHeaderComponents}
                     </ul>
                 )}
             </div>
-            <div className="flex flex-1 m-2 pb-1 overflow-auto rounded">{children}</div>
+            {!isContentHidden && (
+                <div className="flex flex-1 m-2 pb-1 overflow-auto rounded">{children}</div>
+            )}
         </div>
     );
 }

--- a/ui/apps/platform/src/Components/NetworkEntityTabbedOverlay/NetworkEntityTabHeader.js
+++ b/ui/apps/platform/src/Components/NetworkEntityTabbedOverlay/NetworkEntityTabHeader.js
@@ -8,9 +8,15 @@ const tabHeaderClassName =
 
 function NetworkEntityTabHeader({ title, isActive, onSelectTab, dataTestId }) {
     const className = isActive ? activeTabHeaderClassName : tabHeaderClassName;
+
+    function onSelectTabHandler(event) {
+        event.stopPropagation();
+        onSelectTab(event);
+    }
+
     return (
         <li key={title} className="ml-2 first:ml-0" data-testid={dataTestId}>
-            <button type="button" className={className} onClick={onSelectTab}>
+            <button type="button" className={className} onClick={onSelectTabHandler}>
                 {title}
             </button>
         </li>

--- a/ui/apps/platform/src/Containers/Network/SidePanel/useDetailsOverlayToggle.ts
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/useDetailsOverlayToggle.ts
@@ -1,0 +1,21 @@
+import useLocalStorage from 'hooks/useLocalStorage';
+
+type UseDetailsOverlayToggleResult = {
+    isContentHidden: boolean;
+    toggleContentHidden: () => void;
+};
+
+function useDetailsOverlayToggle(): UseDetailsOverlayToggleResult {
+    const [isContentHidden, setIsContentHidden] = useLocalStorage(
+        'networkDetailOverlayToggleValue',
+        false
+    );
+
+    function toggleContentHidden() {
+        setIsContentHidden(!isContentHidden);
+    }
+
+    return { isContentHidden, toggleContentHidden };
+}
+
+export default useDetailsOverlayToggle;


### PR DESCRIPTION
## Description

This is a quick fix for Network Graph. Added expanding/closing functionality for the overlay in Network Graph

https://issues.redhat.com/browse/ROX-8928

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

Deployment Details
<img width="1552" alt="Screen Shot 2022-01-25 at 9 36 45 AM" src="https://user-images.githubusercontent.com/4805485/151029809-831cd530-2a85-417b-8002-bb19affd7713.png">
<img width="1552" alt="Screen Shot 2022-01-25 at 9 37 36 AM" src="https://user-images.githubusercontent.com/4805485/151029831-4b4b6137-028f-4737-a6e8-a1b9ec184b44.png">

Namespace Details
<img width="1552" alt="Screen Shot 2022-01-25 at 9 51 37 AM" src="https://user-images.githubusercontent.com/4805485/151031739-bcfff20b-7a83-4a3f-becb-f093bc350e81.png">
<img width="1552" alt="Screen Shot 2022-01-25 at 9 51 40 AM" src="https://user-images.githubusercontent.com/4805485/151031759-baa4def7-2b5e-40f6-bda6-6accfbd99c78.png">

External Entities Details
<img width="1552" alt="Screen Shot 2022-01-25 at 9 51 44 AM" src="https://user-images.githubusercontent.com/4805485/151031778-dd0df6c4-2caa-4284-bc9d-5d69443cdeb2.png">
<img width="1552" alt="Screen Shot 2022-01-25 at 9 51 46 AM" src="https://user-images.githubusercontent.com/4805485/151031796-df3f91e9-8d3a-401f-81d1-d55132ffe4c9.png">
