### PR TITLE
ROX-9283: Enable ECR auto-integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   does not match the `:authority` (`Host`) header. This feature can be turned off by setting the environment variable
   `ROX_ALLOW_MISDIRECTED_REQUESTS=true`.
 - Fixed permissioms checks in the UI that prevented users with certain limited permissions from creating report configurations.
+- Registry integrations for ECR are now auto-generated if the cluster's cloud provider is AWS, and the nodes' Instance IAM Role has policies granting access to ECR.  Customers can turn this feature off by disabling the EC2 instance metadata service in their nodes.
 
 ## [69.1]
 

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -46,7 +46,7 @@ var (
 	PostgresDatastore = registerFeature("Enable Postgres Datastore", "ROX_POSTGRES_DATASTORE", false)
 
 	// ECRAutoIntegration enables detection of ECR-based deployments to generate auto-integrations from ECR auth tokens.
-	ECRAutoIntegration = registerFeature("Enable ECR auto-integrations when running on AWS nodes", "ROX_ECR_AUTO_INTEGRATION", false)
+	ECRAutoIntegration = registerFeature("Enable ECR auto-integrations when running on AWS nodes", "ROX_ECR_AUTO_INTEGRATION", true)
 
 	// NetworkPolicySystemPolicy enables two system policy fields (Missing (Ingress|Egress) Network Policy) to check deployments
 	// against network policies applied in the secured cluster.


### PR DESCRIPTION
## Description

This is a follow-up to enable ECR auto-integrations introduced by #1006, and adds a CHANGELOG entry.

## Checklist
- [ ] ~Investigated and inspected CI test results~ N/A
- [ ] ~Unit test and regression tests added~ N/A
- [x] Evaluated and added CHANGELOG entry if required
- [ ] ~Determined and documented upgrade steps~ N/A
- [x] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

N/A

