### PR TITLE
ROX-9824: Fix panic

### DIFF
--- a/sensor/kubernetes/listener/resources/networkpolicy.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy.go
@@ -34,8 +34,7 @@ func (h *networkPolicyDispatcher) ProcessEvent(obj, old interface{}, action cent
 
 	if features.NetworkPolicySystemPolicy.Enabled() {
 		var roxOldNetpol *storage.NetworkPolicy
-		oldNp := old.(*networkingV1.NetworkPolicy)
-		if oldNp != nil {
+		if oldNp, ok := old.(*networkingV1.NetworkPolicy); ok && oldNp != nil {
 			roxOldNetpol = networkPolicyConversion.KubernetesNetworkPolicyWrap{NetworkPolicy: oldNp}.ToRoxNetworkPolicy()
 		}
 		sel := h.getSelector(roxNetpol, roxOldNetpol)

--- a/sensor/kubernetes/listener/resources/networkpolicy_test.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_test.go
@@ -149,8 +149,8 @@ func (suite *NetworkPolicyDispatcherSuite) Test_ProcessEvent() {
 	}
 
 	cases := map[string]struct {
-		netpol              *networkingV1.NetworkPolicy
-		oldNetpol           *networkingV1.NetworkPolicy
+		netpol              interface{}
+		oldNetpol           interface{}
 		action              central.ResourceAction
 		expectedEvents      map[string]*central.SensorEvent
 		expectedDeployments []*deploymentWrap
@@ -390,7 +390,7 @@ func (suite *NetworkPolicyDispatcherSuite) Test_ProcessEvent() {
 	}
 	for name, c := range cases {
 		suite.T().Run(name, func(t *testing.T) {
-			c.expectedEvents = createSensorEvent(c.netpol, c.action)
+			c.expectedEvents = createSensorEvent(c.netpol.(*networkingV1.NetworkPolicy), c.action)
 			deps := map[string]*deploymentWrap{}
 			processDeploymentMock := suite.detector.EXPECT().ProcessDeployment(gomock.Any(), gomock.Eq(central.ResourceAction_UPDATE_RESOURCE)).DoAndReturn(func(d *storage.Deployment, _ central.ResourceAction) {
 				deps[d.GetId()] = &deploymentWrap{


### PR DESCRIPTION
## Description

Apparently in some special cases (adding network policy), the `old` object was nil and we were not checking this.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
  - ~They should exist already~
  - We corrected them with @lvalerom - thanks!
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

- [x] Manual deployment of local cluster
- [x] CI
