### PR TITLE
Add Postgres scale tests via ci-postgres-scale-tests label

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3758,7 +3758,6 @@ jobs:
     - STORAGE_CLASS: faster
     - STORAGE_SIZE: 100
     - LOAD_BALANCER: lb
-    - OUTPUT_FORMAT: helm
     - ROX_POSTGRES_DATASTORE: true
 
     steps:


### PR DESCRIPTION
## Description

Runs a scale test and purposefully compares it against the nightly run from GKE. This will compare rocksdb to the current run which 🤞 shows that many postgres functions are faster

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI should run
