### PR TITLE
Implement save in PatternFly policy wizard

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/policyValidationSchemas.ts
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/policyValidationSchemas.ts
@@ -3,7 +3,7 @@ import * as yup from 'yup';
 
 import { WizardPolicyStep4, WizardScope } from '../policies.utils';
 
-const validationSchema1 = yup.object().shape({
+const validationSchemaStep1 = yup.object().shape({
     name: yup.string().trim().required('Policy name is required'),
     severity: yup
         .string()
@@ -12,14 +12,20 @@ const validationSchema1 = yup.object().shape({
     categories: yup.array().of(yup.string().trim()).min(1, 'At least one category is required'), // TODO redundant? .required('Category is required'),
 });
 
-const validationSchema2 = yup.object().shape({
+const validationSchemaStep2 = yup.object().shape({
+    eventSource: yup.string().when('lifecycleStages', {
+        is: (lifecycleStages: string[]) => lifecycleStages.includes('RUNTIME'),
+        then: (eventSourceSchema) =>
+            eventSourceSchema.oneOf(['DEPLOYMENT_EVENT', 'AUDIT_LOG_EVENT']),
+        otherwise: (eventSourceSchema) => eventSourceSchema.oneOf(['NOT_APPLICABLE']),
+    }),
     lifecycleStages: yup
         .array()
         .of(yup.string().trim().oneOf(['BUILD', 'DEPLOY', 'RUNTIME']))
         .min(1, 'At least one lifecycle state is required'), // TODO redundant? .required('Lifecycle stage is required'),
 });
 
-const validationSchema3 = yup.object().shape({
+const validationSchemaStep3 = yup.object().shape({
     policySections: yup
         .array()
         .of(
@@ -111,11 +117,11 @@ const validationSchemaDefault = yup.object().shape({});
 export function getValidationSchema(stepId: number | string | undefined): yup.Schema {
     switch (stepId) {
         case 1:
-            return validationSchema1;
+            return validationSchemaStep1;
         case 2:
-            return validationSchema2;
+            return validationSchemaStep2;
         case 3:
-            return validationSchema3;
+            return validationSchemaStep3;
         case 4:
             return validationSchemaStep4;
         default:


### PR DESCRIPTION
## Description

1. Edit Wizard/PolicyWizard.tsx
    * Write `onSubmit` function for `useFormik` hook
    * Add `onSave={submitForm}` prop to `Wizard` element
    * Edit `enableNext: dirty && isValidOnServer && !isSubmitting` prop for step 5

2. Edit Wizard/policyValidationSchemas.ts
    * Add `Step` to names for consistency with subfolders
    * Add `eventSource` to `validationSchemaStep2` see **Testing performed**

3. Edit Wizard/Step5/ReviewPolicyForm.tsx
    * Add `setIsValidOnServer` prop so dry run request can enable or disable **Save** button
    * Add `setPolicyErrorMessage` and `setIsBadRequest` props for dry run failure
    * Add `policyErrorMessage` and `isBadRequest` props to render failure for either dry run or save requests
    * Rename `errorMessageFromDryRun` as `checkDryRunErrorMessage`
    * Add `Alert` element for `policyErrorMessage` under **Review policy**
    * Replace `variant="danger"` with `variant="warning"` prop for `Alert` element under **Preview violations**

### Residue

1. Investigate why **Next** button does not become disabled after I click to clear a selected check box under **Lifecycle stages** in step 2
2. I forgot to test formik `initialValues`
    * **Cancel** after making changes in edit, and then immediately edit again
    * **Save** and then immediately edit again

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. Start Platform UI

    * `export ROX_POLICIES_PATTERNFLY=true`
    * `yarn deploy-local`
    * `yarn start`

### Policy behavior step 2

Without criterion for `eventSource`

1. Under **Lifecycle stages**, click **Runtime**, and then **Next** becomes enabled
2. Under **Event sources**, do not click either
3. Click **Next** and select **Image registry** criterion in step 3
4. Click **Next** and click **Next**, and then under **Preview violations** in step 5

This picture reminded me to move start dry run request failure under **Review policy**
![step5-error-Preview-eventSource](https://user-images.githubusercontent.com/11862657/151635843-61990614-1d14-4f43-9351-41f0cf0dd95c.png)

With criterion for `eventSource`

1. Under **Lifecycle stages**, click **Runtime**, and then **Next** remains disabled
2. Under **Event sources**, click **Deployment**, and then **Next** becomes enabled
3. Click **Next** and select **Image registry** criterion in step 3
4. Click **Next** and click **Next**, and then under **Preview violations** in step 5

Ditto
![step5-error-Preview-policyGroup](https://user-images.githubusercontent.com/11862657/151635922-df0e5cfe-1474-45ec-8605-33d3d9b62f63.png)

### Create policy

1. Select a runtime policy criterion for a build lifecycle policy and see error message under **Review policy**
    ![create-step5-review-failure](https://user-images.githubusercontent.com/11862657/151635933-92873f7d-5994-4d6e-b00b-e664c7c69461.png)

2. Replace with valid policy criterion and see **Save** button enabled
    ![create-step5-enabled](https://user-images.githubusercontent.com/11862657/151635951-f15d7dbf-b7b8-4548-9043-7cf834396cd1.png)

3. Click **Save** and see policies table

### Edit policy

1. See **Save** button enabled
    ![edit-step5-enabled](https://user-images.githubusercontent.com/11862657/151635979-d327b416-6698-4e79-b77a-85fc94278ebd.png)

2. Click **Save** and see policies table
    ![edit-save-success](https://user-images.githubusercontent.com/11862657/151635990-ce7d6da5-0a57-41e1-96be-fa49bbe9fad6.png)

### Clone policy

Save policy and see policies table
