### PR TITLE
Apply Namespace filters to autocomplete search result in Net Graph filter bar.

### DIFF
--- a/ui/apps/platform/src/Containers/Network/Header/NetworkSearch.js
+++ b/ui/apps/platform/src/Containers/Network/Header/NetworkSearch.js
@@ -16,6 +16,7 @@ import './NetworkSearch.css';
 function NetworkSearch({
     searchOptions,
     searchModifiers,
+    selectedNamespaceFilters,
     setSearchOptions,
     setSearchSuggestions,
     closeSidePanel,
@@ -27,10 +28,15 @@ function NetworkSearch({
         }
     }
 
-    let prependAutocompleteQuery;
     const orchestratorComponentShowState = localStorage.getItem(ORCHESTRATOR_COMPONENT_KEY);
-    if (orchestratorComponentShowState !== 'true') {
-        prependAutocompleteQuery = [...orchestratorComponentOption];
+    const prependAutocompleteQuery =
+        orchestratorComponentShowState !== 'true' ? [...orchestratorComponentOption] : [];
+
+    if (selectedNamespaceFilters.length) {
+        prependAutocompleteQuery.push({ value: 'Namespace:', type: 'categoryOption' });
+        selectedNamespaceFilters.forEach((nsFilter) =>
+            prependAutocompleteQuery.push({ value: nsFilter })
+        );
     }
 
     return (
@@ -52,6 +58,7 @@ function NetworkSearch({
 const mapStateToProps = createStructuredSelector({
     searchOptions: selectors.getNetworkSearchOptions,
     searchModifiers: selectors.getNetworkSearchModifiers,
+    selectedNamespaceFilters: selectors.getSelectedNamespaceFilters,
 });
 
 const mapDispatchToProps = {


### PR DESCRIPTION
## Description

The changes moving the Namespace filtering into a separate widget on the Network Graph page caused the filter bar to no longer scope autocomplete requests to the selected namespaces. This resulted in search suggestions showing items from every namespace in the cluster, instead of items from the selected namespace(s).

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

The following are performed against a QA demo cluster.

Tested that only "stackrox" deployments are suggested when only the "stackrox" namespace is enabled:
![image](https://user-images.githubusercontent.com/1292638/161334047-d034edc3-3b1a-4c0d-be8a-c6f22c2b97c2.png)

Test that the addition of the "payments" namespace adds "payments" deployments to the suggestions:
![image](https://user-images.githubusercontent.com/1292638/161334156-aed5431f-03a5-46ea-8436-341980342987.png)

Test the removing the "stackrox" namespace only shows search suggestions for the "payments" namespace:
![image](https://user-images.githubusercontent.com/1292638/161334233-86d0b37b-ff8a-416a-aed1-930ffa49d235.png)

Test the above scenarios with other search options (e.g. Image OS):
![image](https://user-images.githubusercontent.com/1292638/161334356-c776b7ec-0b1d-45f5-a221-dee2e3cbc883.png)

