### PR TITLE
ROX-8550: Retry on failed operator bundle scorecard tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4255,7 +4255,7 @@ jobs:
 
     - run:
         name: Run Operator Bundle Scorecard tests
-        command: ./operator/scripts/retry.sh 4 make -C operator bundle-test-image
+        command: ./operator/scripts/retry.sh 4 2 make -C operator bundle-test-image
 
     - collect-k8s-logs:
         orchestrator-flavor: openshift

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4184,7 +4184,7 @@ jobs:
 
     - run:
         name: Run Operator Bundle Scorecard tests
-        command: ./operator/scripts/retry.sh 4 make -C operator bundle-test-image
+        command: ./operator/scripts/retry.sh 4 2 make -C operator bundle-test-image
 
     - collect-k8s-logs:
         orchestrator-flavor: openshift

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4184,7 +4184,7 @@ jobs:
 
     - run:
         name: Run Operator Bundle Scorecard tests
-        command: make -C operator bundle-test-image
+        command: ./operator/scripts/retry.sh 4 make -C operator bundle-test-image
 
     - collect-k8s-logs:
         orchestrator-flavor: openshift
@@ -4255,7 +4255,7 @@ jobs:
 
     - run:
         name: Run Operator Bundle Scorecard tests
-        command: make -C operator bundle-test-image
+        command: ./operator/scripts/retry.sh 4 make -C operator bundle-test-image
 
     - collect-k8s-logs:
         orchestrator-flavor: openshift

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -144,7 +144,7 @@ KUSTOMIZE = $(PROJECT_DIR)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
 
-OPERATOR_SDK_VERSION = 1.14.0
+OPERATOR_SDK_VERSION = 1.18.1
 OPERATOR_SDK = $(PROJECT_DIR)/bin/operator-sdk-$(OPERATOR_SDK_VERSION)
 .PHONY: operator-sdk
 operator-sdk: ## Download operator-sdk necessary for scaffolding and bundling.

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -144,7 +144,7 @@ KUSTOMIZE = $(PROJECT_DIR)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
 
-OPERATOR_SDK_VERSION = 1.18.1
+OPERATOR_SDK_VERSION = 1.14.0
 OPERATOR_SDK = $(PROJECT_DIR)/bin/operator-sdk-$(OPERATOR_SDK_VERSION)
 .PHONY: operator-sdk
 operator-sdk: ## Download operator-sdk necessary for scaffolding and bundling.

--- a/operator/scripts/retry.sh
+++ b/operator/scripts/retry.sh
@@ -5,18 +5,14 @@ set -eu -o pipefail
 # shellcheck source=./hack/common.sh
 source "$(dirname "$0")/../hack/common.sh"
 
-eecho() {
-  echo "$@" >&2
-}
-
 die() {
-  eecho "$@"
+  log "$@"
   exit 1
 }
 
 function main() {
     if [ $# -lt 2 ]; then
-        die "Usage: $0 <number of attempts> <command> [ <command arg> ... ]"
+        die "Usage: $0 <number of attempts> <delay between attempts in seconds> <command> [ <command arg> ... ]"
     fi
 
     local -r n_attempts="${1:-}"; shift
@@ -29,8 +25,8 @@ function main() {
         die "Error: '$delay' is not a number of seconds."
     fi
 
-    eecho "** Executing '$*' with $n_attempts attempts **"
-    eecho
+    log "** Executing '$*' with $n_attempts attempts **"
+    log
     retry "$n_attempts" "$delay" "$@"
 }
 

--- a/operator/scripts/retry.sh
+++ b/operator/scripts/retry.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+DELAY_BETWEEN_ATTEMPTS=2 # Seconds
+
+eecho() {
+  echo "$@" >&2
+}
+
+die() {
+  eecho "$@"
+  exit 1
+}
+
+if [ $# -lt 1 ]; then
+    die "Usage: $0 <number of retries> <command> [ <command arg> ... ]"
+fi
+
+N_ATTEMPTS="$1"
+shift
+
+if ! [ "$N_ATTEMPTS" -gt 0 ] 2>/dev/null; then
+    die "Error: '$N_ATTEMPTS' is not a valid number of attempts, please provide a positive natural number."
+fi
+
+CMD=$*
+
+for i in $(seq 1 "$N_ATTEMPTS"); do
+    eecho "** Executing '$CMD' (attempt $i of $N_ATTEMPTS) **"
+    eecho
+    $CMD
+    ret=$?
+    eecho
+    if [ $ret -eq 0 ]; then
+        exit 0
+    fi
+    if [ "$i" -lt "$N_ATTEMPTS" ]; then
+        sleep $DELAY_BETWEEN_ATTEMPTS
+    fi
+done
+
+eecho
+die "** Command failed $N_ATTEMPTS times in a row, giving up"

--- a/operator/scripts/retry.sh
+++ b/operator/scripts/retry.sh
@@ -1,6 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
-DELAY_BETWEEN_ATTEMPTS=2 # Seconds
+set -eu -o pipefail
+
+# shellcheck source=./hack/common.sh
+source "$(dirname "$0")/../hack/common.sh"
 
 eecho() {
   echo "$@" >&2
@@ -11,32 +14,24 @@ die() {
   exit 1
 }
 
-if [ $# -lt 1 ]; then
-    die "Usage: $0 <number of retries> <command> [ <command arg> ... ]"
-fi
-
-N_ATTEMPTS="$1"
-shift
-
-if ! [ "$N_ATTEMPTS" -gt 0 ] 2>/dev/null; then
-    die "Error: '$N_ATTEMPTS' is not a valid number of attempts, please provide a positive natural number."
-fi
-
-CMD=$*
-
-for i in $(seq 1 "$N_ATTEMPTS"); do
-    eecho "** Executing '$CMD' (attempt $i of $N_ATTEMPTS) **"
-    eecho
-    $CMD
-    ret=$?
-    eecho
-    if [ $ret -eq 0 ]; then
-        exit 0
+function main() {
+    if [ $# -lt 2 ]; then
+        die "Usage: $0 <number of attempts> <command> [ <command arg> ... ]"
     fi
-    if [ "$i" -lt "$N_ATTEMPTS" ]; then
-        sleep $DELAY_BETWEEN_ATTEMPTS
-    fi
-done
 
-eecho
-die "** Command failed $N_ATTEMPTS times in a row, giving up"
+    local -r n_attempts="${1:-}"; shift
+    if ! [ "$n_attempts" -gt 0 ] 2>/dev/null; then
+        die "Error: '$n_attempts' is not a valid number of attempts, please provide a positive natural number."
+    fi
+
+    local -r delay="${1:-}"; shift
+    if ! { [ "$delay" -gt 0 ] 2>/dev/null || [ "$delay" -eq 0 ] 2>/dev/null; }; then
+        die "Error: '$delay' is not a number of seconds."
+    fi
+
+    eecho "** Executing '$*' with $n_attempts attempts **"
+    eecho
+    retry "$n_attempts" "$delay" "$@"
+}
+
+main "$@"


### PR DESCRIPTION
## Description

We keep seeing CI failures for the operator bundle scorecard test.

The problem has been reported to upstream by others but it has not been fixed yet.
As a (hopefully) quick fix, I suggest to use a simple retry mechanism as implemented in this PR.

I have also bumped the used operator-sdk version.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~~Unit test and regression tests added~~ (n/a)
- [x] ~~Evaluated and added CHANGELOG entry if required~~ (n/a)
- [x] ~~Determined and documented upgrade steps~~ (n/a)
- [x] ~~Documented user facing changes (create PR based on [stackrox/openshift-docs]~~ (n/a) (https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

This PR's sole intent is to improve test reliability.