### PR TITLE
Revert "bump grpc version for qa tests to 1.44.0 (#726)"

### DIFF
--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -15,7 +15,7 @@ repositories {
     mavenCentral()
 }
 
-def grpcVersion = '1.44.0'
+def grpcVersion = '1.21.0'
 // If the proto versions are changed, be sure it is also changed in make/protogen.mk.
 def protocVersion = '3.19.4'
 def protobufVersion = '3.19.4'


### PR DESCRIPTION
This reverts commit 1cdf9e13080a49d726ee129460254fd9ceda2ede.

## Description

This breaks CI for some reason...

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~

## Testing Performed

CI
