### PR TITLE
Fix validation problem for Runtime lifecycle stage on policies wizard step 2

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/policies.utils.ts
@@ -100,22 +100,46 @@ export const lifecycleStagesToEnforcementActionsMap: Record<LifecycleStage, Enfo
     RUNTIME: ['KILL_POD_ENFORCEMENT', 'FAIL_KUBE_REQUEST_ENFORCEMENT'],
 };
 
+export function hasEnforcementActionForLifecycleStage(
+    lifecycleStage: LifecycleStage,
+    enforcementActions: EnforcementAction[]
+) {
+    const enforcementActionsForLifecycleStage =
+        lifecycleStagesToEnforcementActionsMap[lifecycleStage];
+
+    return enforcementActions.some((enforcementAction) =>
+        enforcementActionsForLifecycleStage.includes(enforcementAction)
+    );
+}
+
 export function getEnforcementLifecycleStages(
     lifecycleStages: LifecycleStage[],
     enforcementActions: EnforcementAction[]
 ): LifecycleStage[] {
     return lifecycleStages.filter((lifecycleStage) => {
-        const enforcementActionsForLifecycleStage =
-            lifecycleStagesToEnforcementActionsMap[lifecycleStage];
-
-        return enforcementActions.some((enforcementAction) =>
-            enforcementActionsForLifecycleStage.includes(enforcementAction)
-        );
+        return hasEnforcementActionForLifecycleStage(lifecycleStage, enforcementActions);
     });
 }
 
 export function formatResponse(enforcementLifecycleStages: LifecycleStage[]): string {
     return enforcementLifecycleStages.length === 0 ? 'Inform' : 'Enforce';
+}
+
+export function appendEnforcementActionsForAddedLifecycleStage(
+    lifecycleStage: LifecycleStage,
+    enforcementActions: EnforcementAction[]
+): EnforcementAction[] {
+    return [...enforcementActions, ...lifecycleStagesToEnforcementActionsMap[lifecycleStage]];
+}
+
+export function filterEnforcementActionsForRemovedLifecycleStage(
+    lifecycleStage: LifecycleStage,
+    enforcementActions: EnforcementAction[]
+): EnforcementAction[] {
+    return enforcementActions.filter(
+        (enforcementAction) =>
+            !lifecycleStagesToEnforcementActionsMap[lifecycleStage].includes(enforcementAction)
+    );
 }
 
 // eventSource


### PR DESCRIPTION
## Description

Problem: When you clear the **Runtime** checkbox, the separate `setFieldValue` calls for `lifecycleStages` and `eventSource` cause inconsistent incorrect validation.

Solution: When user makes a change which causes code to make a change, call `setValues` so validation schema receives all mutually-dependent changes together.

1. Edit Wizard/Step2/PolicyBehaviorForm.tsx
    * Add `false` argument to `setFieldValue` calls if because code changes the value or if changed values are on other steps
    * Rewrite `onChangeLifecycleStage` with `setValues` call
    * Rewrite `onChangeEnforcementActions` to call append and filter functions from utils

2. Edit policies.utils.ts
    * Factor out `hasEnforcementActionForLifecycleStage` function
    * Add `appendEnforcementActionsForAddedLifecycleStage` function
    * Add `filterEnforcementActionsForRemovedLifecycleStage` function

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. Go to /main/policies-pf
2. Click **Create policy**, get to step 2 and see **Next** button is disabled
3. Click to select **Deploy** and see **Next** button is enabled
4. Click to select **Runtime** and see **Next** button is disabled and **Event sources** is enabled
5. Click **Deployment** and see **Next** button is enabled
6. Click to clear **Runtime** and see **Event sources** is disabled (correct)
    * but **Next** button is disabled (incorrect baseline behavior)
    * and **Next** button is enabled (correct improved behavior)