### PR TITLE
ROX-9526: Sensor detect & extract ECR docker integrations

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -82,3 +82,9 @@ func (d *DockerConfigEntry) UnmarshalJSON(data []byte) error {
 	d.Username, d.Password, err = decodeDockerConfigFieldAuth(tmp.Auth)
 	return err
 }
+
+// CreateFromAuthString decodes the given docker auth string into a DockerConfigEntry.
+func CreateFromAuthString(auth string) (d DockerConfigEntry, err error) {
+	d.Username, d.Password, err = decodeDockerConfigFieldAuth(auth)
+	return
+}

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -44,4 +44,7 @@ var (
 
 	// PostgresDatastore enables Postgres datastore.
 	PostgresDatastore = registerFeature("Enable Postgres Datastore", "ROX_POSTGRES_DATASTORE", false)
+
+	// ECRAutoIntegration enables detection of ECR-based deployments to generate auto-integrations from ECR auth tokens.
+	ECRAutoIntegration = registerFeature("Enable ECR auto-integrations when running on AWS nodes", "ROX_ECR_AUTO_INTEGRATION", false)
 )

--- a/sensor/common/awscredentials/registry.go
+++ b/sensor/common/awscredentials/registry.go
@@ -1,0 +1,162 @@
+// Package awscredentials provides Sensor components that can retrieve, cache,
+// refresh and offer AWS-based credentials and tokens.
+package awscredentials
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/docker/config"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	ecrRegistryRegex = regexp.MustCompile(`\d+\.dkr\.ecr\.[^.]+\.amazonaws\.com`)
+	log              = logging.LoggerForModule()
+)
+
+// RegistryCredentialsManager is a sensor component that manages
+// credentials for docker registries.
+type RegistryCredentialsManager interface {
+	// GetDockerConfigEntry returns the most recent docker config credential for the given
+	// registry URI, or `nil` if not available.
+	GetDockerConfigEntry(r string) *config.DockerConfigEntry
+	Start()
+	Stop()
+}
+
+// ecrCredentialsManager manages credentials pulled from global ECR registries.
+type ecrCredentialsManager struct {
+	dockerConfigEntry *config.DockerConfigEntry
+	dockerConfigLock  sync.RWMutex
+	ecrClient         *ecr.ECR
+	expiresAt         time.Time
+	stopSignal        concurrency.Signal
+}
+
+// NewECRCredentialsManager checks for AWS provider information and, if valid,
+// creates an ECR credential manager instance.
+func NewECRCredentialsManager(providerID string) (RegistryCredentialsManager, error) {
+	if !strings.HasPrefix(providerID, "aws://") {
+		return nil, errors.Errorf("node provider is not AWS: %v", providerID)
+	}
+	log.Infof("detected AWS-based node: providerId=%s", providerID)
+	awsS, err := session.NewSession()
+	if err != nil {
+		return nil, errors.Errorf("could not create AWS session: %v", err)
+	}
+	region, err := ec2metadata.New(awsS).Region()
+	if err != nil {
+		return nil, errors.Errorf("EC2 instance metadata service failed or is not available: %v", err)
+	}
+	log.Infof("EC2 instance metadata service is active: awsRegion=%q", region)
+	return &ecrCredentialsManager{
+		ecrClient:  ecr.New(awsS, &aws.Config{Region: &region}),
+		stopSignal: concurrency.NewSignal(),
+	}, nil
+}
+
+func (m *ecrCredentialsManager) Start() {
+	const refreshInterval = 5 * time.Minute
+	go m.refreshLoop(refreshInterval)
+}
+
+// refreshLoop ticks every refresh interval when the auth token is close to expiring.
+//
+// We currently use 1h threshold to renew the auth token. The rationale is,
+// `GetAuthorizationToken` tokens have a lifetime of 12h, and we don't really
+// need to refresh regularly, only when close to expire. One hour seemed
+// reasonable enough, to accommodate for any temporary failure that might arise
+// that prevents us from getting a new token. Notice we also retry linearly,
+// which also seemed reasonable given the `GetAuthorizationToken` API call rate
+// is 500 rps.
+func (m *ecrCredentialsManager) refreshLoop(refreshInterval time.Duration) {
+	log.Infof("starting ECR credentials manager, refresh interval: %v", refreshInterval)
+	ticker := time.NewTicker(refreshInterval)
+	defer ticker.Stop()
+	for {
+		if m.authWillExpireIn(time.Hour) {
+			err := m.refreshAuthToken()
+			if err != nil {
+				log.Warnf("failed to refresh ECR authentication token: %v", err)
+			}
+		}
+		select {
+		case <-ticker.C:
+			continue
+		case <-m.stopSignal.Done():
+			return
+		}
+	}
+}
+
+func (m *ecrCredentialsManager) Stop() {
+	m.stopSignal.Signal()
+}
+
+func (m *ecrCredentialsManager) GetDockerConfigEntry(registry string) *config.DockerConfigEntry {
+	if !ecrRegistryRegex.MatchString(registry) {
+		return nil
+	}
+	return m.getConfigIfValid()
+}
+
+// refreshAuthToken Contact AWS ECR to get a new auth token.
+func (m *ecrCredentialsManager) refreshAuthToken() error {
+	authToken, err := m.ecrClient.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{})
+	if err != nil {
+		return errors.Errorf("failed to get token: %v", err)
+	}
+	if len(authToken.AuthorizationData) == 0 {
+		return errors.Errorf("received empty token: %q", authToken)
+	}
+	authData := authToken.AuthorizationData[0]
+	dockerConfigEntry, err := config.CreateFromAuthString(*authData.AuthorizationToken)
+	if err != nil {
+		return errors.Errorf("failed to create docker config from token: %v", err)
+	}
+	expiresAt := *authData.ExpiresAt
+	m.setConfig(dockerConfigEntry, expiresAt)
+	log.Infof("ECR's auth token refreshed, expires at: %v", expiresAt)
+	return nil
+}
+
+// getConfigIfValid returns the current docker config if it is valid (i.e. not
+// expired), otherwise returns nil
+func (m *ecrCredentialsManager) getConfigIfValid() *config.DockerConfigEntry {
+	m.dockerConfigLock.RLock()
+	defer m.dockerConfigLock.RUnlock()
+	if m.authIsValid() && m.dockerConfigEntry != nil {
+		// Make a copy to encapsulate the config object.
+		entry := *m.dockerConfigEntry
+		return &entry
+	}
+	return nil
+}
+
+// setConfig sets the current docker config and its expiration timestamp.
+func (m *ecrCredentialsManager) setConfig(dockerConfigEntry config.DockerConfigEntry, expiresAt time.Time) {
+	m.dockerConfigLock.Lock()
+	defer m.dockerConfigLock.Unlock()
+	m.dockerConfigEntry = &dockerConfigEntry
+	m.expiresAt = expiresAt
+}
+
+// authIsValid returns true if the current auth token hasn't expired.
+func (m *ecrCredentialsManager) authIsValid() bool {
+	return time.Now().Before(m.expiresAt)
+}
+
+// authWillExpireIn returns true if auth token is expired or will expire within
+// the given duration.
+func (m *ecrCredentialsManager) authWillExpireIn(duration time.Duration) bool {
+	return time.Now().Add(duration).After(m.expiresAt)
+}

--- a/sensor/common/awscredentials/registry_test.go
+++ b/sensor/common/awscredentials/registry_test.go
@@ -1,0 +1,88 @@
+package awscredentials
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/docker/config"
+)
+
+func Test_ecrCredentialsManager_GetDockerConfigEntry(t *testing.T) {
+	type fields struct {
+		dockerConfigEntry *config.DockerConfigEntry
+		ecrClient         *ecr.ECR
+		expiresAt         time.Time
+		stopSignal        concurrency.Signal
+	}
+	type args struct {
+		registry string
+	}
+	type test struct {
+		name   string
+		fields fields
+		args   args
+		want   *config.DockerConfigEntry
+	}
+	sampleConfig := config.DockerConfigEntry{Username: "foo", Password: "bar"}
+	tests := []test{
+		{
+			name:   "should return nil if token is invalid.",
+			fields: fields{},
+			args:   args{"123.dkr.ecr.foo-bar-1.amazonaws.com"},
+			want:   nil,
+		},
+		{
+			name: "should return nil if not ECR registry.",
+			fields: fields{
+				dockerConfigEntry: &sampleConfig,
+				// Expires in the future.
+				expiresAt: time.Now().Add(time.Hour),
+			},
+			args: args{"docker.io"},
+			want: nil,
+		},
+		{
+			name: "should return docker config if token valid.",
+			fields: fields{
+				dockerConfigEntry: &sampleConfig,
+				// Expires in the future.
+				expiresAt: time.Now().Add(time.Hour),
+			},
+			args: args{"123.dkr.ecr.foo-bar-1.amazonaws.com"},
+			want: &sampleConfig,
+		},
+	}
+	for i, r := range []string{
+		"dkr.ecr.foo-bar-1.amazonaws.com",        // missing account
+		"1234.dkr.ecr.amazonaws.com",             // missing region
+		"foobar.dkr.ecr.foo-bar-1.amazonaws.com", // invalid account
+	} {
+		tests = append(tests, test{
+			name: fmt.Sprintf("should return docker config regex is valid#%d.", i),
+			fields: fields{
+				dockerConfigEntry: &sampleConfig,
+				// Expires in the future.
+				expiresAt: time.Now().Add(time.Hour),
+			},
+			args: args{registry: r},
+			want: nil,
+		})
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &ecrCredentialsManager{
+				dockerConfigEntry: tt.fields.dockerConfigEntry,
+				ecrClient:         tt.fields.ecrClient,
+				expiresAt:         tt.fields.expiresAt,
+				stopSignal:        tt.fields.stopSignal,
+			}
+			if got := m.GetDockerConfigEntry(tt.args.registry); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetDockerConfigEntry() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/sensor/kubernetes/listener/listener.go
+++ b/sensor/kubernetes/listener/listener.go
@@ -1,13 +1,18 @@
 package listener
 
 import (
+	"context"
+
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/awscredentials"
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -20,13 +25,33 @@ type SensorEventListener interface {
 }
 
 // New returns a new kubernetes listener.
-func New(client client.Interface, configHandler config.Handler, detector detector.Detector) common.SensorComponent {
+func New(client client.Interface, configHandler config.Handler, detector detector.Detector, nodeName string) common.SensorComponent {
 	k := &listenerImpl{
-		client:        client,
-		eventsC:       make(chan *central.MsgFromSensor, 10),
-		stopSig:       concurrency.NewSignal(),
-		configHandler: configHandler,
-		detector:      detector,
+		client:             client,
+		eventsC:            make(chan *central.MsgFromSensor, 10),
+		stopSig:            concurrency.NewSignal(),
+		configHandler:      configHandler,
+		detector:           detector,
+		credentialsManager: createCredentialsManager(client, nodeName),
 	}
 	return k
+}
+
+// createCredentialsManager retrieves Sensor's node provider ID and creates an AWS credentials manager.
+func createCredentialsManager(client client.Interface, nodeName string) (credentialsManager awscredentials.RegistryCredentialsManager) {
+	if !features.ECRAutoIntegration.Enabled() {
+		log.Debugf("ECR credential manager is disabled")
+		return
+	}
+	node, err := client.Kubernetes().CoreV1().Nodes().Get(
+		context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		log.Infof("failed to get node and retrieve its ProviderId: %v", err)
+		return
+	}
+	credentialsManager, err = awscredentials.NewECRCredentialsManager(node.Spec.ProviderID)
+	if err != nil {
+		log.Warnf("ECR credential manager is not available: %v", err)
+	}
+	return
 }

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -66,8 +66,17 @@ func (k *listenerImpl) handleAllEvents() {
 	}
 	// Create the dispatcher registry, which provides dispatchers to all of the handlers.
 	podInformer := resyncingSif.Core().V1().Pods()
-	dispatchers := resources.NewDispatcherRegistry(clusterID, podInformer.Lister(), profileLister, clusterentities.StoreInstance(),
-		processfilter.Singleton(), k.configHandler, k.detector, orchestratornamespaces.Singleton())
+	dispatchers := resources.NewDispatcherRegistry(
+		clusterID,
+		podInformer.Lister(),
+		profileLister,
+		clusterentities.StoreInstance(),
+		processfilter.Singleton(),
+		k.configHandler,
+		k.detector,
+		orchestratornamespaces.Singleton(),
+		k.credentialsManager,
+	)
 
 	namespaceInformer := sif.Core().V1().Namespaces().Informer()
 	secretInformer := sif.Core().V1().Secrets().Informer()

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	metricsPkg "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/process/filter"
+	"github.com/stackrox/rox/sensor/common/awscredentials"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/detector"
@@ -51,9 +52,17 @@ type DispatcherRegistry interface {
 }
 
 // NewDispatcherRegistry creates and returns a new DispatcherRegistry.
-func NewDispatcherRegistry(clusterID string, podLister v1Listers.PodLister, profileLister cache.GenericLister,
-	entityStore *clusterentities.Store, processFilter filter.Filter,
-	configHandler config.Handler, detector detector.Detector, namespaces *orchestratornamespaces.OrchestratorNamespaces) DispatcherRegistry {
+func NewDispatcherRegistry(
+	clusterID string,
+	podLister v1Listers.PodLister,
+	profileLister cache.GenericLister,
+	entityStore *clusterentities.Store,
+	processFilter filter.Filter,
+	configHandler config.Handler,
+	detector detector.Detector,
+	namespaces *orchestratornamespaces.OrchestratorNamespaces,
+	credentialsManager awscredentials.RegistryCredentialsManager,
+) DispatcherRegistry {
 	serviceStore := newServiceStore()
 	deploymentStore := DeploymentStoreSingleton()
 	podStore := PodStoreSingleton()
@@ -66,7 +75,7 @@ func NewDispatcherRegistry(clusterID string, podLister v1Listers.PodLister, prof
 
 	return &registryImpl{
 		deploymentHandler: newDeploymentHandler(clusterID, serviceStore, deploymentStore, podStore, endpointManager, nsStore,
-			rbacUpdater, podLister, processFilter, configHandler, detector, namespaces),
+			rbacUpdater, podLister, processFilter, configHandler, detector, namespaces, credentialsManager),
 
 		rbacDispatcher:            rbac.NewDispatcher(rbacUpdater),
 		namespaceDispatcher:       newNamespaceDispatcher(nsStore, serviceStore, deploymentStore, podStore),

--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -134,7 +134,9 @@ func newSecretDispatcher(regStore *registry.Store) *secretDispatcher {
 	}
 }
 
-func dockerConfigToImageIntegration(registry string, dce config.DockerConfigEntry) *storage.ImageIntegration {
+// DockerConfigToImageIntegration creates an image integration for a given
+// registry URL and docker config.
+func DockerConfigToImageIntegration(registry string, dce config.DockerConfigEntry) *storage.ImageIntegration {
 	registryType := docker.GenericDockerRegistryType
 	if urlfmt.TrimHTTPPrefixes(registry) == redhatRegistryEndpoint {
 		registryType = rhel.RedHatRegistryType
@@ -202,7 +204,7 @@ func (s *secretDispatcher) processDockerConfigEvent(secret *v1.Secret, action ce
 		}
 
 		if !features.LocalImageScanning.Enabled() || !fromDefaultSA {
-			ii := dockerConfigToImageIntegration(registry, dce)
+			ii := DockerConfigToImageIntegration(registry, dce)
 			sensorEvents = append(sensorEvents, &central.SensorEvent{
 				// Only update is supported at this time.
 				Action: central.ResourceAction_UPDATE_RESOURCE,

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -103,10 +103,8 @@ func CreateSensor(client client.Interface, workloadHandler *fake.WorkloadManager
 	}
 
 	imageCache := expiringcache.NewExpiringCache(env.ReprocessInterval.DurationSetting())
-
 	policyDetector := detector.New(enforcer, admCtrlSettingsMgr, resources.DeploymentStoreSingleton(), imageCache, auditLogEventsInput, auditLogCollectionManager)
-
-	admCtrlMsgForwarder := admissioncontroller.NewAdmCtrlMsgForwarder(admCtrlSettingsMgr, listener.New(client, configHandler, policyDetector))
+	admCtrlMsgForwarder := admissioncontroller.NewAdmCtrlMsgForwarder(admCtrlSettingsMgr, listener.New(client, configHandler, policyDetector, k8sNodeName.Setting()))
 
 	upgradeCmdHandler, err := upgrade.NewCommandHandler(configHandler)
 	if err != nil {


### PR DESCRIPTION
## Description

Introduce a component in Sensor that will detect AWS credentials offered by AWS Instance Node Role, and use it to send Docker Registry Integrations for ECR registries when handling deployments. It is behind a feature flag, which is disabled by default.

The desired outcome is to use it as a building block to create automatic ECR registry integrations. But the current patch is functional in the sense that it will correctly detect ECR-based deployments and create registry integrations for them.

## Checklist
- [x] Investigated and inspected CI test results.
- [x] Unit test and regression tests added.
- [ ] Evaluated and added CHANGELOG entry if required.
- [x] Determined and documented upgrade steps.
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs)).

If any of these don't apply, please comment below.

## Testing Performed

1. Deploy stackrox to an EKS cluster.
   - The cluster Instance Node role needs a policy that allows access to ECR, to both allow deployments from ECR and also to allow Sensor to pull secrets to scan images.
2. Add an image to an ECR registry. Double-check the resource policy to allow the EKS Instance Role to access it.
   - You can do that by using the AWS cli, for example, `aws ecr get-login-password`.
3. Create a pod with the image in (2.)
4. Go to integrations, see an integration was created for the registry from (2.). Also the registry used by EKS itself to deploy their own services in the cluster -- usually that is not accessible by the instance role credentials .
5. Go to the vulnerability page and verify your image was scanned.
