### PR TITLE
Fix setting labels manually on PRs that got labels from labeler.

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -14,3 +14,4 @@ jobs:
     - uses: actions/labeler@v3
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: ""


### PR DESCRIPTION
## Description

Right now, somehow, its not possible _sometimes_ to set labels on PRs which have labels added by labeler (they will be unchecked after some time). For reference, see [this PR](https://github.com/stackrox/stackrox/pull/805) and [this PR](https://github.com/stackrox/stackrox/pull/819) as examples for it not working.
There are, however, PRs where it is working, see [this PR](https://github.com/stackrox/stackrox/pull/787) and [this PR](https://github.com/stackrox/stackrox/pull/790).

It appears that PRs that are created at the beginning with "non-labeler" labels are retaining them, afterwards it seems not to be possible to set those manually.

The issue I found were of [this sort](https://github.com/actions/labeler/issues/112), where the labeler is preventing manual labels from being added. I'll try this workaround for now, unsetting the `sync-labels` property to check whether this will help.
