### PR TITLE
Install bundle helpers deps into user dir.

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -336,8 +336,9 @@ upgrade-via-olm: kuttl
 # Commands to enter local Python virtual environment and get needed dependencies there.
 ACTIVATE_PYTHON = python3 -m venv bundle_helpers/.venv ;\
 	. bundle_helpers/.venv/bin/activate ;\
-	pip3 install --upgrade pip==21.3.1 setuptools==60.2.0 ;\
-	pip3 install -r bundle_helpers/requirements.txt
+	pip3 install --user --upgrade pip==21.3.1 setuptools==60.2.0 ;\
+	pip3 install --user -r bundle_helpers/requirements.txt ;\
+	export PYTHONPATH=$$(python3 -c 'import site; print(site.USER_SITE)'):$$PYTHONPATH
 
 .PHONY: bundle
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.


### PR DESCRIPTION
## Description

When using python and `pip3` installed via `nix`, trying to `pip3 install` python packages into the site-wide (nix-controlled) directory is disallowed (and rightly so):

```
ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: '/nix/store/afi0ysqw20yiiw2gr2d28dx40bc4ddf8-python3-3.9.10/lib/python3.9/site-packages/PyYAML-5.4.1.dist-info'
Consider using the `--user` option or check the permissions.
```

So install the modules to a user directory and export a `$PYTHONPATH` such that they are accessible to python interpreter.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs)).~

## Testing Performed

Made sure the affected targets (`make bundle bundle-build`) work OK on my RHEL box.
@SimonBaeumer please make sure these also work on a Mac
@msugakov please make sure these also work on Ubuntu