### PR TITLE
Log internal error before panic

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -466,12 +466,12 @@ func startGRPCServer() {
 
 	if devbuild.IsEnabled() {
 		config.UnaryInterceptors = append(config.UnaryInterceptors,
-			errors.PanicOnInvariantViolationUnaryInterceptor,
 			errors.LogInternalErrorInterceptor,
+			errors.PanicOnInvariantViolationUnaryInterceptor,
 		)
 		config.StreamInterceptors = append(config.StreamInterceptors,
-			errors.PanicOnInvariantViolationStreamInterceptor,
 			errors.LogInternalErrorStreamInterceptor,
+			errors.PanicOnInvariantViolationStreamInterceptor,
 		)
 		// This helps validate that SAC is being used correctly.
 		config.UnaryInterceptors = append(config.UnaryInterceptors, transitional.VerifySACScopeChecksInterceptor)


### PR DESCRIPTION
## Description

Check for suspicious entries in logs fails when it catch `panic`. Unfortunately one of our interceptors that was called before logging interceptor has `Panic` in it's name and this causes failures. We should fix all errors and assign them into proper classes so nothing will be logged except of unexpected internal errors caused by real issues. Now, let's just change order of interceptors so `panic` will not appear in logs.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

CI