### PR TITLE
PF Policies: Making "Review policy" dry run section collapsible

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step5/ReviewPolicyForm.css
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step5/ReviewPolicyForm.css
@@ -4,9 +4,8 @@
  * Assume alignSelfStretch (in .tsx file) so columns have equal height for border.
  */
 #policy-page .pf-l-flex.pf-m-row > .review-policy {
-    border-right-color: var(--pf-global--BorderColor--100);
-    border-right-style: solid;
-    border-right-width: var(--pf-global--BorderWidth--sm);
-    margin-right: var(--pf-global--spacer--lg); /* override --pf-l-flex--spacer which has md value */
+    margin-right: var(
+        --pf-global--spacer--lg
+    ); /* override --pf-l-flex--spacer which has md value */
     padding-right: var(--pf-global--spacer--lg);
 }

--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step5/ReviewPolicyForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step5/ReviewPolicyForm.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect, useState } from 'react';
-import { Alert, Flex, FlexItem, Spinner, Title, Divider } from '@patternfly/react-core';
+import { Alert, Flex, FlexItem, Spinner, Title, Divider, Button } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 
 import { DryRunAlert, checkDryRun, startDryRun } from 'services/PoliciesService';
@@ -21,6 +21,7 @@ type ReviewPolicyFormProps = {
 function ReviewPolicyForm({ clusters, notifiers }: ReviewPolicyFormProps): ReactElement {
     const { values } = useFormikContext<Policy>();
 
+    const [showPolicyResults, setShowPolicyResults] = useState(true);
     const [isRunningDryRun, setIsRunningDryRun] = useState(false);
     const [jobIdOfDryRun, setJobIdOfDryRun] = useState('');
     const [errorMessageFromDryRun, setErrorMessageFromDryRun] = useState('');
@@ -82,15 +83,27 @@ function ReviewPolicyForm({ clusters, notifiers }: ReviewPolicyFormProps): React
 
     /* eslint-disable no-nested-ternary */
     return (
-        <Flex direction={{ default: 'row' }}>
+        <Flex>
             <Flex
                 flex={{ default: 'flex_1' }}
                 direction={{ default: 'column' }}
                 alignSelf={{ default: 'alignSelfStretch' }}
                 className="review-policy"
             >
-                <Title headingLevel="h2">Review policy</Title>
-                <div>Review policy settings and violations.</div>
+                <Flex>
+                    <FlexItem flex={{ default: 'flex_1' }}>
+                        <Title headingLevel="h2">Review policy</Title>
+                        <div>Review policy settings and violations.</div>
+                    </FlexItem>
+                    <FlexItem className="pf-u-pr-md" alignSelf={{ default: 'alignSelfCenter' }}>
+                        <Button
+                            variant="secondary"
+                            onClick={() => setShowPolicyResults(!showPolicyResults)}
+                        >
+                            Policy results
+                        </Button>
+                    </FlexItem>
+                </Flex>
                 <Divider component="div" />
                 <PolicyDetailContent
                     clusters={clusters}
@@ -99,32 +112,37 @@ function ReviewPolicyForm({ clusters, notifiers }: ReviewPolicyFormProps): React
                     isReview
                 />
             </Flex>
-            <Flex
-                flex={{ default: 'flex_1' }}
-                direction={{ default: 'column' }}
-                alignSelf={{ default: 'alignSelfStretch' }}
-                className="preview-violations"
-            >
-                <Title headingLevel="h2">Preview violations</Title>
-                <div className="pf-u-mb-md pf-u-mt-sm">
-                    The policy settings you have selected will generate violations for the following
-                    deployments. Before you save the policy, verify that the violations seem
-                    accurate.
-                </div>
-                {isRunningDryRun ? (
-                    <Flex justifyContent={{ default: 'justifyContentCenter' }}>
-                        <FlexItem>
-                            <Spinner isSVG />
-                        </FlexItem>
+            {showPolicyResults && (
+                <>
+                    <Divider component="div" isVertical />
+                    <Flex
+                        flex={{ default: 'flex_1' }}
+                        direction={{ default: 'column' }}
+                        alignSelf={{ default: 'alignSelfStretch' }}
+                        className="preview-violations"
+                    >
+                        <Title headingLevel="h2">Preview violations</Title>
+                        <div className="pf-u-mb-md pf-u-mt-sm">
+                            The policy settings you have selected will generate violations for the
+                            following deployments. Before you save the policy, verify that the
+                            violations seem accurate.
+                        </div>
+                        {isRunningDryRun ? (
+                            <Flex justifyContent={{ default: 'justifyContentCenter' }}>
+                                <FlexItem>
+                                    <Spinner isSVG />
+                                </FlexItem>
+                            </Flex>
+                        ) : errorMessageFromDryRun ? (
+                            <Alert title="Request failure for violations" variant="danger" isInline>
+                                {errorMessageFromDryRun}
+                            </Alert>
+                        ) : (
+                            <PreviewViolations alertsFromDryRun={alertsFromDryRun} />
+                        )}
                     </Flex>
-                ) : errorMessageFromDryRun ? (
-                    <Alert title="Request failure for violations" variant="danger" isInline>
-                        {errorMessageFromDryRun}
-                    </Alert>
-                ) : (
-                    <PreviewViolations alertsFromDryRun={alertsFromDryRun} />
-                )}
-            </Flex>
+                </>
+            )}
         </Flex>
     );
     /* eslint-enable no-nested-ternary */


### PR DESCRIPTION
## Description

Dry run section should be open by default
![image](https://user-images.githubusercontent.com/10412893/151096509-d59cb3bb-69fd-41e5-a438-10d2058877c7.png)

it should collapse on `policy results` button click
![image](https://user-images.githubusercontent.com/10412893/151096537-9e8cb774-d8d9-419a-a2d4-012d8681ee5a.png)

it should open again on `policy results` button click

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
