### PR TITLE
ROX-10011: Added e2e tests for roxctl scanner generate

### DIFF
--- a/tests/roxctl/bats-tests/cluster/scanner-generate.bats
+++ b/tests/roxctl/bats-tests/cluster/scanner-generate.bats
@@ -46,6 +46,9 @@ assert_number_of_k8s_resources() {
   run_scanner_generate_and_check openshift4
 
   assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
+
+  # The only difference between OpenShift and OpenShift 4 configurations is that OpenShift 4 configuration has additional
+  # mounted volume. It's called "trusted-ca-volume" and we use it to identify OpenShift 4 configuration.
   run -0 grep -q 'trusted-ca-volume' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   assert_number_of_k8s_resources 16
 }

--- a/tests/roxctl/bats-tests/cluster/scanner-generate.bats
+++ b/tests/roxctl/bats-tests/cluster/scanner-generate.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+load "../helpers.bash"
+
+output_dir=""
+
+setup_file() {
+  local -r roxctl_version="$(roxctl-development version || true)"
+  echo "Testing roxctl version: '${roxctl_version}'" >&3
+
+  command -v yq || skip "Command 'yq' required. Check: https://github.com/mikefarah/yq"
+  [[ -n "${API_ENDPOINT}" ]] || fail "Environment variable 'API_ENDPOINT' required"
+  [[ -n "${ROX_PASSWORD}" ]] || fail "Environment variable 'ROX_PASSWORD' required"
+}
+
+setup() {
+  output_dir="$(mktemp -d -u)"
+}
+
+teardown() {
+  rm -rf "${output_dir}"
+}
+
+scanner_generate() {
+  run roxctl_authenticated scanner generate \
+    --output-dir "${output_dir}" "$@"
+
+  assert_success
+}
+
+run_scanner_generate_and_check() {
+  local -r cluster_type="$1";shift
+
+  scanner_generate --cluster-type "${cluster_type}" "$@"
+  assert_success
+}
+
+@test "[openshift4] roxctl scanner generate" {
+  run_scanner_generate_and_check openshift4
+
+  assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
+  run yq 'select(document_index == 0) | .spec.template.spec.volumes[] | select(.name == "trusted-ca-volume") | .name' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
+  assert_output 'trusted-ca-volume'
+}
+
+@test "[openshift] roxctl scanner generate" {
+  run_scanner_generate_and_check openshift
+
+  assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
+  run yq 'select(document_index == 0) | .spec.template.spec.containers[] | select(.name == "scanner") | .env[] | select(.name == "ROX_OPENSHIFT_API") | .value' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
+  assert_output 'true'
+
+  run yq 'select(document_index == 0) | .spec.template.spec.volumes[] | select(.name == "trusted-ca-volume") | .name' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
+  assert_output ''
+}
+
+@test "[k8s] roxctl scanner generate" {
+  run_scanner_generate_and_check k8s
+
+  assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
+  run yq 'select(document_index == 0) | .spec.template.spec.containers[] | select(.name == "scanner") | .env[] | select(.name == "ROX_OPENSHIFT_API") | .value' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
+  assert_output ''
+}
+
+@test "[k8s istio-support] roxctl scanner generate" {
+  run_scanner_generate_and_check k8s --istio-support 1.7
+
+  assert_file_exist "${output_dir}/scanner/02-scanner-07-service.yaml"
+  run -0 grep -q "^apiVersion: networking.istio.io/v1alpha3" "${output_dir}/scanner/02-scanner-07-service.yaml"
+}
+
+@test "[k8s scanner-image] roxctl scanner generate" {
+  run_scanner_generate_and_check k8s --scanner-image bats-tests
+
+  assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
+  run -0 grep -q "bats-tests" "${output_dir}/scanner/02-scanner-06-deployment.yaml"
+}

--- a/tests/roxctl/bats-tests/cluster/scanner-generate.bats
+++ b/tests/roxctl/bats-tests/cluster/scanner-generate.bats
@@ -8,7 +8,7 @@ setup_file() {
   local -r roxctl_version="$(roxctl-development version || true)"
   echo "Testing roxctl version: '${roxctl_version}'" >&3
 
-  command -v yq || skip "Command 'yq' required. Check: https://github.com/mikefarah/yq"
+  command -v grep || skip "Command 'grep' required."
   [[ -n "${API_ENDPOINT}" ]] || fail "Environment variable 'API_ENDPOINT' required"
   [[ -n "${ROX_PASSWORD}" ]] || fail "Environment variable 'ROX_PASSWORD' required"
 }
@@ -39,27 +39,25 @@ run_scanner_generate_and_check() {
   run_scanner_generate_and_check openshift4
 
   assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  run yq 'select(document_index == 0) | .spec.template.spec.volumes[] | select(.name == "trusted-ca-volume") | .name' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  assert_output 'trusted-ca-volume'
+  run -0 grep -q 'trusted-ca-volume' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
 }
 
 @test "[openshift] roxctl scanner generate" {
   run_scanner_generate_and_check openshift
 
   assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  run yq 'select(document_index == 0) | .spec.template.spec.containers[] | select(.name == "scanner") | .env[] | select(.name == "ROX_OPENSHIFT_API") | .value' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  assert_output 'true'
-
-  run yq 'select(document_index == 0) | .spec.template.spec.volumes[] | select(.name == "trusted-ca-volume") | .name' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  assert_output ''
+  run -0 grep -q 'ROX_OPENSHIFT_API' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
+  run -1 grep -q 'trusted-ca-volume' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
 }
 
 @test "[k8s] roxctl scanner generate" {
   run_scanner_generate_and_check k8s
 
+  assert_file_exist "${output_dir}/scanner/scripts/setup.sh"
+  run -0 grep -q 'KUBE_COMMAND:-kubectl' "${output_dir}/scanner/scripts/setup.sh"
+
   assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  run yq 'select(document_index == 0) | .spec.template.spec.containers[] | select(.name == "scanner") | .env[] | select(.name == "ROX_OPENSHIFT_API") | .value' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  assert_output ''
+  run -1 grep -q 'ROX_OPENSHIFT_API' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
 }
 
 @test "[k8s istio-support] roxctl scanner generate" {

--- a/tests/roxctl/bats-tests/cluster/scanner-generate.bats
+++ b/tests/roxctl/bats-tests/cluster/scanner-generate.bats
@@ -47,9 +47,10 @@ assert_number_of_k8s_resources() {
 
   assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
 
-  # The only difference between OpenShift and OpenShift 4 configurations is that OpenShift 4 configuration has additional
-  # mounted volume. It's called "trusted-ca-volume" and we use it to identify OpenShift 4 configuration.
+  # The only difference between OpenShift and OpenShift 4 configurations is that OpenShift 4 configuration has
+  # additional mounted volume. It's called "trusted-ca-volume" and we use it to identify OpenShift 4 configuration.
   run -0 grep -q 'trusted-ca-volume' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
+  run -0 grep -q 'ROX_OPENSHIFT_API' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   assert_number_of_k8s_resources 16
 }
 


### PR DESCRIPTION
## Description

Added end to end test for `roxctl scanner generate` command. The following options are tested:
- different cluster types: k8s, openshift, openshift4
- following command options are tested: istio-support and scanner-image
- command option `offline-mode` is not tested. Unable to differentiate results. It could be that option is obsolete.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ - nothing relevant
- ~~[ ] Determined and documented upgrade steps~~ - nothing to update on client side
- ~~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~ - nothing changed on user facing

## Testing Performed

Required environment:
- cluster has to be up and running
- `API_ENDPOINT` and `ROX_PASSWORD` environment variables set

The following command can be executed from the repo root directory:
```
tests/roxctl/bats-tests/cluster/scanner-generate.bats
```
