### PR TITLE
Can jump to any step in policy wizard for clone or edit

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/PolicyWizard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/PolicyWizard.tsx
@@ -104,6 +104,8 @@ function PolicyWizard({ pageAction, policy }: PolicyWizardProps): ReactElement {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [stepId]); // but not validateForm
 
+    const canJumpToAny = pageAction === 'clone' || pageAction === 'edit';
+
     return (
         <>
             <PageSection variant="light" isFilled id="policy-page" className="pf-u-pb-0">
@@ -134,28 +136,28 @@ function PolicyWizard({ pageAction, policy }: PolicyWizardProps): ReactElement {
                                         mitreVectorsLocked={values.mitreVectorsLocked}
                                     />
                                 ),
-                                canJumpTo: stepIdReached >= 1,
+                                canJumpTo: canJumpToAny || stepIdReached >= 1,
                                 enableNext: isValidOnClient,
                             },
                             {
                                 id: 2,
                                 name: 'Policy behavior',
                                 component: <PolicyBehaviorForm />,
-                                canJumpTo: stepIdReached >= 2,
+                                canJumpTo: canJumpToAny || stepIdReached >= 2,
                                 enableNext: isValidOnClient,
                             },
                             {
                                 id: 3,
                                 name: 'Policy criteria',
                                 component: <PolicyCriteriaForm />,
-                                canJumpTo: stepIdReached >= 3,
+                                canJumpTo: canJumpToAny || stepIdReached >= 3,
                                 enableNext: isValidOnClient,
                             },
                             {
                                 id: 4,
                                 name: 'Policy scope',
                                 component: <PolicyScopeForm />,
-                                canJumpTo: stepIdReached >= 4,
+                                canJumpTo: canJumpToAny || stepIdReached >= 4,
                                 enableNext: isValidOnClient,
                             },
                             {
@@ -171,7 +173,7 @@ function PolicyWizard({ pageAction, policy }: PolicyWizardProps): ReactElement {
                                     />
                                 ),
                                 nextButtonText: 'Save',
-                                canJumpTo: stepIdReached >= 5,
+                                canJumpTo: canJumpToAny || stepIdReached >= 5,
                                 enableNext: dirty && isValidOnServer && !isSubmitting,
                             },
                         ]}


### PR DESCRIPTION
## Description

Although you must go step by step when you **create** or **generate** a policy; you should be able to go to any step when you **clone** or **edit** a policy.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

clone: can jump to any
![clone](https://user-images.githubusercontent.com/11862657/153289882-a8ad8f51-cfaf-4646-b4ac-e5c0e01a32a0.png)

create: can **not** jump to any
![create](https://user-images.githubusercontent.com/11862657/153289871-fac92bab-a3a6-4361-8110-cd3cbbaddda6.png)

edit: can jump to any
![edit](https://user-images.githubusercontent.com/11862657/153289853-2bb07c12-d110-4dd8-903e-52e2915a5200.png)

generate: can **not** jump to any
![generate](https://user-images.githubusercontent.com/11862657/153289835-4998e60f-42e2-4ea0-8fb7-2f8ee7485039.png)

