### PR TITLE
ROX-8695 Increase golang-lint timeout to 4m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,11 +159,11 @@ ifdef CI
 	@echo 'The environment indicates we are in CI; running linters in check mode.'
 	@echo 'If this fails, run `make style`.'
 	@echo "Running with no tags..."
-	golangci-lint run
+	golangci-lint run --timeout 4m0s
 	@echo "Running with release tags..."
 	@# We use --tests=false because some unit tests don't compile with release tags,
 	@# since they use functions that we don't define in the release build. That's okay.
-	golangci-lint run --build-tags "$(subst $(comma),$(space),$(RELEASE_GOTAGS))" --tests=false
+	golangci-lint run --timeout 4m0s --build-tags "$(subst $(comma),$(space),$(RELEASE_GOTAGS))" --tests=false
 else
 	golangci-lint run --fix
 	golangci-lint run --fix --build-tags "$(subst $(comma),$(space),$(RELEASE_GOTAGS))" --tests=false


### PR DESCRIPTION
## Description

Default timeout of `golang-lint run` is 1m. This PR increases it to 4m to avoid CI flakes.

I grabbed this ticket as a low-hanging fruit assigned to Maple from the [CI flakes dashboard](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12343264).

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~


## Testing Performed

- [x] CI

```
+ golangci-lint
The environment indicates we are in CI; running linters in check mode.
If this fails, run `make style`.
Running with no tags...
golangci-lint run --timeout 4m0s
Running with release tags...
golangci-lint run --timeout 4m0s --build-tags "release" --tests=false
```