### PR TITLE
CI: Fix build for tags

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -118,8 +118,8 @@ get_central_diagnostics() {
 push_main_and_roxctl_images() {
     info "Pushing main and roxctl images"
 
-    if [[ -z "${1:-}" ]]; then
-        die "missing arg or value. usage: push_main_and_roxctl_images <branch>"
+    if [[ "$#" -ne 1 ]]; then
+        die "missing arg. usage: push_main_and_roxctl_images <branch>"
     fi
 
     require_environment "DOCKER_IO_PUSH_USERNAME"


### PR DESCRIPTION
## Description

#918 broke the build for tagged CI runs e.g. nightlies. This change handles branch="".

## Checklist
- [x] Investigated and inspected CI test results
- [x] Run a tagged build - https://app.circleci.com/pipelines/github/stackrox/stackrox/6939/workflows/25be91ad-0b0b-4fab-a2d2-4dacca64dee8

## Testing Performed

CI is sufficient. The tagged build (tagged a branch commit) runs with `CIRCLECI_BRANCH=` https://app.circleci.com/pipelines/github/stackrox/stackrox/6939/workflows/25be91ad-0b0b-4fab-a2d2-4dacca64dee8/jobs/304864?invite=true#step-99-5