### PR TITLE
Jv/rox 9202 run stackrox circleci from collector circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1791,6 +1791,17 @@ commands:
       - run:
           name: Configure Deployment Environment
           command: |
+            function check_and_set() {
+                local name="$1"
+                local value="$2"
+                if [[ -z "${value}" ]]; then
+                    echo "Parameter ${name} is missing"
+                    some_missing=1
+                else
+                    cci-export "$name" "${value}"
+                fi
+            }
+
             cci-export KUBECONFIG "$PWD/openshift/artifacts/config"
             cci-export CLAIRIFY_IMAGE_TAG 0.5.2
             cci-export OPENSHIFT_HOST "$(cat openshift/artifacts/master)"
@@ -1806,7 +1817,7 @@ commands:
             cci-export SCANNER_DB_IMAGE "quay.io/$REPO/scanner-db:$(cat "$(git rev-parse --show-toplevel)/SCANNER_VERSION")"
 
             if [[ -z "<< pipeline.parameters.collector_version >>" ]]; then
-              cci-export COLLECTOR_VERSION "<< pipeline.parameters.collector_version >>"
+              check_and_set COLLECTOR_VERSION "<< pipeline.parameters.collector_version >>"
             fi
 
       - remove-existing-stackrox-resources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1816,9 +1816,7 @@ commands:
             cci-export SCANNER_IMAGE "quay.io/$REPO/scanner:$(cat "$(git rev-parse --show-toplevel)/SCANNER_VERSION")"
             cci-export SCANNER_DB_IMAGE "quay.io/$REPO/scanner-db:$(cat "$(git rev-parse --show-toplevel)/SCANNER_VERSION")"
 
-            if [[ -z "<< pipeline.parameters.collector_version >>" ]]; then
-              check_and_set COLLECTOR_VERSION "<< pipeline.parameters.collector_version >>"
-            fi
+            check_and_set COLLECTOR_VERSION "<< pipeline.parameters.collector_version >>"
 
       - remove-existing-stackrox-resources
       - *setupGoogleAppCreds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1795,6 +1795,7 @@ commands:
           name: Configure Deployment Environment
           command: |
             function check_and_set() {
+                echo "In check_and_set"
                 local name="$1"
                 local value="$2"
                 if [[ -z "${value}" ]]; then
@@ -1802,6 +1803,7 @@ commands:
                     some_missing=1
                 else
                     cci-export "$name" "${value}"
+                    echo "exporting $name $value"
                 fi
             }
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,6 +492,9 @@ parameters:
     type: string
     # Caution when editing: make sure groups would correspond to BASH_REMATCH use.
     default: '^([[:digit:]]+(\.[[:digit:]]+)*)(-rc\.[[:digit:]]+)?$'
+  collector_version:
+    type: string
+    default: ""
 
 orbs:
   win: circleci/windows@2.2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1805,6 +1805,10 @@ commands:
             cci-export SCANNER_IMAGE "quay.io/$REPO/scanner:$(cat "$(git rev-parse --show-toplevel)/SCANNER_VERSION")"
             cci-export SCANNER_DB_IMAGE "quay.io/$REPO/scanner-db:$(cat "$(git rev-parse --show-toplevel)/SCANNER_VERSION")"
 
+            if [[ -z "<< pipeline.parameters.collector_version >>" ]]; then
+              cci-export COLLECTOR_VERSION "<< pipeline.parameters.collector_version >>"
+            fi
+
       - remove-existing-stackrox-resources
       - *setupGoogleAppCreds
       - *setupLicense

--- a/Makefile
+++ b/Makefile
@@ -679,7 +679,11 @@ ossls-notice: deps
 
 .PHONY: collector-tag
 collector-tag:
+ifdef COLLECTOR_VERSION
+	@echo $(COLLECTOR_VERSION)
+else
 	@cat COLLECTOR_VERSION
+endif
 
 .PHONY: docs-tag
 docs-tag:


### PR DESCRIPTION
## Description

Enables COLLECTOR_VERSION to be set in CircleCI using a pipeline parameter. This is a companion PR to https://github.com/stackrox/collector/pull/618 which enables the stackrox CircleCI to be run from the collector CircleCI

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Determined and documented upgrade steps

No unit or integration tests are needed as this is only a change to CircleCI

## Testing Performed

Ran CircleCI here https://github.com/stackrox/collector/pull/618 multiple times to make sure that the stackrox CircleCI ran as expected.
