### PR TITLE
Redirect to Not Found page instead of main dashboard for unmatched paths in UI

### DIFF
--- a/ui/apps/platform/src/Components/PageNotFound.tsx
+++ b/ui/apps/platform/src/Components/PageNotFound.tsx
@@ -5,8 +5,8 @@ import { mainPath } from 'routePaths';
 import NotFoundMessage from 'Components/NotFoundMessage';
 
 export type PageNotFoundProps = {
-    resourceType: string;
-    useCase: string;
+    resourceType?: string;
+    useCase?: string;
 };
 
 const PageNotFound = ({ resourceType = '', useCase = '' }: PageNotFoundProps): ReactElement => {

--- a/ui/apps/platform/src/Components/PageNotFound.tsx
+++ b/ui/apps/platform/src/Components/PageNotFound.tsx
@@ -12,7 +12,7 @@ export type PageNotFoundProps = {
 const PageNotFound = ({ resourceType = '', useCase = '' }: PageNotFoundProps): ReactElement => {
     const resourceTypeName = (resourceType || 'resource').toLowerCase();
     const url = useCase ? `${mainPath}/${useCase}` : mainPath;
-    const title = `Unfortunately, the ${resourceTypeName} you are looking for cannot be found.`;
+    const title = `Unfortunately, the ${resourceTypeName} you are looking for cannot be found`;
     const message =
         "It may have changed, did not exist, or no longer exists. Try using search from the dashboard to find what you're looking for.";
 

--- a/ui/apps/platform/src/Containers/AppPage.tsx
+++ b/ui/apps/platform/src/Containers/AppPage.tsx
@@ -19,7 +19,7 @@ function AppPage(): ReactElement {
                 <Route path={loginPath} component={LoginPage} />
                 <Route path={testLoginResultsPath} component={TestLoginResultsPage} />
                 <Route path={authResponsePrefix} component={LoadingSection} />
-                <Redirect from="/" to={mainPath} />
+                <Route path="/" exact render={() => <Redirect to={mainPath} />} />
             </Switch>
         </>
     );

--- a/ui/apps/platform/src/Containers/AppPage.tsx
+++ b/ui/apps/platform/src/Containers/AppPage.tsx
@@ -19,7 +19,7 @@ function AppPage(): ReactElement {
                 <Route path={loginPath} component={LoginPage} />
                 <Route path={testLoginResultsPath} component={TestLoginResultsPage} />
                 <Route path={authResponsePrefix} component={LoadingSection} />
-                <Route path="/" exact render={() => <Redirect to={mainPath} />} />
+                <Route path="/" render={() => <Redirect to={mainPath} />} />
             </Switch>
         </>
     );

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -3,6 +3,7 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 
 import {
     mainPath,
+    notFoundPath,
     dashboardPath,
     networkPath,
     violationsPath,
@@ -26,6 +27,8 @@ import {
 import { useTheme } from 'Containers/ThemeProvider';
 
 import asyncComponent from 'Components/AsyncComponent';
+import PageNotFound from 'Components/PageNotFound';
+import PageTitle from 'Components/PageTitle';
 import ErrorBoundary from 'Containers/ErrorBoundary';
 import { HasReadAccess } from 'hooks/usePermissions';
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
@@ -66,6 +69,15 @@ const AsyncSystemHealthPagePF = asyncComponent(
     () => import('Containers/SystemHealth/PatternFly/SystemHealthDashboard')
 );
 
+function NotFoundPage(): ReactElement {
+    return (
+        <>
+            <PageTitle title="Not Found" />
+            <PageNotFound />
+        </>
+    );
+}
+
 type BodyProps = {
     hasReadAccess: HasReadAccess;
     isFeatureFlagEnabled: IsFeatureFlagEnabled;
@@ -90,6 +102,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
             <ErrorBoundary>
                 <Switch>
                     <Route path={dashboardPath} component={AsyncDashboardPage} />
+                    <Route path={notFoundPath} component={NotFoundPage} />
                     <Route path={networkPath} component={AsyncNetworkPage} />
                     <Route path={violationsPath} component={AsyncViolationsPage} />
                     <Route path={compliancePath} component={AsyncCompliancePage} />
@@ -117,7 +130,8 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     {isSystemHealthPatternFlyEnabled && (
                         <Route path={systemHealthPathPF} component={AsyncSystemHealthPagePF} />
                     )}
-                    <Redirect from={mainPath} to={dashboardPath} />
+                    <Route path={mainPath} exact render={() => <Redirect to={dashboardPath} />} />
+                    <Route path={mainPath} render={() => <Redirect to={notFoundPath} />} />
                 </Switch>
             </ErrorBoundary>
         </div>

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -34,6 +34,15 @@ import { HasReadAccess } from 'hooks/usePermissions';
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import { knownBackendFlags } from 'utils/featureFlags';
 
+function NotFoundPage(): ReactElement {
+    return (
+        <>
+            <PageTitle title="Not Found" />
+            <PageNotFound />
+        </>
+    );
+}
+
 const AsyncApiDocsPage = asyncComponent(() => import('Containers/Docs/ApiPage'));
 const AsyncDashboardPage = asyncComponent(() => import('Containers/Dashboard/DashboardPage'));
 const AsyncNetworkPage = asyncComponent(() => import('Containers/Network/Page'));
@@ -69,15 +78,6 @@ const AsyncSystemHealthPagePF = asyncComponent(
     () => import('Containers/SystemHealth/PatternFly/SystemHealthDashboard')
 );
 
-function NotFoundPage(): ReactElement {
-    return (
-        <>
-            <PageTitle title="Not Found" />
-            <PageNotFound />
-        </>
-    );
-}
-
 type BodyProps = {
     hasReadAccess: HasReadAccess;
     isFeatureFlagEnabled: IsFeatureFlagEnabled;
@@ -101,8 +101,8 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
         >
             <ErrorBoundary>
                 <Switch>
-                    <Route path={dashboardPath} component={AsyncDashboardPage} />
                     <Route path={notFoundPath} component={NotFoundPage} />
+                    <Route path={dashboardPath} component={AsyncDashboardPage} />
                     <Route path={networkPath} component={AsyncNetworkPage} />
                     <Route path={violationsPath} component={AsyncViolationsPage} />
                     <Route path={compliancePath} component={AsyncCompliancePage} />

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
+import { PageSection } from '@patternfly/react-core';
 
 import {
     mainPath,
@@ -36,10 +37,10 @@ import { knownBackendFlags } from 'utils/featureFlags';
 
 function NotFoundPage(): ReactElement {
     return (
-        <>
+        <PageSection variant="light">
             <PageTitle title="Not Found" />
             <PageNotFound />
-        </>
+        </PageSection>
     );
 }
 

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -9,6 +9,7 @@ export const loginPath = '/login';
 export const testLoginResultsPath = '/test-login-results';
 export const authResponsePrefix = '/auth/response/';
 
+export const notFoundPath = `${mainPath}/404`;
 export const dashboardPath = `${mainPath}/dashboard`;
 export const networkBasePath = `${mainPath}/network`;
 export const networkPath = `${networkBasePath}/:deploymentId?/:externalType?`;


### PR DESCRIPTION
## Description

Follow up action to discussion thread starting with https://github.com/stackrox/stackrox/pull/1171#pullrequestreview-932011200

Take another step toward the goal of consistent feedback for the following:
1. Path does not match any pattern
2. Path does match a pattern, but feature flag is not enabled
3. Path does match a pattern, but user role does not have access
4. Path does match a pattern, but resource type does not exist (see Residue)
5. Path does match a pattern, but resource id does not exist (see Residue)

Previous inconsistent behavior before #1171
* Redirect to main dashboard if path does not match any pattern
* Redirect to main dashboard if path does match a specific pattern, but feature flag turned off or user role does not have access
* Render `PageNotFound` if path does match a generic pattern, but second-level resource does not exist (for example, /main/vulnerability-management/unknown)
* Render `PageNotFound` if path does match generic pattern, but second-level id does not exist (for example, /main/vulnerability-management/policies?…)

Somewhat more inconsistent behavior after #1171
* Redirect to main dashboard if path does not match any pattern
* Redirect to main dashboard if path does match a specific pattern, but feature flag turned off or user role does not have access
* Render `PageNotFound` if path does match specific pattern, but feature flag turned off or user role does not have access, and path does match a generic pattern, but second-level resource does not exist (for example, /main/vulnerability-management/reports)
* Render `PageNotFound` if path does match generic pattern, but second-level resource does not exist (for example, /main/vulnerability-management/unknown)
* Render `PageNotFound` if path does match generic pattern, but second-level id does not exist (for example, /main/vulnerability-management/policies?…)

Incrementally improved behavior
* `Body` redirects to 404 which renders `NotFoundPage` for 1
* `Body` redirects to 404 which renders `NotFoundPage` for 2 or 3, except if path matches a generic pattern, therefore does not (yet) redirect, see next item
* Some containers render `PageNotFound` at the original path for 4 (see Residue)
* Some containers render `PageNotFound` at the original path for 5 (see Residue)

### Residue

Proposal for discussion:
1. Continue to display **Not Found** if resource type or resource id does not match.
2. Redirect to 404 at deepest depth 0, 1, 2 that does match, for example:
    * /main/404 for /main/unknown (this pull request) with link to Dashboard
    * /main/vulnerability-management/404 for /main/vulnerability-management/reports if feature flag is not enabled or if no role access, with link to Vulnerability Management Dashboard
    * /main/vulneratility-management/cves/404 for /main/vulnerability-management/cves?…unknownId with link to Vulnerability Management CVEs

Here is an observation and a brainstorm about workflow page addresses, related to 404 at deepest depth:

#### Classic workflow with side panel

Current resource type or id is at end of query string:
1. /main/vulnerability-management/cves
2. /main/vulnerability-management/cves?workflowState[0][t]=CVE&**workflowState[0][i]=CVE-2021-20231**
3. /main/vulnerability-management/cves?workflowState[0][t]=CVE&workflowState[0][i]=CVE-2021-20231&**workflowState[1][t]=IMAGE**
4. /main/vulnerability-management/cves?workflowState[0][t]=CVE&workflowState[0][i]=CVE-2021-20231&workflowState[1][t]=IMAGE&workflowState[2][t]=IMAGE&**workflowState[2][i]=sha256%3Ad1217333dd1f1c76da0a9dbe85aef481c0fde0643a900c3f7113caf3fe4db1d7**
5. /main/vulnerability-management/image/sha256:d1217333dd1f1c76da0a9dbe85aef481c0fde0643a900c3f7113caf3fe4db1d7/**deployments**
6. /main/vulnerability-management/image/sha256:d1217333dd1f1c76da0a9dbe85aef481c0fde0643a900c3f7113caf3fe4db1d7/deployments?workflowState[0][t]=DEPLOYMENT&**workflowState[0][i]=65b80760-848e-4a6f-9d25-7599ca40f258**

Steps 3 and 4 display **Images** and **Image** but **cves** is resource type at depth 1
Steps 5 and 6 display **Deployments** and **Deployment** but **image** is resource type at depth 1

#### Future workflow without side panel

Current resource type and id might be at beginning of address and breadcrumb stack might be in query string?

1. /main/vulnerability-management/cves
2. /main/vulnerability-management/cves/**CVE-2021-20231**
3. /main/vulnerability-management/**images**?workflowState[0][t]=CVE&workflowState[0][i]=CVE-2021-20231
4. /main/vulnerability-management/images/**sha256%3Ad1217333dd1f1c76da0a9dbe85aef481c0fde0643a900c3f7113caf3fe4db1d7**?workflowState[0][t]=CVE&workflowState[0][i]=CVE-2021-20231
5. /main/vulnerability-management/**deployments**?workflowState[0][t]=IMAGE&workflowState[0][i]=sha256:d1217333dd1f1c76da0a9dbe85aef481c0fde0643a900c3f7113caf3fe4db1d7
5. /main/vulnerability-management/deployments/**65b80760-848e-4a6f-9d25-7599ca40f258**?workflowState[0][t]=IMAGE&workflowState[0][i]=sha256:d1217333dd1f1c76da0a9dbe85aef481c0fde0643a900c3f7113caf3fe4db1d7

### React Router

https://reactrouter.com/docs/en/v6/upgrading/v5#remove-redirects-inside-switch

> Remove any `<Redirect>` elements that are directly inside a `<Switch>`.

* If you want to redirect client-side, move your `<Redirect>` into a `<Route render>` prop.
* Normal `<Redirect>` elements that are not inside a `<Switch>` are ok to remain. They will become `<Navigate>` elements in v6. [We can evaluate this option when the time comes.]

### PatternFly

https://www.patternfly.org/v4/ux-writing/http-404-pages/

For an example of path, `patternfly.org/v4/unknown` redirects to `patternfly.org/v4/404/`

### Changes

1. Edit src/Components/PageNotFound.tsx
    * Declare `resourceType` and `useCase` props as optional.

2. Edit src/Containers/AppPage.tsx
    * Move `Redirect` element into `render` prop of `Route` element.

3. Edit src/Containers/MainPage/Body.tsx
    * Define `NotFoundPage` which returns `PageTitle` and `PageNotFound` elements
    * Add `<Route path={notFoundPath} component={NotFoundPage} />`
    * Move `Redirect` element into `render` prop of `Route` element, which does have `exact` prop.
    * Add `Redirect` element in `render` prop of `Route` element, which does not have `exact` prop.

3. Edit src/routePaths.js
    * Export `notFoundPath` for /main/404

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

## Testing Performed

* https://localhost:3000 redirects to /main/dashboard
* https://localhost:3000/unknown ~renders black screen~ redirects to /main and then to /main/dashboard
* https://localhost:3000/main redirects to /main/dashboard
* https://localhost:3000/main/dashboard renders Dashboard
* https://localhost:3000/main/unknown redirects to /main/404 and renders `NotFoundPage`
* https://localhost:3000/main/vulnerability-management renders Vulnerability Management Dashboard
* https://localhost:3000/main/vulnerability-management/reports with access renders Vulnerability Management Reporting
* https://localhost:3000/main/vulnerability-management/reports without access renders PageNotFound
* https://localhost:3000/main/vulnerability-management/unknown renders `PageNotFound`
* https://localhost:3000/main/system-health-pf with feature flag renders System Health
* https://localhost:3000/main/system-health-pf without feature flag redirects to /main/404 and renders `NotFoundPage`

Picture of first draft /main/404 without `PageSection` element has mixed PatternFly and classic style
![NotFoundPage-without-PageSection](https://user-images.githubusercontent.com/11862657/162267010-629eb6c5-4a02-4995-9117-a6b193427a39.png)

Picture of second draft /main/404 with `PageSection` element has PatternFly style
![NotFoundPage-with-PageSection](https://user-images.githubusercontent.com/11862657/162266993-e25dc0a3-aba7-4f45-8f9f-52da152fb622.png)

