### PR TITLE
ROX-9248: Add postgres datastore feature flag

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -44,4 +44,7 @@ var (
 
 	// ImageSignatureVerification enables image signature verification.
 	ImageSignatureVerification = registerFeature("Enable Image Signature Verification workflow", "ROX_VERIFY_IMAGE_SIGNATURE", false)
+
+	// PostgresDatastore enables Postgres datastore.
+	PostgresDatastore = registerFeature("Enable Postgres Datastore", "ROX_POSTGRES_DATASTORE", false)
 )


### PR DESCRIPTION
## Description

Add postgres datastore feature flag to disable postgres related features until manually enabled by user.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

CI