### PR TITLE
Fix broken auth provider test now that open-source code has no auth0 in CI

### DIFF
--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -55,6 +55,9 @@ describe('Access Control Auth providers', () => {
     });
 
     it('list has headings, link, button, and table head cells, and no breadcrumbs', () => {
+        cy.intercept('GET', authProvidersApi.list, {
+            fixture: 'auth/authProviders-id1-id2-id3.json',
+        }).as('GetAuthProviders');
         visitAuthProviders();
 
         cy.get(selectors.breadcrumbNav).should('not.exist');


### PR DESCRIPTION
## Description

I confirmed with the open-source team, that `AUTH0_SUPPORT` is now false by default, and that was causing a failure in CI. 

We were assuming our auth0 account would be listed in one of the UI e2e tests, but this PR now mocks that.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

* CI for this PR
* Confirms that whole test suite passes now, by running it locally
![Screen Shot 2022-04-01 at 6 29 10 AM](https://user-images.githubusercontent.com/715729/161247219-82a7087a-a513-4535-920a-e1fb9007fcbf.png)
