### PR TITLE
ROX-9996: Fix image signature verification policy criteria for images verified by multiple integrations

### DIFF
--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -236,22 +236,18 @@ func ConstructImage(image *storage.Image) (*pathutil.AugmentedObj, error) {
 	}
 
 	if features.ImageSignatureVerification.Enabled() {
-		verifierIds := []string{}
+		ids := []string{}
 		for _, result := range image.GetSignatureVerificationData().GetResults() {
 			if result.GetStatus() == storage.ImageSignatureVerificationResult_VERIFIED {
-				verifierIds = append(verifierIds, result.GetVerifierId())
+				ids = append(ids, result.GetVerifierId())
 			}
 		}
 		// When the object is not created, the policy will not match, but it should match.
-		// Any image that DOESN'T have any signature should also be visible here (I guess?).
-		// This means, we will have to create a dummy entry within the object that will make it
-		// possible for us to match the policy and create alerts.
 		if err := obj.AddPlainObjAt(
 			&imageSignatureVerification{
-				VerifierIDs: verifierIds,
+				VerifierIDs: ids,
 			},
 			pathutil.FieldStep("SignatureVerificationData"),
-			pathutil.FieldStep("Results"),
 			pathutil.FieldStep(imageSignatureVerifiedKey)); err != nil {
 			return nil, utils.Should(err)
 		}

--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -236,43 +236,26 @@ func ConstructImage(image *storage.Image) (*pathutil.AugmentedObj, error) {
 	}
 
 	if features.ImageSignatureVerification.Enabled() {
-		i := 0
-		// Since policies query for image verification status as a single boolean field, we add it to the image here.
+		verifierIds := []string{}
 		for _, result := range image.GetSignatureVerificationData().GetResults() {
 			if result.GetStatus() == storage.ImageSignatureVerificationResult_VERIFIED {
-				if err := addSignatureVerificationResult(obj, i, result.GetVerifierId()); err != nil {
-					return nil, utils.Should(err)
-				}
-				i++
+				verifierIds = append(verifierIds, result.GetVerifierId())
 			}
 		}
 		// When the object is not created, the policy will not match, but it should match.
 		// Any image that DOESN'T have any signature should also be visible here (I guess?).
 		// This means, we will have to create a dummy entry within the object that will make it
 		// possible for us to match the policy and create alerts.
-		if i == 0 {
-			if err := addSignatureVerificationResult(obj, i, ""); err != nil {
-				return nil, utils.Should(err)
-			}
+		if err := obj.AddPlainObjAt(
+			&imageSignatureVerification{
+				VerifierIDs: verifierIds,
+			},
+			pathutil.FieldStep("SignatureVerificationData"),
+			pathutil.FieldStep("Results"),
+			pathutil.FieldStep(imageSignatureVerifiedKey)); err != nil {
+			return nil, utils.Should(err)
 		}
 	}
 
 	return obj, nil
-}
-
-// addSignatureVerificationResult will add a signature verification result to
-// the augmented object.
-func addSignatureVerificationResult(obj *pathutil.AugmentedObj, i int, id string) error {
-	err := obj.AddPlainObjAt(
-		&imageSignatureVerification{
-			VerifierID: id,
-		},
-		pathutil.FieldStep("SignatureVerificationData"),
-		pathutil.FieldStep("Results"),
-		pathutil.IndexStep(i),
-		pathutil.FieldStep(imageSignatureVerifiedKey))
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/pkg/booleanpolicy/augmentedobjs/custom_types.go
+++ b/pkg/booleanpolicy/augmentedobjs/custom_types.go
@@ -80,5 +80,5 @@ type envVar struct {
 }
 
 type imageSignatureVerification struct {
-	VerifierID string `search:"Image Signature Verified By"`
+	VerifierIDs []string `search:"Image Signature Verified By"`
 }

--- a/pkg/booleanpolicy/augmentedobjs/meta.go
+++ b/pkg/booleanpolicy/augmentedobjs/meta.go
@@ -34,7 +34,7 @@ var (
 	ImageMeta = pathutil.NewAugmentedObjMeta((*storage.Image)(nil)).
 			AddPlainObjectAt([]string{"Metadata", "V1", "Layers", dockerfileLineAugmentKey}, (*dockerfileLine)(nil)).
 			AddPlainObjectAt([]string{"Scan", "Components", componentAndVersionAugmentKey}, (*componentAndVersion)(nil)).
-			AddPlainObjectAt([]string{"SignatureVerificationData", "Results", imageSignatureVerifiedKey}, (*imageSignatureVerification)(nil))
+			AddPlainObjectAt([]string{"SignatureVerificationData", imageSignatureVerifiedKey}, (*imageSignatureVerification)(nil))
 
 	ProcessMeta = pathutil.NewAugmentedObjMeta((*storage.ProcessIndicator)(nil)).
 			AddPlainObjectAt([]string{baselineResultAugmentKey}, (*baselineResult)(nil))

--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -2150,9 +2150,7 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 	)
 
 	var images = []*storage.Image{
-		/**/
 		imageWithSignatureVerificationResults("image_no_results", []*storage.ImageSignatureVerificationResult{{}}),
-		/** /
 		imageWithSignatureVerificationResults("image_empty_results", []*storage.ImageSignatureVerificationResult{{
 			VerifierId: "",
 			Status:     storage.ImageSignatureVerificationResult_UNSET,
@@ -2161,18 +2159,18 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 		imageWithSignatureVerificationResults("verified_by_0", []*storage.ImageSignatureVerificationResult{{
 			VerifierId: verifier0,
 			Status:     storage.ImageSignatureVerificationResult_VERIFIED,
-		}}), /** /
+		}}),
 		imageWithSignatureVerificationResults("unverified_image", []*storage.ImageSignatureVerificationResult{{
 			VerifierId: unverifier,
 			Status:     storage.ImageSignatureVerificationResult_UNSET,
-		}}),/**/
+		}}),
 		imageWithSignatureVerificationResults("verified_by_3", []*storage.ImageSignatureVerificationResult{{
 			VerifierId: verifier2,
 			Status:     storage.ImageSignatureVerificationResult_FAILED_VERIFICATION,
 		}, {
 			VerifierId: verifier3,
 			Status:     storage.ImageSignatureVerificationResult_VERIFIED,
-		}}), /**/
+		}}),
 		imageWithSignatureVerificationResults("verified_by_2_and_3", []*storage.ImageSignatureVerificationResult{{
 			VerifierId: verifier2,
 			Status:     storage.ImageSignatureVerificationResult_VERIFIED,
@@ -2196,7 +2194,7 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 		negate          bool
 		expectedMatches set.FrozenStringSet
 	}{
-		/*{
+		{
 			values:          []string{verifier0},
 			negate:          true,
 			expectedMatches: set.NewFrozenStringSet("verified_by_0"),
@@ -2224,7 +2222,7 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 		{
 			values:          []string{verifier2},
 			negate:          false,
-			expectedMatches: allImages,
+			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_2_and_3")),
 		},
 		{
 			values:          []string{verifier0, verifier2},
@@ -2235,25 +2233,22 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 			values:          []string{verifier2, verifier3},
 			negate:          false,
 			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_3", "verified_by_2_and_3")),
-		},/**/
-		// TODO(ROX-9996): Fix construction of the augmented object to allow for matching
-		// several verifier IDs.
-		/** /
+		},
 		{
 			values:          []string{verifier0, verifier2},
 			negate:          false,
 			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_0", "verified_by_2_and_3")),
-		},/**/
+		},
 		{
 			values:          []string{verifier2, verifier3},
 			negate:          false,
 			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_3", "verified_by_2_and_3")),
 		},
-		/** /{
+		{
 			values:          []string{unverifier},
 			negate:          false,
 			expectedMatches: allImages,
-		},/**/
+		},
 	} {
 		c := testCase
 

--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -2198,6 +2198,13 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 		return messages
 	}
 
+	suite.Run("Test disallowed AND operator", func() {
+		_, err := BuildImageMatcher(policyWithSingleFieldAndValues(fieldnames.ImageSignatureVerifiedBy,
+			[]string{verifier0}, false, storage.BooleanOperator_AND))
+		suite.EqualError(err,
+			"policy validation error: operator AND is not allowed for field \"Image Signature Verified By\"")
+	})
+
 	for i, testCase := range []struct {
 		values          []string
 		expectedMatches set.FrozenStringSet

--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -2150,23 +2150,29 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 	)
 
 	var images = []*storage.Image{
+		/**/
 		imageWithSignatureVerificationResults("image_no_results", []*storage.ImageSignatureVerificationResult{{}}),
+		/** /
+		imageWithSignatureVerificationResults("image_empty_results", []*storage.ImageSignatureVerificationResult{{
+			VerifierId: "",
+			Status:     storage.ImageSignatureVerificationResult_UNSET,
+		}}),
 		imageWithSignatureVerificationResults("image_nil_results", nil),
 		imageWithSignatureVerificationResults("verified_by_0", []*storage.ImageSignatureVerificationResult{{
 			VerifierId: verifier0,
 			Status:     storage.ImageSignatureVerificationResult_VERIFIED,
-		}}),
+		}}), /** /
 		imageWithSignatureVerificationResults("unverified_image", []*storage.ImageSignatureVerificationResult{{
 			VerifierId: unverifier,
 			Status:     storage.ImageSignatureVerificationResult_UNSET,
-		}}),
+		}}),/**/
 		imageWithSignatureVerificationResults("verified_by_3", []*storage.ImageSignatureVerificationResult{{
 			VerifierId: verifier2,
 			Status:     storage.ImageSignatureVerificationResult_FAILED_VERIFICATION,
 		}, {
 			VerifierId: verifier3,
 			Status:     storage.ImageSignatureVerificationResult_VERIFIED,
-		}}),
+		}}), /**/
 		imageWithSignatureVerificationResults("verified_by_2_and_3", []*storage.ImageSignatureVerificationResult{{
 			VerifierId: verifier2,
 			Status:     storage.ImageSignatureVerificationResult_VERIFIED,
@@ -2190,7 +2196,7 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 		negate          bool
 		expectedMatches set.FrozenStringSet
 	}{
-		{
+		/*{
 			values:          []string{verifier0},
 			negate:          true,
 			expectedMatches: set.NewFrozenStringSet("verified_by_0"),
@@ -2229,24 +2235,25 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 			values:          []string{verifier2, verifier3},
 			negate:          false,
 			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_3", "verified_by_2_and_3")),
-		},
+		},/**/
 		// TODO(ROX-9996): Fix construction of the augmented object to allow for matching
 		// several verifier IDs.
-		/*{
+		/** /
+		{
 			values:          []string{verifier0, verifier2},
 			negate:          false,
 			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_0", "verified_by_2_and_3")),
-		},
+		},/**/
 		{
 			values:          []string{verifier2, verifier3},
 			negate:          false,
 			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_3", "verified_by_2_and_3")),
-		},*/
-		{
+		},
+		/** /{
 			values:          []string{unverifier},
 			negate:          false,
 			expectedMatches: allImages,
-		},
+		},/**/
 	} {
 		c := testCase
 

--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -2238,7 +2238,7 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_0", "verified_by_2_and_3")),
 		},
 		{
-			values:          []string{verifier3},
+			values:          []string{verifier2, verifier3},
 			negate:          false,
 			expectedMatches: allImages.Difference(set.NewFrozenStringSet("verified_by_3", "verified_by_2_and_3")),
 		},*/

--- a/pkg/booleanpolicy/field_metadata.go
+++ b/pkg/booleanpolicy/field_metadata.go
@@ -403,7 +403,7 @@ func initializeFieldMetadata() FieldMetadata {
 				return signatureIntegrationIDValueRegex
 			},
 			[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
-			[]RuntimeFieldType{})
+			[]RuntimeFieldType{}, negationForbidden)
 	}
 
 	f.registerFieldMetadata(fieldnames.ImageTag,

--- a/pkg/booleanpolicy/query_to_field_value_mappers.go
+++ b/pkg/booleanpolicy/query_to_field_value_mappers.go
@@ -23,7 +23,6 @@ var (
 		search.VolumeReadonly:                newMapper(fieldnames.WritableMountedVolume, invertBooleanMap),
 		search.ImageCreatedTime:              newMapper(fieldnames.ImageAge, numberOfDaysSinceMap),
 		search.ImageScanTime:                 newMapper(fieldnames.ImageScanAge, numberOfDaysSinceMap),
-		search.ImageSignatureVerifiedBy:      newMapper(fieldnames.ImageSignatureVerifiedBy, directMap),
 		search.ServiceAccountPermissionLevel: newMapper(fieldnames.MinimumRBACPermissions, serviceAccountPermissionLevelMap),
 		search.ExposureLevel:                 newMapper(fieldnames.PortExposure, directMap),
 		search.AddCapabilities:               newMapper(fieldnames.AddCaps, directMap),

--- a/pkg/booleanpolicy/validate.go
+++ b/pkg/booleanpolicy/validate.go
@@ -59,6 +59,8 @@ func Validate(p *storage.Policy, options ...ValidateOption) error {
 		errorList.AddError(validatePolicySection(section, configuration, p.GetEventSource()))
 	}
 
+	// Special case for ImageSignatureVerifiedBy policy for which we don't allow
+	// AND operator due to the UI limitations.
 	for _, ps := range p.PolicySections {
 		for _, pg := range ps.PolicyGroups {
 			if pg.FieldName == fieldnames.ImageSignatureVerifiedBy && pg.BooleanOperator == storage.BooleanOperator_AND {

--- a/pkg/booleanpolicy/validate.go
+++ b/pkg/booleanpolicy/validate.go
@@ -58,6 +58,15 @@ func Validate(p *storage.Policy, options ...ValidateOption) error {
 	for _, section := range p.GetPolicySections() {
 		errorList.AddError(validatePolicySection(section, configuration, p.GetEventSource()))
 	}
+
+	for _, ps := range p.PolicySections {
+		for _, pg := range ps.PolicyGroups {
+			if pg.FieldName == fieldnames.ImageSignatureVerifiedBy && pg.BooleanOperator == storage.BooleanOperator_AND {
+				errorList.AddStringf("operator AND is not allowed for field %q", fieldnames.ImageSignatureVerifiedBy)
+			}
+		}
+	}
+
 	return errorList.ToError()
 }
 

--- a/pkg/booleanpolicy/violationmessages/printer/container.go
+++ b/pkg/booleanpolicy/violationmessages/printer/container.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stackrox/rox/pkg/booleanpolicy/augmentedobjs"
 	"github.com/stackrox/rox/pkg/search"
-	"github.com/stackrox/rox/pkg/stringutils"
 )
 
 const (
@@ -170,29 +169,31 @@ func imageSignatureVerifiedPrinter(fieldMap map[string][]string) ([]string, erro
 		ContainerName: maybeGetSingleValueFromFieldMap(augmentedobjs.ContainerNameCustomTag, fieldMap),
 		Status:        "unverified",
 	}
+
 	tmpl, err := getTemplate(imageSignatureVerifiedTemplate)
 	if err != nil {
 		return nil, err
 	}
 
 	var result []string
-	if verifiedBy, ok := fieldMap[augmentedobjs.ImageSignatureVerifiedCustomTag]; ok && stringutils.FirstNonEmpty(verifiedBy...) != "" {
-		for _, id := range verifiedBy {
-			if id != "" {
+	if ids, ok := fieldMap[augmentedobjs.ImageSignatureVerifiedCustomTag]; ok {
+		for _, id := range ids {
+			if id != "" && id != "<empty>" {
 				r.Status = "verified by " + id
-				s, err := executeTemplateT(tmpl, r)
+				message, err := executeTemplateT(tmpl, r)
 				if err != nil {
 					return nil, err
 				}
-				result = append(result, s)
+				result = append(result, message)
 			}
 		}
-	} else {
-		s, err := executeTemplateT(tmpl, r)
+	}
+	if len(result) == 0 {
+		message, err := executeTemplateT(tmpl, r)
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, s)
+		result = append(result, message)
 	}
 	return result, nil
 }

--- a/pkg/booleanpolicy/violationmessages/printer/container.go
+++ b/pkg/booleanpolicy/violationmessages/printer/container.go
@@ -170,30 +170,25 @@ func imageSignatureVerifiedPrinter(fieldMap map[string][]string) ([]string, erro
 		Status:        "unverified",
 	}
 
-	tmpl, err := getTemplate(imageSignatureVerifiedTemplate)
-	if err != nil {
-		return nil, err
-	}
-
 	var result []string
 	if ids, ok := fieldMap[augmentedobjs.ImageSignatureVerifiedCustomTag]; ok {
 		for _, id := range ids {
 			if id != "" && id != "<empty>" {
 				r.Status = "verified by " + id
-				message, err := executeTemplateT(tmpl, r)
+				message, err := executeTemplate(imageSignatureVerifiedTemplate, r)
 				if err != nil {
 					return nil, err
 				}
-				result = append(result, message)
+				result = append(result, message...)
 			}
 		}
 	}
 	if len(result) == 0 {
-		message, err := executeTemplateT(tmpl, r)
+		message, err := executeTemplate(imageSignatureVerifiedTemplate, r)
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, message)
+		result = append(result, message...)
 	}
 	return result, nil
 }

--- a/pkg/booleanpolicy/violationmessages/printer/util.go
+++ b/pkg/booleanpolicy/violationmessages/printer/util.go
@@ -80,7 +80,7 @@ func getSingleValueFromFieldMap(f string, fieldMap map[string][]string) (string,
 	return values[0], nil
 }
 
-func getTemplate(tpl string) (*template.Template, error) {
+func executeTemplate(tpl string, values interface{}) ([]string, error) {
 	tmpl := lazyTemplateCache.Get(tpl)
 	if tmpl == nil {
 		var err error
@@ -90,26 +90,11 @@ func getTemplate(tpl string) (*template.Template, error) {
 		}
 		lazyTemplateCache.Set(tpl, tmpl)
 	}
-	return tmpl, nil
-}
 
-func executeTemplateT(tmpl *template.Template, values interface{}) (string, error) {
 	var sb strings.Builder
-	if err := tmpl.Execute(&sb, values); err != nil {
-		return "", err
-	}
-	return sb.String(), nil
-}
-
-func executeTemplate(tpl string, values interface{}) ([]string, error) {
-	tmpl, err := getTemplate(tpl)
+	err := tmpl.Execute(&sb, values)
 	if err != nil {
 		return nil, err
 	}
-
-	result, err := executeTemplateT(tmpl, values)
-	if err != nil {
-		return nil, err
-	}
-	return []string{result}, nil
+	return []string{sb.String()}, nil
 }

--- a/pkg/booleanpolicy/violationmessages/printer/util.go
+++ b/pkg/booleanpolicy/violationmessages/printer/util.go
@@ -80,7 +80,7 @@ func getSingleValueFromFieldMap(f string, fieldMap map[string][]string) (string,
 	return values[0], nil
 }
 
-func executeTemplate(tpl string, values interface{}) ([]string, error) {
+func getTemplate(tpl string) (*template.Template, error) {
 	tmpl := lazyTemplateCache.Get(tpl)
 	if tmpl == nil {
 		var err error
@@ -90,11 +90,26 @@ func executeTemplate(tpl string, values interface{}) ([]string, error) {
 		}
 		lazyTemplateCache.Set(tpl, tmpl)
 	}
+	return tmpl, nil
+}
 
+func executeTemplateT(tmpl *template.Template, values interface{}) (string, error) {
 	var sb strings.Builder
-	err := tmpl.Execute(&sb, values)
+	if err := tmpl.Execute(&sb, values); err != nil {
+		return "", err
+	}
+	return sb.String(), nil
+}
+
+func executeTemplate(tpl string, values interface{}) ([]string, error) {
+	tmpl, err := getTemplate(tpl)
 	if err != nil {
 		return nil, err
 	}
-	return []string{sb.String()}, nil
+
+	result, err := executeTemplateT(tmpl, values)
+	if err != nil {
+		return nil, err
+	}
+	return []string{result}, nil
 }

--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -144,7 +144,7 @@ w9e2Azq1OYIh/pbeBMHARDrBaqqmuMR9+BfAaPAYdkNTU6f58M2zBbuL0A==
         assert unverifiableSignatureIntegrationID
         CREATED_SIGNATURE_INTEGRATIONS.put(UNVERIFIABLE, unverifiableSignatureIntegrationID)
 
-        Signature integration "Distroless+Tekton" which holds both distroless and tekton cosign public keys.
+        // Signature integration "Distroless+Tekton" which holds both distroless and tekton cosign public keys.
         Map<String,String> mergedKeys = DISTROLESS_PUBLIC_KEY.clone() as Map<String, String>
         mergedKeys.putAll(TEKTON_COSIGN_PUBLIC_KEY.entrySet())
         String distrolessAndTektonSignatureIntegrationID = createSignatureIntegration(

--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -34,7 +34,7 @@ class ImageSignatureVerificationTest extends BaseSpecification {
             DISTROLESS,
             TEKTON,
             UNVERIFIABLE,
-            DISTROLESS_AND_TEKTON
+            DISTROLESS_AND_TEKTON,
     ]
 
     // Public keys used within signature integrations.

--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -26,8 +26,7 @@ class ImageSignatureVerificationTest extends BaseSpecification {
     static final private String DISTROLESS = "Distroless"
     static final private String TEKTON = "Tekton"
     static final private String UNVERIFIABLE = "Unverifiable"
-    // TODO(ROX-9996): Uncomment after we can handle multiple verification results.
-    //static final private String DISTROLESS_AND_TEKTON = "Distroless+Tekton"
+    static final private String DISTROLESS_AND_TEKTON = "Distroless+Tekton"
 
     // List of integration names used within tests.
     // NOTE: If you add a new name, make sure to add it here.
@@ -35,8 +34,7 @@ class ImageSignatureVerificationTest extends BaseSpecification {
             DISTROLESS,
             TEKTON,
             UNVERIFIABLE,
-            // TODO(ROX-9996): Uncomment after we can handle multiple verification results.
-            //DISTROLESS_AND_TEKTON
+            DISTROLESS_AND_TEKTON
     ]
 
     // Public keys used within signature integrations.
@@ -146,8 +144,7 @@ w9e2Azq1OYIh/pbeBMHARDrBaqqmuMR9+BfAaPAYdkNTU6f58M2zBbuL0A==
         assert unverifiableSignatureIntegrationID
         CREATED_SIGNATURE_INTEGRATIONS.put(UNVERIFIABLE, unverifiableSignatureIntegrationID)
 
-        // TODO(ROX-9996): Uncomment after we can handle multiple verification results.
-        /* Signature integration "Distroless+Tekton" which holds both distroless and tekton cosign public keys.
+        Signature integration "Distroless+Tekton" which holds both distroless and tekton cosign public keys.
         Map<String,String> mergedKeys = DISTROLESS_PUBLIC_KEY.clone() as Map<String, String>
         mergedKeys.putAll(TEKTON_COSIGN_PUBLIC_KEY.entrySet())
         String distrolessAndTektonSignatureIntegrationID = createSignatureIntegration(
@@ -155,7 +152,6 @@ w9e2Azq1OYIh/pbeBMHARDrBaqqmuMR9+BfAaPAYdkNTU6f58M2zBbuL0A==
         )
         assert distrolessAndTektonSignatureIntegrationID
         createdSignatureIntegrations.put(DISTROLESS_AND_TEKTON, distrolessAndTektonSignatureIntegrationID)
-        */
 
         // Create all required deployments.
         orchestrator.batchCreateDeployments(DEPLOYMENTS)
@@ -218,13 +214,11 @@ w9e2Azq1OYIh/pbeBMHARDrBaqqmuMR9+BfAaPAYdkNTU6f58M2zBbuL0A==
         UNVERIFIABLE | TEKTON_DEPLOYMENT            | true
         UNVERIFIABLE | WITHOUT_SIGNATURE_DEPLOYMENT | true
         UNVERIFIABLE | UNVERIFIABLE_DEPLOYMENT      | true
-        // TODO(ROX-9996): Uncomment after we can handle multiple verification results.
-        /* Distroless and tekton should create alerts for all deployments except thos using distroless / tekton images.
+        // Distroless and tekton should create alerts for all deployments except thos using distroless / tekton images.
         DISTROLESS_AND_TEKTON | UNVERIFIABLE_DEPLOYMENT | true
         DISTROLESS_AND_TEKTON | WITHOUT_SIGNATURE_DEPLOYMENT | true
         DISTROLESS_AND_TEKTON | TEKTON_DEPLOYMENT | false
         DISTROLESS_AND_TEKTON | DISTROLESS_DEPLOYMENT | false
-        */
     }
 
     // Helper which creates a policy builder for a policy which uses the image signature policy criteria.


### PR DESCRIPTION
## Description

Fixes to the augmented object building and to the alert printer.

Split `executeTemplate` function to separately usable parts.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

