### PR TITLE
ROX-8799: Refactoring of roxctl scanner command

### DIFF
--- a/roxctl/maincommand/command.go
+++ b/roxctl/maincommand/command.go
@@ -79,7 +79,7 @@ func Command() *cobra.Command {
 		deployment.Command(cliEnvironment),
 		logconvert.Command(),
 		image.Command(cliEnvironment),
-		scanner.Command(),
+		scanner.Command(cliEnvironment),
 		sensor.Command(cliEnvironment),
 		helm.Command(cliEnvironment),
 		versionCommand(),

--- a/roxctl/scanner/generate/generate.go
+++ b/roxctl/scanner/generate/generate.go
@@ -95,10 +95,10 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		},
 	}
 
-	c.PersistentFlags().Var(clustertype.Value(storage.ClusterType_KUBERNETES_CLUSTER), "cluster-type", "type of cluster the scanner will run on (k8s, openshift)")
+	c.PersistentFlags().Var(clustertype.Value(storage.ClusterType_KUBERNETES_CLUSTER), "cluster-type", "Type of cluster the scanner will run on (k8s, openshift)")
 
 	c.Flags().StringVar(&scannerGenerateCmd.outputDir, "output-dir", "", "Output directory for scanner bundle (leave blank for default)")
-	c.Flags().BoolVar(&scannerGenerateCmd.apiParams.OfflineMode, "offline-mode", false, "whether to run the scanner in offline mode (so "+
+	c.Flags().BoolVar(&scannerGenerateCmd.apiParams.OfflineMode, "offline-mode", false, "Whether to run the scanner in offline mode (so "+
 		"it doesn't reach out to the internet for updates)")
 	c.Flags().StringVar(&scannerGenerateCmd.apiParams.ScannerImage, flags.FlagNameScannerImage, "", "Scanner image to use (leave blank to use server default)")
 	c.Flags().StringVar(&scannerGenerateCmd.apiParams.IstioVersion, istioSupportArg, "",

--- a/roxctl/scanner/generate/generate.go
+++ b/roxctl/scanner/generate/generate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/apiparams"
 	"github.com/stackrox/rox/pkg/istioutils"
+	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/common/zipdownload"
 	"github.com/stackrox/rox/roxctl/scanner/clustertype"
@@ -26,6 +27,9 @@ type scannerGenerateCommand struct {
 	outputDir string
 	apiParams apiparams.Scanner
 	timeout   time.Duration
+
+	// Properties that are injected or constructed.
+	env environment.Environment
 }
 
 func (cmd *scannerGenerateCommand) construct(c *cobra.Command) {
@@ -68,8 +72,8 @@ func (cmd *scannerGenerateCommand) generate() error {
 }
 
 // Command represents the generate command.
-func Command() *cobra.Command {
-	scannerGenerateCmd := &scannerGenerateCommand{}
+func Command(cliEnvironment environment.Environment) *cobra.Command {
+	scannerGenerateCmd := &scannerGenerateCommand{env: cliEnvironment}
 
 	c := &cobra.Command{
 		Use:  "generate",

--- a/roxctl/scanner/generate/generate.go
+++ b/roxctl/scanner/generate/generate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -16,46 +17,81 @@ import (
 	"github.com/stackrox/rox/roxctl/scanner/clustertype"
 )
 
-// Options stores options related to scanner generate commands.
-type Options struct {
-	OutputDir string
+const (
+	scannerGenerateAPIPath = "/api/extensions/scanner/zip"
+)
+
+type scannerGenerateCommand struct {
+	// Properties that are bound to cobra flags.
+	outputDir string
+	apiParams apiparams.Scanner
+	timeout   time.Duration
+}
+
+func (cmd *scannerGenerateCommand) construct(c *cobra.Command) {
+	cmd.timeout = flags.Timeout(c)
+}
+
+func (cmd *scannerGenerateCommand) validate() error {
+	// validate supported Istio versions
+	if cmd.apiParams.IstioVersion != "" {
+		for _, istioVersion := range istioutils.ListKnownIstioVersions() {
+			if cmd.apiParams.IstioVersion == istioVersion {
+				return nil
+			}
+		}
+
+		return errors.New("unsupported Istio version")
+	}
+
+	return nil
+}
+
+func (cmd *scannerGenerateCommand) generate() error {
+	cmd.apiParams.ClusterType = clustertype.Get().String()
+	body, err := json.Marshal(cmd.apiParams)
+	if err != nil {
+		return errors.Wrap(err, "could not marshal scanner params")
+	}
+
+	err = zipdownload.GetZip(zipdownload.GetZipOptions{
+		Path:       scannerGenerateAPIPath,
+		Method:     http.MethodPost,
+		Body:       body,
+		Timeout:    cmd.timeout,
+		BundleType: "scanner",
+		ExpandZip:  true,
+		OutputDir:  cmd.outputDir,
+	})
+
+	return errors.Wrap(err, "could not get scanner zip")
 }
 
 // Command represents the generate command.
 func Command() *cobra.Command {
-	var params apiparams.Scanner
-	var opts Options
+	scannerGenerateCmd := &scannerGenerateCommand{}
 
 	c := &cobra.Command{
 		Use:  "generate",
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, args []string) error {
-			params.ClusterType = clustertype.Get().String()
-			body, err := json.Marshal(params)
-			if err != nil {
-				return errors.Wrap(err, "could not marshal scanner params")
+			scannerGenerateCmd.construct(c)
+
+			if err := scannerGenerateCmd.validate(); err != nil {
+				return err
 			}
-			timeout := flags.Timeout(c)
-			err = zipdownload.GetZip(zipdownload.GetZipOptions{
-				Path:       "/api/extensions/scanner/zip",
-				Method:     http.MethodPost,
-				Body:       body,
-				Timeout:    timeout,
-				BundleType: "scanner",
-				ExpandZip:  true,
-				OutputDir:  opts.OutputDir,
-			})
-			return errors.Wrap(err, "could not get scanner zip")
+
+			return scannerGenerateCmd.generate()
 		},
 	}
 
 	c.PersistentFlags().Var(clustertype.Value(storage.ClusterType_KUBERNETES_CLUSTER), "cluster-type", "type of cluster the scanner will run on (k8s, openshift)")
 
-	c.Flags().StringVar(&opts.OutputDir, "output-dir", "", "Output directory for scanner bundle (leave blank for default)")
-	c.Flags().BoolVar(&params.OfflineMode, "offline-mode", false, "whether to run the scanner in offline mode (so "+
+	c.Flags().StringVar(&scannerGenerateCmd.outputDir, "output-dir", "", "Output directory for scanner bundle (leave blank for default)")
+	c.Flags().BoolVar(&scannerGenerateCmd.apiParams.OfflineMode, "offline-mode", false, "whether to run the scanner in offline mode (so "+
 		"it doesn't reach out to the internet for updates)")
-	c.Flags().StringVar(&params.ScannerImage, flags.FlagNameScannerImage, "", "Scanner image to use (leave blank to use server default)")
-	c.Flags().StringVar(&params.IstioVersion, "istio-support", "",
+	c.Flags().StringVar(&scannerGenerateCmd.apiParams.ScannerImage, flags.FlagNameScannerImage, "", "Scanner image to use (leave blank to use server default)")
+	c.Flags().StringVar(&scannerGenerateCmd.apiParams.IstioVersion, "istio-support", "",
 		fmt.Sprintf(
 			"Generate deployment files supporting the given Istio version. Valid versions: %s",
 			strings.Join(istioutils.ListKnownIstioVersions(), ", ")))

--- a/roxctl/scanner/generate/generate.go
+++ b/roxctl/scanner/generate/generate.go
@@ -74,7 +74,7 @@ func (cmd *scannerGenerateCommand) generate() error {
 		OutputDir:  cmd.outputDir,
 	})
 
-	return errors.Wrap(err, "could not get scanner zip")
+	return errors.Wrap(err, "could not get scanner bundle")
 }
 
 // Command represents the generate command.

--- a/roxctl/scanner/generate/generate.go
+++ b/roxctl/scanner/generate/generate.go
@@ -33,7 +33,7 @@ func (cmd *scannerGenerateCommand) construct(c *cobra.Command) {
 }
 
 func (cmd *scannerGenerateCommand) validate() error {
-	// validate supported Istio versions
+	// Validate supported Istio versions.
 	if cmd.apiParams.IstioVersion != "" {
 		for _, istioVersion := range istioutils.ListKnownIstioVersions() {
 			if cmd.apiParams.IstioVersion == istioVersion {

--- a/roxctl/scanner/generate/generate.go
+++ b/roxctl/scanner/generate/generate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/apiparams"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/istioutils"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
@@ -20,6 +21,8 @@ import (
 
 const (
 	scannerGenerateAPIPath = "/api/extensions/scanner/zip"
+
+	istioSupportArg = "istio-support"
 )
 
 type scannerGenerateCommand struct {
@@ -45,7 +48,10 @@ func (cmd *scannerGenerateCommand) validate() error {
 			}
 		}
 
-		return errors.New("unsupported Istio version")
+		return errox.NewErrInvalidArgs(fmt.Sprintf(
+			"unsupported Istio version %q used for argument %q. Use one of the following: [%s]",
+			cmd.apiParams.IstioVersion, "--"+istioSupportArg, strings.Join(istioutils.ListKnownIstioVersions(), "|"),
+		))
 	}
 
 	return nil
@@ -95,7 +101,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c.Flags().BoolVar(&scannerGenerateCmd.apiParams.OfflineMode, "offline-mode", false, "whether to run the scanner in offline mode (so "+
 		"it doesn't reach out to the internet for updates)")
 	c.Flags().StringVar(&scannerGenerateCmd.apiParams.ScannerImage, flags.FlagNameScannerImage, "", "Scanner image to use (leave blank to use server default)")
-	c.Flags().StringVar(&scannerGenerateCmd.apiParams.IstioVersion, "istio-support", "",
+	c.Flags().StringVar(&scannerGenerateCmd.apiParams.IstioVersion, istioSupportArg, "",
 		fmt.Sprintf(
 			"Generate deployment files supporting the given Istio version. Valid versions: %s",
 			strings.Join(istioutils.ListKnownIstioVersions(), ", ")))

--- a/roxctl/scanner/generate/generate_test.go
+++ b/roxctl/scanner/generate/generate_test.go
@@ -1,6 +1,8 @@
 package generate
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stackrox/rox/pkg/apiparams"
@@ -12,7 +14,12 @@ func TestScannerGenerateValidation(t *testing.T) {
 	t.Run("not supported Istio version", func(t *testing.T) {
 		cmdBadIstio := scannerGenerateCommand{apiParams: apiparams.Scanner{IstioVersion: "0.1.0"}}
 
-		require.EqualError(t, cmdBadIstio.validate(), "unsupported Istio version")
+		expectedErrorStr := fmt.Sprintf(
+			"invalid arguments: unsupported Istio version %q used for argument %q. Use one of the following: [%s]",
+			"0.1.0", "--"+istioSupportArg, strings.Join(istioutils.ListKnownIstioVersions(), "|"),
+		)
+
+		require.EqualError(t, cmdBadIstio.validate(), expectedErrorStr)
 	})
 
 	t.Run("supported Istio version", func(t *testing.T) {

--- a/roxctl/scanner/generate/generate_test.go
+++ b/roxctl/scanner/generate/generate_test.go
@@ -25,12 +25,12 @@ func TestScannerGenerateValidation(t *testing.T) {
 	t.Run("supported Istio version", func(t *testing.T) {
 		cmd := scannerGenerateCommand{apiParams: apiparams.Scanner{IstioVersion: istioutils.ListKnownIstioVersions()[0]}}
 
-		require.Nil(t, cmd.validate())
+		require.NoError(t, cmd.validate())
 	})
 
 	t.Run("not provided Istio version", func(t *testing.T) {
 		cmd := scannerGenerateCommand{}
 
-		require.Nil(t, cmd.validate())
+		require.NoError(t, cmd.validate())
 	})
 }

--- a/roxctl/scanner/generate/generate_test.go
+++ b/roxctl/scanner/generate/generate_test.go
@@ -1,0 +1,29 @@
+package generate
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/apiparams"
+	"github.com/stackrox/rox/pkg/istioutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScannerGenerateValidation(t *testing.T) {
+	t.Run("not supported Istio version", func(t *testing.T) {
+		cmdBadIstio := scannerGenerateCommand{apiParams: apiparams.Scanner{IstioVersion: "0.1.0"}}
+
+		require.EqualError(t, cmdBadIstio.validate(), "unsupported Istio version")
+	})
+
+	t.Run("supported Istio version", func(t *testing.T) {
+		cmd := scannerGenerateCommand{apiParams: apiparams.Scanner{IstioVersion: istioutils.ListKnownIstioVersions()[0]}}
+
+		require.Nil(t, cmd.validate())
+	})
+
+	t.Run("not provided Istio version", func(t *testing.T) {
+		cmd := scannerGenerateCommand{}
+
+		require.Nil(t, cmd.validate())
+	})
+}

--- a/roxctl/scanner/generate/generate_test.go
+++ b/roxctl/scanner/generate/generate_test.go
@@ -1,7 +1,6 @@
 package generate
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -16,15 +15,12 @@ func TestScannerGenerateValidation(t *testing.T) {
 	t.Run("not supported Istio version", func(t *testing.T) {
 		cmdBadIstio := scannerGenerateCommand{apiParams: apiparams.Scanner{IstioVersion: "0.1.0"}}
 
-		expectedErr := errox.NewErrInvalidArgs(fmt.Sprintf(
-			"unsupported Istio version %q used for argument %q. Use one of the following: [%s]",
-			"0.1.0", "--"+istioSupportArg, strings.Join(istioutils.ListKnownIstioVersions(), "|"),
-		))
 		actualErr := cmdBadIstio.validate()
-
 		require.Error(t, actualErr)
 		assert.ErrorIs(t, actualErr, errox.InvalidArgs)
-		assert.EqualError(t, actualErr, expectedErr.Error())
+
+		expectedListOfIstioVersions := strings.Join(istioutils.ListKnownIstioVersions(), "|")
+		assert.Contains(t, actualErr.Error(), expectedListOfIstioVersions)
 	})
 
 	t.Run("supported Istio version", func(t *testing.T) {

--- a/roxctl/scanner/scanner.go
+++ b/roxctl/scanner/scanner.go
@@ -4,20 +4,21 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/scanner/generate"
 	"github.com/stackrox/rox/roxctl/scanner/uploaddb"
 )
 
 // Command controls all of the functions being applied to a sensor
-func Command() *cobra.Command {
+func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
 		Use: "scanner",
 	}
 	flags.AddTimeoutWithDefault(c, time.Minute)
 	c.AddCommand(
 		generate.Command(),
-		uploaddb.Command(),
+		uploaddb.Command(cliEnvironment),
 	)
 	return c
 }

--- a/roxctl/scanner/scanner.go
+++ b/roxctl/scanner/scanner.go
@@ -17,7 +17,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	}
 	flags.AddTimeoutWithDefault(c, time.Minute)
 	c.AddCommand(
-		generate.Command(),
+		generate.Command(cliEnvironment),
 		uploaddb.Command(cliEnvironment),
 	)
 	return c

--- a/roxctl/scanner/uploaddb/uploaddb.go
+++ b/roxctl/scanner/uploaddb/uploaddb.go
@@ -1,48 +1,75 @@
 package uploaddb
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common"
+	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
 )
 
+const (
+	scannerUploadDbAPIPath = "/api/extensions/scannerdefinitions"
+)
+
+type scannerUploadDbCommand struct {
+	// Properties that are bound to cobra flags.
+	filename string
+	timeout  time.Duration
+
+	// Properties that are injected or constructed.
+	env environment.Environment
+}
+
+func (cmd *scannerUploadDbCommand) construct(c *cobra.Command) {
+	cmd.timeout = flags.Timeout(c)
+}
+
+func (cmd *scannerUploadDbCommand) uploadDd() error {
+	file, err := os.Open(cmd.filename)
+	if err != nil {
+		return errors.Wrap(err, "could not open file")
+	}
+	defer utils.IgnoreError(file.Close)
+
+	resp, err := common.DoHTTPRequestAndCheck200(scannerUploadDbAPIPath, cmd.timeout, http.MethodPost, file)
+	if err != nil {
+		return errors.Wrap(err, "could not connect with scanner definitions API")
+	}
+	defer utils.IgnoreError(resp.Body.Close)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read body")
+	}
+
+	cmd.env.Logger().InfofLn("%s", string(body))
+
+	return nil
+}
+
 // Command represents the command.
-func Command() *cobra.Command {
-	var filename string
+func Command(cliEnvironment environment.Environment) *cobra.Command {
+	scannerUploadDbCmd := &scannerUploadDbCommand{env: cliEnvironment}
 
 	c := &cobra.Command{
 		Use:  "upload-db",
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, args []string) error {
-			file, err := os.Open(filename)
-			if err != nil {
-				return errors.Wrap(err, "Could not open file")
-			}
-			defer utils.IgnoreError(file.Close)
+			scannerUploadDbCmd.construct(c)
 
-			resp, err := common.DoHTTPRequestAndCheck200("/api/extensions/scannerdefinitions",
-				flags.Timeout(c), http.MethodPost, file)
-			if err != nil {
-				return errors.Wrap(err, "could not connect with scanner definitions API")
-			}
-			defer utils.IgnoreError(resp.Body.Close)
-			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return errors.Wrap(err, "failed to read body")
-			}
-			fmt.Println(string(body))
-			return nil
+			return scannerUploadDbCmd.uploadDd()
 		},
 	}
 
-	c.Flags().StringVar(&filename, "scanner-db-file", "", "file containing the dumped Scanner definitions DB")
+	c.Flags().StringVar(&scannerUploadDbCmd.filename, "scanner-db-file", "", "file containing the dumped Scanner definitions DB")
 	utils.Must(c.MarkFlagRequired("scanner-db-file"))
+
 	return c
 }

--- a/roxctl/scanner/uploaddb/uploaddb.go
+++ b/roxctl/scanner/uploaddb/uploaddb.go
@@ -68,7 +68,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		},
 	}
 
-	c.Flags().StringVar(&scannerUploadDbCmd.filename, "scanner-db-file", "", "file containing the dumped Scanner definitions DB")
+	c.Flags().StringVar(&scannerUploadDbCmd.filename, "scanner-db-file", "", "File containing the dumped Scanner definitions DB")
 	utils.Must(c.MarkFlagRequired("scanner-db-file"))
 
 	return c

--- a/roxctl/scanner/uploaddb/uploaddb.go
+++ b/roxctl/scanner/uploaddb/uploaddb.go
@@ -49,7 +49,7 @@ func (cmd *scannerUploadDbCommand) uploadDd() error {
 		return errors.Wrap(err, "failed to read body")
 	}
 
-	cmd.env.Logger().InfofLn("%s", string(body))
+	cmd.env.Logger().PrintfLn("%s", string(body))
 
 	return nil
 }

--- a/roxctl/scanner/uploaddb/uploaddb_test.go
+++ b/roxctl/scanner/uploaddb/uploaddb_test.go
@@ -10,13 +10,11 @@ import (
 )
 
 func TestScannerUploadDbCommandFail(t *testing.T) {
-	t.Run("non existing filename", func(t *testing.T) {
-		cmdNoFile := scannerUploadDbCommand{filename: "non-existing-filename"}
+	cmdNoFile := scannerUploadDbCommand{filename: "non-existing-filename"}
 
-		actualErr := cmdNoFile.uploadDd()
+	actualErr := cmdNoFile.uploadDd()
 
-		require.Error(t, actualErr)
-		assert.ErrorIs(t, errors.Cause(actualErr), fs.ErrNotExist)
-		assert.EqualError(t, cmdNoFile.uploadDd(), "could not open file: open non-existing-filename: no such file or directory")
-	})
+	require.Error(t, actualErr)
+	assert.ErrorIs(t, errors.Cause(actualErr), fs.ErrNotExist)
+	assert.EqualError(t, cmdNoFile.uploadDd(), "could not open file: open non-existing-filename: no such file or directory")
 }

--- a/roxctl/scanner/uploaddb/uploaddb_test.go
+++ b/roxctl/scanner/uploaddb/uploaddb_test.go
@@ -4,7 +4,6 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,6 +14,5 @@ func TestScannerUploadDbCommandFail(t *testing.T) {
 	actualErr := cmdNoFile.uploadDd()
 
 	require.Error(t, actualErr)
-	assert.ErrorIs(t, errors.Cause(actualErr), fs.ErrNotExist)
-	assert.EqualError(t, cmdNoFile.uploadDd(), "could not open file: open non-existing-filename: no such file or directory")
+	assert.ErrorIs(t, actualErr, fs.ErrNotExist)
 }

--- a/roxctl/scanner/uploaddb/uploaddb_test.go
+++ b/roxctl/scanner/uploaddb/uploaddb_test.go
@@ -1,0 +1,15 @@
+package uploaddb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScannerUploadDbCommandFail(t *testing.T) {
+	t.Run("non existing filename", func(t *testing.T) {
+		cmdNoFile := scannerUploadDbCommand{filename: "non-existing-filename"}
+
+		require.EqualError(t, cmdNoFile.uploadDd(), "could not open file: open non-existing-filename: no such file or directory")
+	})
+}

--- a/roxctl/scanner/uploaddb/uploaddb_test.go
+++ b/roxctl/scanner/uploaddb/uploaddb_test.go
@@ -1,8 +1,11 @@
 package uploaddb
 
 import (
+	"io/fs"
 	"testing"
 
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -10,6 +13,10 @@ func TestScannerUploadDbCommandFail(t *testing.T) {
 	t.Run("non existing filename", func(t *testing.T) {
 		cmdNoFile := scannerUploadDbCommand{filename: "non-existing-filename"}
 
-		require.EqualError(t, cmdNoFile.uploadDd(), "could not open file: open non-existing-filename: no such file or directory")
+		actualErr := cmdNoFile.uploadDd()
+
+		require.Error(t, actualErr)
+		assert.ErrorIs(t, errors.Cause(actualErr), fs.ErrNotExist)
+		assert.EqualError(t, cmdNoFile.uploadDd(), "could not open file: open non-existing-filename: no such file or directory")
 	})
 }


### PR DESCRIPTION
## Description

Following changes are made:
- introduced `environment.Environment.Logger()` to `scanner` commands. Relevant only for `upload-db`
- refactored `scanner` commands to follow: `construct -> validate -> execute` flow
- added unit tests

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ - changes are not relevant for CHANGELOG
- ~~[ ] Determined and documented upgrade steps~~ - not required
- ~~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~ - not required, since commands are not changed

## Testing Performed

1. For `scanner upload-db` zip with scanner definitions is required. I have fetched one here: https://docs.openshift.com/acs/3.68/configuration/enable-offline-mode.html#download-scanner-definitions_enable-offline-mode 
I have used that file and tested `upload-db` with following command:
```
./bin/darwin/roxctl --insecure-skip-tls-verify --insecure --endpoint https://localhost:8000 -p $ROX_PASSWORD scanner upload-db --scanner-db-file ./scanner-vuln-updates.zip
```
That command reaches execution path where `environment.Environment.Logger()` is used. And I have got expected output:
```
Successfully stored the offline vulnerability definitions
```

2. For `scanner generate` main changes are in validation of command parameters. I have used following commands to test validation:

- should work since Istio version is supported
```
./bin/darwin/roxctl --insecure-skip-tls-verify --insecure --endpoint https://localhost:8000 -p $ROX_PASSWORD scanner generate --istio-support 1.7
```

- should fail because Istio version is not supported
```
./bin/darwin/roxctl --insecure-skip-tls-verify --insecure --endpoint https://localhost:8000 -p $ROX_PASSWORD scanner generate --istio-support 2.2
```

- should work because Istio version is not provided
```
./bin/darwin/roxctl --insecure-skip-tls-verify --insecure --endpoint https://localhost:8000 -p $ROX_PASSWORD scanner generate
```
