### PR TITLE
ROX-9228 Fix OpenShift 4.6 provisioning failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1087,7 +1087,7 @@ commands:
       - run:
           name: Destroy OpenShift 4 cluster
           environment:
-            - OPENSHIFT_4_AUTOMATION_VERSION: 0.2.17
+            - OPENSHIFT_4_AUTOMATION_VERSION: 0.2.18-35-gdd80648215-snapshot
           command: |
             if [ ! -d "$PWD/<< parameters.cluster-name >>" ]; then
               echo "OpenShift 4 Cluster not created (due to missing artifacts), skipping destroy."
@@ -2103,7 +2103,7 @@ commands:
       - run:
           name: Create OpenShift 4 cluster
           environment:
-          - OPENSHIFT_4_AUTOMATION_VERSION: 0.2.17
+          - OPENSHIFT_4_AUTOMATION_VERSION: 0.2.18-35-gdd80648215-snapshot
           - GCP_PROJECT: stackrox-ci
           command: |
             mkdir $PWD/<< parameters.cluster-name >>


### PR DESCRIPTION
## Description

Use "ocp/stable-4.6" instead of "ocp/stable-4.6" for CI Nightly testing.

https://issues.redhat.com/browse/ROX-9228

## Testing Performed

* TODO(sbostick): awaiting results
  * https://app.circleci.com/pipelines/github/stackrox/stackrox/4927/workflows/1157635f-daf0-476a-8fbd-4384319676d3/jobs/219243
* Note that only 'ci-openshift-4-operator-tests' provisions an OpenShift 4.6 cluster; everything else uses ocp/stable-4.7
  * https://github.com/stackrox/stackrox/blob/master/.circleci/config.yml#L3407
