### PR TITLE
Only debug log invalid process signal

### DIFF
--- a/sensor/common/signal/signal_service.go
+++ b/sensor/common/signal/signal_service.go
@@ -123,10 +123,10 @@ func (s *serviceImpl) receiveMessages(stream sensorAPI.SignalService_PushSignals
 
 			processSignal.ExecFilePath = stringutils.OrDefault(processSignal.GetExecFilePath(), processSignal.GetName())
 			if !isProcessSignalValid(processSignal) {
+				log.Debugf("Invalid process signal: %+v", processSignal)
 				continue
 			}
 
-			log.Debugf("Process Signal: %+v", processSignal)
 			s.processPipeline.Process(processSignal)
 		default:
 			// Currently eat unhandled signals


### PR DESCRIPTION
## Description

These logs are cluttering the Sensor's debug logs.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed

Saw the logs were much less cluttered in an OpenShift environment.
