### PR TITLE
feat: adding pagination using the params

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
@@ -3,9 +3,9 @@
 import React, { ReactElement } from 'react';
 import { Bullseye, PageSection, PageSectionVariants, Spinner } from '@patternfly/react-core';
 
-import usePagination from 'hooks/patternfly/usePagination';
 import ACSEmptyState from 'Components/ACSEmptyState';
 import useURLSort, { SortOption } from 'hooks/patternfly/useURLSort';
+import useURLPagination from 'hooks/patternfly/useURLPagination';
 import ObservedCVEsTable from './ObservedCVEsTable';
 import useImageVulnerabilities from '../useImageVulnerabilities';
 
@@ -20,7 +20,7 @@ const defaultSortOption: SortOption = {
 };
 
 function ObservedCVEs({ imageId }: ObservedCVEsProps): ReactElement {
-    const { page, perPage, onSetPage, onPerPageSelect } = usePagination();
+    const { page, perPage, onSetPage, onPerPageSelect } = useURLPagination();
     const { sortOption, getSortParams } = useURLSort({
         sortFields,
         defaultSortOption,

--- a/ui/apps/platform/src/hooks/patternfly/useURLPagination.test.js
+++ b/ui/apps/platform/src/hooks/patternfly/useURLPagination.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+
+import useURLPagination from './useURLPagination';
+
+const history = createMemoryHistory();
+
+const wrapper = ({ children }) => {
+    return <Router history={history}>{children}</Router>;
+};
+
+describe('useURLPagination', () => {
+    it('should get the default pagination values', () => {
+        const { result } = renderHook(
+            () => {
+                return useURLPagination();
+            },
+            {
+                wrapper,
+            }
+        );
+
+        expect(result.current.page).toEqual(1);
+        expect(result.current.perPage).toEqual(20);
+    });
+
+    // @TODO: Add more tests
+});

--- a/ui/apps/platform/src/hooks/patternfly/useURLPagination.ts
+++ b/ui/apps/platform/src/hooks/patternfly/useURLPagination.ts
@@ -1,0 +1,42 @@
+import useURLSearchState from './useURLSearchState';
+
+export type PageOption = {
+    page: string;
+    perPage: string;
+};
+
+export type UsePaginationResult = {
+    page: number;
+    perPage: number;
+    onSetPage: (event, page: number) => void;
+    onPerPageSelect: (event, perPage: number) => void;
+};
+
+function usePagination(): UsePaginationResult {
+    const [pageOption, setPageOption] = useURLSearchState<PageOption>('pageOption');
+
+    // get the page option values from the URL, if available
+    // otherwise, use the default sort option values
+    const page = pageOption?.page ? Number(pageOption?.page) : 1;
+    const perPage = pageOption?.perPage ? Number(pageOption?.perPage) : 20;
+
+    function onSetPage(_, newPage) {
+        const newPageOption: PageOption = {
+            page: newPage,
+            perPage: String(perPage),
+        };
+        setPageOption(newPageOption);
+    }
+
+    function onPerPageSelect(_, newPerPage) {
+        const newPageOption: PageOption = {
+            page: String(page),
+            perPage: newPerPage,
+        };
+        setPageOption(newPageOption);
+    }
+
+    return { page, perPage, onSetPage, onPerPageSelect };
+}
+
+export default usePagination;

--- a/ui/apps/platform/src/hooks/patternfly/useURLSearchState.ts
+++ b/ui/apps/platform/src/hooks/patternfly/useURLSearchState.ts
@@ -1,0 +1,35 @@
+import { useLocation, useHistory } from 'react-router-dom';
+
+import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
+
+type SearchObject<T> = Record<string, T>;
+
+type UseURLSearchStateResult<T> = [
+    searchURLState: T | undefined,
+    setSearchURLState: (newValue: T) => void
+];
+
+function useURLSearchState<T>(accessor: string): UseURLSearchStateResult<T> {
+    const history = useHistory();
+    const location = useLocation();
+    const searchURLState: T | undefined = getQueryObject<SearchObject<T>>(location.search)?.[
+        accessor
+    ];
+
+    function setSearchURLState(newValue) {
+        const querySearchObject = getQueryObject<Record<string, string | string[]>>(
+            location.search
+        );
+        const newSortOptionString = getQueryString({
+            ...querySearchObject,
+            [accessor]: newValue,
+        });
+        history.replace({
+            search: newSortOptionString,
+        });
+    }
+
+    return [searchURLState, setSearchURLState];
+}
+
+export default useURLSearchState;

--- a/ui/apps/platform/src/hooks/patternfly/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/patternfly/useURLSort.ts
@@ -3,17 +3,12 @@ import { useLocation, useHistory } from 'react-router-dom';
 import { ThProps } from '@patternfly/react-table';
 
 import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
+import useURLSearchState from './useURLSearchState';
 
 export type SortOption = {
     field: string;
     direction: 'asc' | 'desc';
 };
-
-type SearchObject = {
-    sortOption?: SortOption;
-};
-
-type SortOptionFilter = SortOption | undefined;
 
 export type GetSortParams = (field: string) => ThProps['sort'] | undefined;
 
@@ -28,16 +23,12 @@ type UseTableSortResult = {
 };
 
 function useURLSort({ sortFields, defaultSortOption }: UseTableSortProps): UseTableSortResult {
-    const history = useHistory();
-    const location = useLocation();
-    const sortOptionFilter: SortOptionFilter = getQueryObject<SearchObject>(
-        location.search
-    )?.sortOption;
+    const [sortOption, setSortOption] = useURLSearchState<SortOption>('sortOption');
 
     // get the sort option values from the URL, if available
     // otherwise, use the default sort option values
-    const activeSortField = sortOptionFilter?.field || defaultSortOption.field;
-    const activeSortDirection = sortOptionFilter?.direction || defaultSortOption.direction;
+    const activeSortField = sortOption?.field || defaultSortOption.field;
+    const activeSortDirection = sortOption?.direction || defaultSortOption.direction;
 
     // we'll use this to map the sort fields to an index PatternFly can use internally
     const [fieldToIndexMap, setFieldToIndexMap] = useState<Record<string, number>>({});
@@ -64,19 +55,11 @@ function useURLSort({ sortFields, defaultSortOption }: UseTableSortProps): UseTa
             },
             onSort: (_event, _index, direction) => {
                 // modify the URL based on the new sort
-                const querySearchObject = getQueryObject<Record<string, string | string[]>>(
-                    location.search
-                );
-                const newSortOptionString = getQueryString({
-                    ...querySearchObject,
-                    sortOption: {
-                        field,
-                        direction,
-                    },
-                });
-                history.replace({
-                    search: newSortOptionString,
-                });
+                const newSortOption: SortOption = {
+                    field,
+                    direction
+                }
+                setSortOption(newSortOption);
             },
             columnIndex,
         };


### PR DESCRIPTION
## Description

We can distinguish between having a hook for just pagination using local state vs. pagination using the URL state. If the local state solution is necessary, we can use the following hook: `usePagination`.  In order to use pagination through the URL we can use the following hook: `useURLPagination`.

The `useURLPagination` hook will use the following format in the URL:

```
?pageOption[page]=1&pageOption[perPage]=20
```

The `useURLPagination` hook will return the following values:

```
const { page, perPage, setPage, setPerPage } = useURLPagination();
```

**Output**
* **page** - the current page
* **perPage** - the number of items to be shown per page
* **setPage** - setter for `page`
* **setPerPage** - setter for `perPage`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added