### PR TITLE
Make info color more visible for roxctl.

### DIFF
--- a/roxctl/common/environment/log_test.go
+++ b/roxctl/common/environment/log_test.go
@@ -33,7 +33,7 @@ func TestLogger(t *testing.T) {
 		{
 			name:   "Info",
 			fun:    func(l Logger) { l.InfofLn(in) },
-			errOut: "\x1b[34;2mINFO:\t(TOTAL: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)\n\x1b[0m",
+			errOut: "\x1b[94mINFO:\t(TOTAL: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)\n\x1b[0m",
 		},
 		{
 			name:   "Warn",

--- a/roxctl/common/printer/colorprinter.go
+++ b/roxctl/common/printer/colorprinter.go
@@ -57,7 +57,7 @@ func DefaultColorPrinter() ColorfulPrinter {
 	c := &colorPrinter{
 		err:             color.New(color.FgRed, color.Bold).FprintfFunc(),
 		warn:            color.New(color.FgHiMagenta).FprintfFunc(),
-		info:            color.New(color.FgBlue, color.Faint).FprintfFunc(),
+		info:            color.New(color.FgHiBlue).FprintfFunc(),
 		bold:            color.New(color.Bold).FprintfFunc(),
 		colorKeyWordMap: wordToColorfulWord,
 	}


### PR DESCRIPTION
## Description

Previously, `INFO` message's color was not as readable as one would like.

Previously:
(Linux)
![image](https://user-images.githubusercontent.com/89904305/155698541-878eef3a-e310-4497-9e0d-39cc6ea8fb7a.png)
(MacOS)
![Screenshot 2022-02-25 at 11 24 01](https://user-images.githubusercontent.com/89904305/155698887-70d0f22c-1e11-489f-a4b9-c24e46394edb.png)

Now:
(MacOS)
![Screenshot 2022-02-25 at 11 25 34](https://user-images.githubusercontent.com/89904305/155699066-5a388348-343d-42ae-8dd2-0fcf25234828.png)



## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
