### PR TITLE
Add onTimeout prop for toast Alert elements in policies pages

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Detail/PolicyDetail.tsx
@@ -253,6 +253,7 @@ function PolicyDetail({
                             variant={AlertVariant[variant]}
                             title={title}
                             timeout={4000}
+                            onTimeout={() => removeToast(key)}
                             actionClose={
                                 <AlertActionCloseButton
                                     title={title}

--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Table/PoliciesTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Table/PoliciesTablePage.tsx
@@ -211,6 +211,7 @@ function PoliciesTablePage({
                         variant={AlertVariant[variant]}
                         title={title}
                         timeout={4000}
+                        onTimeout={() => removeToast(key)}
                         actionClose={
                             <AlertActionCloseButton
                                 title={title}


### PR DESCRIPTION
## Description

**Problem**: Although toast alert elements disappear because of `timeout` prop, all toast alerts reappear when the page component re-renders.

**Residue**: The visibly obvious re-rerendering needs investigation.

**Solution**: Add `onTimeout={() => removeToast(key)}` prop in `Alert` element adapted from `onClose={() => removeToast(key)}` prop in `AlertActionCloseButton` element

https://www.patternfly.org/v4/components/alert/#props

Because `removeToast` uses `filter` method, no error (although maybe re-rendering) if there is a racing condition for user to close toast just before timeout.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Add `console.log(toasts.length) statement in PoliciesTablePage.tsx to see that number of toasts increases even though they disappear because of timeout.

1. Add to search filter: category **Severity:** and value **LOW_SEVERITY**
2. Click **Reassess all** button to render a toast alert
3. Click **Export policy to JSON** row action to render a toast alert
4. Remove from search filter: value **LOW_SEVERITY** and then category **Severity:**

**Problem**: without `onTimeout` prop the number of toasts increases
![Problem-without-onTimeout](https://user-images.githubusercontent.com/11862657/156608082-4781351b-16c3-4c4a-8e19-998260bd80bb.png)

**Solution**: with `onTimeout` prop the number of toasts increments and then decrements
![Solution-with-onTimeout](https://user-images.githubusercontent.com/11862657/156608052-3db7ca28-145f-485c-af74-9081b02cf117.png)

