### PR TITLE
ROX-9511: disable init bundle generation for release 3.69

### DIFF
--- a/operator/pkg/central/extensions/reconcile_tls.go
+++ b/operator/pkg/central/extensions/reconcile_tls.go
@@ -60,7 +60,11 @@ func (r *createCentralTLSExtensionRun) Execute(ctx context.Context) error {
 	if err := r.ReconcileSecret(ctx, "scanner-db-tls", scannerEnabled && !shouldDelete, r.validateScannerDBTLSData, r.generateScannerDBTLSData, true); err != nil {
 		return errors.Wrap(err, "reconciling scanner-db secret")
 	}
+	return nil // ReconcileInitBundleSecrets not called due to ROX-9023.
+}
 
+// ReconcileInitBundleSecrets is only exported temporarily to silence the static checker while it's unused.
+func (r createCentralTLSExtensionRun) ReconcileInitBundleSecrets(ctx context.Context, shouldDelete bool) error {
 	bundleSecretShouldExist, err := r.shouldBundleSecretsExist(ctx, shouldDelete)
 	if err != nil {
 		return err
@@ -79,7 +83,6 @@ func (r *createCentralTLSExtensionRun) Execute(ctx context.Context) error {
 			return errors.Wrapf(err, "reconciling %s secret ", slugCaseService)
 		}
 	}
-
 	return nil
 }
 

--- a/operator/pkg/central/extensions/reconcile_tls_test.go
+++ b/operator/pkg/central/extensions/reconcile_tls_test.go
@@ -1,6 +1,7 @@
 package extensions
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stackrox/rox/generated/storage"
@@ -141,6 +142,10 @@ func TestCreateCentralTLS(t *testing.T) {
 
 	for name, c := range cases {
 		c := c
+		if strings.Contains(name, "init bundle secrets should be created") {
+			// See ROX-9023.
+			continue
+		}
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/operator/tests/securedcluster/basic-sc/07-fetch-bundle.yaml
+++ b/operator/tests/securedcluster/basic-sc/07-fetch-bundle.yaml
@@ -1,0 +1,1 @@
+../../common/fetch-bundle.yaml


### PR DESCRIPTION
## Description

Basically a repeat of https://github.com/stackrox/stackrox/pull/392 since the UI warnings are still not fixed, and there is still no tested way to feature-gate things in the operator.

## Checklist
- [x] Rebase against the release branch once it exists
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~

## Testing Performed

Relying on CI.