### PR TITLE
ROX-9157: Dedupe waitable queue as the most recent entry is more up to date

### DIFF
--- a/pkg/dackbox/utils/queue/waitable.go
+++ b/pkg/dackbox/utils/queue/waitable.go
@@ -63,7 +63,7 @@ func (q *waitableQueueImpl) push(qi *queuedItem) {
 
 	q.notEmptySig.Signal()
 
-	if qi.key != nil {
+	if len(qi.key) != 0 {
 		if oldQi, ok := q.dedupeMap[string(qi.key)]; ok {
 			*oldQi = *qi
 			return
@@ -87,7 +87,7 @@ func (q *waitableQueueImpl) Pop() ([]byte, proto.Message, *concurrency.Signal) {
 	}
 
 	qi := qiInter.(*queuedItem)
-	if qi.key != nil {
+	if len(qi.key) != 0 {
 		delete(q.dedupeMap, string(qi.key))
 	}
 


### PR DESCRIPTION
## Description

Title, but the reason this is important is because in reprocessing, many objects are pushed to the lazy queue including the same CVE potentially many many times

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
