### PR TITLE
make go binaries executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -554,6 +554,8 @@ endif
 	cp bin/linux/upgrader          image/bin/sensor-upgrader
 	cp bin/linux/admission-control image/bin/admission-control
 	cp bin/linux/collection        image/bin/compliance
+	# Workaround to bug in lima: https://github.com/lima-vm/lima/issues/602
+	find image/bin -not -path "*/.*" -type f -exec chmod +x {} \;
 
 
 .PHONY: copy-binaries-to-image-dir


### PR DESCRIPTION
Lima manages virtual machines on macOS, which can be used as a
replacement to `Docker Desktop`. Currently, Lima contains a bug that
leads to go binaries not being executable if they have been built inside
a mounted volume (https://github.com/lima-vm/lima/issues/602).

As a workaround, add execution to the file permissions explicitly. This
should be a no-op when Lima is not used, for example on Linux systems.