### PR TITLE
CI: An on-demand and customized build_all

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2654,6 +2654,7 @@ jobs:
           root: /go/src/github.com/stackrox/rox
           paths:
             - CI_TAG
+            - COLLECTOR_VERSION
 
   pre-build-ui-stackrox:
     executor: custom

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,13 @@ loginToGCR: &loginToGCR
     command: docker login -u _json_key --password-stdin \<<<"$GCLOUD_SERVICE_ACCOUNT_CIRCLECI_ROX" https://gcr.io
     when: always
 
+configureGit: &configureGit
+  run:
+    name: Configure git
+    command: |
+      git config user.email "roxbot@stackrox.com"
+      git config user.name "RoxBot"
+
 restoreGoBuildCache: &restoreGoBuildCache
   restore_cache:
     name: Restoring Go build cache
@@ -2636,6 +2643,7 @@ jobs:
     resource_class: small
     steps:
       - checkout
+      - *configureGit
       - run:
           name: Allow a custom Collector version
           command: |
@@ -2643,7 +2651,7 @@ jobs:
               echo "Using a custom collector version: << pipeline.parameters.collector_version >>"
               echo "<< pipeline.parameters.collector_version >>" > COLLECTOR_VERSION
               # Ensure that this CI pipeline has a unique tag and that it does
-              # not overwrite images built from the same git ref.
+              # not overwrite images built from the original git ref.
               git commit -m 'avoid overwrite of existing image' COLLECTOR_VERSION
             else
               echo "A custom collector version was not set"
@@ -4460,11 +4468,7 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: Configure git
-          command: |
-            git config user.email "roxbot@stackrox.com"
-            git config user.name "RoxBot"
+      *configureGit
 
       - add_ssh_keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2637,19 +2637,22 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Creating a consistent tag for CI workflow
-          command: |
-            make --quiet tag | tee CI_TAG_TMP
-            mv CI_TAG_TMP CI_TAG
-      - run:
           name: Allow a custom Collector version
           command: |
             if [[ -n "<< pipeline.parameters.collector_version >>" ]]; then
               echo "Using a custom collector version: << pipeline.parameters.collector_version >>"
               echo "<< pipeline.parameters.collector_version >>" > COLLECTOR_VERSION
+              # Ensure that this CI pipeline has a unique tag and that it does
+              # not overwrite images built from the same git ref.
+              git commit -m 'avoid overwrite of existing image' COLLECTOR_VERSION
             else
               echo "A custom collector version was not set"
             fi
+      - run:
+          name: Creating a consistent tag for CI workflow
+          command: |
+            make --quiet tag | tee CI_TAG_TMP
+            mv CI_TAG_TMP CI_TAG
       - persist_to_workspace:
           root: /go/src/github.com/stackrox/rox
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5057,7 +5057,7 @@ workflows:
   #     "branch": "<your branch>",
   #     "parameters": {
   #         "trigger_on_demand": true,
-  #         "workflow_name": "build_all"
+  #         "workflow_name": "build_all",
   #         "collector_version": "1.2.3"
   #     }
   # }'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,6 +492,9 @@ parameters:
     type: string
     # Caution when editing: make sure groups would correspond to BASH_REMATCH use.
     default: '^([[:digit:]]+(\.[[:digit:]]+)*)(-rc\.[[:digit:]]+)?$'
+  collector_version:
+    type: string
+    default: ""
 
 orbs:
   win: circleci/windows@2.2.0
@@ -2628,7 +2631,7 @@ jobs:
   # Build jobs
   ###
 
-  pre-create-tag:
+  pre-create-parameters:
     executor: custom
     resource_class: small
     steps:
@@ -2638,6 +2641,15 @@ jobs:
           command: |
             make --quiet tag | tee CI_TAG_TMP
             mv CI_TAG_TMP CI_TAG
+      - run:
+          name: Allow a custom Collector version
+          command: |
+            if [[ -n "<< pipeline.parameters.collector_version >>" ]]; then
+              echo "Using a custom collector version: << pipeline.parameters.collector_version >>"
+              echo "<< pipeline.parameters.collector_version >>" > COLLECTOR_VERSION
+            else
+              echo "A custom collector version was not set"
+            fi
       - persist_to_workspace:
           root: /go/src/github.com/stackrox/rox
           paths:
@@ -4652,7 +4664,7 @@ workflows:
   build_all:
     when:
       not: << pipeline.parameters.trigger_on_demand >>
-    jobs:
+    jobs: &buildAllJobs
       - slack-notify:
           filters:
             tags:
@@ -4680,24 +4692,24 @@ workflows:
           <<: *runOnAllTagsWithQuayIOPullCtx
       - integration-unit-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
-      - pre-create-tag:
+      - pre-create-parameters:
           <<: *runOnAllTagsWithQuayIOPullCtx
       - pre-build-ui-stackrox:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
-            - pre-create-tag
+            - pre-create-parameters
       - pre-build-ui-rhacs:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
-            - pre-create-tag
+            - pre-create-parameters
       - pre-build-cli:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
-            - pre-create-tag
+            - pre-create-parameters
       - pre-build-go-binaries:
           <<: *runOnAllTagsWithPushCtx
           requires:
-            - pre-create-tag
+            - pre-create-parameters
       - build-stackrox:
           <<: *runOnAllTagsWithPushCtx
           requires:
@@ -5002,20 +5014,20 @@ workflows:
     when:
       equal: [ "build-rhacs", << pipeline.parameters.workflow_name >> ]
     jobs:
-      - pre-create-tag:
+      - pre-create-parameters:
           context: custom-executor-pull
       - pre-build-ui-rhacs:
           context: custom-executor-pull
           requires:
-            - pre-create-tag
+            - pre-create-parameters
       - pre-build-cli:
           context: custom-executor-pull
           requires:
-            - pre-create-tag
+            - pre-create-parameters
       - pre-build-go-binaries:
           context: docker-io-push
           requires:
-            - pre-create-tag
+            - pre-create-parameters
       - build-rhacs:
           context: docker-io-push
           requires:
@@ -5029,3 +5041,21 @@ workflows:
     jobs:
       - designated-image-tests:
           context: quay-rhacs-eng-readonly
+
+  # To trigger build_all with custom parameters.
+  #
+  #   curl -X POST --header 'Content-Type: application/json' \
+  #        --header "Circle-Token: <your CI token>" https://circleci.com/api/v2/project/github/stackrox/stackrox/pipeline -d '{
+  #     "branch": "<your branch>",
+  #     "parameters": {
+  #         "trigger_on_demand": true,
+  #         "workflow_name": "build_all"
+  #         "collector_version": "1.2.3"
+  #     }
+  # }'
+
+  build_all_on_demand:
+    when:
+      equal: [ "build_all", << pipeline.parameters.workflow_name >> ]
+    jobs:
+      *buildAllJobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4468,7 +4468,7 @@ jobs:
     steps:
       - checkout
 
-      *configureGit
+      - *configureGit
 
       - add_ssh_keys:
           fingerprints:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,11 @@ TESTFLAGS=-race -p 4
 BASE_DIR=$(CURDIR)
 
 ifeq ($(TAG),)
+ifeq (,$(wildcard CI_TAG))
 TAG=$(shell git describe --tags --abbrev=10 --dirty --long --exclude '*-nightly-*')
+else
+TAG=$(cat CI_TAG)
+endif
 endif
 
 # ROX_IMAGE_FLAVOR is an ARG used in Dockerfiles that defines the default registries for main, scaner, and collector images.

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ifeq ($(TAG),)
 ifeq (,$(wildcard CI_TAG))
 TAG=$(shell git describe --tags --abbrev=10 --dirty --long --exclude '*-nightly-*')
 else
-TAG=$(cat CI_TAG)
+TAG=$(shell cat CI_TAG)
 endif
 endif
 


### PR DESCRIPTION
## Description

Collector would like to run StackRox CI against a specific collector version. This PR makes that possible.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Regular PR CI is [fine](https://app.circleci.com/pipelines/github/stackrox/stackrox/8766/workflows/d71546df-d09d-42f0-b1b3-883c2f8ed7df).
- [x] `build_all_on_demand` with a valid different COLLECTOR_VERSION 3.7.3, ensure that version is used and CI is [fine](https://app.circleci.com/pipelines/github/stackrox/stackrox/8771/workflows/243567a2-a2cb-48f0-81f9-2817bb2d5d7d).
- [x] `build_all_on_demand` with an invalid COLLECTOR_VERSION 1.2.3, builds should [fail](https://app.circleci.com/pipelines/github/stackrox/stackrox/8767/workflows/34b87601-e72b-4442-9515-7ec88bef37ef/jobs/388028).
