### PR TITLE
RS-421 colorful output sensor generate

### DIFF
--- a/roxctl/maincommand/command.go
+++ b/roxctl/maincommand/command.go
@@ -78,7 +78,7 @@ func Command() *cobra.Command {
 		logconvert.Command(),
 		image.Command(cliEnvironment),
 		scanner.Command(),
-		sensor.Command(),
+		sensor.Command(cliEnvironment),
 		helm.Command(cliEnvironment),
 		versionCommand(),
 		completion.Command(),

--- a/roxctl/sensor/generate/openshift.go
+++ b/roxctl/sensor/generate/openshift.go
@@ -1,9 +1,6 @@
 package generate
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/generated/storage"
@@ -30,7 +27,7 @@ func openshift() *cobra.Command {
 			cluster.Type = storage.ClusterType_OPENSHIFT_CLUSTER
 			switch openshiftVersion {
 			case 0:
-				fmt.Fprintf(os.Stderr, "%s\n\n", noteOpenShift3xCompatibilityMode)
+				logger.WarnfLn(noteOpenShift3xCompatibilityMode)
 			case 3:
 			case 4:
 				cluster.Type = storage.ClusterType_OPENSHIFT4_CLUSTER
@@ -43,7 +40,7 @@ func openshift() *cobra.Command {
 			} else if *admissionControllerEvents && cluster.Type == storage.ClusterType_OPENSHIFT_CLUSTER {
 				// The below `Validate` call would also catch this, but catching it here allows us to print more
 				// CLI-relevant error messages that reference flag names.
-				fmt.Fprintf(os.Stderr, "%s\n\n", errorAdmCntrlNotSupportedOnOpenShift3x)
+				logger.ErrfLn(errorAdmCntrlNotSupportedOnOpenShift3x)
 				return errors.New("incompatible flag settings")
 			}
 			cluster.AdmissionControllerEvents = *admissionControllerEvents
@@ -53,7 +50,7 @@ func openshift() *cobra.Command {
 			if disableAuditLogCollection == nil {
 				disableAuditLogCollection = pointers.Bool(cluster.Type != storage.ClusterType_OPENSHIFT4_CLUSTER)
 			} else if !*disableAuditLogCollection && cluster.Type != storage.ClusterType_OPENSHIFT4_CLUSTER {
-				fmt.Fprintf(os.Stderr, "%s\n\n", errorAuditLogsNotSupportedOnOpenShift3x)
+				logger.ErrfLn(errorAuditLogsNotSupportedOnOpenShift3x)
 				return errors.New("incompatible flag settings")
 			}
 			cluster.DynamicConfig.DisableAuditLogs = *disableAuditLogCollection

--- a/roxctl/sensor/sensor.go
+++ b/roxctl/sensor/sensor.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/sensor/generate"
 	"github.com/stackrox/rox/roxctl/sensor/generatecerts"
@@ -11,12 +12,12 @@ import (
 )
 
 // Command controls all of the functions being applied to a sensor
-func Command() *cobra.Command {
+func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
 		Use: "sensor",
 	}
 	c.AddCommand(
-		generate.Command(),
+		generate.Command(cliEnvironment),
 		getbundle.Command(),
 		generatecerts.Command(),
 	)


### PR DESCRIPTION
## Description

This PR fixes two different issues: [RS-421](https://issues.redhat.com/browse/RS-421) which is a leftover from the RHACS flavor changes and [ROX-9179](https://issues.redhat.com/browse/ROX-9179) regarding a missing line break in a warning. 

### Missing line break

When running `roxctl sensor generate` against an older version of central (e.g. `3.67.2`) and using a roxctl built from master, the following warning is shown:
```
WARNING: Running older version of central.
 Can't rely on central configuration to determine default values. Using docker.io/stackrox as main registry.Successfully wrote sensor folder "..."
```

There is a missing line break in between "registry." and "Successfully". 

Here's the result after adding the line break and colorful output:
![image](https://user-images.githubusercontent.com/6811076/152124578-7c25419e-a70e-4507-ad7f-bb7e5f1dacf2.png)


## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~~Unit test and regression tests added~~ `roxctl sensor generate` tests are being added in parallel
- [x] ~~Evaluated and added CHANGELOG entry if required~~ Not sure if a changelog is needed just for additional colorful output. Please advise here.
- [x] ~~Determined and documented upgrade steps~~

## Testing Performed

- Manual tests to check if the colorful output is shown correctly
- Additional E2E tests are being added for `roxctl sensor generate` in PR #488 