### PR TITLE
ROX-8619: Set admission timeoutSeconds default and increase limit (take 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ## [NEXT RELEASE]
 
+- The default Admission Controller "fail open" timeout has been changed from 3 seconds to 20 seconds in Helm templates.
+- The maximum Admission Controller "fail open" timeout has been set at 25 seconds in Helm template verification performed by the Operator.
+  - This change is *not* backwards compatible; if an existing Custom Resource sets the value to > 25 seconds, then it will fail validation in case operator is downgraded. This change is accepted because the operator is still in v1alpha1 and subject to change.
+- The admission webhook timeout is now set to the admission controller timeout plus 2 seconds.
+
 ## [69.0]
 
 - `collector` image with `-slim` in the image tag is no longer published (`collector-slim` with suffix in the image name will continue to be published).

--- a/dev-tools/helmdiff.sh
+++ b/dev-tools/helmdiff.sh
@@ -16,12 +16,21 @@ for CHART in ${CHARTS}; do
   $ROXCTL helm output --debug --remove ${CHART} --output-dir="${TMP_ROOT}/${CHART}-new"
 done
 
+REPO_STAT="$(git diff --stat)"
 # TODO(ebensh): Use smart branch root (if present) instead of master.
+if [[ -n $REPO_STAT ]]; then
+  echo "Saving uncommitted changes with 'git stash push'."
+  git stash push
+fi
 git switch master
 for CHART in ${CHARTS}; do
   $ROXCTL helm output --debug --remove ${CHART} --output-dir="${TMP_ROOT}/${CHART}-old"
 done
 git switch ${WORKING_BRANCH}
+if [[ -n $REPO_STAT ]]; then
+  echo "Restoring uncommitted changes with 'git stash pop'."
+  git stash pop
+fi
 
 echo "Rendering a dry run installation of the stackrox-central-services helm charts as Kubernetes manifests:"
 for VERSION in "old" "new"; do

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -38,7 +38,7 @@ admissionControl:
     enforceOnCreates: false
     scanInline: false
     disableBypass: false
-    timeout: 3
+    timeout: 20
     enforceOnUpdates: false
 
 collector:

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -181,7 +181,7 @@ webhooks:
     {{- if ne ._rox.env.openshift 3 }}
     sideEffects: NoneOnDryRun
     admissionReviewVersions: [ "v1", "v1beta1" ]
-    timeoutSeconds: 27
+    timeoutSeconds: {{ add 2 ._rox.admissionControl.dynamic.timeout }}
     {{- end }}
     rules:
       - apiGroups:
@@ -229,7 +229,7 @@ webhooks:
     {{- if ne ._rox.env.openshift 3 }}
     sideEffects: NoneOnDryRun
     admissionReviewVersions: [ "v1", "v1beta1" ]
-    timeoutSeconds: 27
+    timeoutSeconds: {{ add 2 ._rox.admissionControl.dynamic.timeout }}
     {{- end }}
     rules:
       - apiGroups:

--- a/image/templates/helm/stackrox-secured-cluster/values.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/values.yaml.htpl
@@ -25,7 +25,7 @@ config:
     enforceOnUpdates: [< default false .AdmissionControlEnforceOnUpdates >]
     scanInline: [< default false .ScanInline >]
     disableBypass: [< default false .DisableBypass >]
-    timeout: [< default 3 .TimeoutSeconds >]
+    timeout: [< default 20 .TimeoutSeconds >]
   registryOverride:
   disableTaintTolerations: [< default false (not .TolerationsEnabled ) >]
   createUpgraderServiceAccount: [< default false .CreateUpgraderSA >]

--- a/operator/apis/platform/v1alpha1/securedcluster_types.go
+++ b/operator/apis/platform/v1alpha1/securedcluster_types.go
@@ -120,9 +120,10 @@ type AdmissionControlComponentSpec struct {
 
 	// Maximum timeout period for admission review, upon which admission review will fail open.
 	// Use it to set request timeouts when you enable inline image scanning.
-	//+kubebuilder:default=3
+	// The default kubectl timeout is 30 seconds; taking padding into account, this should not exceed 25 seconds.
+	//+kubebuilder:default=20
 	//+kubebuilder:validation:Minimum=1
-	//+kubebuilder:validation:Maximum=10
+	//+kubebuilder:validation:Maximum=25
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=5
 	TimeoutSeconds *int32 `json:"timeoutSeconds,omitempty"`
 

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -112,12 +112,14 @@ spec:
                         type: object
                     type: object
                   timeoutSeconds:
-                    default: 3
+                    default: 20
                     description: Maximum timeout period for admission review, upon
                       which admission review will fail open. Use it to set request
-                      timeouts when you enable inline image scanning.
+                      timeouts when you enable inline image scanning. The default
+                      kubectl timeout is 30 seconds; taking padding into account,
+                      this should not exceed 25 seconds.
                     format: int32
-                    maximum: 10
+                    maximum: 25
                     minimum: 1
                     type: integer
                   tolerations:

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -398,7 +398,8 @@ spec:
         path: admissionControl.contactImageScanners
       - description: Maximum timeout period for admission review, upon which admission
           review will fail open. Use it to set request timeouts when you enable inline
-          image scanning.
+          image scanning. The default kubectl timeout is 30 seconds; taking padding
+          into account, this should not exceed 25 seconds.
         displayName: Timeout Seconds
         path: admissionControl.timeoutSeconds
       - description: Enables teams to bypass admission control in a monitored manner

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -114,12 +114,14 @@ spec:
                         type: object
                     type: object
                   timeoutSeconds:
-                    default: 3
+                    default: 20
                     description: Maximum timeout period for admission review, upon
                       which admission review will fail open. Use it to set request
-                      timeouts when you enable inline image scanning.
+                      timeouts when you enable inline image scanning. The default
+                      kubectl timeout is 30 seconds; taking padding into account,
+                      this should not exceed 25 seconds.
                     format: int32
-                    maximum: 10
+                    maximum: 25
                     minimum: 1
                     type: integer
                   tolerations:

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -435,7 +435,8 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:.autoScaling:Enabled
       - description: Maximum timeout period for admission review, upon which admission
           review will fail open. Use it to set request timeouts when you enable inline
-          image scanning.
+          image scanning. The default kubectl timeout is 30 seconds; taking padding
+          into account, this should not exceed 25 seconds.
         displayName: Timeout Seconds
         path: admissionControl.timeoutSeconds
       - description: Settings for the components running on each node in the cluster

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -56,3 +56,16 @@ tests:
   expect: |
     .validatingwebhookconfigurations[].apiVersion | assertThat(. == "admissionregistration.k8s.io/v1beta1")
     .validatingwebhookconfigurations[].webhooks[] | assertThat(.admissionReviewVersions == null)
+
+- name: "Webhook timeout pads AdmissionController timeout by 2 seconds"
+  tests:
+    - name: "default AdmissionController timeout is 20s + 2s padding"
+      expect: |
+        .validatingwebhookconfigurations[].webhooks[].timeoutSeconds | assertThat(. == 20 + 2)
+    - name: "override sets value correctly"
+      values:
+        admissionControl:
+          dynamic:
+            timeout: 10
+      expect: |
+        .validatingwebhookconfigurations[].webhooks[].timeoutSeconds | assertThat(. == 10 + 2)


### PR DESCRIPTION
## Description

This is a roll-forward of https://github.com/stackrox/stackrox/pull/80 with gke-api-upgrade-tests fixed.

Increase the admission controller timeoutSeconds default 20 and maximum allowed value to 27 seconds.

The default kubectl timeout is 30 seconds, which (with padding) gives us our 27 second maximum for admission control.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- ~[ ] Determined and documented upgrade steps~

If any of these don't apply, please comment below.

## Testing Performed

Ran helm tests, inspected CI, and ran helmdiff.sh, compared the values of applying the secured cluster template before and after: