### PR TITLE
Increase visual contrast for toggle group button that is selected but disabled

### DIFF
--- a/ui/apps/platform/src/css/acs.css
+++ b/ui/apps/platform/src/css/acs.css
@@ -38,8 +38,8 @@
 }
 
 /*
- * ToggleGroupItem button that is selected but disabled needs more contrast with unselected button.
+ * ToggleGroupItem button that is selected but disabled needs more contrast to distinguish from unselected button.
  */
 button:disabled.pf-c-toggle-group__button.pf-m-selected {
-    background-color: var(--pf-c-toggle-group__button--m-selected--BackgroundColor); /* same as selected and enabled */
+    background-color: var(--pf-c-toggle-group__button--m-selected--BackgroundColor);
 }


### PR DESCRIPTION
## Description

The style on policy detail and policy wizard step 5 makes it hard to see which button is selected.

Add a generic override because the problem is not specific to policy criteria.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Step 3 Policy criteria: selected enabled button has black text on blue background with blue border
![step3](https://user-images.githubusercontent.com/11862657/156861694-f6cb8bc5-044c-4a97-a935-93ed847ba895.png)

Step 5 Review policy

* Too little contrast: selected disabled button has gray text on gray background with blue border
    ![step5](https://user-images.githubusercontent.com/11862657/156861705-e2f33e43-7c2b-4410-8750-78c9bb2bb245.png)

* Improved contrast: selected disabled button has gray text on blue background with blue border
    ![step5-rule](https://user-images.githubusercontent.com/11862657/156861718-0721179d-8686-4497-b3f9-a0ef89dc433c.png)

