### PR TITLE
Adjust to take `apollo-ci:stackrox-build-*` images from `quay.io`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,12 @@ endif
 ROX_IMAGE_FLAVOR ?= $(shell if [[ "$(GOTAGS)" == *"$(RELEASE_GOTAGS)"* ]]; then echo "stackrox.io"; else echo "development_build"; fi)
 
 BUILD_IMAGE_VERSION=$(shell sed 's/\s*\#.*//' BUILD_IMAGE_VERSION)
-BUILD_IMAGE := stackrox/apollo-ci:$(BUILD_IMAGE_VERSION)
+BUILD_IMAGE := quay.io/rhacs-eng/apollo-ci:$(BUILD_IMAGE_VERSION)
 MONITORING_IMAGE := stackrox/monitoring:$(shell cat MONITORING_VERSION)
 DOCS_IMAGE_BASE := stackrox/docs
 
 ifdef CI
     QUAY_REPO := rhacs-eng
-    BUILD_IMAGE := quay.io/$(QUAY_REPO)/apollo-ci:$(BUILD_IMAGE_VERSION)
     MONITORING_IMAGE := quay.io/$(QUAY_REPO)/monitoring:$(shell cat MONITORING_VERSION)
     DOCS_IMAGE_BASE := quay.io/$(QUAY_REPO)/docs
 endif


### PR DESCRIPTION
## Description

`make image` ran against `master` branch showed me this:

![image](https://user-images.githubusercontent.com/537715/156371535-c4e741f3-99f4-49be-80d0-33c75e936343.png)

See https://github.com/stackrox/rox-ci-image/blob/559955a820b6cfece086e0b58b97044492945fef/.circleci/config.yml#L142
Related to changes in https://github.com/stackrox/rox-ci-image/pull/112

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~

## Testing Performed

* [x] `make image` runs locally
* [ ] CI is happy