### PR TITLE
Delete obsolete cy.server call in System Health integration tests

### DIFF
--- a/ui/apps/platform/cypress/integration/systemHealth/integrations.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/integrations.test.js
@@ -96,7 +96,6 @@ describe('System Health Integrations fixtures', () => {
 
     // re-enable when we update this test to work with ROX-7120 System Health in PatternFly
     it.skip('should have counts in healthy text', () => {
-
         // 2 / 3 healthy integrations
         cy.intercept('GET', integrationHealthApi.imageIntegrations, {
             body: {


### PR DESCRIPTION
## Description

Warm up exercise. Forgot to delete `cy.server` when replaced `cy.route` with `cy.intercept` calls.

Find `cy.server` in cypress/integration: from 25 results in 15 files to 23 results in 14 files.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

1. `yarn cypress-open` in ui/apps/platform
    * systemHealth/integrations.test.js