### PR TITLE
Rename ACSEmptyState as EmptyStateTemplate and move to PatternFly folder

### DIFF
--- a/ui/apps/platform/src/Components/ACSEmptyState/index.ts
+++ b/ui/apps/platform/src/Components/ACSEmptyState/index.ts
@@ -1,1 +1,0 @@
-export { default } from './ACSEmptyState';

--- a/ui/apps/platform/src/Components/PatternFly/EmptyStateTemplate/EmptyStateTemplate.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/EmptyStateTemplate/EmptyStateTemplate.tsx
@@ -8,13 +8,17 @@ import {
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
 
-type ACSEmptyStateProps = {
+type EmptyStateTemplateProps = {
     children?: ReactNode;
     title: string;
-    headingLevel?: 'h1' | 'h2' | 'h3';
+    headingLevel: 'h1' | 'h2' | 'h3' | 'h4';
 };
 
-function ACSEmptyState({ children, title, headingLevel = 'h1' }: ACSEmptyStateProps): ReactElement {
+function EmptyStateTemplate({
+    children,
+    title,
+    headingLevel,
+}: EmptyStateTemplateProps): ReactElement {
     return (
         <EmptyState variant={EmptyStateVariant.large}>
             <EmptyStateIcon icon={CubesIcon} />
@@ -26,4 +30,4 @@ function ACSEmptyState({ children, title, headingLevel = 'h1' }: ACSEmptyStatePr
     );
 }
 
-export default ACSEmptyState;
+export default EmptyStateTemplate;

--- a/ui/apps/platform/src/Components/PatternFly/EmptyStateTemplate/index.ts
+++ b/ui/apps/platform/src/Components/PatternFly/EmptyStateTemplate/index.ts
@@ -1,0 +1,1 @@
+export { default } from './EmptyStateTemplate';

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -17,7 +17,7 @@ import {
 } from '@patternfly/react-core';
 import { CaretDownIcon } from '@patternfly/react-icons';
 
-import ACSEmptyState from 'Components/ACSEmptyState';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import NotFoundMessage from 'Components/NotFoundMessage';
 import { actions as authActions, types as authActionTypes } from 'reducers/auth';
 import { actions as groupActions } from 'reducers/groups';
@@ -189,9 +189,9 @@ function AuthProviders(): ReactElement {
                             {pluralize(authProvidersWithRules.length, 'result')} found
                         </Title>
                         {authProvidersWithRules.length === 0 && (
-                            <ACSEmptyState title="No auth providers" headingLevel="h2">
+                            <EmptyStateTemplate title="No auth providers" headingLevel="h3">
                                 Please add one.
-                            </ACSEmptyState>
+                            </EmptyStateTemplate>
                         )}
                         {authProvidersWithRules.length > 0 && (
                             <AuthProvidersList

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -14,7 +14,7 @@ import { useParams, Link } from 'react-router-dom';
 import resolvePath from 'object-resolve-path';
 import pluralize from 'pluralize';
 
-import ACSEmptyState from 'Components/ACSEmptyState';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import useTableSelection from 'hooks/useTableSelection';
 import useIntegrationPermissions from '../hooks/useIntegrationPermissions';
@@ -233,9 +233,9 @@ function IntegrationsTable({
                         </Tbody>
                     </TableComposable>
                 ) : (
-                    <ACSEmptyState
-                        key="no-results"
+                    <EmptyStateTemplate
                         title="No integrations of this type are currently configured."
+                        headingLevel="h3"
                     />
                 )}
             </PageSection>

--- a/ui/apps/platform/src/Containers/Search/SearchResults.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchResults.tsx
@@ -17,7 +17,7 @@ import { TableComposable, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-tab
 import { addSearchModifier, addSearchKeyword } from 'utils/searchUtils';
 import { selectors } from 'reducers';
 import { actions as globalSearchActions } from 'reducers/globalSearch';
-import ACSEmptyState from 'Components/ACSEmptyState';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import RelatedLink from './RelatedLink';
 
 type GlobalSearchResult = {
@@ -340,9 +340,9 @@ function SearchResults({
             </Tbody>
         </TableComposable>
     ) : (
-        <ACSEmptyState key="no-results" title="No results for your chosen filters">
+        <EmptyStateTemplate title="No results for your chosen filters" headingLevel="h2">
             Try changing the filter values.
-        </ACSEmptyState>
+        </EmptyStateTemplate>
     );
 
     const activeTabKey = tabs.findIndex((tab) => tab.category === defaultTab?.category) || 0;
@@ -377,9 +377,12 @@ function SearchResults({
 
     return !globalSearchOptions.length ? (
         <Bullseye>
-            <ACSEmptyState title="Search all data across Advanced Cluster Security">
+            <EmptyStateTemplate
+                title="Search all data across Advanced Cluster Security"
+                headingLevel="h1"
+            >
                 Choose one or more filter values to search.
-            </ACSEmptyState>
+            </EmptyStateTemplate>
         </Bullseye>
     ) : (
         <div className="bg-base-100 flex-1" data-testid="global-search-results">

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePage.tsx
@@ -18,7 +18,7 @@ import {
     ToolbarItem,
 } from '@patternfly/react-core';
 
-import ACSEmptyState from 'Components/ACSEmptyState';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import PageTitle from 'Components/PageTitle';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import { searchCategories } from 'constants/entityTypes';
@@ -174,7 +174,10 @@ function ReportTablePage({ query }: ReportTablePageProps): ReactElement {
             )}
             {!isLoading && !reports?.length && (
                 <PageSection variant={PageSectionVariants.light} isFilled>
-                    <ACSEmptyState title="No reports are currently configured." />
+                    <EmptyStateTemplate
+                        title="No reports are currently configured."
+                        headingLevel="h2"
+                    />
                 </PageSection>
             )}
         </>

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferrals.tsx
@@ -4,7 +4,7 @@ import usePagination from 'hooks/patternfly/usePagination';
 import queryService from 'utils/queryService';
 import useSearch from 'hooks/useSearch';
 import { PageSection, PageSectionVariants } from '@patternfly/react-core';
-import ACSEmptyState from 'Components/ACSEmptyState';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import useVulnerabilityRequests from '../useVulnerabilityRequests';
 import ApprovedDeferralsTable from './ApprovedDeferralsTable';
 
@@ -43,7 +43,7 @@ function ApprovedDeferrals(): ReactElement {
     if (!isLoading && rows && rows.length === 0) {
         return (
             <PageSection variant={PageSectionVariants.light} isFilled>
-                <ACSEmptyState title="No deferral requests were approved." />
+                <EmptyStateTemplate title="No deferral requests were approved." headingLevel="h2" />
             </PageSection>
         );
     }

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositives.tsx
@@ -4,7 +4,7 @@ import usePagination from 'hooks/patternfly/usePagination';
 import queryService from 'utils/queryService';
 import useSearch from 'hooks/useSearch';
 import { PageSection, PageSectionVariants } from '@patternfly/react-core';
-import ACSEmptyState from 'Components/ACSEmptyState';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import useVulnerabilityRequests from '../useVulnerabilityRequests';
 import ApprovedFalsePositivesTable from './ApprovedFalsePositivesTable';
 
@@ -42,7 +42,10 @@ function ApprovedFalsePositives(): ReactElement {
     if (!isLoading && rows && rows.length === 0) {
         return (
             <PageSection variant={PageSectionVariants.light} isFilled>
-                <ACSEmptyState title="No false positive requests were approved." />
+                <EmptyStateTemplate
+                    title="No false positive requests were approved."
+                    headingLevel="h2"
+                />
             </PageSection>
         );
     }

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
@@ -20,7 +20,7 @@ import { UsePaginationResult } from 'hooks/patternfly/usePagination';
 import usePermissions from 'hooks/usePermissions';
 import useAuthStatus from 'hooks/useAuthStatus';
 import { SearchFilter } from 'types/search';
-import ACSEmptyState from 'Components/ACSEmptyState';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { GetSortParams } from 'hooks/patternfly/useTableSort';
 import AffectedComponentsButton from '../AffectedComponents/AffectedComponentsButton';
 import { Vulnerability } from '../imageVulnerabilities.graphql';
@@ -187,7 +187,10 @@ function DeferredCVEsTable({
                         <Tr>
                             <Td colSpan={9}>
                                 <PageSection variant={PageSectionVariants.light} isFilled>
-                                    <ACSEmptyState title="No deferral requests were approved." />
+                                    <EmptyStateTemplate
+                                        title="No deferral requests were approved."
+                                        headingLevel="h3"
+                                    />
                                 </PageSection>
                             </Td>
                         </Tr>

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
@@ -20,7 +20,7 @@ import { UsePaginationResult } from 'hooks/patternfly/usePagination';
 import usePermissions from 'hooks/usePermissions';
 import useAuthStatus from 'hooks/useAuthStatus';
 import { SearchFilter } from 'types/search';
-import ACSEmptyState from 'Components/ACSEmptyState';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { GetSortParams } from 'hooks/patternfly/useTableSort';
 import AffectedComponentsButton from '../AffectedComponents/AffectedComponentsButton';
 import { Vulnerability } from '../imageVulnerabilities.graphql';
@@ -187,7 +187,10 @@ function FalsePositiveCVEsTable({
                         <Tr>
                             <Td colSpan={9}>
                                 <PageSection variant={PageSectionVariants.light} isFilled>
-                                    <ACSEmptyState title="No false positive requests were approved." />
+                                    <EmptyStateTemplate
+                                        title="No false positive requests were approved."
+                                        headingLevel="h3"
+                                    />
                                 </PageSection>
                             </Td>
                         </Tr>

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
@@ -26,7 +26,7 @@ import CVSSScoreLabel from 'Components/PatternFly/CVSSScoreLabel';
 import DateTimeFormat from 'Components/PatternFly/DateTimeFormat';
 import usePermissions from 'hooks/usePermissions';
 import { SearchFilter } from 'types/search';
-import ACSEmptyState from 'Components/ACSEmptyState';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { GetSortParams } from 'hooks/patternfly/useTableSort';
 import DeferralFormModal from './DeferralFormModal';
 import FalsePositiveRequestModal from './FalsePositiveFormModal';
@@ -215,7 +215,10 @@ function ObservedCVEsTable({
                         <Tr>
                             <Td colSpan={7}>
                                 <PageSection variant={PageSectionVariants.light} isFilled>
-                                    <ACSEmptyState title="No CVEs available" />
+                                    <EmptyStateTemplate
+                                        title="No CVEs available"
+                                        headingLevel="h3"
+                                    />
                                 </PageSection>
                             </Td>
                         </Tr>

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovals.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovals.tsx
@@ -5,7 +5,7 @@ import queryService from 'utils/queryService';
 import useSearch from 'hooks/useSearch';
 import { SearchFilter } from 'types/search';
 import { PageSection, PageSectionVariants } from '@patternfly/react-core';
-import ACSEmptyState from 'Components/ACSEmptyState';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import PendingApprovalsTable from './PendingApprovalsTable';
 import useVulnerabilityRequests from '../useVulnerabilityRequests';
 
@@ -52,7 +52,7 @@ function PendingApprovals(): ReactElement {
     if (!isLoading && rows && rows.length === 0) {
         return (
             <PageSection variant={PageSectionVariants.light} isFilled>
-                <ACSEmptyState title="No pending requests to approve." />
+                <EmptyStateTemplate title="No pending requests to approve." headingLevel="h2" />
             </PageSection>
         );
     }


### PR DESCRIPTION
## Description

Reduce references to product branding: replace `'Components/ACSEmptyState'` with `'Components/PatternFly/EmptyStateTemplate'`

Although more attention to accessibility might cause us to ask whether heading is semantically appropriate if no `children` content:
* Make `headingLevel` required to reduce the chance of incorrect heading hierarchy.
* Add `'h4'` as a possible value, because it seems possible: 1. Vulnerability Management 2. Image 3. Image Findings 4. No deferral requests were approved

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Integrations
![IntegrationsTable](https://user-images.githubusercontent.com/11862657/157523808-3e67dd96-5354-4434-b803-9635cecd2617.png)

### Search

![SearchResults-h1](https://user-images.githubusercontent.com/11862657/157523847-36b68459-eb27-4f90-856c-3990ab5432c1.png)

![SearchResults-h2](https://user-images.githubusercontent.com/11862657/157523871-a6142636-6e90-4efa-ab45-2f0a3cf264ec.png)

### Vulnerability Management Risk Acceptance

![PendingApprovals p ng](https://user-images.githubusercontent.com/11862657/157523946-8285d9cc-4ec4-4216-b951-faaedc0c7ea4.png)

![DeferredCVEsTable](https://user-images.githubusercontent.com/11862657/157523973-465c7e1a-b632-4d25-b7e1-e18675791b66.png)

### Vulnerability Management Reporting

![ReportTablePanel](https://user-images.githubusercontent.com/11862657/157524000-5d48d72c-177e-4da1-beb0-129abf668017.png)