### PR TITLE
Update pull request template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,14 +9,17 @@ Feel free to remove this section if it is overkill for your PR, and the title of
 - [ ] Unit test and regression tests added
 - [ ] Evaluated and added CHANGELOG entry if required
 - [ ] Determined and documented upgrade steps
-- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs)).
+- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))
 
 If any of these don't apply, please comment below.
 
 ## Testing Performed
 
 TODO(replace-me)
-Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
-In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.
+Use this space to explain how you tested your PR, or, if you didn't test it, why
+you did not do so. Valid reasons include, for example, "CI is sufficient",
+"No testable changes". Feel free to attach JSON snippets, curl commands,
+screenshots.
 
-For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
+In addition to reviewing your code, reviewers **must** also review your testing
+instructions and make sure they are sufficient.


### PR DESCRIPTION
## Description

The link to "testing steps" is now dead. We can link to [Red Hat confluence](https://docs.engineering.redhat.com/display/StackRox/Proposal%3A+Explicitly+List+Testing+Steps+on+PRs) but this is suboptimal because no external contributor would have access to it. Instead, this PR removes the link and expands the description a bit.

## Checklist
- [ ] ~Investigated and inspected CI test results~
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Not a functional change