### PR TITLE
ROX-9967: Temporary switch off init-bundle rotation in the operator

### DIFF
--- a/operator/pkg/central/extensions/reconcile_tls.go
+++ b/operator/pkg/central/extensions/reconcile_tls.go
@@ -69,12 +69,11 @@ func (r *createCentralTLSExtensionRun) Execute(ctx context.Context) error {
 	if err := r.ReconcileSecret(ctx, "scanner-db-tls", scannerEnabled && !shouldDelete, r.validateScannerDBTLSData, r.generateScannerDBTLSData, true); err != nil {
 		return errors.Wrap(err, "reconciling scanner-db secret")
 	}
-	return nil // ReconcileInitBundleSecrets not called due to ROX-9023. TODO(ROX-9969): call after the init-bundle cert rotation stabilization.
+	return nil // reconcileInitBundleSecrets not called due to ROX-9023. TODO(ROX-9969): call after the init-bundle cert rotation stabilization.
 }
 
-// ReconcileInitBundleSecrets is only exported temporarily to silence the static checker while it's unused.
-// TODO(ROX-9969): make private after the init-bundle cert rotation stabilization.
-func (r createCentralTLSExtensionRun) ReconcileInitBundleSecrets(ctx context.Context, shouldDelete bool) error {
+//lint:ignore U1000 ignore unused method. TODO(ROX-9969): remove lint ignore after the init-bundle cert rotation stabilization.
+func (r createCentralTLSExtensionRun) reconcileInitBundleSecrets(ctx context.Context, shouldDelete bool) error {
 	bundleSecretShouldExist, err := r.shouldBundleSecretsExist(ctx, shouldDelete)
 	if err != nil {
 		return err

--- a/operator/pkg/central/extensions/reconcile_tls.go
+++ b/operator/pkg/central/extensions/reconcile_tls.go
@@ -69,7 +69,12 @@ func (r *createCentralTLSExtensionRun) Execute(ctx context.Context) error {
 	if err := r.ReconcileSecret(ctx, "scanner-db-tls", scannerEnabled && !shouldDelete, r.validateScannerDBTLSData, r.generateScannerDBTLSData, true); err != nil {
 		return errors.Wrap(err, "reconciling scanner-db secret")
 	}
+	return nil // ReconcileInitBundleSecrets not called due to ROX-9023. TODO(ROX-9969): call after the init-bundle cert rotation stabilization.
+}
 
+// ReconcileInitBundleSecrets is only exported temporarily to silence the static checker while it's unused.
+// TODO(ROX-9969): make private after the init-bundle cert rotation stabilization.
+func (r createCentralTLSExtensionRun) ReconcileInitBundleSecrets(ctx context.Context, shouldDelete bool) error {
 	bundleSecretShouldExist, err := r.shouldBundleSecretsExist(ctx, shouldDelete)
 	if err != nil {
 		return err
@@ -87,7 +92,6 @@ func (r *createCentralTLSExtensionRun) Execute(ctx context.Context) error {
 			return errors.Wrapf(err, "reconciling %s secret", secretName)
 		}
 	}
-
 	return nil
 }
 

--- a/operator/pkg/central/extensions/reconcile_tls_test.go
+++ b/operator/pkg/central/extensions/reconcile_tls_test.go
@@ -2,6 +2,7 @@ package extensions
 
 import (
 	"crypto/x509"
+	"strings"
 	"testing"
 	"time"
 
@@ -143,6 +144,10 @@ func TestCreateCentralTLS(t *testing.T) {
 
 	for name, c := range cases {
 		c := c
+		if strings.Contains(name, "init bundle secrets should be created") {
+			// See ROX-9023.
+			continue
+		}
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/operator/pkg/central/extensions/reconcile_tls_test.go
+++ b/operator/pkg/central/extensions/reconcile_tls_test.go
@@ -145,7 +145,8 @@ func TestCreateCentralTLS(t *testing.T) {
 	for name, c := range cases {
 		c := c
 		if strings.Contains(name, "init bundle secrets should be created") {
-			// See ROX-9023.
+			// See ROX-9967.
+			// TODO(ROX-9969): Remove this exclusion after the init-bundle cert rotation stabilization.
 			continue
 		}
 		t.Run(name, func(t *testing.T) {

--- a/operator/tests/securedcluster/basic-sc/07-fetch-bundle.yaml
+++ b/operator/tests/securedcluster/basic-sc/07-fetch-bundle.yaml
@@ -1,0 +1,1 @@
+../../common/fetch-bundle.yaml


### PR DESCRIPTION
## Description

Temporary disabling the init bundle provisioning due to the lack of capacity.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

Disabling the functionality. CI checks should be enough.
