### PR TITLE
Edit RHACS references in UI part 1

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/DeleteClusterInitBundleConfirmationModal.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/DeleteClusterInitBundleConfirmationModal.tsx
@@ -125,9 +125,8 @@ function DeleteClusterInitBundleConfirmationModal({
                         ) : (
                             <Alert title="Clusters depend on this bundle" variant="danger" isInline>
                                 <p>
-                                    In clusters that depend on this bundle, Red Hat Advanced Cluster
-                                    Security deployments like Sensor will lose connectivity to
-                                    Central.
+                                    In clusters that depend on this bundle, security deployments
+                                    like Sensor will lose connectivity to Central.
                                 </p>
                                 <p className="pf-u-mt-md">
                                     We recommend that you <strong>replace</strong> this bundle in

--- a/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/BaselineSimulation/BaselineSimulation.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/BaselineSimulation/BaselineSimulation.tsx
@@ -59,7 +59,7 @@ function BaselineSimulation({ deploymentId }: BaselineSimulationProps): ReactEle
                 setUndoModification(response);
             })
             .catch((err) => {
-                // if there is no ACS-applied undo record, that is returned as an error
+                // if there is application-applied undo record, that is returned as an error
                 // so we filter that type of error out, before throwing
                 if (!err?.response?.data?.message?.includes('no undo record stored')) {
                     throw Error('Error retrieving possible undo network policy');
@@ -89,8 +89,8 @@ function BaselineSimulation({ deploymentId }: BaselineSimulationProps): ReactEle
                 </PanelHead>
                 {!!undoModification && (
                     <p className="px-3 py-2">
-                        The last policy applied through Red Hat Advanced Cluster Security was
-                        applied by <strong>{undoModification?.undoRecord?.user}</strong> on{' '}
+                        The last network policy was applied by{' '}
+                        <strong>{undoModification?.undoRecord?.user}</strong> on{' '}
                         <strong>
                             {getDateTime(undoModification?.undoRecord?.applyTimestamp || '')}
                         </strong>

--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Modal/ImportPolicyJSONUpload.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Modal/ImportPolicyJSONUpload.tsx
@@ -57,7 +57,7 @@ function ImportPolicyJSONUpload({
     return (
         <>
             <ModalBoxBody>
-                Upload a policy JSON file to import one or more ACS policies
+                Upload a policy JSON file to import a previously exported security policy
                 <FileUpload
                     id="policies-json-import"
                     type="text"

--- a/ui/apps/platform/src/services/NetworkService.js
+++ b/ui/apps/platform/src/services/NetworkService.js
@@ -64,7 +64,7 @@ export function fetchBaselineComparison({ deploymentId }) {
 
 // TODO: wire this through redux saga, like the `fetchBaselineComparison` above
 /*
- * Fetches the diff view of flows between the network policies last applied by ACS to the
+ * Fetches the diff view of flows between the network policies last applied to the
  * specified deployment and the previous state before that application.
  *
  * @returns {Promise<Object, Error>}


### PR DESCRIPTION
## Description

1. src/Containers/Integrations/IntegrationsListPage/DeleteClusterInitBundleConfirmationModal.tsx
    * replace: In clusters that depend on this bundle, **Red Hat Advanced Cluster Security** deployments like Sensor will lose connectivity to Central.
    * with: In clusters that depend on this bundle, **security** deployments like Sensor will lose connectivity to Central.

2. src/Containers/Network/SidePanel/NetworkDeploymentOverlay/BaselineSimulation/BaselineSimulation.tsx
    * replace: The last policy applied through **Red Hat Advanced Cluster Security** was applied by …
    * with: The last **network** policy was applied by …

3. src/Containers/Policies/PatternFly/Modal/ImportPolicyJSONUpload.tsx
    * replace: Upload a policy JSON file to import **one or more ACS policies**
    * with: Upload a policy JSON file to import **a previously exported security policy**

4. src/Containers/Policies/PatternFly/Wizard/Step2/PolicyBehaviorForm.tsx
    wait until after 69 release to prevent merge conflicts with any critical fixes

5. src/services/NetworkService.js
    * replace: Fetches the diff view of flows between the network policies last applied **by ACS** to the …
    * with: Fetches the diff view of flows between the network policies last applied to the …

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed