### PR TITLE
ROX-9487: Define Sensor env vars for connecting to local scanner

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -119,17 +119,13 @@ spec:
         {{- if ._rox.env.openshift }}
         - name: ROX_OPENSHIFT_API
           value: "true"
-        {{- end}}
+        [<- if and (not .KubectlOutput) .FeatureFlags.ROX_LOCAL_IMAGE_SCANNING >]
         - name: ROX_USE_LOCAL_SCANNER
-        {{- if ._rox.scanner }}
-          value: {{ not ._rox.scanner.disable }}
-          {{- if not ._rox.scanner.disable }}
+          value: {{ not ._rox.scanner.disable | not | not }}
         - name: ROX_SCANNER_GRPC_ENDPOINT
           value: {{ printf "scanner.%s.svc:8443" .Release.Namespace }}
-          {{- end }}
-        {{- else }}
-          value: "false"
-        {{- end }}
+        [<- end >]
+        {{- end}}
         [<- if not .KubectlOutput >]
         - name: ROX_HELM_CLUSTER_CONFIG_FP
           value: {{ quote ._rox._configFP }}

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/scanner-slim/scanner-slim.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/scanner-slim/scanner-slim.test.yaml
@@ -113,18 +113,11 @@ tests:
         select(.name == "ROX_USE_LOCAL_SCANNER") | assertThat(.value == false)
 
 - name: "sensor connects to local scanner using the correct GRPC endpoint"
-  tests:
-  - name: "env var is missing when scanner is disabled"
-    set:
-      scanner.disable: true
-    expect: |
-      [.deployments["sensor"].spec.template.spec.containers[0].env[] | select(.name == "ROX_SCANNER_GRPC_ENDPOINT")] | assertThat(length == 0)
-  - name: "when scanner is enabled"
-    release:
-      namespace: custom-ns
-    set:
-      allowNonstandardNamespace: true
-      scanner.disable: false
-    expect: |
-      .deployments["sensor"].spec.template.spec.containers[0].env[] |
-        select(.name == "ROX_SCANNER_GRPC_ENDPOINT") | assertThat(.value == "scanner.custom-ns.svc:8443")
+  release:
+    namespace: custom-ns
+  set:
+    allowNonstandardNamespace: true
+    scanner.disable: false
+  expect: |
+    .deployments["sensor"].spec.template.spec.containers[0].env[] |
+      select(.name == "ROX_SCANNER_GRPC_ENDPOINT") | assertThat(.value == "scanner.custom-ns.svc:8443")


### PR DESCRIPTION
## Description

https://github.com/stackrox/stackrox/pull/747 declares env vars for connecting to local scanner, that Sensor uses in [sensor/common/scannerclient/singleton.go](https://github.com/stackrox/stackrox/blob/master/sensor/common/scannerclient/singleton.go) to connect to local scanner This change defines the values for those variables:

- `ROX_USE_LOCAL_SCANNER` is defined to `not ._rox.scanner.disable`, which is defined in [image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl](https://github.com/stackrox/stackrox/blob/master/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl) according to the supported installation configurations.
- `ROX_SCANNER_GRPC_ENDPOINT` is defined taking into account that:
  - in [image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl](https://github.com/stackrox/stackrox/blob/master/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl) the value of `containerPort` with `name: grpc` for container with `name: scanner` is hardcoded to `8443`
  - in [image/templates/helm/shared/templates/02-scanner-07-service.yaml](https://github.com/stackrox/stackrox/blob/master/image/templates/helm/shared/templates/02-scanner-07-service.yaml) in case `{{- if not ._rox.scanner.disable -}}` the Scanner service is defined with ` name: {{ ._rox.scanner.name }}` and `namespace: {{ .Release.Namespace }}`

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps

No CHANGELOG entry or upgrade steps required.

## Testing Performed

Added helm test. 

```bash
go test -v  github.com/stackrox/rox/pkg/helm/charts/tests/securedclusterservices -run TestWithHelmtest/testdata/helmtest/scanner-slim.test.yaml

go test -v  github.com/stackrox/rox/pkg/helm/charts/tests/securedclusterservices && \
go test -v github.com/stackrox/rox/central/clusters/zip && \
go test -v github.com/stackrox/rox/roxctl/helm/output
```