### PR TITLE
Revert "ROX-8170, ROX-8171: Show Inactive state and state on nested CVE table in Active VM flow"

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.js
@@ -61,7 +61,8 @@ function VulnMgmtComponentOverview({ data, entityContext }) {
     if (hasDeploymentAsAncestor) {
         metadataKeyValuePairs.push({
             key: 'Active status',
-            value: activeState?.state ?? 'Undetermined',
+            // TODO: allow other states like Inactive through, once they can be determined with precision
+            value: activeState?.state === 'Active' ? activeState.state : 'Undetermined',
         });
     }
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Components/VulnMgmtListComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Components/VulnMgmtListComponents.js
@@ -92,9 +92,10 @@ export function getComponentTableColumns(workflowState) {
                             </div>
                         );
                     }
-                    case 'Inactive': {
-                        return <div className="mx-auto">{activeStatus}</div>;
-                    }
+                    // TODO: uncomment the following case,  once Inactive can be determined with precision
+                    // case 'Inactive': {
+                    //     return <div className="mx-auto">{activeStatus}</div>;
+                    // }
                     case 'Undetermined':
                     default: {
                         return <div className="mx-auto">Undetermined</div>;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.js
@@ -1,11 +1,11 @@
 import entityTypes from 'constants/entityTypes';
 
 export function getFilteredCVEColumns(columns, workflowState) {
-    const shouldKeepActiveColumn =
-        workflowState.isCurrentSingle(entityTypes.DEPLOYMENT) ||
-        workflowState.isPrecedingSingle(entityTypes.DEPLOYMENT) ||
-        (workflowState.getSingleAncestorOfType(entityTypes.DEPLOYMENT) &&
-            workflowState.getSingleAncestorOfType(entityTypes.IMAGE));
+    // TODO: when active status for CVEs becomes available
+    // uncomment the following check
+    // const shouldKeepActiveColumn =
+    //     workflowState.isCurrentSingle(entityTypes.DEPLOYMENT) ||
+    //     workflowState.isPrecedingSingle(entityTypes.DEPLOYMENT);
 
     const shouldKeepFixedByColumn =
         workflowState.isPreceding(entityTypes.COMPONENT) ||
@@ -24,7 +24,10 @@ export function getFilteredCVEColumns(columns, workflowState) {
     return columns.filter((col) => {
         switch (col.accessor) {
             case 'isActive': {
-                return !!shouldKeepActiveColumn;
+                // TODO: when active status for CVEs becomes available
+                // uncomment the following actual check, and remove the always-false return
+                // return !!shouldKeepActiveColumn;
+                return false;
             }
             case 'fixedByVersion': {
                 return shouldKeepFixedByColumn;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
@@ -116,18 +116,19 @@ export function getCveTableColumns(workflowState) {
                             </div>
                         );
                     }
-                    case 'Inactive': {
-                        return <div className="mx-auto">{activeStatus}</div>;
-                    }
+                    // TODO: uncomment the following case,  once Inactive can be determined with precision
+                    // case 'Inactive': {
+                    //     return <div className="mx-auto">{activeStatus}</div>;
+                    // }
                     case 'Undetermined':
                     default: {
                         return <div className="mx-auto">Undetermined</div>;
                     }
                 }
             },
-            id: cveSortFields.ACTIVE,
+            id: cveSortFields.FIXABLE,
             accessor: 'isActive',
-            sortField: cveSortFields.ACTIVE,
+            sortField: cveSortFields.FIXABLE,
             sortable: false,
         },
         {


### PR DESCRIPTION
Reverts stackrox/stackrox#378

If we decide to revert the Active Vulnerability Management feature to the 67 level, then this PR needs to be approved, merged, and cherry-picked into the 68 release.

Testing:
1. CI errors are known flakes
2. Exploratory testing
- Deployed PR build image
- Checked previous contexts to make sure Active/Undetermined is still displayed
-- deployment → images → list of components
-- deployment → images-> individual component
- Checked new context to make sure no active column is displayed yet
-- deployment → images → list of cves (as ms2 target)

deployment → images → list of components
![Screen Shot 2022-01-28 at 2 15 51 PM](https://user-images.githubusercontent.com/715729/151608423-017bd17b-3fb1-4837-a73d-1b1347908111.png)

deployment → images-> individual component
![Screen Shot 2022-01-28 at 2 16 07 PM](https://user-images.githubusercontent.com/715729/151608441-ba25c451-3fb8-4a8c-828f-d7382514fa02.png)


Note lack of active info on these screens (expected because of revert)
![Screen Shot 2022-01-28 at 2 16 42 PM](https://user-images.githubusercontent.com/715729/151608455-180cc36c-31d3-45b0-ab3c-7ce6e8f50334.png)
![Screen Shot 2022-01-28 at 2 16 26 PM](https://user-images.githubusercontent.com/715729/151608457-98839c1b-84f2-40c6-9de0-b78360edcb0d.png)
