### PR TITLE
add go mod tidy to each restore cache step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ restoreGoModCache: &restoreGoModCache
 
 goModTidy: &goModTidy
   run:
-    name: go mod tidy
+    name: Ensure all go modules are present
     command: go mod tidy
     when: always
 


### PR DESCRIPTION
## Description

This ensures the go mod cache always exists in steps which may need it. This is useful for the reverted PR which failed CI due to lack of go cache: #742 

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~

## Testing Performed

CI
