### PR TITLE
Add debug log statements for signature fetching / verification.

### DIFF
--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -613,8 +613,7 @@ func (e *enricherImpl) enrichWithSignature(ctx context.Context, enrichmentContex
 	if len(fetchedSignatures) == 0 {
 		// Delete existing signatures on the image if we fetched zero.
 		if len(img.GetSignature().GetSignatures()) != 0 {
-			log.Debugf("No signatures found but image %q had existing signatures, "+
-				"deleting those", imgName)
+			log.Debugf("No signatures found but image %q had existing signatures, deleting those", imgName)
 			img.Signature = nil
 			return true, nil
 		}

--- a/pkg/signatures/public_key_verifier.go
+++ b/pkg/signatures/public_key_verifier.go
@@ -71,6 +71,8 @@ func newCosignPublicKeyVerifier(config *storage.CosignPublicKeyVerification) (*c
 // as well as the claim verification of the payload of the signature.
 func (c *cosignPublicKeyVerifier) VerifySignature(ctx context.Context,
 	image *storage.Image) (storage.ImageSignatureVerificationResult_Status, error) {
+	log.Debugf("Verifying signatures of image %q with the following public keys: %+v",
+		image.GetName().GetFullName(), c.parsedPublicKeys)
 	// Short circuit if we do not have any public keys configured to verify against.
 	if len(c.parsedPublicKeys) == 0 {
 		return storage.ImageSignatureVerificationResult_FAILED_VERIFICATION, errNoKeysToVerifyAgainst

--- a/pkg/signatures/public_key_verifier.go
+++ b/pkg/signatures/public_key_verifier.go
@@ -71,8 +71,6 @@ func newCosignPublicKeyVerifier(config *storage.CosignPublicKeyVerification) (*c
 // as well as the claim verification of the payload of the signature.
 func (c *cosignPublicKeyVerifier) VerifySignature(ctx context.Context,
 	image *storage.Image) (storage.ImageSignatureVerificationResult_Status, error) {
-	log.Debugf("Verifying signatures of image %q with the following public keys: %+v",
-		image.GetName().GetFullName(), c.parsedPublicKeys)
 	// Short circuit if we do not have any public keys configured to verify against.
 	if len(c.parsedPublicKeys) == 0 {
 		return storage.ImageSignatureVerificationResult_FAILED_VERIFICATION, errNoKeysToVerifyAgainst


### PR DESCRIPTION
## Description

Small QoL change to add debug log statements for fetching and verifying signatures within the image enricher / public key verifier, so we can investigate potential issues more easily.

