### PR TITLE
ROX-9723: Integration Scoped access control tests for secret resource type

### DIFF
--- a/central/secret/datastore/datastore_sac_test.go
+++ b/central/secret/datastore/datastore_sac_test.go
@@ -501,6 +501,9 @@ var secretUnrestrictedSACObjectSearchTestCases = map[string]secretSACSearchResul
 }
 
 func (s *secretDatastoreSACTestSuite) runCountTest(testParams secretSACSearchResult) {
+	if features.PostgresDatastore.Enabled() {
+		s.T().Skip("Skipping search tests in postgres mode")
+	}
 	ctx := s.testContexts[testParams.scopeKey]
 	resultCount, err := s.datastore.Count(ctx, nil)
 	s.NoError(err)
@@ -525,6 +528,9 @@ func (s *secretDatastoreSACTestSuite) TestSecretUnrestrictedCount() {
 }
 
 func (s *secretDatastoreSACTestSuite) runCountSecretsTest(testParams secretSACSearchResult) {
+	if features.PostgresDatastore.Enabled() {
+		s.T().Skip("Skipping search tests in postgres mode")
+	}
 	ctx := s.testContexts[testParams.scopeKey]
 	resultCount, err := s.datastore.CountSecrets(ctx)
 	s.NoError(err)
@@ -549,6 +555,9 @@ func (s *secretDatastoreSACTestSuite) TestSecretUnrestrictedCountSecrets() {
 }
 
 func (s *secretDatastoreSACTestSuite) runSearchTest(testParams secretSACSearchResult) {
+	if features.PostgresDatastore.Enabled() {
+		s.T().Skip("Skipping search tests in postgres mode")
+	}
 	ctx := s.testContexts[testParams.scopeKey]
 	searchResults, err := s.datastore.Search(ctx, nil)
 	s.NoError(err)
@@ -573,6 +582,9 @@ func (s *secretDatastoreSACTestSuite) TestSecretUnrestrictedSearch() {
 }
 
 func (s *secretDatastoreSACTestSuite) runSearchSecretsTest(testParams secretSACSearchResult) {
+	if features.PostgresDatastore.Enabled() {
+		s.T().Skip("Skipping search tests in postgres mode")
+	}
 	ctx := s.testContexts[testParams.scopeKey]
 	searchResults, err := s.datastore.SearchSecrets(ctx, nil)
 	s.NoError(err)
@@ -597,6 +609,9 @@ func (s *secretDatastoreSACTestSuite) TestSecretUnrestrictedSearchSecrets() {
 }
 
 func (s *secretDatastoreSACTestSuite) runSearchListSecretsTest(testParams secretSACSearchResult) {
+	if features.PostgresDatastore.Enabled() {
+		s.T().Skip("Skipping search tests in postgres mode")
+	}
 	ctx := s.testContexts[testParams.scopeKey]
 	searchResults, err := s.datastore.SearchListSecrets(ctx, nil)
 	s.NoError(err)
@@ -625,6 +640,9 @@ func (s *secretDatastoreSACTestSuite) TestSecretUnrestrictedSearchListSecrets() 
 }
 
 func (s *secretDatastoreSACTestSuite) runSearchRawSecretsTest(testParams secretSACSearchResult) {
+	if features.PostgresDatastore.Enabled() {
+		s.T().Skip("Skipping search tests in postgres mode")
+	}
 	ctx := s.testContexts[testParams.scopeKey]
 	searchResults, err := s.datastore.SearchRawSecrets(ctx, nil)
 	s.NoError(err)

--- a/central/secret/datastore/datastore_sac_test.go
+++ b/central/secret/datastore/datastore_sac_test.go
@@ -1,0 +1,653 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blevesearch/bleve"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/central/globalindex"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/central/secret/internal/index"
+	"github.com/stackrox/rox/central/secret/internal/store"
+	pgStore "github.com/stackrox/rox/central/secret/internal/store/postgres"
+	rdbStore "github.com/stackrox/rox/central/secret/internal/store/rocksdb"
+	"github.com/stackrox/rox/central/secret/mappings"
+	"github.com/stackrox/rox/central/secret/search"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/sac/testutils"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	cleanupCtxKey = testutils.UnrestrictedReadWriteCtx
+)
+
+func TestSecretDatastoreSAC(t *testing.T) {
+	suite.Run(t, new(secretDatastoreSACTestSuite))
+}
+
+type secretDatastoreSACTestSuite struct {
+	suite.Suite
+
+	engine *rocksdb.RocksDB
+	index  *bleve.Index
+
+	pool *pgxpool.Pool
+
+	storage store.Store
+	indexer index.Indexer
+	search  search.Searcher
+
+	datastore DataStore
+
+	testContexts map[string]context.Context
+
+	testSecretIDs []string
+}
+
+func (s *secretDatastoreSACTestSuite) SetupSuite() {
+	var err error
+	secretObj := "secretSACTest"
+
+	if features.PostgresDatastore.Enabled() {
+		ctx := context.Background()
+		source := pgtest.GetConnectionString(s.T())
+		config, err := pgxpool.ParseConfig(source)
+		s.NoError(err)
+		s.pool, err = pgxpool.ConnectConfig(ctx, config)
+		s.NoError(err)
+		pgStore.Destroy(ctx, s.pool)
+		s.storage = pgStore.New(ctx, s.pool)
+		s.indexer = pgStore.NewIndexer(s.pool)
+	} else {
+		s.engine, err = rocksdb.NewTemp(secretObj)
+		s.NoError(err)
+		var bleveindex bleve.Index
+		bleveindex, err = globalindex.TempInitializeIndices(secretObj)
+		s.index = &bleveindex
+		s.NoError(err)
+
+		s.storage = rdbStore.New(s.engine)
+		s.indexer = index.New(*s.index)
+	}
+	s.search = search.New(s.storage, s.indexer)
+	s.datastore, err = New(s.storage, s.indexer, s.search)
+	s.NoError(err)
+
+	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), resources.Secret.GetResource())
+}
+
+func (s *secretDatastoreSACTestSuite) TearDownSuite() {
+	if features.PostgresDatastore.Enabled() {
+		s.pool.Close()
+	} else {
+		err := rocksdb.CloseAndRemove(s.engine)
+		s.NoError(err)
+	}
+}
+
+func (s *secretDatastoreSACTestSuite) SetupTest() {
+	s.testSecretIDs = make([]string, 0)
+
+	// Inject test data set for search tests
+	secrets := fixtures.GetSACTestSecretSet()
+	var err error
+	for _, secret := range secrets {
+		err = s.datastore.UpsertSecret(s.testContexts[testutils.UnrestrictedReadWriteCtx], secret)
+		s.testSecretIDs = append(s.testSecretIDs, secret.GetId())
+		s.NoError(err)
+	}
+}
+
+func (s *secretDatastoreSACTestSuite) TearDownTest() {
+	for _, id := range s.testSecretIDs {
+		s.cleanupSecret(id)
+	}
+}
+
+type crudTest struct {
+	scopeKey      string
+	expectedError error
+	expectError   bool
+	expectFound   bool
+}
+
+func (s *secretDatastoreSACTestSuite) cleanupSecret(ID string) {
+	err := s.datastore.RemoveSecret(s.testContexts[cleanupCtxKey], ID)
+	s.NoError(err)
+}
+
+func (s *secretDatastoreSACTestSuite) TestUpsertSecret() {
+	cases := map[string]crudTest{
+		"(full) read-only cannot upsert": {
+			scopeKey:      testutils.UnrestrictedReadCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write can upsert": {
+			scopeKey:      testutils.UnrestrictedReadWriteCtx,
+			expectError:   false,
+			expectedError: nil,
+		},
+		"full read-write on wrong cluster cannot upsert": {
+			scopeKey:      testutils.Cluster1ReadWriteCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and wrong namespace cannot upsert": {
+			scopeKey:      testutils.Cluster1NamespaceAReadWriteCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and matching namespace cannot upsert": {
+			scopeKey:      testutils.Cluster1NamespaceBReadWriteCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on right cluster but wrong namespaces cannot upsert": {
+			scopeKey:      testutils.Cluster2NamespacesACReadWriteCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write on right cluster cannot upsert": {
+			scopeKey:      testutils.Cluster2ReadWriteCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+			//expectError:   false,
+			//expectedError: nil,
+		},
+		"read-write on the right cluster and namespace cannot upsert": {
+			scopeKey:      testutils.Cluster2NamespaceBReadWriteCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+			//expectError:   false,
+			//expectedError: nil,
+		},
+		"read-write on the right cluster and at least the right namespace can upsert": {
+			scopeKey:      testutils.Cluster2NamespacesABReadWriteCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+			//expectError:   false,
+			//expectedError: nil,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			testSecret := fixtures.GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
+			s.testSecretIDs = append(s.testSecretIDs, testSecret.GetId())
+			ctx := s.testContexts[c.scopeKey]
+			err := s.datastore.UpsertSecret(ctx, testSecret)
+			defer s.cleanupSecret(testSecret.GetId())
+			if !c.expectError {
+				s.NoError(err)
+			} else {
+				s.Equal(c.expectedError, err)
+			}
+		})
+	}
+}
+
+func (s *secretDatastoreSACTestSuite) TestGetSecret() {
+	var err error
+	testSecret := fixtures.GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
+	err = s.datastore.UpsertSecret(s.testContexts[testutils.UnrestrictedReadWriteCtx], testSecret)
+	s.testSecretIDs = append(s.testSecretIDs, testSecret.GetId())
+	s.NoError(err)
+
+	cases := map[string]crudTest{
+		"(full) read-only can read": {
+			scopeKey:    testutils.UnrestrictedReadCtx,
+			expectFound: true,
+		},
+		"full read-write can read": {
+			scopeKey:    testutils.UnrestrictedReadCtx,
+			expectFound: true,
+		},
+		"full read-write on wrong cluster cannot read": {
+			scopeKey:    testutils.Cluster1ReadWriteCtx,
+			expectFound: false,
+		},
+		"read-write on wrong cluster and wrong namespace cannot read": {
+			scopeKey:    testutils.Cluster1NamespaceAReadWriteCtx,
+			expectFound: false,
+		},
+		"read-write on wrong cluster and matching namespace cannot read": {
+			scopeKey:    testutils.Cluster1NamespaceBReadWriteCtx,
+			expectFound: false,
+		},
+		"read-write on right cluster but wrong namespaces cannot read": {
+			scopeKey:    testutils.Cluster2NamespacesACReadWriteCtx,
+			expectFound: false,
+		},
+		"full read-write on right cluster can read": {
+			scopeKey:    testutils.Cluster2ReadWriteCtx,
+			expectFound: true,
+		},
+		"read-write on the right cluster and namespace can read": {
+			scopeKey:    testutils.Cluster2NamespaceBReadWriteCtx,
+			expectFound: true,
+		},
+		"read-write on the right cluster and at least the right namespace can read": {
+			scopeKey:    testutils.Cluster2NamespacesABReadWriteCtx,
+			expectFound: true,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[c.scopeKey]
+			readSecret, found, getErr := s.datastore.GetSecret(ctx, testSecret.GetId())
+			s.NoError(getErr)
+			if c.expectFound {
+				s.True(found)
+				s.Equal(*testSecret, *readSecret)
+			} else {
+				s.False(found)
+				s.Nil(readSecret)
+			}
+		})
+	}
+}
+
+func (s *secretDatastoreSACTestSuite) TestRemoveSecret() {
+	cases := map[string]crudTest{
+		"(full) read-only cannot remove": {
+			scopeKey:      testutils.UnrestrictedReadCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write can remove": {
+			scopeKey:      testutils.UnrestrictedReadWriteCtx,
+			expectError:   false,
+			expectedError: nil,
+		},
+		"full read-write on wrong cluster cannot remove": {
+			scopeKey:      testutils.Cluster1ReadWriteCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and wrong namespace cannot remove": {
+			scopeKey:      testutils.Cluster1NamespaceAReadWriteCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and matching namespace cannot remove": {
+			scopeKey:      testutils.Cluster1NamespaceBReadWriteCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on right cluster but wrong namespaces cannot remove": {
+			scopeKey:      testutils.Cluster2NamespacesACReadWriteCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write on right cluster cannot remove": {
+			scopeKey:      testutils.Cluster2ReadWriteCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+			//expectError:   false,
+			//expectedError: nil,
+		},
+		"read-write on the right cluster and namespace cannot remove": {
+			scopeKey:      testutils.Cluster2NamespaceBReadWriteCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+			//expectError:   false,
+			//expectedError: nil,
+		},
+		"read-write on the right cluster and at least the right namespace cannot remove": {
+			scopeKey:      testutils.Cluster2NamespacesABReadWriteCtx,
+			expectError:   true,
+			expectedError: sac.ErrResourceAccessDenied,
+			//expectError:   false,
+			//expectedError: nil,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			testSecret := fixtures.GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
+			s.testSecretIDs = append(s.testSecretIDs, testSecret.GetId())
+			ctx := s.testContexts[c.scopeKey]
+			var err error
+			err = s.datastore.UpsertSecret(s.testContexts[testutils.UnrestrictedReadWriteCtx], testSecret)
+			defer s.cleanupSecret(testSecret.GetId())
+			s.NoError(err)
+			err = s.datastore.RemoveSecret(ctx, testSecret.GetId())
+			if !c.expectError {
+				s.NoError(err)
+			} else {
+				s.Equal(c.expectedError, err)
+			}
+		})
+	}
+}
+
+type secretSACSearchResult struct {
+	scopeKey     string
+	resultCounts map[string]map[string]int // Top level is the cluster ID, then namespace
+}
+
+// The SAC secret test dataset defined in pkg/fixtures/secret.go has the following secret distribution
+// Cluster1::NamespaceA: 8 secrets
+// Cluster1::NamespaceB: 5 secrets
+// Cluster2::NamespaceB: 3 secrets
+// Cluster2::NamespaceC: 2 secrets
+var secretScopedSACSearchTestCases = map[string]secretSACSearchResult{
+	"Cluster1 read-write access should only see Cluster1 secrets": {
+		scopeKey: testutils.Cluster1ReadWriteCtx,
+		resultCounts: map[string]map[string]int{
+			testconsts.Cluster1: {
+				testconsts.NamespaceA: 8,
+				testconsts.NamespaceB: 5,
+			},
+		},
+	},
+	"Cluster1 and NamespaceA read-write access should only see Cluster1 and NamespaceA secrets": {
+		scopeKey: testutils.Cluster1NamespaceAReadWriteCtx,
+		resultCounts: map[string]map[string]int{
+			testconsts.Cluster1: {
+				testconsts.NamespaceA: 8,
+			},
+		},
+	},
+	"Cluster1 and NamespaceB read-write access should only see Cluster1 and NamespaceB secrets": {
+		scopeKey: testutils.Cluster1NamespaceBReadWriteCtx,
+		resultCounts: map[string]map[string]int{
+			testconsts.Cluster1: {
+				testconsts.NamespaceB: 5,
+			},
+		},
+	},
+	"Cluster1 and NamespaceC read-write access should see no secret": {
+		scopeKey:     testutils.Cluster1NamespaceCReadWriteCtx,
+		resultCounts: map[string]map[string]int{},
+	},
+	"Cluster1 and Namespaces A and B read-write access should only see appropriate cluster/namespace secrets": {
+		scopeKey: testutils.Cluster1NamespacesABReadWriteCtx,
+		resultCounts: map[string]map[string]int{
+			testconsts.Cluster1: {
+				testconsts.NamespaceA: 8,
+				testconsts.NamespaceB: 5,
+			},
+		},
+	},
+	"Cluster1 and Namespaces A and C read-write access should only see appropriate cluster/namespace secrets": {
+		scopeKey: testutils.Cluster1NamespacesACReadWriteCtx,
+		resultCounts: map[string]map[string]int{
+			testconsts.Cluster1: {
+				testconsts.NamespaceA: 8,
+			},
+		},
+	},
+	"Cluster1 and Namespaces B and C read-write access should only see appropriate cluster/namespace secrets": {
+		scopeKey: testutils.Cluster1NamespacesBCReadWriteCtx,
+		resultCounts: map[string]map[string]int{
+			testconsts.Cluster1: {
+				testconsts.NamespaceB: 5,
+			},
+		},
+	},
+	"Cluster2 read-write access should only see Cluster2 secrets": {
+		scopeKey: testutils.Cluster2ReadWriteCtx,
+		resultCounts: map[string]map[string]int{
+			testconsts.Cluster2: {
+				testconsts.NamespaceB: 3,
+				testconsts.NamespaceC: 2,
+			},
+		},
+	},
+	"Cluster2 and NamespaceA read-write access should see no secret": {
+		scopeKey:     testutils.Cluster2NamespaceAReadWriteCtx,
+		resultCounts: map[string]map[string]int{},
+	},
+	"Cluster2 and NamespaceB read-write access should only see Cluster2 and NamespaceB secrets": {
+		scopeKey: testutils.Cluster2NamespaceBReadWriteCtx,
+		resultCounts: map[string]map[string]int{
+			testconsts.Cluster2: {
+				testconsts.NamespaceB: 3,
+			},
+		},
+	},
+	"Cluster2 and NamespaceC read-write access should only see Cluster2 and NamespaceC secrets": {
+		scopeKey: testutils.Cluster2NamespaceCReadWriteCtx,
+		resultCounts: map[string]map[string]int{
+			testconsts.Cluster2: {
+				testconsts.NamespaceC: 2,
+			},
+		},
+	},
+	"Cluster2 and Namespaces A and B read-write access should only see appropriate cluster/namespace secrets": {
+		scopeKey: testutils.Cluster2NamespacesABReadWriteCtx,
+		resultCounts: map[string]map[string]int{
+			testconsts.Cluster2: {
+				testconsts.NamespaceB: 3,
+			},
+		},
+	},
+	"Cluster2 and Namespaces A and C read-write access should only see appropriate cluster/namespace secrets": {
+		scopeKey: testutils.Cluster2NamespacesACReadWriteCtx,
+		resultCounts: map[string]map[string]int{
+			testconsts.Cluster2: {
+				testconsts.NamespaceC: 2,
+			},
+		},
+	},
+	"Cluster2 and Namespaces B and C read-write access should only see appropriate cluster/namespace secrets": {
+		scopeKey: testutils.Cluster2NamespacesBCReadWriteCtx,
+		resultCounts: map[string]map[string]int{
+			testconsts.Cluster2: {
+				testconsts.NamespaceB: 3,
+				testconsts.NamespaceC: 2,
+			},
+		},
+	},
+}
+
+var secretUnrestrictedSACSearchTestCases = map[string]secretSACSearchResult{
+	"full read access should see all secrets": {
+		// SAC search fields are not injected in query when running unscoped search
+		// Therefore results cannot be dispatched per cluster and namespace
+		scopeKey: testutils.UnrestrictedReadCtx,
+		resultCounts: map[string]map[string]int{
+			"": {"": 18},
+		},
+	},
+	"full read-write access should see all secrets": {
+		// SAC search fields are not injected in query when running unscoped search
+		// Therefore results cannot be dispatched per cluster and namespace
+		scopeKey: testutils.UnrestrictedReadWriteCtx,
+		resultCounts: map[string]map[string]int{
+			"": {"": 18},
+		},
+	},
+}
+
+var secretUnrestrictedSACObjectSearchTestCases = map[string]secretSACSearchResult{
+	"full read access should see all secrets": {
+		scopeKey: testutils.UnrestrictedReadCtx,
+		resultCounts: map[string]map[string]int{
+			testconsts.Cluster1: {
+				testconsts.NamespaceA: 8,
+				testconsts.NamespaceB: 5,
+			},
+			testconsts.Cluster2: {
+				testconsts.NamespaceB: 3,
+				testconsts.NamespaceC: 2,
+			},
+		},
+	},
+	"full read-write access should see all secrets": {
+		scopeKey: testutils.UnrestrictedReadWriteCtx,
+		resultCounts: map[string]map[string]int{
+			testconsts.Cluster1: {
+				testconsts.NamespaceA: 8,
+				testconsts.NamespaceB: 5,
+			},
+			testconsts.Cluster2: {
+				testconsts.NamespaceB: 3,
+				testconsts.NamespaceC: 2,
+			},
+		},
+	},
+}
+
+func (s *secretDatastoreSACTestSuite) runCountTest(testParams secretSACSearchResult) {
+	ctx := s.testContexts[testParams.scopeKey]
+	resultCount, err := s.datastore.Count(ctx, nil)
+	s.NoError(err)
+	expectedResultCount := testutils.AggregateCounts(s.T(), testParams.resultCounts)
+	s.Equal(expectedResultCount, resultCount)
+}
+
+func (s *secretDatastoreSACTestSuite) TestSecretScopedCount() {
+	for name, c := range secretScopedSACSearchTestCases {
+		s.Run(name, func() {
+			s.runCountTest(c)
+		})
+	}
+}
+
+func (s *secretDatastoreSACTestSuite) TestSecretUnrestrictedCount() {
+	for name, c := range secretUnrestrictedSACSearchTestCases {
+		s.Run(name, func() {
+			s.runCountTest(c)
+		})
+	}
+}
+
+func (s *secretDatastoreSACTestSuite) runCountSecretsTest(testParams secretSACSearchResult) {
+	ctx := s.testContexts[testParams.scopeKey]
+	resultCount, err := s.datastore.CountSecrets(ctx)
+	s.NoError(err)
+	expectedResultCount := testutils.AggregateCounts(s.T(), testParams.resultCounts)
+	s.Equal(expectedResultCount, resultCount)
+}
+
+func (s *secretDatastoreSACTestSuite) TestSecretScopedCountSecrets() {
+	for name, c := range secretScopedSACSearchTestCases {
+		s.Run(name, func() {
+			s.runCountSecretsTest(c)
+		})
+	}
+}
+
+func (s *secretDatastoreSACTestSuite) TestSecretUnrestrictedCountSecrets() {
+	for name, c := range secretUnrestrictedSACSearchTestCases {
+		s.Run(name, func() {
+			s.runCountSecretsTest(c)
+		})
+	}
+}
+
+func (s *secretDatastoreSACTestSuite) runSearchTest(testParams secretSACSearchResult) {
+	ctx := s.testContexts[testParams.scopeKey]
+	searchResults, err := s.datastore.Search(ctx, nil)
+	s.NoError(err)
+	resultCounts := testutils.CountResultsPerClusterAndNamespace(s.T(), searchResults, mappings.OptionsMap)
+	testutils.ValidateSACSearchResultDistribution(&s.Suite, testParams.resultCounts, resultCounts)
+}
+
+func (s *secretDatastoreSACTestSuite) TestSecretScopedSearch() {
+	for name, c := range secretScopedSACSearchTestCases {
+		s.Run(name, func() {
+			s.runSearchTest(c)
+		})
+	}
+}
+
+func (s *secretDatastoreSACTestSuite) TestSecretUnrestrictedSearch() {
+	for name, c := range secretUnrestrictedSACSearchTestCases {
+		s.Run(name, func() {
+			s.runSearchTest(c)
+		})
+	}
+}
+
+func (s *secretDatastoreSACTestSuite) runSearchSecretsTest(testParams secretSACSearchResult) {
+	ctx := s.testContexts[testParams.scopeKey]
+	searchResults, err := s.datastore.SearchSecrets(ctx, nil)
+	s.NoError(err)
+	resultDistribution := testutils.CountSearchResultsPerClusterAndNamespace(s.T(), searchResults, mappings.OptionsMap)
+	testutils.ValidateSACSearchResultDistribution(&s.Suite, testParams.resultCounts, resultDistribution)
+}
+
+func (s *secretDatastoreSACTestSuite) TestSecretScopedSearchSecrets() {
+	for name, c := range secretScopedSACSearchTestCases {
+		s.Run(name, func() {
+			s.runSearchSecretsTest(c)
+		})
+	}
+}
+
+func (s *secretDatastoreSACTestSuite) TestSecretUnrestrictedSearchSecrets() {
+	for name, c := range secretUnrestrictedSACSearchTestCases {
+		s.Run(name, func() {
+			s.runSearchSecretsTest(c)
+		})
+	}
+}
+
+func (s *secretDatastoreSACTestSuite) runSearchListSecretsTest(testParams secretSACSearchResult) {
+	ctx := s.testContexts[testParams.scopeKey]
+	searchResults, err := s.datastore.SearchListSecrets(ctx, nil)
+	s.NoError(err)
+	resultObjects := make([]sac.NamespaceScopedObject, 0, len(searchResults))
+	for ix := range searchResults {
+		resultObjects = append(resultObjects, searchResults[ix])
+	}
+	resultCount := testutils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), resultObjects)
+	testutils.ValidateSACSearchResultDistribution(&s.Suite, testParams.resultCounts, resultCount)
+}
+
+func (s *secretDatastoreSACTestSuite) TestSecretScopedSearchListSecrets() {
+	for name, c := range secretScopedSACSearchTestCases {
+		s.Run(name, func() {
+			s.runSearchListSecretsTest(c)
+		})
+	}
+}
+
+func (s *secretDatastoreSACTestSuite) TestSecretUnrestrictedSearchListSecrets() {
+	for name, c := range secretUnrestrictedSACObjectSearchTestCases {
+		s.Run(name, func() {
+			s.runSearchListSecretsTest(c)
+		})
+	}
+}
+
+func (s *secretDatastoreSACTestSuite) runSearchRawSecretsTest(testParams secretSACSearchResult) {
+	ctx := s.testContexts[testParams.scopeKey]
+	searchResults, err := s.datastore.SearchRawSecrets(ctx, nil)
+	s.NoError(err)
+	resultObjects := make([]sac.NamespaceScopedObject, 0, len(searchResults))
+	for ix := range searchResults {
+		resultObjects = append(resultObjects, searchResults[ix])
+	}
+	resultCount := testutils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), resultObjects)
+	testutils.ValidateSACSearchResultDistribution(&s.Suite, testParams.resultCounts, resultCount)
+}
+
+func (s *secretDatastoreSACTestSuite) TestSecretScopedSearchRawSecrets() {
+	for name, c := range secretScopedSACSearchTestCases {
+		s.Run(name, func() {
+			s.runSearchRawSecretsTest(c)
+		})
+	}
+}
+
+func (s *secretDatastoreSACTestSuite) TestSecretUnrestrictedSearchRawSecrets() {
+	for name, c := range secretUnrestrictedSACObjectSearchTestCases {
+		s.Run(name, func() {
+			s.runSearchRawSecretsTest(c)
+		})
+	}
+}

--- a/central/secret/datastore/datastore_sac_test.go
+++ b/central/secret/datastore/datastore_sac_test.go
@@ -81,7 +81,7 @@ func (s *secretDatastoreSACTestSuite) SetupSuite() {
 	s.datastore, err = New(s.storage, s.indexer, s.search)
 	s.NoError(err)
 
-	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), resources.Secret.GetResource())
+	s.testContexts = testutils.GetNamespaceScopedTestContexts(s.T(), context.Background(), resources.Secret.GetResource())
 }
 
 func (s *secretDatastoreSACTestSuite) TearDownSuite() {

--- a/central/secret/datastore/datastore_sac_test.go
+++ b/central/secret/datastore/datastore_sac_test.go
@@ -81,7 +81,7 @@ func (s *secretDatastoreSACTestSuite) SetupSuite() {
 	s.datastore, err = New(s.storage, s.indexer, s.search)
 	s.NoError(err)
 
-	s.testContexts = testutils.GetNamespaceScopedTestContexts(s.T(), context.Background(), resources.Secret.GetResource())
+	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.Secret.GetResource())
 }
 
 func (s *secretDatastoreSACTestSuite) TearDownSuite() {

--- a/pkg/fixtures/secret.go
+++ b/pkg/fixtures/secret.go
@@ -2,15 +2,23 @@ package fixtures
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/uuid"
 )
 
 // GetSecret returns a mock Secret
 func GetSecret() *storage.Secret {
+	return GetScopedSecret("ID", "clusterid", "")
+}
+
+// GetScopedSecret returns a mock Secret belonging to the input scope
+func GetScopedSecret(ID string, clusterID string, namespace string) *storage.Secret {
 	return &storage.Secret{
-		Id:          "ID",
+		Id:          ID,
 		Name:        "secretName",
-		ClusterId:   "clusterid",
+		ClusterId:   clusterID,
 		ClusterName: "clustername",
+		Namespace:   namespace,
 		Files: []*storage.SecretDataFile{
 			{
 				Name: "foo",
@@ -18,4 +26,28 @@ func GetSecret() *storage.Secret {
 			},
 		},
 	}
+}
+
+// GetSACTestSecretSet returns a set of mock secrets that can be used for scoped access control tests
+func GetSACTestSecretSet() []*storage.Secret {
+	secrets := make([]*storage.Secret, 0, 18)
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceB))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceB))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceB))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceB))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceB))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceC))
+	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceC))
+	return secrets
 }

--- a/pkg/fixtures/secret.go
+++ b/pkg/fixtures/secret.go
@@ -30,24 +30,29 @@ func GetScopedSecret(ID string, clusterID string, namespace string) *storage.Sec
 
 // GetSACTestSecretSet returns a set of mock secrets that can be used for scoped access control tests
 func GetSACTestSecretSet() []*storage.Secret {
-	secrets := make([]*storage.Secret, 0, 18)
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceA))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceB))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceB))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceB))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceB))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster1, testconsts.NamespaceB))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceC))
-	secrets = append(secrets, GetScopedSecret(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceC))
+	secrets := []*storage.Secret{
+		scopedSecret(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedSecret(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedSecret(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedSecret(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedSecret(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedSecret(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedSecret(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedSecret(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedSecret(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedSecret(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedSecret(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedSecret(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedSecret(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedSecret(testconsts.Cluster2, testconsts.NamespaceB),
+		scopedSecret(testconsts.Cluster2, testconsts.NamespaceB),
+		scopedSecret(testconsts.Cluster2, testconsts.NamespaceB),
+		scopedSecret(testconsts.Cluster2, testconsts.NamespaceC),
+		scopedSecret(testconsts.Cluster2, testconsts.NamespaceC),
+	}
 	return secrets
+}
+
+func scopedSecret(clusterID string, namespace string) *storage.Secret {
+	return GetScopedSecret(uuid.NewV4().String(), clusterID, namespace)
 }

--- a/pkg/sac/testconsts/sac_consts.go
+++ b/pkg/sac/testconsts/sac_consts.go
@@ -1,0 +1,11 @@
+package testconsts
+
+// Clusters and Namespaces for scoped access control tests
+const (
+	Cluster1   = "cluster1"
+	Cluster2   = "cluster2"
+	Cluster3   = "cluster3"
+	NamespaceA = "namespaceA"
+	NamespaceB = "namespaceB"
+	NamespaceC = "namespaceC"
+)

--- a/pkg/sac/testutils/test_contexts.go
+++ b/pkg/sac/testutils/test_contexts.go
@@ -1,0 +1,180 @@
+package testutils
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+)
+
+// Keys to use the pre-defined scopes provided with GetNamespaceScopedTestContexts
+const (
+	UnrestrictedReadCtx              = "UnrestrictedReadCtx"
+	UnrestrictedReadWriteCtx         = "UnrestrictedReadWriteCtx"
+	Cluster1ReadWriteCtx             = "Cluster1ReadWriteCtx"
+	Cluster1NamespaceAReadWriteCtx   = "Cluster1NamespaceAReadWriteCtx"
+	Cluster1NamespaceBReadWriteCtx   = "Cluster1NamespaceBReadWriteCtx"
+	Cluster1NamespaceCReadWriteCtx   = "Cluster1NamespaceCReadWriteCtx"
+	Cluster1NamespacesABReadWriteCtx = "Cluster1NamespacesABReadWriteCtx"
+	Cluster1NamespacesACReadWriteCtx = "Cluster1NamespacesACReadWriteCtx"
+	Cluster1NamespacesBCReadWriteCtx = "Cluster1NamespacesBCReadWriteCtx"
+	Cluster2ReadWriteCtx             = "Cluster2ReadWriteCtx"
+	Cluster2NamespaceAReadWriteCtx   = "Cluster2NamespaceAReadWriteCtx"
+	Cluster2NamespaceBReadWriteCtx   = "Cluster2NamespaceBReadWriteCtx"
+	Cluster2NamespaceCReadWriteCtx   = "Cluster2NamespaceCReadWriteCtx"
+	Cluster2NamespacesABReadWriteCtx = "Cluster2NamespacesABReadWriteCtx"
+	Cluster2NamespacesACReadWriteCtx = "Cluster2NamespacesACReadWriteCtx"
+	Cluster2NamespacesBCReadWriteCtx = "Cluster2NamespacesBCReadWriteCtx"
+	Cluster3ReadWriteCtx             = "Cluster3ReadWriteCtx"
+	MixedClusterAndNamespaceReadCtx  = "MixedClusterAndNamespaceReadCtx"
+)
+
+// GetNamespaceScopedTestContexts provides a set of pre-defined scoped contexts for use in scoped access control tests
+func GetNamespaceScopedTestContexts(ctx context.Context, resource permissions.Resource) map[string]context.Context {
+	contextMap := make(map[string]context.Context, 0)
+
+	contextMap[UnrestrictedReadCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resource)))
+
+	contextMap[UnrestrictedReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource)))
+
+	contextMap[Cluster1ReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource),
+				sac.ClusterScopeKeys(testconsts.Cluster1)))
+
+	contextMap[Cluster1NamespaceAReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource),
+				sac.ClusterScopeKeys(testconsts.Cluster1),
+				sac.NamespaceScopeKeys(testconsts.NamespaceA)))
+
+	contextMap[Cluster1NamespaceBReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource),
+				sac.ClusterScopeKeys(testconsts.Cluster1),
+				sac.NamespaceScopeKeys(testconsts.NamespaceB)))
+
+	contextMap[Cluster1NamespaceCReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource),
+				sac.ClusterScopeKeys(testconsts.Cluster1),
+				sac.NamespaceScopeKeys(testconsts.NamespaceC)))
+
+	contextMap[Cluster1NamespacesABReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource),
+				sac.ClusterScopeKeys(testconsts.Cluster1),
+				sac.NamespaceScopeKeys(testconsts.NamespaceA, testconsts.NamespaceB)))
+
+	contextMap[Cluster1NamespacesACReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource),
+				sac.ClusterScopeKeys(testconsts.Cluster1),
+				sac.NamespaceScopeKeys(testconsts.NamespaceA, testconsts.NamespaceC)))
+
+	contextMap[Cluster1NamespacesBCReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource),
+				sac.ClusterScopeKeys(testconsts.Cluster1),
+				sac.NamespaceScopeKeys(testconsts.NamespaceB, testconsts.NamespaceC)))
+
+	contextMap[Cluster2ReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource),
+				sac.ClusterScopeKeys(testconsts.Cluster2)))
+
+	contextMap[Cluster2NamespaceAReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource),
+				sac.ClusterScopeKeys(testconsts.Cluster2),
+				sac.NamespaceScopeKeys(testconsts.NamespaceA)))
+
+	contextMap[Cluster2NamespaceBReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource),
+				sac.ClusterScopeKeys(testconsts.Cluster2),
+				sac.NamespaceScopeKeys(testconsts.NamespaceB)))
+
+	contextMap[Cluster2NamespaceCReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource),
+				sac.ClusterScopeKeys(testconsts.Cluster2),
+				sac.NamespaceScopeKeys(testconsts.NamespaceC)))
+
+	contextMap[Cluster2NamespacesABReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource),
+				sac.ClusterScopeKeys(testconsts.Cluster2),
+				sac.NamespaceScopeKeys(testconsts.NamespaceA, testconsts.NamespaceB)))
+
+	contextMap[Cluster2NamespacesACReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource),
+				sac.ClusterScopeKeys(testconsts.Cluster2),
+				sac.NamespaceScopeKeys(testconsts.NamespaceA, testconsts.NamespaceC)))
+
+	contextMap[Cluster2NamespacesBCReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource),
+				sac.ClusterScopeKeys(testconsts.Cluster2),
+				sac.NamespaceScopeKeys(testconsts.NamespaceB, testconsts.NamespaceC)))
+
+	contextMap[Cluster3ReadWriteCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resource),
+				sac.ClusterScopeKeys(testconsts.Cluster3)))
+
+	contextMap[MixedClusterAndNamespaceReadCtx] =
+		sac.WithGlobalAccessScopeChecker(ctx,
+			sac.OneStepSCC{
+				sac.AccessModeScopeKey(storage.Access_READ_ACCESS): sac.OneStepSCC{
+					sac.ResourceScopeKey(resource): sac.OneStepSCC{
+						sac.ClusterScopeKey(testconsts.Cluster1): sac.AllowFixedScopes(sac.NamespaceScopeKeys(testconsts.NamespaceA)),
+						sac.ClusterScopeKey(testconsts.Cluster2): sac.AllowAllAccessScopeChecker(),
+						sac.ClusterScopeKey(testconsts.Cluster3): sac.AllowFixedScopes(sac.NamespaceScopeKeys(testconsts.NamespaceC)),
+					},
+				},
+			})
+
+	return contextMap
+}

--- a/pkg/sac/testutils/test_contexts.go
+++ b/pkg/sac/testutils/test_contexts.go
@@ -33,7 +33,7 @@ const (
 )
 
 // GetNamespaceScopedTestContexts provides a set of pre-defined scoped contexts for use in scoped access control tests
-func GetNamespaceScopedTestContexts(t *testing.T, ctx context.Context, resource permissions.Resource) map[string]context.Context {
+func GetNamespaceScopedTestContexts(ctx context.Context, t *testing.T, resource permissions.Resource) map[string]context.Context {
 	contextMap := make(map[string]context.Context, 0)
 
 	contextMap[UnrestrictedReadCtx] =

--- a/pkg/sac/testutils/test_contexts.go
+++ b/pkg/sac/testutils/test_contexts.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"context"
+	"testing"
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
@@ -32,7 +33,7 @@ const (
 )
 
 // GetNamespaceScopedTestContexts provides a set of pre-defined scoped contexts for use in scoped access control tests
-func GetNamespaceScopedTestContexts(ctx context.Context, resource permissions.Resource) map[string]context.Context {
+func GetNamespaceScopedTestContexts(t *testing.T, ctx context.Context, resource permissions.Resource) map[string]context.Context {
 	contextMap := make(map[string]context.Context, 0)
 
 	contextMap[UnrestrictedReadCtx] =
@@ -166,15 +167,18 @@ func GetNamespaceScopedTestContexts(ctx context.Context, resource permissions.Re
 
 	contextMap[MixedClusterAndNamespaceReadCtx] =
 		sac.WithGlobalAccessScopeChecker(ctx,
-			sac.OneStepSCC{
-				sac.AccessModeScopeKey(storage.Access_READ_ACCESS): sac.OneStepSCC{
-					sac.ResourceScopeKey(resource): sac.OneStepSCC{
-						sac.ClusterScopeKey(testconsts.Cluster1): sac.AllowFixedScopes(sac.NamespaceScopeKeys(testconsts.NamespaceA)),
-						sac.ClusterScopeKey(testconsts.Cluster2): sac.AllowAllAccessScopeChecker(),
-						sac.ClusterScopeKey(testconsts.Cluster3): sac.AllowFixedScopes(sac.NamespaceScopeKeys(testconsts.NamespaceC)),
+			sac.TestScopeCheckerCoreFromFullScopeMap(t,
+				sac.TestScopeMap{
+					storage.Access_READ_ACCESS: {
+						resource: &sac.TestResourceScope{
+							Clusters: map[string]*sac.TestClusterScope{
+								testconsts.Cluster1: {Namespaces: []string{testconsts.NamespaceA}},
+								testconsts.Cluster2: {Included: true},
+								testconsts.Cluster3: {Namespaces: []string{testconsts.NamespaceC}},
+							},
+						},
 					},
-				},
-			})
+				}))
 
 	return contextMap
 }

--- a/pkg/sac/testutils/testresult_distribution.go
+++ b/pkg/sac/testutils/testresult_distribution.go
@@ -1,0 +1,122 @@
+package testutils
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/sac"
+	searchPkg "github.com/stackrox/rox/pkg/search"
+	"github.com/stretchr/testify/suite"
+)
+
+// ValidateSACSearchResultDistribution checks whether the obtained result distribution map has the
+// same result distribution as the expected one.
+func ValidateSACSearchResultDistribution(s *suite.Suite, expected, obtained map[string]map[string]int) {
+	s.Equal(len(expected), len(obtained), "unexpected cluster count in result")
+	for clusterID, clusterMap := range expected {
+		_, clusterFound := obtained[clusterID]
+		s.True(clusterFound)
+		if clusterFound {
+			for namespace, count := range clusterMap {
+				_, namespaceFound := obtained[clusterID][namespace]
+				s.True(namespaceFound)
+				s.Equalf(count, obtained[clusterID][namespace], "unexpected count for cluster %s and namespace %s", clusterID, namespace)
+			}
+		}
+	}
+}
+
+// CountResultsPerClusterAndNamespace builds a result distribution map from the search output of a test,
+// counting the results per cluster and namespace.
+func CountResultsPerClusterAndNamespace(_ *testing.T, searchResults []searchPkg.Result, optionsMap searchPkg.OptionsMap) map[string]map[string]int {
+	resultDistribution := make(map[string]map[string]int, 0)
+	clusterIDField, _ := optionsMap.Get(searchPkg.ClusterID.String())
+	namespaceField, _ := optionsMap.Get(searchPkg.Namespace.String())
+	for _, result := range searchResults {
+		var clusterID string
+		var namespace string
+		for k, v := range result.Fields {
+			if k == clusterIDField.GetFieldPath() {
+				clusterID = fmt.Sprintf("%v", v)
+			}
+			if k == namespaceField.GetFieldPath() {
+				namespace = fmt.Sprintf("%v", v)
+			}
+		}
+		if _, clusterIDExists := resultDistribution[clusterID]; !clusterIDExists {
+			resultDistribution[clusterID] = make(map[string]int, 0)
+		}
+		if _, namespaceExists := resultDistribution[clusterID][namespace]; !namespaceExists {
+			resultDistribution[clusterID][namespace] = 0
+		}
+		resultDistribution[clusterID][namespace]++
+	}
+	return resultDistribution
+}
+
+// AggregateCounts returns the aggregated result count of an expected test result distribution map
+func AggregateCounts(_ *testing.T, resultDistribution map[string]map[string]int) int {
+	sum := 0
+	for _, submap := range resultDistribution {
+		for _, count := range submap {
+			sum += count
+		}
+	}
+	return sum
+}
+
+// CountSearchResultsPerClusterAndNamespace builds a result distribution map from the search output of a test,
+// counting the results per cluster and namespace.
+func CountSearchResultsPerClusterAndNamespace(_ *testing.T, results []*v1.SearchResult, optionsMap searchPkg.OptionsMap) map[string]map[string]int {
+	resultDistribution := make(map[string]map[string]int, 0)
+	clusterIDField, _ := optionsMap.Get(searchPkg.ClusterID.String())
+	namespaceField, _ := optionsMap.Get(searchPkg.Namespace.String())
+	for _, result := range results {
+		var clusterID string
+		var namespace string
+		for k, v := range result.GetFieldToMatches() {
+			if k == clusterIDField.GetFieldPath() {
+				if v != nil && len(v.Values) > 0 {
+					clusterID = v.Values[0]
+				}
+			}
+			if k == namespaceField.GetFieldPath() {
+				if v != nil && len(v.Values) > 0 {
+					namespace = v.Values[0]
+				}
+			}
+		}
+		if _, clusterIDExists := resultDistribution[clusterID]; !clusterIDExists {
+			resultDistribution[clusterID] = make(map[string]int, 0)
+		}
+		if _, namespaceExists := resultDistribution[clusterID][namespace]; !namespaceExists {
+			resultDistribution[clusterID][namespace] = 0
+		}
+		resultDistribution[clusterID][namespace]++
+	}
+	return resultDistribution
+}
+
+// CountSearchResultObjectsPerClusterAndNamespace builds a result distribution map from the search output of a test,
+// counting the results per cluster and namespace.
+func CountSearchResultObjectsPerClusterAndNamespace(_ *testing.T, results []sac.NamespaceScopedObject) map[string]map[string]int {
+	resultDistribution := make(map[string]map[string]int, 0)
+	for _, result := range results {
+		var clusterID string
+		var namespace string
+		if result == nil {
+			continue
+		}
+		clusterID = result.GetClusterId()
+		namespace = result.GetNamespace()
+		if _, clusterIDExists := resultDistribution[clusterID]; !clusterIDExists {
+			resultDistribution[clusterID] = make(map[string]int, 0)
+		}
+		if _, namespaceExists := resultDistribution[clusterID][namespace]; !namespaceExists {
+			resultDistribution[clusterID][namespace] = 0
+		}
+		resultDistribution[clusterID][namespace]++
+	}
+	return resultDistribution
+}

--- a/pkg/sac/testutils/testresult_distribution.go
+++ b/pkg/sac/testutils/testresult_distribution.go
@@ -102,13 +102,11 @@ func CountSearchResultsPerClusterAndNamespace(_ *testing.T, results []*v1.Search
 func CountSearchResultObjectsPerClusterAndNamespace(_ *testing.T, results []sac.NamespaceScopedObject) map[string]map[string]int {
 	resultDistribution := make(map[string]map[string]int, 0)
 	for _, result := range results {
-		var clusterID string
-		var namespace string
 		if result == nil {
 			continue
 		}
-		clusterID = result.GetClusterId()
-		namespace = result.GetNamespace()
+		clusterID := result.GetClusterId()
+		namespace := result.GetNamespace()
 		if _, clusterIDExists := resultDistribution[clusterID]; !clusterIDExists {
 			resultDistribution[clusterID] = make(map[string]int, 0)
 		}

--- a/pkg/sac/testutils/testresult_distribution.go
+++ b/pkg/sac/testutils/testresult_distribution.go
@@ -1,7 +1,6 @@
 package testutils
 
 import (
-	"fmt"
 	"testing"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -36,12 +35,12 @@ func CountResultsPerClusterAndNamespace(_ *testing.T, searchResults []searchPkg.
 	for _, result := range searchResults {
 		var clusterID string
 		var namespace string
-		for k, v := range result.Fields {
+		for k, v := range result.Matches {
 			if k == clusterIDField.GetFieldPath() {
-				clusterID = fmt.Sprintf("%v", v)
+				clusterID = v[0]
 			}
 			if k == namespaceField.GetFieldPath() {
-				namespace = fmt.Sprintf("%v", v)
+				namespace = v[0]
 			}
 		}
 		if _, clusterIDExists := resultDistribution[clusterID]; !clusterIDExists {


### PR DESCRIPTION
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~ 
~~- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs] (https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs)).~~

If any of these don't apply, please comment below.
This pull request only adds integration tests for scoped access control against one specific resource type. It does not alter the user experience, nor requires data model changes

## Testing Performed

Locally running the added tests is the level of testing performed so far.