### PR TITLE
ROX-9199: Increase wait time and retry on quay image scan failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4366,7 +4366,7 @@ jobs:
       - run:
           name: Check for fixable vulns
           command: |
-            ./release/scripts/vuln_check.sh
+            ./release/scripts/vuln_check.sh || ./release/scripts/vuln_check.sh
 
   ###
   # Infrastructure and workflow utility jobs

--- a/release/scripts/vuln_check.sh
+++ b/release/scripts/vuln_check.sh
@@ -37,12 +37,14 @@ function compare_fixable_vulns {
   local count=1
 
   echo "Getting scan status for ${image_name}"
+  wait=30
+  count=0
   scan_present=$(quay_curl "${image_name}/manifest/${CURRENT_IMAGE}/security?vulnerabilities=true" | jq -r '.status')
   until [ "$scan_present" = "scanned" ] || [ "$count" -gt 100 ]; do
-    echo "Waiting for scan to complete..."
+    echo "${count} Waiting ${wait}s for scan to complete..."
     scan_present=$(quay_curl "${image_name}/manifest/${CURRENT_IMAGE}/security?vulnerabilities=true" | jq -r '.status')
     count=$((count+1))
-    sleep 15
+    sleep $wait
   done
 
   # if scan never completes, print error message, mark image as failed, and move on to the next


### PR DESCRIPTION
## Description

Quay is unstable and many times our scan timeouts. This PR double wait time between single scans retries and retry the whole procedure if fails.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI