### PR TITLE
Remove slim image defaults from central chart

### DIFF
--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -62,12 +62,6 @@ defaults:
       name: [< required "" .ScannerImageRemote >]
       tag: [< required "" .ScannerImageTag >]
 
-    [< if .FeatureFlags.ROX_LOCAL_IMAGE_SCANNING ->]
-    slimImage:
-      name: [< required "" .ScannerSlimImageRemote >]
-      tag: [< required "" .ScannerImageTag >]
-    [< end >]
-
     dbResources:
       limits:
         cpu: "2000m"
@@ -79,12 +73,6 @@ defaults:
     dbImage:
       name: [< required "" .ScannerDBImageRemote >]
       tag: [< required "" .ScannerImageTag >]
-
-    [< if .FeatureFlags.ROX_LOCAL_IMAGE_SCANNING ->]
-    slimDBImage:
-      name: [< required "" .ScannerDBSlimImageRemote >]
-      tag: [< required "" .ScannerImageTag >]
-    [< end >]
 
   system:
     createSCCs: [< not .Operator >]


### PR DESCRIPTION
## Description

Remove slim images from Central chart, still a legacy from a previous implementation to introduce the meta values and slim mode.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

 - CI
