### PR TITLE
Fix reprocess of verification results for existing images.

### DIFF
--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -120,7 +120,7 @@ func (e *enricherImpl) EnrichWithSignatureVerificationData(ctx context.Context, 
 		return EnrichmentResult{}, errors.New("the image signature verification feature is not enabled")
 	}
 
-	updated, err := e.enrichWithSignatureVerificationData(ctx, EnrichmentContext{}, image)
+	updated, err := e.enrichWithSignatureVerificationData(ctx, EnrichmentContext{FetchOpt: ForceRefetchSignaturesOnly}, image)
 
 	return EnrichmentResult{
 		ImageUpdated: updated,
@@ -521,10 +521,9 @@ func (e *enricherImpl) enrichWithSignatureVerificationData(ctx context.Context, 
 		return false, nil
 	}
 
-	// We can neglect updated signatures here, since refetching is tied to the same FetchOption for both signature and
-	// verification results. If we decide to introduce a new fetch option for signature verification only, we need to
-	// account for updated signatures to not have stale verification results after the enrichment process.
-	if img.GetSignatureVerificationData() != nil {
+	// The image will use cached or existing values. If we are enriching during i.e. change of signature integration,
+	// we have to make sure we force a re-verification to not return stale data.
+	if img.GetSignatureVerificationData() != nil && enrichmentContext.FetchOpt != ForceRefetchSignaturesOnly {
 		return false, nil
 	}
 


### PR DESCRIPTION
# Description

Previously, we did not force a re-verification of results for images which already had existing results, since result != nil would also be true.
Now, added the correct FetchOption so we ensure we force a re-verification for images with existing results when going through reprocessing after signature integration changes.

## Testing Performed
- Manual tests & QA tests (once they are merged)
