### PR TITLE
Replace cypress server and route with intercept in networkGraph part 1

### DIFF
--- a/ui/apps/platform/cypress/integration/networkGraph/connections.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/connections.test.js
@@ -1,29 +1,13 @@
-import * as api from '../../constants/apiEndpoints';
-import { url as networkUrl, selectors as networkPageSelectors } from '../../constants/NetworkPage';
+import { selectors as networkPageSelectors } from '../../constants/NetworkPage';
 import withAuth from '../../helpers/basicAuth';
 import {
     mouseOverEdgeByNames,
     ensureEdgeNotPresent,
-    selectNamespaceFilters,
+    visitNetworkGraphWithMockedData,
 } from '../../helpers/networkGraph';
 import selectors from '../../selectors/index';
 
 const { cytoscapeContainer } = networkPageSelectors;
-
-function navigateToNetworkGraphWithMockedData() {
-    cy.server();
-
-    cy.fixture('network/networkGraph.json').as('networkGraphJson');
-    cy.route('GET', api.network.networkGraph, '@networkGraphJson').as('networkGraph');
-
-    cy.fixture('network/networkPolicies.json').as('networkPoliciesJson');
-    cy.route('GET', api.network.networkPoliciesGraph, '@networkPoliciesJson').as('networkPolicies');
-
-    cy.visit(networkUrl);
-    selectNamespaceFilters('stackrox');
-    cy.wait('@networkGraph');
-    cy.wait('@networkPolicies');
-}
 
 describe('Network Graph connections filter', () => {
     withAuth();
@@ -36,7 +20,7 @@ describe('Network Graph connections filter', () => {
     const allowedSubstring = 'allowed connection';
 
     it('active appears in namespace edge tooltip', () => {
-        navigateToNetworkGraphWithMockedData();
+        visitNetworkGraphWithMockedData();
 
         cy.get(networkPageSelectors.buttons.activeFilter).click();
 
@@ -50,7 +34,7 @@ describe('Network Graph connections filter', () => {
     });
 
     it('allowed appears in namespace edge tooltip', () => {
-        navigateToNetworkGraphWithMockedData();
+        visitNetworkGraphWithMockedData();
 
         cy.get(networkPageSelectors.buttons.allowedFilter).click();
 
@@ -64,7 +48,7 @@ describe('Network Graph connections filter', () => {
     });
 
     it('active and allowed both appear for all in namespace edge tooltip', () => {
-        navigateToNetworkGraphWithMockedData();
+        visitNetworkGraphWithMockedData();
 
         cy.get(networkPageSelectors.buttons.allFilter).click();
 
@@ -78,7 +62,7 @@ describe('Network Graph connections filter', () => {
     });
 
     it('should not show namespace edges when user hides them', () => {
-        navigateToNetworkGraphWithMockedData();
+        visitNetworkGraphWithMockedData();
 
         cy.get(networkPageSelectors.buttons.allFilter).click();
         cy.get(networkPageSelectors.buttons.hideNsEdgesFilter).click();

--- a/ui/apps/platform/cypress/integration/networkGraph/externalEntities.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/externalEntities.test.js
@@ -1,39 +1,22 @@
-import { url as networkUrl, selectors as networkPageSelectors } from '../../constants/NetworkPage';
+import { selectors as networkPageSelectors } from '../../constants/NetworkPage';
 // TODO: import selectors from '../../selectors';
 
-import * as api from '../../constants/apiEndpoints';
 import withAuth from '../../helpers/basicAuth';
 import {
-    // TODO:    clickOnNodeByName,
+    // TODO: clickOnNodeByName,
     // TODO: filterDeployments,
     filterNamespaces,
     filterClusters,
     filterInternet,
-    selectNamespaceFilters,
+    visitNetworkGraphWithMockedData,
 } from '../../helpers/networkGraph';
 
 describe('External Entities on Network Graph', () => {
     withAuth();
 
-    beforeEach(() => {
-        cy.server();
-
-        cy.fixture('network/networkGraph.json').as('networkGraphJson');
-        cy.route('GET', api.network.networkGraph, '@networkGraphJson').as('networkGraph');
-
-        cy.fixture('network/networkPolicies.json').as('networkPoliciesJson');
-        cy.route('GET', api.network.networkPoliciesGraph, '@networkPoliciesJson').as(
-            'networkPolicies'
-        );
-
-        cy.visit(networkUrl);
-        selectNamespaceFilters('stackrox');
-        cy.wait('@networkGraph');
-        cy.wait('@networkPolicies');
-    });
-
     describe('Baseline state', () => {
         it('should group the namespaces into a cluster wrapper', () => {
+            visitNetworkGraphWithMockedData();
             cy.getCytoscape(networkPageSelectors.cytoscapeContainer).then((cytoscape) => {
                 const clusters = cytoscape.nodes().filter(filterClusters);
                 expect(clusters.size()).to.equal(1);
@@ -47,6 +30,7 @@ describe('External Entities on Network Graph', () => {
         });
 
         it('should group external connections into a node outside the cluster', () => {
+            visitNetworkGraphWithMockedData();
             cy.getCytoscape(networkPageSelectors.cytoscapeContainer).then((cytoscape) => {
                 const externalEntities = cytoscape.nodes().filter(filterInternet);
                 expect(externalEntities.size()).to.equal(1);

--- a/ui/apps/platform/cypress/integration/networkGraph/tooltip.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/tooltip.test.js
@@ -1,43 +1,20 @@
 import * as api from '../../constants/apiEndpoints';
-import { url as networkUrl, selectors as networkPageSelectors } from '../../constants/NetworkPage';
+import { selectors as networkPageSelectors } from '../../constants/NetworkPage';
 import withAuth from '../../helpers/basicAuth';
-import { clickOnNodeByName, mouseOverNodeByName } from '../../helpers/networkGraph';
+import {
+    clickOnNodeByName,
+    mouseOverNodeByName,
+    visitNetworkGraphWithMockedData,
+} from '../../helpers/networkGraph';
 import selectors from '../../selectors/index';
 
 const { cytoscapeContainer } = networkPageSelectors;
-
-function navigateToNetworkGraphWithMockedData() {
-    cy.server();
-
-    cy.fixture('network/networkGraph.json').as('networkGraphJson');
-    cy.route('GET', api.network.networkGraph, '@networkGraphJson').as('networkGraph');
-
-    cy.fixture('network/networkPolicies.json').as('networkPoliciesJson');
-    cy.route('GET', api.network.networkPoliciesGraph, '@networkPoliciesJson').as('networkPolicies');
-
-    cy.visit(networkUrl);
-    cy.wait('@networkGraph');
-    cy.wait('@networkPolicies');
-}
 
 // TODO: update mock data to reflect the new Anomalous/Baseline Flows of Network Detection
 describe.skip('Network Graph tooltip', () => {
     withAuth();
 
     describe('deployment node', () => {
-        beforeEach(() => {
-            cy.server();
-            cy.route('GET', api.risks.riskyDeployments).as('deployments');
-
-            cy.fixture('network/networkGraph.json').as('networkGraphJson');
-            cy.route('GET', api.network.networkGraph, '@networkGraphJson').as('networkGraph');
-
-            cy.fixture('network/networkPolicies.json').as('networkPoliciesJson');
-            cy.route('GET', api.network.networkPoliciesGraph, '@networkPoliciesJson').as(
-                'networkPolicies'
-            );
-        });
-
         const {
             table: { cells: cellsSelector },
         } = selectors;
@@ -49,10 +26,11 @@ describe.skip('Network Graph tooltip', () => {
         const getEgressFlowsText = (count) => `${count} egress flows`;
 
         // TODO: re-enable when https://stack-rox.atlassian.net/browse/ROX-5904 is fixed
-        xit('has no bidirectional', () => {
-            cy.fixture('network/sensorDeployment.json').as('sensorDeploymentJson');
-            cy.route('GET', api.network.deployment, '@sensorDeploymentJson').as('sensorDeployment');
-            navigateToNetworkGraphWithMockedData();
+        it.skip('has no bidirectional', () => {
+            cy.intercept('GET', api.network.deployment, {
+                fixture: 'network/sensorDeployment.json',
+            }).as('sensorDeployment');
+            visitNetworkGraphWithMockedData();
 
             const name = 'sensor';
 
@@ -87,11 +65,10 @@ describe.skip('Network Graph tooltip', () => {
         });
 
         it('has bidirectional', () => {
-            cy.fixture('network/centralDeployment.json').as('centralDeploymentJson');
-            cy.route('GET', api.network.deployment, '@centralDeploymentJson').as(
-                'centralDeployment'
-            );
-            navigateToNetworkGraphWithMockedData();
+            cy.intercept('GET', api.network.deployment, {
+                fixture: 'network/centralDeployment.json',
+            }).as('centralDeployment');
+            visitNetworkGraphWithMockedData();
 
             const name = 'central';
 
@@ -126,11 +103,10 @@ describe.skip('Network Graph tooltip', () => {
         });
 
         it('has ingress only', () => {
-            cy.fixture('network/scannerDbDeployment.json').as('scannerDbDeploymentJson');
-            cy.route('GET', api.network.deployment, '@scannerDbDeploymentJson').as(
-                'scannerDbDeployment'
-            );
-            navigateToNetworkGraphWithMockedData();
+            cy.intercept('GET', api.network.deployment, {
+                fixture: 'network/scannerDbDeployment.json',
+            }).as('scannerDbDeployment');
+            visitNetworkGraphWithMockedData();
 
             const name = 'scanner-db';
 
@@ -167,11 +143,10 @@ describe.skip('Network Graph tooltip', () => {
         });
 
         it('has egress only', () => {
-            cy.fixture('network/collectorDeployment.json').as('collectorDeploymentJson');
-            cy.route('GET', api.network.deployment, '@collectorDeploymentJson').as(
-                'collectorDeployment'
-            );
-            navigateToNetworkGraphWithMockedData();
+            cy.intercept('GET', api.network.deployment, {
+                fixture: 'network/collectorDeployment.json',
+            }).as('collectorDeployment');
+            visitNetworkGraphWithMockedData();
 
             const name = 'collector';
 


### PR DESCRIPTION
## Description

> In a future release, support for `cy.server()` and `cy.route()` will be removed.

* Find `cy.server` in cypress/integration: from 22 results in 13 files to 18 results in 10 files.
* Find `cy.route` in cypress/integration: from 63 results in 14 files to 50 results in 11 files.

### Generic changes

https://docs.cypress.io/guides/references/migration-guide#Migrating-cy-route-to-cy-intercept

* Delete `cy.server()` and `beforeEach`
* Replace `cy.route(method, url)` with `cy.intercept(method, url)` in helper functions
* Replace `cy.route(method, url, '@fixtureAlias')` with `cy.intercept(method, url, { fixture: 'fixtureUrl' })`

### Specific changes

1. helpers/networkGraph.js
    * Add `intercept` and `wait` for clusters after `visit` and before `selectNamespaceFilters` in `visitNetworkGraphWithMockedData` helper function

2. networkGraph/connections.test.js
    * Replace local `navigateToNetworkGraphWithMockedData` function with `visitNetworkGraphWithMockedData` from helpers

3. networkGraph/externalEntities.test.js
    * Replace `beforeEach` call with `visitNetworkGraphWithMockedData` call in each test

4. networkGraph/tooltip.test.js although cannot test because `describe.skip`
    * Replace local `navigateToNetworkGraphWithMockedData` function with `visitNetworkGraphWithMockedData` from helpers
    * Delete `beforeEach` call because redundant with helper function and no wait for risky deployments request
    * Replace `xit` with `it.skip` to avoid confusion with find occurrences

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Ran tests one at a time in local deployment
