### PR TITLE
Fix integration tests which create tag for change in PatternFly 2022.03

### DIFF
--- a/ui/apps/platform/cypress/integration/configmanagement/tags.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/tags.test.js
@@ -26,7 +26,7 @@ describe('Config Management Violation Tags', () => {
         cy.wait(['@getTags', '@tagsAutocomplete']);
 
         const tag = randomstring.generate(7);
-        cy.get(selectors.sidePanel1.violationTags.input).type(`${tag}{enter}`);
+        cy.get(selectors.sidePanel1.violationTags.input).type(`${tag}{enter}{downArrow}{enter}`);
         cy.wait(['@getTags', '@tagsAutocomplete']);
         cy.get(`${selectors.sidePanel1.violationTags.values}:contains("${tag}")`).should('exist');
     });

--- a/ui/apps/platform/cypress/integration/risk/processtags.test.js
+++ b/ui/apps/platform/cypress/integration/risk/processtags.test.js
@@ -33,7 +33,7 @@ function addTagToTheFirstProcessInDeployment(deploymentName, tag) {
     openDeployment(deploymentName);
     unfoldFirstProcessCard();
 
-    cy.get(selectors.sidePanel.firstProcessCard.tags.input).type(`${tag}{enter}`);
+    cy.get(selectors.sidePanel.firstProcessCard.tags.input).type(`${tag}{enter}{downArrow}{enter}`);
     cy.wait(['@getTags', '@tagsAutocomplete']);
 }
 
@@ -54,7 +54,9 @@ describe(
             const tag = randomstring.generate(7);
             addTagToTheFirstProcessInDeployment('central', tag);
             // do it again to check that no duplicate tags can be added
-            cy.get(selectors.sidePanel.firstProcessCard.tags.input).type(`${tag}{enter}`);
+            cy.get(selectors.sidePanel.firstProcessCard.tags.input).type(
+                `${tag}{enter}{downArrow}{enter}`
+            );
 
             // pressing {enter} won't save the tag, only one would be displayed as tag chip
             cy.get(selectors.sidePanel.firstProcessCard.tags.values)

--- a/ui/apps/platform/cypress/integration/vulnmanagement/tags.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/tags.test.js
@@ -28,7 +28,7 @@ describe('Vuln Management Violation Tags', () => {
         cy.wait(['@getTags', '@tagsAutocomplete']);
 
         const tag = randomstring.generate(7);
-        cy.get(selectors.sidePanel1.violationTags.input).type(`${tag}{enter}`);
+        cy.get(selectors.sidePanel1.violationTags.input).type(`${tag}{enter}{downArrow}{enter}`);
         cy.wait(['@getTags', '@tagsAutocomplete']);
         cy.get(`${selectors.sidePanel1.violationTags.values}:contains("${tag}")`).should('exist');
     });


### PR DESCRIPTION
## Description

ROX-9724

https://app.circleci.com/pipelines/github/stackrox/stackrox/6970/workflows/c40440d5-3952-422b-b58b-60bea217fb84/jobs/306805

CypressError: Timed out retrying after 5000ms: `cy.wait()` timed out waiting `5000ms` for the 2nd request to the route: `getTags`. No request ever occurred.

* Config Management Violation Tags should add and save tag
* Risk Page Process Tags should add tag without allowing duplicates
* Risk Page Process Tags should search by a process tag
* Risk Page Process Tags should remove tag
* Vuln Management Violation Tags should add and save tag

Verified change in behavior from PatternFly 2022.02 to 2022.03 #927 although gk-ui-e2e-tests passed for branch they started failing on master here [Update: Gavin noticed that testing workflow got stuck and was still running 3 days later: I failed to notice that number passing was 40 instead of 50-something]

Instead of adding tag, enter key leaves drop-down menu open, therefore no second request

https://github.com/patternfly/patternfly-react/pull/6966

> the `enter` selection behavior is now prevented for typeahead until the arrow keys are used to move to an option.
<img width="419" alt="create-tag" src="https://user-images.githubusercontent.com/11862657/158839617-a6120503-4780-4232-9f12-0e8b72c0f176.png">

Therefore, replace `{enter}` with `{enter}{downArrow}{enter}` in the tests

Residue:
* Create whatever is not visibly selected on enter and down arrow before second enter
* Investigate existing behavior reported by Michaël that entering a tag the second time seems to delete the first occurrence.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Fixed integration tests

## Testing Performed

1. `yarn cypress-open` in ui/apps/platform and then see tests fail before and pass after the change
    * configmanagement/tags.test.js
    * risk/processtags.test.js
    * vulnmanagement/tags.test.js