### PR TITLE
Replace cypress server and route with intercept in systemHealth vulnDefinitions

### DIFF
--- a/ui/apps/platform/cypress/integration/systemHealth/vulnDefinitions.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/vulnDefinitions.test.js
@@ -7,12 +7,10 @@ const nbsp = '\u00A0';
 describe('System Health Vulnerability Definitions local deployment', () => {
     withAuth();
 
-    beforeEach(() => {
-        cy.server();
-        cy.route('GET', integrationHealthApi.vulnDefinitions).as('GetVulnerabilityDefinitionsInfo');
-    });
-
     it('should have widget and up to date text', () => {
+        cy.intercept('GET', integrationHealthApi.vulnDefinitions).as(
+            'GetVulnerabilityDefinitionsInfo'
+        );
         cy.visit(systemHealthUrl);
         cy.wait('@GetVulnerabilityDefinitionsInfo');
 
@@ -32,11 +30,9 @@ describe('System Health Vulnerability Definitions fixtures', () => {
         const currentDatetime = new Date('2020-12-10T03:04:59.377369440Z'); // exactly 24 hours
         cy.clock(currentDatetime.getTime(), ['Date', 'setInterval']);
 
-        cy.server();
-        cy.route('GET', integrationHealthApi.vulnDefinitions, {
-            lastUpdatedTimestamp: '2020-12-09T03:04:59.377369440Z',
+        cy.intercept('GET', integrationHealthApi.vulnDefinitions, {
+            body: { lastUpdatedTimestamp: '2020-12-09T03:04:59.377369440Z' },
         }).as('GetVulnerabilityDefinitionsInfo');
-
         cy.visit(systemHealthUrl);
         cy.wait('@GetVulnerabilityDefinitionsInfo');
 


### PR DESCRIPTION
## Description

> In a future release, support for `cy.server()` and `cy.route()` will be removed.

* Find `cy.server` in cypress/integration: from 16 results in 9 files to 14 results in 8 files.
* Find `cy.route` in cypress/integration: from 45 results in 10 files to 43 results in 9 files.

### Generic changes

https://docs.cypress.io/guides/references/migration-guide#Migrating-cy-route-to-cy-intercept

* Delete `cy.server()` and `beforeEach`
* Replace `cy.route(method, url)` with `cy.intercept(method, url)`
* Replace `cy.route(method, url, { … })` with `cy.intercept(method, url, { body: { … } })`

### Specific changes

1. integration/systemHealth/vulnDefinitions.test.js
    * Replace `cy.server` and `cy.route` in `beforeEach` with `cy.intercept` in first test
    * Replace `cy.server` and `cy.route` with `cy.intercept` in second test

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Ran tests one at a time in local deployment