### PR TITLE
ROX-9209: disable grafana collection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1530,10 +1530,6 @@ commands:
       - *restoreDB
       - check-stackrox-logs
       - *storeQALogs
-      - *connectToMonitoring
-      - *collectMonitoringImages
-      - *storeMonitoringImages
-      - *storeMonitoringMetrics
 
       - teardown-anchore:
           cluster-id: << parameters.cluster-id >>
@@ -3900,10 +3896,6 @@ jobs:
             zip -r /tmp/pprof.zip /tmp/pprof
 
       - *storeProfilingResults
-      - *connectToMonitoring
-      - *collectMonitoringImages
-      - *storeMonitoringImages
-      - *storeMonitoringMetrics
       - collect-k8s-logs
       - get-and-store-debug-dump
       - get-and-store-diagnostic-bundle


### PR DESCRIPTION
## Description

This PR simply disables grafana data collection to avoid flakes like ROX-9209. It leaves the YAML macros available in case people need them i.e. along the lines of `benchmarkDashboard` etc. It leaves the deployment of the monitoring stack intact for similar reasons.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient