### PR TITLE
ROX-9665: Display placeholder in policy criteria only for Select element

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step3/PolicyCriteriaFieldInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step3/PolicyCriteriaFieldInput.tsx
@@ -92,7 +92,7 @@ function PolicyCriteriaFieldInput({
                     id={name}
                     isDisabled={readOnly}
                     onChange={handleChangeValue}
-                    placeholder={descriptor.placeholder}
+                    // placeholder={descriptor.placeholder}
                 />
             );
         case 'select':

--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step3/PolicyCriteriaFieldSubInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step3/PolicyCriteriaFieldSubInput.tsx
@@ -51,7 +51,7 @@ function PolicyCriteriaFieldSubInput({
                         type="text"
                         id={name}
                         isDisabled={readOnly}
-                        placeholder={subComponent.placeholder}
+                        // placeholder={subComponent.placeholder}
                         onChange={(v) => setValue(v)}
                     />
                 </FormGroup>


### PR DESCRIPTION
## Description

https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder#usability

> Placeholder text with sufficient color contrast may be interpreted as entered input. Placeholder text will also disappear when a person enters content into an `<input>` element. Both of these circumstances can interfere with successful form completion, especially for people with cognitive concerns.

### Possible follow up

An alternate approach to providing placeholder information is to include it outside of the input in close visual proximity, then use `aria-describedby` to programmatically associate the `<input>` with its hint.

Display placeholder with PatternFly `helperText` prop:
* For example, **whatever** if it is an example of a value; however, delete `placeholder` prop from descriptor if it is an obvious example
* **Whatever** is it is a description of a value, like its units

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### TextInput for Image contents: Image age

Entered value 1
![TextInput-with-value](https://user-images.githubusercontent.com/11862657/157750119-7d5ff57c-2966-416e-bed4-a95bb5c14517.png)

Problem: With placeholder value 1
![TextInput-with-placeholder](https://user-images.githubusercontent.com/11862657/157750141-21327835-0484-43c9-9c81-dddbae88319f.png)

Solution: Without placeholder
![TextInput-without-placeholder](https://user-images.githubusercontent.com/11862657/157750159-11184c8a-b1a9-487c-9185-835d5f1342b4.png)

### Select for  Image contents: Severity

Select at left has default placeholder because descriptor has no property
Select at right has placeholder from descriptor property

![Select](https://user-images.githubusercontent.com/11862657/157750182-652129a4-0d9a-4a7d-9b27-2d2860f8885a.png)