### PR TITLE
ROX-9813 set enforcement not supported for Network Policy fields

### DIFF
--- a/central/policy/service/validator.go
+++ b/central/policy/service/validator.go
@@ -11,8 +11,10 @@ import (
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/booleanpolicy"
+	"github.com/stackrox/rox/pkg/booleanpolicy/augmentedobjs"
 	"github.com/stackrox/rox/pkg/booleanpolicy/policyversion"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/policies"
 	"github.com/stackrox/rox/pkg/scopecomp"
 )
@@ -87,6 +89,9 @@ func (s *policyValidator) internalValidate(policy *storage.Policy, additionalVal
 	errorList.AddError(s.validateExclusions(policy))
 	errorList.AddError(s.validateCapabilities(policy))
 	errorList.AddError(s.validateEventSource(policy))
+	if features.NetworkPolicySystemPolicy.Enabled() {
+		errorList.AddError(s.validateNetworkPolicyEnforcement(policy))
+	}
 
 	for _, validator := range additionalValidators {
 		errorList.AddError(validator(policy))
@@ -376,4 +381,17 @@ func removeEnforcementForLifecycle(policy *storage.Policy, stage storage.Lifecyc
 
 func (s *policyValidator) isAuditEventPolicy(policy *storage.Policy) bool {
 	return policy.GetEventSource() == storage.EventSource_AUDIT_LOG_EVENT
+}
+
+func (s *policyValidator) validateNetworkPolicyEnforcement(policy *storage.Policy) error {
+	if len(policy.GetEnforcementActions()) > 0 {
+		for _, s := range policy.GetPolicySections() {
+			for _, g := range s.GetPolicyGroups() {
+				if g.GetFieldName() == augmentedobjs.MissingEgressPolicyCustomTag || g.GetFieldName() == augmentedobjs.MissingIngressPolicyCustomTag {
+					return errors.New("enforcement of Network Policies is not allowed yet")
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/central/policy/service/validator_test.go
+++ b/central/policy/service/validator_test.go
@@ -10,9 +10,11 @@ import (
 	clusterMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	notifierMocks "github.com/stackrox/rox/central/notifier/datastore/mocks"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/booleanpolicy/augmentedobjs"
 	"github.com/stackrox/rox/pkg/booleanpolicy/fieldnames"
 	"github.com/stackrox/rox/pkg/booleanpolicy/policyversion"
 	"github.com/stackrox/rox/pkg/defaults/policies"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/testutils/envisolator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -41,8 +43,9 @@ func (s *PolicyValidatorTestSuite) SetupTest() {
 	s.nStorage = notifierMocks.NewMockDataStore(s.mockCtrl)
 	s.cStorage = clusterMocks.NewMockDataStore(s.mockCtrl)
 
-	s.validator = newPolicyValidator(s.nStorage)
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
+	s.envIsolator.Setenv(features.NetworkPolicySystemPolicy.EnvVar(), "true")
+	s.validator = newPolicyValidator(s.nStorage)
 }
 
 func (s *PolicyValidatorTestSuite) TearDownTest() {
@@ -707,4 +710,77 @@ func (s *PolicyValidatorTestSuite) TestValidateAuditEventSource() {
 			},
 		},
 	}))
+}
+
+func (s *PolicyValidatorTestSuite) TestValidateEnforcement() {
+	cases := map[string]struct {
+		policy        *storage.Policy
+		expectedError string
+		featureFlag   bool
+	}{
+		"Missing Egress Policy Field": {
+			policy: &storage.Policy{
+				EnforcementActions: []storage.EnforcementAction{
+					storage.EnforcementAction_SCALE_TO_ZERO_ENFORCEMENT,
+				},
+				PolicySections: []*storage.PolicySection{
+					{
+						PolicyGroups: []*storage.PolicyGroup{
+							{
+								FieldName: augmentedobjs.MissingEgressPolicyCustomTag,
+							},
+						},
+					},
+				},
+			},
+			featureFlag:   true,
+			expectedError: fmt.Sprintf("enforcement of %s is not allowed", augmentedobjs.MissingEgressPolicyCustomTag),
+		},
+		"Missing Ingress Policy Field": {
+			policy: &storage.Policy{
+				EnforcementActions: []storage.EnforcementAction{
+					storage.EnforcementAction_SCALE_TO_ZERO_ENFORCEMENT,
+				},
+				PolicySections: []*storage.PolicySection{
+					{
+						PolicyGroups: []*storage.PolicyGroup{
+							{
+								FieldName: augmentedobjs.MissingIngressPolicyCustomTag,
+							},
+						},
+					},
+				},
+			},
+			featureFlag:   true,
+			expectedError: fmt.Sprintf("enforcement of %s is not allowed", augmentedobjs.MissingIngressPolicyCustomTag),
+		},
+		"Enforceable Policy Field": {
+			policy: &storage.Policy{
+				EnforcementActions: []storage.EnforcementAction{
+					storage.EnforcementAction_SCALE_TO_ZERO_ENFORCEMENT,
+				},
+				PolicySections: []*storage.PolicySection{
+					{
+						PolicyGroups: []*storage.PolicyGroup{
+							{
+								FieldName: augmentedobjs.ContainerNameCustomTag,
+							},
+						},
+					},
+				},
+			},
+			featureFlag:   true,
+			expectedError: "",
+		},
+	}
+	for name, c := range cases {
+		s.T().Run(name, func(t *testing.T) {
+			err := s.validator.validateEnforcement(c.policy)
+			if c.expectedError != "" {
+				assert.Equal(t, c.expectedError, err.Error())
+			} else {
+				assert.Truef(t, err == nil, "Error not expected")
+			}
+		})
+	}
 }

--- a/central/policy/service/validator_test.go
+++ b/central/policy/service/validator_test.go
@@ -713,6 +713,10 @@ func (s *PolicyValidatorTestSuite) TestValidateAuditEventSource() {
 }
 
 func (s *PolicyValidatorTestSuite) TestValidateEnforcement() {
+	if !features.NetworkPolicySystemPolicy.Enabled() {
+		s.T().Skipf("Skipping test since the %s variable is not set", features.NetworkPolicySystemPolicy.EnvVar())
+	}
+
 	cases := map[string]struct {
 		policy        *storage.Policy
 		expectedError string


### PR DESCRIPTION
## Description

Disallow enforcement of Network Policy System Policy fields.

Right now we don't support enforcement of these kind of fields. If enforcement is set we return an error at the creation time.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* [x] Unit testing
* [x] Manual testing

Creating a System Policy like:

```json
{
	"name": "Deployments should have ingress and egress Network Policy",
	"severity": "MEDIUM_SEVERITY",
	"disabled": false,
	"enforcementActions": [
	    "SCALE_TO_ZERO_ENFORCEMENT"
	    ],
	"lifecycleStages": [
		"DEPLOY"
	],
	"eventSource": "NOT_APPLICABLE",
	"isDefault": false,
	"categories": [
		"Anomalous Activity"
	],
	"policySections": [
		{
			"sectionName": "Policy Section 1",
			"policyGroups": [
				{
					"fieldName": "Missing Ingress Network Policy",
					"values": [
						{
							"value": "true"
						}
					]
				},
				{
					"fieldName": "Missing Egress Network Policy",
					"values": [
						{
							"value": "true"
						}
					]
				}
			]
		}
	]
}
```

Should return an error:

```json
{
  "error": "policy invalid error: enforcement of Missing Ingress Network Policy is not allowed: invalid arguments",
  "code": 3,
  "message": "policy invalid error: enforcement of Missing Ingress Network Policy is not allowed: invalid arguments",
  "details": []
}
```
