### PR TITLE
Reduce scope of network graphql call to only return the required data.

### DIFF
--- a/ui/apps/platform/src/Containers/Network/Header/useNamespaceFilters.ts
+++ b/ui/apps/platform/src/Containers/Network/Header/useNamespaceFilters.ts
@@ -1,10 +1,9 @@
 import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
-import { useQuery } from '@apollo/client';
+import { gql, useQuery } from '@apollo/client';
 
 import { selectors } from 'reducers';
-import { CLUSTER_WITH_NAMESPACES } from 'queries/cluster';
 
 type SelectorState = { selectedClusterId: string | null; selectedNamespaceFilters: string[] };
 type SelectorResult = SelectorState;
@@ -14,7 +13,6 @@ const selector = createStructuredSelector<SelectorState, SelectorResult>({
     selectedNamespaceFilters: selectors.getSelectedNamespaceFilters,
 });
 
-// TODO This is a minimum expected return type - do we have clearly defined typings elsewhere?
 type NamespaceMetadataResp = {
     id: string;
     results: {
@@ -25,6 +23,19 @@ type NamespaceMetadataResp = {
         }[];
     };
 };
+
+export const NAMESPACES_FOR_CLUSTER_QUERY = gql`
+    query getClusterNamespaceNames($id: ID!) {
+        results: cluster(id: $id) {
+            id
+            namespaces {
+                metadata {
+                    name
+                }
+            }
+        }
+    }
+`;
 
 function useNamespaceFilters() {
     const [availableNamespaceFilters, setAvailableNamespaceFilters] = useState<string[]>([]);
@@ -38,7 +49,7 @@ function useNamespaceFilters() {
         : { skip: true };
 
     const { loading, error, data } = useQuery<NamespaceMetadataResp, { id: string }>(
-        CLUSTER_WITH_NAMESPACES,
+        NAMESPACES_FOR_CLUSTER_QUERY,
         queryOptions
     );
 


### PR DESCRIPTION
## Description

This PR reduces the scope of the GraphQL call used in the NamespaceSelect component to only request namespace names given a cluster id. The previous version of the query reused an existing gql query that pulled additional metadata as well as data for all of the nodes that were part of the selected query. Since none of this information is needed, it was pure overhead and is removed for this use case.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

Test that namespaces belonging to a cluster are loaded correctly when visiting the Network Graph page:
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/1292638/160839366-1622905c-fbcc-43d2-8ff1-a9f73c750114.png">

Test that selecting a namespace correctly loads data into the graph:
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/1292638/160839444-a5c36856-724b-42f5-aedf-32813ad2ec1c.png">

Test that changing the selected cluster correctly loads a new list of namespaces:
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/1292638/160840078-cf067e33-a1ff-42a0-bc8e-b48f9645eca6.png">

