### PR TITLE
Update offline bundle creation to respect unified image tags

### DIFF
--- a/scripts/offline-bundle/create.sh
+++ b/scripts/offline-bundle/create.sh
@@ -32,7 +32,7 @@ save_with_rhel() {
   local last_dir=$4
 
   save "$registry" "$name" "$tag" "${last_dir}"
-  export_image "$name" "${registry}/${name}-rhel:${tag}" "${last_dir}-rhel"
+  export_image "$name" "${registry}/${name}:${tag}" "${last_dir}-rhel"
 }
 
 bundle() {
@@ -57,18 +57,15 @@ main() {
     local main_tag="$(make --quiet tag)"
     save_with_rhel "stackrox.io" "main" "${main_tag}" "image-bundle"
 
-    # Scanner uses the version contained in the SCANNER_VERSION file.
-    local scanner_tag="$(cat SCANNER_VERSION)"
-    save_with_rhel "stackrox.io" "scanner" "${scanner_tag}" "image-bundle"
-    save_with_rhel "stackrox.io" "scanner-db" "${scanner_tag}" "image-bundle"
+    # Scanner uses the same version as Main.
+    save_with_rhel "stackrox.io" "scanner" "${main_tag}" "image-bundle"
+    save_with_rhel "stackrox.io" "scanner-db" "${main_tag}" "image-bundle"
 
     # The docs image (only advertised offline) uses the release tag (same as Main).
-    local docs_tag=${main_tag}
-    save "stackrox.io" "docs" "${docs_tag}" "image-bundle"
+    save "stackrox.io" "docs" "${main_tag}" "image-bundle"
 
-    # Collector uses the version contained in the COLLECTOR_VERSION file.
-    local collector_tag="$(cat COLLECTOR_VERSION)"
-    save_with_rhel "collector.stackrox.io" "collector" "${collector_tag}-latest" "image-collector-bundle"
+    # Collector uses the same version as Main.
+    save_with_rhel "collector.stackrox.io" "collector" "${main_tag}" "image-collector-bundle"
 
     store_roxctl "image-bundle"
     store_roxctl "image-bundle-rhel"


### PR DESCRIPTION
## Description

This goes as part of https://issues.redhat.com/browse/RS-172 and induced by changes that we made: main tag == scanner tag == collector tag. See https://github.com/stackrox/stackrox/blob/58e2e67d37b869e341b0b99d9f5044b482f778b1/.circleci/config.yml#L4593-L4599

Also, the script now pulls only non-rhel images but does it twice using for both rhel and non-rhel bundle. This is because all our images are now rhel-based and we may want to eventually get rid of the ones with `-rhel` suffix.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~ no :(
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ not needed.
- ~~[ ] Determined and documented upgrade steps~~ not needed.

## Testing Performed

None! Please check the code with me so that we have some sort of confidence that it works at the time of the release.

Tested `scripts/offline-bundle/create.sh` by

1. Applied the following changes to it.
<details><summary>Show me changes</summary>
<p>

```
diff --git a/scripts/offline-bundle/create.sh b/scripts/offline-bundle/create.sh
index 49019b304..b556548d5 100755
--- a/scripts/offline-bundle/create.sh
+++ b/scripts/offline-bundle/create.sh
@@ -54,21 +54,21 @@ store_roxctl() {
 
 main() {
     # Main uses the version reported by make tag.
-    local main_tag="$(make --quiet tag)"
-    save_with_rhel "stackrox.io" "main" "${main_tag}" "image-bundle"
+    local main_tag="3.68.0-rc.5"
+    save_with_rhel "docker.io/stackrox" "main" "${main_tag}" "image-bundle"
 
     # Scanner uses the same version as Main.
-    save_with_rhel "stackrox.io" "scanner" "${main_tag}" "image-bundle"
-    save_with_rhel "stackrox.io" "scanner-db" "${main_tag}" "image-bundle"
+    save_with_rhel "docker.io/stackrox" "scanner" "${main_tag}" "image-bundle"
+    save_with_rhel "docker.io/stackrox" "scanner-db" "${main_tag}" "image-bundle"
 
     # The docs image (only advertised offline) uses the release tag (same as Main).
-    save "stackrox.io" "docs" "${main_tag}" "image-bundle"
+    #save "docker.io/stackrox" "docs" "${main_tag}" "image-bundle"
 
     # Collector uses the same version as Main.
-    save_with_rhel "collector.stackrox.io" "collector" "${main_tag}" "image-collector-bundle"
+    save_with_rhel "docker.io/stackrox" "collector" "${main_tag}" "image-collector-bundle"
 
-    store_roxctl "image-bundle"
-    store_roxctl "image-bundle-rhel"
+    #store_roxctl "image-bundle"
+    #store_roxctl "image-bundle-rhel"
 
     bundle "image-bundle"
     bundle "image-collector-bundle"
```

</p>
</details>

2. Then `make offline-bundle`.
3. Listed archive contents
```
$ tar tvf scripts/offline-bundle/image-bundle.tgz 
drwxrwxr-x misha/misha       0 2022-01-28 18:06 image-bundle/
-rw------- misha/misha 477963776 2022-01-28 18:06 image-bundle/scanner-db.img
-rw------- misha/misha 927603712 2022-01-28 18:05 image-bundle/main.img
-rwxrwxr-x misha/misha      2502 2021-12-07 09:28 image-bundle/import.sh
-rw-rw-r-- misha/misha       694 2021-12-07 09:28 image-bundle/README.txt
-rw------- misha/misha 907618304 2022-01-28 18:06 image-bundle/scanner.img

$ tar tvf scripts/offline-bundle/image-bundle-rhel.tgz 
drwxrwxr-x misha/misha       0 2022-01-28 18:06 image-bundle-rhel/
-rw------- misha/misha 477963776 2022-01-28 18:06 image-bundle-rhel/scanner-db.img
-rw------- misha/misha 927603712 2022-01-28 18:05 image-bundle-rhel/main.img
-rwxrwxr-x misha/misha      2532 2021-12-07 09:28 image-bundle-rhel/import.sh
-rw-rw-r-- misha/misha       694 2021-12-07 09:28 image-bundle-rhel/README.txt
-rw------- misha/misha 907618304 2022-01-28 18:06 image-bundle-rhel/scanner.img

$ tar tvf scripts/offline-bundle/image-collector-bundle.tgz      
drwxrwxr-x misha/misha       0 2022-01-28 18:07 image-collector-bundle/
-rwxrwxr-x misha/misha    1101 2021-12-07 09:28 image-collector-bundle/import.sh
-rw-rw-r-- misha/misha     224 2021-12-07 09:28 image-collector-bundle/README.txt
-rw------- misha/misha 2107130368 2022-01-28 18:07 image-collector-bundle/collector.img

$ tar tvf scripts/offline-bundle/image-collector-bundle-rhel.tgz 
drwxrwxr-x misha/misha       0 2022-01-28 18:07 image-collector-bundle-rhel/
-rwxrwxr-x misha/misha    1111 2021-12-07 09:28 image-collector-bundle-rhel/import.sh
-rw-rw-r-- misha/misha     224 2021-12-07 09:28 image-collector-bundle-rhel/README.txt
-rw------- misha/misha 2107130368 2022-01-28 18:07 image-collector-bundle-rhel/collector.img
```