### PR TITLE
ROX-9863: Drop inherited privileges from operator process 

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -80,4 +80,4 @@ USER 65534:65534
 
 # Wrap entrypoint with capsh to drop inhereited capabilities which were passed by default via the moby container engine.
 # See issue https://bugzilla.redhat.com/show_bug.cgi?id=2066837
-ENTRYPOINT ["capsh", "--inh=''", "-c /usr/local/bin/stackrox-operator"]
+ENTRYPOINT ["capsh", "--inh=''", "--", "-c /usr/local/bin/stackrox-operator"]

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -80,4 +80,4 @@ USER 65534:65534
 
 # Wrap entrypoint with capsh to drop inhereited capabilities which were passed by default via the moby container engine.
 # See issue https://bugzilla.redhat.com/show_bug.cgi?id=2066837
-ENTRYPOINT ["capsh", "--inh=''", "--", "-c /usr/local/bin/stackrox-operator"]
+ENTRYPOINT ["capsh", "--inh=", "--", "-c", "/usr/local/bin/stackrox-operator"]

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -78,4 +78,6 @@ COPY --from=builder ${roxpath}/stackrox-operator /usr/local/bin/
 # Error: container has runAsNonRoot and image has non-numeric user (nobody), cannot verify user is non-root (pod: "stackrox-operator-controller-manager-75bc744454-bkbjr_stackrox-operator-system(49874aae-2695-4d3a-afd3-8723914d2af5)", container: manager)
 USER 65534:65534
 
-ENTRYPOINT ["/usr/local/bin/stackrox-operator"]
+# Wrap entrypoint with capsh to drop inhereited capabilities which were passed by default via the moby container engine.
+# See issue https://bugzilla.redhat.com/show_bug.cgi?id=2066837
+ENTRYPOINT ["capsh", "--inh=''", "-c /usr/local/bin/stackrox-operator"]


### PR DESCRIPTION
## Description

Drop inherited caps from operator container's process to avoid privilege escalations.
As we don't set any caps on our binary the exploit is limited to the default caps provided to the bounding caps of the caller of the process. 
See [1] to get the default caps set by docker.

Also important to note that using this exploit requires calling `execve`.

See:
[1] Default CAPS: https://github.com/moby/moby/blob/master/oci/caps/defaults.go
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2066837
Security Patch: https://github.com/moby/moby/commit/2bbc786e4c59761d722d2d1518cd0a32829bc07f

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

 - CI
 - Manually check inherited caps

```
# Build operator image
make docker-build

# Run docker image
docker run -it --entrypoint /bin/sh docker.io/stackrox/stackrox-operator:$(make tag)

# Create new process
$ /bin/sh

# Create new process and inspect inherited caps. CapInh and CapBnd are the same but CapInh should be empty.
sh-4.4$ cat /proc/$$/status | grep Cap
CapInh: 00000000a80425fb
CapPrm: 0000000000000000
CapEff: 0000000000000000
CapBnd: 00000000a80425fb
CapAmb: 0000000000000000

# close process
$ exit

# Drop inherited caps from new process. If we would start /bin/sh directly you could observe that the CapBnd and CapInh contain the same cap set (expressed as hex).
sh-4.4$ capsh --inh="" -- -c "/bin/sh"

# Read caps from new process
sh-4.4$ cat /proc/$$/status | grep Cap
CapInh: 0000000000000000
CapPrm: 0000000000000000
CapEff: 0000000000000000
CapBnd: 00000000a80425fb
CapAmb: 0000000000000000


# btw: These are the caps the operator runs in docker by default locally:
sh-4.4$ getpcaps $$
Capabilities for `1': = cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_chroot,cap_mknod,cap_audit_write,cap_setfcap+i
```


### Minimal test image:

```
# Dockerfile.test
FROM registry.access.redhat.com/ubi8-minimal:8.5

ENTRYPOINT ["capsh", "--inh=", "--", "-c", "cat /proc/$$/status"]
```

```
❯ docker build -f Dockerfile.test -t test . && docker run docker.io/library/test
[+] Building 0.5s (5/5) FINISHED                                                                                                                                                    
 => [internal] load build definition from Dockerfile.test                                                                                                                      0.0s
 => => transferring dockerfile: 41B                                                                                                                                            0.0s
 => [internal] load .dockerignore                                                                                                                                              0.0s
 => => transferring context: 35B                                                                                                                                               0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi8-minimal:8.5                                                                                                   0.4s
 => CACHED [1/1] FROM registry.access.redhat.com/ubi8-minimal:8.5@sha256:574f201d7ed185a9932c91cef5d397f5298dff9df08bc2ebb266c6d1e6284cd1                                      0.0s
 => exporting to image                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                        0.0s
 => => writing image sha256:b59649c3d38a01bd63f2fe6fde5033416e0d0e9b3c8bd7977d9a7d8aae657725                                                                                   0.0s
 => => naming to docker.io/library/test                                                                                                                                        0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
[...]
CapInh: 0000000000000000
CapPrm: 00000000a80425fb
CapEff: 00000000a80425fb
CapBnd: 00000000a80425fb
CapAmb: 0000000000000000
[...]
```