### PR TITLE
Remove AsyncScanner

### DIFF
--- a/pkg/images/enricher/enricher.go
+++ b/pkg/images/enricher/enricher.go
@@ -39,10 +39,6 @@ type EnrichmentContext struct {
 	// EnforcementOnly indicates that we don't care about any violations unless they have enforcement enabled.
 	EnforcementOnly bool
 
-	// UseNonBlockingCallsWherePossible tells the enricher to make non-blocking calls to image scanners where that is
-	// possible. Note that, if NoExternalMetadata is true, this param is irrelevant since no external calls are made at all.
-	UseNonBlockingCallsWherePossible bool
-
 	// Internal is used to indicate when the caller is internal.
 	// This is used to indicate that we do not want to fail upon failing to find integrations.
 	Internal bool

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -256,7 +256,7 @@ func (e *enricherImpl) enrichWithScan(ctx EnrichmentContext, image *storage.Imag
 	}
 
 	for _, scanner := range scanners.GetAll() {
-		result, err := e.enrichImageWithScanner(ctx, image, scanner)
+		result, err := e.enrichImageWithScanner(image, scanner)
 		if err != nil {
 			var currentScannerErrors int32
 			concurrency.WithLock(&e.scannerErrorsLock, func() {
@@ -311,43 +311,28 @@ func normalizeVulnerabilities(scan *storage.ImageScan) {
 	}
 }
 
-func (e *enricherImpl) enrichImageWithScanner(ctx EnrichmentContext, image *storage.Image, scanner scannerTypes.ImageScanner) (ScanResult, error) {
+func (e *enricherImpl) enrichImageWithScanner(image *storage.Image, scanner scannerTypes.ImageScanner) (ScanResult, error) {
 	if !scanner.Match(image.GetName()) {
 		return ScanNotDone, nil
 	}
 
-	var scan *storage.ImageScan
+	sema := scanner.MaxConcurrentScanSemaphore()
+	_ = sema.Acquire(context.Background(), 1)
+	defer sema.Release(1)
 
-	if asyncScanner, ok := scanner.(scannerTypes.AsyncScanner); ok && ctx.UseNonBlockingCallsWherePossible {
-		_ = e.asyncRateLimiter.Wait(context.Background())
-
-		var err error
-		scan, err = asyncScanner.GetOrTriggerScan(image)
-		if err != nil {
-			return ScanNotDone, errors.Wrapf(err, "Error triggering scan for %q with scanner %q", image.GetName().GetFullName(), scanner.Name())
-		}
-		if scan == nil {
-			return ScanTriggered, nil
-		}
-	} else {
-		sema := scanner.MaxConcurrentScanSemaphore()
-		_ = sema.Acquire(context.Background(), 1)
-		defer sema.Release(1)
-
-		var err error
-		scanStartTime := time.Now()
-		scan, err = scanner.GetScan(image)
-		e.metrics.SetScanDurationTime(scanStartTime, scanner.Name(), err)
-		if err != nil {
-			return ScanNotDone, errors.Wrapf(err, "Error scanning %q with scanner %q", image.GetName().GetFullName(), scanner.Name())
-		}
-		if scan == nil {
-			return ScanNotDone, nil
-		}
-
-		// normalize the vulns
-		normalizeVulnerabilities(scan)
+	scanStartTime := time.Now()
+	scan, err := scanner.GetScan(image)
+	e.metrics.SetScanDurationTime(scanStartTime, scanner.Name(), err)
+	if err != nil {
+		return ScanNotDone, errors.Wrapf(err, "Error scanning %q with scanner %q", image.GetName().GetFullName(), scanner.Name())
 	}
+	if scan == nil {
+		return ScanNotDone, nil
+	}
+
+	// normalize the vulns
+	normalizeVulnerabilities(scan)
+
 	scan.DataSource = scanner.DataSource()
 
 	// Assume:

--- a/pkg/scanners/anchore/anchore.go
+++ b/pkg/scanners/anchore/anchore.go
@@ -202,10 +202,6 @@ func (a *anchore) Test() error {
 	return err
 }
 
-func (a *anchore) GetOrTriggerScan(image *storage.Image) (*storage.ImageScan, error) {
-	return a.getOrTriggerScan(image)
-}
-
 func (a *anchore) GetScan(image *storage.Image) (*storage.ImageScan, error) {
 	for attempt := 0; attempt < maxPollAttempts; attempt++ {
 		scan, err := a.getOrTriggerScan(image)

--- a/pkg/scanners/types/types.go
+++ b/pkg/scanners/types/types.go
@@ -27,15 +27,6 @@ type ImageScanner interface {
 	DataSource() *storage.DataSource
 }
 
-// AsyncScanner is an image scanner that can be accessed asynchronously.
-type AsyncScanner interface {
-	Scanner
-	// GetOrTriggerScan does a non-blocking request to the scanner.
-	// It gets the scan for the given image if it exists;
-	// if not, implementations trigger a new one and instantly return.
-	GetOrTriggerScan(image *storage.Image) (*storage.ImageScan, error)
-}
-
 // NodeScanner is the interface all node scanners must implement
 type NodeScanner interface {
 	NodeScanSemaphore


### PR DESCRIPTION
## Description

We never actually use this, so let's just remove it...

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed

CI. Anchore was the only "async" scanner, but the tests all use it synchronously, too.
