### PR TITLE
ROX-7580: Use standard StackRox logo for init-bundles on integrations page

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.js
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.js
@@ -9,7 +9,6 @@ import email from 'images/email.svg';
 import google from 'images/google-cloud.svg';
 import googleregistry from 'images/google-container.svg';
 import googleartifact from 'images/google-artifact.svg';
-import helm from 'images/helm.svg';
 import ibm from 'images/ibm-ccr.svg';
 import jira from 'images/jira.svg';
 import logo from 'images/StackRox-integration-logo.svg';
@@ -46,7 +45,7 @@ const integrationsList = {
             label: 'Cluster Init Bundle',
             type: 'clusterInitBundle',
             source: 'authProviders',
-            image: helm,
+            image: logo,
         },
     ],
     imageIntegrations: [


### PR DESCRIPTION
## Description

Replace Helm logo for init-bundles on integrations page with StackRox logo because init-bundles are not Helm-specific anymore, as they are also used in the context of operator-managed deployments

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
