### PR TITLE
ROX-9558: Allow user to save cloned policy without making any changes

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/PolicyWizard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/PolicyWizard.tsx
@@ -189,7 +189,10 @@ function PolicyWizard({ pageAction, policy }: PolicyWizardProps): ReactElement {
                                 ),
                                 nextButtonText: 'Save',
                                 canJumpTo: canJumpToAny || stepIdReached >= 5,
-                                enableNext: dirty && isValidOnServer && !isSubmitting,
+                                enableNext:
+                                    (dirty || pageAction === 'clone') &&
+                                    isValidOnServer &&
+                                    !isSubmitting,
                             },
                         ]}
                         onBack={onBack}


### PR DESCRIPTION
## Description

Unlike edit an existing policy, in which **Save** button is disabled if no changes, to clone an existing policy, the name has been changed, therefore **Save** button should be enabled even if no additional changes.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Incorrect behavior: Clone existing with no changes: **Save** button is disabled
![clone-incorrect-disabled](https://user-images.githubusercontent.com/11862657/156663856-83d5086d-7099-4bdd-ab6e-518875b837a2.png)


Corrected behavior: Clone existing with no changes: **Save** button is enabled
![clone-correct-enabled](https://user-images.githubusercontent.com/11862657/156663834-a6a539b1-09d3-4156-adea-f761cd9cdd9d.png)

Edit existing policy with no changes: **Save** button is still disabled
![edit-disabled](https://user-images.githubusercontent.com/11862657/156663817-c88561f0-0e64-4898-bd07-d8585d8131cd.png)

