### PR TITLE
ROX-9141: Make CVE name clickable in the image findings tables

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/CVESummaryLink.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/CVESummaryLink.tsx
@@ -1,0 +1,22 @@
+import React, { ReactElement, useContext } from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from '@patternfly/react-core';
+
+import workflowStateContext from 'Containers/workflowStateContext';
+
+type CVESummaryLinkProps = {
+    cve: string;
+};
+
+function CVESummaryLink({ cve }: CVESummaryLinkProps): ReactElement {
+    const workflowState = useContext(workflowStateContext);
+    const url = workflowState.pushRelatedEntity('CVE', cve).toUrl();
+
+    return (
+        <Button variant="link" isInline>
+            <Link to={url}>{cve}</Link>
+        </Button>
+    );
+}
+
+export default CVESummaryLink;

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
@@ -24,6 +24,7 @@ import UndoVulnRequestModal from '../UndoVulnRequestModal';
 import RequestCommentsButton from '../RequestComments/RequestCommentsButton';
 import DeferralExpirationDate from '../DeferralExpirationDate';
 import VulnerabilityRequestScope from '../PendingApprovals/VulnerabilityRequestScope';
+import CVESummaryLink from '../CVESummaryLink';
 
 export type DeferredCVEsTableProps = {
     rows: Vulnerability[];
@@ -153,7 +154,9 @@ function DeferredCVEsTable({
                                         isSelected: selected[rowIndex],
                                     }}
                                 />
-                                <Td dataLabel="Cell">{row.cve}</Td>
+                                <Td dataLabel="CVE">
+                                    <CVESummaryLink cve={row.cve} />
+                                </Td>
                                 <Td dataLabel="Fixable">{row.isFixable ? 'Yes' : 'No'}</Td>
                                 <Td dataLabel="Severity">
                                     <VulnerabilitySeverityLabel severity={row.severity} />

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
@@ -23,6 +23,7 @@ import UndoVulnRequestModal from '../UndoVulnRequestModal';
 import FalsePositiveCVEActionsColumn from './FalsePositiveCVEActionsColumns';
 import RequestCommentsButton from '../RequestComments/RequestCommentsButton';
 import VulnerabilityRequestScope from '../PendingApprovals/VulnerabilityRequestScope';
+import CVESummaryLink from '../CVESummaryLink';
 
 export type FalsePositiveCVEsTableProps = {
     rows: Vulnerability[];
@@ -151,7 +152,9 @@ function FalsePositiveCVEsTable({
                                         isSelected: selected[rowIndex],
                                     }}
                                 />
-                                <Td dataLabel="Cell">{row.cve}</Td>
+                                <Td dataLabel="CVE">
+                                    <CVESummaryLink cve={row.cve} />
+                                </Td>
                                 <Td dataLabel="Fixable">{row.isFixable ? 'Yes' : 'No'}</Td>
                                 <Td dataLabel="Severity">
                                     <VulnerabilitySeverityLabel severity={row.severity} />

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
@@ -28,6 +28,7 @@ import useDeferVulnerability from './useDeferVulnerability';
 import useMarkFalsePositive from './useMarkFalsePositive';
 import AffectedComponentsButton from '../AffectedComponents/AffectedComponentsButton';
 import PendingApprovalPopover from './PendingApprovalPopover';
+import CVESummaryLink from '../CVESummaryLink';
 
 export type CVEsToBeAssessed = {
     type: 'DEFERRAL' | 'FALSE_POSITIVE';
@@ -196,7 +197,9 @@ function ObservedCVEsTable({
                                 />
                                 <Td dataLabel="CVE">
                                     <Flex alignItems={{ default: 'alignItemsCenter' }}>
-                                        <FlexItem>{row.cve}</FlexItem>
+                                        <FlexItem>
+                                            <CVESummaryLink cve={row.cve} />
+                                        </FlexItem>
                                         {row.vulnerabilityRequest?.id &&
                                             !row.vulnerabilityRequest.expired && (
                                                 <FlexItem>


### PR DESCRIPTION
## Description

The CVE name should now be clickable and show the CVE details in the side panel

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed


https://user-images.githubusercontent.com/4805485/151614686-ee07ace3-310b-4713-b4db-468e0b7c4f91.mov

https://user-images.githubusercontent.com/4805485/151614721-34812ce9-66ee-4fd8-bb4b-8638d702015d.mov


