### PR TITLE
Revert "ROX-9206: errox.CausedBy for error reclassification (#647)"

### DIFF
--- a/pkg/errox/errors.go
+++ b/pkg/errox/errors.go
@@ -1,5 +1,9 @@
 package errox
 
+import (
+	"fmt"
+)
+
 // Sentinel errors for generic error classes.
 //
 // Note that error messages are the only reliable indicator of the error type
@@ -47,28 +51,32 @@ var (
 	// When adding a new error please update the translators in this package (gRPC, etc.).
 )
 
-// GenericNoValidRole wraps NoValidRole with a generic error message.
+// GenericNoValidRole wraps ErrNoValidRole with a generic error message.
 func GenericNoValidRole() error {
-	return NoValidRole.New("access for this user is not authorized: no valid role," +
-		" please contact your system administrator")
+	return fmt.Errorf("access for this user is not authorized: %w, please contact your system administrator",
+		NoValidRole)
 }
 
-// NewErrNotAuthorized wraps NotAuthorized into an explanation.
+func explain(err error, explanation string) error {
+	return fmt.Errorf("%w: %s", err, explanation)
+}
+
+// NewErrNotAuthorized wraps ErrNotAuthorized into an explanation.
 func NewErrNotAuthorized(explanation string) error {
-	return NotAuthorized.CausedBy(explanation)
+	return explain(NotAuthorized, explanation)
 }
 
-// NewErrNoCredentials wraps NoCredentials into an explanation.
+// NewErrNoCredentials wraps ErrNoCredentials into an explanation.
 func NewErrNoCredentials(explanation string) error {
-	return NoCredentials.CausedBy(explanation)
+	return explain(NoCredentials, explanation)
 }
 
-// NewErrInvariantViolation wraps InvariantViolation into an explanation.
+// NewErrInvariantViolation wraps ErrInvariantViolation into an explanation.
 func NewErrInvariantViolation(explanation string) error {
-	return InvariantViolation.CausedBy(explanation)
+	return explain(InvariantViolation, explanation)
 }
 
-// NewErrInvalidArgs wraps InvalidArgs into an explanation.
+// NewErrInvalidArgs wraps ErrInvalidArgs into an explanation.
 func NewErrInvalidArgs(explanation string) error {
-	return InvalidArgs.CausedBy(explanation)
+	return explain(InvalidArgs, explanation)
 }

--- a/pkg/sac/err_permission_denied.go
+++ b/pkg/sac/err_permission_denied.go
@@ -6,5 +6,5 @@ import (
 
 var (
 	// ErrResourceAccessDenied is the error when permission is denied for a SAC reason.
-	ErrResourceAccessDenied = errox.NotAuthorized.New("access to resource denied")
+	ErrResourceAccessDenied = errox.New(errox.NotAuthorized, "access to resource denied")
 )


### PR DESCRIPTION
This reverts commit eb9a5357fd978466c2f298723d24856f9b489afa.

## Description

Reverting  "ROX-9206: errox.CausedBy for error reclassification (#647)" that was breaking the build, see e.g. [this](https://app.circleci.com/pipelines/github/stackrox/stackrox/6212/workflows/33184f00-d36e-4816-b94c-271d63e750a7/jobs/278019)

