### PR TITLE
ROX-7902: Try increasing timeout when searching splunk for syslog notifications

### DIFF
--- a/qa-tests-backend/src/main/groovy/objects/Notifiers.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/Notifiers.groovy
@@ -366,7 +366,7 @@ class SyslogNotifier extends Notifier {
     }
 
     void validateViolationNotification(Policy policy, Deployment deployment, boolean strictIntegrationTesting) {
-        def response = SplunkUtil.waitForSplunkSyslog(splunkPort, 30)
+        def response = SplunkUtil.waitForSplunkSyslog(splunkPort, 90)
         // We must have received at least one syslog message
         assert response.size() > 0
     }


### PR DESCRIPTION
## Description

In the failed tests, it was unable to fetch anything from splunk (which is used as a sink for syslog events). Given how rare it is, I suspect it's because splunk hadn't indexed the events in time. Trying out a longer timeout

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

n/a

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
