### PR TITLE
Delete unneeded StackRox references from code comments in UI

### DIFF
--- a/ui/apps/platform/src/Containers/Docs/ApiPage.js
+++ b/ui/apps/platform/src/Containers/Docs/ApiPage.js
@@ -30,7 +30,7 @@ function SwaggerBrowser({ uri }) {
     }
     if (result) {
         return (
-            // Redoc components unreadable with StackRox dark theme, their styles need to be tuned
+            // Redoc components unreadable with classic dark theme, their styles need to be tuned
             <RedocStandalone spec={result.data} />
         );
     }

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/DiagnosticBundleDialogBox.test.ts
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/DiagnosticBundleDialogBox.test.ts
@@ -73,7 +73,7 @@ describe('Diagnostic Bundle dialog box', () => {
             expect(startingTimeRegExp.test(startingTimeText)).toBe(false);
         });
 
-        it('should not match StackRox stringification', () => {
+        it('should not match application stringification', () => {
             const startingTimeText = '10/20/2020 17:22:00';
 
             expect(startingTimeRegExp.test(startingTimeText)).toBe(false);

--- a/ui/apps/platform/src/Containers/SystemHealth/PatternFly/utils/diagnosticBundleUtils.test.ts
+++ b/ui/apps/platform/src/Containers/SystemHealth/PatternFly/utils/diagnosticBundleUtils.test.ts
@@ -73,7 +73,7 @@ describe('Diagnostic Bundle dialog box', () => {
             expect(startingTimeRegExp.test(startingTimeText)).toBe(false);
         });
 
-        it('should not match StackRox stringification', () => {
+        it('should not match application stringification', () => {
             const startingTimeText = '10/20/2020 17:22:00';
 
             expect(startingTimeRegExp.test(startingTimeText)).toBe(false);

--- a/ui/apps/platform/src/app.tw.css
+++ b/ui/apps/platform/src/app.tw.css
@@ -787,7 +787,7 @@ h6 {
 .redoc-wrap {
     /* TODO: discover a way to export CSS vars from our tailwind-config package
        for now, repeating light theme colors here,
-       because Redoc components unreadable with StackRox dark theme,
+       because Redoc components unreadable with classic dark theme,
        their styles need to be tuned
     */
 

--- a/ui/apps/platform/src/services/MetadataService.js
+++ b/ui/apps/platform/src/services/MetadataService.js
@@ -1,7 +1,7 @@
 import axios from './instance';
 
 /**
- * Fetches StackRox metadata.
+ * Fetches metadata.
  * @returns {Promise<Object, Error>} fulfilled with response
  */
 

--- a/ui/apps/platform/src/services/NetworkService.js
+++ b/ui/apps/platform/src/services/NetworkService.js
@@ -133,7 +133,7 @@ export function toggleAlertBaselineViolations({ deploymentId, enable }) {
 }
 
 /*
- * Retrieves the last StackRox-applied policy for a deployement
+ * Retrieves the last security policy applied for a deployement
  *
  * @param   {string}  deploymentId
  * @returns {Promise<Object, Error>}
@@ -414,7 +414,7 @@ export function deleteCIDRBlock(blockId) {
 }
 
 /**
- * Gets the default StackRox generated CIDR blocks toggle state.
+ * Gets the default application generated CIDR blocks toggle state.
  *
  * @returns {Promise<Object, Error>}
  */
@@ -425,7 +425,7 @@ export function getHideDefaultExternalSrcs() {
 }
 
 /**
- * Sets the default StackRox generated CIDR blocks to be on or off.
+ * Sets the default application generated CIDR blocks to be on or off.
  *
  * @returns {Promise<Object, Error>}
  */

--- a/ui/apps/platform/src/types/cluster.proto.ts
+++ b/ui/apps/platform/src/types/cluster.proto.ts
@@ -89,7 +89,7 @@ export type CompleteClusterConfig = {
     clusterLabels: Record<string, string>;
 };
 
-// StackRoxDeploymentIdentification aims at uniquely identifying a StackRox Sensor deployment. It is used to determine
+// SensorDeploymentIdentification aims at uniquely identifying a Sensor deployment. It is used to determine
 // whether a sensor connection comes from a sensor pod that has restarted or was recreated (possibly after a network
 // partition), or from a deployment in a different namespace or cluster.
 export type SensorDeploymentIdentification = {


### PR DESCRIPTION
## Description

To reduce the number of search results and as warm up exercise before editing references which are visible in user interface.

* src/app.tw.css
* src/Containers/Docs/ApiPage.js
* src/Containers/SystemHealth/Components/DiagnosticBundleDialogBox.test.ts
* src/Containers/SystemHealth/PatternFly/utils/diagnosticBundleUtils.test.ts
* src/services/MetadataService.js
* src/services/NetworkService.js
* src/types/cluster.proto.ts

Residue
* src/services/PDFExportService.ts left alone to reduce chance of merge conflict

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed
