### PR TITLE
Convert search-related code to TypeScript.

### DIFF
--- a/ui/apps/platform/src/Components/SearchFilterInput/SearchFilterInput.tsx
+++ b/ui/apps/platform/src/Components/SearchFilterInput/SearchFilterInput.tsx
@@ -3,12 +3,13 @@ import React, { useEffect, useState } from 'react';
 import SearchInput, { createSearchModifiers } from 'Components/SearchInput';
 import { fetchAutoCompleteResults } from 'services/SearchService';
 import { SearchEntry, SearchFilter } from 'types/search';
+import { SearchCategory } from 'constants/searchOptions';
 
 type SearchFilterInputProps = {
     className: string;
     handleChangeSearchFilter: (searchFilter: SearchFilter) => void;
     placeholder: string;
-    searchCategory: string;
+    searchCategory: SearchCategory;
     searchFilter: SearchFilter;
     searchOptions: string[]; // differs from searchOptions prop of SearchInput
 };

--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Table/PoliciesTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Table/PoliciesTablePage.tsx
@@ -26,8 +26,8 @@ import { ListPolicy } from 'types/policy.proto';
 import { NotifierIntegration } from 'types/notifier.proto';
 import { SearchFilter } from 'types/search';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
-import { getRequestQueryStringForSearchFilter } from '../policies.utils';
 import ImportPolicyJSONModal from '../Modal/ImportPolicyJSONModal';
 import PoliciesTable from './PoliciesTable';
 

--- a/ui/apps/platform/src/Containers/Policies/PatternFly/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/policies.utils.ts
@@ -79,17 +79,6 @@ export function getSearchStringForFilter(s: SearchFilter): string {
     );
 }
 
-/*
- * Return request query string for search filter. Omit filter criterion:
- * If option does not have value.
- */
-export function getRequestQueryStringForSearchFilter(searchFilter: SearchFilter): string {
-    return Object.entries(searchFilter)
-        .filter(([, value]) => value.length !== 0)
-        .map(([key, value]) => `${key}:${Array.isArray(value) ? value.join(',') : value}`)
-        .join('+');
-}
-
 // categories
 
 export function formatCategories(categories: string[]): string {

--- a/ui/apps/platform/src/Containers/Search/SearchResults.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchResults.tsx
@@ -17,6 +17,7 @@ import { TableComposable, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-tab
 import { addSearchModifier, addSearchKeyword } from 'utils/searchUtils';
 import { selectors } from 'reducers';
 import { actions as globalSearchActions } from 'reducers/globalSearch';
+import { GlobalSearchOption } from 'types/search';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import RelatedLink from './RelatedLink';
 
@@ -27,12 +28,6 @@ type GlobalSearchResult = {
     fieldToMatch: Record<string, unknown>;
     score: number;
     location: string;
-};
-
-type GlobalSearchOption = {
-    value: string;
-    label: string;
-    type?: string;
 };
 
 type SearchTab = {

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -5,7 +5,7 @@ import Raven from 'raven-js';
 import { PageSection, Bullseye, Alert, Divider, Title } from '@patternfly/react-core';
 
 import { actions as alertActions } from 'reducers/alerts';
-import { SearchEntry, SearchState } from 'reducers/pageSearch';
+import { SearchState } from 'reducers/pageSearch';
 import { selectors } from 'reducers';
 import { fetchAlerts, fetchAlertCount } from 'services/AlertsService';
 
@@ -13,6 +13,7 @@ import useEntitiesByIdsCache from 'hooks/useEntitiesByIdsCache';
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';
 import VIOLATION_STATES from 'constants/violationStates';
 import { ENFORCEMENT_ACTIONS } from 'constants/enforcementActions';
+import { SearchEntry } from 'types/search';
 
 import ReduxSearchInput from 'Containers/Search/ReduxSearchInput';
 import useTableSort from 'hooks/useTableSort';

--- a/ui/apps/platform/src/constants/searchOptions.ts
+++ b/ui/apps/platform/src/constants/searchOptions.ts
@@ -1,4 +1,15 @@
-export const SEARCH_CATEGORIES = {
+export type SearchCategory =
+    | 'ALERTS'
+    | 'DEPLOYMENTS'
+    | 'IMAGES'
+    | 'POLICIES'
+    | 'PROCESS_INDICATORS'
+    | 'SEARCH_UNSET'
+    | 'SECRETS'
+    | 'COMPLIANCE'
+    | 'SUBJECT';
+
+export const SEARCH_CATEGORIES: Record<SearchCategory, SearchCategory> = {
     ALERTS: 'ALERTS',
     DEPLOYMENTS: 'DEPLOYMENTS',
     IMAGES: 'IMAGES',

--- a/ui/apps/platform/src/reducers/pageSearch.ts
+++ b/ui/apps/platform/src/reducers/pageSearch.ts
@@ -1,11 +1,6 @@
 import isEqual from 'lodash/isEqual';
 import capitalize from 'lodash/capitalize';
-
-export type SearchEntry = {
-    type?: 'categoryOption';
-    value: string;
-    label: string;
-};
+import { SearchEntry } from 'types/search';
 
 export type SearchState = {
     searchOptions: SearchEntry[];

--- a/ui/apps/platform/src/types/search.ts
+++ b/ui/apps/platform/src/types/search.ts
@@ -17,3 +17,19 @@ export type SearchEntry = {
     value: string; // an option ends with a colon
     label: string; // an option ends with a colon
 };
+
+export type GlobalSearchOption = {
+    value: string;
+    label: string;
+    type?: string;
+};
+
+export type RestSortOption = {
+    field: string;
+    reversed: boolean;
+};
+
+export type GraphQLSortOption = {
+    id: string;
+    desc: boolean;
+};

--- a/ui/apps/platform/src/utils/queryStringUtils.ts
+++ b/ui/apps/platform/src/utils/queryStringUtils.ts
@@ -4,8 +4,8 @@ export type BasePageAction = 'create' | 'edit';
 
 export type ExtendedPageAction = BasePageAction | 'clone' | 'generate';
 
-export function getQueryObject<T>(search: string): T {
-    return qs.parse(search, { ignoreQueryPrefix: true }) as unknown as T;
+export function getQueryObject<T extends qs.ParsedQs>(search: string): T {
+    return qs.parse(search, { ignoreQueryPrefix: true }) as T;
 }
 
 export function getQueryString<T>(searchObject: T): string {

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -1,3 +1,11 @@
+import {
+    SearchEntry,
+    GlobalSearchOption,
+    RestSortOption,
+    GraphQLSortOption,
+    SearchFilter,
+} from 'types/search';
+
 /**
  *  Adds a search modifier to the searchOptions
  *
@@ -5,7 +13,10 @@
  *  @param {!string} modifier a modifier term (ie. 'Cluster:')
  *  @returns {!Object[]} the modified search options
  */
-export function addSearchModifier(searchOptions, modifier) {
+export function addSearchModifier(
+    searchOptions: GlobalSearchOption[],
+    modifier: string
+): GlobalSearchOption[] {
     const chip = { value: modifier, label: modifier, type: 'categoryOption' };
     return [...searchOptions, chip];
 }
@@ -17,7 +28,10 @@ export function addSearchModifier(searchOptions, modifier) {
  *  @param {!string} keyword a keyword term (ie. 'remote')
  *  @returns {!Object[]} the modified search options
  */
-export function addSearchKeyword(searchOptions, keyword) {
+export function addSearchKeyword(
+    searchOptions: GlobalSearchOption[],
+    keyword: string
+): GlobalSearchOption[] {
     const chip = { value: keyword, label: keyword, className: 'Select-create-option-placeholder' };
     return [...searchOptions, chip];
 }
@@ -35,7 +49,10 @@ export function hasSearchModifier(searchOptions, modifier) {
     );
 }
 
-export function getViewStateFromSearch(search, key) {
+export function getViewStateFromSearch(
+    search: Record<string, string | boolean>,
+    key: string
+): boolean {
     return !!(
         key &&
         search &&
@@ -45,7 +62,10 @@ export function getViewStateFromSearch(search, key) {
     ); // and the value of the search for that key cannot be false or the string "false", see https://stack-rox.atlassian.net/browse/ROX-4278
 }
 
-export function filterAllowedSearch(allowed = [], currentSearch = {}) {
+export function filterAllowedSearch(
+    allowed: string[] = [],
+    currentSearch: Record<string, string> = {}
+): Record<string, string> {
     const filtered = Object.keys(currentSearch)
         .filter((key) => allowed.includes(key))
         .reduce((newSearch, key) => {
@@ -58,8 +78,8 @@ export function filterAllowedSearch(allowed = [], currentSearch = {}) {
     return filtered;
 }
 
-export function convertToRestSearch(workflowSearch) {
-    const emptyArray = [];
+export function convertToRestSearch(workflowSearch: Record<string, string>): SearchEntry[] {
+    const emptyArray: SearchEntry[] = [];
     if (!workflowSearch) {
         return emptyArray;
     }
@@ -68,7 +88,11 @@ export function convertToRestSearch(workflowSearch) {
         const keyWithColon = `${key}:`;
         const value = workflowSearch[key];
 
-        const searchOption = { label: keyWithColon, value: keyWithColon, type: 'categoryOption' };
+        const searchOption: SearchEntry = {
+            label: keyWithColon,
+            value: keyWithColon,
+            type: 'categoryOption',
+        };
         const searchValue = { label: value, value: value || '' };
 
         return searchValue.value ? acc.concat(searchOption, searchValue) : acc;
@@ -77,16 +101,27 @@ export function convertToRestSearch(workflowSearch) {
     return restSearch;
 }
 
-export function convertSortToGraphQLFormat({ field, reversed }) {
+export function convertSortToGraphQLFormat({ field, reversed }: RestSortOption): GraphQLSortOption {
     return {
         id: field,
         desc: reversed,
     };
 }
 
-export function convertSortToRestFormat(graphqlSort) {
+export function convertSortToRestFormat(graphqlSort: GraphQLSortOption[]): Partial<RestSortOption> {
     return {
         field: graphqlSort[0]?.id,
         reversed: graphqlSort[0]?.desc,
     };
+}
+
+/*
+ * Return request query string for search filter. Omit filter criterion:
+ * If option does not have value.
+ */
+export function getRequestQueryStringForSearchFilter(searchFilter: SearchFilter): string {
+    return Object.entries(searchFilter)
+        .filter(([, value]) => value.length !== 0)
+        .map(([key, value]) => `${key}:${Array.isArray(value) ? value.join(',') : value}`)
+        .join('+');
 }


### PR DESCRIPTION
## Description

This PR is some pre-work for the "Violations URL params in search" work that is upcoming. It converts a handful of files to TS that are related to search, and moves some types/functions to locations that are higher level for code that is reused in multiple places.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

Tested that Policy search works (this is the only code where logic has changed - just moving of a function to another file):
![image](https://user-images.githubusercontent.com/1292638/161146187-2c291c57-a6f4-4508-b4ff-0c15e79a66d2.png)

Tested that Risk search works:
![image](https://user-images.githubusercontent.com/1292638/161146565-2f5f1e99-12bd-4725-b8e3-cc41a0f6ce0e.png)

Tested that VulnMgmt CVE search works:
![image](https://user-images.githubusercontent.com/1292638/161146872-7351c79d-2f8b-4414-b350-b118efa74aae.png)



