### PR TITLE
Convert Network Graph Header and ClusterSelect components to TS

### DIFF
--- a/ui/apps/platform/src/Containers/Network/Header/ClusterSelect.tsx
+++ b/ui/apps/platform/src/Containers/Network/Header/ClusterSelect.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { Select, SelectOption } from '@patternfly/react-core';
@@ -10,13 +10,13 @@ import { actions as pageActions } from 'reducers/network/page';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { Cluster } from 'types/cluster.proto';
 
-interface ClusterSelectProps {
+type ClusterSelectProps = {
     selectClusterId: (clusterId: string) => void;
     closeSidePanel: () => void;
     clusters: Cluster[];
     selectedClusterId?: string;
     isDisabled?: boolean;
-}
+};
 
 const ClusterSelect = ({
     selectClusterId,
@@ -24,7 +24,7 @@ const ClusterSelect = ({
     clusters,
     selectedClusterId = '',
     isDisabled = false,
-}: ClusterSelectProps) => {
+}: ClusterSelectProps): ReactElement => {
     const { closeSelect, isOpen, onToggle } = useSelectToggle();
     function changeCluster(_e, clusterId) {
         selectClusterId(clusterId);
@@ -32,15 +32,11 @@ const ClusterSelect = ({
         closeSidePanel();
     }
 
-    if (!clusters.length) {
-        return null;
-    }
-
     return (
         <Select
             isOpen={isOpen}
             onToggle={onToggle}
-            isDisabled={isDisabled}
+            isDisabled={isDisabled || !clusters.length}
             selections={selectedClusterId}
             placeholderText="Select a cluster"
             onSelect={changeCluster}

--- a/ui/apps/platform/src/Containers/Network/Header/Header.tsx
+++ b/ui/apps/platform/src/Containers/Network/Header/Header.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { Divider, Flex, PageSection, Title } from '@patternfly/react-core';
 
 import CIDRFormButton from './CIDRFormButton';
 import FilterToolbar from './FilterToolbar';
 import SimulatorButton from './SimulatorButton';
 
-interface HeaderProps {
+type HeaderProps = {
     isSimulationOn: boolean;
-}
+};
 
-function Header({ isSimulationOn }: HeaderProps) {
+function Header({ isSimulationOn }: HeaderProps): ReactElement {
     return (
         <>
             <PageSection variant="light">


### PR DESCRIPTION
## Description

A couple of JS->TS conversions that came from the network namespace work, but that are completely de-coupled from that PR.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Test that Header renders and Cluster dropdown works correctly.
![image](https://user-images.githubusercontent.com/1292638/159571781-4c8d287c-e4bd-46d4-94e8-5d2a1d89415f.png)

