### PR TITLE
Disable Scanner if ROX_LOCAL_IMAGE_SCANNING is enabled in secured cluster

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -27,13 +27,6 @@
 {{ $values := deepCopy $.Values }}
 {{ include "srox.applyCompatibilityTranslation" (list $ $values) }}
 
-[<- if .FeatureFlags.ROX_LOCAL_IMAGE_SCANNING ->]
-{{/*
-    #TODO(ROX-8672): Add setup and defaulting logic to secured cluster chart
-    Scanner setup
-  */}}
-[<- end ->]
-
 {{/*
     $rox / ._rox is the dictionary in which _all_ data that is modified by the init logic
     is stored.
@@ -43,6 +36,14 @@
 {{ $rox := deepCopy $values }}
 {{ $_ := include "srox.mergeInto" (list $rox ($.Files.Get "internal/config-shape.yaml" | fromYaml)) }}
 {{ $_ = set $ "_rox" $rox }}
+
+[< if .FeatureFlags.ROX_LOCAL_IMAGE_SCANNING ->]
+{{/*
+  #TODO(ROX-8672): Add setup and defaulting logic to secured cluster chart
+    Scanner setup
+  */}}
+{{ $_ := set $._rox "scanner" (dict "disable" true) }}
+[<- end >]
 
 {{/* Set the config fingerprint as computed or overridden via values. */}}
 {{ $configFP = default $configFP $._rox.meta.configFingerprintOverride }}


### PR DESCRIPTION
## Description

Scanner should be opt-in to enable until the feature is finished, even if the feature flag is enabled because otherwise it is not possible to install StackRox.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

 - Execute Helm chart with feature flag enabled