### PR TITLE
Remove validation requirement for policy criteria values

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/policyValidationSchemas.ts
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/policyValidationSchemas.ts
@@ -67,7 +67,7 @@ const validationSchemaStep3 = yup.object().shape({
                                 .array()
                                 .of(
                                     yup.object().shape({
-                                        value: yup.string().trim().required(),
+                                        value: yup.string(), // dryrun validates whether value is required
                                     })
                                 )
                                 .min(1)


### PR DESCRIPTION
## Description

Not all values are required and more criteria have been and are being added.

If you leave out a required value, then it will fail in step 5 Review policy.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Disallowed annotions

Incorrect **Next** is disabled when **value** is empty
![incorrect-disabled](https://user-images.githubusercontent.com/11862657/156666404-ae194227-8429-4528-9c41-81c01bcb7883.png)

Correct **Next** is enabled when **value** is empty
![correct-enabled](https://user-images.githubusercontent.com/11862657/156666397-bbcf71fa-3cbe-428b-9f40-217b2a937b80.png)

