### PR TITLE
Fix access scope validation incorrect error builder

### DIFF
--- a/central/role/validate.go
+++ b/central/role/validate.go
@@ -110,7 +110,7 @@ func ValidateSimpleAccessScope(scope *storage.SimpleAccessScope) error {
 
 	err := ValidateSimpleAccessScopeRules(scope.GetRules())
 	if err != nil {
-		multiErr = multierror.Append(err)
+		multiErr = multierror.Append(multiErr, err)
 	}
 
 	return multiErr

--- a/central/role/validate_test.go
+++ b/central/role/validate_test.go
@@ -211,7 +211,7 @@ func TestValidateSimpleAccessScope(t *testing.T) {
 		}, {
 			name: "multiple errors",
 			scope: &storage.SimpleAccessScope{
-				Id:   mockGoodID,
+				Id:   mockBadID,
 				Name: mockName,
 				Rules: &storage.SimpleAccessScope_Rules{
 					IncludedNamespaces: []*storage.SimpleAccessScope_Rules_Namespace{
@@ -220,7 +220,7 @@ func TestValidateSimpleAccessScope(t *testing.T) {
 						{Requirements: []*storage.SetBasedLabelSelector_Requirement{
 							{Key: "valid", Op: 42, Values: []string{"value"}},
 						}}}}},
-			expectedNumberOfErrors: 2,
+			expectedNumberOfErrors: 3,
 		}, {
 			name: "invalid selectors",
 			scope: &storage.SimpleAccessScope{
@@ -254,7 +254,7 @@ func TestValidateSimpleAccessScope(t *testing.T) {
 			err := ValidateSimpleAccessScope(tc.scope)
 			var target *multierror.Error
 			if errors.As(err, &target) {
-				assert.Equal(t, target.Len(), tc.expectedNumberOfErrors)
+				assert.Equal(t, tc.expectedNumberOfErrors, target.Len())
 			} else {
 				assert.Zero(t, tc.expectedNumberOfErrors)
 				assert.NoError(t, err)


### PR DESCRIPTION
## Description

Access scope validation drops already existing `multiErr` when rule errors are present.
Also fixed argument order(expected -> actual)

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

1. Changed existing test case to include this code path
