### PR TITLE
ROX-9536: Add EffectiveAccessScope to scope checker

### DIFF
--- a/central/sac/authorizer/builtin_scoped_authorizer.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer.go
@@ -89,7 +89,7 @@ func (a *globalScopeChecker) PerformChecks(_ context.Context) error {
 	return nil
 }
 
-func (a *globalScopeChecker) EffectiveAccessScope() (*effectiveaccessscope.ScopeTree, error) {
+func (a *globalScopeChecker) EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {
 	return nil, errors.New("global scope checker has no effective access scope")
 }
 
@@ -183,7 +183,7 @@ func (a *resourceLevelScopeCheckerCore) TryAllowed() sac.TryAllowedResult {
 	return sac.Deny
 }
 
-func (a *resourceLevelScopeCheckerCore) EffectiveAccessScope() (*effectiveaccessscope.ScopeTree, error) {
+func (a *resourceLevelScopeCheckerCore) EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {
 	// TODO(ROX-9537): Implement it
 	// 1. Get all roles and filter them to get only roles with desired access level (here: READ_ACCESS)
 	// 2. For every role get it's effective access scope (EAS)

--- a/central/sac/transitional/permission_recording_scc.go
+++ b/central/sac/transitional/permission_recording_scc.go
@@ -112,6 +112,6 @@ func (s *permissionRecordingSCC) UsedPermissions() permissions.PermissionMap {
 	return s.rec.UsedPermissions()
 }
 
-func (s *permissionRecordingSCC) EffectiveAccessScope() (*effectiveaccessscope.ScopeTree, error) {
-	return s.wrapped.EffectiveAccessScope()
+func (s *permissionRecordingSCC) EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {
+	return s.wrapped.EffectiveAccessScope(resource)
 }

--- a/pkg/sac/allow_fixed_scopes_checker_core.go
+++ b/pkg/sac/allow_fixed_scopes_checker_core.go
@@ -3,6 +3,7 @@ package sac
 import (
 	"context"
 
+	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
 )
 
@@ -50,7 +51,7 @@ func (c allowFixedScopesCheckerCore) SubScopeChecker(key ScopeKey) ScopeCheckerC
 	return denyAllScopeCheckerCore
 }
 
-func (c allowFixedScopesCheckerCore) EffectiveAccessScope() (*effectiveaccessscope.ScopeTree, error) {
+func (c allowFixedScopesCheckerCore) EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {
 	// TODO(ROX-9537): Implement it
 	panic("Implement me: ROX-9537")
 }

--- a/pkg/sac/error_scope_checker_core.go
+++ b/pkg/sac/error_scope_checker_core.go
@@ -3,6 +3,7 @@ package sac
 import (
 	"context"
 
+	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
 )
 
@@ -31,6 +32,6 @@ func ErrorAccessScopeCheckerCore(err error) ScopeCheckerCore {
 	}
 }
 
-func (s errScopeCheckerCore) EffectiveAccessScope() (*effectiveaccessscope.ScopeTree, error) {
+func (s errScopeCheckerCore) EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {
 	return effectiveaccessscope.DenyAllEffectiveAccessScope(), s.err
 }

--- a/pkg/sac/mocks/scope_checker_core.go
+++ b/pkg/sac/mocks/scope_checker_core.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	permissions "github.com/stackrox/rox/pkg/auth/permissions"
 	sac "github.com/stackrox/rox/pkg/sac"
 	effectiveaccessscope "github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
 )
@@ -37,18 +38,18 @@ func (m *MockScopeCheckerCore) EXPECT() *MockScopeCheckerCoreMockRecorder {
 }
 
 // EffectiveAccessScope mocks base method.
-func (m *MockScopeCheckerCore) EffectiveAccessScope() (*effectiveaccessscope.ScopeTree, error) {
+func (m *MockScopeCheckerCore) EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EffectiveAccessScope")
+	ret := m.ctrl.Call(m, "EffectiveAccessScope", resource)
 	ret0, _ := ret[0].(*effectiveaccessscope.ScopeTree)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EffectiveAccessScope indicates an expected call of EffectiveAccessScope.
-func (mr *MockScopeCheckerCoreMockRecorder) EffectiveAccessScope() *gomock.Call {
+func (mr *MockScopeCheckerCoreMockRecorder) EffectiveAccessScope(resource interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EffectiveAccessScope", reflect.TypeOf((*MockScopeCheckerCore)(nil).EffectiveAccessScope))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EffectiveAccessScope", reflect.TypeOf((*MockScopeCheckerCore)(nil).EffectiveAccessScope), resource)
 }
 
 // PerformChecks mocks base method.

--- a/pkg/sac/one_step_scope_checker_core.go
+++ b/pkg/sac/one_step_scope_checker_core.go
@@ -3,6 +3,7 @@ package sac
 import (
 	"context"
 
+	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
 )
 
@@ -36,7 +37,7 @@ func (c OneStepSCC) PerformChecks(ctx context.Context) error {
 }
 
 // EffectiveAccessScope fix me.
-func (c OneStepSCC) EffectiveAccessScope() (*effectiveaccessscope.ScopeTree, error) {
+func (c OneStepSCC) EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {
 	// TODO(ROX-9537): Implement it
 	panic("Implement me: ROX-9537")
 }

--- a/pkg/sac/scope_checker.go
+++ b/pkg/sac/scope_checker.go
@@ -167,6 +167,6 @@ func (c ScopeChecker) Check(ctx context.Context, pred ScopePredicate) (bool, err
 }
 
 // EffectiveAccessScope returns underlying effective access scope.
-func (c ScopeChecker) EffectiveAccessScope() (*effectiveaccessscope.ScopeTree, error) {
-	return c.core.EffectiveAccessScope()
+func (c ScopeChecker) EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {
+	return c.core.EffectiveAccessScope(resource)
 }

--- a/pkg/sac/scope_checker_core.go
+++ b/pkg/sac/scope_checker_core.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/stackrox/default-authz-plugin/pkg/payload"
+	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
 )
 
@@ -42,7 +43,7 @@ type ScopeCheckerCore interface {
 	PerformChecks(ctx context.Context) error
 	// EffectiveAccessScope returns effective access scope for given principal stored in context.
 	// If checker is not at resource level then it returns an error.
-	EffectiveAccessScope() (*effectiveaccessscope.ScopeTree, error)
+	EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error)
 }
 
 // NewRootScopeCheckerCore returns a ScopeCheckerCore with a root AccessScope

--- a/pkg/sac/scope_checker_core_impl.go
+++ b/pkg/sac/scope_checker_core_impl.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/default-authz-plugin/pkg/payload"
+	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
 	"github.com/stackrox/rox/pkg/sync"
@@ -90,7 +91,7 @@ func (scc *ScopeCheckerCoreImpl) PerformChecks(ctx context.Context) error {
 }
 
 // EffectiveAccessScope always returns error as plugin does not support it.
-func (scc *ScopeCheckerCoreImpl) EffectiveAccessScope() (*effectiveaccessscope.ScopeTree, error) {
+func (scc *ScopeCheckerCoreImpl) EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {
 	return nil, errors.New("not supported: use built-in authorizer")
 }
 

--- a/pkg/sac/uniform_scope_checker_core.go
+++ b/pkg/sac/uniform_scope_checker_core.go
@@ -3,6 +3,7 @@ package sac
 import (
 	"context"
 
+	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
 )
 
@@ -38,7 +39,7 @@ func (s uniformScopeCheckerCore) PerformChecks(ctx context.Context) error {
 	return nil
 }
 
-func (s uniformScopeCheckerCore) EffectiveAccessScope() (*effectiveaccessscope.ScopeTree, error) {
+func (s uniformScopeCheckerCore) EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {
 	if s {
 		return effectiveaccessscope.UnrestrictedEffectiveAccessScope(), nil
 	}


### PR DESCRIPTION
## Description

Add method to extract EAS from scope checker, implement easy cases and leave placeholders for hard cases that requires implementation.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI