### PR TITLE
Noise reduction: Not every make target needs go mods downloaded

### DIFF
--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -21,9 +21,11 @@ GENERATED_API_GW_SRCS = $(SERVICE_PROTOS_REL:%.proto=$(GENERATED_BASE_PATH)/%.pb
 GENERATED_API_SWAGGER_SPECS = $(API_SERVICE_PROTOS:%.proto=$(GENERATED_BASE_PATH)/%.swagger.json)
 
 SCANNER_DIR = $(shell go list -f '{{.Dir}}' -m github.com/stackrox/scanner)
+ifneq ($(SCANNER_DIR),)
 SCANNER_PROTO_BASE_PATH = $(SCANNER_DIR)/proto
 ALL_SCANNER_PROTOS = $(shell find $(SCANNER_PROTO_BASE_PATH) -name '*.proto')
 ALL_SCANNER_PROTOS_REL = $(ALL_SCANNER_PROTOS:$(SCANNER_PROTO_BASE_PATH)/%=%)
+endif
 
 ##############
 ## Protobuf ##


### PR DESCRIPTION
## Description

This should remove instances of `find: '/proto': No such file or directory` in situations where go mods have not been downloaded.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient