### PR TITLE
Replace beforeEach in system health clusters cypress integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -1,0 +1,9 @@
+import * as api from '../constants/apiEndpoints';
+import { url } from '../constants/DashboardPage';
+
+// eslint-disable-next-line import/prefer-default-export
+export function visitMainDashboard() {
+    cy.intercept('POST', api.dashboard.summaryCounts).as('summaryCounts');
+    cy.visit(url);
+    cy.wait('@summaryCounts');
+}

--- a/ui/apps/platform/cypress/helpers/nav.js
+++ b/ui/apps/platform/cypress/helpers/nav.js
@@ -1,0 +1,20 @@
+import navSelectors from '../selectors/navigation';
+import { visitMainDashboard } from './main';
+
+/*
+ * For example, visitFromLeftNav('Violations');
+ */
+export function visitFromLeftNav(itemText) {
+    visitMainDashboard();
+    cy.get(`${navSelectors.navLinks}:contains("${itemText}")`).click();
+}
+
+/*
+ * For example, visitFromLeftNavExpandable('Vulnerability Management', 'Reporting');
+ * For example, visitFromLeftNavExpandable('Platform Configuration', 'Integrations');
+ */
+export function visitFromLeftNavExpandable(expandableTitle, itemText) {
+    visitMainDashboard();
+    cy.get(`${navSelectors.navExpandable}:contains("${expandableTitle}")`).click();
+    cy.get(`${navSelectors.nestedNavLinks}:contains("${itemText}")`).click();
+}


### PR DESCRIPTION
## Description

Test flakes

1. System Health Clusters health fixture "before each" hook for "should have counts in Cluster Overview"
    The following error originated from your application code, not from Cypress. It was caused by an unhandled promise rejection.
    Network Error
    * https://app.circleci.com/pipelines/github/stackrox/stackrox/5011/workflows/5acd6d01-03a8-4751-b04e-5dc683865ff4/jobs/223277

2. Cluster Health should appear in the form for alpha-amsterdam-1
    The following error originated from your application code, not from Cypress. It was caused by an unhandled promise rejection.
    Network Error
    * https://app.circleci.com/pipelines/github/stackrox/stackrox/5332/workflows/52e172a0-6aa1-42b1-97ce-504675cfbe26/jobs/238431

3. Cluster Health should appear in the form for lambda-liverpool-11
    AssertionError: Timed out retrying after 4000ms: Expected to find element: `[data-testid="cluster-form"] input[name="name"]`, but never found it.
    * https://app.circleci.com/pipelines/github/stackrox/stackrox/5319/workflows/ea53d4d2-8587-4e73-b04a-fdbd7c58d51d/jobs/237683

Add specific helper functions to test file and import generic helper functions (which might be useful elsewhere as follow up)

By the way, I commented out wait for clusters in PatternFly version, because the incomplete version does not yet make the request

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

1. In ui folder
    ```sh
    export ROX_SYSTEM_HEALTH_PF=true
    yarn deploy-local
    yarn start
    ```

2. In ui/apps/platform folder
    ```sh
    export CYPRESS_ROX_SYSTEM_HEALTH_PF=true
    yarn cypress-open
    ```
    and then select
    * systemHealth/clusters.test.js