### PR TITLE
Add helmdiff.sh to dev-tools

### DIFF
--- a/dev-tools/helmdiff.sh
+++ b/dev-tools/helmdiff.sh
@@ -16,7 +16,7 @@ for CHART in ${CHARTS}; do
   $ROXCTL helm output --debug --remove ${CHART} --output-dir="${TMP_ROOT}/${CHART}-new"
 done
 
-# TODO: Use smart branch root instead of master.
+# TODO(ebensh): Use smart branch root (if present) instead of master.
 git switch master
 for CHART in ${CHARTS}; do
   $ROXCTL helm output --debug --remove ${CHART} --output-dir="${TMP_ROOT}/${CHART}-old"


### PR DESCRIPTION
## Description

A tool to render Helm Metatemplates to Helm charts to dry run installation manifests, providing diff commands for each stage.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

Ran the tool, ran the diff commands output, inspected output.