### PR TITLE
ROX-9664: Fix weird number input bug in policy criteria

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step3/PolicyCriteriaFieldSubInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step3/PolicyCriteriaFieldSubInput.tsx
@@ -20,18 +20,6 @@ function PolicyCriteriaFieldSubInput({
     const { value } = field;
     const { setValue } = helper;
 
-    function handleChangeNumberValue(val) {
-        const newValue = Number.isNaN(val) ? 0 : Number(val);
-        const { max, min = 0 } = subComponent;
-        if (max && newValue > max) {
-            setValue(max);
-        } else if (newValue < min) {
-            setValue(min);
-        } else {
-            setValue(newValue);
-        }
-    }
-
     function handleChangeSelect(e, val) {
         setIsSelectOpen(false);
         setValue(val);
@@ -59,11 +47,12 @@ function PolicyCriteriaFieldSubInput({
         case 'number':
             return (
                 <TextInput
-                    value={Number(value)}
+                    value={value}
                     type="number"
                     id={name}
                     isDisabled={readOnly}
-                    onChange={handleChangeNumberValue}
+                    onChange={(v) => setValue(v)}
+                    placeholder="(ex. 5)"
                     className="pf-u-w-25"
                 />
             );


### PR DESCRIPTION
## Description

Since the input is of type `number` I don't think we need to do anything fancy to convert it to a number. This will however let the value be empty though. That's good considering the bug in the video below. But I'm also wondering if that might cause issues that I'm not aware of. Let me know if it will. 


Bug:

https://user-images.githubusercontent.com/4805485/157758398-567f63be-fb6f-46c6-89cb-8c897b91460b.mov

- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

1. Go to the Policies page
2. Create a policy
3. Add whatever details you need and get to the `Policy criteria` section
4. Under `Deployment metadata` drag the `Replicas` criteria to the main area
5. Try changing the value for the number input like in the vide

It shouldn't cause any weird issues anymore 