### PR TITLE
feat: using the URL state for sorting and pagination

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
@@ -2,10 +2,10 @@
 /* eslint-disable react/no-array-index-key */
 import React, { ReactElement, useState } from 'react';
 
-import usePagination from 'hooks/patternfly/usePagination';
 import { SearchFilter } from 'types/search';
 import queryService from 'utils/queryService';
-import useTableSort, { SortOption } from 'hooks/patternfly/useTableSort';
+import useURLSort, { SortOption } from 'hooks/patternfly/useURLSort';
+import useURLPagination from 'hooks/patternfly/useURLPagination';
 import ObservedCVEsTable from './ObservedCVEsTable';
 import useImageVulnerabilities from '../useImageVulnerabilities';
 
@@ -21,8 +21,8 @@ const defaultSortOption: SortOption = {
 
 function ObservedCVEs({ imageId }: ObservedCVEsProps): ReactElement {
     const [searchFilter, setSearchFilter] = useState<SearchFilter>({});
-    const { page, perPage, onSetPage, onPerPageSelect } = usePagination();
-    const { sortOption, getSortParams } = useTableSort({
+    const { page, perPage, onSetPage, onPerPageSelect } = useURLPagination();
+    const { sortOption, getSortParams } = useURLSort({
         sortFields,
         defaultSortOption,
     });
@@ -60,10 +60,10 @@ function ObservedCVEs({ imageId }: ObservedCVEsProps): ReactElement {
             perPage={perPage}
             onSetPage={onSetPage}
             onPerPageSelect={onPerPageSelect}
+            getSortParams={getSortParams}
             updateTable={refetchQuery}
             searchFilter={searchFilter}
             setSearchFilter={setSearchFilter}
-            getSortParams={getSortParams}
         />
     );
 }

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
@@ -27,7 +27,7 @@ import DateTimeFormat from 'Components/PatternFly/DateTimeFormat';
 import usePermissions from 'hooks/usePermissions';
 import { SearchFilter } from 'types/search';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
-import { GetSortParams } from 'hooks/patternfly/useTableSort';
+import { GetSortParams } from 'hooks/patternfly/useURLSort';
 import DeferralFormModal from './DeferralFormModal';
 import FalsePositiveRequestModal from './FalsePositiveFormModal';
 import { Vulnerability } from '../imageVulnerabilities.graphql';

--- a/ui/apps/platform/src/hooks/patternfly/useURLPagination.test.js
+++ b/ui/apps/platform/src/hooks/patternfly/useURLPagination.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+
+import useURLPagination from './useURLPagination';
+
+const history = createMemoryHistory();
+
+const wrapper = ({ children }) => {
+    return <Router history={history}>{children}</Router>;
+};
+
+describe('useURLPagination', () => {
+    it('should get the default pagination values', () => {
+        const { result } = renderHook(
+            () => {
+                return useURLPagination();
+            },
+            {
+                wrapper,
+            }
+        );
+
+        expect(result.current.page).toEqual(1);
+        expect(result.current.perPage).toEqual(20);
+    });
+
+    // @TODO: Add more tests
+});

--- a/ui/apps/platform/src/hooks/patternfly/useURLPagination.ts
+++ b/ui/apps/platform/src/hooks/patternfly/useURLPagination.ts
@@ -1,0 +1,42 @@
+import useURLSearchState from './useURLSearchState';
+
+export type PageOption = {
+    page: string;
+    perPage: string;
+};
+
+export type UseURLPaginationResult = {
+    page: number;
+    perPage: number;
+    onSetPage: (event, page: number) => void;
+    onPerPageSelect: (event, perPage: number) => void;
+};
+
+function useURLPagination(): UseURLPaginationResult {
+    const [pageOption, setPageOption] = useURLSearchState<PageOption>('pageOption');
+
+    // get the page option values from the URL, if available
+    // otherwise, use the default sort option values
+    const page = pageOption?.page ? Number(pageOption?.page) : 1;
+    const perPage = pageOption?.perPage ? Number(pageOption?.perPage) : 20;
+
+    function onSetPage(_, newPage) {
+        const newPageOption: PageOption = {
+            page: newPage,
+            perPage: String(perPage),
+        };
+        setPageOption(newPageOption);
+    }
+
+    function onPerPageSelect(_, newPerPage) {
+        const newPageOption: PageOption = {
+            page: String(page),
+            perPage: newPerPage,
+        };
+        setPageOption(newPageOption);
+    }
+
+    return { page, perPage, onSetPage, onPerPageSelect };
+}
+
+export default useURLPagination;

--- a/ui/apps/platform/src/hooks/patternfly/useURLSearchState.ts
+++ b/ui/apps/platform/src/hooks/patternfly/useURLSearchState.ts
@@ -1,0 +1,34 @@
+import { useLocation, useHistory } from 'react-router-dom';
+
+import { SearchFilter } from 'types/search';
+import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
+
+type SearchObject<T> = Record<string, T>;
+
+type UseURLSearchStateResult<T> = [
+    searchURLState: T | undefined,
+    setSearchURLState: (newValue: T) => void
+];
+
+function useURLSearchState<T>(accessor: string): UseURLSearchStateResult<T> {
+    const history = useHistory();
+    const location = useLocation();
+    const searchURLState: T | undefined = getQueryObject<SearchObject<T>>(location.search)?.[
+        accessor
+    ];
+
+    function setSearchURLState(newValue) {
+        const querySearchObject = getQueryObject<SearchFilter>(location.search);
+        const newSearchURLState = getQueryString({
+            ...querySearchObject,
+            [accessor]: newValue,
+        });
+        history.replace({
+            search: newSearchURLState,
+        });
+    }
+
+    return [searchURLState, setSearchURLState];
+}
+
+export default useURLSearchState;

--- a/ui/apps/platform/src/hooks/patternfly/useURLSort.test.js
+++ b/ui/apps/platform/src/hooks/patternfly/useURLSort.test.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+
+import useURLSort from './useURLSort';
+
+const history = createMemoryHistory();
+
+const params = {
+    sortFields: ['Name', 'Status'],
+    defaultSortOption: {
+        field: 'Name',
+        direction: 'desc',
+    },
+};
+
+const wrapper = ({ children }) => {
+    return <Router history={history}>{children}</Router>;
+};
+
+describe('useURLSort', () => {
+    it('should get the sort options from URL by default', () => {
+        const { result } = renderHook(
+            () => {
+                return useURLSort(params);
+            },
+            {
+                wrapper,
+            }
+        );
+
+        expect(result.current.sortOption.field).toEqual('Name');
+        expect(result.current.sortOption.direction).toEqual('desc');
+    });
+
+    it('should keep sorting to the "Status" field and change direction to "asc"', () => {
+        const { result } = renderHook(
+            () => {
+                return useURLSort(params);
+            },
+            {
+                wrapper,
+            }
+        );
+
+        act(() => {
+            result.current.getSortParams('Name').onSort(null, null, 'asc');
+        });
+
+        expect(result.current.sortOption.field).toEqual('Name');
+        expect(result.current.sortOption.direction).toEqual('asc');
+    });
+
+    it('should change sorting to the "Status" field and direction to "desc"', () => {
+        const { result } = renderHook(
+            () => {
+                return useURLSort(params);
+            },
+            {
+                wrapper,
+            }
+        );
+
+        act(() => {
+            result.current.getSortParams('Status').onSort(null, null, 'desc');
+        });
+
+        expect(result.current.sortOption.field).toEqual('Status');
+        expect(result.current.sortOption.direction).toEqual('desc');
+    });
+});

--- a/ui/apps/platform/src/hooks/patternfly/useURLSort.test.js
+++ b/ui/apps/platform/src/hooks/patternfly/useURLSort.test.js
@@ -31,7 +31,7 @@ describe('useURLSort', () => {
         );
 
         expect(result.current.sortOption.field).toEqual('Name');
-        expect(result.current.sortOption.direction).toEqual('desc');
+        expect(result.current.sortOption.reversed).toEqual(true);
     });
 
     it('should keep sorting to the "Status" field and change direction to "asc"', () => {
@@ -49,7 +49,7 @@ describe('useURLSort', () => {
         });
 
         expect(result.current.sortOption.field).toEqual('Name');
-        expect(result.current.sortOption.direction).toEqual('asc');
+        expect(result.current.sortOption.reversed).toEqual(false);
     });
 
     it('should change sorting to the "Status" field and direction to "desc"', () => {
@@ -67,6 +67,6 @@ describe('useURLSort', () => {
         });
 
         expect(result.current.sortOption.field).toEqual('Status');
-        expect(result.current.sortOption.direction).toEqual('desc');
+        expect(result.current.sortOption.reversed).toEqual(true);
     });
 });

--- a/ui/apps/platform/src/hooks/patternfly/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/patternfly/useURLSort.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import { ThProps } from '@patternfly/react-table';
+
+import useURLSearchState from './useURLSearchState';
+
+export type SortOption = {
+    field: string;
+    direction: 'asc' | 'desc';
+};
+
+export type GetSortParams = (field: string) => ThProps['sort'] | undefined;
+
+type UseTableSortProps = {
+    sortFields: string[];
+    defaultSortOption: SortOption;
+};
+
+type UseTableSortResult = {
+    sortOption: {
+        field: string;
+        reversed: boolean;
+    };
+    getSortParams: GetSortParams;
+};
+
+function useURLSort({ sortFields, defaultSortOption }: UseTableSortProps): UseTableSortResult {
+    const [sortOption, setSortOption] = useURLSearchState<SortOption>('sortOption');
+
+    // get the sort option values from the URL, if available
+    // otherwise, use the default sort option values
+    const activeSortField = sortOption?.field || defaultSortOption.field;
+    const activeSortDirection = sortOption?.direction || defaultSortOption.direction;
+
+    // we'll use this to map the sort fields to an index PatternFly can use internally
+    const [fieldToIndexMap, setFieldToIndexMap] = useState<Record<string, number>>({});
+
+    // we'll construct a map of sort fields to indices that will make it easier to work with
+    // PatternFly
+    useEffect(() => {
+        const newFieldToIndexMap = sortFields.reduce((acc, curr, index) => {
+            acc[curr] = index;
+            return acc;
+        }, {} as Record<string, number>);
+        setFieldToIndexMap(newFieldToIndexMap);
+    }, [sortFields]);
+
+    function getSortParams(field: string): ThProps['sort'] {
+        const index = fieldToIndexMap[field];
+        const activeSortIndex = activeSortField ? fieldToIndexMap[activeSortField] : undefined;
+
+        return {
+            sortBy: {
+                index: activeSortIndex,
+                direction: activeSortDirection,
+                defaultDirection: 'desc',
+            },
+            onSort: (_event, _index, direction) => {
+                // modify the URL based on the new sort
+                const newSortOption: SortOption = {
+                    field,
+                    direction,
+                };
+                setSortOption(newSortOption);
+            },
+            columnIndex: index,
+        };
+    }
+
+    return {
+        sortOption: {
+            field: activeSortField,
+            reversed: activeSortDirection === 'desc',
+        },
+        getSortParams,
+    };
+}
+
+export default useURLSort;


### PR DESCRIPTION
## Description

### Sorting

 In order to use sorting through the URL we can use the following hook: `useURLSort`.

The `useURLSort` hook will use the following format in the URL:

```
?sortOption[field]=Severity&sortOption[direction]=desc
```

The `useURLSort` hook will take in and return the following values:

```
const { sortOption, getSortParams } = useURLSort({
        sortFields,
        defaultSortOption,
});
```

**Input**
* **sortFields** - An array of string values that you can sort by (ie. `['Severity', 'CVSS', 'Discovered']`)
* **defaultSortOption** - The default sort values when the URL does not include it
```
{
    field: 'Severity',
    direction: 'desc'
}
```

**Output**
* **sortOption** - The sort values from the URL
```
{
    field: 'Severity',
    direction: 'desc'
}
```
* **getSortParams** - An altered version of the `getSortParams` you see in the following example: https://www.patternfly.org/v4/components/table#composable-sortable--wrapping-headers. You can pass the sort field name and it'll return the proper sort object to pass to a `Th` in PatternFly. Instead of passing a number value, I altered it so we just supply the field name to make it easier to map things internally
```
<Th sort={getSortParams('Severity')}>Severity</Th>
``` 

### Pagination

We can distinguish between having a hook for just pagination using local state vs. pagination using the URL state. If the local state solution is necessary, we can use the following hook: `usePagination`.  In order to use pagination through the URL we can use the following hook: `useURLPagination`.

The `useURLPagination` hook will use the following format in the URL:

```
?pageOption[page]=1&pageOption[perPage]=20
```

The `useURLPagination` hook will return the following values:

```
const { page, perPage, setPage, setPerPage } = useURLPagination();
```

**Output**
* **page** - the current page
* **perPage** - the number of items to be shown per page
* **setPage** - setter for `page`
* **setPerPage** - setter for `perPage`