### PR TITLE
Revert "ROX-9130: Add scanner-slim flavor tests"

### DIFF
--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/development/development.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/development/development.test.yaml
@@ -11,15 +11,3 @@ tests:
   expect: |
     assertMainIs("docker.io/stackrox/main:3.0.99.0")
     assertCollectorIs("docker.io/stackrox/collector:99.9.9-slim")
-
-- name: scanner image
-  server:
-    visibleSchemas:
-    - openshift-4.1.0
-    availableSchemas:
-    - openshift-4.1.0
-  set:
-    scanner.disable: false
-  expect: |
-    assertScannerIs("docker.io/stackrox/scanner-slim:99.9.9")
-    assertScannerDBIs("docker.io/stackrox/scanner-db-slim:99.9.9")

--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/override/override.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/override/override.test.yaml
@@ -11,16 +11,3 @@ tests:
   expect: |
     assertMainIs("test.registry/main:custom-main")
     assertCollectorIs("test.registry/collector:custom-collector-slim")
-
-- name: scanner image
-  server:
-    visibleSchemas:
-    - openshift-4.1.0
-    availableSchemas:
-    - openshift-4.1.0
-  set:
-    scanner.disable: false
-  expect: |
-    .deployments["scanner-db"] | toyaml | print
-    assertScannerIs("test.registry/scanner-slim:custom-scanner")
-    assertScannerDBIs("test.registry/scanner-db-slim:custom-scanner")

--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/rhacs/rhacs.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/rhacs/rhacs.test.yaml
@@ -5,22 +5,9 @@ tests:
   expect: |
     assertMainIs("registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.0.99.0")
     assertCollectorIs("registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:3.0.99.0")
-
 - name: slim mode
   set:
     collector.slimMode: true
   expect: |
     assertMainIs("registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.0.99.0")
     assertCollectorIs("registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:3.0.99.0")
-
-- name: scanner image
-  server:
-    visibleSchemas:
-    - openshift-4.1.0
-    availableSchemas:
-    - openshift-4.1.0
-  set:
-    scanner.disable: false
-  expect: |
-    assertScannerIs("registry.redhat.io/advanced-cluster-security/rhacs-scanner-slim-rhel8:3.0.99.0")
-    assertScannerDBIs("registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-slim-rhel8:3.0.99.0")

--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/stackrox/stackrox.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/stackrox/stackrox.test.yaml
@@ -11,15 +11,3 @@ tests:
   expect: |
     assertMainIs("stackrox.io/main:3.0.99.0")
     assertCollectorIs("collector.stackrox.io/collector-slim:3.0.99.0")
-
-- name: scanner image
-  server:
-    visibleSchemas:
-    - openshift-4.1.0
-    availableSchemas:
-    - openshift-4.1.0
-  set:
-    scanner.disable: false
-  expect: |
-    assertScannerIs("stackrox.io/scanner-slim:3.0.99.0")
-    assertScannerDBIs("stackrox.io/scanner-db-slim:3.0.99.0")

--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/suite.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/suite.yaml
@@ -13,11 +13,6 @@ defs: |
   def assertCollectorIs(name):
     container(.daemonsets.collector; "collector") | assertThat(.image == name);
 
-  def assertScannerIs(name):
-    container(.deployments.scanner; "scanner") | assertThat(.image == name);
-
-  def assertScannerDBIs(name):
-    container(.deployments["scanner-db"]; "db") | assertThat(.image == name);
 server:
   visibleSchemas:
   - kubernetes-1.20.2

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/scanner-slim/scanner-slim.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/scanner-slim/scanner-slim.test.yaml
@@ -17,6 +17,7 @@ tests:
     set:
       env.openshift: 3
 
+
 - name: "scanner is disabled should not be installed by default"
   expect: |
     .deployments["scanner"] | assertThat(. == null)


### PR DESCRIPTION
Reverts stackrox/stackrox#1060 as it introduces instabilities in CI.