### PR TITLE
Remove negated policy criteria option + align texts to "Trusted image signers"

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step3/ImageSignersCriteriaFieldInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step3/ImageSignersCriteriaFieldInput.tsx
@@ -84,7 +84,7 @@ function ImageSignersCriteriaFieldInput({ setValue, value, readOnly = false }): 
             >
                 <ModalBoxBody>
                     <PageSection variant="light">
-                        Select integrated trust image signers from the table below.
+                        Select trusted image signers from the table below.
                         <TableComposable variant="compact" isStickyHeader>
                             <Thead>
                                 <Tr>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Form/descriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Form/descriptors.tsx
@@ -230,11 +230,10 @@ export type TextDescriptor = {
 
 // TODO: merge with policyConfigurationDescriptor after ROX_VERIFY_IMAGE_SIGNATURE enabled by default
 export const imageSigningCriteriaDescriptor: SignatureDescriptor = {
-    label: 'Trust image signers',
+    label: 'Trusted image signers',
     name: imageSigningCriteriaName,
-    shortName: 'Trust image signers',
-    longName: 'Trust image signers',
-    negatedName: 'Do not trust image signers',
+    shortName: 'Trusted image signers',
+    longName: 'Trusted image signers',
     category: policyCriteriaCategories.IMAGE_REGISTRY,
     type: 'signaturePolicyCriteria',
     canBooleanLogic: true,


### PR DESCRIPTION
## Description

Both changes were discussed offline.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

<img width="1493" alt="Screenshot 2022-03-30 at 21 16 21" src="https://user-images.githubusercontent.com/78353299/160914824-51ad1b21-458c-4b0f-aad9-321de3effe95.png">

