### PR TITLE
ROX-9901: Use moderate instead of medium in VM report form

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportForm.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportForm.tsx
@@ -349,7 +349,7 @@ function VulnMgmtReportForm({
                                                 Important
                                             </SelectOption>
                                             <SelectOption value="MODERATE_VULNERABILITY_SEVERITY">
-                                                Medium
+                                                Moderate
                                             </SelectOption>
                                             <SelectOption value="LOW_VULNERABILITY_SEVERITY">
                                                 Low


### PR DESCRIPTION
## Description

The UI Copy for vulnerability severity is inconsistent with Red Hat standards. Medium in CVE Severities should be "Moderate" Instead for consistency.

Recall that in CVE severity we are using the Red Hat scale
https://access.redhat.com/security/updates/classification

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Old, incorrect wording:
<img width="1552" alt="image-2022-03-28-12-00-24-319" src="https://user-images.githubusercontent.com/715729/162301318-ecdf28fe-7446-4ec6-a1ad-2ce1fc5539ad.png">


New, correct wording
![Screen Shot 2022-04-07 at 3 57 28 PM](https://user-images.githubusercontent.com/715729/162301412-b3fff6ce-5b48-439b-a6f7-680c8364c014.png)
