### PR TITLE
Replace beforeEach in general cypress integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/DashboardPage.js
+++ b/ui/apps/platform/cypress/constants/DashboardPage.js
@@ -7,6 +7,7 @@ export const selectors = {
     buttons: {
         viewAll: 'button:contains("View All")',
     },
+    summaryCount: '[data-testid="summary-tile-count"]',
     sectionHeaders: {
         systemViolations: 'h2:contains("System Violations")',
         compliance: 'h2:contains("Compliance")',

--- a/ui/apps/platform/cypress/constants/GeneralPage.js
+++ b/ui/apps/platform/cypress/constants/GeneralPage.js
@@ -2,7 +2,6 @@ const selectors = {
     navLinks: {
         first: 'ul.pf-c-nav__list li:first a',
         others: 'ul.pf-c-nav__list li:not(:first) a',
-        list: 'nav.top-navigation li',
         apidocs: '[data-testid="API Reference"]',
     },
     leftNavLinks: 'nav.left-navigation li a',

--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -134,6 +134,7 @@ export const certGen = {
 
 export const dashboard = {
     timeseries: '/v1/alerts/summary/timeseries?*',
+    summaryCounts: graphql('summary_counts'),
 };
 
 export const metadata = 'v1/metadata';


### PR DESCRIPTION
## Description

Test flake:

* https://app.circleci.com/pipelines/github/stackrox/stackrox/4738/workflows/16a767b3-547a-4d44-aa7a-e480c3867ed0/jobs/210714
* https://app.circleci.com/pipelines/github/stackrox/stackrox/5105/workflows/6c57c42f-42a3-46f8-ba0c-67e784dae244/jobs/227589

> General sanity checks should have correct page titles based on URL "before each" hook for "for User Profile" - CypressError: Cypress command timeout of 4000ms exceeded.

1. Specific changes
    * User Profile test is preceded by API Reference test, the only test which has `timeout` option. Move API Reference to last place. If it causes problems in the future, skip it.

2. Generic changes
    * Import url from constants files for page title tests
    * Add intercept and wait for requests which seem the most relevant and also the last before rendering (for example, summary counts on main dashboard)
    * To enable summary counts test, replace selector for summary counts on top nav with summary counts on main dashboard
    * Replace rare selector alias to avoid confusion in search results for `as` for intercept alias
    * Replace `cy.url` with `cy.location` to make assertion more precise
    * Rewrite get-should-expect assertions with complete selectors which are more descriptive and robust

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

1. `yarn cypress-open` in ui/apps/platform and then
    * general.test.js notice `'should allow to navigate to another page after exception happens on a page'` test fails for development build in local deployment