### PR TITLE
ROX-9942: Fix deployment label and annotation overlap

### DIFF
--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -100,6 +100,12 @@ button.pf-c-tree-view__node {
 
 /* For classic components to equal or exceed z-index of PatternFly elements. */
 
+/* override PatternFly DescriptionList horizontal variant to allow long keys and values to wrap */
+.pf-c-description-list__term,
+.pf-c-description-list__description{
+    word-break: break-all;
+}
+
 .z-xs-100 {
     z-index: 100; /* --pf-global--ZIndex--xs */
 }


### PR DESCRIPTION
## Description

The PF DescriptionList (horizontal variant) isn't wrapping Kubernetes-style label and annotations keys, because they don't contain characters that the CSS `overflow-wrap: break-word` value recognizes as "word break characters". (Periods don't count.)

After trying several different things, I settled on the simplest solution which changed the PF behavior the least: allow those elements to break in the middle of words.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Problem:
![Screen Shot 2022-04-05 at 4 15 37 PM](https://user-images.githubusercontent.com/715729/161843146-45fd41db-616d-42c5-8385-fa26f0166e11.png)

This solution:
![Screen Shot 2022-04-05 at 4 15 07 PM](https://user-images.githubusercontent.com/715729/161843174-41148507-31de-42c3-b3a1-8e5691e5f1f8.png)
