### PR TITLE
Add `-trimpath` for go build

### DIFF
--- a/scripts/go-tool.sh
+++ b/scripts/go-tool.sh
@@ -101,7 +101,7 @@ function invoke_go_build() {
   if [[ "$DEBUG_BUILD" == "yes" ]]; then
     gcflags+=(-gcflags "all=-N -l")
   fi
-  invoke_go build "${gcflags[@]}" "$@"
+  invoke_go build -trimpath "${gcflags[@]}" "$@"
 }
 
 function go_run() (


### PR DESCRIPTION
## Description

> [`-trimpath` remove all file system paths from the resulting executable. Instead of absolute file system paths, the recorded file names will begin with either "go" (for the standard library), or a module path@version (when using modules), or a plain import path (when using GOPATH).](https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

CI