### PR TITLE
Fix typo in rocksdb store file template

### DIFF
--- a/tools/generate-helpers/rocksdb-bindings/main.go
+++ b/tools/generate-helpers/rocksdb-bindings/main.go
@@ -105,7 +105,7 @@ func New(db *rocksdb.RocksDB) Store {
 	globaldb.RegisterBucket(bucket, "{{.Type}}")
 	{{- if .UniqKeyFunc}}
 	return &storeImpl{
-		crud: generic.NewUniqueKeyCRUD(db, bucket, {{if .NoKeyField}}nil{{else}}keyFunc{{end}}, allocCluster, uniqKeyFunc, {{.TrackIndex}}),
+		crud: generic.NewUniqueKeyCRUD(db, bucket, {{if .NoKeyField}}nil{{else}}keyFunc{{end}}, alloc, uniqKeyFunc, {{.TrackIndex}}),
 	}
 	{{- else}}
 	return &storeImpl{


### PR DESCRIPTION
## Description

`alloc` is a function in template, but `allocCluster` is not

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

Used `gogen` on this file: https://github.com/stackrox/stackrox/blob/bf91adf4f67b700d04ccde7edb2fe349e2731545/central/signature/store/rocksdb/gen.go


