### PR TITLE
Replace cypress server and route with intercept in networkGraph part 2

### DIFF
--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -118,7 +118,15 @@ export function filterBySourceTarget(sourceNode, targetNode) {
     };
 }
 
-// visit helpers
+// search filters
+
+export function selectDeploymentFilter(deploymentName) {
+    cy.intercept('GET', api.network.networkGraph).as('networkGraph');
+    cy.intercept('GET', api.network.networkPoliciesGraph).as('networkPolicies');
+    cy.get(networkGraphSelectors.toolbar.filterSelect).type('Deployment{enter}');
+    cy.get(networkGraphSelectors.toolbar.filterSelect).type(`${deploymentName}{enter}{esc}`);
+    cy.wait(['@networkGraph', '@networkPolicies']);
+}
 
 export function selectNamespaceFilters(...namespaces) {
     cy.get(networkGraphSelectors.toolbar.namespaceSelect).click();
@@ -126,6 +134,19 @@ export function selectNamespaceFilters(...namespaces) {
         cy.contains(`${selectSelectors.patternFlySelect.openMenu} span`, ns).click();
     });
     cy.get(networkGraphSelectors.toolbar.namespaceSelect).click();
+}
+
+// visit helpers
+
+export function visitNetworkGraphWithNamespaceFilters(...namespaces) {
+    cy.intercept('GET', api.clusters.list).as('clusters');
+    cy.visit(networkUrl);
+    cy.wait('@clusters');
+
+    cy.intercept('GET', api.network.networkGraph).as('networkGraph');
+    cy.intercept('GET', api.network.networkPoliciesGraph).as('networkPolicies');
+    selectNamespaceFilters(...namespaces);
+    cy.wait(['@networkGraph', '@networkPolicies']);
 }
 
 export function visitNetworkGraphWithMockedData() {


### PR DESCRIPTION
## Description

> In a future release, support for `cy.server()` and `cy.route()` will be removed.

* Find `cy.server` in cypress/integration: from 18 results in 10 files to 17 results in 9 files.
* Find `cy.route` in cypress/integration: from 50 results in 11 files to 45 results in 10 files.

### Generic changes

https://docs.cypress.io/guides/references/migration-guide#Migrating-cy-route-to-cy-intercept

* Delete `cy.server()` and `beforeEach`
* Replace `cy.route(method, url)` with `cy.intercept(method, url)` in helper functions
* Replace `cy.route(method, url, '@fixtureAlias')` with `cy.intercept(method, url, { fixture: 'fixtureUrl' })`

### Specific changes

1. Network Deployment Details
    * Call `visitNetworkGraphWithMockData` helper function
    * Add `intercept` and `wait` for deployment request

2. Network Graph Search
    * Call `visitNetworkGraphWithNamespaceFilters` helper function
    * Factor out `selectDeploymentFilter` helper function

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

@sachaudh
* Can you verify that the pictures are what you expect?
* Are there more descriptive names for tests 2 and 3 below? /cc @dvail did the test change for namespace filter?

Ran tests one at a time in local deployment

1. should open up the Deployments Side Panel when a deployment is clicked
    <img width="963" alt="networkGraph-1" src="https://user-images.githubusercontent.com/11862657/160710666-460ed044-7971-4430-b9f8-706c2d2e977b.png">

2. should filter to show only the deployments from the stackrox namespace and deployments connected to them
    <img width="964" alt="networkGraph-2" src="https://user-images.githubusercontent.com/11862657/160710688-f1c32130-e221-451d-8a6d-2b22e49896e5.png">

3. should filter to show only the stackrox namespace and deployments connected to stackrox namespace
    <img width="965" alt="networkGraph-3" src="https://user-images.githubusercontent.com/11862657/160710738-e25c08f3-52ef-4874-bd96-3b11842c532b.png">

4. should filter to show only a specific deployment and deployments connected to it
    <img width="964" alt="networkGraph-4" src="https://user-images.githubusercontent.com/11862657/160710772-7e3c7786-8209-4c4e-b5c3-120a09c87be5.png">

