### PR TITLE
ROX-9684: Close postgres connection only if it was enabled

### DIFF
--- a/central/alert/datastore/internal/store/postgres/index_test.go
+++ b/central/alert/datastore/internal/store/postgres/index_test.go
@@ -55,8 +55,10 @@ func (s *AlertsIndexSuite) SetupTest() {
 }
 
 func (s *AlertsIndexSuite) TearDownTest() {
+	if features.PostgresDatastore.Enabled() {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
-	s.pool.Close()
 }
 
 func (s *AlertsIndexSuite) TestIndex() {

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/index_test.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/index_test.go
@@ -59,8 +59,10 @@ func (s *IndexSuite) SetupTest() {
 }
 
 func (s *IndexSuite) TearDownTest() {
+	if features.PostgresDatastore.Enabled() {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
-	s.pool.Close()
 }
 
 func (s *IndexSuite) getStruct(i int, f func(s *storage.TestMultiKeyStruct)) *storage.TestMultiKeyStruct {


### PR DESCRIPTION
## Description

For some reason during nightly build env isolator is not changing env and we end up trying to close pool that should not be closed since it was never created.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs)).

If any of these don't apply, please comment below.

## Testing Performed

CI