### PR TITLE
Replace div with heading for deployment name in policy preview violations

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step5/PreviewViolations.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step5/PreviewViolations.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { List, ListItem } from '@patternfly/react-core';
+import { List, ListItem, Title } from '@patternfly/react-core';
 
 import { DryRunAlert } from 'services/PoliciesService';
 
@@ -24,7 +24,9 @@ function PreviewViolations({ alertsFromDryRun }: PreviewViolationsProps): ReactE
                 return (
                     // eslint-disable-next-line react/no-array-index-key
                     <div key={alertIndex}>
-                        <div className={className}>{deployment}</div>
+                        <Title headingLevel="h3" className={className}>
+                            {deployment}
+                        </Title>
                         <List>
                             {violations.map((violation, violationIndex) => (
                                 // eslint-disable-next-line react/no-array-index-key


### PR DESCRIPTION
## Description

Observation in testing was lack of visual distinction between explanation paragraphs and preview results.

Webinar in which blind user demonstrated accessibility of web sites showed the value for understanding content:
* headings (this change to visually distinguish deployment as heading, which it is)
* lists, because screen reader says the number of elements

https://www.smashingmagazine.com/2019/02/accessibility-webinar/

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

For a policy which has violations

Less semantic, visually distinctive, and accessible with `div` element
![div](https://user-images.githubusercontent.com/11862657/156661258-7ddbc43b-b689-44f3-8862-d610f6e48b4e.png)

More semantic, visually distinctive, and accessible with `Title` element
![h3 div](https://user-images.githubusercontent.com/11862657/156661238-02c378b9-ee6a-45a7-8125-d57fe26a3540.png)

