### PR TITLE
Increase timeout for NetworkFlowTest

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -2,6 +2,7 @@ import static com.jayway.restassured.RestAssured.given
 
 import com.jayway.restassured.response.Response
 import io.grpc.StatusRuntimeException
+import java.util.concurrent.TimeUnit
 import orchestratormanager.OrchestratorTypes
 import org.yaml.snakeyaml.Yaml
 
@@ -32,6 +33,8 @@ import util.NetworkGraphUtil
 import util.Timer
 
 import org.junit.Assume
+import org.junit.Rule
+import org.junit.rules.Timeout
 import org.junit.experimental.categories.Category
 import spock.lang.Ignore
 import spock.lang.Shared
@@ -40,6 +43,9 @@ import spock.lang.Unroll
 
 @Stepwise
 class NetworkFlowTest extends BaseSpecification {
+    @Rule
+    @SuppressWarnings(["JUnitPublicProperty"])
+    Timeout globalTimeout = new Timeout(1000, TimeUnit.SECONDS)
 
     // Deployment names
     static final private String UDPCONNECTIONTARGET = "udp-connection-target"


### PR DESCRIPTION
## Description

When NetworkFlowTest retries it fails because of timeout. This PR double this timeout.

```
NetworkFlowTest > Verify one-time connections show at first, but do not appear again FAILED
    org.junit.runners.model.TestTimedOutException: test timed out after 500 seconds
        at util.Timer.IsValid(Timer.groovy:24)
        at orchestratormanager.Kubernetes.waitForNamespaceDeletion(Kubernetes.groovy:2274)
        at orchestratormanager.Kubernetes.deleteNamespace(Kubernetes.groovy:2267)
        at NetworkFlowTest.destroyDeployments(NetworkFlowTest.groovy:236)
        at NetworkFlowTest.rebuildForRetries(NetworkFlowTest.groovy:247)
        at NetworkFlowTest.Verify one-time connections show at first, but do not appear again(NetworkFlowTest.groovy:259)
```
https://app.circleci.com/pipelines/github/stackrox/stackrox/3926/workflows/6e1a49de-7c8d-47e0-b24d-120219407e6d/jobs/173128/steps

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

CI