### PR TITLE
ROX-9962: Fix import policy error display when not a duplicate

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Modal/ImportPolicyJSONModalError.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Modal/ImportPolicyJSONModalError.tsx
@@ -44,6 +44,7 @@ function ImportPolicyJSONError({
         setDuplicateResolution({ ...duplicateResolution, [key]: value });
     }
 
+    const duplicateErrorsOnly = duplicateErrors.length > 0;
     const showKeepBothPolicies = hasDuplicateIdOnly(duplicateErrors);
     const isBlocked = checkForBlockedSubmit({
         numPolicies: policies?.length ?? 0,
@@ -73,7 +74,11 @@ function ImportPolicyJSONError({
                 <ModalBoxBody>
                     Address the errors below to continue importing policies
                     <Alert
-                        title="Policies already exist"
+                        title={
+                            duplicateErrorsOnly
+                                ? 'Policies already exist'
+                                : 'Errors trying to import policies'
+                        }
                         variant="danger"
                         className="pf-u-mt-md"
                         isInline
@@ -85,7 +90,7 @@ function ImportPolicyJSONError({
                                 </li>
                             ))}
                         </ul>
-                        {duplicateErrors && (
+                        {duplicateErrorsOnly && (
                             <DuplicatePolicyForm
                                 updateResolution={updateResolution}
                                 showKeepBothPolicies={showKeepBothPolicies}
@@ -94,14 +99,16 @@ function ImportPolicyJSONError({
                     </Alert>
                 </ModalBoxBody>
                 <ModalBoxFooter>
-                    <Button
-                        key="import"
-                        variant="primary"
-                        onClick={startImportPolicies}
-                        isDisabled={isBlocked}
-                    >
-                        Resume import
-                    </Button>
+                    {duplicateErrorsOnly && (
+                        <Button
+                            key="import"
+                            variant="primary"
+                            onClick={startImportPolicies}
+                            isDisabled={isBlocked}
+                        >
+                            Resume import
+                        </Button>
+                    )}
                     <Button key="cancel" variant="link" onClick={handleCancelModal}>
                         Cancel
                     </Button>

--- a/ui/apps/platform/src/Containers/Policies/Table/PolicyImport.utils.js
+++ b/ui/apps/platform/src/Containers/Policies/Table/PolicyImport.utils.js
@@ -141,7 +141,7 @@ export function hasDuplicateIdOnly(importErrors) {
 export function checkDupeOnlyErrors(importErrors) {
     return (
         importErrors?.length &&
-        importErrors.find((policyErrors) => {
+        importErrors.every((policyErrors) => {
             const hasInvalidPolicy = policyErrors.some((err) => err.type === 'invalid_policy');
             const hasDupeErrors = policyErrors.some((err) => err.type.includes('dup'));
 


### PR DESCRIPTION
## Description

As part of the work to deprecate pre-versions 1.1 policy formats, backend found that the error display for errors like "bad format..." were confusingly showing duplicate resolution choices.

This, PR into the backend work branch, fixes the error display for those types of errors.

As often happens, I noticed many opportunities for refactoring and improvement in the existing import handling code, but I resisted the urge to do more than necessary to fix the problem. (Full disclosure: I wrote the original frontend import code, and so it was particularly hard for me to resist the urge to improve it out of shame.)


## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Confirmed that all existing UI e2e tests still pass

Manual testing

(new) Correct display of errors not related to duplicates
![Screen Shot 2022-04-01 at 1 17 39 PM](https://user-images.githubusercontent.com/715729/161325869-8f5f3ddf-9e9b-486d-9086-4fb8b35e56da.png)

(confirmed existing behavior) Duplicate problems are still displayed correctly
![Screen Shot 2022-04-01 at 2 05 32 PM](https://user-images.githubusercontent.com/715729/161325962-a3aa8a8b-aa06-48e4-8e12-48949c39f197.png)

(confirmed existing behavior) Policies with no errors or duplication import immediately
![Screen Shot 2022-04-01 at 2 26 47 PM](https://user-images.githubusercontent.com/715729/161326312-2b2bd7dd-aee0-4299-b0f4-520d0646d575.png)
