### PR TITLE
Adjust scanner-slim and scanner-db-slim image names to comply with CPaaS name scheme

### DIFF
--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -78,12 +78,12 @@ defaults:
 
     dbImage:
       name: [< required "" .ScannerDBImageRemote >]
-      tag: [< required "" .ScannerDBImageTag >]
+      tag: [< required "" .ScannerImageTag >]
 
     [< if .FeatureFlags.ROX_LOCAL_IMAGE_SCANNING ->]
     slimDBImage:
       name: [< required "" .ScannerDBSlimImageRemote >]
-      tag: [< required "" .ScannerDBImageTag >]
+      tag: [< required "" .ScannerImageTag >]
     [< end >]
 
   system:

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/50-images.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/50-images.yaml.htpl
@@ -16,7 +16,7 @@ image:
     tag: [< required "" .ScannerImageTag >]
   scannerDb:
     name: [< required "" .ScannerDBSlimImageRemote >]
-    tag: [< required "" .ScannerDBImageTag >]
+    tag: [< required "" .ScannerImageTag >]
   [< end >]
 ---
 # Add registry defaults

--- a/pkg/helm/charts/meta.go
+++ b/pkg/helm/charts/meta.go
@@ -22,7 +22,6 @@ type MetaValues struct {
 	ScannerImageTag                  string
 	ScannerDBImageRemote             string
 	ScannerDBSlimImageRemote         string
-	ScannerDBImageTag                string
 	RenderMode                       string
 	ChartRepo                        defaults.ChartRepo
 	ImagePullSecrets                 defaults.ImagePullSecrets
@@ -70,7 +69,6 @@ func GetMetaValuesForFlavor(imageFlavor defaults.ImageFlavor) *MetaValues {
 		ScannerImageTag:          imageFlavor.ScannerImageTag,
 		ScannerDBImageRemote:     imageFlavor.ScannerDBImageName,
 		ScannerDBSlimImageRemote: imageFlavor.ScannerDBSlimImageName,
-		ScannerDBImageTag:        imageFlavor.ScannerDBImageTag,
 		RenderMode:               "",
 		ChartRepo:                imageFlavor.ChartRepo,
 		ImagePullSecrets:         imageFlavor.ImagePullSecrets,

--- a/pkg/helm/charts/tests/centralservices/flavor/flavor_test.go
+++ b/pkg/helm/charts/tests/centralservices/flavor/flavor_test.go
@@ -26,7 +26,6 @@ func customFlavor(t *testing.T) defaults.ImageFlavor {
 		ScannerDBSlimImageName: "scanner-slim",
 		ScannerDBImageName:     "custom-scanner-db",
 
-		ScannerDBImageTag: "3.2.1",
 		ChartRepo: defaults.ChartRepo{
 			URL: "url",
 		},
@@ -44,7 +43,6 @@ func TestOverriddenTagsAreRenderedInTheChart(t *testing.T) {
 		MetaValuesOverridesFunc: func(values *charts.MetaValues) {
 			values.ImageTag = "custom-main"
 			values.ScannerImageTag = "custom-scanner"
-			values.ScannerDBImageTag = "custom-scanner-db"
 		},
 		HelmTestOpts: []helmTest.LoaderOpt{helmTest.WithAdditionalTestDirs(path.Join(testDir, "override"))},
 	})

--- a/pkg/helm/charts/tests/centralservices/flavor/testdata/helmtest/override/override.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/flavor/testdata/helmtest/override/override.test.yaml
@@ -3,4 +3,4 @@ tests:
   expect: |
     assertCentral("test.registry/main:custom-main")
     assertScanner("test.registry/scanner:custom-scanner")
-    assertScannerDB("test.registry/scanner-db:custom-scanner-db")
+    assertScannerDB("test.registry/scanner-db:custom-scanner")

--- a/pkg/images/defaults/flavor.go
+++ b/pkg/images/defaults/flavor.go
@@ -78,12 +78,12 @@ type ImageFlavor struct {
 	CollectorSlimImageName string
 	CollectorSlimImageTag  string
 
+	// ScannerImageTag is used for all scanner* images (scanner, scanner-db, scanner-slim and scanner-db-slim)
+	ScannerImageTag        string
 	ScannerImageName       string
 	ScannerSlimImageName   string
-	ScannerImageTag        string
 	ScannerDBImageName     string
 	ScannerDBSlimImageName string
-	ScannerDBImageTag      string
 
 	ChartRepo        ChartRepo
 	ImagePullSecrets ImagePullSecrets
@@ -110,7 +110,6 @@ func DevelopmentBuildImageFlavor() ImageFlavor {
 		ScannerImageTag:        v.ScannerVersion,
 		ScannerDBImageName:     "scanner-db",
 		ScannerDBSlimImageName: "scanner-db-slim",
-		ScannerDBImageTag:      v.ScannerVersion,
 
 		ChartRepo: ChartRepo{
 			URL: "https://charts.stackrox.io",
@@ -141,7 +140,6 @@ func StackRoxIOReleaseImageFlavor() ImageFlavor {
 		ScannerImageTag:        v.ScannerVersion,
 		ScannerDBImageName:     "scanner-db",
 		ScannerDBSlimImageName: "scanner-db-slim",
-		ScannerDBImageTag:      v.ScannerVersion,
 
 		ChartRepo: ChartRepo{
 			URL: "https://charts.stackrox.io",
@@ -171,7 +169,6 @@ func RHACSReleaseImageFlavor() ImageFlavor {
 		ScannerImageTag:        v.ScannerVersion,
 		ScannerDBImageName:     "rhacs-scanner-db-rhel8",
 		ScannerDBSlimImageName: "rhacs-scanner-db-slim-rhel8",
-		ScannerDBImageTag:      v.ScannerVersion,
 
 		ChartRepo: ChartRepo{
 			URL: "https://mirror.openshift.com/pub/rhacs/charts",
@@ -254,7 +251,7 @@ func (f *ImageFlavor) ScannerImage() string {
 
 // ScannerDBImage is the container image reference (full name) for the scanner-db image.
 func (f *ImageFlavor) ScannerDBImage() string {
-	return fmt.Sprintf("%s/%s:%s", f.MainRegistry, f.ScannerDBImageName, f.ScannerDBImageTag)
+	return fmt.Sprintf("%s/%s:%s", f.MainRegistry, f.ScannerDBImageName, f.ScannerImageTag)
 }
 
 // MainImage is the container image reference (full name) for the "main" image.

--- a/pkg/images/defaults/testutils/flavor.go
+++ b/pkg/images/defaults/testutils/flavor.go
@@ -27,7 +27,6 @@ func MakeImageFlavorForTest(t *testing.T) defaults.ImageFlavor {
 		ScannerImageTag:        "2.2.2",
 		ScannerDBImageName:     "scanner-db",
 		ScannerDBSlimImageName: "scanner-db-slim",
-		ScannerDBImageTag:      "2.2.2",
 		ChartRepo: defaults.ChartRepo{
 			URL: "some.url/path/to/chart",
 		},

--- a/pkg/renderer/images.go
+++ b/pkg/renderer/images.go
@@ -90,7 +90,7 @@ func configureImageOverrides(c *Config, imageFlavor defaults.ImageFlavor) {
 	imageOverrides["Scanner"] = ComputeImageOverrides(c.K8sConfig.ScannerImage, registry, imageFlavor.ScannerImageName,
 		imageFlavor.ScannerImageTag)
 	imageOverrides["ScannerDB"] = ComputeImageOverrides(c.K8sConfig.ScannerDBImage, registry, imageFlavor.ScannerDBImageName,
-		imageFlavor.ScannerDBImageTag)
+		imageFlavor.ScannerImageTag)
 
 	c.K8sConfig.ImageOverrides = imageOverrides
 }


### PR DESCRIPTION
## Description

CPaaS adds `rhacs-` prefix and `-rhel8` suffix to all image names except the operator.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~

## Testing Perform

CI
