### PR TITLE
Dedupe REMOVE actions from Sensor

### DIFF
--- a/sensor/common/deduper/deduper.go
+++ b/sensor/common/deduper/deduper.go
@@ -55,7 +55,13 @@ func (d *deduper) Send(msg *central.MsgFromSensor) error {
 		resourceType: reflect.TypeOf(event.GetResource()),
 	}
 	if event.GetAction() == central.ResourceAction_REMOVE_RESOURCE {
+		priorLen := len(d.lastSent)
 		delete(d.lastSent, key)
+		// Do not send a remove message for something that has not been seen before
+		// This also effectively dedupes REMOVE actions
+		if priorLen == len(d.lastSent) {
+			return nil
+		}
 		return d.stream.Send(msg)
 	}
 


### PR DESCRIPTION
## Description

Pods and deployments can have multiple removes sent. We've seen way more removes than updates and creates meaning that the same object is being asked to be removed multiple times. This is very expensive

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

CI