### PR TITLE
Go back to policy detail page after edit and save

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Detail/PolicyDetail.tsx
@@ -78,6 +78,7 @@ function PolicyDetail({
             search: 'action=clone',
         });
     }
+
     function onExportPolicy() {
         setIsRequesting(true);
         exportPolicies([id])


### PR DESCRIPTION
## Description

Problem: Because **Edit policy** action on policy page calls `history.replace(…)` then `history.goBack()` goes back to policies table

Solution: Replace `onEditPolicy` callback with `ButtonLink` element

* Either **Save** or **Cancel** go back to policy page after **Edit policy** action (or to policies table, after **Edit policy** row action).
* Also, either **Save** or **Cancel** go back to **original** policy page after **Clone policy** action (or to policies table, after **Clone policy** row action). Although this might not seem entirely intuitive, it is a consistent behavior that is unlikely to break if the code changes.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

* Edit policy from policies table, and the **Save** or **Cancel** go back to policies table
* Edit policy from policy page, and the **Save** or **Cancel** go back to policy page
* Clone policy from policy page, and the **Save** or **Cancel** go back to **original** policy page