### PR TITLE
ROX-9992: CI: SCC for OpenShift

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4679,7 +4679,6 @@ jobs:
       - ROX_NETWORK_BASELINE_OBSERVATION_PERIOD: 2m
       - ROX_VERIFY_IMAGE_SIGNATURE: true
 
-
     steps:
       - run-qa-tests:
           cluster-id: openshift-rosa-api-e2e-tests
@@ -4702,6 +4701,7 @@ jobs:
                   oc_login_command=$(grep "oc login https.*username.*password" "$PWD/artifacts/log/rosa-create-admin.log")
                   eval "$oc_login_command --insecure-skip-tls-verify=true"
                   oc get nodes
+                  oc apply -f "qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
           destroy-cluster:
             - nop-steps-stanza
       - destroy-rosa-cluster
@@ -4741,6 +4741,7 @@ jobs:
                   source "$PWD/artifacts/dotenv"
                   oc login "$API_ENDPOINT" --username "$CONSOLE_USER" --password "$CONSOLE_PASSWORD" --insecure-skip-tls-verify=true
                   oc get nodes
+                  oc apply -f "qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
           destroy-cluster:
             - nop-steps-stanza
       - destroy-aro-cluster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1542,6 +1542,7 @@ commands:
           command: |
             if [[ "<< parameters.orchestrator-flavor >>" == "openshift" ]]; then
               export CLUSTER=OPENSHIFT
+              oc apply -f "qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
             else
               export CLUSTER=K8S
             fi
@@ -4701,7 +4702,6 @@ jobs:
                   oc_login_command=$(grep "oc login https.*username.*password" "$PWD/artifacts/log/rosa-create-admin.log")
                   eval "$oc_login_command --insecure-skip-tls-verify=true"
                   oc get nodes
-                  oc apply -f "qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
           destroy-cluster:
             - nop-steps-stanza
       - destroy-rosa-cluster
@@ -4741,7 +4741,6 @@ jobs:
                   source "$PWD/artifacts/dotenv"
                   oc login "$API_ENDPOINT" --username "$CONSOLE_USER" --password "$CONSOLE_PASSWORD" --insecure-skip-tls-verify=true
                   oc get nodes
-                  oc apply -f "qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
           destroy-cluster:
             - nop-steps-stanza
       - destroy-aro-cluster
@@ -4787,7 +4786,6 @@ jobs:
                     --password "$CLUSTER_PASSWORD" \
                     --insecure-skip-tls-verify=true
                   oc get nodes
-                  oc apply -f "qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
           destroy-cluster:
             - nop-steps-stanza
       - destroy-osd-aws-cluster
@@ -4833,7 +4831,6 @@ jobs:
                     --password "$CLUSTER_PASSWORD" \
                     --insecure-skip-tls-verify=true
                   oc get nodes
-                  oc apply -f "qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
           destroy-cluster:
             - nop-steps-stanza
       - destroy-osd-gcp-cluster

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
@@ -7,6 +7,7 @@ import io.fabric8.openshift.api.model.Route
 import io.fabric8.openshift.api.model.RouteBuilder
 import io.fabric8.openshift.api.model.SecurityContextConstraints
 import io.fabric8.openshift.client.OpenShiftClient
+import util.Env
 import util.Timer
 
 class OpenShift extends Kubernetes {
@@ -41,7 +42,11 @@ class OpenShift extends Kubernetes {
         }
 
         try {
-            SecurityContextConstraints anyuid = oClient.securityContextConstraints().withName("qatest-anyuid").get()
+            String sccName = "anyuid"
+            if (Env.CI_JOBNAME =~ /-(osd|rosa|aro)-/) {
+                sccName = "qatest-anyuid"
+            }
+            SecurityContextConstraints anyuid = oClient.securityContextConstraints().withName(sccName).get()
             if (anyuid != null &&
                     (!anyuid.users.contains("system:serviceaccount:" + ns + ":default") ||
                             !anyuid.allowHostNetwork ||

--- a/qa-tests-backend/src/main/groovy/services/ClusterService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ClusterService.groovy
@@ -125,6 +125,7 @@ class ClusterService extends BaseService {
         }
         isAKS
     }
+
     static Boolean isOpenShift3() {
         return getCluster().getType() == ClusterOuterClass.ClusterType.OPENSHIFT_CLUSTER
     }


### PR DESCRIPTION
## Description

OpenShift 3 and 4 tests started failing after #601. This PR changes the OpenShift SCC setting for those environments back to "anyuid".

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient. There are some failures that appear to be unrelated flakes but in general openshift 3 & 4 tests are improved.