### PR TITLE
Fix local db expansion as rocksdb_ldb may not exist

### DIFF
--- a/local/expand-db.sh
+++ b/local/expand-db.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -e
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 if [[ -z $1 ]]; then
@@ -13,6 +15,6 @@ unzip -d "${DIR}/database-restore/expanded" $1
 mkdir -p "${DIR}/database-restore/expanded/rocksdb"
 tar -xvf "${DIR}/database-restore/expanded/rocks.db" -C "${DIR}/database-restore/expanded/rocksdb"
 mkdir -p "${DIR}/database-restore/full/rocksdb"
-rocksdb_ldb --db="${DIR}/database-restore/full/rocksdb" restore --backup_dir="${DIR}/database-restore/expanded/rocksdb"
+go run "${DIR}/expand/main.go" --backup  "${DIR}/database-restore/expanded/rocksdb" --restored "${DIR}/database-restore/full/rocksdb"
 mv "${DIR}/database-restore/expanded/bolt.db" "${DIR}/database-restore/full/bolt.db"
 rm -rf "${DIR}/database-restore/expanded"

--- a/local/expand/main.go
+++ b/local/expand/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/tecbot/gorocksdb"
+)
+
+func main() {
+	var (
+		backup   string
+		restored string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "rocksdb_restore",
+		Short: "Restores rocksdb",
+		RunE: func(*cobra.Command, []string) error {
+			if backup == "" {
+				return errors.New("backup flag needs to be specified")
+			}
+			if restored == "" {
+				return errors.New("restore location needs to be specified")
+			}
+
+			fmt.Printf("Expanding database from %s to %s\n", backup, restored)
+			be, err := gorocksdb.OpenBackupEngine(gorocksdb.NewDefaultOptions(), backup)
+			if err != nil {
+				panic(err)
+			}
+			if err := be.RestoreDBFromLatestBackup(restored, restored, gorocksdb.NewRestoreOptions()); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&backup, "backup", "", "location of the rocksdb backup")
+	cmd.Flags().StringVar(&restored, "restored", "", "location to expand the new database")
+	if err := cmd.Execute(); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
## Description

Was able to expand and run
```
globaldb/dackbox: 2022/01/25 10:40:18.077308 initialize.go:178: Info: re-indexing all keys in bucket: image_vuln
globaldb/dackbox: 2022/01/25 10:40:18.131157 initialize.go:192: Info: indexing 10435 keys in bucket: image_vuln
globaldb/dackbox: 2022/01/25 10:40:22.889381 initialize.go:178: Info: re-indexing all keys in bucket: comp_to_vuln
globaldb/dackbox: 2022/01/25 10:40:23.166165 initialize.go:192: Info: indexing 95114 keys in bucket: comp_to_vuln
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

Local only
