### PR TITLE
Do not log internal error stacktrace

### DIFF
--- a/pkg/grpc/errors/interceptor.go
+++ b/pkg/grpc/errors/interceptor.go
@@ -57,7 +57,7 @@ func LogInternalErrorStreamInterceptor(srv interface{}, ss grpc.ServerStream, _ 
 
 func logErrorIfInternal(err error) {
 	if grpcStatus := ErrToGrpcStatus(err); grpcStatus.Code() == codes.Internal {
-		log.Errorf("Internal error occurred: %+v", err)
+		log.Errorf("Internal error occurred: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Description

As we have interceptor that contains `Panic` in its name any appearance of it in logs will cause error.
This PR removes stack trace from log (#681) to make CI green again.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

CI