### PR TITLE
ROX-10001: Fix default role flag for Vulnerability Report Creator role

### DIFF
--- a/ui/apps/platform/src/constants/accessControl.ts
+++ b/ui/apps/platform/src/constants/accessControl.ts
@@ -14,7 +14,7 @@ const defaultRoles = {
     'Sensor Creator': true,
     'Vulnerability Management Approver': true,
     'Vulnerability Management Requester': true,
-    'Vulnerability Reporter': true,
+    'Vulnerability Report Creator': true,
 };
 
 export function getIsDefaultRoleName(name: string): boolean {


### PR DESCRIPTION
## Description

Bug: Vulnerability Report Creator appeared to be editable and deletable in the UI, even though it is not, because it is a built-in default role that comes into the system. (This wasn't actionable, because the API would prevent actual editing or deleting, but it could be confusing.)

## Checklist
- [x] Investigated and inspected CI test results (ui e2e tests failures are unrelated flakes)


## Testing Performed

Before, incorrect visual:
![Screen Shot 2022-04-06 at 12 44 25 PM](https://user-images.githubusercontent.com/715729/162070561-0c2336a1-0d5f-4ac0-9af9-1c141be5e63f.png)

Fixed visual:
![Screen Shot 2022-04-06 at 4 47 42 PM](https://user-images.githubusercontent.com/715729/162070677-9e7d2052-bd91-489a-bcdb-5e2655a43d46.png)
![Screen Shot 2022-04-06 at 4 47 48 PM](https://user-images.githubusercontent.com/715729/162070679-1c296a4a-a3ec-4abc-96e9-773bfb149aa4.png)
