### PR TITLE
ROX-9938: Adding Create option to image exclusion field in Policy Wizard

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step4/PolicyScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step4/PolicyScopeForm.tsx
@@ -11,7 +11,6 @@ import {
     Select,
     SelectVariant,
     SelectOption,
-    Form,
     FormGroup,
 } from '@patternfly/react-core';
 


### PR DESCRIPTION
## Description

Providing feature parity with classic UI functionality in allowing the user to create an excluded image option in the dropdown.
<img width="863" alt="image" src="https://user-images.githubusercontent.com/10412893/160745497-38c62ed6-7ce5-4ed5-a480-d10760d2596c.png">


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
