### PR TITLE
ROX-9512: Add documentation link about `REACT_ENV_` convention

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2578,9 +2578,8 @@ jobs:
       EKS_AUTOMATION_VERSION: 0.2.17
       # All CI builds go out with commercial product branding.
       # TODO(ROX-9513): a separate CI setup is required for open source/community builds.
-      # Note that the `REACT_APP` prefix is a convention used by
-      # React tooling that is required to inject this env variable into
-      # the build.
+      # Note that the `REACT_APP` prefix is a convention used by React tooling that is required to inject this env
+      # variable into the build. See https://create-react-app.dev/docs/adding-custom-environment-variables/
       REACT_APP_ROX_PRODUCT_BRANDING: RHACS_BRANDING
     steps:
       - checkout


### PR DESCRIPTION
## Description

The last bit that would allow me resolve [ROX-9512](https://issues.redhat.com/browse/ROX-9512).

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

Most of the above doesn't apply due to documentation nature of change.

## Testing Performed

* CI should be green enough.
