### PR TITLE
ROX-9198: Add Severity Rating to CSV

### DIFF
--- a/central/cve/csv/handler.go
+++ b/central/cve/csv/handler.go
@@ -66,6 +66,7 @@ var (
 		"CVE",
 		"CVE Type(s)",
 		"Fixable",
+		"Severity Rating",
 		"CVSS Score",
 		"Env Impact (%s)",
 		"Impact Score",
@@ -113,6 +114,7 @@ type cveRow struct {
 	cveID           string
 	cveTypes        string
 	fixable         string
+	severity        string
 	cvssScore       string
 	envImpact       string
 	impactScore     string
@@ -136,11 +138,12 @@ func newCSVResults(header []string, sort bool) csvResults {
 }
 
 func (c *csvResults) addRow(row cveRow) {
-	// cve, cveTypes, fixable, cvss score, env impact, impact score, deployments, images, nodes, components, scanned time, published time, summary
+	// cve, cveTypes, fixable, severity rating, cvss score, env impact, impact score, deployments, images, nodes, components, scanned time, published time, summary
 	value := []string{
 		row.cveID,
 		row.cveTypes,
 		row.fixable,
+		row.severity,
 		row.cvssScore,
 		row.envImpact,
 		row.impactScore,
@@ -197,6 +200,7 @@ func CVECSVHandler() http.HandlerFunc {
 				errorList.AddError(err)
 			}
 			dataRow.fixable = strconv.FormatBool(isFixable)
+			dataRow.severity = d.Severity(ctx)
 			dataRow.cvssScore = fmt.Sprintf("%.2f (%s)", d.Cvss(ctx), d.ScoreVersion(ctx))
 			envImpact, err := d.EnvImpact(ctx)
 			if err != nil {


### PR DESCRIPTION
## Description

Add Severity Rating to CVE CSV. We received an email from a user who was confused why this was not present, and they assumed a CVE with a 9.8 CVSS was Critical, when it was actually Low. They would have known that had we had this field present in the CSV.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~

## Testing Performed

Manually download the CVE CSV from a local cluster.
