### PR TITLE
Use official golang image to build operator

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -13,9 +13,6 @@ ENV GOPATH=/workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-# Add GitHub hosts as known ones so that git does not complain.
-RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-
 # Cache deps before building and copying source so that we don't need to re-download as much and so that source changes
 # don't invalidate our downloaded layer.
 # We're not using `go mod tidy` here becuase go mod tidy needs to examine _source code_ in order to find unused modules.
@@ -28,7 +25,7 @@ RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 # However it does _not_ seem to resolve packages _incorrectly_ and so should be safe especially given that downloaded
 # packages are only used during build and later this docker layer is discarded (only resulting binary goes in the final
 # image).
-RUN --mount=type=ssh,required=true go mod download
+RUN go mod download
 
 # Copy operator source
 COPY operator/ operator/

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,13 +1,9 @@
 # We have to emulate directory layout as in the repo so that imports in go files work fine.
 ARG roxpath=/workspace/src/github.com/stackrox/rox
 
-# Use CentOS Stream 8 image as the base builder because it has recent Go and git packages needed for the build.
-# https://wiki.centos.org/FAQ/CentOSStream#Where_do_I_get_CentOS_Stream_container_images.3F
-FROM quay.io/centos/centos:stream8 as builder-base
-RUN yum update --security -y && yum install -y golang git
+FROM golang:1.17 as builder
 
 # Build the manager binary
-FROM builder-base as builder
 ARG roxpath
 
 WORKDIR ${roxpath}/
@@ -19,10 +15,6 @@ COPY go.sum go.sum
 
 # Add GitHub hosts as known ones so that git does not complain.
 RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-
-# Make sure that private and source-only packages on github.com can be downloaded successfully as go modules.
-RUN echo '[url "git@github.com:"]' >> ~/.gitconfig && echo -e '\tinsteadOf = https://github.com/' >> ~/.gitconfig
-ENV GOPRIVATE="github.com/stackrox/*"
 
 # Cache deps before building and copying source so that we don't need to re-download as much and so that source changes
 # don't invalidate our downloaded layer.


### PR DESCRIPTION
## Description

Currently we are using stream8 and install dependencies for every build. This PR replaces it with official golang image so we have pinned golang version but still get latest updates to it.

This should prevent issues like this: https://app.circleci.com/pipelines/github/stackrox/stackrox/8929/workflows/614b3394-3a73-4ed9-8426-f1aac1f01d28/jobs/396277?invite=true#step-109-199

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI