### PR TITLE
ROX-9545: Use manifest API instead of deprecated image API in quay.io

### DIFF
--- a/release/scripts/vuln_check.sh
+++ b/release/scripts/vuln_check.sh
@@ -19,7 +19,7 @@ function compare_fixable_vulns {
   local image_name=$1
   local image_tag=$2
 
-  echo "Fetching current image id from quay for $image_name:$image_tag"
+  echo "Fetching current image SHA from quay for $image_name:$image_tag"
   img_data="$(quay_curl "${image_name}/tag/?specificTag=${image_tag}" | jq -r '.tags | first')"
   if [[ "$(jq -r '.is_manifest_list' <<<"$img_data")" == "true" ]]; then
     img_data="$(quay_curl "${image_name}/tag/?specificTag=${image_tag}-amd64" | jq -r '.tags | first')"


### PR DESCRIPTION
## Description

From quay.io support:

> The image API is deprecated and cannot be used anymore. Quay.io now internally functions only on manifests.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps

If any of these don't apply, please comment below.

## Testing Performed

https://app.circleci.com/pipelines/github/stackrox/stackrox/6129/workflows/323f9000-92cb-4c73-83d3-bdfc93306b30/jobs/274209