### PR TITLE
Do not run the labeller action for dependabot PRs.

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   label-pr:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
     - uses: actions/labeler@v3
       with:


### PR DESCRIPTION
## Description

Since the dependabot is not part of the organization, the `GITHUB_TOKEN` will be read-only for  target `pull_request`.
Skip the action if the dependabot is the actor, to avoid an error during execution (since the `action/labeler` requires a read-write `GITHUB_TOKEN`).
