### PR TITLE
Update `import-additional-cas` script to copy the injected CAs as well

### DIFF
--- a/image/static-bin/import-additional-cas
+++ b/image/static-bin/import-additional-cas
@@ -4,7 +4,7 @@ set -euo pipefail
 
 copy_existing () {
     src=$1
-    if [ -d "$src" ] && [ "$(ls -A "$src")" ]; then
+    if [ -d "$src" ] && [ "$(ls -A -I "..*" "$src")" ]; then
         cp -L "$src"/* /etc/pki/ca-trust/source/anchors
     fi
 }

--- a/image/static-bin/import-additional-cas
+++ b/image/static-bin/import-additional-cas
@@ -2,6 +2,14 @@
 
 set -euo pipefail
 
-cp -L /usr/local/share/ca-certificates/* /etc/pki/injected-ca-trust/* \
-    /etc/pki/ca-trust/source/anchors 2>/dev/null \
-    && update-ca-trust || echo "No custom certificates"
+copy_existing () {
+    src=$1
+    if [ -d "$src" ] && [ "$(ls -A "$src")" ]; then
+        cp -L "$src"/* /etc/pki/ca-trust/source/anchors
+    fi
+}
+
+copy_existing /usr/local/share/ca-certificates
+copy_existing /etc/pki/injected-ca-trust
+
+update-ca-trust

--- a/image/static-bin/import-additional-cas
+++ b/image/static-bin/import-additional-cas
@@ -3,4 +3,5 @@
 set -euo pipefail
 
 cp -L /usr/local/share/ca-certificates/* /etc/pki/injected-ca-trust/* \
-    /etc/pki/ca-trust/source/anchors && update-ca-trust || echo "No custom certificates"
+    /etc/pki/ca-trust/source/anchors 2>/dev/null \
+    && update-ca-trust || echo "No custom certificates"

--- a/image/static-bin/import-additional-cas
+++ b/image/static-bin/import-additional-cas
@@ -2,4 +2,5 @@
 
 set -euo pipefail
 
-cp -L /usr/local/share/ca-certificates/* /etc/pki/ca-trust/source/anchors && update-ca-trust || echo "No custom certificates"
+cp -L /usr/local/share/ca-certificates/* /etc/pki/injected-ca-trust/* \
+    /etc/pki/ca-trust/source/anchors && update-ca-trust || echo "No custom certificates"

--- a/image/static-bin/import-additional-cas
+++ b/image/static-bin/import-additional-cas
@@ -5,7 +5,9 @@ set -euo pipefail
 copy_existing () {
     src=$1
     if [ -d "$src" ] && [ "$(ls -A -I "..*" "$src")" ]; then
-        cp -L "$src"/* /etc/pki/ca-trust/source/anchors
+        cp -v -L "$src"/* /etc/pki/ca-trust/source/anchors
+    else
+        echo "No certificates found in $src"
     fi
 }
 


### PR DESCRIPTION
The injected CAs are the ones injected by the Openshift Network Operator. See ROX-8392.

The script should ignore empty or non-existing source directories, and fail on errors.
Not using `find` as it is not included in ubi8-minimal.