### PR TITLE
Update the number of components in struts-app due to new scanner

### DIFF
--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -390,7 +390,7 @@ class DefaultPoliciesTest extends BaseSpecification {
 
         "Number of Components in Image"   | 1.5f     | null |
                 "Image \"quay.io/rhacs-eng/qa:struts-app\"" +
-                " contains 16[67] components" | []
+                " contains 169 components" | []
 
         "Image Freshness"                 | 1.5f     | null | null | []
         // TODO(ROX-9637)


### PR DESCRIPTION
## Description
We fixed some java attribution logic and we find 3 new components with the following vulns. These look pretty accurate
```
{
  "name": "commons_beanutils",
  "version": "1.6",
  "location": "usr/local/tomcat/webapps/ROOT.war:WEB-INF/lib/commons-beanutils-1.7.0.jar",
  "vulns": [
    {
      "cve": "CVE-2014-0114",
      "summary": "Apache Commons BeanUtils, as distributed in lib/commons-beanutils-1.8.0.jar in Apache Struts 1.x through 1.3.10 and in other products requiring commons-beanutils through 1.9.2, does not suppress the class property, which allows remote attackers to \"manipulate\" the ClassLoader and execute arbitrary code via the class parameter, as demonstrated by the passing of this parameter to the getClass method of the ActionForm object in Struts 1."
    },
    {
      "cve": "CVE-2019-10086",
      "summary": "In Apache Commons Beanutils 1.9.2, a special BeanIntrospector class was added which allows suppressing the ability for an attacker to access the classloader via the class property available on all Java objects. We, however were not using this by default characteristic of the PropertyUtilsBean."
    }
  ]
}

{
  "name": "commons_collections",
  "version": "3.1",
  "location": "usr/local/tomcat/webapps/ROOT.war:WEB-INF/lib/commons-collections-3.1.jar",
  "vulns": [
    {
      "cve": "CVE-2015-6420",
      "summary": "Serialized-object interfaces in certain Cisco Collaboration and Social Media; Endpoint Clients and Client Software; Network Application, Service, and Acceleration; Network and Content Security Devices; Network Management and Provisioning; Routing and Switching - Enterprise and Service Provider; Unified Computing; Voice and Unified Communications Devices; Video, Streaming, TelePresence, and Transcoding Devices; Wireless; and Cisco Hosted Services products allow remote attackers to execute arbitrary commands via a crafted serialized Java object, related to the Apache Commons Collections (ACC) library."
    }
  ]
}

{
  "name": "velocity_tools",
  "version": "1.3",
  "location": "usr/local/tomcat/webapps/ROOT.war:WEB-INF/lib/velocity-tools-1.3.jar",
  "vulns": [
    {
      "cve": "CVE-2020-13959",
      "summary": "The default error page for VelocityView in Apache Velocity Tools prior to 3.1 reflects back the vm file that was entered as part of the URL. An attacker can set an XSS payload file as this vm file in the URL which results in this payload being executed. XSS vulnerabilities allow attackers to execute arbitrary JavaScript in the context of the attacked website and the attacked user. This can be abused to steal session cookies, perform requests in the name of the victim or for phishing attacks."
    }
  ]
}
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI