### PR TITLE
Override dark mode for search filter and table check boxes in PatternFly

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Table/PoliciesTable.tsx
@@ -215,7 +215,7 @@ function PoliciesTable({
                         className="pf-u-flex-grow-1 pf-u-flex-shrink-1"
                     >
                         <SearchFilterInput
-                            className="w-full"
+                            className="w-full theme-light"
                             handleChangeSearchFilter={handleChangeSearchFilter}
                             placeholder="Filter policies"
                             searchCategory="POLICIES"

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -157,7 +157,7 @@ function ViolationsTablePage(): ReactElement {
     return (
         <PageSection variant="light" isFilled id="violations-table">
             <ReduxSearchInput
-                className="w-full"
+                className="w-full theme-light"
                 searchOptions={searchOptions}
                 searchModifiers={searchModifiers}
                 setSearchOptions={setSearchOptions}

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -84,6 +84,11 @@ body {
     align-self: center;
 }
 
+/* Override filter which simulates dark background color */
+.theme-dark .pf-c-table input[type='checkbox'] {
+    filter: inherit; /* replace invert(0.3) */
+}
+
 button.pf-c-tree-view__node {
     font-weight: inherit; /* override 600 from ui-components */
 }


### PR DESCRIPTION
## Description

Override dark mode for search filter and table check boxes in PatternFly

1. Add `theme-light` to `className` prop for StackRox theme classes within component
    * `SearchFilterInput` element in PoliciesTable.tsx
    * `ReduxSearchInput` elementn in ViolationsTablePage.tsx

2. Add style rule to trumps.css which overrides the following:

    ```css
    .theme-dark input[type='checkbox'] {
        filter: invert(0.3);
    }
    ```

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Policies

Dark mode without override has classic background color
![policies-without](https://user-images.githubusercontent.com/11862657/152056609-2e7a4191-597b-44b6-9b41-c64703651a70.png)

Dark mode with override does not have classic background color
![policies-with](https://user-images.githubusercontent.com/11862657/152056587-480e8760-440f-4627-b462-4b060aea5bd3.png)

### Violations

Dark mode without override has classic background color
![violations-without](https://user-images.githubusercontent.com/11862657/152056572-22e2654b-08d0-4efc-8b52-a20abb822ebd.png)

Dark mode with override does not have classic background color
![violations-with](https://user-images.githubusercontent.com/11862657/152056563-5f848983-b2f1-4663-b425-721e1537dd87.png)