### PR TITLE
fix: removing violations breadcrumbs when viewing the top-most view

### DIFF
--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -21,7 +21,6 @@ import ViolationsTablePanel from './ViolationsTablePanel';
 import tableColumnDescriptor from './violationTableColumnDescriptors';
 
 import './ViolationsTablePage.css';
-import ViolationsBreadcrumbs from './ViolationsBreadcrumbs';
 
 function runAfter5Seconds(fn: () => void) {
     return new Promise(() => {
@@ -159,7 +158,6 @@ function ViolationsTablePage(): ReactElement {
 
     return (
         <>
-            <ViolationsBreadcrumbs />
             <PageSection variant="light" id="violations-table">
                 <Title headingLevel="h1">Violations</Title>
                 <Divider className="pf-u-py-md" />


### PR DESCRIPTION
## Description

When viewing the Violations table page, the breadcrumb made it look like there was a second header. I actually thought it was a bug as well until I saw the code and noticed it was the breadcrumbs. Maybe it would be better to omit it at the root page, and only show breadcrumbs in the nested views. I saw we did something like that for the Integrations pages too

## Testing Performed

Before
<img width="1552" alt="Screen Shot 2022-03-11 at 12 14 50 PM" src="https://user-images.githubusercontent.com/4805485/157954261-ae8bbc50-ba99-4bab-9698-0547f03bb79d.png">
<img width="1552" alt="Screen Shot 2022-03-11 at 12 14 54 PM" src="https://user-images.githubusercontent.com/4805485/157954269-ff15a3fc-3541-4cb8-9c76-a4b14a2dddae.png">

After
<img width="1552" alt="Screen Shot 2022-03-11 at 12 11 44 PM" src="https://user-images.githubusercontent.com/4805485/157954286-163765e0-e22e-4240-91f9-6426663df084.png">
<img width="1552" alt="Screen Shot 2022-03-11 at 12 11 47 PM" src="https://user-images.githubusercontent.com/4805485/157954298-ddc5a3ba-3479-4769-8f85-b487ec28080e.png">
