### PR TITLE
Troubleshooting build failure on PR branch

### DIFF
--- a/central/integrationhealth/reporter/health_reporter_impl.go
+++ b/central/integrationhealth/reporter/health_reporter_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/gogo/protobuf/types"
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/integrationhealth/datastore"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -25,17 +26,19 @@ var (
 
 // DatastoreBasedIntegrationHealthReporter updates the integration health in the central database
 type DatastoreBasedIntegrationHealthReporter struct {
-	healthUpdates        chan *storage.IntegrationHealth
+	healthUpdates chan *storage.IntegrationHealth
+	healthRemoval chan string
+
 	stopSig              concurrency.Signal
 	latestDBTimestampMap map[string]*types.Timestamp
-
-	integrationDS datastore.DataStore
+	integrationDS        datastore.DataStore
 }
 
 // New returns a new datastore based integration health reporter
 func New(datastore datastore.DataStore) *DatastoreBasedIntegrationHealthReporter {
 	d := &DatastoreBasedIntegrationHealthReporter{
 		healthUpdates:        make(chan *storage.IntegrationHealth, 5),
+		healthRemoval:        make(chan string, 5),
 		stopSig:              concurrency.NewSignal(),
 		latestDBTimestampMap: make(map[string]*types.Timestamp),
 		integrationDS:        datastore,
@@ -73,11 +76,11 @@ func (d *DatastoreBasedIntegrationHealthReporter) Register(id, name string, typ 
 
 // RemoveIntegrationHealth removes the health entry corresponding to the integration
 func (d *DatastoreBasedIntegrationHealthReporter) RemoveIntegrationHealth(id string) error {
-	err := d.integrationDS.RemoveIntegrationHealth(allAccessCtx, id)
-	if err == nil {
-		delete(d.latestDBTimestampMap, id)
+	if err := d.integrationDS.RemoveIntegrationHealth(allAccessCtx, id); err != nil {
+		return errors.Wrapf(err, "Error removing health for integration %s", id)
 	}
-	return err
+	d.healthRemoval <- id
+	return nil
 }
 
 // UpdateIntegrationHealthAsync updates the health of the integration
@@ -113,6 +116,9 @@ func (d *DatastoreBasedIntegrationHealthReporter) processIntegrationHealthUpdate
 					log.Errorf("Error updating health for integration %s (%s): %v", health.Name, health.Id, err)
 				}
 			}
+		case id := <-d.healthRemoval:
+			delete(d.latestDBTimestampMap, id)
+
 		case <-d.stopSig.Done():
 			return
 		}


### PR DESCRIPTION
Troubleshooting build failure on PR branch.
Build failure impacts https://github.com/stackrox/stackrox/pull/423/files.

**Repro:** https://app.circleci.com/pipelines/github/stackrox/stackrox/3748/workflows/c1d3b323-ed8e-43d6-9019-4f3cb6ebbea3

**After rebase:** https://app.circleci.com/pipelines/github/stackrox/stackrox/3749/workflows/cea664a3-f5cf-454c-a874-8d6c20ce60ec

Confirmed rebase doesn't seem to be pushing to _origin_.

Latest experiment
```
git checkout master
git pull

git branch -d boo-rox-7855
git checkout boo-rox-7855
git pull

git checkout master
git pull
git checkout -b shane/branch-from-a39602e5c a39602e5c

    [shane/branch-from-a39602e5c]$ git log --decorate --graph --abbrev-commit --date=relative -n1
    * commit a39602e5c (HEAD -> shane/branch-from-a39602e5c)
    | Author: Linda Song <ls@stackrox.com>
    | Date:   6 days ago
    |
    |     PF Policies: Making "Review policy" dry run section collapsible (#445)

    [boo-rox-7855=]$ git log --decorate --graph --abbrev-commit --date=relative -n2
    * commit faf4a14bf (HEAD -> boo-rox-7855, origin/boo-rox-7855)
    | Author: Khushboo Sancheti <ks@stackrox.com>
    | Date:   8 days ago
    |
    |     ROX-7855: Fix data race, use a new channel for removes, to do in memory timestamp map updates in the health reporter
    |
    * commit a39602e5c (shane/branch-from-a39602e5c)
    | Author: Linda Song <ls@stackrox.com>
    | Date:   6 days ago
    |
    |     PF Policies: Making "Review policy" dry run section collapsible (#445)

git merge boo-rox-7855
git push -u origin shane/branch-from-a39602e5c
git rebase master
git push origin --force-with-lease

    (base) [13:56:49] shane@shane-mbp:github.com/stackrox/stackrox
    [shane/branch-from-a39602e5c=]$ glg --name-status -n3
    * commit 773c7c37a (HEAD -> shane/branch-from-a39602e5c, origin/shane/branch-from-a39602e5c)
      | Author: Khushboo Sancheti <ks@stackrox.com>
      | Date:   8 days ago
      |
      |     ROX-7855: Fix data race, use a new channel for removes, to do in memory timestamp map updates in the health reporter
      |
      | M     central/integrationhealth/reporter/health_reporter_impl.go
      |
      * commit b7701600e (origin/master, origin/HEAD, master)
      | Author: Jouko Virtanen <jouko@stackrox.com>
      | Date:   2 hours ago
      |
      |     Jv/update collector version to support minikube (#407)
      |
      |     * X-Smart-Branch-Parent: master
      |
      |     * Updated collector version to be the most compatible with Minikube
      |
      |     * Updated to latest collector version
      |
      | M     COLLECTOR_VERSION
      |
      * commit 70b0d5bf0
      | Author: Linda Song <ls@stackrox.com>
      | Date:   3 hours ago
      |
      |     PF Policies Wizard Scrolling (#504)
      |
      | M     ui/apps/platform/src/Containers/Policies/PatternFly/Detail/PolicyDetail.tsx
      | M     ui/apps/platform/src/Containers/Policies/PatternFly/PolicyPage.tsx
      | A     ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/PolicyWizard.css
      | M     ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/PolicyWizard.tsx
```