### PR TITLE
Delete obsolete label from dependabot configuration for UI

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,7 +16,6 @@ updates:
     labels:
       - "ci-no-api-tests"
       - "ci-no-qa-tests"
-      - "ci-no-upgrade-tests"
       - "dependencies"
     reviewers:
       - "stackrox/ui-dep-updaters"


### PR DESCRIPTION
## Description

https://github.com/stackrox/stackrox/pull/931#issuecomment-1067158129

> The following labels could not be found: `ci-no-upgrade-tests`.

Upgrade tests are an additive not subtractive option now.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed