### PR TITLE
Prevent panic when running nil/empty search queries against Postgres

### DIFF
--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -158,7 +158,7 @@ func standardizeQueryAndPopulatePath(q *v1.Query, optionsMap searchPkg.OptionsMa
 
 	fromClause := stringutils.JoinNonEmpty(", ", froms...)
 	selQuery := generateSelectFields(queryEntry, schema.LocalPrimaryKeys(), selectType)
-	pagination, err := getPaginationQuery(q.Pagination, schema, dbFields)
+	pagination, err := getPaginationQuery(q.GetPagination(), schema, dbFields)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -135,6 +135,18 @@ func TestMultiTableQueries(t *testing.T) {
 				Data:  []interface{}{"central%"},
 			},
 		},
+		{
+			desc: "nil query",
+			q:    nil,
+			expected: &query{
+				Select: selectQuery{
+					Query: "select deployments.Id",
+				},
+				From:  "deployments",
+				Where: "",
+				Data:  []interface{}{},
+			},
+		},
 	} {
 		t.Run(c.desc, func(t *testing.T) {
 			actual, err := standardizeQueryAndPopulatePath(c.q, mappings.OptionsMap, deploymentBaseSchema, GET)


### PR DESCRIPTION
## Description

Postgres integration tests for secret datastore highlighted a panic condition when looking up pagination information on nil queries.
This change prevents the situation leading to the panic.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
-~~ [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Manual testing of the tests from PR https://github.com/stackrox/stackrox/pull/942 against the development of https://github.com/stackrox/stackrox/pull/1235