### PR TITLE
[DO NOT MERGE] Re-enable OpenShift internal image scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - This change is *not* backwards compatible; if an existing Custom Resource sets the value to > 25 seconds, then it will fail validation in case operator is downgraded. This change is accepted because the operator is still in v1alpha1 and subject to change.
 - The admission webhook timeout is now set to the admission controller timeout plus 2 seconds.
 
+## [69.1]
+
+- A version of Scanner and ScannerDB will be installed in each OpenShift cluster to support images stored in the OpenShift Internal Image Registry.
+  - The images are "slimmed" down versions of Scanner and ScannerDB
+    - scanner-slim and scanner-db-slim
+  - They require the same resources as the normal Scanner and ScannerDB.
+
 ## [69.0]
 
 - `collector` image with `-slim` in the image tag is no longer published (`collector-slim` with suffix in the image name will continue to be published).

--- a/operator/deployment.yaml
+++ b/operator/deployment.yaml
@@ -1,0 +1,118 @@
+#apiVersion: apps/v1
+#kind: Deployment
+#metadata:
+#  name: nginx-deployment
+#  namespace: qa
+#  labels:
+#    app: nginx
+#spec:
+#  replicas: 1
+#  selector:
+#    matchLabels:
+#      app: nginx
+#  template:
+#    metadata:
+#      labels:
+#        app: nginx
+#    spec:
+#      containers:
+#      - name: nginx
+#        image: image-registry.openshift-image-registry.svc:5000/qa/nginx:1.18.0
+#        ports:
+#        - containerPort: 80
+#---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jenkins-deployment
+  namespace: qa1
+  labels:
+    app: jenkins
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jenkins
+  template:
+    metadata:
+      labels:
+        app: jenkins
+    spec:
+      containers:
+      - name: jenkins
+        image: image-registry.openshift-image-registry.svc:5000/qa1/sandbox:jenkins-agent-maven-35-rhel7
+        ports:
+        - containerPort: 80
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodejs-deployment
+  namespace: qa
+  labels:
+    app: nodejs
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodejs
+  template:
+    metadata:
+      labels:
+        app: nodejs
+    spec:
+      containers:
+      - name: nodejs
+        image: image-registry.openshift-image-registry.svc:5000/qa/sandbox:nodejs-10
+        ports:
+        - containerPort: 80
+---
+#
+#apiVersion: apps/v1
+#kind: Deployment
+#metadata:
+#  name: log4j-deployment
+#  namespace: qa2
+#  labels:
+#    app: log4j
+#spec:
+#  replicas: 1
+#  selector:
+#    matchLabels:
+#      app: log4j
+#  template:
+#    metadata:
+#      labels:
+#        app: log4j
+#    spec:
+#      containers:
+#      - name: log4j
+#        image: image-registry.openshift-image-registry.svc:5000/qa2/sandbox:log4j-2-12-2
+#        ports:
+#        - containerPort: 80
+#---
+#
+#apiVersion: apps/v1
+#kind: Deployment
+#metadata:
+#  name: logstash-deployment
+#  namespace: qa3
+#  labels:
+#    app: logstash
+#spec:
+#  replicas: 1
+#  selector:
+#    matchLabels:
+#      app: logstash
+#  template:
+#    metadata:
+#      labels:
+#        app: logstash
+#    spec:
+#      containers:
+#      - name: logstash
+#        image: image-registry.openshift-image-registry.svc:5000/qa3/logstash:7.13.3
+#        ports:
+#        - containerPort: 80

--- a/operator/pkg/securedcluster/values/translation/translation_test.go
+++ b/operator/pkg/securedcluster/values/translation/translation_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackrox/rox/operator/pkg/utils/testutils"
 	testingUtils "github.com/stackrox/rox/operator/pkg/values/testing"
 	"github.com/stackrox/rox/operator/pkg/values/translation"
-	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/testutils/envisolator"
 	"github.com/stretchr/testify/assert"
@@ -540,11 +539,6 @@ func (s TranslationTestSuite) TestTranslate() {
 			delete(got["meta"].(map[string]interface{}), "configFingerprintOverride")
 			if len(got["meta"].(map[string]interface{})) == 0 {
 				delete(got, "meta")
-			}
-
-			// TODO(ROX-8466): Remove if feature flag gets enabled
-			if buildinfo.ReleaseBuild {
-				delete(wantAsValues, "scanner")
 			}
 
 			assert.Equal(t, wantAsValues, got)

--- a/operator/scanner-crd.yaml
+++ b/operator/scanner-crd.yaml
@@ -1,0 +1,10 @@
+apiVersion: platform.stackrox.io/v1alpha1
+kind: SecuredCluster
+metadata:
+  namespace: stackrox
+  name: stackrox-secured-cluster-services
+spec:
+  clusterName: secured-cluster-1
+  scanner:
+    scannerComponent: AutoSense
+  centralEndpoint: central-stackrox.apps.rt-03-15-red-manufacturer-see.openshift.infra.rox.systems:443

--- a/operator/set-pull-secret.sh
+++ b/operator/set-pull-secret.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+registry="docker.io"
+user=$(echo $REGISTRY_USERNAME)
+password=$(echo $REGISTRY_PASSWORD)
+
+oc get secret/pull-secret -n openshift-config --template='{{index .data ".dockerconfigjson" | base64decode}}' >/tmp/pull_secret
+
+oc registry login --registry="$registry" --auth-basic="$user:$password" --to=/tmp/pull_secret
+
+oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=/tmp/pull_secret

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -37,7 +37,7 @@ var (
 	VulnReporting = registerFeature("Enable creation of scheduled vulnerability reports to be sent via email notifier", "ROX_VULN_REPORTING", true)
 
 	// LocalImageScanning enables OpenShift local-image scanning.
-	LocalImageScanning = registerFeature("Enable OpenShift local-image scanning", "ROX_LOCAL_IMAGE_SCANNING", false)
+	LocalImageScanning = registerFeature("Enable OpenShift local-image scanning", "ROX_LOCAL_IMAGE_SCANNING", true)
 
 	// ImageSignatureVerification enables image signature verification.
 	ImageSignatureVerification = registerFeature("Enable Image Signature Verification workflow", "ROX_VERIFY_IMAGE_SIGNATURE", false)


### PR DESCRIPTION
## Description

After 3.69.0 was cut, we are ready to enable this feature flag.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required
- ~[ ] Determined and documented upgrade steps~
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

CI
