### PR TITLE
Add permissions for store singleton for startup writes

### DIFF
--- a/central/role/datastore/singleton.go
+++ b/central/role/datastore/singleton.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	permissionsUtils "github.com/stackrox/rox/pkg/auth/permissions/utils"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -53,7 +54,10 @@ func Singleton() DataStore {
 			}
 		}
 
-		ctx := context.TODO()
+		ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resources.Role)))
 		roles, permissionSets, accessScopes := getDefaultObjects()
 		utils.Must(roleStorage.UpsertMany(ctx, roles))
 		utils.Must(permissionSetStorage.UpsertMany(ctx, permissionSets))

--- a/central/vulnerabilityrequest/datastore/datastore.go
+++ b/central/vulnerabilityrequest/datastore/datastore.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/blevesearch/bleve"
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/central/vulnerabilityrequest/cache"
 	"github.com/stackrox/rox/central/vulnerabilityrequest/datastore/internal/searcher"
 	"github.com/stackrox/rox/central/vulnerabilityrequest/datastore/internal/store"
@@ -14,6 +15,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	pkgRocksDB "github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/testutils"
 )
@@ -43,17 +45,22 @@ type DataStore interface {
 }
 
 // New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(storage store.Store, indexer index.Indexer, searcher searcher.Searcher,
+func New(s store.Store, indexer index.Indexer, searcher searcher.Searcher,
 	pendingReqCache cache.VulnReqCache, activeReqCache cache.VulnReqCache) (DataStore, error) {
 	d := &datastoreImpl{
-		store:           storage,
+		store:           s,
 		index:           indexer,
 		searcher:        searcher,
 		pendingReqCache: pendingReqCache,
 		activeReqCache:  activeReqCache,
 	}
 
-	if err := d.buildIndex(context.TODO()); err != nil {
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.VulnerabilityManagementRequests, resources.VulnerabilityManagementApprovals)))
+
+	if err := d.buildIndex(ctx); err != nil {
 		return nil, errors.Wrap(err, "failed to build index from existing store")
 	}
 	return d, nil


### PR DESCRIPTION
## Description

After adding scope check to store in #961 we need to add permissions for role singleton to do initial writes to db.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

```
export MAIN_IMAGE_TAG=3.69.x-326-gacf9c6c821
ROX_POSTGRES_DATASTORE=true STORAGE_SIZE=100  MONITORING_IMAGE=quay.io/rhacs-eng/monitoring:1.1.0 STORAGE=pvc ./deploy/k8s/deploy-local.sh
 roxcurl /v1/metadata -v
```