### PR TITLE
ROX-9483: Crash when searching images by process indicators due to missing index

### DIFF
--- a/central/deployment/datastore/datastore_bench_test.go
+++ b/central/deployment/datastore/datastore_bench_test.go
@@ -53,7 +53,7 @@ func BenchmarkSearchAllDeployments(b *testing.B) {
 	deploymentsIndexer := index.New(bleveIndex, bleveIndex)
 	deploymentsSearcher := search.New(storage, dacky, nil, nil, nil, nil, nil, deploymentsIndexer, nil)
 
-	imageDS := imageDatastore.New(dacky, concurrency.NewKeyFence(), bleveIndex, false, nil, ranking.NewRanker(), ranking.NewRanker())
+	imageDS := imageDatastore.New(dacky, concurrency.NewKeyFence(), bleveIndex, bleveIndex, false, nil, ranking.NewRanker(), ranking.NewRanker())
 
 	deploymentsDatastore := newDatastoreImpl(storage, nil, deploymentsIndexer, deploymentsSearcher, imageDS, nil, nil, nil, nil,
 		nil, ranking.NewRanker(), ranking.NewRanker(), ranking.NewRanker())

--- a/central/graphql/resolvers/vulnerability_requests_test.go
+++ b/central/graphql/resolvers/vulnerability_requests_test.go
@@ -265,7 +265,7 @@ func (s *VulnRequestResolverTestSuite) SetupTest() {
 }
 
 func (s *VulnRequestResolverTestSuite) createImageDataStore(dacky *dackbox.DackBox) {
-	imageDataStore := imageDS.New(dacky, concurrency.NewKeyFence(), s.bleveIndex, true, nil, ranking.ImageRanker(), ranking.ComponentRanker())
+	imageDataStore := imageDS.New(dacky, concurrency.NewKeyFence(), s.bleveIndex, s.bleveIndex, true, nil, ranking.ImageRanker(), ranking.ComponentRanker())
 	s.imageDataStore = imageDataStore
 }
 

--- a/central/image/datastore/datastore.go
+++ b/central/image/datastore/datastore.go
@@ -45,7 +45,7 @@ type DataStore interface {
 	Exists(ctx context.Context, id string) (bool, error)
 }
 
-func newDatastore(dacky *dackbox.DackBox, storage store.Store, bleveIndex bleve.Index, risks riskDS.DataStore, imageRanker *ranking.Ranker, imageComponentRanker *ranking.Ranker) DataStore {
+func newDatastore(dacky *dackbox.DackBox, storage store.Store, bleveIndex bleve.Index, processIndex bleve.Index, risks riskDS.DataStore, imageRanker *ranking.Ranker, imageComponentRanker *ranking.Ranker) DataStore {
 	indexer := imageIndexer.New(bleveIndex)
 
 	searcher := search.New(storage,
@@ -55,7 +55,7 @@ func newDatastore(dacky *dackbox.DackBox, storage store.Store, bleveIndex bleve.
 		componentIndexer.New(bleveIndex),
 		imageComponentEdgeIndexer.New(bleveIndex),
 		imageIndexer.New(bleveIndex),
-		deploymentIndexer.New(bleveIndex, nil),
+		deploymentIndexer.New(bleveIndex, processIndex),
 		imageCVEEdgeIndexer.New(bleveIndex),
 	)
 	ds := newDatastoreImpl(storage, indexer, searcher, risks, imageRanker, imageComponentRanker)
@@ -67,7 +67,7 @@ func newDatastore(dacky *dackbox.DackBox, storage store.Store, bleveIndex bleve.
 // New returns a new instance of DataStore using the input store, indexer, and searcher.
 // noUpdateTimestamps controls whether timestamps are automatically updated when upserting images.
 // This should be set to `false` except for some tests.
-func New(dacky *dackbox.DackBox, keyFence concurrency.KeyFence, bleveIndex bleve.Index, noUpdateTimestamps bool, risks riskDS.DataStore, imageRanker *ranking.Ranker, imageComponentRanker *ranking.Ranker) DataStore {
+func New(dacky *dackbox.DackBox, keyFence concurrency.KeyFence, bleveIndex bleve.Index, processIndex bleve.Index, noUpdateTimestamps bool, risks riskDS.DataStore, imageRanker *ranking.Ranker, imageComponentRanker *ranking.Ranker) DataStore {
 	storage := dackBoxStore.New(dacky, keyFence, noUpdateTimestamps)
-	return newDatastore(dacky, storage, bleveIndex, risks, imageRanker, imageComponentRanker)
+	return newDatastore(dacky, storage, bleveIndex, processIndex, risks, imageRanker, imageComponentRanker)
 }

--- a/central/image/datastore/datastore_bench_test.go
+++ b/central/image/datastore/datastore_bench_test.go
@@ -40,7 +40,7 @@ func BenchmarkImages(b *testing.B) {
 	bleveIndex, err := globalindex.InitializeIndices("main", blevePath, globalindex.EphemeralIndex, "")
 	require.NoError(b, err)
 
-	imageDS := New(dacky, concurrency.NewKeyFence(), bleveIndex, false, nil, ranking.NewRanker(), ranking.NewRanker())
+	imageDS := New(dacky, concurrency.NewKeyFence(), bleveIndex, bleveIndex, false, nil, ranking.NewRanker(), ranking.NewRanker())
 
 	// Generate CVEs and components for the image.
 	var components []*storage.EmbeddedImageScanComponent

--- a/central/image/datastore/datastore_impl_test.go
+++ b/central/image/datastore/datastore_impl_test.go
@@ -81,7 +81,7 @@ func (suite *ImageDataStoreTestSuite) SetupSuite() {
 
 	suite.mockRisk = mockRisks.NewMockDataStore(gomock.NewController(suite.T()))
 
-	suite.datastore = New(dacky, concurrency.NewKeyFence(), bleveIndex, false, suite.mockRisk, ranking.ImageRanker(), ranking.ComponentRanker())
+	suite.datastore = New(dacky, concurrency.NewKeyFence(), bleveIndex, bleveIndex, false, suite.mockRisk, ranking.ImageRanker(), ranking.ComponentRanker())
 }
 
 func (suite *ImageDataStoreTestSuite) TearDownSuite() {

--- a/central/image/datastore/singleton.go
+++ b/central/image/datastore/singleton.go
@@ -18,6 +18,7 @@ func initialize() {
 	ad = New(dackbox.GetGlobalDackBox(),
 		dackbox.GetKeyFence(),
 		globalindex.GetGlobalIndex(),
+		globalindex.GetProcessIndex(),
 		false,
 		riskDS.Singleton(),
 		ranking.ImageRanker(),

--- a/central/imagecomponent/search/searcher_impl_test.go
+++ b/central/imagecomponent/search/searcher_impl_test.go
@@ -98,7 +98,7 @@ func (suite *ImageComponentSearchTestSuite) SetupSuite() {
 
 	suite.mockRisk = mockRisks.NewMockDataStore(gomock.NewController(suite.T()))
 
-	suite.imageDataStore = imageDatastore.New(dacky, concurrency.NewKeyFence(), bleveIndex, false, suite.mockRisk, ranking.NewRanker(), ranking.NewRanker())
+	suite.imageDataStore = imageDatastore.New(dacky, concurrency.NewKeyFence(), bleveIndex, bleveIndex, false, suite.mockRisk, ranking.NewRanker(), ranking.NewRanker())
 	suite.nodeDataStore = nodeDatastore.New(dacky, concurrency.NewKeyFence(), bleveIndex, suite.mockRisk, ranking.NewRanker(), ranking.NewRanker())
 
 	index := componentIndex.New(bleveIndex)

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -193,7 +193,7 @@ func generateImageDataStructures(ctx context.Context, t *testing.T) (alertDatast
 	registry.RegisterWrapper(imageDackBox.Bucket, imageIndex.Wrapper{})
 
 	// Initialize real datastore
-	images := imageDatastore.New(dacky, concurrency.NewKeyFence(), bleveIndex, true, mockRiskDatastore, ranking.NewRanker(), ranking.NewRanker())
+	images := imageDatastore.New(dacky, concurrency.NewKeyFence(), bleveIndex, bleveIndex, true, mockRiskDatastore, ranking.NewRanker(), ranking.NewRanker())
 
 	mockProcessDataStore := processIndicatorDatastoreMocks.NewMockDataStore(ctrl)
 

--- a/central/reprocessor/reprocessor_test.go
+++ b/central/reprocessor/reprocessor_test.go
@@ -54,7 +54,7 @@ func TestGetActiveImageIDs(t *testing.T) {
 	reg.RegisterWrapper(imageComponentDackbox.Bucket, imageComponentIndex.Wrapper{})
 	reg.RegisterWrapper(imageComponentEdgeDackbox.Bucket, imageComponentEdgeIndex.Wrapper{})
 
-	imageDS := imageDatastore.New(dacky, concurrency.NewKeyFence(), bleveIndex, false, nil, ranking.NewRanker(), ranking.NewRanker())
+	imageDS := imageDatastore.New(dacky, concurrency.NewKeyFence(), bleveIndex, bleveIndex, false, nil, ranking.NewRanker(), ranking.NewRanker())
 
 	deploymentsDS := deploymentDatastore.New(dacky, concurrency.NewKeyFence(), nil, bleveIndex, bleveIndex, nil, nil, nil, nil,
 		nil, filter.NewFilter(5, []int{5}), ranking.NewRanker(), ranking.NewRanker(), ranking.NewRanker())

--- a/central/vulnerabilityrequest/manager/querymgr/query_manager_impl_test.go
+++ b/central/vulnerabilityrequest/manager/querymgr/query_manager_impl_test.go
@@ -101,7 +101,7 @@ func (s *VulnReqQueryManagerTestSuite) SetupTest() {
 }
 
 func (s *VulnReqQueryManagerTestSuite) createImageDataStore(dacky *dackbox.DackBox) {
-	imageDataStore := imageDS.New(dacky, concurrency.NewKeyFence(), s.bleveIndex, true, nil, ranking.ImageRanker(), ranking.ComponentRanker())
+	imageDataStore := imageDS.New(dacky, concurrency.NewKeyFence(), s.bleveIndex, s.bleveIndex, true, nil, ranking.ImageRanker(), ranking.ComponentRanker())
 	s.imageDataStore = imageDataStore
 }
 

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
@@ -194,7 +194,7 @@ func (s *VulnRequestManagerTestSuite) SetupTest() {
 }
 
 func (s *VulnRequestManagerTestSuite) createImageDataStore(dacky *dackbox.DackBox) {
-	imageDataStore := imageDS.New(dacky, concurrency.NewKeyFence(), s.bleveIndex, true, nil, ranking.ImageRanker(), ranking.ComponentRanker())
+	imageDataStore := imageDS.New(dacky, concurrency.NewKeyFence(), s.bleveIndex, s.bleveIndex, true, nil, ranking.ImageRanker(), ranking.ComponentRanker())
 	s.imageDataStore = imageDataStore
 }
 


### PR DESCRIPTION
## Description

When searching by process name (or path or ID) in global search, it will crash when running the image searcher. This is because when the image DS was created, a nil processIndex was provided.

## Checklist
- [ ] Investigated and inspected CI test results
~[ ] Unit test and regression tests added~
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed

manual and using hack.go

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
