### PR TITLE
ROX-9406 - Add cross compiling options to create-bundle when DEBUG_BUILD is set

### DIFF
--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -88,7 +88,13 @@ cp -pr "${INPUT_ROOT}/ui/build/"*           "${bundle_root}/ui/"
 
 mkdir -p "${bundle_root}/go/bin"
 if [[ "$DEBUG_BUILD" == "yes" ]]; then
-  GOBIN="${bundle_root}/go/bin" go install github.com/go-delve/delve/cmd/dlv@latest
+  if [[ "$OSTYPE" != "linux-gnu"* ]]; then
+    GOBIN= GOOS=linux GOARCH=amd64 GOPATH="${bundle_root}/go" go install github.com/go-delve/delve/cmd/dlv@latest
+    mv $bundle_root/go/bin/linux_amd64/dlv $bundle_root/go/bin/dlv
+    rm -r $bundle_root/go/bin/linux_amd64
+  else
+    GOBIN="${bundle_root}/go/bin" go install github.com/go-delve/delve/cmd/dlv@latest
+  fi
 fi
 
 # Extract data from data container image
@@ -114,4 +120,5 @@ fi
 tar cz "${tar_chown_args[@]}" --file "$OUTPUT_BUNDLE" --directory "${bundle_root}" .
 
 # Clean up after success
+chmod -R u+w "${bundle_root}"
 rm -r "${bundle_root}"


### PR DESCRIPTION
## Description

If the `DEBUG_BUILD` variable is set to yes, the script `create-bundle` will install the delve debugger in the resulting image with:

```
go install github.com/go-delve/delve/cmd/dlv@latest
```

This works if the host machine is Linux, but for MacOS it will install the MacOS version of the debugger, thus making it fail later when one tries to run it within the image.

GOAL: Modify `create-bundle` to make it install the correct `dlv` version when one is creating the images from a non-Linux host.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed

Creating the images with `DEBUG_BUILD` set to yes on macOS and check if it is possible to debug remotely.
