### PR TITLE
Use scratch image for operator

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -46,19 +46,16 @@ COPY operator/build/status.sh status.sh
 RUN git init && git add .
 
 # Build the operator binary.
-RUN GOOS=$(go env GOOS) scripts/go-build.sh operator
+RUN GOOS=$(go env GOOS) CGO_ENABLED=0 scripts/go-build.sh operator
 # Copy the operator binary to a location from where it will be taken into the final image.
 RUN cp -a bin/$(go env GOOS)/operator stackrox-operator
 
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.5
+FROM scratch
 
 ARG roxpath
 
 ARG ROX_IMAGE_FLAVOR
 ENV ROX_IMAGE_FLAVOR=${ROX_IMAGE_FLAVOR}
-
-RUN microdnf update && microdnf clean all && rm -rf /var/cache/yum/*
 
 COPY --from=builder ${roxpath}/stackrox-operator /usr/local/bin/
 


### PR DESCRIPTION
## Description

Currently we are using `ubi8-minimal` image but we only put operator there that could be build without CGO.
Operator should not require any other binaries or libs so there is no need to use system image and we can use `scratch` image.
This will result in smaller image and faster build time (we don't need to update dependencies since we don't have any) and more secure image (again no deps). 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
