### PR TITLE
ROX-9559: Cancel clone from policies table should go back to table

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Table/PoliciesTable.tsx
@@ -170,7 +170,7 @@ function PoliciesTable({
     }
 
     function onClonePolicy(id: string) {
-        history.replace({
+        history.push({
             pathname: `${policiesBasePath}/${id}`,
             search: 'action=clone',
         });


### PR DESCRIPTION
## Description

Incorrect behavior was go back to main dashboard, because this interaction has `replace` instead of `push` as for all of the others.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Verified the following scenarios:

1. From **policies table** was incorrect for clone but correct for edit
    * Was incorrect for **clone** with `replace` go back to page in history preceding the policies table (for example, main dashboard)
    * Now is correct for **clone** with `push` go back to previous page (that is, policies table)
    * Was and is correct for **edit** with `push` go back to previous page (that is, policies table)
 
2. From **policy page** was and is correct for clone and edit
    * Correct for **clone** with `push` go back to previous page (that is, policy page)
    * Correct for **edit** with `push` go back to previous page (that is, policy page)