### PR TITLE
ROX-9143: Adding table sorting to the Image Findings tables

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
@@ -5,6 +5,7 @@ import React, { ReactElement, useState } from 'react';
 import usePagination from 'hooks/patternfly/usePagination';
 import { SearchFilter } from 'types/search';
 import queryService from 'utils/queryService';
+import useTableSort, { SortOption } from 'hooks/patternfly/useTableSort';
 import DeferredCVEsTable from './DeferredCVEsTable';
 import useImageVulnerabilities from '../useImageVulnerabilities';
 
@@ -12,9 +13,19 @@ type DeferredCVEsProps = {
     imageId: string;
 };
 
+const sortFields = ['Severity'];
+const defaultSortOption: SortOption = {
+    field: 'Severity',
+    direction: 'desc',
+};
+
 function DeferredCVEs({ imageId }: DeferredCVEsProps): ReactElement {
     const [searchFilter, setSearchFilter] = useState<SearchFilter>({});
     const { page, perPage, onSetPage, onPerPageSelect } = usePagination();
+    const { sortOption, getSortParams } = useTableSort({
+        sortFields,
+        defaultSortOption,
+    });
 
     const vulnsQuery = queryService.objectToWhereClause({
         ...searchFilter,
@@ -27,10 +38,7 @@ function DeferredCVEs({ imageId }: DeferredCVEsProps): ReactElement {
         pagination: {
             limit: perPage,
             offset: (page - 1) * perPage,
-            sortOption: {
-                field: 'Severity',
-                reversed: true,
-            },
+            sortOption,
         },
     });
 
@@ -49,6 +57,7 @@ function DeferredCVEs({ imageId }: DeferredCVEsProps): ReactElement {
             updateTable={refetchQuery}
             searchFilter={searchFilter}
             setSearchFilter={setSearchFilter}
+            getSortParams={getSortParams}
         />
     );
 }

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
@@ -21,6 +21,7 @@ import usePermissions from 'hooks/usePermissions';
 import useAuthStatus from 'hooks/useAuthStatus';
 import { SearchFilter } from 'types/search';
 import ACSEmptyState from 'Components/ACSEmptyState';
+import { GetSortParams } from 'hooks/patternfly/useTableSort';
 import AffectedComponentsButton from '../AffectedComponents/AffectedComponentsButton';
 import { Vulnerability } from '../imageVulnerabilities.graphql';
 import { DeferredCVEsToBeAssessed } from './types';
@@ -41,6 +42,7 @@ export type DeferredCVEsTableProps = {
     updateTable: () => void;
     searchFilter: SearchFilter;
     setSearchFilter: React.Dispatch<React.SetStateAction<SearchFilter>>;
+    getSortParams: GetSortParams;
 } & UsePaginationResult;
 
 function DeferredCVEsTable({
@@ -54,6 +56,7 @@ function DeferredCVEsTable({
     searchFilter,
     setSearchFilter,
     isLoading,
+    getSortParams,
 }: DeferredCVEsTableProps): ReactElement {
     const {
         selected,
@@ -162,7 +165,7 @@ function DeferredCVEsTable({
                         />
                         <Th>CVE</Th>
                         <Th>Fixable</Th>
-                        <Th>Severity</Th>
+                        <Th sort={getSortParams('Severity')}>Severity</Th>
                         <Th>Expires</Th>
                         <Th modifier="fitContent">Scope</Th>
                         <Th>Affected Components</Th>

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
@@ -5,6 +5,7 @@ import React, { ReactElement, useState } from 'react';
 import usePagination from 'hooks/patternfly/usePagination';
 import { SearchFilter } from 'types/search';
 import queryService from 'utils/queryService';
+import useTableSort, { SortOption } from 'hooks/patternfly/useTableSort';
 import FalsePositiveCVEsTable from './FalsePositiveCVEsTable';
 import useImageVulnerabilities from '../useImageVulnerabilities';
 
@@ -12,9 +13,19 @@ type FalsePositiveCVEsProps = {
     imageId: string;
 };
 
+const sortFields = ['Severity'];
+const defaultSortOption: SortOption = {
+    field: 'Severity',
+    direction: 'desc',
+};
+
 function FalsePositiveCVEs({ imageId }: FalsePositiveCVEsProps): ReactElement {
     const [searchFilter, setSearchFilter] = useState<SearchFilter>({});
     const { page, perPage, onSetPage, onPerPageSelect } = usePagination();
+    const { sortOption, getSortParams } = useTableSort({
+        sortFields,
+        defaultSortOption,
+    });
 
     const vulnsQuery = queryService.objectToWhereClause({
         ...searchFilter,
@@ -27,10 +38,7 @@ function FalsePositiveCVEs({ imageId }: FalsePositiveCVEsProps): ReactElement {
         pagination: {
             limit: perPage,
             offset: (page - 1) * perPage,
-            sortOption: {
-                field: 'Severity',
-                reversed: true,
-            },
+            sortOption,
         },
     });
 
@@ -49,6 +57,7 @@ function FalsePositiveCVEs({ imageId }: FalsePositiveCVEsProps): ReactElement {
             updateTable={refetchQuery}
             searchFilter={searchFilter}
             setSearchFilter={setSearchFilter}
+            getSortParams={getSortParams}
         />
     );
 }

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
@@ -21,6 +21,7 @@ import usePermissions from 'hooks/usePermissions';
 import useAuthStatus from 'hooks/useAuthStatus';
 import { SearchFilter } from 'types/search';
 import ACSEmptyState from 'Components/ACSEmptyState';
+import { GetSortParams } from 'hooks/patternfly/useTableSort';
 import AffectedComponentsButton from '../AffectedComponents/AffectedComponentsButton';
 import { Vulnerability } from '../imageVulnerabilities.graphql';
 import { FalsePositiveCVEsToBeAssessed } from './types';
@@ -40,6 +41,7 @@ export type FalsePositiveCVEsTableProps = {
     updateTable: () => void;
     searchFilter: SearchFilter;
     setSearchFilter: React.Dispatch<React.SetStateAction<SearchFilter>>;
+    getSortParams: GetSortParams;
 } & UsePaginationResult;
 
 function FalsePositiveCVEsTable({
@@ -53,6 +55,7 @@ function FalsePositiveCVEsTable({
     searchFilter,
     setSearchFilter,
     isLoading,
+    getSortParams,
 }: FalsePositiveCVEsTableProps): ReactElement {
     const {
         selected,
@@ -161,7 +164,7 @@ function FalsePositiveCVEsTable({
                         />
                         <Th>CVE</Th>
                         <Th>Fixable</Th>
-                        <Th>Severity</Th>
+                        <Th sort={getSortParams('Severity')}>Severity</Th>
                         <Th modifier="fitContent">Scope</Th>
                         <Th>Affected Components</Th>
                         <Th>Comments</Th>

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
@@ -5,6 +5,7 @@ import React, { ReactElement, useState } from 'react';
 import usePagination from 'hooks/patternfly/usePagination';
 import { SearchFilter } from 'types/search';
 import queryService from 'utils/queryService';
+import useTableSort, { SortOption } from 'hooks/patternfly/useTableSort';
 import ObservedCVEsTable from './ObservedCVEsTable';
 import useImageVulnerabilities from '../useImageVulnerabilities';
 
@@ -12,9 +13,19 @@ type ObservedCVEsProps = {
     imageId: string;
 };
 
+const sortFields = ['Severity', 'CVSS', 'Discovered'];
+const defaultSortOption: SortOption = {
+    field: 'Severity',
+    direction: 'desc',
+};
+
 function ObservedCVEs({ imageId }: ObservedCVEsProps): ReactElement {
     const [searchFilter, setSearchFilter] = useState<SearchFilter>({});
     const { page, perPage, onSetPage, onPerPageSelect } = usePagination();
+    const { sortOption, getSortParams } = useTableSort({
+        sortFields,
+        defaultSortOption,
+    });
 
     const vulnsQuery = queryService.objectToWhereClause({
         ...searchFilter,
@@ -27,10 +38,7 @@ function ObservedCVEs({ imageId }: ObservedCVEsProps): ReactElement {
         pagination: {
             limit: perPage,
             offset: (page - 1) * perPage,
-            sortOption: {
-                field: 'Severity',
-                reversed: true,
-            },
+            sortOption,
         },
     });
 
@@ -55,6 +63,7 @@ function ObservedCVEs({ imageId }: ObservedCVEsProps): ReactElement {
             updateTable={refetchQuery}
             searchFilter={searchFilter}
             setSearchFilter={setSearchFilter}
+            getSortParams={getSortParams}
         />
     );
 }

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
@@ -27,6 +27,7 @@ import DateTimeFormat from 'Components/PatternFly/DateTimeFormat';
 import usePermissions from 'hooks/usePermissions';
 import { SearchFilter } from 'types/search';
 import ACSEmptyState from 'Components/ACSEmptyState';
+import { GetSortParams } from 'hooks/patternfly/useTableSort';
 import DeferralFormModal from './DeferralFormModal';
 import FalsePositiveRequestModal from './FalsePositiveFormModal';
 import { Vulnerability } from '../imageVulnerabilities.graphql';
@@ -53,6 +54,7 @@ export type ObservedCVEsTableProps = {
     updateTable: () => void;
     searchFilter: SearchFilter;
     setSearchFilter: React.Dispatch<React.SetStateAction<SearchFilter>>;
+    getSortParams: GetSortParams;
 } & UsePaginationResult;
 
 function ObservedCVEsTable({
@@ -69,6 +71,7 @@ function ObservedCVEsTable({
     searchFilter,
     setSearchFilter,
     isLoading,
+    getSortParams,
 }: ObservedCVEsTableProps): ReactElement {
     const {
         selected,
@@ -192,10 +195,10 @@ function ObservedCVEsTable({
                         />
                         <Th>CVE</Th>
                         <Th>Fixable</Th>
-                        <Th>Severity</Th>
-                        <Th>CVSS score</Th>
+                        <Th sort={getSortParams('Severity')}>Severity</Th>
+                        <Th sort={getSortParams('CVSS')}>CVSS score</Th>
                         <Th>Affected components</Th>
-                        <Th>Discovered</Th>
+                        <Th sort={getSortParams('Discovered')}>Discovered</Th>
                     </Tr>
                 </Thead>
                 <Tbody>

--- a/ui/apps/platform/src/hooks/patternfly/useTableSort.ts
+++ b/ui/apps/platform/src/hooks/patternfly/useTableSort.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { ThProps } from '@patternfly/react-table';
+
+export type SortOption = {
+    field: string;
+    direction: 'asc' | 'desc';
+};
+
+export type GetSortParams = (field: string) => ThProps['sort'];
+
+type UseTableSortProps = {
+    sortFields: string[];
+    defaultSortOption: SortOption;
+};
+
+type UseTableSortResult = {
+    sortOption: {
+        field: string;
+        reversed: boolean;
+    };
+    getSortParams: GetSortParams;
+};
+
+function useURLSort({ sortFields, defaultSortOption }: UseTableSortProps): UseTableSortResult {
+    const [sortOption, setSortOption] = useState<SortOption>();
+
+    // get the sort option values from the URL, if available
+    // otherwise, use the default sort option values
+    const activeSortField = sortOption?.field || defaultSortOption.field;
+    const activeSortDirection = sortOption?.direction || defaultSortOption.direction;
+
+    // we'll use this to map the sort fields to an id PatternFly can use internally
+    const [fieldToIdMap, setFieldToIdMap] = useState<Record<string, number>>({});
+
+    // we'll construct a map of sort fields to ids that will make it easier to work with
+    // PatternFly
+    useEffect(() => {
+        const newFieldToIdMap = sortFields.reduce((acc, curr, index) => {
+            acc[curr] = index;
+            return acc;
+        }, {} as Record<string, number>);
+        setFieldToIdMap(newFieldToIdMap);
+    }, [sortFields]);
+
+    function getSortParams(field: string): ThProps['sort'] {
+        const fieldId = fieldToIdMap[field];
+        const activeSortId = activeSortField ? fieldToIdMap[activeSortField] : undefined;
+
+        return {
+            sortBy: {
+                index: activeSortId,
+                direction: activeSortDirection,
+                defaultDirection: 'desc',
+            },
+            onSort: (_event, _index, direction) => {
+                // modify the URL based on the new sort
+                const newSortOption: SortOption = {
+                    field,
+                    direction,
+                };
+                setSortOption(newSortOption);
+            },
+            columnIndex: fieldId,
+        };
+    }
+
+    return {
+        sortOption: {
+            field: activeSortField,
+            reversed: activeSortDirection === 'desc',
+        },
+        getSortParams,
+    };
+}
+
+export default useURLSort;


### PR DESCRIPTION
## Description

I based this hook off the `useTableSort` hook @alwayshooin made previously. I found it to be helpful in abstracting away some logic to make things easier to reuse for other components. I didn't make any edits to the previous `useTableSort` hook because I know some of the tables that use that hook are constructed a bit differently (using columnDescripter-like logic)

### Sorting

 In order to use sorting we can use the following hook: `useTableSort`.

The `useTableSort` hook will take in and return the following values:

```
const { sortOption, getSortParams } = useTableSort({
        sortFields,
        defaultSortOption,
});
```

**Input**
* **sortFields** - An array of string values that you can sort by (ie. `['Severity', 'CVSS', 'Discovered']`)
* **defaultSortOption** - The default sort values when the URL does not include it
```
{
    field: 'Severity',
    direction: 'desc' | 'asc'
}
```

**Output**
* **sortOption** - The sort values from the URL
```
{
    field: 'Severity',
    reversed: true
}
```
* **getSortParams** - An altered version of the `getSortParams` you see in the following example: https://www.patternfly.org/v4/components/table#composable-sortable--wrapping-headers. You can pass the sort field name and it'll return the proper sort object to pass to a `Th` in PatternFly. Instead of passing a number value, I altered it so we just supply the field name to make it easier to map things internally
```
<Th sort={getSortParams('Severity')}>Severity</Th>
``` 

The `getSortParams` is the main difference between this hook and the hook @alwayshooin made. I think it's easier and more reusable to abstract away some of the values we returned in that hook with this function. There's logic in the hook that basically assigns an index to each sort field so we can always look things up by just the sort field name and it will properly return the sort object we can pass to each of the `Th` components. @alwayshooin maybe you can take a look at this PR and see if this would be help improve upon the hook you made previously.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

<img width="1552" alt="Screen Shot 2022-02-15 at 11 18 08 AM" src="https://user-images.githubusercontent.com/4805485/154135728-a7ef0c5c-dad6-4322-8f01-49239fcc5b57.png">
<img width="1552" alt="Screen Shot 2022-02-15 at 11 18 15 AM" src="https://user-images.githubusercontent.com/4805485/154135750-12ae4753-8fe6-4ab5-aaf2-89bf8a53a70b.png">
<img width="1552" alt="Screen Shot 2022-02-15 at 11 18 25 AM" src="https://user-images.githubusercontent.com/4805485/154135758-d82516a1-e29b-44d1-9593-f0378a602263.png">
<img width="1552" alt="Screen Shot 2022-02-15 at 11 21 55 AM" src="https://user-images.githubusercontent.com/4805485/154135765-54906224-7c6b-4e95-9d20-c0c9462b14f3.png">
<img width="1552" alt="Screen Shot 2022-02-15 at 11 23 25 AM" src="https://user-images.githubusercontent.com/4805485/154135770-8cfd4c39-3836-450f-8411-6bef051a277d.png">
