### PR TITLE
Replace cypress server and route with intercept in System Configuration tests

### DIFF
--- a/ui/apps/platform/cypress/integration/systemconfig.test.js
+++ b/ui/apps/platform/cypress/integration/systemconfig.test.js
@@ -98,8 +98,7 @@ describe('System Configuration', () => {
         cy.get(getNumericInputByLabel('Resolved Deploy-Phase Violations')).clear().type(0);
         cy.get(getNumericInputByLabel('Images No Longer Deployed')).clear().type(0);
 
-        cy.get(selectors.pageHeader.saveButton).click();
-        cy.wait(['@putSystemConfiguration', '@getSystemConfiguration']); // visit has intercept for get
+        saveSystemConfiguration();
 
         cy.get(selectors.dataRetention.allRuntimeViolationsBox).should('contain', neverDeletedText);
         cy.get(selectors.dataRetention.resolvedDeployViolationsBox).should(


### PR DESCRIPTION
## Description

> In a future release, support for `cy.server()` and `cy.route()` will be removed.

* Find `cy.server` in cypress/integration: from 23 results in 14 files to 22 results in 13 files.
* Find `cy.route` in cypress/integration: from 64 results in 15 files to 63 results in 14 files.

### Generic changes

https://docs.cypress.io/guides/references/migration-guide#Migrating-cy-route-to-cy-intercept

* Delete `cy.server()` and `beforeEach`
* Replace `cy.route(method, url)` with `cy.intercept(method, url)` in helper functions

### Specific changes

1. Add helper functions
    * `visitSystemConfigurationFromLeftNav`
    * `visitSystemConfiguration`

2. Delete `{ timeout: 10000 }` options
    * `editBaseConfig`

3. Add comment about `{ force: true }` options
    * `editBaseConfig`
    * `disableConfig`

4. Refactor `saveSystemConfiguration` helper function
    * Add intercept and wait for PUT request
    * Move assertion into tests

5. Replace `cy.url()` with `cy.location` and `'contain'` with `'eq'` for more precise assertion

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Ran tests one at a time in local deployment