### PR TITLE
Disable PDF Export buttons while a PDF render is in progress.

### DIFF
--- a/ui/apps/platform/src/Components/WorkflowPDFExportButton.js
+++ b/ui/apps/platform/src/Components/WorkflowPDFExportButton.js
@@ -1,12 +1,14 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { createStructuredSelector } from 'reselect';
 import html2canvas from 'html2canvas';
 import jsPDF from 'jspdf';
 import 'jspdf-autotable';
 import dateFns from 'date-fns';
 import computedStyleToInlineStyle from 'computed-style-to-inline-style';
 import Button from 'Components/Button';
+import { selectors } from 'reducers';
 import { actions } from 'reducers/pdfDownload';
 import { enhanceWordBreak } from 'utils/pdfUtils';
 import { getProductBranding } from 'constants/productBranding';
@@ -38,6 +40,7 @@ class WorkflowPDFExportButton extends Component {
         fileName: PropTypes.string,
         setPDFRequestState: PropTypes.func,
         setPDFSuccessState: PropTypes.func,
+        pdfLoadingStatus: PropTypes.bool,
         onClick: PropTypes.func,
         className: PropTypes.string,
         tableOptions: PropTypes.shape({}),
@@ -55,6 +58,7 @@ class WorkflowPDFExportButton extends Component {
         fileName: 'export',
         setPDFRequestState: null,
         setPDFSuccessState: null,
+        pdfLoadingStatus: false,
         onClick: null,
         className: '',
         pdfTitle: '',
@@ -291,6 +295,8 @@ class WorkflowPDFExportButton extends Component {
     render() {
         return (
             <Button
+                isLoading={this.props.pdfLoadingStatus}
+                disabled={this.props.pdfLoadingStatus}
                 dataTestId="download-pdf-button"
                 className={this.props.className}
                 text="DOWNLOAD PAGE AS PDF"
@@ -300,9 +306,13 @@ class WorkflowPDFExportButton extends Component {
     }
 }
 
+const mapStateToProps = createStructuredSelector({
+    pdfLoadingStatus: selectors.getPdfLoadingStatus,
+});
+
 const mapDispatchToProps = {
     setPDFRequestState: actions.fetchPdf.request,
     setPDFSuccessState: actions.fetchPdf.success,
 };
 
-export default connect(null, mapDispatchToProps)(WorkflowPDFExportButton);
+export default connect(mapStateToProps, mapDispatchToProps)(WorkflowPDFExportButton);


### PR DESCRIPTION
## Description

This fixes an issue @pedrottimark discovered where multiple clicks on a PDF Export button would cause the page to attempt to render and export the PDF multiple times, leading to mal-formed PDFs, runtime errors, or even causing the Chrome tab to crash. This addresses the most likely case where a user clicks multiple times on the PDF Export button, either intentionally or unintentionally, but does not address other PDF export race conditions on the page. (e.g. If you click a sidebar link during PDF export, the page will navigate away before the PDF cleanup is done and crash with an error.)

This PR hooks into the request state tracking already present for PDF exports and disables the button while an export is in-progress.

Note that this issue does not impact the PDF Export dropdown on the Risk Event timeline.



## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

If any of these don't apply, please comment below.

## Testing Performed

Test the following behavior in each of the below locations:

- Compliance page -> export button
- Compliance page -> Cluster List View -> export button
- Config Management -> export button
- Config Management -> Policies List View -> export button
- Vuln Management -> export button
- Vuln Management -> Node List View -> export button

Click the Export button and Download as PDF. The download button should become disabled and display a loading spinner until the download is complete. Additional clicks when the download is in progress should not result in an error.
<img width="451" alt="image" src="https://user-images.githubusercontent.com/1292638/159975415-f71353ba-dd30-4cdc-bae6-d78d9bd6205e.png">

<img width="451" alt="image" src="https://user-images.githubusercontent.com/1292638/159975388-5d286b3b-bf3b-4764-ad0a-e8da969adf55.png">
