### PR TITLE
Add CSS override for PatternFly form style that is broken by TW in prod.

### DIFF
--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -39,6 +39,7 @@ body {
     border-right-color: var(--pf-global--BorderColor--300);
     border-bottom-color: var(--pf-global--BorderColor--200);
     border-left-color: var(--pf-global--BorderColor--300);
+    padding: var(--pf-c-form-control--PaddingTop) var(--pf-c-form-control--PaddingRight) var(--pf-c-form-control--PaddingBottom) var(--pf-c-form-control--PaddingLeft);
 }
 
 .pf-c-form-control:disabled {


### PR DESCRIPTION
## Description

Fixes broken layout of namespace select filter input in production builds by overriding PF style that conflicts with Tailwind.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed
Tested that PatternFly input element does not overlay search icon on top of text in production build.

Production:
![image](https://user-images.githubusercontent.com/1292638/162019141-21a0a8ef-3430-4715-92dd-2820e241f33f.png)

Current staging:
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/1292638/162019335-b5c6b45e-61cc-47a4-a120-4d12b7edfb41.png">


