### PR TITLE
Update prettier 2.6.0 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -165,7 +165,7 @@
         "nyc": "^15.1.0",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^2.5.0",
+        "prettier": "^2.6.0",
         "randomstring": "^1.2.1",
         "react-scripts": "^4.0.1",
         "react-test-renderer": "^17.0.2",

--- a/ui/packages/tailwind-config/package.json
+++ b/ui/packages/tailwind-config/package.json
@@ -38,7 +38,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^2.5.0",
+        "prettier": "^2.6.0",
         "tailwindcss": "^2.0.3"
     }
 }

--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -77,7 +77,7 @@
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^2.5.0",
+        "prettier": "^2.6.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-is": "^17.0.2",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -15531,10 +15531,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.0.tgz#a6370e2d4594e093270419d9cc47f7670488f893"
-  integrity sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==
+prettier@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.0.tgz#12f8f504c4d8ddb76475f441337542fa799207d4"
+  integrity sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==
 
 pretty-bytes@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
## Description

https://prettier.io/blog/2022/03/16/2.6.0.html

* We’ve updated the version of TypeScript that we use to parse TS code to TypeScript 4.6. However, no new syntax was added in this release of TypeScript so we have not had to make any other changes.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

* `yarn lint` in ui
* `yarn build` in ui