### PR TITLE
ROX-8785: Skip network policy test on EKS

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -636,6 +636,8 @@ class NetworkFlowTest extends BaseSpecification {
 
     @Category([BAT])
     def "Verify generated network policies"() {
+        // ROX-8785 - EKS cannot NetworkPolicy (RS-178)
+        Assume.assumeFalse(ClusterService.isEKS())
         given:
         "Get current state of network graph"
         NetworkGraph currentGraph = NetworkGraphService.getNetworkGraph()


### PR DESCRIPTION
## Description

Skip constantly failing test on EKS.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs)).

If any of these don't apply, please comment below.

## Testing Performed

CI