### PR TITLE
CI: store both sets of k8s logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1486,7 +1486,8 @@ commands:
             fi
 
       - collect-k8s-logs
-      - store-k8s-logs
+      - store-k8s-logs:
+          destination: k8s-service-logs-part-1
       - get-and-store-debug-dump
       - get-and-store-diagnostic-bundle
       - get-central-data
@@ -1518,7 +1519,8 @@ commands:
 
       - collect-k8s-logs:
           orchestrator-flavor: << parameters.orchestrator-flavor >>
-      - store-k8s-logs
+      - store-k8s-logs:
+          destination: k8s-service-logs-part-2
       - get-and-store-debug-dump
       - get-and-store-diagnostic-bundle
       - get-central-data:
@@ -1829,7 +1831,8 @@ commands:
 
       - collect-k8s-logs:
           orchestrator-flavor: openshift
-      - store-k8s-logs
+      - store-k8s-logs:
+          destination: k8s-service-logs-part-1
       - get-and-store-debug-dump
       - get-and-store-diagnostic-bundle
       - get-central-data
@@ -1860,7 +1863,8 @@ commands:
 
       - collect-k8s-logs:
           orchestrator-flavor: openshift
-      - store-k8s-logs
+      - store-k8s-logs:
+          destination: k8s-service-logs-part-2
       - get-and-store-debug-dump
       - get-and-store-diagnostic-bundle
       - get-central-data:


### PR DESCRIPTION
## Description

The k8s logs for part 1 of qa tests are overwritten by part 2. This PR store them as artifacts before they are gone. Which will help debug failures like: https://app.circleci.com/pipelines/github/stackrox/stackrox/3849/workflows/48d74358-2d08-495b-ba4b-ec81e434ca11/jobs/169919

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient. Verified it created both sets in gke and openshift tests.
