### PR TITLE
ROX-9823: Triggering evaluation from deployment updates

### DIFF
--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/admissioncontroller"
 	"github.com/stackrox/rox/sensor/common/detector/baseline"
 	networkBaselineEval "github.com/stackrox/rox/sensor/common/detector/networkbaseline"
+	"github.com/stackrox/rox/sensor/common/detector/networkpolicy"
 	"github.com/stackrox/rox/sensor/common/detector/unified"
 	"github.com/stackrox/rox/sensor/common/enforcer"
 	"github.com/stackrox/rox/sensor/common/externalsrcs"
@@ -53,7 +54,7 @@ type Detector interface {
 // New returns a new detector
 func New(enforcer enforcer.Enforcer, admCtrlSettingsMgr admissioncontroller.SettingsManager,
 	deploymentStore store.DeploymentStore, cache expiringcache.Cache, auditLogEvents chan *sensor.AuditEvents,
-	auditLogUpdater updater.Component) Detector {
+	auditLogUpdater updater.Component, networkPolicyStore store.NetworkPolicyStore) Detector {
 	return &detectorImpl{
 		unifiedDetector: unified.NewDetector(),
 
@@ -77,6 +78,8 @@ func New(enforcer enforcer.Enforcer, admCtrlSettingsMgr admissioncontroller.Sett
 		auditStopper:      concurrency.NewStopper(),
 		serializerStopper: concurrency.NewStopper(),
 		alertStopSig:      concurrency.NewSignal(),
+
+		networkpolicyFinder: networkpolicy.NewFinder(networkPolicyStore),
 	}
 }
 
@@ -111,6 +114,8 @@ type detectorImpl struct {
 	alertStopSig      concurrency.Signal
 
 	admissionCacheNeedsFlush bool
+
+	networkpolicyFinder *networkpolicy.Finder
 }
 
 func (d *detectorImpl) Start() error {
@@ -423,7 +428,7 @@ func (d *detectorImpl) processDeploymentNoLock(deployment *storage.Deployment, a
 	case central.ResourceAction_CREATE_RESOURCE:
 		d.deduper.addDeployment(deployment)
 		d.markDeploymentForProcessing(deployment.GetId())
-		go d.enricher.blockingScan(deployment, action)
+		go d.enricher.blockingScan(deployment, d.networkpolicyFinder.GetNetworkPoliciesApplied(deployment), action)
 	case central.ResourceAction_UPDATE_RESOURCE:
 		// Check if the deployment has changes that require detection, which is more expensive than hashing
 		// If not, then just return
@@ -431,7 +436,7 @@ func (d *detectorImpl) processDeploymentNoLock(deployment *storage.Deployment, a
 			return
 		}
 		d.markDeploymentForProcessing(deployment.GetId())
-		go d.enricher.blockingScan(deployment, action)
+		go d.enricher.blockingScan(deployment, d.networkpolicyFinder.GetNetworkPoliciesApplied(deployment), action)
 	}
 }
 

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -206,14 +206,6 @@ func (e *enricher) getImages(deployment *storage.Deployment) []*storage.Image {
 	return images
 }
 
-//func (e *enricher) getNetworkPoliciesApplied(_ *storage.Deployment) *augmentedobjs.NetworkPoliciesApplied {
-//	// @TODO(ROX-9823): Read from network policies from store (ROX-9822) and create augmentedobj
-//	return &augmentedobjs.NetworkPoliciesApplied{
-//		MissingIngressNetworkPolicy: false,
-//		MissingEgressNetworkPolicy:  false,
-//	}
-//}
-
 func (e *enricher) blockingScan(deployment *storage.Deployment, netpolApplied *augmentedobjs.NetworkPoliciesApplied, action central.ResourceAction) {
 	select {
 	case <-e.stopSig.Done():

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -206,15 +206,15 @@ func (e *enricher) getImages(deployment *storage.Deployment) []*storage.Image {
 	return images
 }
 
-func (e *enricher) getNetworkPoliciesApplied(_ *storage.Deployment) *augmentedobjs.NetworkPoliciesApplied {
-	// @TODO(ROX-9823): Read from network policies from store (ROX-9822) and create augmentedobj
-	return &augmentedobjs.NetworkPoliciesApplied{
-		MissingIngressNetworkPolicy: false,
-		MissingEgressNetworkPolicy:  false,
-	}
-}
+//func (e *enricher) getNetworkPoliciesApplied(_ *storage.Deployment) *augmentedobjs.NetworkPoliciesApplied {
+//	// @TODO(ROX-9823): Read from network policies from store (ROX-9822) and create augmentedobj
+//	return &augmentedobjs.NetworkPoliciesApplied{
+//		MissingIngressNetworkPolicy: false,
+//		MissingEgressNetworkPolicy:  false,
+//	}
+//}
 
-func (e *enricher) blockingScan(deployment *storage.Deployment, action central.ResourceAction) {
+func (e *enricher) blockingScan(deployment *storage.Deployment, netpolApplied *augmentedobjs.NetworkPoliciesApplied, action central.ResourceAction) {
 	select {
 	case <-e.stopSig.Done():
 		return
@@ -222,7 +222,7 @@ func (e *enricher) blockingScan(deployment *storage.Deployment, action central.R
 		action:                 action,
 		deployment:             deployment,
 		images:                 e.getImages(deployment),
-		networkPoliciesApplied: e.getNetworkPoliciesApplied(deployment),
+		networkPoliciesApplied: netpolApplied,
 	}:
 	}
 }

--- a/sensor/common/detector/networkpolicy/networkpolicy.go
+++ b/sensor/common/detector/networkpolicy/networkpolicy.go
@@ -6,14 +6,21 @@ import (
 	"github.com/stackrox/rox/sensor/common/store"
 )
 
+// Finder wraps store.NetworkPolicyStore and provides a convenient method to create
+// augmentedobj.NetworkPoliciesApplied object from a deployment.
 type Finder struct {
 	store store.NetworkPolicyStore
 }
 
+// NewFinder creates a new instance of Finder with provided store.
 func NewFinder(store store.NetworkPolicyStore) *Finder {
 	return &Finder{store: store}
 }
 
+// GetNetworkPoliciesApplied creates an augmentedobj.NetworkPoliciesApplied object
+// based on the provided deployment object and the in-memory store.
+// Finder will use storage.NetworkPolicyType array property on storage.NetworkPolicy proto
+// in order to determine presence or absence of a particular network policy type.
 func (np *Finder) GetNetworkPoliciesApplied(deployment *storage.Deployment) *augmentedobjs.NetworkPoliciesApplied {
 	var hasIngress, hasEgress bool
 	for _, policy := range np.store.Find(deployment.Namespace, deployment.Labels) {

--- a/sensor/common/detector/networkpolicy/networkpolicy.go
+++ b/sensor/common/detector/networkpolicy/networkpolicy.go
@@ -32,13 +32,15 @@ func (np *Finder) GetNetworkPoliciesApplied(deployment *storage.Deployment) *aug
 
 	var hasIngress, hasEgress bool
 
-lookingForPolicies:
 	for _, policy := range np.store.Find(deployment.Namespace, deployment.Labels) {
 		for _, policyType := range policy.GetSpec().GetPolicyTypes() {
 			hasIngress = hasIngress || policyType == storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE
 			hasEgress = hasEgress || policyType == storage.NetworkPolicyType_EGRESS_NETWORK_POLICY_TYPE
 			if hasIngress && hasEgress {
-				break lookingForPolicies
+				return &augmentedobjs.NetworkPoliciesApplied{
+					MissingIngressNetworkPolicy: false,
+					MissingEgressNetworkPolicy:  false,
+				}
 			}
 		}
 	}

--- a/sensor/common/detector/networkpolicy/networkpolicy.go
+++ b/sensor/common/detector/networkpolicy/networkpolicy.go
@@ -1,0 +1,33 @@
+package networkpolicy
+
+import (
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/booleanpolicy/augmentedobjs"
+	"github.com/stackrox/rox/sensor/common/store"
+)
+
+type Finder struct {
+	store store.NetworkPolicyStore
+}
+
+func NewFinder(store store.NetworkPolicyStore) *Finder {
+	return &Finder{store: store}
+}
+
+func (np *Finder) GetNetworkPoliciesApplied(deployment *storage.Deployment) *augmentedobjs.NetworkPoliciesApplied {
+	var hasIngress, hasEgress bool
+	for _, policy := range np.store.Find(deployment.Namespace, deployment.Labels) {
+		for _, policyType := range policy.GetSpec().GetPolicyTypes() {
+			if policyType == storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE {
+				hasIngress = true
+			} else if policyType == storage.NetworkPolicyType_EGRESS_NETWORK_POLICY_TYPE {
+				hasEgress = true
+			}
+		}
+	}
+
+	return &augmentedobjs.NetworkPoliciesApplied{
+		MissingIngressNetworkPolicy: !hasIngress,
+		MissingEgressNetworkPolicy:  !hasEgress,
+	}
+}

--- a/sensor/common/detector/networkpolicy/networkpolicy.go
+++ b/sensor/common/detector/networkpolicy/networkpolicy.go
@@ -3,6 +3,7 @@ package networkpolicy
 import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/booleanpolicy/augmentedobjs"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/sensor/common/store"
 )
 
@@ -22,6 +23,13 @@ func NewFinder(store store.NetworkPolicyStore) *Finder {
 // Finder will use storage.NetworkPolicyType array property on storage.NetworkPolicy proto
 // in order to determine presence or absence of a particular network policy type.
 func (np *Finder) GetNetworkPoliciesApplied(deployment *storage.Deployment) *augmentedobjs.NetworkPoliciesApplied {
+	if !features.NetworkPolicySystemPolicy.Enabled() {
+		// If feature flag is disabled we simply don't do the calculation.
+		// It is fine (from the Matcher perspective) to use nil augmented objects
+		// and no violations will be thrown.
+		return nil
+	}
+
 	var hasIngress, hasEgress bool
 	for _, policy := range np.store.Find(deployment.Namespace, deployment.Labels) {
 		for _, policyType := range policy.GetSpec().GetPolicyTypes() {

--- a/sensor/common/detector/networkpolicy/networkpolicy.go
+++ b/sensor/common/detector/networkpolicy/networkpolicy.go
@@ -31,12 +31,14 @@ func (np *Finder) GetNetworkPoliciesApplied(deployment *storage.Deployment) *aug
 	}
 
 	var hasIngress, hasEgress bool
+
+lookingForPolicies:
 	for _, policy := range np.store.Find(deployment.Namespace, deployment.Labels) {
 		for _, policyType := range policy.GetSpec().GetPolicyTypes() {
-			if policyType == storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE {
-				hasIngress = true
-			} else if policyType == storage.NetworkPolicyType_EGRESS_NETWORK_POLICY_TYPE {
-				hasEgress = true
+			hasIngress = hasIngress || policyType == storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE
+			hasEgress = hasEgress || policyType == storage.NetworkPolicyType_EGRESS_NETWORK_POLICY_TYPE
+			if hasIngress && hasEgress {
+				break lookingForPolicies
 			}
 		}
 	}

--- a/sensor/common/detector/networkpolicy/networkpolicy_test.go
+++ b/sensor/common/detector/networkpolicy/networkpolicy_test.go
@@ -64,6 +64,10 @@ func (suite *NetworkPolicySuite) Test_ReturnNilIfFeatureFlagDisabled() {
 }
 
 func (suite *NetworkPolicySuite) Test_GetNetworkPoliciesApplied() {
+	if !features.NetworkPolicySystemPolicy.Enabled() {
+		suite.T().Skip()
+	}
+
 	cases := map[string]struct {
 		policiesInStore         map[string]*storage.NetworkPolicy
 		expectedAugmentedObject *augmentedobjs.NetworkPoliciesApplied

--- a/sensor/common/detector/networkpolicy/networkpolicy_test.go
+++ b/sensor/common/detector/networkpolicy/networkpolicy_test.go
@@ -1,0 +1,138 @@
+package networkpolicy
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/booleanpolicy/augmentedobjs"
+	"github.com/stackrox/rox/sensor/common/store/mocks"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestNetworkPolicy(t *testing.T) {
+	suite.Run(t, new(NetworkPolicySuite))
+}
+
+type NetworkPolicySuite struct {
+	suite.Suite
+
+	networkStore  *mocks.MockNetworkPolicyStore
+	networkPolicy *Finder
+	mockCtrl      *gomock.Controller
+}
+
+var _ suite.SetupTestSuite = (*NetworkPolicySuite)(nil)
+var _ suite.TearDownTestSuite = (*NetworkPolicySuite)(nil)
+
+func (suite *NetworkPolicySuite) SetupTest() {
+	suite.mockCtrl = gomock.NewController(suite.T())
+	suite.networkStore = mocks.NewMockNetworkPolicyStore(suite.mockCtrl)
+	suite.networkPolicy = &Finder{store: suite.networkStore}
+}
+
+func (suite *NetworkPolicySuite) TearDownTest() {
+	suite.mockCtrl.Finish()
+}
+
+func deployment(namespace string, labels map[string]string) *storage.Deployment {
+	dep := new(storage.Deployment)
+	dep.Namespace = namespace
+	dep.Labels = labels
+	return dep
+}
+
+func policy(classificationEnums []storage.NetworkPolicyType) *storage.NetworkPolicy {
+	netpol := new(storage.NetworkPolicy)
+	netpol.Spec = new(storage.NetworkPolicySpec)
+	netpol.Spec.PolicyTypes = classificationEnums
+	return netpol
+}
+
+func (suite *NetworkPolicySuite) Test_GetNetworkPoliciesApplied() {
+	cases := map[string]struct {
+		policiesInStore         map[string]*storage.NetworkPolicy
+		expectedAugmentedObject *augmentedobjs.NetworkPoliciesApplied
+	}{
+		"No policies for deployment": {
+			policiesInStore: map[string]*storage.NetworkPolicy{},
+			expectedAugmentedObject: &augmentedobjs.NetworkPoliciesApplied{
+				MissingIngressNetworkPolicy: true,
+				MissingEgressNetworkPolicy:  true,
+			},
+		},
+		"Ingress Policy": {
+			policiesInStore: map[string]*storage.NetworkPolicy{
+				"id1": policy([]storage.NetworkPolicyType{
+					storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE,
+				}),
+			},
+			expectedAugmentedObject: &augmentedobjs.NetworkPoliciesApplied{
+				MissingIngressNetworkPolicy: false,
+				MissingEgressNetworkPolicy:  true,
+			},
+		},
+		"Egress Policy": {
+			policiesInStore: map[string]*storage.NetworkPolicy{
+				"id1": policy([]storage.NetworkPolicyType{
+					storage.NetworkPolicyType_EGRESS_NETWORK_POLICY_TYPE,
+				}),
+			},
+			expectedAugmentedObject: &augmentedobjs.NetworkPoliciesApplied{
+				MissingIngressNetworkPolicy: true,
+				MissingEgressNetworkPolicy:  false,
+			},
+		},
+		"Ingress and Egress on same policy object": {
+			policiesInStore: map[string]*storage.NetworkPolicy{
+				"id1": policy([]storage.NetworkPolicyType{
+					storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE,
+					storage.NetworkPolicyType_EGRESS_NETWORK_POLICY_TYPE,
+				}),
+			},
+			expectedAugmentedObject: &augmentedobjs.NetworkPoliciesApplied{
+				MissingIngressNetworkPolicy: false,
+				MissingEgressNetworkPolicy:  false,
+			},
+		},
+		"Ingress and Egress on different policy objects": {
+			policiesInStore: map[string]*storage.NetworkPolicy{
+				"id1": policy([]storage.NetworkPolicyType{
+					storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE,
+				}),
+				"id2": policy([]storage.NetworkPolicyType{
+					storage.NetworkPolicyType_EGRESS_NETWORK_POLICY_TYPE,
+				}),
+			},
+			expectedAugmentedObject: &augmentedobjs.NetworkPoliciesApplied{
+				MissingIngressNetworkPolicy: false,
+				MissingEgressNetworkPolicy:  false,
+			},
+		},
+		"Both missing if policy is UNSET": {
+			policiesInStore: map[string]*storage.NetworkPolicy{
+				"id1": policy([]storage.NetworkPolicyType{
+					storage.NetworkPolicyType_UNSET_NETWORK_POLICY_TYPE,
+				}),
+			},
+			expectedAugmentedObject: &augmentedobjs.NetworkPoliciesApplied{
+				MissingIngressNetworkPolicy: true,
+				MissingEgressNetworkPolicy:  true,
+			},
+		},
+	}
+
+	for name, testCase := range cases {
+		ns := "example"
+		labels := map[string]string{"label1": "value1"}
+		dep := deployment(ns, labels)
+
+		suite.Run(name, func() {
+			suite.networkStore.EXPECT().
+				Find(gomock.Eq(ns), gomock.Eq(labels)).
+				Return(testCase.policiesInStore)
+			aug := suite.networkPolicy.GetNetworkPoliciesApplied(dep)
+			suite.Equal(testCase.expectedAugmentedObject, aug)
+		})
+	}
+}

--- a/sensor/common/store/mocks/types.go
+++ b/sensor/common/store/mocks/types.go
@@ -112,3 +112,106 @@ func (mr *MockPodStoreMockRecorder) GetByName(podName, namespace interface{}) *g
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByName", reflect.TypeOf((*MockPodStore)(nil).GetByName), podName, namespace)
 }
+
+// MockNetworkPolicyStore is a mock of NetworkPolicyStore interface.
+type MockNetworkPolicyStore struct {
+	ctrl     *gomock.Controller
+	recorder *MockNetworkPolicyStoreMockRecorder
+}
+
+// MockNetworkPolicyStoreMockRecorder is the mock recorder for MockNetworkPolicyStore.
+type MockNetworkPolicyStoreMockRecorder struct {
+	mock *MockNetworkPolicyStore
+}
+
+// NewMockNetworkPolicyStore creates a new mock instance.
+func NewMockNetworkPolicyStore(ctrl *gomock.Controller) *MockNetworkPolicyStore {
+	mock := &MockNetworkPolicyStore{ctrl: ctrl}
+	mock.recorder = &MockNetworkPolicyStoreMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockNetworkPolicyStore) EXPECT() *MockNetworkPolicyStoreMockRecorder {
+	return m.recorder
+}
+
+// All mocks base method.
+func (m *MockNetworkPolicyStore) All() map[string]*storage.NetworkPolicy {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "All")
+	ret0, _ := ret[0].(map[string]*storage.NetworkPolicy)
+	return ret0
+}
+
+// All indicates an expected call of All.
+func (mr *MockNetworkPolicyStoreMockRecorder) All() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "All", reflect.TypeOf((*MockNetworkPolicyStore)(nil).All))
+}
+
+// Delete mocks base method.
+func (m *MockNetworkPolicyStore) Delete(ID, ns string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Delete", ID, ns)
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockNetworkPolicyStoreMockRecorder) Delete(ID, ns interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockNetworkPolicyStore)(nil).Delete), ID, ns)
+}
+
+// Find mocks base method.
+func (m *MockNetworkPolicyStore) Find(namespace string, labels map[string]string) map[string]*storage.NetworkPolicy {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Find", namespace, labels)
+	ret0, _ := ret[0].(map[string]*storage.NetworkPolicy)
+	return ret0
+}
+
+// Find indicates an expected call of Find.
+func (mr *MockNetworkPolicyStoreMockRecorder) Find(namespace, labels interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockNetworkPolicyStore)(nil).Find), namespace, labels)
+}
+
+// Get mocks base method.
+func (m *MockNetworkPolicyStore) Get(id string) *storage.NetworkPolicy {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", id)
+	ret0, _ := ret[0].(*storage.NetworkPolicy)
+	return ret0
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockNetworkPolicyStoreMockRecorder) Get(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockNetworkPolicyStore)(nil).Get), id)
+}
+
+// Size mocks base method.
+func (m *MockNetworkPolicyStore) Size() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Size")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Size indicates an expected call of Size.
+func (mr *MockNetworkPolicyStoreMockRecorder) Size() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockNetworkPolicyStore)(nil).Size))
+}
+
+// Upsert mocks base method.
+func (m *MockNetworkPolicyStore) Upsert(ns *storage.NetworkPolicy) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Upsert", ns)
+}
+
+// Upsert indicates an expected call of Upsert.
+func (mr *MockNetworkPolicyStoreMockRecorder) Upsert(ns interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*MockNetworkPolicyStore)(nil).Upsert), ns)
+}

--- a/sensor/common/store/types.go
+++ b/sensor/common/store/types.go
@@ -16,6 +16,8 @@ type PodStore interface {
 	GetByName(podName, namespace string) *storage.Pod
 }
 
+// NetworkPolicyStore provides functionality to find matching Network Policies given a deployment
+// object.
 //go:generate mockgen-wrapper
 type NetworkPolicyStore interface {
 	Size() int

--- a/sensor/common/store/types.go
+++ b/sensor/common/store/types.go
@@ -15,3 +15,13 @@ type PodStore interface {
 	GetAll() []*storage.Pod
 	GetByName(podName, namespace string) *storage.Pod
 }
+
+//go:generate mockgen-wrapper
+type NetworkPolicyStore interface {
+	Size() int
+	All() map[string]*storage.NetworkPolicy
+	Get(id string) *storage.NetworkPolicy
+	Upsert(ns *storage.NetworkPolicy)
+	Find(namespace string, labels map[string]string) map[string]*storage.NetworkPolicy
+	Delete(ID, ns string)
+}

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -68,7 +68,7 @@ func NewDispatcherRegistry(
 	podStore := PodStoreSingleton()
 	nodeStore := newNodeStore()
 	nsStore := newNamespaceStore()
-	netPolicyStore := newNetworkPoliciesStore()
+	netPolicyStore := NetworkPolicySingleton()
 	endpointManager := newEndpointManager(serviceStore, deploymentStore, podStore, nodeStore, entityStore)
 	rbacUpdater := rbac.NewStore()
 	portExposureReconciler := newPortExposureReconciler(deploymentStore, serviceStore)

--- a/sensor/kubernetes/listener/resources/networkpolicy.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy.go
@@ -2,26 +2,26 @@ package resources
 
 import (
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/generated/storage"
 	networkPolicyConversion "github.com/stackrox/rox/pkg/protoconv/networkpolicy"
+	"github.com/stackrox/rox/sensor/common/store"
 	networkingV1 "k8s.io/api/networking/v1"
 )
 
-type networkPolicyStore interface {
-	Size() int
-	All() map[string]*storage.NetworkPolicy
-	Get(id string) *storage.NetworkPolicy
-	Upsert(ns *storage.NetworkPolicy)
-	Find(namespace string, labels map[string]string) map[string]*storage.NetworkPolicy
-	Delete(ID, ns string)
-}
+//type networkPolicyStore interface {
+//	Size() int
+//	All() map[string]*storage.NetworkPolicy
+//	Get(id string) *storage.NetworkPolicy
+//	Upsert(ns *storage.NetworkPolicy)
+//	Find(namespace string, labels map[string]string) map[string]*storage.NetworkPolicy
+//	Delete(ID, ns string)
+//}
 
 // networkPolicyDispatcher handles network policy resource events.
 type networkPolicyDispatcher struct {
-	store networkPolicyStore
+	store store.NetworkPolicyStore
 }
 
-func newNetworkPolicyDispatcher(nps networkPolicyStore) *networkPolicyDispatcher {
+func newNetworkPolicyDispatcher(nps  store.NetworkPolicyStore) *networkPolicyDispatcher {
 	return &networkPolicyDispatcher{
 		store: nps,
 	}

--- a/sensor/kubernetes/listener/resources/networkpolicy.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy.go
@@ -7,15 +7,6 @@ import (
 	networkingV1 "k8s.io/api/networking/v1"
 )
 
-//type networkPolicyStore interface {
-//	Size() int
-//	All() map[string]*storage.NetworkPolicy
-//	Get(id string) *storage.NetworkPolicy
-//	Upsert(ns *storage.NetworkPolicy)
-//	Find(namespace string, labels map[string]string) map[string]*storage.NetworkPolicy
-//	Delete(ID, ns string)
-//}
-
 // networkPolicyDispatcher handles network policy resource events.
 type networkPolicyDispatcher struct {
 	store store.NetworkPolicyStore

--- a/sensor/kubernetes/listener/resources/networkpolicy.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy.go
@@ -21,7 +21,7 @@ type networkPolicyDispatcher struct {
 	store store.NetworkPolicyStore
 }
 
-func newNetworkPolicyDispatcher(nps  store.NetworkPolicyStore) *networkPolicyDispatcher {
+func newNetworkPolicyDispatcher(nps store.NetworkPolicyStore) *networkPolicyDispatcher {
 	return &networkPolicyDispatcher{
 		store: nps,
 	}

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"github.com/stackrox/rox/pkg/labels"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/store"
 
 	"github.com/stackrox/rox/generated/storage"
 )
@@ -72,7 +73,7 @@ The operations on the store may allocate additional memory temporarily.
 - Delete: O(1)
 */
 
-var _ networkPolicyStore = (*networkPolicyStoreImpl)(nil)
+var _ store.NetworkPolicyStore = (*networkPolicyStoreImpl)(nil)
 
 type networkPolicyStoreImpl struct {
 	lock sync.RWMutex

--- a/sensor/kubernetes/listener/resources/networkpolicy_store_bench_test.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store_bench_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stackrox/rox/sensor/common/store"
 )
 
 /*
@@ -46,7 +47,7 @@ func generateSetOfAllValues(num int) []string {
 	return arr
 }
 
-func populateStore(s networkPolicyStore, num, numLabels int64, allLabels, allValues []string) {
+func populateStore(s store.NetworkPolicyStore, num, numLabels int64, allLabels, allValues []string) {
 	for i := int64(0); i < num; i++ {
 		np := newNPDummy(uuid.NewV4().String(), getRandom(namespaces), randomLabels(numLabels, allLabels, allValues))
 		s.Upsert(np)

--- a/sensor/kubernetes/listener/resources/singleton.go
+++ b/sensor/kubernetes/listener/resources/singleton.go
@@ -29,6 +29,7 @@ func PodStoreSingleton() *PodStore {
 	return podStore
 }
 
+// NetworkPolicySingleton returns a singleton of NetworkPolicyStore
 func NetworkPolicySingleton() *networkPolicyStoreImpl {
 	netpolInit.Do(func() {
 		netpolStore = newNetworkPoliciesStore()

--- a/sensor/kubernetes/listener/resources/singleton.go
+++ b/sensor/kubernetes/listener/resources/singleton.go
@@ -8,6 +8,9 @@ var (
 
 	psInit   sync.Once
 	podStore *PodStore
+
+	netpolInit sync.Once
+	netpolStore *networkPolicyStoreImpl
 )
 
 // DeploymentStoreSingleton returns a singleton of the DeploymentStore
@@ -24,4 +27,11 @@ func PodStoreSingleton() *PodStore {
 		podStore = newPodStore()
 	})
 	return podStore
+}
+
+func NetworkPolicySingleton() *networkPolicyStoreImpl {
+	netpolInit.Do(func() {
+		netpolStore = newNetworkPoliciesStore()
+	})
+	return netpolStore
 }

--- a/sensor/kubernetes/listener/resources/singleton.go
+++ b/sensor/kubernetes/listener/resources/singleton.go
@@ -9,7 +9,7 @@ var (
 	psInit   sync.Once
 	podStore *PodStore
 
-	netpolInit sync.Once
+	netpolInit  sync.Once
 	netpolStore *networkPolicyStoreImpl
 )
 

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -103,7 +103,7 @@ func CreateSensor(client client.Interface, workloadHandler *fake.WorkloadManager
 	}
 
 	imageCache := expiringcache.NewExpiringCache(env.ReprocessInterval.DurationSetting())
-	policyDetector := detector.New(enforcer, admCtrlSettingsMgr, resources.DeploymentStoreSingleton(), imageCache, auditLogEventsInput, auditLogCollectionManager)
+	policyDetector := detector.New(enforcer, admCtrlSettingsMgr, resources.DeploymentStoreSingleton(), imageCache, auditLogEventsInput, auditLogCollectionManager, resources.NetworkPolicySingleton())
 	admCtrlMsgForwarder := admissioncontroller.NewAdmCtrlMsgForwarder(admCtrlSettingsMgr, listener.New(client, configHandler, policyDetector, k8sNodeName.Setting()))
 
 	upgradeCmdHandler, err := upgrade.NewCommandHandler(configHandler)


### PR DESCRIPTION
## Description

This PR implements the Network Policy association on Deployment updates from Kubernetes. It introduces the following changes to the application:

1. Creates an exportable interface `NetworkPolicyStore` and introduces a singleton and mock wrappers for the same.
2. Introduces new `networkpolicy` package under detector to encapsulate the creation of `augmentedobj.NetworkPolicyApplied` objects. 
3. Guard the creation of object by feature flag. `nil` will be passed to the evaluator in this case, which isn't a problem since a `nil` augmented child path won't be evaluated and hence no violation will be triggered [as exercised here](https://github.com/stackrox/stackrox/blob/master/pkg/booleanpolicy/default_policies_test.go#L3182-L3185).

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- [x] Unit tests and CI
- [x] Manual test on infra cluster to check if violation is triggered

Manual test steps:

1. Make sure the deployed cluster has feature-flag `ROX_NETPOL_FIELDS` enabled 
2. Create a policy field for checking missing ingress violations (`POST /v1/policies`):
```json
{
	"name": "Deployments should have ingress Network Policy",
	"severity": "MEDIUM_SEVERITY",
	"disabled": false,
	"lifecycleStages": [
		"DEPLOY"
	],
	"eventSource": "NOT_APPLICABLE",
	"isDefault": false,
	"categories": [
		"Anomalous Activity"
	],
	"policySections": [
		{
			"sectionName": "No missing policies",
			"policyGroups": [
				{
					"fieldName": "Missing Ingress Network Policy",
					"values": [
						{
							"value": "true"
						}
					]
				}
			]
		}
	]
}
```
3. Apply `nginx-deployment.yaml` to `default` namespace:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
```
4. Check that the violation is triggered:
![image](https://user-images.githubusercontent.com/6811076/161708201-087f8c21-4767-481a-a51a-9a799cca28a4.png)
5. Create a new ingress `NetworkPolicy` that matches `nginx-deployment`
```yaml
kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
metadata:
  name: allow-all
  namespace: default
spec:
  podSelector:
    matchLabels:
      app: nginx
  ingress:
  - {}
```
6. **(!)** Scale up the number of replicas in `nginx-deployment`
```
kubectl scale deploy/nginx-deployment --replicas 4
```
7. Check that the violation is gone
![image](https://user-images.githubusercontent.com/6811076/161708490-2acc0783-c058-4e11-ac06-27407da7f72a.png)


---

**(!)** Step (6) is a intermediary step that is only required while #1132 is not merged. Since sensor will only re-trigger evaluations on deployment updates for now. 