### PR TITLE
Filter out graph links that contain a source or target that does not have a corresponding node.

### DIFF
--- a/ui/apps/platform/src/utils/networkLink.utils.js
+++ b/ui/apps/platform/src/utils/networkLink.utils.js
@@ -148,7 +148,12 @@ export const getLinks = (nodes, networkEdgeMap, networkNodeMap, filterState) => 
         });
     });
 
-    return filteredLinks;
+    // Remove links that do not have a corresponding node. A link with a `source` or `target` that
+    // does not match an entity id of a node in the filtered node set will cause Cytoscape to
+    // crash during rendering. This crash may be immediate, or when a user hovers over an offending
+    // node in the visualization.
+    const nodeIds = new Set(nodes.map((n) => n.entity.id));
+    return filteredLinks.filter(({ source, target }) => nodeIds.has(source) && nodeIds.has(target));
 };
 
 /**


### PR DESCRIPTION
## Description

This change patches an existing crashing bug that is much more easily exposed with the implementation of a default namespace filter. Essentially this filters out all `edges` that link together two nodes that do not exist in the `nodes` array that is passed to Cytoscape. This may indicate a deeper issue, but the immediate fix prevents the application from crashing when this scenario occurs.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

I've verified that the edge filtering introduced by this PR only occurs in situations that would lead to a crash. Whenever the data is passed along unfiltered, no crash occurs. On the converse of that, _every_ time that the data would be filtered the graph either crashes immediately or crashes when certain nodes are moused over in the visualization.

Testing focused primarily on making sure that in scenarios where a crash was _not_ expected, there was no change to the rendered graph. I did a side by side comparison of the app running on `master` and the app running this branch against the qa-demo, and compared the following scenarios.

Cluster: production
Namespaces: backend, stackrox
Flows: Active

Both master and this branch display:
![image](https://user-images.githubusercontent.com/1292638/161806589-934691b9-02bd-4160-a49c-e641c8841cd2.png)

Cluster: production
Namespaces: backend, stackrox
Flows: Allowed

Both master and this branch display:
![image](https://user-images.githubusercontent.com/1292638/161806905-4fba75b7-db16-4e91-ba9c-2f364f2ac593.png)

Cluster: production
Namespaces: backend, stackrox
Flows: All

Both master and this branch display:
![image](https://user-images.githubusercontent.com/1292638/161807070-29f2d0b1-2c10-4613-9df8-8048ce178b1c.png)

With the addition of a filter for "Deployment: varnish"

master branch **crashes** immediately, this branch displays:
![image](https://user-images.githubusercontent.com/1292638/161808218-466b0889-4ccd-4245-92b0-40ed78375543.png)

With the settings of

Cluster: production
Namespace: backend
Flow: all

master branch **crashes** immediately, this branch displays
![image](https://user-images.githubusercontent.com/1292638/161808682-e7a2537d-7d14-42e2-b634-b6f709beede2.png)

With the settings of

Cluster: production
Namespace: stackrox
Flow: all
Filter: "Deployment: collector"

Both branches display
![image](https://user-images.githubusercontent.com/1292638/161810817-966c4d02-839c-4440-8323-3bbbe91ffc85.png)


With the same settings, hovering over the stackrox/collector node in the graph:

**Crashes** on master branch, does not change anything on this branch
![image](https://user-images.githubusercontent.com/1292638/161811317-335dcaf9-e1a6-44bf-a109-da47895ae94d.png)




