### PR TITLE
ROX-9788: Set ROX_ENABLE_LOCAL_IMAGE_SCANNING var

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -72,6 +72,8 @@ sensor:
   exposeMonitoring: null # bool
   nodeSelector: null # string | dict
   tolerations: null # [dict]
+  localImageScanning:
+    enabled: null # bool
 admissionControl:
   listenOnCreates: null # bool
   listenOnUpdates: null # bool

--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -73,6 +73,9 @@ sensor:
   nodeSelector: null # string | dict
   tolerations: null # [dict]
   localImageScanning:
+    # Enables the local image scanning feature in Sensor. This disabled if local image scanning should not be used to prevent
+    # sensor reaching out to a scanner instance.
+    # This setting does not relate to the scanner deployment configuration which configures whether scanner should be deployed.
     enabled: null # bool
 admissionControl:
   listenOnCreates: null # bool

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -29,6 +29,8 @@ imagePullSecrets:
 
 sensor:
   endpoint: "sensor.{{ required "unknown namespace" ._rox._namespace }}.svc:443"
+  localImageScanning:
+    enabled: false
 
 admissionControl:
   listenOnCreates: false

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -260,7 +260,9 @@
   {{ $centralDeployment := dict }}
   {{ include "srox.safeLookup" (list $ $centralDeployment "apps/v1" "Deployment" $.Release.Namespace "central") }}
   {{ if $centralDeployment.result }}
-    {{ include "srox.fail" "Scanner is not supported to be deployed using this chart within a namespace running Central, must instead be deployed using the Central chart. To fix this error set scanner.disable=true and re-deploy." }}
+    {{ include "srox.note" (list $ "Detected central running in the same namespace. Not deploying scanner from this chart and configuring sensor to use existing scanner instance, if any.") }}
+    {{ $_ := set $._rox.sensor.localImageScanning "enabled" "true" }}
+    {{ $_ := set $._rox.scanner "disable" true }}
   {{ end }}
 {{ end }}
 
@@ -269,8 +271,9 @@
     {{ include "srox.fail" (print "Only scanner slim mode is allowed in Secured Cluster. To solve this, set to slim mode: scanner.mode=slim.") }}
   {{ end }}
 
-  {{ $_ = set $._rox.scanner "slimImage" ._rox.image.scanner }}
-  {{ $_ = set $._rox.scanner "slimDBImage" ._rox.image.scannerDb }}
+  {{ $_ := set $._rox.sensor.localImageScanning "enabled" "true" }}
+  {{ $_ := set $._rox.scanner "slimImage" ._rox.image.scanner }}
+  {{ $_ := set $._rox.scanner "slimDBImage" ._rox.image.scannerDb }}
   {{ include "srox.scannerInit" (list $ $._rox.scanner) }}
   {{ include "srox.configureImagePullSecrets" (list $ "imagePullSecrets" $._rox.imagePullSecrets "secured-cluster-services-main" (list "stackrox" "stackrox-scanner") $.Release.Namespace) }}
 {{ end }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -120,12 +120,14 @@ spec:
         - name: ROX_OPENSHIFT_API
           value: "true"
         [<- if and (not .KubectlOutput) .FeatureFlags.ROX_LOCAL_IMAGE_SCANNING >]
-        - name: ROX_USE_LOCAL_SCANNER
-          value: "{{ not ._rox.scanner.disable | not | not }}"
+        {{- if ._rox.sensor.localImageScanning.enabled }}
         - name: ROX_SCANNER_GRPC_ENDPOINT
           value: {{ printf "scanner.%s.svc:8443" .Release.Namespace }}
+        - name: ROX_LOCAL_IMAGE_SCANNING_ENABLED
+          value: "true"
+        {{- end }}
         [<- end >]
-        {{- end}}
+        {{- end }}
         [<- if not .KubectlOutput >]
         - name: ROX_HELM_CLUSTER_CONFIG_FP
           value: {{ quote ._rox._configFP }}

--- a/operator/pkg/securedcluster/extensions/reconcile_scanner_db_password.go
+++ b/operator/pkg/securedcluster/extensions/reconcile_scanner_db_password.go
@@ -35,14 +35,15 @@ func reconcile(ctx context.Context, s *platform.SecuredCluster, client ctrlClien
 		return nil
 	}
 
-	enabled, err := scanner.AutoSenseLocalScannerSupport(ctx, client, *s)
+	config, err := scanner.AutoSenseLocalScannerConfig(ctx, client, *s)
 	if err != nil {
 		return err
 	}
 
+	// Only reconcile password if resources are deployed with the SecuredCluster.
 	securedClusterWithScanner := &securedClusterWithScannerBearer{
 		SecuredCluster: s,
-		scannerEnabled: enabled,
+		scannerEnabled: config.DeployScannerResources,
 	}
 	return commonExtensions.ReconcileScannerDBPassword(ctx, securedClusterWithScanner, client)
 }

--- a/operator/pkg/securedcluster/scanner/auto_sense.go
+++ b/operator/pkg/securedcluster/scanner/auto_sense.go
@@ -18,10 +18,10 @@ const (
 	clusterVersionDefaultName = "version"
 )
 
-// AutoSenseResult represents the configurations which can be auto-sensed
+// AutoSenseResult represents the configurations which can be auto-sensed.
 type AutoSenseResult struct {
 	// DeployScannerResources indicates that Scanner resources should be deployed by the SecuredCluster controller.
-	// inside the same namespace the existing Scanner instance should be used.
+	// Inside the same namespace the existing Scanner instance should be used.
 	DeployScannerResources bool
 	// EnableLocalImageScanning enables the local image scanning feature in Sensor. If this setting is disabled Sensor
 	// will not scan images locally.

--- a/operator/pkg/securedcluster/scanner/auto_sense_test.go
+++ b/operator/pkg/securedcluster/scanner/auto_sense_test.go
@@ -22,9 +22,10 @@ var securedCluster = platform.SecuredCluster{
 func TestAutoSenseLocalScannerSupportShouldBeEnabled(t *testing.T) {
 	client := testutils.NewFakeClientBuilder(t, testutils.ValidClusterVersion).Build()
 
-	enabled, err := AutoSenseLocalScannerSupport(context.Background(), client, securedCluster)
+	config, err := AutoSenseLocalScannerConfig(context.Background(), client, securedCluster)
 	require.NoError(t, err)
-	assert.True(t, enabled, "Expected Scanner to be enabled for OpenShift cluster if Central is not present")
+	assert.True(t, config.EnableLocalImageScanning)
+	assert.True(t, config.DeployScannerResources)
 }
 
 func TestAutoSenseIsDisabledWithCentralPresentShouldBeDisabled(t *testing.T) {
@@ -36,9 +37,10 @@ func TestAutoSenseIsDisabledWithCentralPresentShouldBeDisabled(t *testing.T) {
 		Spec: platform.CentralSpec{},
 	}).Build()
 
-	enabled, err := AutoSenseLocalScannerSupport(context.Background(), client, securedCluster)
+	config, err := AutoSenseLocalScannerConfig(context.Background(), client, securedCluster)
 	require.NoError(t, err)
-	require.False(t, enabled, "Expected Scanner to be disabled if Central is present")
+	assert.False(t, config.DeployScannerResources, "Expected Scanner resource deployment to be disabled if Central is present")
+	assert.True(t, config.EnableLocalImageScanning, "Expected Local Image Scanning feature to be enabled.")
 }
 
 func TestAutoSenseIsEnabledWithCentralInADifferentNamespace(t *testing.T) {
@@ -50,9 +52,10 @@ func TestAutoSenseIsEnabledWithCentralInADifferentNamespace(t *testing.T) {
 		Spec: platform.CentralSpec{},
 	}).Build()
 
-	enabled, err := AutoSenseLocalScannerSupport(context.Background(), client, securedCluster)
+	config, err := AutoSenseLocalScannerConfig(context.Background(), client, securedCluster)
 	require.NoError(t, err)
-	require.True(t, enabled, "Expected Scanner to be enabled if Central is deployed in a different namespace")
+	require.True(t, config.DeployScannerResources)
+	require.True(t, config.EnableLocalImageScanning)
 }
 
 func TestAutoSenseIsDisabledIfClusterVersionNotFound(t *testing.T) {
@@ -66,15 +69,15 @@ func TestAutoSenseIsDisabledIfClusterVersionNotFound(t *testing.T) {
 		},
 	}).Build()
 
-	enabled, err := AutoSenseLocalScannerSupport(context.Background(), client, securedCluster)
+	config, err := AutoSenseLocalScannerConfig(context.Background(), client, securedCluster)
 	require.Error(t, err)
-	require.False(t, enabled, "Expected an error if clusterversions.config.openshift.io %q not found", clusterVersionDefaultName)
+	require.False(t, config.EnableLocalImageScanning, "Expected an error if clusterversions.config.openshift.io %q not found", clusterVersionDefaultName)
 }
 
 func TestAutoSenseIsDisabledIfClusterVersionKindNotFound(t *testing.T) {
 	client := testutils.NewFakeClientBuilder(t).Build()
 
-	enabled, err := AutoSenseLocalScannerSupport(context.Background(), client, securedCluster)
+	config, err := AutoSenseLocalScannerConfig(context.Background(), client, securedCluster)
 	require.Error(t, err)
-	require.False(t, enabled, "Expected an error if clusterversions.config.openshift.io kind not found")
+	require.False(t, config.EnableLocalImageScanning, "Expected an error if clusterversions.config.openshift.io kind not found")
 }

--- a/operator/pkg/securedcluster/values/translation/translation_test.go
+++ b/operator/pkg/securedcluster/values/translation/translation_test.go
@@ -143,6 +143,11 @@ func (s TranslationTestSuite) TestTranslate() {
 				"scanner": map[string]interface{}{
 					"disable": false,
 				},
+				"sensor": map[string]interface{}{
+					"localImageScanning": map[string]string{
+						"enabled": "true",
+					},
+				},
 			},
 		},
 		"local scanner autosense suppression": {
@@ -152,6 +157,9 @@ func (s TranslationTestSuite) TestTranslate() {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "stackrox"},
 					Spec: platform.SecuredClusterSpec{
 						ClusterName: "test-cluster",
+						Scanner: &platform.LocalScannerComponentSpec{
+							ScannerComponent: platform.LocalScannerComponentDisabled.Pointer(),
+						},
 					},
 				},
 			},
@@ -196,6 +204,11 @@ func (s TranslationTestSuite) TestTranslate() {
 				},
 				"scanner": map[string]interface{}{
 					"disable": false,
+				},
+				"sensor": map[string]interface{}{
+					"localImageScanning": map[string]string{
+						"enabled": "true",
+					},
 				},
 			},
 		},
@@ -387,6 +400,9 @@ func (s TranslationTestSuite) TestTranslate() {
 							"operator": "Exists",
 						},
 					},
+					"localImageScanning": map[string]string{
+						"enabled": "true",
+					},
 				},
 				"admissionControl": map[string]interface{}{
 					"dynamic": map[string]interface{}{
@@ -539,6 +555,10 @@ func (s TranslationTestSuite) TestTranslate() {
 			delete(got["meta"].(map[string]interface{}), "configFingerprintOverride")
 			if len(got["meta"].(map[string]interface{})) == 0 {
 				delete(got, "meta")
+			}
+
+			if !features.LocalImageScanning.Enabled() {
+				delete(wantAsValues, "scanner")
 			}
 
 			assert.Equal(t, wantAsValues, got)

--- a/operator/pkg/values/translation/values_builder_test.go
+++ b/operator/pkg/values/translation/values_builder_test.go
@@ -276,6 +276,33 @@ func TestEmptyKey(t *testing.T) {
 	assertBuildError(t, &v, "attempt to set empty key")
 }
 
+func TestSetData(t *testing.T) {
+	v := NewValuesBuilder()
+	v.SetPathValue("root.child.another child", "test value")
+	require.Empty(t, v.errors)
+
+	assert.Equal(t, map[string]interface{}{
+		"root": map[string]interface{}{
+			"child": map[string]interface{}{
+				"another child": "test value",
+			},
+		},
+	}, v.data)
+}
+
+func TestSetDataDontOverwrite(t *testing.T) {
+	v := NewValuesBuilder()
+	v.SetPathValue("root.child", "already existent")
+	require.NoError(t, v.errors.Unwrap())
+	v.SetPathValue("root.child.grandchild", "fails to be written")
+	require.Error(t, v.errors)
+	assert.Equal(t, map[string]interface{}{
+		"root": map[string]interface{}{
+			"child": "already existent",
+		},
+	}, v.data)
+}
+
 func build(t *testing.T, b *ValuesBuilder) map[string]interface{} {
 	val, err := b.Build()
 	require.NoError(t, err)

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -16,6 +16,6 @@ var (
 	// This is typically used for Sensor to communicate with a local Scanner-slim's gRPC server.
 	ScannerGRPCEndpoint = RegisterSetting("ROX_SCANNER_GRPC_ENDPOINT", WithDefault("scanner.stackrox.svc:8443"))
 
-	// UseLocalScanner is used to specify if Sensor should attempt to scan images via a local Scanner.
-	UseLocalScanner = RegisterBooleanSetting("ROX_USE_LOCAL_SCANNER", false)
+	// LocalImageScanningEnabled is used to specify if Sensor should attempt to scan images via a local Scanner.
+	LocalImageScanningEnabled = RegisterBooleanSetting("ROX_LOCAL_IMAGE_SCANNING_ENABLED", false)
 )

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/scanner-slim/scanner-slim.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/scanner-slim/scanner-slim.test.yaml
@@ -11,6 +11,7 @@ tests:
     container(.deployments["scanner"]; "scanner").image | contains("slim")
     container(.deployments["scanner-db"]; "db").image | contains("slim")
     .securitycontextconstraints | keys | sort | assertThat(. == ["stackrox-admission-control", "stackrox-collector", "stackrox-scanner", "stackrox-sensor"])
+    envVars(.deployments.sensor; "sensor")["ROX_LOCAL_IMAGE_SCANNING_ENABLED"] | assertThat(. == "true")
   tests:
   - name: "on openshift 4"
   - name: "on openshift 3"
@@ -102,14 +103,12 @@ tests:
     set:
       scanner.disable: false
     expect: |
-      .deployments["sensor"].spec.template.spec.containers[0].env[] |
-        select(.name == "ROX_USE_LOCAL_SCANNER") | assertThat(.value)
+      envVars(.deployments.sensor; "sensor")["ROX_LOCAL_IMAGE_SCANNING_ENABLED"] | assertThat(. == "true")
   - name: "local scanner disabled"
     set:
       scanner.disable: true
     expect: |
-      .deployments["sensor"].spec.template.spec.containers[0].env[] |
-        select(.name == "ROX_USE_LOCAL_SCANNER") | assertThat(.value == "false")
+      envVars(.deployments.sensor; "sensor")| assertThat(has("ROX_LOCAL_IMAGE_SCANNING_ENABLED") == false)
 
 - name: "sensor connects to local scanner using the correct GRPC endpoint"
   release:

--- a/sensor/common/scannerclient/singleton.go
+++ b/sensor/common/scannerclient/singleton.go
@@ -15,8 +15,8 @@ var (
 // Only one Client per Sensor is required.
 func GRPCClientSingleton() *Client {
 	once.Do(func() {
-		if !env.OpenshiftAPI.BooleanSetting() {
-			log.Info("Will not attempt to connect to a local scanner")
+		if !env.LocalImageScanningEnabled.BooleanSetting() {
+			log.Info("Local scanning disabled, will not attempt to connect to a local scanner.")
 			return
 		}
 

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -158,7 +158,7 @@ func CreateSensor(client client.Interface, workloadHandler *fake.WorkloadManager
 		return nil, errors.Wrap(err, "creating central client")
 	}
 
-	if features.LocalImageScanning.Enabled() && securedClusterIsNotManagedManually(helmManagedConfig) && env.UseLocalScanner.BooleanSetting() {
+	if features.LocalImageScanning.Enabled() && securedClusterIsNotManagedManually(helmManagedConfig) && env.LocalImageScanningEnabled.BooleanSetting() {
 		podName := os.Getenv("POD_NAME")
 		components = append(components,
 			localscanner.NewLocalScannerTLSIssuer(client.Kubernetes(), sensorNamespace, podName))

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -158,6 +158,8 @@ func CreateSensor(client client.Interface, workloadHandler *fake.WorkloadManager
 		return nil, errors.Wrap(err, "creating central client")
 	}
 
+	// Local scanner can be started even if scanner-tls certs are available in the same namespace because
+	// it ignores secrets not owned by Sensor.
 	if features.LocalImageScanning.Enabled() && securedClusterIsNotManagedManually(helmManagedConfig) && env.LocalImageScanningEnabled.BooleanSetting() {
 		podName := os.Getenv("POD_NAME")
 		components = append(components,


### PR DESCRIPTION
## Description

This PR sets the `ROX_ENABLE_LOCAL_IMAGE_SCANNING` env var to enable local image scanning.

 - Rename `ROX_USE_LOCAL_SCANNER` to `ROX_ENABLE_LOCAL_IMAGE_SCANNING`
 - Add function to set Helm values path in translation logic
 - Add `sensor.localImageScanning.enabled` field to Helm schema
 - Operator:
    - Disable Scanner deployment if Central exists in same namespace; Enable Scanning in Sensor
 - Helm:
   - Disable Scanner deployment if Central exists in same namespace; Enable Scanning in Sensor

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [ ] ~~Determined and documented upgrade steps~~
   - Helm and Operator take care automatically
- [x] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))  

If any of these don't apply, please comment below.

## Testing Performed

 - [x] Install Secured Cluster in the namespace as Central enables Local Image Scanning but does not install resources
    - [x] Operator 
    - [x] Helm
 - [x] Install Secured Cluster in a different namespace installs Scanner and enables local image scanning
    - [x] Operator 
    - [x] Helm