### PR TITLE
Use quay.io/centos/centos:stream8 as a builder

### DIFF
--- a/build/Dockerfile_rhel
+++ b/build/Dockerfile_rhel
@@ -1,4 +1,4 @@
-FROM centos:8 as builder
+FROM quay.io/centos/centos:stream8 as builder
 
 ENV ROCKSDB_VERSION="v6.7.3"
 ENV ZSTD_VERSION="1.4.4"
@@ -25,7 +25,7 @@ RUN cd /tmp/rocksdb && DEBUG_LEVEL=0 make ldb
 RUN curl -L https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz | tar -xJf -
 RUN upx-3.96-amd64_linux/upx -9 /tmp/rocksdb/ldb
 
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 
 ARG GOLANG_VERSION=1.17.2
 


### PR DESCRIPTION
> On January 31, 2022, CentOS team has finally removed all packages for CentOS 8 from the official mirrors. CentOS 8 has reached its end-of-life on December 31, 2021, but the packages were kept on the official mirrors for a while. Now they’re moved to https://vault.centos.org
>
> The proper way of handling the issue would be to migrate to CentOS Stream 8.

https://forketyfork.medium.com/centos-8-no-urls-in-mirrorlist-error-3f87c3466faa