### PR TITLE
Filter net graph edges that have a source NS that is not selected

### DIFF
--- a/ui/apps/platform/src/Components/NetworkGraph/NetworkGraph.js
+++ b/ui/apps/platform/src/Components/NetworkGraph/NetworkGraph.js
@@ -431,7 +431,16 @@ const NetworkGraph = ({
         });
 
         let allNodes = [...namespaceList, ...deploymentList, ...namespaceEdgeNodes];
-        const allEdges = getEdges(configObj);
+
+        const namespaces = new Set(namespaceList.map((ns) => ns.data.id));
+        const allEdges = getEdges(configObj).filter((edge) => {
+            // Filter out candidate edges with a sourceNodeNamespace that does not appear
+            // in the namespaceList. When this occurs, edges are sent to Cytoscape that require
+            // a connection to a node that does not exist, causing the component to crash. This
+            // happens when namespace filtering is applied to the network graph and an edge is
+            // created that connects to a namespace the is not part of the current filter.
+            return namespaces.has(edge.data.sourceNodeNamespace);
+        });
 
         const clusterNode = getClusterNode(selectedClusterName);
         allNodes.push(clusterNode);


### PR DESCRIPTION
## Description

This appears to fix the issue described in https://issues.redhat.com/browse/ROX-9870 that causes the network graph component to crash when "Flow: ALL" is selected against certain combinations of filtered namespaces.

When building the edge map, any edge that contains a source namespace that is not part of one of the selected namespaces is filtered out. This fixes the crashing bug and does not appear to have an impact on the display of the graph when known good combinations of namespaces and "Flow" settings are selected.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

TODO(replace-me)

I will upload screenshots of a variety of scenarios, comparing them to the baseline, if the approach in this PR looks good.