### PR TITLE
ROX-9633: Update product branding in Online Telemetry Data Collection

### DIFF
--- a/ui/apps/platform/src/Containers/SystemConfig/ConfigTelemetryDetailWidget.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/ConfigTelemetryDetailWidget.tsx
@@ -41,8 +41,8 @@ export const ConfigTelemetryDetailContent = (): ReactElement => {
     return (
         <>
             <p className="pf-u-mb-sm">
-                Online telemetry data collection allows StackRox to better utilize anonymized
-                information to enhance your user experience.
+                Online telemetry data collection allows Red Hat to use anonymized information to
+                enhance your user experience.
             </p>
             <ExpandableSection
                 toggleText={isExpanded ? 'Show Less' : 'Show More'}
@@ -50,13 +50,14 @@ export const ConfigTelemetryDetailContent = (): ReactElement => {
                 isExpanded={isExpanded}
             >
                 <p>
-                    By consenting to online data collection, you allow StackRox to store and perform
-                    analytics on data that arises from the usage and operation of the StackRox
-                    Kubernetes Security Platform. This data may contain both operational metrics of
-                    the platform itself, as well as information about the environment(s) in which it
-                    is being used. While the data is associated with your account, we do not collect
-                    any information pertaining to the purpose of these environments; in particular,
-                    we will never collect the names of nodes, workloads or non-default namespaces.
+                    By consenting to online telemetry data collection, you allow Red Hat to store
+                    and perform analytics on data that arises from the usage and operation of Red
+                    Hat Advanced Cluster Security. This data may contain both operational metrics of
+                    the platform itself, as well as information about the environments in which it
+                    is being used. While the data is associated with your account, it does not
+                    include any information about the purpose of these environments; in particular,
+                    no identifying information like names of nodes, workloads or non-default
+                    namespaces.
                 </p>
                 <p className="pf-u-mt-md">
                     You can revoke your consent to online telemetry data collection at any time. If

--- a/ui/apps/platform/src/Containers/SystemConfig/Details.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Grid, GridItem } from '@patternfly/react-core';
 
+import { getProductBranding } from 'constants/productBranding';
 import { SystemConfig, TelemetryConfig } from 'Containers/SystemConfig/SystemConfigTypes';
 import ConfigBannerDetailWidget from './ConfigBannerDetailWidget';
 import ConfigLoginDetailWidget from './ConfigLoginDetailWidget';
@@ -13,6 +14,7 @@ export type DetailsProps = {
 };
 
 function Details({ systemConfig, telemetryConfig }: DetailsProps): ReactElement {
+    const { type } = getProductBranding();
     return (
         <Grid hasGutter>
             <GridItem span={12}>
@@ -27,9 +29,14 @@ function Details({ systemConfig, telemetryConfig }: DetailsProps): ReactElement 
             <GridItem sm={12} md={6}>
                 <ConfigLoginDetailWidget publicConfig={systemConfig?.publicConfig} />
             </GridItem>
-            <GridItem sm={12} md={6}>
-                <ConfigTelemetryDetailWidget telemetryConfig={telemetryConfig} editable={false} />
-            </GridItem>
+            {type === 'RHACS_BRANDING' && (
+                <GridItem sm={12} md={6}>
+                    <ConfigTelemetryDetailWidget
+                        telemetryConfig={telemetryConfig}
+                        editable={false}
+                    />
+                </GridItem>
+            )}
         </Grid>
     );
 }

--- a/ui/apps/platform/src/Containers/SystemConfig/SystemConfigForm/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/SystemConfigForm/SystemConfigForm.tsx
@@ -19,6 +19,7 @@ import {
 } from '@patternfly/react-core';
 
 import ColorPicker from 'Components/ColorPicker';
+import { getProductBranding } from 'constants/productBranding';
 import { ConfigTelemetryDetailContent } from '../ConfigTelemetryDetailWidget';
 import { PrivateConfig, PublicConfig, TelemetryConfig } from '../SystemConfigTypes';
 import FormSelect from './FormSelect';
@@ -41,6 +42,8 @@ const SystemConfigForm = ({
     values,
     setFieldValue,
 }: SystemConfigFormProps): ReactElement => {
+    const { type } = getProductBranding();
+
     function onChange(value, event) {
         return setFieldValue(event.target.id, value, false);
     }
@@ -411,28 +414,30 @@ const SystemConfigForm = ({
                         </CardBody>
                     </Card>
                 </GridItem>
-                <GridItem md={6}>
-                    <Card>
-                        <CardHeader>
-                            <CardHeaderMain>
-                                <CardTitle>Online Telemetry Data Collection</CardTitle>
-                            </CardHeaderMain>
-                            <CardActions>
-                                <Switch
-                                    id="telemetryConfig.enabled"
-                                    label="Enabled"
-                                    labelOff="Disabled"
-                                    isChecked={values?.telemetryConfig?.enabled}
-                                    onChange={onChange}
-                                />
-                            </CardActions>
-                        </CardHeader>
-                        <Divider component="div" />
-                        <CardBody>
-                            <ConfigTelemetryDetailContent />
-                        </CardBody>
-                    </Card>
-                </GridItem>
+                {type === 'RHACS_BRANDING' && (
+                    <GridItem md={6}>
+                        <Card>
+                            <CardHeader>
+                                <CardHeaderMain>
+                                    <CardTitle>Online Telemetry Data Collection</CardTitle>
+                                </CardHeaderMain>
+                                <CardActions>
+                                    <Switch
+                                        id="telemetryConfig.enabled"
+                                        label="Enabled"
+                                        labelOff="Disabled"
+                                        isChecked={values?.telemetryConfig?.enabled}
+                                        onChange={onChange}
+                                    />
+                                </CardActions>
+                            </CardHeader>
+                            <Divider component="div" />
+                            <CardBody>
+                                <ConfigTelemetryDetailContent />
+                            </CardBody>
+                        </Card>
+                    </GridItem>
+                )}
             </Grid>
         </Form>
     );


### PR DESCRIPTION
## Description

Draft pull request pending approval of draft wording.

1. Edit wording to replace **StackRox** with **Red Hat** and similarly for full product name
    * src/Containers/SystemConfig/ConfigTelemetryDetailWidget.tsx

2. Add conditional rendering because option is relevant only for commercial customers
    * src/Containers/SystemConfig/Details.tsx
    * src/Containers/SystemConfig/SystemConfigForm/SystemConfigForm.tsx

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

* Default product branding on CI is Red Hat
* Default product branding in local deployment is StackRox
* Change in local deployment `export REACT_APP_ROX_PRODUCT_BRANDING='RHACS_BRANDING'` before `yarn start`

### integration testing

1. `yarn cypress-open` in ui
    * systemconfig.test.js no tests are affected

### manual testing for StackRox

Detail view before changes does have card with 3 occurrences of **StackRox**
![StackRox-original-view](https://user-images.githubusercontent.com/11862657/158639999-4aa6256f-7b4a-4ba2-b018-60d4979a29d8.png)

Detail view after changes does not have card
![StackRox-improved-view](https://user-images.githubusercontent.com/11862657/158640077-a3dde023-e87f-4f4f-abb5-6f6974330d35.png)

Edit form before changes does have card with 3 occurrences of **StackRox**
![StackRox-original-form](https://user-images.githubusercontent.com/11862657/158640052-91046a85-a7d7-4c2f-9bba-6c3cb4d08a31.png)

Edit form after changes does not have card
![StackRox-improved-form](https://user-images.githubusercontent.com/11862657/158640102-aeaf9a9b-b3f9-4fc5-8249-7976658ef42a.png)

### manual testing for Red Hat

Detail view after changes does have card with 3 occurrences of **Red Hat**
![RedHat-view](https://user-images.githubusercontent.com/11862657/158640145-d27a4175-c448-41b7-b452-6192baf64c26.png)

Edit form after changes does have card with 3 occurrences of **Red Hat**
![RedHat-form](https://user-images.githubusercontent.com/11862657/158640205-70412de6-030a-45fa-8993-e99e3b0b05c8.png)

