### PR TITLE
ROX-9666: Default select value in policy wizard being empty

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step2/PolicyBehaviorForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step2/PolicyBehaviorForm.tsx
@@ -99,6 +99,18 @@ function PolicyBehaviorForm() {
                 false
             );
         });
+
+        // clear policy sections to prevent non-runtime criteria from being sent to BE
+        setFieldValue(
+            'policySections',
+            [
+                {
+                    sectionName: 'Policy Section 1',
+                    policyGroups: [],
+                },
+            ],
+            false
+        );
     }
 
     const responseMethodHelperText = showEnforcement

--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step3/PolicyCriteriaFieldInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step3/PolicyCriteriaFieldInput.tsx
@@ -108,7 +108,7 @@ function PolicyCriteriaFieldInput({
                         isOpen={isSelectOpen}
                         isDisabled={readOnly}
                         selections={value.value}
-                        placeholderText={descriptor.placeholder}
+                        placeholderText={descriptor.placeholder || 'Select an option'}
                     >
                         {descriptor?.options?.map((option) => (
                             <SelectOption key={option.value} value={option.value}>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Form/descriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Form/descriptors.tsx
@@ -1099,6 +1099,7 @@ export const auditLogDescriptor: Descriptor[] = [
         shortName: 'Kubernetes resource',
         category: policyCriteriaCategories.KUBERNETES_EVENTS,
         type: 'select',
+        placeholder: 'Select a resource',
         options: [
             {
                 label: 'Config maps',
@@ -1117,6 +1118,7 @@ export const auditLogDescriptor: Descriptor[] = [
         shortName: 'Kubernetes API verb',
         category: policyCriteriaCategories.KUBERNETES_EVENTS,
         type: 'select',
+        placeholder: 'Select an API verb',
         options: APIVerbs,
         canBooleanLogic: false,
     },


### PR DESCRIPTION
## Description

added placeholder to select dropdowns (user is forced to select an option to set a value)
![image](https://user-images.githubusercontent.com/10412893/157755269-8b8b63f3-8f34-45ed-99ba-b95a1b5238b7.png)

also clearing policy sections on audit log event source
* create a new policy 
* select `deploy` as lifecycle stage in step 2
* add any policy criteria in step 3
* go to step 5 to validate that it gets sent to the BE
* go back to step 2, select `runtime` as lifecycle stage and `audit log` as event source
* go to step 3, the policy criteria should be cleared. add a new policy criteria from the filtered list
* go to step 5, check that the deploy time policy criteria residue did not get sent to BE

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs)).

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
