### PR TITLE
Increase the size of the pod cache

### DIFF
--- a/central/pod/store/cache/cache.go
+++ b/central/pod/store/cache/cache.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	maxCachedPodSize = 5 * size.KB // if it's larger than 5KB, then we aren't going to cache it
-	maxCacheSize     = 20 * size.MB
+	maxCacheSize     = 200 * size.MB
 )
 
 var (


### PR DESCRIPTION
## Description

The pod cache is actually too small for large deployments. Saw this on the scaled up postgres test

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Trivial