### PR TITLE
ROX-9188 - Add scanner disable cert generation test

### DIFF
--- a/pkg/helm/charts/tests/shared/scanner-full/scanner.test.yaml
+++ b/pkg/helm/charts/tests/shared/scanner-full/scanner.test.yaml
@@ -53,6 +53,14 @@ tests:
     .horizontalpodautoscalers["scanner"].spec.minReplicas | assertThat(. == 50)
     .horizontalpodautoscalers["scanner"].spec.maxReplicas | assertThat(. == 100)
 
+- name: "disable scanner cert generation"
+  set:
+    scanner.serviceTLS.generate: false
+    scanner.dbServiceTLS.generate: false
+  expect: |
+    .secrets["scanner-tls"].stringData | assertThat(.["cert.pem"] | length == 0)
+    .secrets["scanner-db-tls"].stringData | assertThat(.["key.pem"] | length == 0)
+
 - name: "scanner with OpenShift 3 and enabled SCCs"
   server:
     visibleSchemas:


### PR DESCRIPTION
## Description

This PR adds a small test to disable the scanner certificate generation in the Helm chart.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

 - CI
