### PR TITLE
ROX-9690: Remove mentions to StackRox on swagger info header

### DIFF
--- a/scripts/mergeswag.sh
+++ b/scripts/mergeswag.sh
@@ -12,22 +12,12 @@ folder="$1"
 export TITLE="API Reference"
 export VERSION="1"
 export DESCRIPTION="API reference for the StackRox Security Platform"
-export CONTACT_EMAIL="support@stackrox.com"
-export LICENSE_NAME="All Rights Reserved"
-export LICENSE_URL="https://www.stackrox.com/"
 
 metadata='{
   "info": {
     "title": env.TITLE,
     "version": env.VERSION,
     "description": env.DESCRIPTION,
-    "contact": {
-      "email": env.CONTACT_EMAIL
-    },
-    "license": {
-      "name": env.LICENSE_NAME,
-      "url": env.LICENSE_URL
-    }
   }
 }'
 


### PR DESCRIPTION
## Description

Removes contact and license information mentioning StackRox from the API docs.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- Here's how the API reference header page looks like after removing the swagger info:
![image](https://user-images.githubusercontent.com/6811076/160766625-3340ad18-3e0d-4c4e-b1d9-1289417a4a3b.png)


