### PR TITLE
Add gitignore for the postgres image build output

### DIFF
--- a/image/postgres/.gitignore
+++ b/image/postgres/.gitignore
@@ -1,0 +1,2 @@
+bundle.tar.gz
+bundle.tar.gz.sha512


### PR DESCRIPTION
## Description

Added .gitignore to not track postgres image output in VCS. 

## Checklist
- ~~[ ] Investigated and inspected CI test results~~
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

No code changes - no docs or tests required

## Testing Performed

N/A
