### PR TITLE
ROX-10010: Improved unit tests for roxctl scanner update-db

### DIFF
--- a/roxctl/scanner/uploaddb/uploaddb_test.go
+++ b/roxctl/scanner/uploaddb/uploaddb_test.go
@@ -96,9 +96,6 @@ func TestScannerUploadDbCommand(t *testing.T) {
 		stdOut, stdErr, err := executeUpdateDbCommand(server.URL)
 
 		require.NoError(t, err)
-		require.NotNil(t, stdErr)
-		require.NotNil(t, stdOut)
-
 		assert.Empty(t, stdErr.String())
 		assert.Equal(t, fmt.Sprintln(expectedResult), stdOut.String())
 	})

--- a/roxctl/scanner/uploaddb/uploaddb_test.go
+++ b/roxctl/scanner/uploaddb/uploaddb_test.go
@@ -76,10 +76,14 @@ func TestScannerUploadDbCommand(t *testing.T) {
 		}))
 		defer server.Close()
 
-		stdOut, _, err := executeUpdateDbCommand(server.URL)
+		stdOut, stdErr, err := executeUpdateDbCommand(server.URL)
 
 		require.Error(t, err)
-		assert.NotNil(t, stdOut)
+		require.NotNil(t, stdOut)
+		require.NotNil(t, stdErr)
+
+		assert.Empty(t, stdOut.String())
+		assert.Empty(t, stdErr.String())
 	})
 
 	t.Run("scanner update-db", func(t *testing.T) {

--- a/roxctl/scanner/uploaddb/uploaddb_test.go
+++ b/roxctl/scanner/uploaddb/uploaddb_test.go
@@ -3,6 +3,7 @@ package uploaddb
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
@@ -33,6 +34,10 @@ func executeUpdateDbCommand(serverURL string) (*bytes.Buffer, *bytes.Buffer, err
 	flags.AddTimeout(cmd)
 	flags.AddConnectionFlags(cmd)
 	flags.AddPassword(cmd)
+
+	cmd.SilenceUsage = true
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	cmdArgs := []string{"--insecure-skip-tls-verify", "--insecure", "--endpoint", serverURL, "--password", "test"}
 	cmdArgs = append(cmdArgs, "--scanner-db-file", tmpFile.Name())

--- a/roxctl/scanner/uploaddb/uploaddb_test.go
+++ b/roxctl/scanner/uploaddb/uploaddb_test.go
@@ -39,6 +39,9 @@ func executeUpdateDbCommand(serverURL string) (*bytes.Buffer, *bytes.Buffer, err
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 
+	// We are using common.DoHTTPRequestAndCheck200 inside uploadDd(). This
+	// function uses  global variables that are set by command execution.
+	// TODO: Change uploadDd function to use HTTPClient from Environment.
 	cmdArgs := []string{"--insecure-skip-tls-verify", "--insecure", "--endpoint", serverURL, "--password", "test"}
 	cmdArgs = append(cmdArgs, "--scanner-db-file", tmpFile.Name())
 	cmd.SetArgs(cmdArgs)


### PR DESCRIPTION
## Description

We have refactored the command with the following PR #1203, but we still didn't fully cover it with unit tests. This PR covers the rest of the functionality with unit tests.

Tests added:
- server error (fe. internal server error, etc.)
- fail reading server response
- the successful execution of the update-db command

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ - no command option changes
- ~~[ ] Determined and documented upgrade steps~~ - no required update steps for clients
- ~~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~ - no user facing changes

## Testing Performed

Since it's additional tests, it sufficient to run them in the following way:
```
cd roxctl/scanner/uploaddb
go test -v
```
