### PR TITLE
Add registry rate limiter for signature fetching. 

### DIFF
--- a/pkg/images/enricher/enricher.go
+++ b/pkg/images/enricher/enricher.go
@@ -136,7 +136,6 @@ func New(cvesSuppressor CVESuppressor, cvesSuppressorV2 CVESuppressor, is integr
 
 		signatureIntegrationGetter: signatureIntegrationGetter,
 		signatureVerifier:          signatures.VerifyAgainstSignatureIntegrations,
-		signatureFetcherLimiter:    rate.NewLimiter(rate.Every(50*time.Millisecond), 1),
 		signatureFetcher:           signatures.NewSignatureFetcher(),
 
 		imageGetter: imageGetter,

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -54,7 +54,6 @@ type enricherImpl struct {
 
 	signatureIntegrationGetter SignatureIntegrationGetter
 	signatureVerifier          signatureVerifierForIntegrations
-	signatureFetcherLimiter    *rate.Limiter
 	signatureFetcher           signatures.SignatureFetcher
 
 	imageGetter ImageGetter
@@ -568,10 +567,6 @@ func (e *enricherImpl) enrichWithSignature(ctx context.Context, enrichmentContex
 
 	var fetchedSignatures []*storage.Signature
 	for _, matchingReg := range matchingRegistries {
-		err := e.signatureFetcherLimiter.Wait(ctx)
-		if err != nil {
-			return false, errors.Wrapf(err, "waiting for rate limiter for registry %q", matchingReg.Name())
-		}
 		// FetchImageSignaturesWithRetries will try fetching of signatures with retries.
 		sigs, err := signatures.FetchImageSignaturesWithRetries(ctx, e.signatureFetcher, img, matchingReg)
 		fetchedSignatures = append(fetchedSignatures, sigs...)

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -818,9 +818,8 @@ func TestEnrichWithSignature_Success(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			e := enricherImpl{
-				integrations:            integrationsSetMock,
-				signatureFetcher:        c.sigFetcher,
-				signatureFetcherLimiter: rate.NewLimiter(rate.Every(10*time.Millisecond), 1),
+				integrations:     integrationsSetMock,
+				signatureFetcher: c.sigFetcher,
 			}
 			updated, err := e.enrichWithSignature(emptyCtx, c.ctx, c.img)
 			assert.NoError(t, err)

--- a/pkg/signatures/factory.go
+++ b/pkg/signatures/factory.go
@@ -10,15 +10,10 @@ import (
 	"github.com/stackrox/rox/pkg/protoconv"
 	registryTypes "github.com/stackrox/rox/pkg/registries/types"
 	"github.com/stackrox/rox/pkg/retry"
-	"golang.org/x/time/rate"
 )
 
 var (
 	log = logging.LoggerForModule()
-
-	// registryRateLimiter is a rate limiter for parallel calls to the registry. This will avoid reaching out to the
-	// registry too many times leading to 429 errors.
-	registryRateLimiter = rate.NewLimiter(rate.Every(50*time.Millisecond), 1)
 )
 
 // SignatureVerifier is responsible for verifying signatures using a specific signature verification method.
@@ -124,10 +119,6 @@ func FetchImageSignaturesWithRetries(ctx context.Context, fetcher SignatureFetch
 	var fetchedSignatures []*storage.Signature
 	var err error
 	err = retry.WithRetry(func() error {
-		err = registryRateLimiter.Wait(ctx)
-		if err != nil {
-			return err
-		}
 		fetchedSignatures, err = fetchAndAppendSignatures(ctx, fetcher, image, registry, fetchedSignatures)
 		return err
 	},

--- a/pkg/signatures/factory.go
+++ b/pkg/signatures/factory.go
@@ -10,10 +10,15 @@ import (
 	"github.com/stackrox/rox/pkg/protoconv"
 	registryTypes "github.com/stackrox/rox/pkg/registries/types"
 	"github.com/stackrox/rox/pkg/retry"
+	"golang.org/x/time/rate"
 )
 
 var (
 	log = logging.LoggerForModule()
+
+	// registryRateLimiter is a rate limiter for parallel calls to the registry. This will avoid reaching out to the
+	// registry too many times leading to 429 errors.
+	registryRateLimiter = rate.NewLimiter(rate.Every(50*time.Millisecond), 1)
 )
 
 // SignatureVerifier is responsible for verifying signatures using a specific signature verification method.
@@ -119,6 +124,10 @@ func FetchImageSignaturesWithRetries(ctx context.Context, fetcher SignatureFetch
 	var fetchedSignatures []*storage.Signature
 	var err error
 	err = retry.WithRetry(func() error {
+		err = registryRateLimiter.Wait(ctx)
+		if err != nil {
+			return err
+		}
 		fetchedSignatures, err = fetchAndAppendSignatures(ctx, fetcher, image, registry, fetchedSignatures)
 		return err
 	},

--- a/pkg/signatures/public_key_fetcher.go
+++ b/pkg/signatures/public_key_fetcher.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	gcrRemote "github.com/google/go-containerregistry/pkg/v1/remote"
@@ -19,14 +20,21 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 	registryTypes "github.com/stackrox/rox/pkg/registries/types"
 	"github.com/stackrox/rox/pkg/retry"
+	"golang.org/x/time/rate"
 )
 
-type cosignPublicKeySignatureFetcher struct{}
+type cosignPublicKeySignatureFetcher struct {
+	// registryRateLimiter is a rate limiter for parallel calls to the registry. This will avoid reaching out to the
+	// registry too many times leading to 429 errors.
+	registryRateLimiter *rate.Limiter
+}
 
 var _ SignatureFetcher = (*cosignPublicKeySignatureFetcher)(nil)
 
 func newCosignPublicKeySignatureFetcher() *cosignPublicKeySignatureFetcher {
-	return &cosignPublicKeySignatureFetcher{}
+	return &cosignPublicKeySignatureFetcher{
+		registryRateLimiter: rate.NewLimiter(rate.Every(50*time.Millisecond), 1),
+	}
 }
 
 var (
@@ -50,6 +58,12 @@ func (c *cosignPublicKeySignatureFetcher) FetchSignatures(ctx context.Context, i
 	imgRef, err := name.ParseReference(imgFullName)
 	if err != nil {
 		return nil, err
+	}
+
+	// Wait until the registry rate limiter allows entrance.
+	err = c.registryRateLimiter.Wait(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "waiting for rate limiter entrance")
 	}
 
 	// Fetch the signatures by injecting the registry specific authentication options to the google/go-containerregistry

--- a/pkg/signatures/public_key_fetcher.go
+++ b/pkg/signatures/public_key_fetcher.go
@@ -63,7 +63,7 @@ func (c *cosignPublicKeySignatureFetcher) FetchSignatures(ctx context.Context, i
 	// Wait until the registry rate limiter allows entrance.
 	err = c.registryRateLimiter.Wait(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "waiting for rate limiter entrance")
+		return nil, errors.Wrapf(err, "waiting for rate limiter entrance for registry %q", registry.Name())
 	}
 
 	// Fetch the signatures by injecting the registry specific authentication options to the google/go-containerregistry

--- a/pkg/signatures/public_key_fetcher_test.go
+++ b/pkg/signatures/public_key_fetcher_test.go
@@ -156,7 +156,7 @@ func TestPublicKey_FetchSignature_Success(t *testing.T) {
 		},
 	}
 
-	f := &cosignPublicKeySignatureFetcher{}
+	f := newCosignPublicKeySignatureFetcher()
 	mockConfig := &registryTypes.Config{
 		Username: "",
 		Password: "",
@@ -174,7 +174,7 @@ func TestPublicKey_FetchSignature_Failure(t *testing.T) {
 	require.NoError(t, err, "setting up registry")
 	defer registryServer.Close()
 
-	f := &cosignPublicKeySignatureFetcher{}
+	f := newCosignPublicKeySignatureFetcher()
 
 	cimg, err := imgUtils.GenerateImageFromString("nginx")
 	require.NoError(t, err, "creating test image")
@@ -197,7 +197,7 @@ func TestPublicKey_FetchSignature_NoSignature(t *testing.T) {
 	require.NoError(t, err, "creating test image")
 	img := types.ToImage(cimg)
 
-	f := &cosignPublicKeySignatureFetcher{}
+	f := newCosignPublicKeySignatureFetcher()
 	reg := &mockRegistry{cfg: &registryTypes.Config{}}
 
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

Follow-up based on [this discussion in a previous PR](https://github.com/stackrox/stackrox/pull/974#discussion_r830155637).

Moved the rate limiter we use for registry access from `images/enricher` to `signatures`, specifically within the `FetchImageSignaturesWithRetries` function.

Now, both the `images/enricher` as well as the `sensor/common/scan` will profit from the rate limiter regarding fetching signatures.
