### PR TITLE
Add more limited helper functions for cluster integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/clusters.js
+++ b/ui/apps/platform/cypress/helpers/clusters.js
@@ -24,21 +24,43 @@ export function visitClusters() {
     cy.wait('@getClusters');
 }
 
+export function visitClustersWithFixture(fixturePath) {
+    cy.intercept('GET', api.clusters.list, {
+        fixture: fixturePath,
+    }).as('getClusters');
+    cy.visit(clustersUrl);
+    cy.wait('@getClusters');
+}
+
 export function visitClustersWithFixtureMetadataDatetime(fixturePath, metadata, datetimeISOString) {
+    cy.intercept('GET', api.clusters.list, {
+        fixture: fixturePath,
+    }).as('getClusters');
+    cy.intercept('GET', api.metadata, {
+        body: metadata,
+    }).as('getMetadata');
+
+    // For comparison to `lastContact` and `sensorCertExpiry` in clusters fixture.
+    const currentDatetime = new Date(datetimeISOString);
+    cy.clock(currentDatetime.getTime(), ['Date', 'setInterval']);
+
+    cy.visit(clustersUrl);
+    cy.wait(['@getClusters', '@getMetadata']);
+}
+
+export function visitClusterByNameWithFixture(clusterName, fixturePath) {
     cy.fixture(fixturePath).then(({ clusters }) => {
         cy.intercept('GET', api.clusters.list, {
             body: { clusters },
         }).as('getClusters');
-        cy.intercept('GET', api.metadata, {
-            body: metadata,
-        }).as('getMetadata');
 
-        // For comparison to `lastContact` and `sensorCertExpiry` in clusters fixture.
-        const currentDatetime = new Date(datetimeISOString);
-        cy.clock(currentDatetime.getTime(), ['Date', 'setInterval']);
+        const cluster = clusters.find(({ name }) => name === clusterName);
+        cy.intercept('GET', api.clusters.single, {
+            body: { cluster },
+        }).as('getCluster');
 
-        cy.visit(clustersUrl);
-        cy.wait(['@getClusters', '@getMetadata']);
+        cy.visit(`${clustersUrl}/${cluster.id}`);
+        cy.wait(['@getClusters', '@getCluster']);
     });
 }
 

--- a/ui/apps/platform/cypress/integration/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/clusters.test.js
@@ -6,7 +6,9 @@ import withAuth from '../helpers/basicAuth';
 import {
     visitClusters,
     visitClustersFromLeftNav,
+    visitClustersWithFixture,
     visitClustersWithFixtureMetadataDatetime,
+    visitClusterByNameWithFixture,
     visitClusterByNameWithFixtureMetadataDatetime,
 } from '../helpers/clusters';
 
@@ -286,20 +288,8 @@ describe('Cluster management', () => {
     withAuth();
 
     it('should indicate which clusters are managed by Helm and the Operator', () => {
-        cy.intercept('GET', clustersApi.list, {
-            fixture: 'clusters/health.json',
-        }).as('getClusters');
-        cy.intercept('GET', clustersApi.kernelSupportAvailable, {
-            body: {
-                kernelSupportAvailable: true,
-            },
-        }).as('getIsKernelSupportAvailable');
-
-        const currentDatetime = new Date('2020-08-31T13:01:00Z');
-        cy.clock(currentDatetime.getTime(), ['Date', 'setInterval']);
-
-        cy.visit(clustersUrl);
-        cy.wait('@getClusters');
+        const fixturePath = 'clusters/health.json';
+        visitClustersWithFixture(fixturePath);
 
         const helmIndicator = '[data-testid="cluster-name"] img[alt="Managed by Helm"]';
         const k8sOperatorIndicator =
@@ -319,13 +309,6 @@ describe('Cluster configuration', () => {
     withAuth();
 
     const fixturePath = 'clusters/health.json';
-    const metadata = {
-        version: '3.0.50.0', // for comparison to `sensorVersion` in clusters fixture
-        buildFlavor: 'release',
-        releaseBuild: true,
-        licenseStatus: 'VALID',
-    };
-    const datetimeISOString = '2020-08-31T13:01:00Z'; // for comparison to `lastContact` and `sensorCertExpiry` in clusters fixture
 
     const assertConfigurationReadOnly = () => {
         const form = cy.get('[data-testid="cluster-form"]').children();
@@ -353,22 +336,12 @@ describe('Cluster configuration', () => {
     };
 
     it('should be read-only for Helm-based installations', () => {
-        visitClusterByNameWithFixtureMetadataDatetime(
-            'alpha-amsterdam-1',
-            fixturePath,
-            metadata,
-            datetimeISOString
-        );
+        visitClusterByNameWithFixture('alpha-amsterdam-1', fixturePath);
         assertConfigurationReadOnly();
     });
 
     it('should be read-only for unknown manager installations that have a defined Helm config', () => {
-        visitClusterByNameWithFixtureMetadataDatetime(
-            'kappa-kilogramme-10',
-            fixturePath,
-            metadata,
-            datetimeISOString
-        );
+        visitClusterByNameWithFixture('kappa-kilogramme-10', fixturePath);
         assertConfigurationReadOnly();
     });
 });


### PR DESCRIPTION
## Description

### Problem

Cluster configuration should be read-only for Helm-based installations
The following error originated from your application code, not from Cypress. It was caused by an unhandled promise rejection.
Network Error
* https://app.circleci.com/pipelines/github/stackrox/stackrox/5501/workflows/316ff6e1-8d7b-474d-b0cb-0a86aa70f7a9/jobs/246081
* https://app.circleci.com/pipelines/github/stackrox/stackrox/5583/workflows/e14ec2cb-7b6f-4a30-a958-dc8753bb2232/jobs/249992
* https://app.circleci.com/pipelines/github/stackrox/stackrox/5612/workflows/5857592d-8b3d-4d98-9384-1641f5aa60da/jobs/251272

### Solution

1. Add `visitClustersWithFixture` because **Cluster configuration** tests do not depend on metadata nor date. My bad to call `visitClusterByNameWithFixtureMetadataDatetime` for them in #703

2. Also simplify `visitClustersWithFixtureMetadataDatetime` in case it is causing cluster health to fail intermittently

3. Add `VisitClusterNameWithFixture` because **Cluster management** test can also use a more limited helper function

**Residue**: Seek a more composable idiom for the helper functions, after the tests have become reliable.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Ran tests locally and now see what happens in CI