### PR TITLE
Update qs 6.10.3 dependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -48,7 +48,7 @@
         "object-resolve-path": "^1.1.1",
         "pluralize": "^8.0.0",
         "prop-types": "^15.7.2",
-        "qs": "^6.10.1",
+        "qs": "^6.10.3",
         "raven-for-redux": "^1.3.1",
         "raven-js": "^3.27.0",
         "react": "^17.0.2",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -15797,10 +15797,10 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.10.1:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
-  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+qs@^6.10.3:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
+  integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
   dependencies:
     side-channel "^1.0.4"
 


### PR DESCRIPTION
## Description

Update early in sprint, even though `stringify` correction is for an edge case unlikely to affect Platform UI

1. https://github.com/ljharb/qs/blob/main/CHANGELOG.md#6103
    * parse: ignore __proto__ keys

2. https://github.com/ljharb/qs/blob/main/CHANGELOG.md#6102
    * stringify: avoid encoding arrayformat comma when encodeValuesOnly = true

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

CI