### PR TITLE
Move ctx from struct fo function signature in ReconcileSecret

### DIFF
--- a/operator/pkg/central/extensions/reconcile_scanner_db_password.go
+++ b/operator/pkg/central/extensions/reconcile_scanner_db_password.go
@@ -25,10 +25,10 @@ func ReconcileScannerDBPasswordExtension(client ctrlClient.Client) extensions.Re
 
 func reconcileScannerDBPassword(ctx context.Context, c *platform.Central, client ctrlClient.Client, _ func(updateStatusFunc), log logr.Logger) error {
 	run := &reconcileScannerDBPasswordExtensionRun{
-		SecretReconciliator: commonExtensions.NewSecretReconciliator(ctx, client, c),
+		SecretReconciliator: commonExtensions.NewSecretReconciliator(client, c),
 		centralObj:          c,
 	}
-	return run.Execute()
+	return run.Execute(ctx)
 }
 
 type reconcileScannerDBPasswordExtensionRun struct {
@@ -36,11 +36,11 @@ type reconcileScannerDBPasswordExtensionRun struct {
 	centralObj *platform.Central
 }
 
-func (r *reconcileScannerDBPasswordExtensionRun) Execute() error {
+func (r *reconcileScannerDBPasswordExtensionRun) Execute(ctx context.Context) error {
 	// Delete any scanner-db password only if the CR is being deleted, or scanner is not enabled.
 	shouldDelete := r.centralObj.DeletionTimestamp != nil || !r.centralObj.Spec.Scanner.IsEnabled()
 
-	if err := r.ReconcileSecret("scanner-db-password", !shouldDelete, r.validateScannerDBPasswordData, r.generateScannerDBPasswordData, true); err != nil {
+	if err := r.ReconcileSecret(ctx, "scanner-db-password", !shouldDelete, r.validateScannerDBPasswordData, r.generateScannerDBPasswordData, true); err != nil {
 		return errors.Wrap(err, "reconciling scanner-db-password secret")
 	}
 

--- a/operator/pkg/central/extensions/reconcile_tls.go
+++ b/operator/pkg/central/extensions/reconcile_tls.go
@@ -30,11 +30,10 @@ func ReconcileCentralTLSExtensions(client ctrlClient.Client) extensions.Reconcil
 
 func reconcileCentralTLS(ctx context.Context, c *platform.Central, client ctrlClient.Client, _ func(updateStatusFunc), log logr.Logger) error {
 	run := &createCentralTLSExtensionRun{
-		SecretReconciliator: commonExtensions.NewSecretReconciliator(ctx, client, c),
+		SecretReconciliator: commonExtensions.NewSecretReconciliator(client, c),
 		centralObj:          c,
-		ctx:                 ctx,
 	}
-	return run.Execute()
+	return run.Execute(ctx)
 }
 
 type createCentralTLSExtensionRun struct {
@@ -42,28 +41,27 @@ type createCentralTLSExtensionRun struct {
 
 	ca         mtls.CA
 	centralObj *platform.Central
-	ctx        context.Context
 }
 
-func (r *createCentralTLSExtensionRun) Execute() error {
+func (r *createCentralTLSExtensionRun) Execute(ctx context.Context) error {
 	shouldDelete := r.centralObj.DeletionTimestamp != nil
 
 	// If we find a broken central-tls secret, do NOT try to auto-fix it. Doing so would invalidate all previously issued certificates
 	// (including sensor certificates and init bundles), and is very unlikely to result in a working state.
-	if err := r.ReconcileSecret("central-tls", !shouldDelete, r.validateAndConsumeCentralTLSData, r.generateCentralTLSData, false); err != nil {
+	if err := r.ReconcileSecret(ctx, "central-tls", !shouldDelete, r.validateAndConsumeCentralTLSData, r.generateCentralTLSData, false); err != nil {
 		return errors.Wrap(err, "reconciling central-tls secret")
 	}
 
 	// scanner and scanner-db certs can be re-issued without a problem.
 	scannerEnabled := r.centralObj.Spec.Scanner.IsEnabled()
-	if err := r.ReconcileSecret("scanner-tls", scannerEnabled && !shouldDelete, r.validateScannerTLSData, r.generateScannerTLSData, true); err != nil {
+	if err := r.ReconcileSecret(ctx, "scanner-tls", scannerEnabled && !shouldDelete, r.validateScannerTLSData, r.generateScannerTLSData, true); err != nil {
 		return errors.Wrap(err, "reconciling scanner secret")
 	}
-	if err := r.ReconcileSecret("scanner-db-tls", scannerEnabled && !shouldDelete, r.validateScannerDBTLSData, r.generateScannerDBTLSData, true); err != nil {
+	if err := r.ReconcileSecret(ctx, "scanner-db-tls", scannerEnabled && !shouldDelete, r.validateScannerDBTLSData, r.generateScannerDBTLSData, true); err != nil {
 		return errors.Wrap(err, "reconciling scanner-db secret")
 	}
 
-	bundleSecretShouldExist, err := r.shouldBundleSecretsExist(shouldDelete)
+	bundleSecretShouldExist, err := r.shouldBundleSecretsExist(ctx, shouldDelete)
 	if err != nil {
 		return err
 	}
@@ -77,7 +75,7 @@ func (r *createCentralTLSExtensionRun) Execute() error {
 		generateFunc := func() (types.SecretDataMap, error) {
 			return r.generateInitBundleTLSData(slugCaseService+"-", serviceType)
 		}
-		if err := r.ReconcileSecret(secretName, bundleSecretShouldExist, validateFunc, generateFunc, fixExistingInitBundleSecret); err != nil {
+		if err := r.ReconcileSecret(ctx, secretName, bundleSecretShouldExist, validateFunc, generateFunc, fixExistingInitBundleSecret); err != nil {
 			return errors.Wrapf(err, "reconciling %s secret ", slugCaseService)
 		}
 	}
@@ -85,12 +83,12 @@ func (r *createCentralTLSExtensionRun) Execute() error {
 	return nil
 }
 
-func (r *createCentralTLSExtensionRun) shouldBundleSecretsExist(shouldDelete bool) (bool, error) {
+func (r *createCentralTLSExtensionRun) shouldBundleSecretsExist(ctx context.Context, shouldDelete bool) (bool, error) {
 	if shouldDelete {
 		// Don't bother listing secured clusters if we're ensuring absence of bundle for other reasons.
 		return false, nil
 	}
-	securedClusterPresent, err := r.isSiblingSecuredClusterPresent()
+	securedClusterPresent, err := r.isSiblingSecuredClusterPresent(ctx)
 	if err != nil {
 		return false, errors.Wrap(err, "determining whether to create init bundle failed")
 	}
@@ -188,10 +186,10 @@ func (r *createCentralTLSExtensionRun) generateInitBundleTLSData(fileNamePrefix 
 	return fileMap, nil
 }
 
-func (r *createCentralTLSExtensionRun) isSiblingSecuredClusterPresent() (bool, error) {
+func (r *createCentralTLSExtensionRun) isSiblingSecuredClusterPresent(ctx context.Context) (bool, error) {
 	list := &platform.SecuredClusterList{}
 	namespace := r.centralObj.GetNamespace()
-	if err := r.Client().List(r.ctx, list, ctrlClient.InNamespace(namespace)); err != nil {
+	if err := r.Client().List(ctx, list, ctrlClient.InNamespace(namespace)); err != nil {
 		return false, errors.Wrapf(err, "cannot list securedclusters in namespace %q", namespace)
 	}
 	return len(list.Items) > 0, nil

--- a/operator/pkg/common/extensions/secret_reconciliator.go
+++ b/operator/pkg/common/extensions/secret_reconciliator.go
@@ -26,9 +26,8 @@ type k8sObject interface {
 
 // NewSecretReconciliator creates a new SecretReconciliator. It takes a context and controller client.
 // The obj parameter is the owner object (i.e. a custom resource).
-func NewSecretReconciliator(ctx context.Context, client ctrlClient.Client, obj k8sObject) *SecretReconciliator {
+func NewSecretReconciliator(client ctrlClient.Client, obj k8sObject) *SecretReconciliator {
 	return &SecretReconciliator{
-		ctx:    ctx,
 		client: client,
 		obj:    obj,
 	}
@@ -36,7 +35,6 @@ func NewSecretReconciliator(ctx context.Context, client ctrlClient.Client, obj k
 
 // SecretReconciliator reconciles a secret.
 type SecretReconciliator struct {
-	ctx    context.Context
 	client ctrlClient.Client
 	obj    k8sObject
 }
@@ -57,10 +55,10 @@ func (r *SecretReconciliator) Namespace() string {
 // changing an invalid secret can bring more harm than good.
 // In this case this function will return an error if "validate" rejects the secret.
 // Also note that (regardless of the value of "fixExisting") this function will never touch a secret which is not owned by the object passed to the constructor.
-func (r *SecretReconciliator) ReconcileSecret(name string, shouldExist bool, validate validateSecretDataFunc, generate generateSecretDataFunc, fixExisting bool) error {
+func (r *SecretReconciliator) ReconcileSecret(ctx context.Context, name string, shouldExist bool, validate validateSecretDataFunc, generate generateSecretDataFunc, fixExisting bool) error {
 	secret := &coreV1.Secret{}
 	key := ctrlClient.ObjectKey{Namespace: r.Namespace(), Name: name}
-	if err := r.Client().Get(r.ctx, key, secret); err != nil {
+	if err := r.Client().Get(ctx, key, secret); err != nil {
 		if !apiErrors.IsNotFound(err) {
 			return errors.Wrapf(err, "checking existence of %s secret", name)
 		}
@@ -71,7 +69,7 @@ func (r *SecretReconciliator) ReconcileSecret(name string, shouldExist bool, val
 			return nil
 		}
 
-		if err := utils.DeleteExact(r.ctx, r.Client(), secret); err != nil && !apiErrors.IsNotFound(err) {
+		if err := utils.DeleteExact(ctx, r.Client(), secret); err != nil && !apiErrors.IsNotFound(err) {
 			return errors.Wrapf(err, "deleting %s secret", name)
 		}
 		return nil
@@ -115,12 +113,12 @@ func (r *SecretReconciliator) ReconcileSecret(name string, shouldExist bool, val
 	}
 
 	if secret == nil {
-		if err := r.Client().Create(r.ctx, newSecret); err != nil {
+		if err := r.Client().Create(ctx, newSecret); err != nil {
 			return errors.Wrapf(err, "creating new %s secret", name)
 		}
 	} else {
 		newSecret.ResourceVersion = secret.ResourceVersion
-		if err := r.Client().Update(r.ctx, newSecret); err != nil {
+		if err := r.Client().Update(ctx, newSecret); err != nil {
 			return errors.Wrapf(err, "updating %s secret because existing instance failed validation", secret.Name)
 		}
 	}


### PR DESCRIPTION
## Description

Move the context parameter from the struct to the function signature according to Go's doc best-practice (https://github.com/golang/go/blob/master/src/context/context.go#L29-L35)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

 - CI