### PR TITLE
Fix GraphQLResourcePaginationTest

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-00-serviceaccount.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-00-serviceaccount.yaml
@@ -15,6 +15,7 @@ imagePullSecrets:
 {{- range $secretName := ._rox.imagePullSecrets._names }}
 - name: {{ quote $secretName }}
 {{- end }}
+{{ if ._rox.central.enableCentralDB -}}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -30,4 +31,5 @@ metadata:
 imagePullSecrets:
 {{- range $secretName := ._rox.imagePullSecrets._names }}
 - name: {{ quote $secretName }}
+{{- end }}
 {{- end }}

--- a/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
@@ -30,6 +30,8 @@ class GraphQLResourcePaginationTest extends BaseSpecification {
         def objs = resultRet.getValue()["${topResource}s"]
         assert objs.size() != 0
 
+        println "Got top level objects: ${objs}"
+
         def sublistGraphQLQuery = "query get${topResource}_${subResource}(" +
                 "\$id: ID!, \$query: String, \$pagination: Pagination) {" +
                 "${topResource}(id:\$id) { ${subResource}(query: \$query, pagination: \$pagination) { id } } }"
@@ -64,7 +66,7 @@ class GraphQLResourcePaginationTest extends BaseSpecification {
         "k8sRole"    | "Role:system:node-bootstrapper" | null | "subjects"
         "k8sRole"    | "Namespace:stackrox+Role:edit"  | null | "serviceAccounts"
 
-        "serviceAccount" | "Service Account:central" | null |  "k8sRoles"
+        "serviceAccount" | "Service Account:\"central\"" | null |  "k8sRoles"
     }
 
     @Unroll


### PR DESCRIPTION
## Description

There are two problems here:
1. We do a prefix match for "Service Account" with prefix "central" with limit "1", so we will effectively pull up a random one if there are multiple matching service accounts. Some of the service accounts may not have corresponding k8s roles, so if we end up getting one of those, the rest of the test fails. I fixed this by using an exact match.
2. The reason this problem was introduced in the first place was that I was created the `central-db` service account unconditionally, so make that conditional on `enableCentralDB`.

## Checklist
- [x] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- [X] Evaluated and added CHANGELOG entry if required
- [X] Determined and documented upgrade steps
- [X] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI