### PR TITLE
ROX-9877: Fix flavor helmtest versions

### DIFF
--- a/pkg/helm/charts/tests/securedclusterservices/flavor/flavor_test.go
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/flavor_test.go
@@ -34,14 +34,16 @@ func TestWithDifferentImageFlavors(t *testing.T) {
 	testbuildinfo.SetForTest(t)
 	// having a function as value allows to successfully run this test without dependency to GOTAGS='' and GOTAGS='release'
 	imageFlavorCases := map[string]func() defaults.ImageFlavor{
-		// TODO(ROX-9877): Re-enable development flavor test
-		// "development": func() defaults.ImageFlavor {
-		// 	return defaults.DevelopmentBuildImageFlavor()
-		// },
+		"development": func() defaults.ImageFlavor {
+			testutils.SetVersion(t, testutils.GetExampleVersion(t))
+			return defaults.DevelopmentBuildImageFlavor()
+		},
 		"stackrox": func() defaults.ImageFlavor {
+			testutils.SetVersion(t, testutils.GetExampleVersionUnified(t))
 			return defaults.StackRoxIOReleaseImageFlavor()
 		},
 		"rhacs": func() defaults.ImageFlavor {
+			testutils.SetVersion(t, testutils.GetExampleVersionUnified(t))
 			return defaults.RHACSReleaseImageFlavor()
 		},
 	}
@@ -49,7 +51,6 @@ func TestWithDifferentImageFlavors(t *testing.T) {
 	for name, f := range imageFlavorCases {
 		imageFlavor := f()
 		t.Run(name, func(t *testing.T) {
-			testutils.SetVersion(t, testutils.GetExampleVersionUnified(t))
 			helmChartTestUtils.RunHelmTestSuite(t, testDir, image.SecuredClusterServicesChartPrefix, helmChartTestUtils.RunHelmTestSuiteOpts{
 				Flavor: &imageFlavor,
 				MetaValuesOverridesFunc: func(values *charts.MetaValues) {


### PR DESCRIPTION
## Description

Since the `development.test.yaml` file depends on the non-unified versions, we need to set `testutils.GetExampleVersion` as opposed to `testutils.GetExampleVersionUnified` during test setup. 

I'm surprised the tests passed when this was removed originally. They failed locally when I uncommented the development test.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed
- Let's hope for a green CI
