### PR TITLE
 Restore call to rox.configureImagePullSecrets for imagePullSecrets

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -290,7 +290,7 @@
   {{ $_ = set $._rox.scanner "slimImage" ._rox.image.scanner }}
   {{ $_ = set $._rox.scanner "slimDBImage" ._rox.image.scannerDb }}
   {{ include "srox.scannerInit" (list $ $._rox.scanner) }}
-{{ include "srox.configureImagePullSecrets" (list $ "imagePullSecrets" $._rox.imagePullSecrets "secured-cluster-services-main" (list "stackrox" "stackrox-scanner") $.Release.Namespace) }}
+  {{ include "srox.configureImagePullSecrets" (list $ "imagePullSecrets" $._rox.imagePullSecrets "secured-cluster-services-main" (list "stackrox" "stackrox-scanner") $.Release.Namespace) }}
 {{ end }}
 [<- end >]
 


### PR DESCRIPTION
## Description

The call to `"srox.configureImagePullSecrets"` added in https://github.com/stackrox/stackrox/pull/788/files was removed probably during a merge, but not its tests so they are failing https://app.circleci.com/pipelines/github/stackrox/stackrox/6550/workflows/a5294b51-f5cf-4aa8-b1a4-db2eb0dd6a67/jobs/290692/tests.

Note this PR only adds https://github.com/stackrox/stackrox/pull/887/commits/9c889314e94de24201fb19849f5c9b6d87c55e2d which is a line that is present in master https://github.com/stackrox/stackrox/blob/master/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl#L293

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs)).

If any of these don't apply, please comment below.

## Testing Performed

```bash
go test -v  github.com/stackrox/rox/pkg/helm/charts/tests/securedclusterservices && \
go test -v github.com/stackrox/rox/central/clusters/zip && \
go test -v github.com/stackrox/rox/roxctl/helm/output
```
