### PR TITLE
ROX-9727: fix top riskiest deployments and top riskiest images widgets errors

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.constants.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.constants.ts
@@ -3,3 +3,11 @@ export const imageWatchStatuses = {
     NOT_WATCHED: 'NOT_WATCHED',
     WATCHED: 'WATCHED',
 };
+
+export const entityPriorityField = {
+    CLUSTER: 'Cluster Risk Priority',
+    NODE: 'Node Risk Priority',
+    NAMESPACE: 'Namespace Risk Priority',
+    DEPLOYMENT: 'Deployment Risk Priority',
+    IMAGE: 'Image Risk Priority',
+};

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
@@ -19,6 +19,7 @@ import entityTypes from 'constants/entityTypes';
 import { WIDGET_PAGINATION_START_OFFSET } from 'constants/workflowPages.constants';
 import { entitySortFieldsMap } from 'constants/sortFields';
 import { resourceLabels } from 'messages/common';
+import { entityPriorityField } from 'Containers/VulnMgmt/VulnMgmt.constants';
 
 const TOP_RISKIEST_IMAGES = gql`
     query topRiskiestImages($query: String, $pagination: Pagination) {
@@ -267,7 +268,7 @@ const TopRiskiestEntities = ({ entityContext, limit }) => {
             query: queryService.entityContextToQueryString(entityContext),
             pagination: queryService.getPagination(
                 {
-                    id: 'Priority',
+                    id: entityPriorityField[selectedEntity],
                     desc: false,
                 },
                 WIDGET_PAGINATION_START_OFFSET,

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.js
@@ -24,6 +24,7 @@ import { checkForPermissionErrorMessage } from 'utils/permissionUtils';
 import { getSeverityByCvss } from 'utils/vulnerabilityUtils';
 import { entitySortFieldsMap, cveSortFields } from 'constants/sortFields';
 import { WIDGET_PAGINATION_START_OFFSET } from 'constants/workflowPages.constants';
+import { entityPriorityField } from 'Containers/VulnMgmt/VulnMgmt.constants';
 
 const ENTITY_COUNT = 25;
 const VULN_COUNT = 50;
@@ -353,7 +354,7 @@ const TopRiskyEntitiesByVulnerabilities = ({
         vulnQuery: queryService.objectToWhereClause(vulnQuery),
         entityPagination: queryService.getPagination(
             {
-                id: 'Priority',
+                id: entityPriorityField[selectedEntityType],
                 desc: false,
             },
             WIDGET_PAGINATION_START_OFFSET,


### PR DESCRIPTION
## Description

This fixes the `top riskiest _ by cve count & cvss score` widget and `top riskiest _` widgets in the vuln management dashboard page

## Testing Performed

https://user-images.githubusercontent.com/4805485/158465048-c2f31fe7-0aa2-40ef-8367-5f6e194f2096.mov

