### PR TITLE
Increase default Scanner memory limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Entries in this file should be limited to:
 Please avoid adding duplicate information across this changelog and JIRA/doc input pages.
 
 ## [NEXT RELEASE]
+- Increased default Scanner memory limit from 3000 MiB to 4GiB.
 - API changes/deprecations:
   - `GetKernelSupportAvailable (GET /v1/clusters-env/kernel-support-available)` is deprecated, use `GetClusterDefaults (GET /v1/cluster-defaults)` instead.
 

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -55,7 +55,7 @@ defaults:
         memory: "1500Mi"
         cpu: "1000m"
       limits:
-        memory: "3000Mi"
+        memory: "4Gi"
         cpu: "2000m"
 
     image:

--- a/image/templates/helm/stackrox-central/values-public.yaml.example
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example
@@ -311,7 +311,7 @@
 #       memory: "1500Mi"
 #       cpu: "1000m"
 #     limits:
-#       memory: "3000Mi"
+#       memory: "4Gi"
 #       cpu: "2000m"
 #
 #   # Custom resource overrides for the Scanner DB deployment.

--- a/image/templates/helm/stackrox-central/values.yaml
+++ b/image/templates/helm/stackrox-central/values.yaml
@@ -209,7 +209,7 @@
 #      memory: "1500Mi"
 #      cpu: "1000m"
 #    limits:
-#      memory: "3000Mi"
+#      memory: "4Gi"
 #      cpu: "2000m"
 #
 #  image:

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/70-scanner.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/70-scanner.yaml
@@ -14,7 +14,7 @@ scanner:
       memory: "1500Mi"
       cpu: "1000m"
     limits:
-      memory: "3000Mi"
+      memory: "4Gi"
       cpu: "2000m"
 
   dbResources:

--- a/image/templates/helm/stackrox-secured-cluster/values-scanner.yaml.example
+++ b/image/templates/helm/stackrox-secured-cluster/values-scanner.yaml.example
@@ -75,7 +75,7 @@
 #       memory: "1500Mi"
 #       cpu: "1000m"
 #     limits:
-#       memory: "3000Mi"
+#       memory: "4Gi"
 #       cpu: "2000m"
 #
 #   # Custom resource overrides for the Scanner DB deployment.


### PR DESCRIPTION
## Description

Increase default Scanner memory limit to 4GiB. The online docs have a different set of numbers with the recommended upper limit of 8GiB. This diff is to make the recommended upper limit in par with upper limit tested in Scanner and in online doc.  

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
