### PR TITLE
RS-454: Run gke-upgrade-test under OpenShift CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4876,21 +4876,6 @@ jobs:
             - nop-steps-stanza
       - destroy-osd-gcp-cluster
 
-  openshift-ci-upgrade-test:
-    executor: custom
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /go/src/github.com/stackrox/rox
-      - openshift-ci-mimic-env
-      - run:
-          name: Run the OpenShift CI upgrade test hook
-          command: |
-            .openshift-ci/gke_upgrade_test.py
-      - store_artifacts:
-          path: /tmp/artifact_dir/howto-locate-artifacts.html
-          destination: howto-locate-artifacts.html
-
 workflows:
   version: 2
 
@@ -5225,16 +5210,6 @@ workflows:
               only: /.*/
             branches:
               ignore: /.*/
-          requires:
-            - build-stackrox
-            - build-rhacs
-
-      - openshift-ci-upgrade-test:
-          context:
-          - quay-rhacs-eng-readonly
-          filters:
-            branches:
-              only: /.*(osci).*/
           requires:
             - build-stackrox
             - build-rhacs

--- a/.openshift-ci-migration/README.md
+++ b/.openshift-ci-migration/README.md
@@ -1,0 +1,7 @@
+These files serve as a migration path to run CI using OpenShift CI. OpenShift CI
+is configured to run test jobs against stackrox/rox-openshift-ci-mirror where
+`migrate.sh` is used to invoke the job in the context of a matching branch in
+stackrox/stackrox.
+
+OpenShift CI: https://github.com/openshift/release
+Configuration for StackRox: https://github.com/openshift/release/tree/master/ci-operator/config/stackrox

--- a/.openshift-ci-migration/lib.sh
+++ b/.openshift-ci-migration/lib.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+info() {
+    echo "INFO: $(date): $*"
+}
+
+die() {
+    echo >&2 "$@"
+    exit 1
+}
+
+is_CI() {
+    [[ "${CI:-}" == "true" ]]
+}
+
+is_CIRCLECI() {
+    [[ "${CIRCLECI:-}" == "true" ]]
+}
+
+is_OPENSHIFT_CI() {
+    [[ "${OPENSHIFT_CI:-}" == "true" ]]
+}
+
+require_environment() {
+    if [[ "$#" -lt 1 ]]; then
+        die "usage: require_environment NAME [reason]"
+    fi
+
+    (
+        set +u
+        if [[ -z "$(eval echo "\$$1")" ]]; then
+            varname="$1"
+            shift
+            message="missing \"$varname\" environment variable"
+            if [[ "$#" -gt 0 ]]; then
+                message="$message: $*"
+            fi
+            die "$message"
+        fi
+    )
+}
+
+require_executable() {
+    if [[ "$#" -lt 1 ]]; then
+        die "usage: require_executable NAME [reason]"
+    fi
+
+    if ! command -v "$1" >/dev/null 2>&1; then
+        varname="$1"
+        shift
+        message="missing \"$varname\" executable"
+        if [[ "$#" -gt 0 ]]; then
+            message="$message: $*"
+        fi
+        die "$message"
+    fi
+}
+
+pr_has_label() {
+    if [[ -z "${1:-}" ]]; then
+        die "usage: pr_has_label <expected label>"
+    fi
+
+    require_environment "GITHUB_TOKEN"
+
+    local expected_label="$1"
+    get_pr_details | jq '([.labels | .[].name]  // []) | .[]' -r | grep -qx "${expected_label}"
+}
+
+get_pr_details() {
+    require_environment "GITHUB_TOKEN"
+
+    local pull_request
+    local org
+    local repo
+
+    if is_CIRCLECI; then
+        [ -n "${CIRCLE_PULL_REQUEST}" ] || { echo "Not on a PR, ignoring label overrides"; exit 3; }
+        [ -n "${CIRCLE_PROJECT_USERNAME}" ] || { echo "CIRCLE_PROJECT_USERNAME not found" ; exit 2; }
+        [ -n "${CIRCLE_PROJECT_REPONAME}" ] || { echo "CIRCLE_PROJECT_REPONAME not found" ; exit 2; }
+        pull_request="${CIRCLE_PULL_REQUEST}"
+        org="${CIRCLE_PROJECT_USERNAME}"
+        repo="${CIRCLE_PROJECT_REPONAME}"
+    elif is_OPENSHIFT_CI; then
+        pull_request=$(jq -r <<<"$JOB_SPEC" '.refs.pulls[0].number')
+        org=$(jq -r <<<"$JOB_SPEC" '.refs.org')
+        repo=$(jq -r <<<"$JOB_SPEC" '.refs.repo')
+    else
+        die "not supported"
+    fi
+
+    url="https://api.github.com/repos/${org}/${repo}/pulls/${pull_request}"
+    curl -sS -H "Authorization: token ${GITHUB_TOKEN}" "${url}"
+}

--- a/.openshift-ci-migration/migrate.sh
+++ b/.openshift-ci-migration/migrate.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+source "$ROOT/.openshift-ci-migration/lib.sh"
+
+set -euo pipefail
+
+for cred in /tmp/secret/**/[A-Z]*; do
+    export "$(basename "$cred")"="$(cat "$cred")"
+done
+
+if pr_has_label "debug-tests"; then
+    set -x
+fi
+
+if pr_has_label "delay-tests"; then
+    function hold() {
+        info "Holding on for debug"
+        sleep 3600
+    }
+    trap hold EXIT
+fi
+
+# For cci-export, override BASH_ENV from stackrox-test with something that is writable.
+BASH_ENV=$(mktemp)
+export BASH_ENV
+
+# Clone the target repo
+cd /go/src/github.com/stackrox
+git clone https://github.com/stackrox/stackrox.git
+cd stackrox
+
+# Checkout the PR branch
+org=$(jq -r <<<"$JOB_SPEC" '.refs.org')
+repo=$(jq -r <<<"$JOB_SPEC" '.refs.repo')
+if [[ "$org" == "openshift" && "$repo" == "release" ]]; then
+    info "This is an openshift CI rehearse run and will run against master."
+else
+    head_ref=$(get_pr_details | jq -r '.head.ref')
+    info "Will try to checkout a matching PR branch using: $head_ref"
+    git checkout "$head_ref"
+fi
+
+# make deps as a tire kick
+make deps
+
+# there is no build in OSCI yet, so hard code a known good one for migration
+echo "3.69.x-310-g23ca4e5107" > CI_TAG
+
+# Handoff to target repo dispatch
+.openshift-ci/dispatch.sh "$*"
+
+info "nothing to see here either"

--- a/.openshift-ci/README.md
+++ b/.openshift-ci/README.md
@@ -1,0 +1,1 @@
+This folder contains hooks to run OpenShift CI jobs. 

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+source "$ROOT/scripts/ci/lib.sh"
+
+set -euo pipefail
+
+for cred in /tmp/secret/**/[A-Z]*; do
+    export "$(basename "$cred")"="$(cat "$cred")"
+done
+
+openshift_ci_mods
+
+if pr_has_label "delay-tests"; then
+    function hold() {
+        info "Holding on for debug"
+        sleep 3600
+    }
+    trap hold EXIT
+fi
+
+if [[ "$#" -lt 1 ]]; then
+    die "usage: dispatch <ci-job> [<...other parameters...>]"
+fi
+
+ci_job="$1"
+shift
+
+case "$ci_job" in
+    gke-upgrade-tests)
+        "$ROOT/.openshift-ci/gke_upgrade_test.py"
+        ;;
+    *)
+        # For ease of initial integration this function does not fail when the
+        # job is unknown.
+        info "nothing to see here"
+        exit 0
+esac

--- a/.openshift-ci/gke_upgrade_test.py
+++ b/.openshift-ci/gke_upgrade_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -u
 
 """
 A hook for OpenShift CI to execute an upgrade test in a GKE cluster

--- a/.openshift-ci/posts.py
+++ b/.openshift-ci/posts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-Common steps for after tests are complete
+Common steps when tests complete
 """
 
 import subprocess

--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -126,8 +126,6 @@ dependencies {
     implementation 'commons-codec:commons-codec:1.15'
 }
 
-
-
 tasks.withType(Test) {
     def testGroups = new TestGroups(System.getProperty("groups"))
 

--- a/qa-tests-backend/gradlew
+++ b/qa-tests-backend/gradlew
@@ -44,7 +44,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+DEFAULT_JVM_OPTS='"-Xmx1g" "-Xms512m"'
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"

--- a/qa-tests-backend/gradlew
+++ b/qa-tests-backend/gradlew
@@ -44,7 +44,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx1g" "-Xms512m"'
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"

--- a/qa-tests-backend/settings.gradle
+++ b/qa-tests-backend/settings.gradle
@@ -16,22 +16,3 @@ include 'services:webservice'
 */
 
 rootProject.name = 'qa-tests-backend'
-
-if (System.getenv("OPENSHIFT_CI")) {
-
-    println "Env HOME: " + System.getenv("HOME")
-    println "Property user.home: " + System.getProperty("user.home")
-    println "Property java.util.prefs.userRoot: " + System.getProperty("java.util.prefs.userRoot")
-
-    if (System.getProperty("user.home") == "/") {
-        System.setProperty("user.home", "/tmp")
-        println "Set user.home: " + System.getProperty("user.home")
-    }
-
-    // Mimic JDK prefs
-    gradle.ext.userRootDir =
-            new File(System.getProperty("java.util.prefs.userRoot",
-                    System.getProperty("user.home")), ".java/.userPrefs")
-
-    println("userRootDir: " + gradle.ext.userRootDir.path)
-}

--- a/qa-tests-backend/settings.gradle
+++ b/qa-tests-backend/settings.gradle
@@ -17,3 +17,21 @@ include 'services:webservice'
 
 rootProject.name = 'qa-tests-backend'
 
+if (System.getenv("OPENSHIFT_CI")) {
+
+    println "Env HOME: " + System.getenv("HOME")
+    println "Property user.home: " + System.getProperty("user.home")
+    println "Property java.util.prefs.userRoot: " + System.getProperty("java.util.prefs.userRoot")
+
+    if (System.getProperty("user.home") == "/") {
+        System.setProperty("user.home", "/tmp")
+        println "Set user.home: " + System.getProperty("user.home")
+    }
+
+    // Mimic JDK prefs
+    gradle.ext.userRootDir =
+            new File(System.getProperty("java.util.prefs.userRoot",
+                    System.getProperty("user.home")), ".java/.userPrefs")
+
+    println("userRootDir: " + gradle.ext.userRootDir.path)
+}

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -143,7 +143,9 @@ class BaseSpecification extends Specification {
             BaseService.setUseClientCert(false)
             withRetry(30, 1) {
                 services.ApiTokenService.revokeToken(tokenResp.metadata.id)
-                RoleService.deleteRole(testRole.name)
+                if (testRole) {
+                    RoleService.deleteRole(testRole.name)
+                }
             }
         }
 

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -77,13 +77,13 @@ create_cluster() {
     if is_OPENSHIFT_CI; then
         require_environment "JOB_NAME"
         require_environment "BUILD_ID"
-        tags="${tags},stackrox-ci-${JOB_NAME}"
-        labels="${labels},stackrox-ci-job=${JOB_NAME},stackrox-ci-build-id=${BUILD_ID}"
+        tags="${tags},stackrox-ci-${JOB_NAME:0:50}"
+        labels="${labels},stackrox-ci-job=${JOB_NAME:0:63},stackrox-ci-build-id=${BUILD_ID:0:63}"
     elif is_CIRCLECI; then
         require_environment "CIRCLE_JOB"
         require_environment "CIRCLE_WORKFLOW_ID"
-        tags="${tags},stackrox-ci-${CIRCLE_JOB}"
-        labels="${labels},stackrox-ci-job=${CIRCLE_JOB},stackrox-ci-workflow=${CIRCLE_WORKFLOW_ID}"
+        tags="${tags},stackrox-ci-${CIRCLE_JOB:0:50}"
+        labels="${labels},stackrox-ci-job=${CIRCLE_JOB:0:63},stackrox-ci-workflow=${CIRCLE_WORKFLOW_ID:0:63}"
     else
         die "Support is missing for this CI environment"
     fi
@@ -258,6 +258,8 @@ teardown_gke_cluster() {
     "$SCRIPTS_ROOT/scripts/ci/cleanup-deployment.sh" || true
 
     gcloud container clusters delete "$CLUSTER_NAME" --async
+
+    info "Cluster deleting asynchronously"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -383,6 +383,60 @@ mark_collector_release() {
     /scripts/create_update_pr.sh "${branch_name}" collector "Update RELEASED_VERSIONS" "Add entry into the RELEASED_VERSIONS file"
 }
 
+pr_has_label() {
+    if [[ -z "${1:-}" ]]; then
+        die "usage: pr_has_label <expected label>"
+    fi
+
+    require_environment "GITHUB_TOKEN"
+
+    local expected_label="$1"
+    get_pr_details | jq '([.labels | .[].name]  // []) | .[]' -r | grep -qx "${expected_label}"
+}
+
+get_pr_details() {
+    require_environment "GITHUB_TOKEN"
+
+    local pull_request
+    local org
+    local repo
+
+    if is_CIRCLECI; then
+        [ -n "${CIRCLE_PULL_REQUEST}" ] || { echo "Not on a PR, ignoring label overrides"; exit 3; }
+        [ -n "${CIRCLE_PROJECT_USERNAME}" ] || { echo "CIRCLE_PROJECT_USERNAME not found" ; exit 2; }
+        [ -n "${CIRCLE_PROJECT_REPONAME}" ] || { echo "CIRCLE_PROJECT_REPONAME not found" ; exit 2; }
+        pull_request="${CIRCLE_PULL_REQUEST}"
+        org="${CIRCLE_PROJECT_USERNAME}"
+        repo="${CIRCLE_PROJECT_REPONAME}"
+    elif is_OPENSHIFT_CI; then
+        pull_request=$(jq -r <<<"$JOB_SPEC" '.refs.pulls[0].number')
+        org=$(jq -r <<<"$JOB_SPEC" '.refs.org')
+        repo=$(jq -r <<<"$JOB_SPEC" '.refs.repo')
+    else
+        die "not supported"
+    fi
+
+    url="https://api.github.com/repos/${org}/${repo}/pulls/${pull_request}"
+    curl -sS -H "Authorization: token ${GITHUB_TOKEN}" "${url}"
+}
+
+openshift_ci_mods() {
+    # For ci_export(), override BASH_ENV from stackrox-test with something that is writable.
+    BASH_ENV=$(mktemp)
+    export BASH_ENV
+
+    # For gradle
+    info "HOME ${HOME:-}"
+    export GRADLE_USER_HOME="${HOME}"
+    info "GRADLE_USER_HOME ${GRADLE_USER_HOME:-}"
+    # For OpenJDK
+    set -x
+    mkdir -p "/tmp/.java/.userPrefs"
+    chmod -R 0777 "/tmp/.java"
+    ls -laR "/tmp/.java"
+    set +x
+}
+
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     if [[ "$#" -lt 1 ]]; then
         die "When invoked at the command line a method is required."

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -75,6 +75,11 @@ preamble() {
         die "Only linux or darwin are supported for this test"
     fi
 
+    if is_OPENSHIFT_CI; then
+        # TODO RS-494 will provide the binaries
+        make cli-linux upgrader
+    fi
+
     require_executable "$TEST_ROOT/bin/$TEST_HOST_OS/roxctl"
     require_executable "$TEST_ROOT/bin/$TEST_HOST_OS/upgrader"
 
@@ -85,7 +90,7 @@ preamble() {
         fi
         (cd "$REPO_FOR_TIME_TRAVEL" && git checkout master && git reset --hard && git pull)
     else
-        (cd "$(dirname "$REPO_FOR_TIME_TRAVEL")" && git clone git@github.com:stackrox/stackrox.git "$(basename "$REPO_FOR_TIME_TRAVEL")")
+        (cd "$(dirname "$REPO_FOR_TIME_TRAVEL")" && git clone https://github.com/stackrox/stackrox.git "$(basename "$REPO_FOR_TIME_TRAVEL")")
     fi
 
     if is_CI; then


### PR DESCRIPTION
## Description

This PR contains the changes required to make the `gke-upgrade-test` CI job run under OpenShift CI (OSCI). It also contains a copy of the tooling (`.openshift-ci-migration`) that resides in the intermediate repo (`stackrox/rox-openshift-ci-mirror`) that OSCI is configured to run against.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI:
- [x] Circle CI [upgrade test](https://app.circleci.com/pipelines/github/stackrox/stackrox/9327/workflows/3bda91bc-1c6d-4010-870a-4378f5efad38/jobs/419191)
- [x] OSCI [upgrade test](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_rox-openshift-ci-mirror/7/pull-ci-stackrox-rox-openshift-ci-mirror-master-gke-upgrade-tests/1513630471941001216)