### PR TITLE
RS-457: Checksum hub-comment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2889,6 +2889,7 @@ jobs:
           name: Comment on PR
           command: |
             wget --quiet https://github.com/joshdk/hub-comment/releases/download/0.1.0-rc6/hub-comment_linux_amd64
+            echo "2a2640f44737873dfe30da0d5b8453419d48a494f277a70fd9108e4204fc4a53 hub-comment_linux_amd64" | sha256sum -c -
             sudo install hub-comment_linux_amd64 /usr/bin/hub-comment
 
             export TAG=$(make --quiet tag)


### PR DESCRIPTION
## Description

This PR runs a checksum for hub-comment, a larger task to checksum all 3rd party downloaded binaries is tracked in RS-457.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient