### PR TITLE
Use `snappy` package from CentOS Stream instead of just-CentOS

### DIFF
--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -96,7 +96,7 @@ extract_from_image "${DATA_IMAGE}" "/stackrox-data" "${bundle_root}/stackrox/sta
 extract_from_image "${BUILDER_IMAGE}" "/usr/local/bin/ldb" "${bundle_root}/usr/local/bin/ldb"
 
 # Install all the required compression packages for RocksDB to compile
-rpm_base_url="https://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages"
+rpm_base_url="http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages"
 rpm_suffix="el8.x86_64.rpm"
 
 curl -s -f -o "${bundle_root}/snappy.rpm" "${rpm_base_url}/snappy-1.1.8-3.${rpm_suffix}"


### PR DESCRIPTION
## Description

The root cause was investigated here https://srox.slack.com/archives/C02U7TC4KNK/p1643626687285499
In `create-bundle.sh` this command is failing
```
+ curl -s -f -o /tmp/tmp.TziMEhFA3b/snappy.rpm http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/snappy-1.1.8-3.el8.x86_64.rpm
make: *** [Makefile:531: /home/misha/go/src/github.com/stackrox/stackrox/image/rhel/bundle.tar.gz] Error 22
```
That's because the website returns `404` now. RIP CentOS.

A proper fix would be not to use anything from CentOS, and use the official Red Hat repos. However, the issue is that `snappy` is not part of UBI. (Why do you do this to us Red Hat?) Getting it from RHEL repos means that everyone would have to activate `subscription-manager` in order to build images locally. That's kind of big deal because of credentials.

As quick-fix alternative, I suggest to pull the package from the CentOS **Stream** which is alive product of Red Hat.

How I found the package location.

1. Googled for the location of CentOS Stream images. Found this wiki.centos.org/FAQ/CentOSStream#What_artifacts_are_built.3F

2. Started a container `docker run --rm -it quay.io/centos/centos:stream8`

3. In the container - get info about `snappy` package
```
$ dnf update -y
$ dnf info snappy.x86_64
Last metadata expiration check: 0:00:54 ago on Mon Jan 31 11:39:04 2022.
Available Packages
Name         : snappy
Version      : 1.1.8
Release      : 3.el8
Architecture : x86_64
Size         : 37 k
Source       : snappy-1.1.8-3.el8.src.rpm
Repository   : baseos
Summary      : Fast compression and decompression library
URL          : https://github.com/google/snappy
License      : BSD
Description  : Snappy is a compression/decompression library. It does not aim for maximum
...
```
Two important things here: package version snappy-1.1.8-3.el8 (matches the one in our script) and repository baseos.

4. In the container - get info about `baseos` repository
```
$ dnf repolist --verbose
...
Repo-id            : baseos
Repo-name          : CentOS Stream 8 - BaseOS
Repo-revision      : 8-stream
Repo-distro-tags      : [cpe:/o:centos-stream:centos-stream:8]:  ,  , 8, C, O, S, S, a, e, e, m, n, r, t, t
Repo-updated       : Fri Jan 28 17:04:05 2022
Repo-pkgs          : 7227
Repo-available-pkgs: 7225
Repo-size          : 9.1 G
Repo-mirrors       : http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=BaseOS&infra=stock
Repo-baseurl       : http://mirror.softaculous.com/centos/8-stream/BaseOS/x86_64/os/ (9 more)
Repo-expire        : 172800 second(s) (last: Mon Jan 31 11:39:00 2022)
Repo-filename      : /etc/yum.repos.d/CentOS-Stream-BaseOS.repo
...
```

5. Check http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=BaseOS&infra=stock
Its output varies from request to request and based on requester's geography. For me now it is
```
http://mirror.eu.oneandone.net/linux/distributions/centos/8-stream/BaseOS/x86_64/os/
http://centos.bio.lmu.de/8-stream/BaseOS/x86_64/os/
http://mirror.netzwerge.de/centos/8-stream/BaseOS/x86_64/os/
http://ftp.fau.de/centos/8-stream/BaseOS/x86_64/os/
...
```

6. The important thing is that the url structure is similar to what we used before.
CentOS repo path before /centos/8/BaseOS/x86_64/os/Packages
Stream repo paths /centos/8-stream/BaseOS/x86_64/os/

7. Guess that the difference is /8/ v.s. /8-stream/ and use that with what it seems official mirror.centos.org.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~ CI is regression test.
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ - not needed.
- ~~[ ] Determined and documented upgrade steps~~ - not needed.

## Testing Performed

* `build` job should succeed in CircleCI.

