### PR TITLE
Update deps when test tools or linters has been updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,12 @@ clean-proto-generated-srcs:
 .PHONY: generated-srcs
 generated-srcs: go-generated-srcs
 
-deps: go.mod
+deps: $(BASE_DIR)/go.sum tools/linters/go.sum tools/test/go.sum
+	@echo "+ $@"
+	@touch deps
+
+%/go.sum: %/go.mod
+	@cd $*
 	@echo "+ $@"
 	@$(eval GOMOCK_REFLECT_DIRS=`find . -type d -name 'gomock_reflect_*'`)
 	@test -z $(GOMOCK_REFLECT_DIRS) || { echo "Found leftover gomock directories. Please remove them and rerun make deps!"; echo $(GOMOCK_REFLECT_DIRS); exit 1; }
@@ -311,7 +316,7 @@ ifdef CI
 	@git diff --exit-code -- go.mod go.sum || { echo "go.mod/go.sum files were updated after running 'go mod tidy', run this command on your local machine and commit the results." ; exit 1 ; }
 	go mod verify
 endif
-	@touch deps
+	@touch $@
 
 .PHONY: clean-deps
 clean-deps:


### PR DESCRIPTION
## Description

After splitting go.mod in #83 we need to ensure `go.sum`s are verified and up to date. 
We also need to update tools when `go.mod`s has changed.
This PR creates a new rule that will check and generate `go.sum` out of `go.mod` to be used in `deps` target.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs)).

If any of these don't apply, please comment below.

## Testing Performed

```bash
$ touch go.mod tools/linters/go.mod tools/test/go.mod
$ make deps
+ /home/janisz/go/src/github.com/stackrox/stackrox/go.sum
+ tools/linters/go.sum
+ tools/test/go.sum
+ deps
$ make deps
make: 'deps' is up to date.
$ touch tools/linters/go.mod
$ make deps
+ tools/linters/go.sum
+ deps
```


CI