### PR TITLE
Revert "ROX-8619: Set admission timeoutSeconds default and increase limit"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,6 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - Note that this only affects users who are storing their policies externally and keeping those policies in sync with Central. There is no action required for users who are not taking this approach.
   - Support for system policies with `policyVersion` unset will be removed in 3.71. All such externally stored policies must be converted to policy version 1.0 or higher. To do so, import the policies into the system, and then export the previously imported policies. The exported policies will now be in supported policy version format (>=1.0), which can be ensured by checking the `policyVersion` field.
 - Vulnerability Risk Assessment: Deferral update requests that are in pending state can now be canceled.
-- The default Admission Controller "fail open" timeout has been changed from 3 seconds to 20 seconds in Helm templates.
-- The maximum Admission Controller "fail open" timeout has been set at 25 seconds in Helm template verification performed by the Operator.
-  - This change is *not* backwards compatible; if an existing Custom Resource sets the value to > 25 seconds, then it will fail validation in case operator is downgraded. This change is accepted because the operator is still in v1alpha1 and subject to change.
-- The Admission Controller webhook timeout is now padded an additional 2 seconds.
-  - e.g. if the Admission Controller timeout is 25 seconds, the webhook's timeout will now be 27 (25 + 2) seconds.
 
 ## [68.0]
 

--- a/dev-tools/helmdiff.sh
+++ b/dev-tools/helmdiff.sh
@@ -16,21 +16,12 @@ for CHART in ${CHARTS}; do
   $ROXCTL helm output --debug --remove ${CHART} --output-dir="${TMP_ROOT}/${CHART}-new"
 done
 
-REPO_STAT="$(git diff --stat)"
 # TODO(ebensh): Use smart branch root (if present) instead of master.
-if [[ -n $REPO_STAT ]]; then
-  echo "Saving uncommitted changes with 'git stash push'."
-  git stash push
-fi
 git switch master
 for CHART in ${CHARTS}; do
   $ROXCTL helm output --debug --remove ${CHART} --output-dir="${TMP_ROOT}/${CHART}-old"
 done
 git switch ${WORKING_BRANCH}
-if [[ -n $REPO_STAT ]]; then
-  echo "Restoring uncommitted changes with 'git stash pop'."
-  git stash pop
-fi
 
 echo "Rendering a dry run installation of the stackrox-central-services helm charts as Kubernetes manifests:"
 for VERSION in "old" "new"; do

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -38,7 +38,7 @@ admissionControl:
     enforceOnCreates: false
     scanInline: false
     disableBypass: false
-    timeout: 20
+    timeout: 3
     enforceOnUpdates: false
 
 collector:

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -181,7 +181,7 @@ webhooks:
     {{- if ne ._rox.env.openshift 3 }}
     sideEffects: NoneOnDryRun
     admissionReviewVersions: [ "v1", "v1beta1" ]
-    timeoutSeconds: {{ add 2 ._rox.admissionControl.dynamic.timeout }}
+    timeoutSeconds: 27
     {{- end }}
     rules:
       - apiGroups:
@@ -229,7 +229,7 @@ webhooks:
     {{- if ne ._rox.env.openshift 3 }}
     sideEffects: NoneOnDryRun
     admissionReviewVersions: [ "v1", "v1beta1" ]
-    timeoutSeconds: {{ add 2 ._rox.admissionControl.dynamic.timeout }}
+    timeoutSeconds: 27
     {{- end }}
     rules:
       - apiGroups:

--- a/image/templates/helm/stackrox-secured-cluster/values.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/values.yaml.htpl
@@ -25,7 +25,7 @@ config:
     enforceOnUpdates: [< default false .AdmissionControlEnforceOnUpdates >]
     scanInline: [< default false .ScanInline >]
     disableBypass: [< default false .DisableBypass >]
-    timeout: [< default 20 .TimeoutSeconds >]
+    timeout: [< default 3 .TimeoutSeconds >]
   registryOverride:
   disableTaintTolerations: [< default false (not .TolerationsEnabled ) >]
   createUpgraderServiceAccount: [< default false .CreateUpgraderSA >]

--- a/operator/apis/platform/v1alpha1/securedcluster_types.go
+++ b/operator/apis/platform/v1alpha1/securedcluster_types.go
@@ -115,10 +115,9 @@ type AdmissionControlComponentSpec struct {
 
 	// Maximum timeout period for admission review, upon which admission review will fail open.
 	// Use it to set request timeouts when you enable inline image scanning.
-	// The default kubectl timeout is 30 seconds; taking padding into account, this should not exceed 25 seconds.
-	//+kubebuilder:default=20
+	//+kubebuilder:default=3
 	//+kubebuilder:validation:Minimum=1
-	//+kubebuilder:validation:Maximum=25
+	//+kubebuilder:validation:Maximum=10
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=5
 	TimeoutSeconds *int32 `json:"timeoutSeconds,omitempty"`
 

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -112,14 +112,12 @@ spec:
                         type: object
                     type: object
                   timeoutSeconds:
-                    default: 20
+                    default: 3
                     description: Maximum timeout period for admission review, upon
                       which admission review will fail open. Use it to set request
-                      timeouts when you enable inline image scanning. The default
-                      kubectl timeout is 30 seconds; taking padding into account,
-                      this should not exceed 25 seconds.
+                      timeouts when you enable inline image scanning.
                     format: int32
-                    maximum: 25
+                    maximum: 10
                     minimum: 1
                     type: integer
                   tolerations:

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -393,8 +393,7 @@ spec:
         path: admissionControl.contactImageScanners
       - description: Maximum timeout period for admission review, upon which admission
           review will fail open. Use it to set request timeouts when you enable inline
-          image scanning. The default kubectl timeout is 30 seconds; taking padding
-          into account, this should not exceed 25 seconds.
+          image scanning.
         displayName: Timeout Seconds
         path: admissionControl.timeoutSeconds
       - description: Enables teams to bypass admission control in a monitored manner

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -114,14 +114,12 @@ spec:
                         type: object
                     type: object
                   timeoutSeconds:
-                    default: 20
+                    default: 3
                     description: Maximum timeout period for admission review, upon
                       which admission review will fail open. Use it to set request
-                      timeouts when you enable inline image scanning. The default
-                      kubectl timeout is 30 seconds; taking padding into account,
-                      this should not exceed 25 seconds.
+                      timeouts when you enable inline image scanning.
                     format: int32
-                    maximum: 25
+                    maximum: 10
                     minimum: 1
                     type: integer
                   tolerations:

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -404,8 +404,7 @@ spec:
         path: admissionControl.contactImageScanners
       - description: Maximum timeout period for admission review, upon which admission
           review will fail open. Use it to set request timeouts when you enable inline
-          image scanning. The default kubectl timeout is 30 seconds; taking padding
-          into account, this should not exceed 25 seconds.
+          image scanning.
         displayName: Timeout Seconds
         path: admissionControl.timeoutSeconds
       - description: Settings for the components running on each node in the cluster

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -56,16 +56,3 @@ tests:
   expect: |
     .validatingwebhookconfigurations[].apiVersion | assertThat(. == "admissionregistration.k8s.io/v1beta1")
     .validatingwebhookconfigurations[].webhooks[] | assertThat(.admissionReviewVersions == null)
-
-- name: "Webhook timeout pads AdmissionController timeout by 2 seconds"
-  tests:
-    - name: "default AdmissionController timeout is 20s + 2s padding"
-      expect: |
-        .validatingwebhookconfigurations[].webhooks[].timeoutSeconds | assertThat(. == 20 + 2)
-    - name: "override sets value correctly"
-      values:
-        admissionControl:
-          dynamic:
-            timeout: 10
-      expect: |
-        .validatingwebhookconfigurations[].webhooks[].timeoutSeconds | assertThat(. == 10 + 2)


### PR DESCRIPTION
Reverts stackrox/stackrox#80

This is breaking the upgrade tests, which ran on `master` branch when merged but not on the PR before merging. Rolling back to get to an unbroken state then will roll forward with a fix.