### PR TITLE
Delete obsolete watchSaveRequest and watchTestRequest in integrationSagas

### DIFF
--- a/ui/apps/platform/src/sagas/integrationSagas.js
+++ b/ui/apps/platform/src/sagas/integrationSagas.js
@@ -106,7 +106,6 @@ function* watchFetchRequest() {
 }
 
 function* deleteIntegrations({ source, sourceType, ids }) {
-    console.log('deleteIntegrations'); // eslint-disable-line no-console
     try {
         if (source === 'authProviders') {
             yield call(AuthService.deleteAuthProviders, ids);


### PR DESCRIPTION
## Description

Left over after work on integrations

Redux actions superseded by requests:
* Save: https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationActions.ts#L41-L66
* Test: https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationActions.ts#L68-L79

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### integration testing

1. `yarn cypress-open` in ui
    * integrations/apiTokens.test.js
    * integrations/clusterInitBundles.test.js
    * integrations/externalBackups.test.js
    * integrations/general.test.js
    * integrations/imageIntegrations.test.js
    * integrations/notifiers.test.js
    * integrations/signatureIntegrations.test.js

### manual testing

Add temporary `console.log` in integrationSagas

* `deleteIntegrations` expected to see
* `saveIntegration` expected not to see
* `testIntegration` expected not to see

Do the following:

1. /main/integrations/imageIntegrations/docker and then delete existing integration

2. /main/integrations/imageIntegrations/docker/id and then edit and test

3. /main/integrations/notifiers/email and then create and save
