### PR TITLE
Remove vars from PG stores

### DIFF
--- a/central/alert/datastore/internal/store/postgres/index.go
+++ b/central/alert/datastore/internal/store/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_ALERTS, walker.Walk(reflect.TypeOf((*storage.Alert)(nil)), "alerts"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_ALERTS, walker.Walk(reflect.TypeOf((*storage.Alert)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "alerts"
 	countStmt  = "SELECT COUNT(*) FROM alerts"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM alerts WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("alerts", "Alert")
+	globaldb.RegisterTable(baseTable, "Alert")
 }
 
 type Store interface {

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "apitokens"
 	countStmt  = "SELECT COUNT(*) FROM apitokens"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM apitokens WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("apitokens", "TokenMetadata")
+	globaldb.RegisterTable(baseTable, "TokenMetadata")
 }
 
 type Store interface {

--- a/central/cluster/store/cluster/postgres/index.go
+++ b/central/cluster/store/cluster/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTERS, walker.Walk(reflect.TypeOf((*storage.Cluster)(nil)), "clusters"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTERS, walker.Walk(reflect.TypeOf((*storage.Cluster)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "clusters"
 	countStmt  = "SELECT COUNT(*) FROM clusters"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM clusters WHERE Id = $1 AND HealthStatus_Id = $2)"
 
@@ -26,7 +27,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("clusters", "Cluster")
+	globaldb.RegisterTable(baseTable, "Cluster")
 }
 
 type Store interface {

--- a/central/cluster/store/cluster_health_status/postgres/store.go
+++ b/central/cluster/store/cluster_health_status/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "cluster_health_status"
 	countStmt  = "SELECT COUNT(*) FROM cluster_health_status"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM cluster_health_status WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("cluster_health_status", "ClusterHealthStatus")
+	globaldb.RegisterTable(baseTable, "ClusterHealthStatus")
 }
 
 type Store interface {

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "clusterinitbundles"
 	countStmt  = "SELECT COUNT(*) FROM clusterinitbundles"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM clusterinitbundles WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("clusterinitbundles", "InitBundleMeta")
+	globaldb.RegisterTable(baseTable, "InitBundleMeta")
 }
 
 type Store interface {

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "integrationhealth"
 	countStmt  = "SELECT COUNT(*) FROM integrationhealth"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM integrationhealth WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("integrationhealth", "IntegrationHealth")
+	globaldb.RegisterTable(baseTable, "IntegrationHealth")
 }
 
 type Store interface {

--- a/central/namespace/store/postgres/index.go
+++ b/central/namespace/store/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_NAMESPACES, walker.Walk(reflect.TypeOf((*storage.NamespaceMetadata)(nil)), "namespaces"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_NAMESPACES, walker.Walk(reflect.TypeOf((*storage.NamespaceMetadata)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "namespaces"
 	countStmt  = "SELECT COUNT(*) FROM namespaces"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM namespaces WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("namespaces", "NamespaceMetadata")
+	globaldb.RegisterTable(baseTable, "NamespaceMetadata")
 }
 
 type Store interface {

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "networkbaseline"
 	countStmt  = "SELECT COUNT(*) FROM networkbaseline"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM networkbaseline WHERE DeploymentId = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("networkbaseline", "NetworkBaseline")
+	globaldb.RegisterTable(baseTable, "NetworkBaseline")
 }
 
 type Store interface {

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "networkentity"
 	countStmt  = "SELECT COUNT(*) FROM networkentity"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM networkentity WHERE Info_Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("networkentity", "NetworkEntity")
+	globaldb.RegisterTable(baseTable, "NetworkEntity")
 }
 
 type Store interface {

--- a/central/pod/store/postgres/index.go
+++ b/central/pod/store/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_PODS, walker.Walk(reflect.TypeOf((*storage.Pod)(nil)), "pods"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_PODS, walker.Walk(reflect.TypeOf((*storage.Pod)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "pods"
 	countStmt  = "SELECT COUNT(*) FROM pods"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM pods WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("pods", "Pod")
+	globaldb.RegisterTable(baseTable, "Pod")
 }
 
 type Store interface {

--- a/central/policy/store/postgres/index.go
+++ b/central/policy/store/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_POLICIES, walker.Walk(reflect.TypeOf((*storage.Policy)(nil)), "policy"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_POLICIES, walker.Walk(reflect.TypeOf((*storage.Policy)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "policy"
 	countStmt  = "SELECT COUNT(*) FROM policy"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM policy WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("policy", "Policy")
+	globaldb.RegisterTable(baseTable, "Policy")
 }
 
 type Store interface {

--- a/central/processbaseline/store/postgres/index.go
+++ b/central/processbaseline/store/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_PROCESS_BASELINES, walker.Walk(reflect.TypeOf((*storage.ProcessBaseline)(nil)), "processbaselines"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_PROCESS_BASELINES, walker.Walk(reflect.TypeOf((*storage.ProcessBaseline)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "processbaselines"
 	countStmt  = "SELECT COUNT(*) FROM processbaselines"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM processbaselines WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("processbaselines", "ProcessBaseline")
+	globaldb.RegisterTable(baseTable, "ProcessBaseline")
 }
 
 type Store interface {

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "processwhitelistresults"
 	countStmt  = "SELECT COUNT(*) FROM processwhitelistresults"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM processwhitelistresults WHERE DeploymentId = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("processwhitelistresults", "ProcessBaselineResults")
+	globaldb.RegisterTable(baseTable, "ProcessBaselineResults")
 }
 
 type Store interface {

--- a/central/processindicator/store/postgres/index.go
+++ b/central/processindicator/store/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_PROCESS_INDICATORS, walker.Walk(reflect.TypeOf((*storage.ProcessIndicator)(nil)), "process_indicators"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_PROCESS_INDICATORS, walker.Walk(reflect.TypeOf((*storage.ProcessIndicator)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "process_indicators"
 	countStmt  = "SELECT COUNT(*) FROM process_indicators"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM process_indicators WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("process_indicators", "ProcessIndicator")
+	globaldb.RegisterTable(baseTable, "ProcessIndicator")
 }
 
 type Store interface {

--- a/central/rbac/k8srole/internal/store/postgres/index.go
+++ b/central/rbac/k8srole/internal/store/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_ROLES, walker.Walk(reflect.TypeOf((*storage.K8SRole)(nil)), "k8sroles"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_ROLES, walker.Walk(reflect.TypeOf((*storage.K8SRole)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "k8sroles"
 	countStmt  = "SELECT COUNT(*) FROM k8sroles"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM k8sroles WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("k8sroles", "K8SRole")
+	globaldb.RegisterTable(baseTable, "K8SRole")
 }
 
 type Store interface {

--- a/central/rbac/k8srolebinding/internal/store/postgres/index.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_ROLEBINDINGS, walker.Walk(reflect.TypeOf((*storage.K8SRoleBinding)(nil)), "rolebindings"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_ROLEBINDINGS, walker.Walk(reflect.TypeOf((*storage.K8SRoleBinding)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "rolebindings"
 	countStmt  = "SELECT COUNT(*) FROM rolebindings"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM rolebindings WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("rolebindings", "K8SRoleBinding")
+	globaldb.RegisterTable(baseTable, "K8SRoleBinding")
 }
 
 type Store interface {

--- a/central/reportconfigurations/store/postgres/index.go
+++ b/central/reportconfigurations/store/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_REPORT_CONFIGURATIONS, walker.Walk(reflect.TypeOf((*storage.ReportConfiguration)(nil)), "reportconfigs"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_REPORT_CONFIGURATIONS, walker.Walk(reflect.TypeOf((*storage.ReportConfiguration)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "reportconfigs"
 	countStmt  = "SELECT COUNT(*) FROM reportconfigs"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM reportconfigs WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("reportconfigs", "ReportConfiguration")
+	globaldb.RegisterTable(baseTable, "ReportConfiguration")
 }
 
 type Store interface {

--- a/central/risk/datastore/internal/store/postgres/index.go
+++ b/central/risk/datastore/internal/store/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_RISKS, walker.Walk(reflect.TypeOf((*storage.Risk)(nil)), "risk"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_RISKS, walker.Walk(reflect.TypeOf((*storage.Risk)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "risk"
 	countStmt  = "SELECT COUNT(*) FROM risk"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM risk WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("risk", "Risk")
+	globaldb.RegisterTable(baseTable, "Risk")
 }
 
 type Store interface {

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "permissionsets"
 	countStmt  = "SELECT COUNT(*) FROM permissionsets"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM permissionsets WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("permissionsets", "PermissionSet")
+	globaldb.RegisterTable(baseTable, "PermissionSet")
 }
 
 type Store interface {

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "roles"
 	countStmt  = "SELECT COUNT(*) FROM roles"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM roles WHERE Name = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("roles", "Role")
+	globaldb.RegisterTable(baseTable, "Role")
 }
 
 type Store interface {

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "simpleaccessscopes"
 	countStmt  = "SELECT COUNT(*) FROM simpleaccessscopes"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM simpleaccessscopes WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("simpleaccessscopes", "SimpleAccessScope")
+	globaldb.RegisterTable(baseTable, "SimpleAccessScope")
 }
 
 type Store interface {

--- a/central/secret/internal/store/postgres/index.go
+++ b/central/secret/internal/store/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_SECRETS, walker.Walk(reflect.TypeOf((*storage.Secret)(nil)), "secrets"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_SECRETS, walker.Walk(reflect.TypeOf((*storage.Secret)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "secrets"
 	countStmt  = "SELECT COUNT(*) FROM secrets"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM secrets WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("secrets", "Secret")
+	globaldb.RegisterTable(baseTable, "Secret")
 }
 
 type Store interface {

--- a/central/serviceaccount/internal/store/postgres/index.go
+++ b/central/serviceaccount/internal/store/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_SERVICE_ACCOUNTS, walker.Walk(reflect.TypeOf((*storage.ServiceAccount)(nil)), "serviceaccounts"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_SERVICE_ACCOUNTS, walker.Walk(reflect.TypeOf((*storage.ServiceAccount)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "serviceaccounts"
 	countStmt  = "SELECT COUNT(*) FROM serviceaccounts"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM serviceaccounts WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("serviceaccounts", "ServiceAccount")
+	globaldb.RegisterTable(baseTable, "ServiceAccount")
 }
 
 type Store interface {

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "signatureintegrations"
 	countStmt  = "SELECT COUNT(*) FROM signatureintegrations"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM signatureintegrations WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("signatureintegrations", "SignatureIntegration")
+	globaldb.RegisterTable(baseTable, "SignatureIntegration")
 }
 
 type Store interface {

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/index.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_VULN_REQUEST, walker.Walk(reflect.TypeOf((*storage.VulnerabilityRequest)(nil)), "vulnreq"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_VULN_REQUEST, walker.Walk(reflect.TypeOf((*storage.VulnerabilityRequest)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "vulnreq"
 	countStmt  = "SELECT COUNT(*) FROM vulnreq"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM vulnreq WHERE Id = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("vulnreq", "VulnerabilityRequest")
+	globaldb.RegisterTable(baseTable, "VulnerabilityRequest")
 }
 
 type Store interface {

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "watchedimages"
 	countStmt  = "SELECT COUNT(*) FROM watchedimages"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM watchedimages WHERE Name = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("watchedimages", "WatchedImage")
+	globaldb.RegisterTable(baseTable, "WatchedImage")
 }
 
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/index.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/index.go.tpl
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.{{.SearchCategory}}, walker.Walk(reflect.TypeOf((*{{.Type}})(nil)), "{{.Table}}"))
+	mapping.RegisterCategoryToTable(v1.{{.SearchCategory}}, walker.Walk(reflect.TypeOf((*{{.Type}})(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/index.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_SEARCH_UNSET, walker.Walk(reflect.TypeOf((*storage.TestMultiKeyStruct)(nil)), "multikey"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_SEARCH_UNSET, walker.Walk(reflect.TypeOf((*storage.TestMultiKeyStruct)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "multikey"
 	countStmt  = "SELECT COUNT(*) FROM multikey"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM multikey WHERE Key1 = $1 AND Key2 = $2)"
 
@@ -26,7 +27,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("multikey", "TestMultiKeyStruct")
+	globaldb.RegisterTable(baseTable, "TestMultiKeyStruct")
 }
 
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -31,6 +31,7 @@ import (
 )
 
 const (
+        baseTable = "{{.Table}}"
         countStmt = "SELECT COUNT(*) FROM {{.Table}}"
         existsStmt = "SELECT EXISTS(SELECT 1 FROM {{.Table}} WHERE {{template "whereMatch" $pks}})"
 
@@ -47,7 +48,7 @@ const (
 )
 
 func init() {
-    globaldb.RegisterTable("{{.Table}}", "{{.TrimmedType}}")
+    globaldb.RegisterTable(baseTable, "{{.TrimmedType}}")
 }
 
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/index.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_SEARCH_UNSET, walker.Walk(reflect.TypeOf((*storage.TestSingleKeyStruct)(nil)), "singlekey"))
+	mapping.RegisterCategoryToTable(v1.SearchCategory_SEARCH_UNSET, walker.Walk(reflect.TypeOf((*storage.TestSingleKeyStruct)(nil)), baseTable))
 }
 
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	baseTable  = "singlekey"
 	countStmt  = "SELECT COUNT(*) FROM singlekey"
 	existsStmt = "SELECT EXISTS(SELECT 1 FROM singlekey WHERE Key = $1)"
 
@@ -30,7 +31,7 @@ const (
 )
 
 func init() {
-	globaldb.RegisterTable("singlekey", "TestSingleKeyStruct")
+	globaldb.RegisterTable(baseTable, "TestSingleKeyStruct")
 }
 
 type Store interface {


### PR DESCRIPTION
## Description

Inline `table` as it's used only in one place and shadowed in create table function.
Remove `log` as it's never used.

## Testing Performed

CI