### PR TITLE
ROX-9399: Change default for report severities from none to all

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReport.utils.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReport.utils.ts
@@ -16,7 +16,12 @@ export const emptyReportValues: ReportConfiguration = {
     vulnReportFilters: {
         fixability: 'BOTH',
         sinceLastReport: false,
-        severities: [],
+        severities: [
+            'CRITICAL_VULNERABILITY_SEVERITY',
+            'IMPORTANT_VULNERABILITY_SEVERITY',
+            'MODERATE_VULNERABILITY_SEVERITY',
+            'LOW_VULNERABILITY_SEVERITY',
+        ],
     },
     scopeId: '',
     emailConfig: {


### PR DESCRIPTION
## Description

Product request to make the default selections for Severities in the Vuln Management Report form **all** levels of severity, instead of the nothing initially selected, and forcing the user to choose.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

(Note: automated testing of the PatternFly multi-checkbox Select component is still O^n hard, so skipping for now.)

Manual testing, both initial state, saving as-is, and saving changed, and going back in and editing after save.
<img width="1506" alt="Screen Shot 2022-02-17 at 3 15 03 PM" src="https://user-images.githubusercontent.com/715729/154564313-45ae970b-ba25-41f4-be8d-b601b8f11099.png">
