### PR TITLE
ROX-9878: Disable postgres scale test on tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3022,9 +3022,10 @@ jobs:
     steps:
     - checkout
     - check-backend-changes
-    - check-label-exists-or-skip:
+    - check-to-run:
         label: ci-postgres-scale-tests
         run-on-master: false
+        run-on-tags: false
     - provision-gke-cluster:
         cluster-id: postgres-scale-test
         machine-type: e2-standard-16
@@ -3765,9 +3766,10 @@ jobs:
     steps:
     - checkout
     - check-backend-changes
-    - check-label-exists-or-skip:
+    - check-to-run:
         label: ci-postgres-scale-tests
         run-on-master: false
+        run-on-tags: false
     - setup_remote_docker
     - attach_workspace:
         at: /go/src/github.com/stackrox/rox


### PR DESCRIPTION
## Description

Disable postgres test trigger by tag.
We cannot override the feature flag for release builds and it looks like we do not intend to run it on master commits either.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs]~(https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI test.