### PR TITLE
Update connect-ui.sh script to use current dev gcloud proejct

### DIFF
--- a/scripts/connect-ui.sh
+++ b/scripts/connect-ui.sh
@@ -26,7 +26,7 @@ fi
 # Openshift: us-east1-d
 
 # get gcloud user name
-gcloud container clusters get-credentials "${CLUSTER_NAME}" --project stackrox-ci $zone || {
+gcloud container clusters get-credentials "${CLUSTER_NAME}" --project srox-temp-dev-test $zone || {
   exit 1
 }
 [[ -n "$GCLOUD_USER" ]] || GCLOUD_USER="$(gcloud config get-value account 2>/dev/null)"


### PR DESCRIPTION
## Description

This fixed make the process described in this document work again.

https://github.com/stackrox/dev-docs/blob/main/docs/knowledge-base/%5BFE%5D%20Use-remote-Central-for-local-front-end-dev.md

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Ran the script locally, indirectly through `yarn connect <cluster-name>`, and it worked.
