### PR TITLE
Catch failure on rpm download failure

### DIFF
--- a/image/postgres/create-bundle.sh
+++ b/image/postgres/create-bundle.sh
@@ -2,7 +2,6 @@
 # Creates a tgz bundle of all binary artifacts needed for scanner-db-rhel
 
 set -euo pipefail
-set -x
 
 die() {
     echo >&2 "$@"
@@ -52,13 +51,13 @@ cp -p "${INPUT_ROOT}"/*.conf "${bundle_root}/etc/"
 
 # Get postgres RPMs directly
 postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_version}-x86_64"
-curl -s -o "${bundle_root}/postgres.rpm" \
+curl -sS --fail -o "${bundle_root}/postgres.rpm" \
     "${postgres_url}/postgresql${postgres_major}-${postgres_minor}.rpm"
-curl -s -o "${bundle_root}/postgres-server.rpm" \
+curl -sS --fail -o "${bundle_root}/postgres-server.rpm" \
     "${postgres_url}/postgresql${postgres_major}-server-${postgres_minor}.rpm"
-curl -s -o "${bundle_root}/postgres-libs.rpm" \
+curl -sS --fail -o "${bundle_root}/postgres-libs.rpm" \
     "${postgres_url}/postgresql${postgres_major}-libs-${postgres_minor}.rpm"
-curl -s -o "${bundle_root}/postgres-contrib.rpm" \
+curl -sS --fail -o "${bundle_root}/postgres-contrib.rpm" \
     "${postgres_url}/postgresql${postgres_major}-contrib-${postgres_minor}.rpm"
 
 # =============================================================================
@@ -67,7 +66,7 @@ curl -s -o "${bundle_root}/postgres-contrib.rpm" \
 if tar --version | grep -q "gnu" ; then
   tar_chown_args=("--owner=root:0" "--group=root:0")
 else
-  tar_chown_args=("--uid=root:0" "--gid=root:0")
+  tar_chown_args=("--uid=0" "--uname=root" "--gid=0" "--gname=root")
 fi
 
 # Create output bundle of all files in $bundle_root


### PR DESCRIPTION
## Description

Fix two issues:
1. Add --fail flag on curl download rpm image, without this flag, the curl return 0 if the file is not found.
2. Change tar flags, bsdtar checks the uid and gid to be integer in latest version.
Check https://github.com/libarchive/libarchive/issues/1068 for details.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs]~(https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
CI and make image
TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
