### PR TITLE
Update prettier 2.6.1 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -165,7 +165,7 @@
         "nyc": "^15.1.0",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^2.6.0",
+        "prettier": "^2.6.1",
         "randomstring": "^1.2.1",
         "react-scripts": "^4.0.1",
         "react-test-renderer": "^17.0.2",

--- a/ui/packages/tailwind-config/package.json
+++ b/ui/packages/tailwind-config/package.json
@@ -38,7 +38,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^2.6.0",
+        "prettier": "^2.6.1",
         "tailwindcss": "^2.0.3"
     }
 }

--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -77,7 +77,7 @@
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^2.6.0",
+        "prettier": "^2.6.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-is": "^17.0.2",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -15531,10 +15531,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.0.tgz#12f8f504c4d8ddb76475f441337542fa799207d4"
-  integrity sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==
+prettier@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.1.tgz#d472797e0d7461605c1609808e27b80c0f9cfe17"
+  integrity sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==
 
 pretty-bytes@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
## Description

https://github.com/prettier/prettier/blob/main/CHANGELOG.md#261

* Fix minimist security issue: update minimist from 1.2.5 to 1.2.6

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

* `yarn lint` in ui
* `yarn build` in ui