### PR TITLE
Update cypress 9.5.2 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -139,7 +139,7 @@
         "@types/react-dom": "^17.0.11",
         "@types/react-redux": "^7.1.20",
         "autoprefixer": "^10.2.5",
-        "cypress": "^9.5.0",
+        "cypress": "^9.5.2",
         "cypress-file-upload": "^5.0.8",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7532,10 +7532,10 @@ cypress-file-upload@^5.0.8:
   resolved "https://registry.yarnpkg.com/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz#d8824cbeaab798e44be8009769f9a6c9daa1b4a1"
   integrity sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==
 
-cypress@^9.5.0:
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.5.0.tgz#704a79f0d3d4e775f433334eb8f5ae065e3bea31"
-  integrity sha512-rC5QPolKsVjJ8QJZ7IeZ6HlKM4gswBGZc0XvoAJNL8urQCSL8zTX0A/ai/h35WfF47NQ0iSZnwIXBlHX3MOUIQ==
+cypress@^9.5.2:
+  version "9.5.2"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.5.2.tgz#8fb6ee4a890fbc35620800810bf6fb11995927bd"
+  integrity sha512-gYiQYvJozMzDOriUV1rCt6CeRM/pRK4nhwGJj3nJQyX2BoUdTCVwp30xDMKc771HiNVhBtgj5o5/iBdVDVXQUg==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## Description

https://github.com/cypress-io/cypress/releases/tag/v9.5.2

* Updates were made to the pre-release build setup such that Cypress will use a unique cache folder for each pre-release installation on a machine. This removes the need to run `cypress clear cache` before installing a new pre-release version of Cypress or before installing a new released version of Cypress after a pre-release version had been installed.
* Updates were made to explicitly disable the `Origin-Agent-Cluster` header for proxied responses to ensure `document.domain` can continue to be set with Chrome v106+.
* Upgraded `url-parse` dependency from 1.5.6 to 1.5.9 to address NVD security vulnerabilities: CVE-2022-0639, CVE-2022-0686, and CVE-2022-0691.

https://github.com/cypress-io/cypress/releases/tag/v9.5.1

* Fixed an issue where Cypress would throw an error when reporting or wrapping errors with booleans or numbers.
* Upgraded `url-parse` dependency from 1.5.2 to 1.5.6 to avoid authorization bypass through user-controlled key to address NVD security vulnerability: CVE-2022-0512.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn cypress-open` in ui/apps/platform and then
    * policies/PatternFly/policiesTable.test.js
