### PR TITLE
Replace cypress server and route with intercept in networkGraph part 3

### DIFF
--- a/ui/apps/platform/cypress/constants/NetworkPage.js
+++ b/ui/apps/platform/cypress/constants/NetworkPage.js
@@ -48,6 +48,7 @@ export const selectors = {
         allFilter: 'button[data-testid="network-connections-filter-all"]:contains("all")',
         hideNsEdgesFilter: '[data-testid="namespace-flows-filter"] button:contains("Hide")',
         stopSimulation: '.simulator-mode button:contains("Stop")',
+        confirmationButton: 'button:contains("Yes")',
     },
     detailsPanel: scopeSelectors(networkPanels.detailsPanel, {
         header: '[data-testid="network-details-panel-header"]',

--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -140,15 +140,15 @@ export const dashboard = {
 export const metadata = 'v1/metadata';
 
 export const network = {
-    networkBaselineLock: '/v1/networkbaseline/**/lock',
-    networkBaselineUnlock: '/v1/networkbaseline/**/unlock',
-    networkBaseline: '/v1/networkbaseline/**',
-    networkBaselineStatus: '/v1/networkbaseline/**/status',
+    networkBaselineLock: '/v1/networkbaseline/*/lock',
+    networkBaselineUnlock: '/v1/networkbaseline/*/unlock',
+    networkBaselinePeers: '/v1/networkbaseline/*/peers',
+    networkBaselineStatus: '/v1/networkbaseline/*/status',
     networkPoliciesGraph: '/v1/networkpolicies/cluster/*',
     networkGraph: '/v1/networkgraph/cluster/*',
     epoch: '/v1/networkpolicies/graph/epoch',
     simulate: '/v1/networkpolicies/simulate/*',
-    deployment: 'v1/deployments/*',
+    deployment: '/v1/deployments/*',
 };
 
 export const policies = {

--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -28,6 +28,12 @@ export function clickOnNodeByName(cytoscape, node) {
     filteredNodes.emit('click');
 }
 
+export function clickOnDeploymentNodeByName(cytoscape, name) {
+    cy.intercept('GET', api.network.deployment).as('getDeployment');
+    clickOnNodeByName(cytoscape, { type: 'DEPLOYMENT', name });
+    cy.wait('@getDeployment');
+}
+
 export function mouseOverNodeById(cytoscape, node) {
     const element = cytoscape.getElementById(node.id);
     if (!element) {
@@ -116,6 +122,16 @@ export function filterBySourceTarget(sourceNode, targetNode) {
             `An edge type between a (${sourceNode.type}) and (${targetNode.type}) does not exist`
         );
     };
+}
+
+// network flows
+
+export function clickConfirmationButton() {
+    cy.intercept('GET', api.network.networkGraph).as('networkGraph');
+    cy.intercept('GET', api.network.networkPoliciesGraph).as('networkPoliciesGraph');
+    cy.intercept('POST', api.network.networkBaselineStatus).as('networkBaselineStatus');
+    cy.get(networkGraphSelectors.buttons.confirmationButton).click();
+    cy.wait(['@networkGraph', '@networkPoliciesGraph', '@networkBaselineStatus']);
 }
 
 // search filters

--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -124,16 +124,6 @@ export function filterBySourceTarget(sourceNode, targetNode) {
     };
 }
 
-// network flows
-
-export function clickConfirmationButton() {
-    cy.intercept('GET', api.network.networkGraph).as('networkGraph');
-    cy.intercept('GET', api.network.networkPoliciesGraph).as('networkPoliciesGraph');
-    cy.intercept('POST', api.network.networkBaselineStatus).as('networkBaselineStatus');
-    cy.get(networkGraphSelectors.buttons.confirmationButton).click();
-    cy.wait(['@networkGraph', '@networkPoliciesGraph', '@networkBaselineStatus']);
-}
-
 // search filters
 
 export function selectDeploymentFilter(deploymentName) {

--- a/ui/apps/platform/cypress/integration/networkGraph/networkFlows.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkFlows.test.js
@@ -1,41 +1,31 @@
-import { url as networkUrl, selectors as networkPageSelectors } from '../../constants/NetworkPage';
+import { selectors as networkPageSelectors } from '../../constants/NetworkPage';
 import selectors from '../../selectors';
 import * as api from '../../constants/apiEndpoints';
 import withAuth from '../../helpers/basicAuth';
-import { clickOnNodeByName, selectNamespaceFilters } from '../../helpers/networkGraph';
+import {
+    clickConfirmationButton,
+    clickOnDeploymentNodeByName,
+    visitNetworkGraphWithNamespaceFilters,
+} from '../../helpers/networkGraph';
 
 const tableDataRows = 'table tr[data-testid="data-row"]';
 const tableStatusHeaders = 'table tr[data-testid="subhead-row"]';
 const sensorTableRow = `${tableDataRows}:contains("sensor")`;
-const confirmationButton = 'button:contains("Yes")';
 const markAsAnomalousButton = `${sensorTableRow} button:contains("Mark as anomalous")`;
 const baselineSettingsTab = `${selectors.tab.tabs}:contains('Baseline Settings')`;
 
 describe('Network Baseline Flows', () => {
     withAuth();
-    beforeEach(() => {
-        cy.server();
-
-        cy.route('GET', api.network.networkPoliciesGraph).as('networkPoliciesGraph');
-        cy.route('GET', api.network.networkGraph).as('networkGraph');
-        cy.route('GET', api.network.networkBaseline).as('networkBaseline');
-        cy.route('POST', api.network.networkBaselineStatus).as('networkBaselineStatus');
-        cy.route('PATCH', api.network.networkBaselineLock).as('networkBaselineLock');
-        cy.route('PATCH', api.network.networkBaselineUnlock).as('networkBaselineUnlock');
-
-        cy.visit(networkUrl);
-        selectNamespaceFilters('stackrox');
-        cy.wait('@networkPoliciesGraph');
-        cy.wait('@networkGraph');
-    });
 
     describe('Navigating to Deployment', () => {
         it('should navigate to a different deployment when clicking the "Navigate" button', () => {
+            visitNetworkGraphWithNamespaceFilters('stackrox');
+
             cy.getCytoscape(networkPageSelectors.cytoscapeContainer).then((cytoscape) => {
                 const tabbedOverlayHeader = '[data-testid="network-entity-tabbed-overlay-header"]';
                 const navigateButton = `${sensorTableRow} button:contains("Navigate")`;
 
-                clickOnNodeByName(cytoscape, { type: 'DEPLOYMENT', name: 'central' });
+                clickOnDeploymentNodeByName(cytoscape, 'central');
 
                 cy.get(tabbedOverlayHeader).contains('central');
 
@@ -49,8 +39,10 @@ describe('Network Baseline Flows', () => {
 
     describe('Active Network Flows', () => {
         it('should show anomalous flows section above the baseline flows', () => {
+            visitNetworkGraphWithNamespaceFilters('stackrox');
+
             cy.getCytoscape(networkPageSelectors.cytoscapeContainer).then((cytoscape) => {
-                clickOnNodeByName(cytoscape, { type: 'DEPLOYMENT', name: 'central' });
+                clickOnDeploymentNodeByName(cytoscape, 'central');
 
                 cy.get(tableStatusHeaders).eq(0).contains('Anomalous Flow');
                 cy.get(tableStatusHeaders).eq(1).contains('Baseline Flow');
@@ -60,65 +52,65 @@ describe('Network Baseline Flows', () => {
 
     describe('Toggling Status of Active Baseline Network Flows', () => {
         it('should be able to toggle status of a single flow', () => {
+            visitNetworkGraphWithNamespaceFilters('stackrox');
+
             cy.getCytoscape(networkPageSelectors.cytoscapeContainer).then((cytoscape) => {
                 const addToBaselineButton = `${sensorTableRow} button:contains("Add to baseline")`;
 
-                clickOnNodeByName(cytoscape, { type: 'DEPLOYMENT', name: 'central' });
+                clickOnDeploymentNodeByName(cytoscape, 'central');
+
+                cy.intercept('GET', api.network.networkGraph).as('networkGraph');
+                cy.intercept('GET', api.network.networkPoliciesGraph).as('networkPoliciesGraph');
+                cy.intercept('POST', api.network.networkBaselineStatus).as('networkBaselineStatus');
 
                 // marking a baseline flow as anomalous should show up as anomalous
                 cy.get(sensorTableRow).trigger('mouseover');
                 cy.get(markAsAnomalousButton).click();
-                cy.wait('@networkPoliciesGraph');
-                cy.wait('@networkGraph');
-                cy.wait('@networkBaselineStatus');
+                cy.wait(['@networkGraph', '@networkPoliciesGraph', '@networkBaselineStatus']);
                 cy.get(sensorTableRow).trigger('mouseover');
                 cy.get(addToBaselineButton);
 
                 // marking an anomalous flow as baseline should show up as baseline
                 cy.get(addToBaselineButton).click();
-                cy.wait('@networkPoliciesGraph');
-                cy.wait('@networkGraph');
-                cy.wait('@networkBaselineStatus');
+                cy.wait(['@networkGraph', '@networkPoliciesGraph', '@networkBaselineStatus']);
                 cy.get(sensorTableRow).trigger('mouseover');
                 cy.get(markAsAnomalousButton);
             });
         });
 
         it('should be able to toggle status of all flows', () => {
+            visitNetworkGraphWithNamespaceFilters('stackrox');
+
             cy.getCytoscape(networkPageSelectors.cytoscapeContainer).then((cytoscape) => {
                 const markAllAsAnomalousButton = 'button:contains("Mark all as anomalous")';
                 const addAllToBaselineButton = 'button:contains("Add all to baseline")';
                 const noAnomalousFlows = 'td:contains("No anomalous flows")';
                 const noBaselineFlows = 'td:contains("No baseline flows")';
 
-                clickOnNodeByName(cytoscape, { type: 'DEPLOYMENT', name: 'central' });
+                clickOnDeploymentNodeByName(cytoscape, 'central');
 
                 // marking all baseline flows as anomalous should show up as anomalous
                 cy.get(markAllAsAnomalousButton).click();
-                cy.get(confirmationButton).click();
-                cy.wait('@networkPoliciesGraph');
-                cy.wait('@networkGraph');
-                cy.wait('@networkBaselineStatus');
+                clickConfirmationButton();
                 cy.get(noBaselineFlows);
 
                 // marking all anomalous flows as baseline should show up as baseline
                 cy.get(addAllToBaselineButton).click();
-                cy.get(confirmationButton).click();
-                cy.wait('@networkPoliciesGraph');
-                cy.wait('@networkGraph');
-                cy.wait('@networkBaselineStatus');
+                clickConfirmationButton();
                 cy.get(noAnomalousFlows);
             });
         });
 
         it('should be able to toggle status of selected flows', () => {
+            visitNetworkGraphWithNamespaceFilters('stackrox');
+
             cy.getCytoscape(networkPageSelectors.cytoscapeContainer).then((cytoscape) => {
                 const anomalousStatusHeader = `${tableStatusHeaders}:eq(0)`;
                 const sensorTableRowCheckbox = `${sensorTableRow} input[type=checkbox]`;
                 const markSelectedAsAnomalousButton = 'button:contains("Mark 1 as anomalous")';
                 const addSelectedToBaselineButton = 'button:contains("Add 1 to baseline")';
 
-                clickOnNodeByName(cytoscape, { type: 'DEPLOYMENT', name: 'central' });
+                clickOnDeploymentNodeByName(cytoscape, 'central');
 
                 cy.get(anomalousStatusHeader)
                     .invoke('text')
@@ -133,19 +125,13 @@ describe('Network Baseline Flows', () => {
                         // marking selected baseline flows as anomalous should show up as anomalous
                         cy.get(sensorTableRowCheckbox).check();
                         cy.get(markSelectedAsAnomalousButton).click();
-                        cy.get(confirmationButton).click();
-                        cy.wait('@networkPoliciesGraph');
-                        cy.wait('@networkGraph');
-                        cy.wait('@networkBaselineStatus');
+                        clickConfirmationButton();
                         cy.get(postAnomalousFlowsText);
 
                         // marking selected anomalous flows as baseline should show up as baseline
                         cy.get(sensorTableRowCheckbox).check();
                         cy.get(addSelectedToBaselineButton).click();
-                        cy.get(confirmationButton).click();
-                        cy.wait('@networkPoliciesGraph');
-                        cy.wait('@networkGraph');
-                        cy.wait('@networkBaselineStatus');
+                        clickConfirmationButton();
                         cy.get(prevAnomalousFlowsText);
                     });
             });
@@ -154,20 +140,25 @@ describe('Network Baseline Flows', () => {
 
     describe('Baseline Settings', () => {
         it('should not show the anomalous flows section', () => {
+            visitNetworkGraphWithNamespaceFilters('stackrox');
+
             cy.getCytoscape(networkPageSelectors.cytoscapeContainer).then((cytoscape) => {
-                clickOnNodeByName(cytoscape, { type: 'DEPLOYMENT', name: 'central' });
+                clickOnDeploymentNodeByName(cytoscape, 'central');
+
                 cy.get(baselineSettingsTab).click();
                 cy.get(tableStatusHeaders).eq(0).contains('Baseline Flow');
             });
         });
 
         it('should be able to toggle status of a single baseline flow', () => {
+            visitNetworkGraphWithNamespaceFilters('stackrox');
+
             cy.getCytoscape(networkPageSelectors.cytoscapeContainer).then((cytoscape) => {
                 const baselineStatusHeader = `${tableStatusHeaders}:eq(0)`;
 
-                clickOnNodeByName(cytoscape, { type: 'DEPLOYMENT', name: 'central' });
-                cy.get(baselineSettingsTab).click();
+                clickOnDeploymentNodeByName(cytoscape, 'central');
 
+                cy.get(baselineSettingsTab).click();
                 cy.get(baselineStatusHeader)
                     .invoke('text')
                     .then((baselineFlowsText) => {
@@ -178,11 +169,21 @@ describe('Network Baseline Flows', () => {
                         } Baseline Flow")`;
 
                         // marking a baseline flow as anomalous should remove it from the baseline
+                        cy.intercept('PATCH', api.network.networkBaselinePeers).as(
+                            'networkBaselinePeers'
+                        );
+                        cy.intercept('GET', api.network.networkGraph).as('networkGraph');
+                        cy.intercept('GET', api.network.networkPoliciesGraph).as(
+                            'networkPoliciesGraph'
+                        );
                         cy.get(sensorTableRow).trigger('mouseover');
                         cy.get(markAsAnomalousButton).click();
-                        cy.wait('@networkPoliciesGraph');
-                        cy.wait('@networkGraph');
-                        cy.wait('@networkBaselineStatus');
+                        cy.wait([
+                            '@networkBaselinePeers',
+                            '@networkGraph',
+                            '@networkPoliciesGraph',
+                        ]);
+
                         cy.get(postNumBaselineFlowsText);
                     });
             });
@@ -190,18 +191,30 @@ describe('Network Baseline Flows', () => {
 
         describe('Cluster with Helm management', () => {
             it('should toggle the alert on baseline violations toggle', () => {
+                visitNetworkGraphWithNamespaceFilters('stackrox');
+
                 cy.getCytoscape(networkPageSelectors.cytoscapeContainer).then((cytoscape) => {
-                    const baselineViolationsToggle = '[data-testid="toggle-switch-checkbox"]';
-                    clickOnNodeByName(cytoscape, { type: 'DEPLOYMENT', name: 'central' });
+                    clickOnDeploymentNodeByName(cytoscape, 'central');
+
                     cy.get(baselineSettingsTab).click();
+
+                    const baselineViolationsToggle = '[data-testid="toggle-switch-checkbox"]';
+
                     cy.get(baselineViolationsToggle).should('not.be.checked');
+
+                    cy.intercept('PATCH', api.network.networkBaselineLock).as(
+                        'networkBaselineLock'
+                    );
                     cy.get(baselineViolationsToggle).check({ force: true });
                     cy.wait('@networkBaselineLock');
-                    cy.wait('@networkBaseline');
+
                     cy.get(baselineViolationsToggle).should('be.checked');
+                    cy.intercept('PATCH', api.network.networkBaselineUnlock).as(
+                        'networkBaselineUnlock'
+                    );
                     cy.get(baselineViolationsToggle).uncheck({ force: true });
                     cy.wait('@networkBaselineUnlock');
-                    cy.wait('@networkBaseline');
+
                     cy.get(baselineViolationsToggle).should('not.be.checked');
                 });
             });

--- a/ui/apps/platform/cypress/integration/networkGraph/networkFlows.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkFlows.test.js
@@ -3,7 +3,6 @@ import selectors from '../../selectors';
 import * as api from '../../constants/apiEndpoints';
 import withAuth from '../../helpers/basicAuth';
 import {
-    clickConfirmationButton,
     clickOnDeploymentNodeByName,
     visitNetworkGraphWithNamespaceFilters,
 } from '../../helpers/networkGraph';
@@ -13,6 +12,14 @@ const tableStatusHeaders = 'table tr[data-testid="subhead-row"]';
 const sensorTableRow = `${tableDataRows}:contains("sensor")`;
 const markAsAnomalousButton = `${sensorTableRow} button:contains("Mark as anomalous")`;
 const baselineSettingsTab = `${selectors.tab.tabs}:contains('Baseline Settings')`;
+
+function clickFlowsConfirmationButton() {
+    cy.intercept('GET', api.network.networkGraph).as('networkGraph');
+    cy.intercept('GET', api.network.networkPoliciesGraph).as('networkPoliciesGraph');
+    cy.intercept('POST', api.network.networkBaselineStatus).as('networkBaselineStatus');
+    cy.get(networkPageSelectors.buttons.confirmationButton).click();
+    cy.wait(['@networkGraph', '@networkPoliciesGraph', '@networkBaselineStatus']);
+}
 
 describe('Network Baseline Flows', () => {
     withAuth();
@@ -91,12 +98,12 @@ describe('Network Baseline Flows', () => {
 
                 // marking all baseline flows as anomalous should show up as anomalous
                 cy.get(markAllAsAnomalousButton).click();
-                clickConfirmationButton();
+                clickFlowsConfirmationButton();
                 cy.get(noBaselineFlows);
 
                 // marking all anomalous flows as baseline should show up as baseline
                 cy.get(addAllToBaselineButton).click();
-                clickConfirmationButton();
+                clickFlowsConfirmationButton();
                 cy.get(noAnomalousFlows);
             });
         });
@@ -125,13 +132,13 @@ describe('Network Baseline Flows', () => {
                         // marking selected baseline flows as anomalous should show up as anomalous
                         cy.get(sensorTableRowCheckbox).check();
                         cy.get(markSelectedAsAnomalousButton).click();
-                        clickConfirmationButton();
+                        clickFlowsConfirmationButton();
                         cy.get(postAnomalousFlowsText);
 
                         // marking selected anomalous flows as baseline should show up as baseline
                         cy.get(sensorTableRowCheckbox).check();
                         cy.get(addSelectedToBaselineButton).click();
-                        clickConfirmationButton();
+                        clickFlowsConfirmationButton();
                         cy.get(prevAnomalousFlowsText);
                     });
             });


### PR DESCRIPTION
## Description

> In a future release, support for `cy.server()` and `cy.route()` will be removed.

* Find `cy.server` in cypress/integration: from 12 results in 7 files to 11 results in 6 files.
* Find `cy.route` in cypress/integration: from 40 results in 8 files to 34 results in 7 files.

### Generic changes

https://docs.cypress.io/guides/references/migration-guide#Migrating-cy-route-to-cy-intercept

* Delete `cy.server()` and `beforeEach`
* Replace `cy.route(method, url)` with `cy.intercept(method, url)` in helper functions
* Adjust wildcards in url strings for minimatch

### Specific changes

1. Edit constants/apiEndpoints.js
    * Replace unused generic `networkBaseline` endpoint with specific `networkBaselinePeers` endpoint
    * Replace `**` with `*` to match **next** segment, instead of all segments, preceding `lock`, `unlock`, `status`, and `peers`
    * Add missing slash to `deployment` endpoint

2. Edit constants/NetworkPage.js
    * Add `confirmationButton` selector

3. Edit helpers/networkGraph.js
    * Add `clickOnDeploymentNodeByName` function which waits on requests

4. Edit integration/networkGraph/networkFlows.test.js
    * Replace `beforeEach` call with `visitNetworkGraphWithNamespaceFilters` call in each test
    * Replace `clickOnNodeByName` with `clickOnDeploymentNodeByName` function
    * Factor out `clickFlowsConfirmationButton` function
    * Add explicit `intercept` and `wait` sandwich for some requests in tests

### Residue

Requests in Network panel after you click a deployment node:
1. /v1/deployments/id
2. /v1/networkpolicies/id
3. /v1/deployments/id
4. /v1/networkpolicies/id
5. /v1/deployments/id

The repeated pairs of requests, followed by single deployments request, might explain why `cy.wait` passes for deployments only, but fails for deployments and networkpolicies.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Ran tests one at a time in local deployment

Each time that `'should be able to toggle status of a single baseline flow'` failed, I needed to teardown and redeploy, because it removes the flow from the baseline