### PR TITLE
Disable CIDR blocks and Net Policy buttons when no namespaces are selected.

### DIFF
--- a/ui/apps/platform/src/Containers/Network/Header/Header.tsx
+++ b/ui/apps/platform/src/Containers/Network/Header/Header.tsx
@@ -6,10 +6,11 @@ import FilterToolbar from './FilterToolbar';
 import SimulatorButton from './SimulatorButton';
 
 type HeaderProps = {
+    isGraphDisabled: boolean;
     isSimulationOn: boolean;
 };
 
-function Header({ isSimulationOn }: HeaderProps): ReactElement {
+function Header({ isGraphDisabled, isSimulationOn }: HeaderProps): ReactElement {
     return (
         <>
             <PageSection variant="light">
@@ -17,8 +18,8 @@ function Header({ isSimulationOn }: HeaderProps): ReactElement {
                     <Title className="pf-u-flex-grow-1" headingLevel="h1">
                         Network Graph
                     </Title>
-                    <CIDRFormButton isDisabled={isSimulationOn} />
-                    <SimulatorButton isDisabled={isSimulationOn} />
+                    <CIDRFormButton isDisabled={isGraphDisabled || isSimulationOn} />
+                    <SimulatorButton isDisabled={isGraphDisabled || isSimulationOn} />
                 </Flex>
             </PageSection>
             <Divider component="div" />

--- a/ui/apps/platform/src/Containers/Network/Header/SimulatorButton.tsx
+++ b/ui/apps/platform/src/Containers/Network/Header/SimulatorButton.tsx
@@ -46,7 +46,7 @@ function SimulatorButton({
         <Button
             data-testid={`simulator-button-${creatingOrSimulating ? 'on' : 'off'}`}
             onClick={toggleSimulation}
-            disabled={isDisabled}
+            isDisabled={isDisabled}
             variant="primary"
         >
             Network Policy Simulator

--- a/ui/apps/platform/src/Containers/Network/Page.js
+++ b/ui/apps/platform/src/Containers/Network/Page.js
@@ -117,13 +117,15 @@ function NetworkPage({ closeSidePanel, setDialogueStage, setNetworkModification 
         };
     }, [closeSidePanel, setDialogueStage, setNetworkModification]);
 
+    const isGraphDisabled = selectedNamespaceFilters.length === 0;
+
     return (
         <>
-            <Header isSimulationOn={isSimulationOn} />
+            <Header isGraphDisabled={isGraphDisabled} isSimulationOn={isSimulationOn} />
             <section className="flex flex-1 h-full w-full">
                 <div className="flex flex-1 flex-col w-full overflow-hidden">
                     <div className="flex flex-1 flex-col relative">
-                        {selectedNamespaceFilters.length === 0 ? (
+                        {isGraphDisabled ? (
                             <NoSelectedNamespace clusterName={clusterName} />
                         ) : (
                             <GraphFrame />


### PR DESCRIPTION
## Description

This PR disabled the CIDR blocks and Net Policy buttons when no namespaces are selected in the Network Graph. These buttons do not have a use when no data is visible, and clicking on the Net Policy button will disable the other controls until it is clicked again, creating bad UX.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Viewing the Network Graph page by default will render the buttons as disabled:
![image](https://user-images.githubusercontent.com/1292638/160707163-065f382b-d399-4e7f-b984-2056caf71435.png)

Turning on a namespace enables the buttons:
![image](https://user-images.githubusercontent.com/1292638/160707246-cdd78b90-a1c0-47c6-8674-12858dfdcd61.png)

Clearing the namespaces re-disables the buttons:
![image](https://user-images.githubusercontent.com/1292638/160707415-0615bade-7a9a-44a3-a78a-27cacffa6c40.png)
