### PR TITLE
ROX-9892: Negate image signature verification policy criteria

### DIFF
--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -265,7 +265,7 @@ func ConstructImage(image *storage.Image) (*pathutil.AugmentedObj, error) {
 func addSignatureVerificationResult(obj *pathutil.AugmentedObj, i int, id string) error {
 	err := obj.AddPlainObjAt(
 		&imageSignatureVerification{
-			VerifierId: id,
+			VerifierID: id,
 		},
 		pathutil.FieldStep("SignatureVerificationData"),
 		pathutil.FieldStep("Results"),

--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -6,7 +6,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/booleanpolicy/evaluator/pathutil"
-	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -14,10 +13,6 @@ import (
 const (
 	// CompositeFieldCharSep is the separating character used when we create a composite field.
 	CompositeFieldCharSep = "\t"
-
-	// EmptySignatureIntegrationID is used as placeholder for images that do not have any signatures associated with
-	// them.
-	EmptySignatureIntegrationID = "io.stackrox.signatureintegration.00000000-0000-0000-0000-000000000000"
 )
 
 func findMatchingContainerIdxForProcess(deployment *storage.Deployment, process *storage.ProcessIndicator) (int, error) {
@@ -241,36 +236,22 @@ func ConstructImage(image *storage.Image) (*pathutil.AugmentedObj, error) {
 	}
 
 	if features.ImageSignatureVerification.Enabled() {
-		var addedAtLeastOnSignatureVerificationResult bool
+		i := 0
 		// Since policies query for image verification status as a single boolean field, we add it to the image here.
-		for i, result := range image.GetSignatureVerificationData().GetResults() {
+		for _, result := range image.GetSignatureVerificationData().GetResults() {
 			if result.GetStatus() == storage.ImageSignatureVerificationResult_VERIFIED {
-				if result.GetVerifierId() == "" {
-					return nil, utils.Should(errox.InvariantViolation.New(
-						"missing verifier ID in signature verification results"))
-				}
-				err := obj.AddPlainObjAt(
-					&imageSignatureVerification{
-						VerifiedBy: result.GetVerifierId(),
-					},
-					pathutil.FieldStep("SignatureVerificationData"),
-					pathutil.FieldStep("Results"),
-					pathutil.IndexStep(i),
-					pathutil.FieldStep(imageSignatureVerifiedKey),
-				)
-				if err != nil {
+				if err := addSignatureVerificationResult(obj, i, result.GetVerifierId()); err != nil {
 					return nil, utils.Should(err)
 				}
-
-				addedAtLeastOnSignatureVerificationResult = true
+				i++
 			}
 		}
 		// When the object is not created, the policy will not match, but it should match.
 		// Any image that DOESN'T have any signature should also be visible here (I guess?).
 		// This means, we will have to create a dummy entry within the object that will make it
 		// possible for us to match the policy and create alerts.
-		if !addedAtLeastOnSignatureVerificationResult {
-			if err := addPlaceHolderSignatureVerificationResult(obj); err != nil {
+		if i == 0 {
+			if err := addSignatureVerificationResult(obj, i, ""); err != nil {
 				return nil, utils.Should(err)
 			}
 		}
@@ -279,16 +260,16 @@ func ConstructImage(image *storage.Image) (*pathutil.AugmentedObj, error) {
 	return obj, nil
 }
 
-// addPlaceHolderSignatureVerificationResult will add a placeholder signature verification result holding
-// EmptySignatureIntegrationID.
-func addPlaceHolderSignatureVerificationResult(obj *pathutil.AugmentedObj) error {
+// addSignatureVerificationResult will add a signature verification result to
+// the augmented object.
+func addSignatureVerificationResult(obj *pathutil.AugmentedObj, i int, id string) error {
 	err := obj.AddPlainObjAt(
 		&imageSignatureVerification{
-			VerifiedBy: EmptySignatureIntegrationID,
+			VerifierId: id,
 		},
 		pathutil.FieldStep("SignatureVerificationData"),
 		pathutil.FieldStep("Results"),
-		pathutil.IndexStep(0),
+		pathutil.IndexStep(i),
 		pathutil.FieldStep(imageSignatureVerifiedKey))
 	if err != nil {
 		return err

--- a/pkg/booleanpolicy/augmentedobjs/custom_types.go
+++ b/pkg/booleanpolicy/augmentedobjs/custom_types.go
@@ -80,5 +80,5 @@ type envVar struct {
 }
 
 type imageSignatureVerification struct {
-	VerifierId string `search:"Image Signature Verified By"`
+	VerifierID string `search:"Image Signature Verified By"`
 }

--- a/pkg/booleanpolicy/augmentedobjs/custom_types.go
+++ b/pkg/booleanpolicy/augmentedobjs/custom_types.go
@@ -80,5 +80,5 @@ type envVar struct {
 }
 
 type imageSignatureVerification struct {
-	VerifiedBy string `search:"Image Signature Verified By"`
+	VerifierId string `search:"Image Signature Verified By"`
 }

--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -2226,20 +2226,22 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 			expectedMatches: set.NewFrozenStringSet("verified_by_0", "verified_by_2_and_3"),
 		},
 		{
-			values:          []string{verifier0, verifier2}, // images not verified by neither 0, nor 2
-			negate:          false,
-			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_0", "verified_by_2_and_3")),
-		},
-		{
 			values:          []string{verifier2, verifier3},
 			negate:          false,
 			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_3", "verified_by_2_and_3")),
 		},
+		// TODO(ROX-9996): Fix construction of the augmented object to allow for matching
+		// several verifier IDs.
+		/*{
+			values:          []string{verifier0, verifier2},
+			negate:          false,
+			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_0", "verified_by_2_and_3")),
+		},
 		{
-			values:          []string{verifier3}, // images not verified by verifier3
+			values:          []string{verifier3},
 			negate:          false,
 			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_3", "verified_by_2_and_3")),
-		},
+		},*/
 		{
 			values:          []string{unverifier},
 			negate:          false,

--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -2192,52 +2192,52 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 	}{
 		{
 			values:          []string{verifier0},
-			negate:          false,
+			negate:          true,
 			expectedMatches: set.NewFrozenStringSet("verified_by_0"),
 		},
 		{
 			values:          []string{verifier0},
-			negate:          true,
+			negate:          false,
 			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_0")),
 		},
 		{
 			values:          []string{verifier1},
-			negate:          false,
+			negate:          true,
 			expectedMatches: set.NewFrozenStringSet(),
 		},
 		{
 			values:          []string{verifier1},
-			negate:          true,
+			negate:          false,
 			expectedMatches: allImages,
 		},
 		{
 			values:          []string{verifier2},
-			negate:          false,
+			negate:          true,
 			expectedMatches: set.NewFrozenStringSet("verified_by_2_and_3"),
 		},
 		{
 			values:          []string{verifier2},
-			negate:          true,
+			negate:          false,
 			expectedMatches: allImages,
 		},
 		{
 			values:          []string{verifier0, verifier2},
-			negate:          false,
+			negate:          true,
 			expectedMatches: set.NewFrozenStringSet("verified_by_0", "verified_by_2_and_3"),
 		},
 		{
 			values:          []string{verifier0, verifier2},
-			negate:          true,
+			negate:          false,
 			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_0")),
 		},
 		{
 			values:          []string{verifier3},
-			negate:          true,
+			negate:          false,
 			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_3")),
 		},
 		{
 			values:          []string{unverifier},
-			negate:          true,
+			negate:          false,
 			expectedMatches: allImages,
 		},
 	} {

--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -2226,14 +2226,19 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 			expectedMatches: set.NewFrozenStringSet("verified_by_0", "verified_by_2_and_3"),
 		},
 		{
-			values:          []string{verifier0, verifier2},
+			values:          []string{verifier0, verifier2}, // images not verified by neither 0, nor 2
 			negate:          false,
-			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_0")),
+			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_0", "verified_by_2_and_3")),
 		},
 		{
-			values:          []string{verifier3},
+			values:          []string{verifier2, verifier3},
 			negate:          false,
-			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_3")),
+			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_3", "verified_by_2_and_3")),
+		},
+		{
+			values:          []string{verifier3}, // images not verified by verifier3
+			negate:          false,
+			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_3", "verified_by_2_and_3")),
 		},
 		{
 			values:          []string{unverifier},

--- a/pkg/booleanpolicy/field_metadata.go
+++ b/pkg/booleanpolicy/field_metadata.go
@@ -395,14 +395,16 @@ func initializeFieldMetadata() FieldMetadata {
 		[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
 		[]RuntimeFieldType{}, negationForbidden, operatorsForbidden)
 
-	f.registerFieldMetadata(fieldnames.ImageSignatureVerifiedBy,
-		querybuilders.ForImageSignatureVerificationStatus(),
-		violationmessages.ImageContextFields,
-		func(*validateConfiguration) *regexp.Regexp {
-			return signatureIntegrationIDValueRegex
-		},
-		[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
-		[]RuntimeFieldType{})
+	if features.ImageSignatureVerification.Enabled() {
+		f.registerFieldMetadata(fieldnames.ImageSignatureVerifiedBy,
+			querybuilders.ForImageSignatureVerificationStatus(),
+			violationmessages.ImageContextFields,
+			func(*validateConfiguration) *regexp.Regexp {
+				return signatureIntegrationIDValueRegex
+			},
+			[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
+			[]RuntimeFieldType{})
+	}
 
 	f.registerFieldMetadata(fieldnames.ImageTag,
 		querybuilders.ForFieldLabelRegex(search.ImageTag),

--- a/pkg/booleanpolicy/field_metadata.go
+++ b/pkg/booleanpolicy/field_metadata.go
@@ -396,7 +396,7 @@ func initializeFieldMetadata() FieldMetadata {
 		[]RuntimeFieldType{}, negationForbidden, operatorsForbidden)
 
 	f.registerFieldMetadata(fieldnames.ImageSignatureVerifiedBy,
-		querybuilders.ForFieldLabel(augmentedobjs.ImageSignatureVerifiedCustomTag),
+		querybuilders.ForImageSignatureVerificationStatus(),
 		violationmessages.ImageContextFields,
 		func(*validateConfiguration) *regexp.Regexp {
 			return signatureIntegrationIDValueRegex

--- a/pkg/booleanpolicy/query_to_field_value_mappers.go
+++ b/pkg/booleanpolicy/query_to_field_value_mappers.go
@@ -23,6 +23,7 @@ var (
 		search.VolumeReadonly:                newMapper(fieldnames.WritableMountedVolume, invertBooleanMap),
 		search.ImageCreatedTime:              newMapper(fieldnames.ImageAge, numberOfDaysSinceMap),
 		search.ImageScanTime:                 newMapper(fieldnames.ImageScanAge, numberOfDaysSinceMap),
+		search.ImageSignatureVerifiedBy:      newMapper(fieldnames.ImageSignatureVerifiedBy, directMap),
 		search.ServiceAccountPermissionLevel: newMapper(fieldnames.MinimumRBACPermissions, serviceAccountPermissionLevelMap),
 		search.ExposureLevel:                 newMapper(fieldnames.PortExposure, directMap),
 		search.AddCapabilities:               newMapper(fieldnames.AddCaps, directMap),

--- a/pkg/booleanpolicy/querybuilders/special_cases.go
+++ b/pkg/booleanpolicy/querybuilders/special_cases.go
@@ -131,3 +131,15 @@ func mapFixedByValue(s string) string {
 	}
 	return valueToStringRegex(s)
 }
+
+// ForImageSignatureVerificationStatus returns a query builder for Image
+// Signature Verification Status.
+func ForImageSignatureVerificationStatus() QueryBuilder {
+	qbf := func(group *storage.PolicyGroup) []*query.FieldQuery {
+		group.Negate = !group.Negate
+		return []*query.FieldQuery{
+			fieldQueryFromGroup(group, search.ImageSignatureVerifiedBy, nil),
+		}
+	}
+	return queryBuilderFunc(qbf)
+}

--- a/pkg/booleanpolicy/querybuilders/special_cases.go
+++ b/pkg/booleanpolicy/querybuilders/special_cases.go
@@ -136,10 +136,12 @@ func mapFixedByValue(s string) string {
 // Signature Verification Status.
 func ForImageSignatureVerificationStatus() QueryBuilder {
 	qbf := func(group *storage.PolicyGroup) []*query.FieldQuery {
-		group.Negate = !group.Negate
-		return []*query.FieldQuery{
-			fieldQueryFromGroup(group, search.ImageSignatureVerifiedBy, nil),
-		}
+		return []*query.FieldQuery{{
+			Field:    search.ImageSignatureVerifiedBy.String(),
+			Values:   mapValues(group, nil),
+			Operator: operatorProtoMap[group.GetBooleanOperator()],
+			Negate:   !group.Negate,
+		}}
 	}
 	return queryBuilderFunc(qbf)
 }

--- a/pkg/booleanpolicy/violationmessages/printer/container.go
+++ b/pkg/booleanpolicy/violationmessages/printer/container.go
@@ -169,8 +169,7 @@ func imageSignatureVerifiedPrinter(fieldMap map[string][]string) ([]string, erro
 		ContainerName: maybeGetSingleValueFromFieldMap(augmentedobjs.ContainerNameCustomTag, fieldMap),
 		Status:        "unverified",
 	}
-	if verifiedBy := maybeGetSingleValueFromFieldMap(augmentedobjs.ImageSignatureVerifiedCustomTag, fieldMap); verifiedBy != "" &&
-		verifiedBy != augmentedobjs.EmptySignatureIntegrationID {
+	if verifiedBy := maybeGetSingleValueFromFieldMap(augmentedobjs.ImageSignatureVerifiedCustomTag, fieldMap); verifiedBy != "" {
 		r.Status = "verified by " + verifiedBy
 	}
 	return executeTemplate(imageSignatureVerifiedTemplate, r)

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -72,7 +72,7 @@ var (
 	ImageName                     = newFieldLabel("Image")
 	ImageSHA                      = newFieldLabel("Image Sha")
 	ImageSignatureFetchedTime     = newFieldLabel("Image Signature Fetched Time")
-	ImageSignatureVerified        = newFieldLabel("Image Signature Verified")
+	ImageSignatureVerifiedBy      = newFieldLabel("Image Signature Verified By")
 	ImageRegistry                 = newFieldLabel("Image Registry")
 	ImageRemote                   = newFieldLabel("Image Remote")
 	ImageScanTime                 = newFieldLabel("Image Scan Time")


### PR DESCRIPTION
## Description

Implement a custom query builder negating the policy group.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
