### PR TITLE
Allow RHSA-2022:1065: openssl security update

### DIFF
--- a/release/scripts/allowed_vulns.json
+++ b/release/scripts/allowed_vulns.json
@@ -52,5 +52,11 @@
         "image": ".*",
         "tag": ".*",
         "reason": "This is a Quay false fixable on ubi8:8.5"
+    },
+    {
+        "vuln": "RHSA-2022:1065: openssl security update",
+        "image": ".*",
+        "tag": ".*",
+        "reason": "This is a Quay false fixable on ubi8:8.5"
     }
 ]


### PR DESCRIPTION
https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?tag=8.5-240&push_date=1647338025000&container-tabs=security