### PR TITLE
ROX-9515: Fix e2e audit log test

### DIFF
--- a/qa-tests-backend/src/test/groovy/AuditScrubbingTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuditScrubbingTest.groovy
@@ -92,7 +92,7 @@ class AuditScrubbingTest extends BaseSpecification {
         where:
         "Data inputs are"
         username              | password              | expectedStatusCode | scenario
-        "foo"                 | "bar"                 | 500                | "invalid basic auth password"
+        "foo"                 | "bar"                 | 403                | "invalid basic auth password"
         Env.mustGetUsername() | Env.mustGetPassword() | 200                | "valid basic auth credentials"
     }
 


### PR DESCRIPTION
## Description

#769 changed code returned to user when invalid credentials were provided from 500 to 403. 
This PR changes e2e tests to reflect this change

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

CI