### PR TITLE
Rename label and short-/longname of policy to be more precise.

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Form/descriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Form/descriptors.tsx
@@ -230,10 +230,10 @@ export type TextDescriptor = {
 
 // TODO: merge with policyConfigurationDescriptor after ROX_VERIFY_IMAGE_SIGNATURE enabled by default
 export const imageSigningCriteriaDescriptor: SignatureDescriptor = {
-    label: 'Trusted image signers',
+    label: 'Not verified by trusted image signers',
     name: imageSigningCriteriaName,
-    shortName: 'Trusted image signers',
-    longName: 'Trusted image signers',
+    shortName: 'Not verified by trusted image signers',
+    longName: 'Not verified by trusted image signers',
     category: policyCriteriaCategories.IMAGE_REGISTRY,
     type: 'signaturePolicyCriteria',
     canBooleanLogic: true,


### PR DESCRIPTION
## Description

Rename the label of the signature policy criteria to highlight that it will alert on images that are **not verified by any of the listed trusted image signers**.

Previously:
![Screenshot 2022-04-08 at 03 39 56](https://user-images.githubusercontent.com/89904305/162347946-08f2b1ec-478d-4e7c-b87e-8e6d5c7a3e19.png)

Now:
![Screenshot 2022-04-08 at 03 56 14](https://user-images.githubusercontent.com/89904305/162347958-08da3491-36b2-4293-888f-3ddd8fed21a2.png)
