### PR TITLE
Reduce log output by signature fetcher.

### DIFF
--- a/pkg/signatures/public_key_fetcher.go
+++ b/pkg/signatures/public_key_fetcher.go
@@ -46,7 +46,7 @@ func (c *cosignPublicKeySignatureFetcher) FetchSignatures(ctx context.Context, i
 	imgFullName := image.GetName().GetFullName()
 	imgRef, err := name.ParseReference(imgFullName)
 	if err != nil {
-		log.Errorf("Parsing image reference %q: %v", imgFullName, err)
+		log.Debugf("Parsing image reference %q: %v", imgFullName, err)
 		return nil, err
 	}
 
@@ -60,7 +60,7 @@ func (c *cosignPublicKeySignatureFetcher) FetchSignatures(ctx context.Context, i
 	// Cosign ref:
 	//  https://github.com/sigstore/cosign/blob/44f3814667ba6a398aef62814cabc82aee4896e5/pkg/cosign/fetch.go#L84-L86
 	if err != nil && !strings.Contains(err.Error(), "no signatures associated") {
-		log.Errorf("Fetching signature for image %q: %v", imgFullName, err)
+		log.Debugf("Fetching signature for image %q: %v", imgFullName, err)
 		return nil, makeTransientErrorRetryable(err)
 	}
 
@@ -75,7 +75,7 @@ func (c *cosignPublicKeySignatureFetcher) FetchSignatures(ctx context.Context, i
 		rawSig, err := base64.StdEncoding.DecodeString(signedPayload.Base64Signature)
 		// We skip the invalid base64 signature and log its occurrence.
 		if err != nil {
-			log.Errorf("Error during decoding of raw signature for image %q: %v",
+			log.Debugf("Error during decoding of raw signature for image %q: %v",
 				imgFullName, err)
 			continue
 		}


### PR DESCRIPTION
## Description

Within the log outputs of central, there are multiple occurrences of errors during fetching:
```
pkg/signatures: 2022/03/22 01:51:33.059390 public_key_fetcher.go:63: Error: Fetching signature for image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:931a443b203d4b7750a9531124f06f4663604efa99115dfc7d9e72b5024146fb": GET https://quay.io/v2/openshift-release-dev/ocp-v4.0-art-dev/manifests/sha256:931a443b203d4b7750a9531124f06f4663604efa99115dfc7d9e72b5024146fb: UNAUTHORIZED: access to the requested resource is not authorized; map[]
pkg/signatures: 2022/03/22 01:51:33.397990 public_key_fetcher.go:63: Error: Fetching signature for image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d99597158ef4baf204e0fe7ed24c1dbc7b0218305077cdaf22c3899a1b3988c7": GET https://quay.io/v2/openshift-release-dev/ocp-v4.0-art-dev/manifests/sha256:d99597158ef4baf204e0fe7ed24c1dbc7b0218305077cdaf22c3899a1b3988c7: UNAUTHORIZED: access to the requested resource is not authorized; map[]
pkg/signatures: 2022/03/22 01:51:33.781978 public_key_fetcher.go:63: Error: Fetching signature for image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:02dd1fceb278d939a1bf7b5981cec092d6d243c90051333d219cfa6f2cb9b882": GET https://quay.io/v2/openshift-release-dev/ocp-v4.0-art-dev/manifests/sha256:02dd1fceb278d939a1bf7b5981cec092d6d243c90051333d219cfa6f2cb9b882: UNAUTHORIZED: access to the requested resource is not authorized; map[]
pkg/signatures: 2022/03/22 01:51:33.838477 public_key_fetcher.go:63: Error: Fetching signature for image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7fade1f30345baa47b6d8a36fc312e3eee13bf7b63c8451f65f0088dcf26d544": GET https://quay.io/v2/openshift-release-dev/ocp-v4.0-art-dev/manifests/sha256:7fade1f30345baa47b6d8a36fc312e3eee13bf7b63c8451f65f0088dcf26d544: UNAUTHORIZED: access to the requested resource is not authorized; map[]
pkg/signatures: 2022/03/22 01:51:33.915875 public_key_fetcher.go:63: Error: Fetching signature for image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b6c1e2606e852ae6fe03a0f6b870ecef57801d03de2d6ef37ab97edee6c6ce67": GET https://quay.io/v2/openshift-release-dev/ocp-v4.0-art-dev/manifests/sha256:b6c1e2606e852ae6fe03a0f6b870ecef57801d03de2d6ef37ab97edee6c6ce67: UNAUTHORIZED: access to the requested resource is not authorized; map[]
pkg/signatures: 2022/03/22 01:51:34.045832 public_key_fetcher.go:63: Error: Fetching signature for image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ea101f1470d4909604d53dec662e2425a71b1662223a11421847f0b21385886a": GET https://quay.io/v2/openshift-release-dev/ocp-v4.0-art-dev/manifests/sha256:ea101f1470d4909604d53dec662e2425a71b1662223a11421847f0b21385886a: UNAUTHORIZED: access to the requested resource is not authorized; map[]
pkg/signatures: 2022/03/22 01:51:34.069133 public_key_fetcher.go:63: Error: Fetching signature for image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:430c0d69337d34f79ff98a5899b53decace913ab3358556cfa739eb034a2cf80": GET https://quay.io/v2/openshift-release-dev/ocp-v4.0-art-dev/manifests/sha256:430c0d69337d34f79ff98a5899b53decace913ab3358556cfa739eb034a2cf80: UNAUTHORIZED: access to the requested resource is not authorized; map[]
pkg/signatures: 2022/03/22 01:51:34.664680 public_key_fetcher.go:63: Error: Fetching signature for image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e798d9d91007a9e49a516a48aa219b128f44052e0e36a36459a22be302f03863": GET https://quay.io/v2/openshift-release-dev/ocp-v4.0-art-dev/manifests/sha256:e798d9d91007a9e49a516a48aa219b128f44052e0e36a36459a22be302f03863: UNAUTHORIZED: access to the requested resource is not authorized; map[]
pkg/signatures: 2022/03/22 01:51:34.769306 public_key_fetcher.go:63: Error: Fetching signature for image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b9657c21b96abde9f506d858db45385ff8df2d345d6986fe71963a38a62c7ed6": GET https://quay.io/v2/openshift-release-dev/ocp-v4.0-art-dev/manifests/sha256:b9657c21b96abde9f506d858db45385ff8df2d345d6986fe71963a38a62c7ed6: UNAUTHORIZED: access to the requested resource is not authorized; map[]
pkg/signatures: 2022/03/22 01:51:34.827771 public_key_fetcher.go:63: Error: Fetching signature for image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7705cc832816c3157194e182f1ec505f1b8dd32803773109c72321a4edd91e84": GET https://quay.io/v2/openshift-release-dev/ocp-v4.0-art-dev/manifests/sha256:7705cc832816c3157194e182f1ec505f1b8dd32803773109c72321a4edd91e84: UNAUTHORIZED: access to the requested resource is not authorized; map[]
pkg/signatures: 2022/03/22 01:51:35.017081 public_key_fetcher.go:63: Error: Fetching signature for image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1e34a1eb508472bc69cb4bf07cd2b77b4fb3c74043b56920a8cfeeec7cc1d912": GET https://quay.io/v2/openshift-release-dev/ocp-v4.0-art-dev/manifests/sha256:1e34a1eb508472bc69cb4bf07cd2b77b4fb3c74043b56920a8cfeeec7cc1d912: UNAUTHORIZED: access to the requested resource is not authorized; map[]
```

It's best to move those logs to debug logs, to have the possibility to still inspect issues if they occur, but refrain from logging per default, as this adds significant amount of log entries.

