### PR TITLE
Exclude injected-cabundle ConfigMap from upgrader

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/.helmtplignore.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/.helmtplignore.htpl
@@ -1,7 +1,6 @@
 [<- if .KubectlOutput >]
 templates/cluster-config.yaml
 templates/openshift-monitoring.yaml
-templates/_injected-ca-bundle.tpl
 templates/00-injected-ca-bundle.yaml
 internal/cluster-config.yaml.tpl
 sensor-chart-upgrade.md


### PR DESCRIPTION
## Description

The `injected-cabundle-stackrox-secured-cluster-services` ConfigMap is used only with Openshift 4 with operator, where the upgrader procedure is not used.
This PR fixes the upgrader tests.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~

## Testing Performed

Unit tests.