### PR TITLE
Set ROX_USE_LOCAL_SCANNER in Sensor to true when central scanner is a…

### DIFF
--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -163,7 +163,7 @@ func CreateSensor(client client.Interface, workloadHandler *fake.WorkloadManager
 		return nil, errors.Wrap(err, "creating central client")
 	}
 
-	if features.LocalImageScanning.Enabled() && securedClusterIsNotManagedManually(helmManagedConfig) {
+	if features.LocalImageScanning.Enabled() && securedClusterIsNotManagedManually(helmManagedConfig) && env.UseLocalScanner.BooleanSetting() {
 		podName := os.Getenv("POD_NAME")
 		components = append(components,
 			localscanner.NewLocalScannerTLSIssuer(client.Kubernetes(), sensorNamespace, podName))


### PR DESCRIPTION
…vailable

## Description

Set ROX_USE_LOCAL_SCANNER in Sensor to true when central scanner is available.

The other consumer of `ROX_USE_LOCAL_SCANNER` is the setup of Sensor, that launches the TLS issuer if this variable is true. That is ok because for the new case the TLS issuer refresher will see that the secrets are owned by the central deployment instead of the sensor deployment , and so it will stop itself

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed


```
go test -v  github.com/stackrox/rox/pkg/helm/charts/tests/securedclusterservices && \
go test -v github.com/stackrox/rox/central/clusters/zip && \
go test -v github.com/stackrox/rox/roxctl/helm/output
```