### PR TITLE
RS-389 Prohibit tags and digests in bundle installations

### DIFF
--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -847,6 +847,7 @@ func (ds *datastoreImpl) LookupOrCreateClusterFromConfig(ctx context.Context, cl
 			Name:               clusterName,
 			InitBundleId:       bundleID,
 			MostRecentSensorId: hello.GetDeploymentIdentification().Clone(),
+			ManagedBy:          manager,
 		}
 		clusterConfig := helmConfig.GetClusterConfig()
 		configureFromHelmConfig(cluster, clusterConfig)

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/images/defaults"
+	imageUtils "github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/sac"
 	pkgSearch "github.com/stackrox/rox/pkg/search"
@@ -913,6 +914,23 @@ func (ds *datastoreImpl) LookupOrCreateClusterFromConfig(ctx context.Context, cl
 	} else {
 		configureFromHelmConfig(cluster, clusterConfig)
 		cluster.HelmConfig = clusterConfig.Clone()
+	}
+
+	// Manually managed clusters drop the tags/digests (if there are any)
+	if clusterValidation.IsManagerManualOrUnknown(cluster.GetManagedBy()) {
+		if cluster.GetMainImage() != "" {
+			var err error
+			if cluster.MainImage, err = imageUtils.DropImageTagAndDigest(cluster.GetMainImage()); err != nil {
+				return nil, err
+			}
+		}
+
+		if cluster.GetCollectorImage() != "" {
+			var err error
+			if cluster.CollectorImage, err = imageUtils.DropImageTagAndDigest(cluster.GetCollectorImage()); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	if !proto.Equal(currentCluster, cluster) {

--- a/central/cluster/datastore/datastore_impl_test.go
+++ b/central/cluster/datastore/datastore_impl_test.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	fakeClusterID   = "FAKECLUSTERID"
-	mainImage       = "docker.io/stackrox/rox:latest"
+	mainImage       = "docker.io/stackrox/rox"
 	centralEndpoint = "central.stackrox:443"
 )
 
@@ -1211,11 +1211,31 @@ func (suite *ClusterDataStoreTestSuite) TestValidateCluster() {
 			expectedError: false,
 		},
 		{
+			name: "Non-trivial image managed by Helm",
+			cluster: &storage.Cluster{
+				MainImage:          "stackrox/main:1.2",
+				Name:               "name",
+				CentralApiEndpoint: "central:443",
+				ManagedBy:          storage.ManagerType_MANAGER_TYPE_HELM_CHART,
+			},
+			expectedError: false,
+		},
+		{
 			name: "Non-trivial image",
 			cluster: &storage.Cluster{
 				MainImage:          "stackrox/main:1.2",
 				Name:               "name",
 				CentralApiEndpoint: "central:443",
+			},
+			expectedError: true,
+		},
+		{
+			name: "Moderately complex image managed by Helm",
+			cluster: &storage.Cluster{
+				MainImage:          "stackrox.io/main:1.2.512-125125",
+				Name:               "name",
+				CentralApiEndpoint: "central:443",
+				ManagedBy:          storage.ManagerType_MANAGER_TYPE_HELM_CHART,
 			},
 			expectedError: false,
 		},
@@ -1226,6 +1246,16 @@ func (suite *ClusterDataStoreTestSuite) TestValidateCluster() {
 				Name:               "name",
 				CentralApiEndpoint: "central:443",
 			},
+			expectedError: true,
+		},
+		{
+			name: "Image with SHA managed by Helm",
+			cluster: &storage.Cluster{
+				MainImage:          "stackrox.io/main@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2",
+				Name:               "name",
+				CentralApiEndpoint: "central:443",
+				ManagedBy:          storage.ManagerType_MANAGER_TYPE_HELM_CHART,
+			},
 			expectedError: false,
 		},
 		{
@@ -1235,7 +1265,7 @@ func (suite *ClusterDataStoreTestSuite) TestValidateCluster() {
 				Name:               "name",
 				CentralApiEndpoint: "central:443",
 			},
-			expectedError: false,
+			expectedError: true,
 		},
 		{
 			name: "Invalid image - contains spaces",

--- a/central/cluster/datastore/datastore_impl_test.go
+++ b/central/cluster/datastore/datastore_impl_test.go
@@ -757,7 +757,7 @@ func (suite *ClusterDataStoreTestSuite) TestLookupOrCreateClusterFromConfig() {
 			bundleID:            bundleID,
 			expectedManagerType: storage.ManagerType_MANAGER_TYPE_MANUAL,
 			expectedHelmConfig:  nil,
-			expectClusterUpsert: true,
+			expectClusterUpsert: false,
 		},
 		// Updating Helm configuration
 		{

--- a/pkg/cluster/validation_test.go
+++ b/pkg/cluster/validation_test.go
@@ -9,7 +9,7 @@ import (
 
 var validCluster = &storage.Cluster{
 	Name:               "cluster-name",
-	MainImage:          "stackrox.io/main:3.0.55.0",
+	MainImage:          "stackrox.io/main",
 	CentralApiEndpoint: "central.stackrox:443",
 	Type:               storage.ClusterType_OPENSHIFT4_CLUSTER,
 }
@@ -26,18 +26,38 @@ func TestPartialValidation(t *testing.T) {
 			configureClusterFn: func(cluster *storage.Cluster) {
 				cluster.MainImage = "invalid image"
 			},
-			expectedErrors: []string{"invalid main image 'invalid image': invalid reference format"},
+			expectedErrors: []string{"invalid image name 'invalid image': invalid reference format"},
 		},
 		"Cluster with empty main image should not fail": {
 			configureClusterFn: func(cluster *storage.Cluster) {
 				cluster.MainImage = ""
 			},
 		},
-		"Cluster with configured collector image tag should fail": {
+		"Cluster with main image with tag should fail when ManagedBy is set to ManagerType_MANAGER_TYPE_UNKNOWN": {
+			configureClusterFn: func(cluster *storage.Cluster) {
+				cluster.MainImage = "docker.io/stackrox/main:some_tag"
+				// cluster.MainImage = "image"
+			},
+			expectedErrors: []string{"main image should not contain tags or digests"},
+		},
+		"Cluster with main image with sha should fail when ManagedBy is set to ManagerType_MANAGER_TYPE_UNKNOWN": {
+			configureClusterFn: func(cluster *storage.Cluster) {
+				cluster.MainImage = "docker.io/stackrox/main@sha256:8755ac54265892c5aea311e3d73ad771dcbb270d022b1c8cf9cdbf3218b46993"
+			},
+			expectedErrors: []string{"main image should not contain tags or digests"},
+		},
+		"Cluster with collector image with tag should fail when ManagedBy is set to ManagerType_MANAGER_TYPE_UNKNOWN": {
 			configureClusterFn: func(cluster *storage.Cluster) {
 				cluster.CollectorImage = "docker.io/stackrox/collector:3.2.0-slim"
+				cluster.HelmConfig = &storage.CompleteClusterConfig{} // Not really needed since ManagedBy is checked first
 			},
-			expectedErrors: []string{"collector image may not specify a tag.  Please remove tag '3.2.0-slim' to continue"},
+			expectedErrors: []string{"collector image should not contain tags or digests"},
+		},
+		"Cluster with collector image with sha should fail when Managedby is set to ManagerType_MANAGER_TYPE_UNKNOWN": {
+			configureClusterFn: func(cluster *storage.Cluster) {
+				cluster.CollectorImage = "docker.io/stackrox/collector@sha256:8755ac54265892c5aea311e3d73ad771dcbb270d022b1c8cf9cdbf3218b46993"
+			},
+			expectedErrors: []string{"collector image should not contain tags or digests"},
 		},
 		"Cluster with configured collector image without tag is valid": {
 			configureClusterFn: func(cluster *storage.Cluster) {
@@ -48,7 +68,7 @@ func TestPartialValidation(t *testing.T) {
 			configureClusterFn: func(cluster *storage.Cluster) {
 				cluster.CollectorImage = "invalid image"
 			},
-			expectedErrors: []string{"invalid collector image 'invalid image': invalid reference format"},
+			expectedErrors: []string{"invalid image name 'invalid image': invalid reference format"},
 		},
 		"Cluster with empty collector image should not fail": {
 			configureClusterFn: func(cluster *storage.Cluster) {
@@ -57,6 +77,7 @@ func TestPartialValidation(t *testing.T) {
 		},
 		"Helm Managed cluster with configured collector image tag is allowed": {
 			configureClusterFn: func(cluster *storage.Cluster) {
+				cluster.ManagedBy = storage.ManagerType_MANAGER_TYPE_HELM_CHART
 				cluster.HelmConfig = &storage.CompleteClusterConfig{}
 				cluster.CollectorImage = "docker.io/stackrox/collector:3.2.0-slim"
 			},

--- a/pkg/images/utils/utils.go
+++ b/pkg/images/utils/utils.go
@@ -243,3 +243,39 @@ func FilterSuppressedCVEsNoClone(img *storage.Image) {
 		}
 	}
 }
+
+// DropImageTagAndDigest drops the tag or digests of a given image.
+// If the image is not a properly formatted image returns an error
+func DropImageTagAndDigest(image string) (string, error) {
+	ref, err := reference.ParseAnyReference(image)
+	if err != nil {
+		return image, errors.Wrapf(err, "invalid image name '%s'", image)
+	}
+
+	if _, ok := ref.(reference.Named); !ok {
+		return image, errors.Errorf("unsupported image name format '%s'", image)
+	}
+
+	namedReference := ref.(reference.Named)
+	familiarName := reference.FamiliarName(namedReference)
+	// If 'image' is already in familiar format
+	if image == reference.FamiliarString(ref) {
+		return familiarName, nil
+	}
+	// If image is partially familiar format: e.g. docker.io/nginx or library/nginx.
+	if len(namedReference.Name()) > len(familiarName) {
+		domain := reference.Domain(namedReference)
+		path := reference.Path(namedReference)
+		// If it does not have a domain, but it has a repository
+		if strings.HasPrefix(image, path) {
+			return path, nil
+		}
+		// If we have 'docker.io' as domain but not the 'library' repository
+		// e.g. docker.io/nginx
+		domainAndName := fmt.Sprintf("%s/%s", domain, familiarName)
+		if strings.HasPrefix(image, domainAndName) {
+			return domainAndName, nil
+		}
+	}
+	return namedReference.Name(), nil
+}

--- a/pkg/images/utils/utils_test.go
+++ b/pkg/images/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stackrox/rox/generated/storage"
@@ -187,4 +188,119 @@ func TestStripCVEDescriptions(t *testing.T) {
 	}
 	// Validate that we at least removed one summary
 	assert.True(t, hitOne)
+}
+
+func TestDropImageTagAndDigest(t *testing.T) {
+	cases := map[string]struct {
+		image         string
+		expectedImage string
+		expectedError error
+	}{
+		"Image with Tag": {
+			image:         "docker.io/stackrox/rox:tag",
+			expectedImage: "docker.io/stackrox/rox",
+			expectedError: nil,
+		},
+		"Image with Digest": {
+			image:         "docker.io/stackrox/rox@sha256:8755ac54265892c5aea311e3d73ad771dcbb270d022b1c8cf9cdbf3218b46993",
+			expectedImage: "docker.io/stackrox/rox",
+			expectedError: nil,
+		},
+		"Image with Tag and Digest": {
+			image:         "docker.io/stackrox/rox:tag@sha256:8755ac54265892c5aea311e3d73ad771dcbb270d022b1c8cf9cdbf3218b46993",
+			expectedImage: "docker.io/stackrox/rox",
+			expectedError: nil,
+		},
+		"Image with no tag or digest": {
+			image:         "docker.io/stackrox/rox",
+			expectedImage: "docker.io/stackrox/rox",
+			expectedError: nil,
+		},
+		"Image with no tag or digest and no domain": {
+			image:         "stackrox/rox",
+			expectedImage: "stackrox/rox",
+			expectedError: nil,
+		},
+		"No registry with tag": {
+			image:         "nginx:tag",
+			expectedImage: "nginx",
+			expectedError: nil,
+		},
+		"No registry with sha": {
+			image:         "nginx@sha256:8755ac54265892c5aea311e3d73ad771dcbb270d022b1c8cf9cdbf3218b46993",
+			expectedImage: "nginx",
+			expectedError: nil,
+		},
+		"No registry with tag and sha": {
+			image:         "nginx:tag@sha256:8755ac54265892c5aea311e3d73ad771dcbb270d022b1c8cf9cdbf3218b46993",
+			expectedImage: "nginx",
+			expectedError: nil,
+		},
+		"No registry": {
+			image:         "nginx",
+			expectedImage: "nginx",
+			expectedError: nil,
+		},
+		"Invalid image": {
+			image:         "invalid image",
+			expectedError: errors.New("invalid image name 'invalid image': invalid reference format"),
+		},
+		"docker.io and library with tag and sha": {
+			image:         "docker.io/library/nginx:tag@sha256:8755ac54265892c5aea311e3d73ad771dcbb270d022b1c8cf9cdbf3218b46993",
+			expectedImage: "docker.io/library/nginx",
+			expectedError: nil,
+		},
+		"No domain, library with tag and sha": {
+			image:         "library/nginx:tag@sha256:8755ac54265892c5aea311e3d73ad771dcbb270d022b1c8cf9cdbf3218b46993",
+			expectedImage: "library/nginx",
+			expectedError: nil,
+		},
+		"Repository with multiple levels and tag": {
+			image:         "docker.io/more/than/three/levels/main:tag",
+			expectedImage: "docker.io/more/than/three/levels/main",
+			expectedError: nil,
+		},
+		"stackrox.io domain with tag and sha": {
+			image:         "stackrox.io/path/main:tag@sha256:8755ac54265892c5aea311e3d73ad771dcbb270d022b1c8cf9cdbf3218b46993",
+			expectedImage: "stackrox.io/path/main",
+			expectedError: nil,
+		},
+		"stackrox.io domain with 'library' path and tag": {
+			image:         "stackrox.io/library/main:tag",
+			expectedImage: "stackrox.io/library/main",
+			expectedError: nil,
+		},
+		"quay.io domain with tag and sha": {
+			image:         "quay.io/path/main:tag@sha256:8755ac54265892c5aea311e3d73ad771dcbb270d022b1c8cf9cdbf3218b46993",
+			expectedImage: "quay.io/path/main",
+			expectedError: nil,
+		},
+		"docker.io domain, no repository with tag and sha": {
+			image:         "docker.io/nginx:tag@sha256:8755ac54265892c5aea311e3d73ad771dcbb270d022b1c8cf9cdbf3218b46993",
+			expectedImage: "docker.io/nginx",
+			expectedError: nil,
+		},
+		"docker.io domain, no repository with tag": {
+			image:         "docker.io/nginx:tag",
+			expectedImage: "docker.io/nginx",
+			expectedError: nil,
+		},
+		"Just sha": {
+			image:         "8755ac54265892c5aea311e3d73ad771dcbb270d022b1c8cf9cdbf3218b46993",
+			expectedError: errors.New("unsupported image name format '8755ac54265892c5aea311e3d73ad771dcbb270d022b1c8cf9cdbf3218b46993'"),
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			resImage, gotError := DropImageTagAndDigest(c.image)
+
+			if c.expectedError == nil {
+				assert.NoError(t, gotError, "expected a valid image but got error")
+				assert.Equal(t, c.expectedImage, resImage, "Expected image %s but got %s", c.expectedImage, resImage)
+			} else {
+				assert.Error(t, gotError)
+				assert.Equal(t, c.expectedError.Error(), gotError.Error())
+			}
+		})
+	}
 }

--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -1344,7 +1344,7 @@ class ComplianceTest extends BaseSpecification {
         when:
         "starting a new cluster and re-running compliance"
         def otherClusterName = "aNewCluster"
-        ClusterService.createCluster(otherClusterName, "stackrox/main:latest", "central.stackrox:443")
+        ClusterService.createCluster(otherClusterName, "stackrox/main", "central.stackrox:443")
         withRetry(10, 2) {
             def clusters = ClusterService.getClusters()
             assert clusters.size() > 1

--- a/qa-tests-backend/src/test/groovy/RbacAuthTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RbacAuthTest.groovy
@@ -44,7 +44,7 @@ spec:
                                 ( {
                                     ClusterService.createCluster(
                                         "automation",
-                                        "stackrox/main:latest",
+                                        "stackrox/main",
                                         "central.stackrox:443")
                                 })],
             "NetworkPolicy": [(RoleOuterClass.Access.READ_ACCESS):

--- a/tests/roxctl/bats-tests/cluster/sensor-generate-image-overrides.bats
+++ b/tests/roxctl/bats-tests/cluster/sensor-generate-image-overrides.bats
@@ -99,7 +99,6 @@ any_version_slim="${any_version}[0-9]+\-slim"
 }
 
 @test "roxctl sensor generate: should fail if main image is provided with tag" {
-  skip "#TODO(RS-389): once we no longer accept tags in the main image this test should pass"
   generate_bundle k8s "--main-image-repository=example.com/stackrox/main:1.2.3" --name "$cluster_name"
   assert_failure
 }


### PR DESCRIPTION
## Description

This PR fixes a regression introduced in #547. This was fixed by setting the `ManagedBy` field in the cluster object creation ([416cd32](https://github.com/stackrox/stackrox/pull/1075/commits/416cd32496d3a3b709589ecf8190a6cdaa12922d)).


According to the official [documentation](https://docs.openshift.com/acs/3.68/configuration/enable-offline-mode.html#topic-name_enable-offline-mode) the user is not allowed to provide custom tags (or digests) when retagging images for private registries. This PR aims to prohibit tags/digests overrides in bundle installations to prevent illegal images to be generated in manifest bundles.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- Manual testing of bundle installations with `roxctl` and `ui` with and without overriding tags
- Manual testing of Helm and Operator installations with and without overriding tags
- Added unit tests to `pkg/cluster` and `pkg/images/utils`
