### PR TITLE
Remove creation of RHEL bundle from release

### DIFF
--- a/scripts/offline-bundle/create.sh
+++ b/scripts/offline-bundle/create.sh
@@ -29,7 +29,6 @@ bundle() {
   local name=$1
   pushd "${DIR}"
   tar -czvf "${name}.tgz" "${name}"
-  tar -czvf "${name}-rhel.tgz" "${name}-rhel"
   popd
 }
 


### PR DESCRIPTION
## Description

While releasing 3.69.0 the `push-release` CI step failed complaining about `image-bundle-rhel` not existing, this bundle was previously removed by #773 and this PR removes a tar command that slipped past that PR.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Since the `push-release` CI job only runs on release tags, the only possible test is to merge it into `3.69.0` and check it works.
