### PR TITLE
Fix "Waiting for Central to respond..." timing out

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -330,6 +330,12 @@ function launch_central {
       hotload_binary central central central
     fi
 
+    # Wait for any pending changes to Central deployment to get reconciled before trying to connect it.
+    # On some systems there's a race condition when port-forward connects to central but its pod then gets deleted due
+    # to ongoing modifications to the central deployment. This port-forward dies and the script hangs "Waiting for
+    # Central to respond" until it times out. Waiting for rollout status should help not get into such situation.
+    kubectl -n stackrox rollout status deploy/central --timeout=3m
+
     # if we have specified that we want to use a load balancer, then use that endpoint instead of localhost
     if [[ "${LOAD_BALANCER}" == "lb" ]]; then
         # wait for LB


### PR DESCRIPTION
## Description

![2022-03-09_14-10](https://user-images.githubusercontent.com/537715/157452752-2440b8e5-f8a6-437e-9a78-91821e06a36d.png)

`deploy-local.sh` stuck waiting for central to respond and eventually failing.

This has been impacting me for some time and I've seen some other folks hit by that. I tried to describe what happened in the comment.
`port-forward` command, if it wasn't redirected to `/dev/null` would log something like this:
```
error: error upgrading connection: unable to upgrade connection: pod not found ("central-57d87fb464-xcg9r_stackrox")
```
In `central` pod logs I found normal request for termination.

Once the change is applied, the picture looks better.

![2022-03-09_14-36](https://user-images.githubusercontent.com/537715/157453508-b5b40fb4-d49d-42a2-a6d9-041576d35db8.png)

It adds half-minute waiting but at least there are no race conditions around port-forward.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~ - not for this change.
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ - no need.
- ~~[ ] Determined and documented upgrade steps~~ - not needed.
- ~~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs)).~~ - not user-facing, internal.

## Testing Performed

- Tested locally.
- Relying on CI to show green lights.