### PR TITLE
ROX-9822: Implement in-memory store for network policies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,5 @@
 [{Makefile,**.mk}]
 indent_style = tab
+
+[**.go]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,2 @@
 [{Makefile,**.mk}]
 indent_style = tab
-
-[**.go]
-indent_style = tab

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -68,6 +68,7 @@ func NewDispatcherRegistry(
 	podStore := PodStoreSingleton()
 	nodeStore := newNodeStore()
 	nsStore := newNamespaceStore()
+	netPolicyStore := newNetworkPoliciesStore()
 	endpointManager := newEndpointManager(serviceStore, deploymentStore, podStore, nodeStore, entityStore)
 	rbacUpdater := rbac.NewStore()
 	portExposureReconciler := newPortExposureReconciler(deploymentStore, serviceStore)
@@ -82,7 +83,7 @@ func NewDispatcherRegistry(
 		serviceDispatcher:         newServiceDispatcher(serviceStore, deploymentStore, endpointManager, portExposureReconciler),
 		osRouteDispatcher:         newRouteDispatcher(serviceStore, portExposureReconciler),
 		secretDispatcher:          newSecretDispatcher(registryStore),
-		networkPolicyDispatcher:   newNetworkPolicyDispatcher(),
+		networkPolicyDispatcher:   newNetworkPolicyDispatcher(netPolicyStore),
 		nodeDispatcher:            newNodeDispatcher(serviceStore, deploymentStore, nodeStore, endpointManager),
 		serviceAccountDispatcher:  newServiceAccountDispatcher(),
 		clusterOperatorDispatcher: newClusterOperatorDispatcher(namespaces),

--- a/sensor/kubernetes/listener/resources/networkpolicy.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy.go
@@ -2,20 +2,43 @@ package resources
 
 import (
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
 	networkPolicyConversion "github.com/stackrox/rox/pkg/protoconv/networkpolicy"
 	networkingV1 "k8s.io/api/networking/v1"
 )
 
-// networkPolicyDispatcher handles network policy resource events.
-type networkPolicyDispatcher struct{}
-
-func newNetworkPolicyDispatcher() *networkPolicyDispatcher {
-	return &networkPolicyDispatcher{}
+type networkPolicyStore interface {
+	Size() int
+	All() map[string]*storage.NetworkPolicy
+	Get(id string) *storage.NetworkPolicy
+	Upsert(ns *storage.NetworkPolicy)
+	Find(namespace string, labels map[string]string) map[string]*storage.NetworkPolicy
+	Delete(ID, ns string)
 }
 
-// Process processes a network policy resource event, and returns the sensor events to generate.
-func (h *networkPolicyDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) []*central.SensorEvent {
-	np := obj.(*networkingV1.NetworkPolicy)
+// networkPolicyDispatcher handles network policy resource events.
+type networkPolicyDispatcher struct {
+	store networkPolicyStore
+}
+
+func newNetworkPolicyDispatcher(nps networkPolicyStore) *networkPolicyDispatcher {
+	return &networkPolicyDispatcher{
+		store: nps,
+	}
+}
+
+// ProcessEvent processes a network policy resource event, and returns the sensor events to generate.
+func (h *networkPolicyDispatcher) ProcessEvent(newObj, _ interface{}, action central.ResourceAction) []*central.SensorEvent {
+	np := newObj.(*networkingV1.NetworkPolicy)
+	netPolicy := networkPolicyConversion.KubernetesNetworkPolicyWrap{NetworkPolicy: np}.ToRoxNetworkPolicy()
+
+	switch action {
+	case central.ResourceAction_CREATE_RESOURCE, central.ResourceAction_UPDATE_RESOURCE:
+		h.store.Upsert(netPolicy)
+	case central.ResourceAction_REMOVE_RESOURCE:
+		h.store.Delete(netPolicy.GetId(), netPolicy.GetNamespace())
+	}
+
 	return []*central.SensorEvent{
 		{
 			Id:     string(np.UID),

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -1,0 +1,178 @@
+package resources
+
+import (
+	"github.com/stackrox/rox/pkg/labels"
+	"github.com/stackrox/rox/pkg/sync"
+
+	"github.com/stackrox/rox/generated/storage"
+)
+
+/* Matching labels using selectors
+
+Selector is a set of labels (map[string]string) that is used for matching the labels.
+Labels are also represented as set (map[string]string) but they are passive in the matching process.
+Note that selectors.Match(labels) != labels.Match(selectors)
+
+"Matching objects must satisfy all the specified label constraints (here called selector terms), though they may have additional labels as well."
+https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#equality-based-requirement
+
+Selectors match labels if all selectors terms are contained in the set of labels.
+Speaking differently, the set of selector terms belongs to the power-set of labels (minus the empty set).
+(See https://en.wikipedia.org/wiki/Power_set)
+
+Selected observations for matching selectors with labels including:
+1. Policy with no selectors (podSelector: {}) matches all deployments in the namespace.
+2. Policy with a selector (podSelector: matchLabels: app: web}) matches pod with matching labels "app: web" but not a service with matching labels "app: web".
+3. Pod with no labels matches only against policies with no selectors.
+
+Example:
+A policy with selectors L1=V1,L2=V2 (having two selector terms: L1=V1 and L2=V2)
+would match a deployment having labels (L1=V1,L2=V2), or (L1=V1,L2=V2,L3=V3),
+but not for (L1=V1).
+A deployment with labels L1=V1,L2=V2 could be matched with policies having the following selectors (L1=V1), (L2=V2), (L1=V1,L2=V2),
+but not (L1=V1,L3=V3).
+*/
+
+/*
+networkPolicyStoreImpl stores a set of network policies as seen in the K8s API.
+
+This store is optimized for quick searches* of network policies that match a given deployment.
+NetworkPolicies use label-selectors to match labels.
+The Find operation returns all NetworkPolicies that would match a given set of labels (within a namespace).
+Example:
+  policiesMatchingDeployment := store.Find("default"), map[string]string{"app": "nginx"})
+
+*) TODO: See ADR-XXX for alternative implementations that were considered
+
+## Complexities
+
+Assumed frequency of operations on the store:
+- Find - arbitrarily often, at least once per each deployment update,
+- Upsert Delete - once per NetworkPolicy update arriving from K8s API,
+- Get - occasionally
+
+Notation used:
+- N = number of elements (network policies) in the store (for a given namespace)
+- K = number of labels in a deployment (passed to the Find function)
+- L = number of label selector terms in a network policy
+
+### Computation
+
+- O(Find) = O(N*K) - iterating over all N policies in a given namespace and matching K labels
+- Upsert - O(1)
+- Delete - O(1)
+
+### Memory
+
+The store stores each network policy exactly once O(n).
+The operations on the store may allocate additional memory temporarily.
+
+- Find: O(1)
+- Upsert: O(1)
+- Delete: O(1)
+*/
+
+var _ networkPolicyStore = (*networkPolicyStoreImpl)(nil)
+
+type networkPolicyStoreImpl struct {
+	lock sync.RWMutex
+	// data: namespace -> result (map: policyID -> policy object ref)
+	data map[string]map[string]*storage.NetworkPolicy
+}
+
+func newNetworkPoliciesStore() *networkPolicyStoreImpl {
+	return &networkPolicyStoreImpl{
+		data: make(map[string]map[string]*storage.NetworkPolicy),
+	}
+}
+
+// Size returns number of network policies in the store
+func (n *networkPolicyStoreImpl) Size() int {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+	size := 0
+	for _, m := range n.data {
+		size += len(m)
+	}
+	return size
+}
+
+// All returns all network policies from all namespaces
+func (n *networkPolicyStoreImpl) All() map[string]*storage.NetworkPolicy {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+	// copying map to ensure that the store contents will not be mutated from outside
+	result := make(map[string]*storage.NetworkPolicy)
+	for _, m := range n.data {
+		for k, v := range m {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+// Delete removes network policy from the store
+func (n *networkPolicyStoreImpl) Delete(ID, ns string) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	if _, nsFound := n.data[ns]; nsFound {
+		delete(n.data[ns], ID)
+		if len(n.data[ns]) == 0 {
+			delete(n.data, ns)
+		}
+	}
+}
+
+// Upsert adds or updates network policy based on the namespace and ID
+func (n *networkPolicyStoreImpl) Upsert(np *storage.NetworkPolicy) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
+	if _, nsFound := n.data[np.GetNamespace()]; !nsFound {
+		n.data[np.GetNamespace()] = make(map[string]*storage.NetworkPolicy)
+	}
+	n.data[np.GetNamespace()][np.GetId()] = np
+}
+
+// Get retrieves network policy for a given ID or nil if the policy cannot be found
+func (n *networkPolicyStoreImpl) Get(id string) *storage.NetworkPolicy {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+
+	for _, m := range n.data {
+		if obj, found := m[id]; found {
+			return obj
+		}
+	}
+	return nil
+}
+
+// Find returns set of NetworkPolicies that match the deployment labels
+func (n *networkPolicyStoreImpl) Find(namespace string, podLabels map[string]string) map[string]*storage.NetworkPolicy {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+
+	results := make(map[string]*storage.NetworkPolicy)
+	nsPolicies, nsFound := n.data[namespace]
+	if !nsFound {
+		return results
+	}
+
+	// Pod with 0 labels should only match policies with 0 selectors.
+	// Apparently 'labels.MatchLabels' does not cover this corner case
+	if len(podLabels) == 0 {
+		for id, policy := range nsPolicies {
+			if policy.GetSpec().GetPodSelector().Size() == 0 {
+				results[id] = policy
+			}
+		}
+		return results
+	}
+
+	for id, policy := range nsPolicies {
+		if labels.MatchLabels(policy.GetSpec().GetPodSelector(), podLabels) {
+			results[id] = policy
+		}
+	}
+	return results
+}

--- a/sensor/kubernetes/listener/resources/networkpolicy_store_bench_test.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store_bench_test.go
@@ -1,0 +1,139 @@
+package resources
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/uuid"
+)
+
+/*
+Running benchmarks
+$  go test -benchmem -timeout 0 -cpu 1 -benchmem -run=^$ -bench ^Benchmark github.com/stackrox/rox/sensor/kubernetes/listener/resources
+*/
+const defaultNS = "default"
+
+var namespaces = []string{defaultNS}
+
+func getRandom(arr []string) string {
+	return arr[rand.Intn(len(arr))]
+}
+
+func randomLabels(num int64, arrLabels, arrValues []string) map[string]string {
+	m := make(map[string]string)
+	for i := int64(0); i < num; i++ {
+		m[getRandom(arrLabels)] = getRandom(arrValues)
+	}
+	return m
+}
+
+func generateSetOfAllLabels(num int) []string {
+	arr := make([]string, num)
+	for i := 0; i < num; i++ {
+		arr[i] = fmt.Sprintf("L%d", i)
+	}
+	return arr
+}
+
+func generateSetOfAllValues(num int) []string {
+	arr := make([]string, num)
+	for i := 0; i < num; i++ {
+		arr[i] = fmt.Sprintf("V%d", i)
+	}
+	return arr
+}
+
+func populateStore(s networkPolicyStore, num, numLabels int64, allLabels, allValues []string) {
+	for i := int64(0); i < num; i++ {
+		np := newNPDummy(uuid.NewV4().String(), getRandom(namespaces), randomLabels(numLabels, allLabels, allValues))
+		s.Upsert(np)
+	}
+}
+
+func newNPDummy(id, ns string, sel map[string]string) *storage.NetworkPolicy {
+	return &storage.NetworkPolicy{
+		Namespace: ns,
+		Id:        id,
+		Spec: &storage.NetworkPolicySpec{
+			PodSelector: &storage.LabelSelector{
+				MatchLabels: sel,
+			},
+		},
+	}
+}
+
+var allLabels16 = generateSetOfAllLabels(16)
+var allValues16 = generateSetOfAllValues(16)
+
+var casesLabels = []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+var casesScale = []int64{2, 3, 4, 5, 6}
+var selectors = make([]map[string]string, 0)
+
+func init() {
+	for _, l := range casesLabels {
+		m := make(map[string]string)
+		for i := 1; i <= int(l); i++ {
+			m[fmt.Sprintf("L%d", i)] = fmt.Sprintf("V%d", i)
+		}
+		selectors = append(selectors, m)
+	}
+}
+
+// Notation used in naming of benchmark scenarios
+//- N = number of elements (network policies) in the store
+//- K = number of labels in a deployment (passed to the Find function)
+//- L = number of label selector terms in a network policy
+
+func BenchmarkFind(b *testing.B) {
+	for labelIdx, numLabels := range casesLabels {
+		for _, scale := range casesScale {
+			s := newNetworkPoliciesStore()
+			populateStore(s, int64(math.Pow(10, float64(scale))), scale, allLabels16, allValues16)
+			b.Run(fmt.Sprintf("K=%d-N=10^%d", numLabels, scale), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					_ = s.Find(defaultNS, selectors[labelIdx])
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkUpsert_Update(b *testing.B) {
+	for labelIdx, numLabels := range casesLabels {
+		for _, scale := range casesScale {
+			s := newNetworkPoliciesStore()
+			populateStore(s, int64(math.Pow(10, float64(scale))), scale, allLabels16, allValues16)
+			// find random existing policy
+			var oldPolicy *storage.NetworkPolicy
+			for _, v := range s.All() {
+				oldPolicy = v
+				break
+			}
+			newPolicy := newNPDummy(oldPolicy.GetId(), defaultNS, selectors[labelIdx])
+			b.Run(fmt.Sprintf("L=%d-N=10^%d", numLabels, scale), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					s.Upsert(newPolicy)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkUpsert_Add(b *testing.B) {
+	for labelIdx, numLabels := range casesLabels {
+		for _, scale := range casesScale {
+			s := newNetworkPoliciesStore()
+			populateStore(s, int64(math.Pow(10, float64(scale))), scale, allLabels16, allValues16)
+			b.Run(fmt.Sprintf("L=%d-N=10^%d", numLabels, scale), func(b *testing.B) {
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					np := newNPDummy(uuid.NewV4().String(), getRandom(namespaces), selectors[labelIdx])
+					s.Upsert(np)
+				}
+			})
+		}
+	}
+}

--- a/sensor/kubernetes/listener/resources/networkpolicy_store_test.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store_test.go
@@ -1,0 +1,170 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNetworkPoliciesStoreFind(t *testing.T) {
+	store := newNetworkPoliciesStore()
+	store.Upsert(newNPDummy("one", defaultNS, map[string]string{"app": "sensor"}))
+	store.Upsert(newNPDummy("two", defaultNS, map[string]string{"app": "sensor", "role": "backend"}))
+	store.Upsert(newNPDummy("three", defaultNS, map[string]string{"app": "central"}))
+	store.Upsert(newNPDummy("four", defaultNS, map[string]string{"app": "central", "role": "frontend"}))
+	store.Upsert(newNPDummy("five", defaultNS, map[string]string{}))
+
+	tests := []struct {
+		name        string
+		podLabels   map[string]string
+		expectedIDs []string
+	}{
+		{
+			name:        "Single kv",
+			podLabels:   map[string]string{"app": "sensor"},
+			expectedIDs: []string{"one", "five"},
+		},
+		{
+			name:        "Double kv full match",
+			podLabels:   map[string]string{"app": "sensor", "role": "backend"},
+			expectedIDs: []string{"one", "two", "five"},
+		},
+		{
+			name:        "Double kv no match",
+			podLabels:   map[string]string{"app": "xxx", "role": "backend"},
+			expectedIDs: []string{"five"},
+		},
+		{
+			name:        "Extra label in the middle",
+			podLabels:   map[string]string{"app": "sensor", "aaa": "xxx", "role": "backend"},
+			expectedIDs: []string{"one", "two", "five"},
+		},
+		{
+			name:        "Unsorted labels",
+			podLabels:   map[string]string{"aaa": "xxx", "role": "backend", "app": "sensor"},
+			expectedIDs: []string{"one", "two", "five"},
+		},
+		{
+			name:        "Empty label value",
+			podLabels:   map[string]string{"role": "", "app": "central"},
+			expectedIDs: []string{"three", "five"},
+		},
+		{
+			name:        "Pod with 0 labels should only match policies with 0 selectors",
+			podLabels:   map[string]string{},
+			expectedIDs: []string{"five"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			found := store.Find(defaultNS, tt.podLabels)
+			assert.Equal(t, len(tt.expectedIDs), len(found), "expected to find %d IDs, but found: %v", len(tt.expectedIDs), found)
+
+			for _, expID := range tt.expectedIDs {
+				assert.Equal(t, expID, found[expID].GetId())
+			}
+		})
+	}
+}
+
+func TestNetworkPoliciesStoreDelete(t *testing.T) {
+	policies := make([]*storage.NetworkPolicy, 0)
+	policies = append(policies, newNPDummy("p1", defaultNS, map[string]string{"app": "sensor"}))
+	policies = append(policies, newNPDummy("p2", defaultNS, map[string]string{"app": "sensor", "role": "backend"}))
+	policies = append(policies, newNPDummy("p3", defaultNS, map[string]string{"app": "central"}))
+	policies = append(policies, newNPDummy("p4", defaultNS, map[string]string{"app": "central", "role": "frontend"}))
+
+	tests := []struct {
+		name            string
+		deleteID        string
+		getIDExpectedID map[string]string
+	}{
+		{
+			name:            "Delete p1",
+			deleteID:        "p1",
+			getIDExpectedID: map[string]string{"p1": "", "p2": "p2"},
+		},
+		{
+			name:            "Delete p2",
+			deleteID:        "p2",
+			getIDExpectedID: map[string]string{"p1": "p1", "p2": ""},
+		},
+		{
+			name:            "Delete not existing",
+			deleteID:        "zzz",
+			getIDExpectedID: map[string]string{"p1": "p1", "p2": "p2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newNetworkPoliciesStore()
+			for _, p := range policies {
+				store.Upsert(p)
+			}
+
+			store.Delete(tt.deleteID, defaultNS)
+			for getID, expectedID := range tt.getIDExpectedID {
+				got := store.Get(getID)
+				if expectedID == "" && got != nil {
+					t.Errorf("Expected to not find ID but found %s", got.GetId())
+				} else {
+					assert.Equal(t, expectedID, got.GetId())
+				}
+			}
+		})
+	}
+}
+
+func TestNetworkPoliciesStoreAll(t *testing.T) {
+	p0 := newNPDummy("p0", defaultNS, map[string]string{})
+	p1 := newNPDummy("p1", defaultNS, map[string]string{"app": "sensor"})
+	p2 := newNPDummy("p2", defaultNS, map[string]string{"app": "sensor", "role": "backend"})
+	p3 := newNPDummy("p3", "otherNS", map[string]string{"role": "other"})
+
+	tests := []struct {
+		name          string
+		policiesToAdd []*storage.NetworkPolicy
+		expectedIDs   []string
+	}{
+		{
+			name:          "Empty store",
+			policiesToAdd: []*storage.NetworkPolicy{},
+			expectedIDs:   []string{},
+		},
+		{
+			name:          "One policy",
+			policiesToAdd: []*storage.NetworkPolicy{p1},
+			expectedIDs:   []string{"p1"},
+		},
+		{
+			name:          "One policy with 0 selectors",
+			policiesToAdd: []*storage.NetworkPolicy{p0},
+			expectedIDs:   []string{"p0"},
+		},
+		{
+			name:          "Two policies",
+			policiesToAdd: []*storage.NetworkPolicy{p1, p2},
+			expectedIDs:   []string{"p1", "p2"},
+		},
+		{
+			name:          "Two policies different namespaces",
+			policiesToAdd: []*storage.NetworkPolicy{p2, p3},
+			expectedIDs:   []string{"p2", "p3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newNetworkPoliciesStore()
+			for _, p := range tt.policiesToAdd {
+				store.Upsert(p)
+			}
+			got := store.All()
+			for _, expectedID := range tt.expectedIDs {
+				assert.Contains(t, got, expectedID)
+			}
+			assert.Equal(t, len(tt.expectedIDs), store.Size())
+			assert.Equal(t, len(tt.expectedIDs), len(got))
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR is a refactor to prepare the code for the implementation of Network Policy support in system policies. In the future, we would need to check which network policies affect a given deployment. For that, we need to store network deployments in the memory and update this storage as new events from K8s API arrive.

This PR adds a in-memory store for holding NetworkPolicies. It is optimized for quickly finding a set of network policies that would match a given deployment. 

See also:
- the docs in the code comments,
- the proposed [ADR-0004](https://github.com/stackrox/architecture-decision-records/pull/9)

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

- [x] CI with existing tests (weak coverage)
- [x] CI with tests added in this PR 
- [x] Locally run benchmarks


## Important questions to reviewers

1. ~~The complexity of `Find` `O(2^k)` is great if k is small (k = number of labels in deployments). However, for K>=10 the performance would be poor. An alternative implementation (much simpler) could do `O(n*k)` (n = num of network policies in the namespace) which may be way better in some conditions. Please state your opinion about this.~~ 
    - We went with alternative implementation with `Find` running in `O(n*k)`
2. ~~Is the memory consumption of `2n` (+temporary allocations) acceptable?~~ 
    - We have a solution that consumes `n` memory now.
4. The store is not implemented as a singleton (but could be). Do you think this is okay? ⚠️ still valid question

## Auxiliary materials

### Benchmark results

```
# Notation used in naming of benchmark scenarios
#- N = number of elements (network policies) in the store
#- K = number of labels in a deployment (passed to the Find function)
#- L = number of label selector terms in a network policy
```

Too much text to put here - see this [spreadsheet for benchmark results](https://docs.google.com/spreadsheets/d/1LuktrPf5CPpPMF_Yf-pe-RoUkake4S8_kehU1oNcR3I/edit#gid=0).