### PR TITLE
Bats test should assert based on central's flavor

### DIFF
--- a/tests/roxctl/bats-tests/helpers.bash
+++ b/tests/roxctl/bats-tests/helpers.bash
@@ -256,5 +256,3 @@ delete_cluster() {
   run roxctl_authenticated cluster delete --name "$name"
   assert_success
 }
-
-


### PR DESCRIPTION
## Description

Since nightly build deploys a cluster with `ROX_IMAGE_FLAVOR=stackrox.io` and PR builds with `ROX_IMAGE_FLAVOR=development_build`, bats tests need to adjust assertions based on the running cluster on that environment. 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~~Unit test and regression tests added~~
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~

## Testing Performed

- [ ] Nongroovy tests passed on regular PR build
- [ ] Nongroovy tests passed on release build
