### PR TITLE
ROX-9898: Prevent clicking on a Delete table action for default policies

### DIFF
--- a/ui/apps/platform/cypress/integration/policies/PatternFly/policiesTable.test.js
+++ b/ui/apps/platform/cypress/integration/policies/PatternFly/policiesTable.test.js
@@ -235,8 +235,10 @@ describe('Policies table', () => {
             cy.get(trSelector).then(([tr]) => {
                 cy.wrap(tr).find(selectors.table.actionsToggleButton).click();
                 cy.wrap(tr)
-                    .find(`${selectors.table.actionsItemButton}:contains("Delete policy")`)
-                    .should('be.disabled');
+                    .find(
+                        `${selectors.table.actionsItemButton}:contains("Cannot delete a default policy")`
+                    )
+                    .should('have.attr', 'aria-disabled', 'true');
             });
         });
     });

--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Detail/PolicyDetail.tsx
@@ -222,7 +222,9 @@ function PolicyDetail({
                                                   isDisabled={isDefault}
                                                   onClick={() => setIsDeleteOpen(true)}
                                               >
-                                                  Delete policy
+                                                  {isDefault
+                                                      ? 'Cannot delete a default policy'
+                                                      : 'Delete policy'}
                                               </DropdownItem>,
                                           ]
                                         : [

--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Table/PoliciesTable.tsx
@@ -431,9 +431,11 @@ function PoliciesTable({
                                           isSeparator: true,
                                       },
                                       {
-                                          title: 'Delete policy',
+                                          title: isDefault
+                                              ? 'Cannot delete a default policy'
+                                              : 'Delete policy',
                                           onClick: () => setDeletingIds([id]),
-                                          disabled: isDefault,
+                                          isDisabled: isDefault,
                                       },
                                   ]
                                 : [exportPolicyAction];


### PR DESCRIPTION
## Description

USER PROBLEM
* As of version 3.70.0, users will no longer be able to delete the default policies included with the StackRox/ACS product
* The table row action dropdown has the Delete item grayed out for default policies, and the cursor does not become a pointer, but that item is still clickable
* When clicked, it still brings up a confirmation dialog, and if confirmed, makes a DELETE request which errors out on the backend.
 
CONDITIONS
Affects all default policies in the policies table view
(Clicking is not allowed for the Delete item in the dropdown Actions menu in the upper-right of the individual view of default policies

ROOT CAUSE
The definition for that Delete action item passed `disabled` to the underlying rendered markup, which is a standard HTML attribute and worked to make the style looked "disabled". However, the PatternFly component expects a customer property `isDisabled` and if present, PatternFly will handle both changing the style AND disabling the click.

FIX
Changed the property name passed in from `disabled` to `isDisabled`

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Tested that Delete can not longer be clicked on default policies
<img width="1495" alt="Screen Shot 2022-03-28 at 1 14 55 PM" src="https://user-images.githubusercontent.com/715729/160491848-dbbb81e3-2bef-47c7-a622-a9634d32176f.png">

Ensured that Delete still available for a user-defined policy
<img width="1495" alt="Screen Shot 2022-03-28 at 1 14 47 PM" src="https://user-images.githubusercontent.com/715729/160491983-834c40e3-05bd-406f-9a6d-21f8d0a87eb9.png">

Ensured that Delete still not available on single view for a default policy
<img width="1495" alt="Screen Shot 2022-03-28 at 1 39 41 PM" src="https://user-images.githubusercontent.com/715729/160492041-95c3a617-38d1-4b56-87ca-7c514c96aa41.png">

Ensured that Delete still available on single view for a user-defined policy
<img width="1495" alt="Screen Shot 2022-03-28 at 1 40 30 PM" src="https://user-images.githubusercontent.com/715729/160492095-de78c869-5cc5-432b-b399-f398145c5dd0.png">
