### PR TITLE
Revert "Revert "ROX-8170, ROX-8171: Show Inactive state and state on nested CVE table in Active VM flow""

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.js
@@ -61,8 +61,7 @@ function VulnMgmtComponentOverview({ data, entityContext }) {
     if (hasDeploymentAsAncestor) {
         metadataKeyValuePairs.push({
             key: 'Active status',
-            // TODO: allow other states like Inactive through, once they can be determined with precision
-            value: activeState?.state === 'Active' ? activeState.state : 'Undetermined',
+            value: activeState?.state ?? 'Undetermined',
         });
     }
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Components/VulnMgmtListComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Components/VulnMgmtListComponents.js
@@ -92,10 +92,9 @@ export function getComponentTableColumns(workflowState) {
                             </div>
                         );
                     }
-                    // TODO: uncomment the following case,  once Inactive can be determined with precision
-                    // case 'Inactive': {
-                    //     return <div className="mx-auto">{activeStatus}</div>;
-                    // }
+                    case 'Inactive': {
+                        return <div className="mx-auto">{activeStatus}</div>;
+                    }
                     case 'Undetermined':
                     default: {
                         return <div className="mx-auto">Undetermined</div>;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.js
@@ -1,11 +1,11 @@
 import entityTypes from 'constants/entityTypes';
 
 export function getFilteredCVEColumns(columns, workflowState) {
-    // TODO: when active status for CVEs becomes available
-    // uncomment the following check
-    // const shouldKeepActiveColumn =
-    //     workflowState.isCurrentSingle(entityTypes.DEPLOYMENT) ||
-    //     workflowState.isPrecedingSingle(entityTypes.DEPLOYMENT);
+    const shouldKeepActiveColumn =
+        workflowState.isCurrentSingle(entityTypes.DEPLOYMENT) ||
+        workflowState.isPrecedingSingle(entityTypes.DEPLOYMENT) ||
+        (workflowState.getSingleAncestorOfType(entityTypes.DEPLOYMENT) &&
+            workflowState.getSingleAncestorOfType(entityTypes.IMAGE));
 
     const shouldKeepFixedByColumn =
         workflowState.isPreceding(entityTypes.COMPONENT) ||
@@ -24,10 +24,7 @@ export function getFilteredCVEColumns(columns, workflowState) {
     return columns.filter((col) => {
         switch (col.accessor) {
             case 'isActive': {
-                // TODO: when active status for CVEs becomes available
-                // uncomment the following actual check, and remove the always-false return
-                // return !!shouldKeepActiveColumn;
-                return false;
+                return !!shouldKeepActiveColumn;
             }
             case 'fixedByVersion': {
                 return shouldKeepFixedByColumn;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
@@ -116,19 +116,18 @@ export function getCveTableColumns(workflowState) {
                             </div>
                         );
                     }
-                    // TODO: uncomment the following case,  once Inactive can be determined with precision
-                    // case 'Inactive': {
-                    //     return <div className="mx-auto">{activeStatus}</div>;
-                    // }
+                    case 'Inactive': {
+                        return <div className="mx-auto">{activeStatus}</div>;
+                    }
                     case 'Undetermined':
                     default: {
                         return <div className="mx-auto">Undetermined</div>;
                     }
                 }
             },
-            id: cveSortFields.FIXABLE,
+            id: cveSortFields.ACTIVE,
             accessor: 'isActive',
-            sortField: cveSortFields.FIXABLE,
+            sortField: cveSortFields.ACTIVE,
             sortable: false,
         },
         {


### PR DESCRIPTION
## Description

Reverts stackrox/stackrox#475

Now that we are ready to release Active Vuln Management Phase 2, we need to add back in the FE changes that we had reverted during the 68 release testing, when we found a blocking issue.

## Checklist
- [x] Investigated and inspected CI test results (ui e2e test failure is a flake)

## Testing

* Observe CI
* Deploy the image built from this second revert PR, deploy, and do exploratory testing
