### PR TITLE
Improve `roxctl ... --help` w.r.t. `--image-defaults`

### DIFF
--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -179,7 +179,7 @@ func createBundle(config renderer.Config) (*zip.Wrapper, error) {
 
 	flavor, err := defaults.GetImageFlavorByName(config.K8sConfig.ImageFlavorName, buildinfo.ReleaseBuild)
 	if err != nil {
-		return nil, errorhelpers.NewErrInvalidArgsf("'--image-defaults': %v", err)
+		return nil, errorhelpers.NewErrInvalidArgsf("'--%s': %v", flags.ImageDefaultsFlagName, err)
 	}
 
 	files, err := renderer.Render(config, flavor)

--- a/roxctl/central/generate/k8s.go
+++ b/roxctl/central/generate/k8s.go
@@ -86,11 +86,12 @@ func k8sBasedOrchestrator(k8sConfig *renderer.K8sConfig, shortName, longName str
 	flags.AddImageDefaults(flagWrap.FlagSet, &k8sConfig.ImageFlavorName)
 
 	// TODO(RS-418): restore default image names or update argument description
-	flagWrap.StringVarP(&k8sConfig.MainImage, "main-image", "i", "", "main image to use (if unset, the default will be used)", "central")
+	defaultImageHelp := fmt.Sprintf("(if unset, a default will be used according to --%s)", flags.ImageDefaultsFlagName)
+	flagWrap.StringVarP(&k8sConfig.MainImage, "main-image", "i", "", "main image to use "+defaultImageHelp, "central")
 	flagWrap.BoolVar(&k8sConfig.OfflineMode, "offline", false, "whether to run StackRox in offline mode, which avoids reaching out to the Internet", "central")
 
-	flagWrap.StringVar(&k8sConfig.ScannerImage, "scanner-image", "", "Scanner image to use (if unset, the default will be used)", "scanner")
-	flagWrap.StringVar(&k8sConfig.ScannerDBImage, "scanner-db-image", "", "Scanner DB image to use (if unset, the default will be used)", "scanner")
+	flagWrap.StringVar(&k8sConfig.ScannerImage, "scanner-image", "", "Scanner image to use "+defaultImageHelp, "scanner")
+	flagWrap.StringVar(&k8sConfig.ScannerDBImage, "scanner-db-image", "", "Scanner DB image to use "+defaultImageHelp, "scanner")
 
 	flagWrap.BoolVar(&k8sConfig.EnableTelemetry, "enable-telemetry", true, "whether to enable telemetry", "central")
 

--- a/roxctl/common/flags/imageFlavor.go
+++ b/roxctl/common/flags/imageFlavor.go
@@ -13,6 +13,9 @@ var (
 	imageFlavorDefault string = defaults.ImageFlavorNameRHACSRelease
 )
 
+// ImageDefaultsFlagName is a shared constant for --image-defaults command line flag.
+const ImageDefaultsFlagName = "image-defaults"
+
 func init() {
 	if !buildinfo.ReleaseBuild {
 		imageFlavorDefault = defaults.ImageFlavorNameDevelopmentBuild
@@ -23,5 +26,5 @@ func init() {
 func AddImageDefaults(pf *pflag.FlagSet, destination *string) {
 	imageFlavorHelpStr := fmt.Sprintf("default container images settings (%v); it controls repositories from where to download the images, image names and tags format",
 		strings.Join(defaults.GetAllowedImageFlavorNames(buildinfo.ReleaseBuild), ", "))
-	pf.StringVar(destination, "image-defaults", imageFlavorDefault, imageFlavorHelpStr)
+	pf.StringVar(destination, ImageDefaultsFlagName, imageFlavorDefault, imageFlavorHelpStr)
 }

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -193,7 +193,7 @@ func Command() *cobra.Command {
 	c.PersistentFlags().StringVar(&cluster.Name, "name", "", "cluster name to identify the cluster")
 	c.PersistentFlags().StringVar(&cluster.CentralApiEndpoint, "central", "central.stackrox:443", "endpoint that sensor should connect to")
 	c.PersistentFlags().StringVar(&cluster.MainImage, "main-image-repository", "", "image repository sensor should be deployed with (if unset, a default will be used)")
-	c.PersistentFlags().StringVar(&cluster.CollectorImage, "collector-image-repository", "", "image repository collector should be deployed with (if unset, the default will be derived according to the effective main-image-repository value)")
+	c.PersistentFlags().StringVar(&cluster.CollectorImage, "collector-image-repository", "", "image repository collector should be deployed with (if unset, a default will be derived according to the effective --main-image-repository value)")
 
 	c.PersistentFlags().Var(&collectionTypeWrapper{CollectionMethod: &cluster.CollectionMethod}, "collection-method", "which collection method to use for runtime support (none, default, kernel-module, ebpf)")
 


### PR DESCRIPTION
## Description

Just went through `--help` arguments that were touched as part of https://issues.redhat.com/browse/RS-172 and reviewed what could be potentially improved.
My main idea was to give users a hint about what happens to image repositories in case of `roxctl central generate` before https://issues.redhat.com/browse/RS-418 is implemented.

### roxctl central generate --help

![image](https://user-images.githubusercontent.com/537715/151356808-db7d1398-132f-49b3-afa7-b9c35b6e5279.png)

### roxctl sensor generate --help

![image](https://user-images.githubusercontent.com/537715/151357114-dc2651e8-fa48-4312-92f1-f2f1a7a935a2.png)

### roxctl helm output --help

![image](https://user-images.githubusercontent.com/537715/151357222-90ad930c-0ea5-4488-b436-e99dfeb6e173.png)

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~ no, tested manually.
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ already there.
- ~~[ ] Determined and documented upgrade steps~~ not needed.

## Testing Performed

* See the screenshots above showing `--help` output.
* Also ran `roxctl helm output` with different combinations of arguments to evidence that warning/error messages still look ok.
```sh
roxctl helm output central-services --remove
roxctl helm output central-services --rhacs --remove
roxctl helm output central-services --image-defaults=rhacs --rhacs --remove
roxctl helm output central-services --image-defaults=rhacs123 --remove
```
