### PR TITLE
Intellij IDEA Javascript/Typescript style settings: prefer absolute paths in import statements

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -6,6 +6,9 @@
     <JSCodeStyleSettings version="0">
       <option name="IMPORT_PREFER_ABSOLUTE_PATH" value="TRUE" />
     </JSCodeStyleSettings>
+    <TypeScriptCodeStyleSettings version="0">
+      <option name="IMPORT_PREFER_ABSOLUTE_PATH" value="TRUE" />
+    </TypeScriptCodeStyleSettings>
     <yaml>
       <option name="INDENT_SEQUENCE_VALUE" value="false" />
     </yaml>


### PR DESCRIPTION
## Description

#### Why
As a backend engineer, I mainly use two IDEs when working on RHACS: Goland and Intellij IDEA. Sometimes I work on the UI from the same IDEs.

As discussed [here](https://github.com/stackrox/stackrox/pull/989#discussion_r831486191), we prefer absolute paths in imports over relative paths in JS/TS files. Change in this PR allows to automatically import with absolute paths in Intellij IDEA, Goland and other Jetbrains products.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Deleted "relative-path" import and auto-imported it as "absolute-path" import
