### PR TITLE
ROX-9554: Retry push manifest on error

### DIFF
--- a/scripts/ci/push-as-manifest-list.sh
+++ b/scripts/ci/push-as-manifest-list.sh
@@ -20,6 +20,7 @@ docker tag "$image" "$arch_image"
 # Try pushing image a few times for the case when quay.io has issues such as "unknown blob"
 pushed=0
 for i in {1..5}; do
+  echo "Pushing ${arch_image}. Attempt ${i}..."
   if docker push "$arch_image"; then
     pushed=1
     break
@@ -33,6 +34,7 @@ docker manifest create "$image" "$arch_image"
 # Try pushing manifest a few times for the case when quay.io has issues
 pushed=0
 for i in {1..5}; do
+  echo "Pushing manifest for ${image}. Attempt ${i}..."
   if docker manifest push "$image"; then
     pushed=1
     break


### PR DESCRIPTION
## Description

Pushing manifests can fail. This PR uses the same approach as for pushing image to retry on error.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

