### PR TITLE
Update yup 1.0.0-beta.3 dependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -93,7 +93,7 @@
         "typeface-open-sans": "^1.1.13",
         "typeface-open-sans-condensed": "^1.1.13",
         "use-deep-compare-effect": "^1.8.1",
-        "yup": "^1.0.0-beta.2"
+        "yup": "^1.0.0-beta.3"
     },
     "resolutions": {
         "react-cytoscapejs/cytoscape": "^3.17.0"

--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -44,8 +44,7 @@
         "initials": "^3.1.1",
         "lodash": "^4.17.21",
         "react-feather": "^2.0.9",
-        "tippy.js": "^6.3.7",
-        "yup": "^1.0.0-beta.2"
+        "tippy.js": "^6.3.7"
     },
     "devDependencies": {
         "@babel/core": "7.12.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -20339,10 +20339,10 @@ yauzl@^2.10.0:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-yup@^1.0.0-beta.2:
-  version "1.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/yup/-/yup-1.0.0-beta.2.tgz#6c0529b77c4a815b1920f3cee6b5f3f56c99afc3"
-  integrity sha512-ngq3WQG5X09dKsCFV9vdikbJn2siJVtz26CIrW3VT8h42whobkOvYb1xcHULsmMJ23cfoc5h0z1erlfqIJdEng==
+yup@^1.0.0-beta.3:
+  version "1.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.0.0-beta.3.tgz#ff9a086a7b4b3f839347d9c33f7ff2101c8bb846"
+  integrity sha512-rM0UOCv1W1vy5lOhIdUJSX0vqRrSlqBEzni5Dp2+apNEBq5rbTC4M/sc/LlAkm5oGWqf1pGkCq6IUFhuCJt7Gg==
   dependencies:
     property-expr "^2.0.4"
     tiny-case "^1.0.2"


### PR DESCRIPTION
## Description

Keep up with yup beta to make sure no regressions because policies validation depends on beta improvements.

https://github.com/jquense/yup/releases/tag/v1.0.0-beta.3

This release fixes a bug with `object().partial` where `required()` schema were still failing validation. Now they will no longer do that. To enable this fix we made a breaking change to the way that `required` is implemented.

* `schema.required` no longer adds a test named 'required', this state can be determined via the schema `spec` or `describe()` metadata
* String schema now override `required` directly to add their length check (this test is called `required` for some ease of back compat)

See https://github.com/jquense/yup/issues/1598

Deleted yup from dependencies of ui-components because only use was ui/packages/ui-components/src/FormTextInput/FormTextInput.stories.tsx
* added in https://github.com/stackrox/rox/pull/6476
* deleted in https://github.com/stackrox/rox/pull/9692

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

Create a new policy and then edit the policy to see that **Next** button is disabled or enabled when expected

### Integration testing

1. `yarn cypress-open` in ui/apps/platfo    * integrations/apiTokens.test.js
    * integrations/clusterInitBundles.test.js
    * integrations/externalBackups.test.js
    * integrations/general.test.js
    * integrations/imageIntegrations.test.js
    * integrations/notifiers.test.js
    * integrations/signatureIntegrations.test.js
    * policies/PatternFly/policyWizardStep3.test.js
