### PR TITLE
ROX-9725: Delete redundant save command in imageIntegrations dtr test

### DIFF
--- a/ui/apps/platform/cypress/integration/integrations/imageIntegrations.test.js
+++ b/ui/apps/platform/cypress/integration/integrations/imageIntegrations.test.js
@@ -290,7 +290,6 @@ describe('Image Integrations Test', () => {
         getInputByLabel('Password').type('password');
 
         cy.get(selectors.buttons.test).should('be.enabled');
-        cy.get(selectors.buttons.save).should('be.enabled').click();
         saveImageIntegrationType(integrationType);
     });
 


### PR DESCRIPTION
## Description

* 03-24 1057 https://app.circleci.com/pipelines/github/stackrox/stackrox/7979/workflows/b82fc22b-8e9b-4109-8258-0296fa3eb8a8/jobs/350817
* 03-28 1092 https://app.circleci.com/pipelines/github/stackrox/stackrox/8164/workflows/37401486-14b7-4796-965c-05fbbb5aee6d/jobs/359655
* 03-29 1100 https://app.circleci.com/pipelines/github/stackrox/stackrox/8267/workflows/8f5425e0-3998-455c-b52e-ac1dba1e3551/jobs/364305

`'should create a new Docker Trusted Registry integration'` incorrectly attempts to click **Save** a second time
![save-2](https://user-images.githubusercontent.com/11862657/160912070-74567dad-6daf-446c-8a2f-e7a0402c8937.png)

Fix my bad in #553
* Added `saveImageIntegrationType` helper function
* Missed deleting one occurrence of `cy.get(selectors.buttons.save).should('be.enabled').click();`

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edit integration test

## Testing Performed

Ran test locally
* Before change: incorrect 2 click **Save**
* After change: correct only 1 click **Save**