### PR TITLE
Replace cypress server and route with intercept in network integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -147,6 +147,7 @@ export const network = {
     networkPoliciesGraph: '/v1/networkpolicies/cluster/*',
     networkGraph: '/v1/networkgraph/cluster/*',
     epoch: '/v1/networkpolicies/graph/epoch',
+    generate: '/v1/networkpolicies/generate/*',
     simulate: '/v1/networkpolicies/simulate/*',
     deployment: 'v1/deployments/*',
 };

--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -1,5 +1,6 @@
 import * as api from '../constants/apiEndpoints';
 import { selectors as networkGraphSelectors, url as networkUrl } from '../constants/NetworkPage';
+import { visitFromLeftNav } from './nav';
 import selectSelectors from '../selectors/select';
 
 const getNodeErrorMessage = (node) => `Could not find node "${node.name}" of type "${node.type}"`;
@@ -138,10 +139,20 @@ export function selectNamespaceFilters(...namespaces) {
 
 // visit helpers
 
-export function visitNetworkGraphWithNamespaceFilters(...namespaces) {
+export function visitNetworkGraphFromLeftNav() {
+    cy.intercept('GET', api.clusters.list).as('clusters');
+    visitFromLeftNav('Network');
+    cy.wait('@clusters');
+}
+
+export function visitNetworkGraph() {
     cy.intercept('GET', api.clusters.list).as('clusters');
     cy.visit(networkUrl);
     cy.wait('@clusters');
+}
+
+export function visitNetworkGraphWithNamespaceFilters(...namespaces) {
+    visitNetworkGraph();
 
     cy.intercept('GET', api.network.networkGraph).as('networkGraph');
     cy.intercept('GET', api.network.networkPoliciesGraph).as('networkPolicies');
@@ -150,7 +161,6 @@ export function visitNetworkGraphWithNamespaceFilters(...namespaces) {
 }
 
 export function visitNetworkGraphWithMockedData() {
-    cy.intercept('GET', api.clusters.list).as('clusters');
     cy.intercept('GET', api.network.networkGraph, { fixture: 'network/networkGraph.json' }).as(
         'networkGraph'
     );
@@ -158,8 +168,8 @@ export function visitNetworkGraphWithMockedData() {
         fixture: 'network/networkPolicies.json',
     }).as('networkPolicies');
 
-    cy.visit(networkUrl);
-    cy.wait('@clusters');
+    visitNetworkGraph();
     selectNamespaceFilters('stackrox');
+
     cy.wait(['@networkGraph', '@networkPolicies']);
 }

--- a/ui/apps/platform/cypress/helpers/risk.js
+++ b/ui/apps/platform/cypress/helpers/risk.js
@@ -1,0 +1,26 @@
+import * as api from '../constants/apiEndpoints';
+import { selectors as riskPageSelectors, url as riskURL } from '../constants/RiskPage';
+import selectors from '../selectors/index';
+
+export function visitRiskDeployments() {
+    cy.intercept('GET', api.risks.riskyDeployments).as('getDeploymentsWithProcessInfo');
+    cy.intercept('GET', api.risks.deploymentsCount).as('getDeploymentsCount');
+    cy.visit(riskURL);
+    cy.wait(['@getDeploymentsWithProcessInfo', '@getDeploymentsCount']);
+}
+
+export function viewRiskDeploymentByName(deploymentName) {
+    // Assume location is risk deployments table.
+    cy.intercept('GET', api.risks.fetchDeploymentWithRisk).as('getDeploymentWithRisk');
+    cy.get(`${selectors.table.rows}:contains("${deploymentName}")`).click();
+    cy.wait('@getDeploymentWithRisk');
+}
+
+export function viewRiskDeploymentInNetworkGraph() {
+    // Assume location is risk deployment panel.
+    cy.intercept('GET', api.network.deployment).as('getDeployment');
+    cy.intercept('GET', api.network.networkGraph).as('getNetworkGraphCluster');
+    cy.intercept('GET', api.network.networkPoliciesGraph).as('getNetworkPoliciesCluster');
+    cy.get(riskPageSelectors.viewDeploymentsInNetworkGraphButton).click();
+    cy.wait(['@getDeployment', '@getNetworkGraphCluster', '@getNetworkPoliciesCluster']);
+}

--- a/ui/apps/platform/cypress/integration/network.test.js
+++ b/ui/apps/platform/cypress/integration/network.test.js
@@ -1,14 +1,24 @@
-import { url as networkUrl, selectors as networkPageSelectors } from '../constants/NetworkPage';
-import { url as riskURL, selectors as riskPageSelectors } from '../constants/RiskPage';
+import { selectors as networkPageSelectors } from '../constants/NetworkPage';
+import selectors from '../selectors/index';
 import toastSelectors from '../selectors/toast';
 import navigationSelectors from '../selectors/navigation';
 
 import * as api from '../constants/apiEndpoints';
 import withAuth from '../helpers/basicAuth';
-import selectors from '../selectors/index';
-import { selectNamespaceFilters } from '../helpers/networkGraph';
+import {
+    viewRiskDeploymentByName,
+    viewRiskDeploymentInNetworkGraph,
+    visitRiskDeployments,
+} from '../helpers/risk';
+import {
+    visitNetworkGraph,
+    visitNetworkGraphFromLeftNav,
+    visitNetworkGraphWithMockedData,
+    visitNetworkGraphWithNamespaceFilters,
+} from '../helpers/networkGraph';
 
 function uploadYAMLFile(fileName, selector) {
+    cy.intercept('POST', api.network.simulate).as('postNetworkPolicySimulate');
     cy.fixture(fileName).then((fileContent) => {
         cy.get(selector).attachFile({
             fileContent,
@@ -17,39 +27,27 @@ function uploadYAMLFile(fileName, selector) {
             encoding: 'utf8',
         });
     });
-}
-
-function navigateToNetworkGraphWithMockedData() {
-    cy.server();
-
-    cy.fixture('network/networkGraph.json').as('networkGraphJson');
-    cy.route('GET', api.network.networkGraph, '@networkGraphJson').as('networkGraph');
-
-    cy.fixture('network/networkPolicies.json').as('networkPoliciesJson');
-    cy.route('GET', api.network.networkPoliciesGraph, '@networkPoliciesJson').as('networkPolicies');
-
-    cy.visit(networkUrl);
-
-    selectNamespaceFilters('stackrox');
-
-    cy.wait('@networkGraph');
-    cy.wait('@networkPolicies');
+    cy.wait('@postNetworkPolicySimulate');
 }
 
 describe('Network page', () => {
     withAuth();
 
+    it('should visit using the left nav', () => {
+        visitNetworkGraphFromLeftNav();
+        cy.get('h1:contains("Network Graph")');
+    });
+
     it('should have selected item in nav bar', () => {
-        const networkNavigationLink = `${navigationSelectors.navLinks}:contains('Network')`;
-
-        navigateToNetworkGraphWithMockedData();
-
-        cy.get(networkNavigationLink).click();
-        cy.get(networkNavigationLink).should('have.class', 'pf-m-current');
+        visitNetworkGraph();
+        cy.get(`${navigationSelectors.navLinks}:contains('Network')`).should(
+            'have.class',
+            'pf-m-current'
+        );
     });
 
     it('should display a legend', () => {
-        navigateToNetworkGraphWithMockedData();
+        visitNetworkGraphWithMockedData();
 
         cy.get(networkPageSelectors.legend.deployments)
             .eq(0)
@@ -98,7 +96,7 @@ describe('Network page', () => {
     });
 
     it('should handle toggle click on simulator network policy button', () => {
-        navigateToNetworkGraphWithMockedData();
+        visitNetworkGraphWithMockedData();
 
         cy.get(networkPageSelectors.buttons.simulatorButtonOff).click();
         cy.get(networkPageSelectors.buttons.viewActiveYamlButton).should('be.visible');
@@ -108,7 +106,7 @@ describe('Network page', () => {
     });
 
     it('should display expected toast message when uploaded yaml without namespace', () => {
-        navigateToNetworkGraphWithMockedData();
+        visitNetworkGraphWithMockedData();
 
         cy.get(networkPageSelectors.buttons.simulatorButtonOff).click();
         uploadYAMLFile('network/policywithoutnamespace.yaml', 'input[type="file"]');
@@ -120,7 +118,7 @@ describe('Network page', () => {
     });
 
     it('should display display policies processed message when uploaded yaml with namespace', () => {
-        navigateToNetworkGraphWithMockedData();
+        visitNetworkGraphWithMockedData();
 
         cy.get(networkPageSelectors.buttons.simulatorButtonOff).click();
         uploadYAMLFile('network/policywithnamespace.yaml', 'input[type="file"]');
@@ -130,15 +128,19 @@ describe('Network page', () => {
     });
 
     it('should show the network policy simulator screen after generating network policies', () => {
-        cy.visit(riskURL);
-        cy.get(selectors.table.rows).eq(0).click({ force: true });
-        cy.get(riskPageSelectors.viewDeploymentsInNetworkGraphButton, { timeout: 10000 }).click();
-        cy.get(networkPageSelectors.networkEntityTabbedOverlay.header, { timeout: 15000 }).should(
-            'be.visible'
-        );
+        visitRiskDeployments();
+        viewRiskDeploymentByName('central');
+        viewRiskDeploymentInNetworkGraph();
+
+        cy.get(networkPageSelectors.networkEntityTabbedOverlay.header).should('be.visible');
         cy.get(networkPageSelectors.buttons.simulatorButtonOff).click();
+
+        cy.intercept('GET', api.network.generate).as('getNetworkPolicyGenerate');
+        cy.intercept('POST', api.network.simulate).as('getNetworkPolicySimulate');
         cy.get(networkPageSelectors.buttons.generateNetworkPolicies).click();
-        cy.get(networkPageSelectors.panels.simulatorPanel, { timeout: 10000 }).should('be.visible');
+        cy.wait(['@getNetworkPolicyGenerate', '@getNetworkPolicySimulate']);
+
+        cy.get(networkPageSelectors.panels.simulatorPanel).should('be.visible');
     });
 });
 
@@ -146,9 +148,10 @@ describe('Network Deployment Details', () => {
     withAuth();
 
     it('should show the port exposure levels using port configuration labels', () => {
-        cy.visit(riskURL);
-        cy.get(`${selectors.table.rows}:contains('central')`).click();
-        cy.get(riskPageSelectors.viewDeploymentsInNetworkGraphButton).click();
+        visitRiskDeployments();
+        viewRiskDeploymentByName('central');
+        viewRiskDeploymentInNetworkGraph();
+
         cy.get(`${selectors.tab.tabs}:contains('Details')`).click();
         cy.get(`[data-testid="exposure"]:contains('ClusterIP')`);
         cy.get(`[data-testid="level"]:contains('ClusterIP')`);
@@ -157,11 +160,6 @@ describe('Network Deployment Details', () => {
 
 describe('Network Policy Simulator', () => {
     withAuth();
-
-    beforeEach(() => {
-        cy.server();
-        cy.route('POST', api.network.simulate).as('simulateGraph');
-    });
 
     it('should update the graph when generating and simulating network policies', () => {
         // this will get the deployments for the 'default' and 'docker' namespace
@@ -176,8 +174,8 @@ describe('Network Policy Simulator', () => {
             return deployments;
         }
 
-        cy.visit(networkUrl);
-        selectNamespaceFilters('stackrox');
+        visitNetworkGraphWithNamespaceFilters('stackrox');
+
         cy.get(networkPageSelectors.buttons.allowedFilter).click();
         cy.getCytoscape('#cytoscapeContainer').then((cytoscape) => {
             const deployments = getDeployments(cytoscape);
@@ -186,9 +184,12 @@ describe('Network Policy Simulator', () => {
                 expect(deployment.hasClass('nonIsolated')).to.equal(true);
             });
             cy.get(networkPageSelectors.buttons.simulatorButtonOff).click();
+
+            cy.intercept('GET', api.network.generate).as('getNetworkPolicyGenerate');
+            cy.intercept('POST', api.network.simulate).as('getNetworkPolicySimulate');
             cy.get(networkPageSelectors.buttons.generateNetworkPolicies).click();
-            // wait for the graph to update with the new data
-            cy.wait('@simulateGraph');
+            cy.wait(['@getNetworkPolicyGenerate', '@getNetworkPolicySimulate']);
+
             cy.getCytoscape('#cytoscapeContainer').then((updatedCytoscape) => {
                 const simulatedDeployments = getDeployments(updatedCytoscape);
                 // After the simulated graph, we want to make sure all the deployments from 'default' and 'docker' namespaces are not non-isolated
@@ -204,9 +205,10 @@ describe('Network Flows Table', () => {
     withAuth();
 
     it('should show the proper table column headers for the network flows table', () => {
-        cy.visit(riskURL);
-        cy.get(`${selectors.table.rows}:contains('central')`).click();
-        cy.get(riskPageSelectors.viewDeploymentsInNetworkGraphButton).click();
+        visitRiskDeployments();
+        viewRiskDeploymentByName('central');
+        viewRiskDeploymentInNetworkGraph();
+
         cy.get(`${selectors.tab.tabs}:contains('Network Flows')`).click();
         cy.get(`${selectors.table.th}:contains('Entity')`);
         cy.get(`${selectors.table.th}:contains('Traffic')`);


### PR DESCRIPTION
## Description

> In a future release, support for `cy.server()` and `cy.route()` will be removed.

* Find `cy.server` in cypress/integration: from 14 results in 8 files to 12 results in 7 files.
* Find `cy.route` in cypress/integration: from 43 results in 9 files to 40 results in 8 files.

### Generic changes

https://docs.cypress.io/guides/references/migration-guide#Migrating-cy-route-to-cy-intercept

* Delete `cy.server()` and `beforeEach`
* Replace `cy.route(method, url)` with `cy.intercept(method, url)` in helper functions

### Specific changes

1. Edit constants/apiEndpoints.js
    * Add `generate` property to `network` object

2. Edit helpers/networkGraph.js
    * Add `visitNetworkGraphFromLeftNav` function
    * Factor out `visitNetworkGraph` function

2. Add helpers/risk.js

3. Edit integration/network.test.js
    * Replace `navigateToNetworkGraphWithMockedData` with `visitNetworkGraphWithMockedData` from helpers/networkGraph.js
    * Add `intercept` and `wait` in `uploadYAMLFile` helper function
    * Add `'should visit using the left nav'` test
    * Edit `'should have selected item in nav bar'` test
    * Factor out risk helper functions
    * In `'should show the network policy simulator screen after generating network policies'` test, replace `eq(0)` for first risk deployment in table with `'central'` deployment to make the test more determinate
    * Add `intercept` and `wait` to network simulator tests
    * Delete `timeout` options

### Residue

* Move to networkGraph folder when there are no or fewer changes, because git and GitHub display as delete one file and add another file if too many changes.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Ran tests one at a time in local deployment