### PR TITLE
Add srox.dumpVar Helm chart debugging helper function

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/_dump_var.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_dump_var.tpl
@@ -1,0 +1,12 @@
+{{/*
+    srox.dumpVar $var
+
+    This function pretty prints the value of the variable as JSON and fails evaluation.
+
+    Use: {{- template "srox.dumpVar" $myVar }}
+
+    Example: {{- template "srox.dumpVar" ._rox.admissionControl }}
+*/}}
+{{ define "srox.dumpVar" }}
+{{- . | mustToPrettyJson | printf "\nThe JSON output of the dumped var is: \n%s" | fail }}
+{{ end }}


### PR DESCRIPTION
## Description

Add srox.dumpVar method for pretty printing a variable and then crashing out to aid debugging Helm charts.

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed

Used the command while debugging https://github.com/stackrox/stackrox/pull/80