### PR TITLE
Avoid tautology in error messages of the role service

### DIFF
--- a/central/role/service/service_impl.go
+++ b/central/role/service/service_impl.go
@@ -117,9 +117,6 @@ func (s *serviceImpl) CreateRole(ctx context.Context, roleRequest *v1.CreateRole
 	}
 	role.Name = roleRequest.GetName()
 
-	if role.GetGlobalAccess() != storage.Access_NO_ACCESS {
-		return nil, errorhelpers.NewErrInvalidArgs("setting global access is not supported")
-	}
 	err := s.roleDataStore.AddRole(ctx, role)
 	if err != nil {
 		return nil, err
@@ -128,9 +125,6 @@ func (s *serviceImpl) CreateRole(ctx context.Context, roleRequest *v1.CreateRole
 }
 
 func (s *serviceImpl) UpdateRole(ctx context.Context, role *storage.Role) (*v1.Empty, error) {
-	if role.GetGlobalAccess() != storage.Access_NO_ACCESS {
-		return nil, errorhelpers.NewErrInvalidArgs("setting global access is not supported.")
-	}
 	err := s.roleDataStore.UpdateRole(ctx, role)
 	if err != nil {
 		return nil, err

--- a/central/role/validate.go
+++ b/central/role/validate.go
@@ -60,12 +60,12 @@ func ValidateRole(role *storage.Role) error {
 		multiErr = multierror.Append(multiErr, err)
 	}
 	if role.GetGlobalAccess() != storage.Access_NO_ACCESS {
-		err := errors.Errorf("role name=%q: globalAccess should not be set, but is set to %s", role.GetName(), role.GetGlobalAccess())
+		err := errors.New("role global_access field must be 'NO_ACCESS' or unset")
 		multiErr = multierror.Append(multiErr, err)
 	}
 
 	if len(role.GetResourceToAccess()) != 0 {
-		err := errors.Errorf("role name=%q: must not have resourceToAccess, use a permission set instead", role.GetName())
+		err := errors.New("role must not set resource_to_access field")
 		multiErr = multierror.Append(multiErr, err)
 	}
 	if role.GetPermissionSetId() == "" {


### PR DESCRIPTION
## Description

This PR cleans up how errors (and hence error messages) are constructed in the Role service.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~

## Testing Performed

CI run.
