### PR TITLE
OSS Branding: Consistency in naming StackRox 

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
+++ b/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
@@ -26,7 +26,7 @@
 ## creating a new cluster with a different name.
 #confirmNewClusterName: null
 #
-## Custom labels associated with a secured cluster in Red Hat Advanced Cluster Security.
+## Custom labels associated with a secured cluster in StackRox.
 #clusterLabels: {}
 #
 ## The gRPC endpoint for accessing StackRox Central.


### PR DESCRIPTION
## Description

This is part of the branding revision on the OpenSource stream. We're leaving the reference to "StackRox" in the comments. Additionally, all across this file, we call the product `StackRox` except in the line changed.

## Checklist
- [ ] ~~Investigated and inspected CI test results~~
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

