### PR TITLE
ROX-9855: Enable image signature verification feature flag by default.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2619,7 +2619,6 @@ jobs:
       - ADMISSION_CONTROLLER_UPDATES: true
       - AUTH0_SUPPORT: false
       - ROX_NETWORK_BASELINE_OBSERVATION_PERIOD: 2m
-      - ROX_VERIFY_IMAGE_SIGNATURE: true
 
     steps:
       - checkout
@@ -3491,7 +3490,6 @@ jobs:
       - ROXDEPLOY_CONFIG_FILE_MAP: "scripts/ci/endpoints/endpoints.yaml"
       - SENSOR_HELM_DEPLOY: true
       - ROX_ACTIVE_VULN_REFRESH_INTERVAL: 1m
-      - ROX_VERIFY_IMAGE_SIGNATURE: true
 
     steps:
       - checkout
@@ -3645,7 +3643,6 @@ jobs:
       - OUTPUT_FORMAT: helm
       - ROX_SYSTEM_HEALTH_PF: true
       - ROX_POLICIES_PATTERNFLY: true
-      - ROX_VERIFY_IMAGE_SIGNATURE: true
       - ROX_NETWORK_DETECTION_BLOCKED_FLOWS: true
 
     steps:
@@ -3712,7 +3709,6 @@ jobs:
       - ADMISSION_CONTROLLER: true
       - ADMISSION_CONTROLLER_UPDATES: true
       - ROX_NETWORK_BASELINE_OBSERVATION_PERIOD: 2m
-      - ROX_VERIFY_IMAGE_SIGNATURE: true
 
     steps:
       - run-qa-tests:
@@ -3735,7 +3731,6 @@ jobs:
       - ADMISSION_CONTROLLER: true
       - ADMISSION_CONTROLLER_UPDATES: true
       - ROX_NETWORK_BASELINE_OBSERVATION_PERIOD: 2m
-      - ROX_VERIFY_IMAGE_SIGNATURE: true
       - ROX_POSTGRES_DATASTORE: true
 
     steps:
@@ -3763,7 +3758,6 @@ jobs:
       - OUTPUT_FORMAT: helm
       - SENSOR_HELM_DEPLOY: true
       - ROX_NETWORK_BASELINE_OBSERVATION_PERIOD: 2m
-      - ROX_VERIFY_IMAGE_SIGNATURE: true
 
     steps:
       - run-qa-tests:
@@ -3823,7 +3817,6 @@ jobs:
       - STORAGE_SIZE: 100
       - LOAD_BALANCER: lb
       - OUTPUT_FORMAT: helm
-      - ROX_VERIFY_IMAGE_SIGNATURE: true
 
     steps:
       - checkout
@@ -3972,7 +3965,6 @@ jobs:
       - SENSOR_HELM_DEPLOY: true
       - ROX_NETWORK_BASELINE_OBSERVATION_PERIOD: 2m
       - ROX_BASELINE_GENERATION_DURATION: 1m
-      - ROX_VERIFY_IMAGE_SIGNATURE: true
 
     steps:
       - check-label-exists-or-skip:
@@ -3993,7 +3985,6 @@ jobs:
       - ADMISSION_CONTROLLER: true
       - ADMISSION_CONTROLLER_UPDATES: true
       - ROX_NETWORK_BASELINE_OBSERVATION_PERIOD: 2m
-      - ROX_VERIFY_IMAGE_SIGNATURE: true
 
     steps:
       - check-label-exists-or-skip:
@@ -4016,7 +4007,6 @@ jobs:
       - ADMISSION_CONTROLLER: true
       - ADMISSION_CONTROLLER_UPDATES: true
       - ROX_NETWORK_BASELINE_OBSERVATION_PERIOD: 2m
-      - ROX_VERIFY_IMAGE_SIGNATURE: true
 
     steps:
       - checkout
@@ -4106,7 +4096,6 @@ jobs:
       - ADMISSION_CONTROLLER: true
       - ADMISSION_CONTROLLER_UPDATES: true
       - ROX_NETWORK_BASELINE_OBSERVATION_PERIOD: 2m
-      - ROX_VERIFY_IMAGE_SIGNATURE: true
 
     steps:
       - run-qa-tests:
@@ -4143,7 +4132,6 @@ jobs:
       - ADMISSION_CONTROLLER: true
       - ADMISSION_CONTROLLER_UPDATES: true
       - ROX_NETWORK_BASELINE_OBSERVATION_PERIOD: 2m
-      - ROX_VERIFY_IMAGE_SIGNATURE: true
 
     steps:
       - run-qa-tests:
@@ -4717,7 +4705,6 @@ jobs:
       - ADMISSION_CONTROLLER: true
       - ADMISSION_CONTROLLER_UPDATES: true
       - ROX_NETWORK_BASELINE_OBSERVATION_PERIOD: 2m
-      - ROX_VERIFY_IMAGE_SIGNATURE: true
 
     steps:
       - run-qa-tests:
@@ -4757,7 +4744,6 @@ jobs:
       - ADMISSION_CONTROLLER: true
       - ADMISSION_CONTROLLER_UPDATES: true
       - ROX_NETWORK_BASELINE_OBSERVATION_PERIOD: 2m
-      - ROX_VERIFY_IMAGE_SIGNATURE: true
 
     steps:
       - run-qa-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,6 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - Fixed permissions checks in the UI that prevented users with certain limited permissions from creating report configurations.
 - ROX-9946: Fixed default permissions for the default Vuln Reporter role to exclude the modify permission on notifiers, since it is not needed for report creation.
 - Added AllowPrivilegeEscalation as a new policy criteria.
-- Image signatures are now supported throughout the system, specifically cosign signatures. A new integration type for
-  signature verification has been added as well as a new policy criteria to alert on images whose signature cannot be
-  verified.
 
 ## [69.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - A new default policy added to detect Spring Cloud Function RCE vulnerability (CVE-2022-22963) and Spring Framework Spring4Shell RCE vulnerability (CVE-2022-22965).
 - Fixed permissions checks in the UI that prevented users with certain limited permissions from creating report configurations.
 - ROX-9946: Fixed default permissions for the default Vuln Reporter role to exclude the modify permission on notifiers, since it is not needed for report creation.
+- Image signatures are now supported throughout the system, specifically cosign signatures. A new integration type for
+  signature verification has been added as well as a new policy criteria to alert on images whose signature cannot be
+  verified.
 
 ## [69.1]
 

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -12,11 +12,13 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac"
 )
 
 const (
@@ -239,11 +241,25 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.SignatureIntegr
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SignatureIntegration) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Upsert, "SignatureIntegration")
 
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(resources.SignatureIntegration)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
 	return s.upsert(ctx, obj)
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SignatureIntegration) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "SignatureIntegration")
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(resources.SignatureIntegration)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)
@@ -255,6 +271,11 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SignatureInt
 // Count returns the number of objects in the store
 func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Count, "SignatureIntegration")
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(resources.SignatureIntegration)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil || !ok {
+		return 0, err
+	}
 
 	row := s.db.QueryRow(ctx, countStmt)
 	var count int
@@ -268,6 +289,13 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Exists, "SignatureIntegration")
 
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(resources.SignatureIntegration)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return false, err
+	} else if !ok {
+		return false, nil
+	}
+
 	row := s.db.QueryRow(ctx, existsStmt, id)
 	var exists bool
 	if err := row.Scan(&exists); err != nil {
@@ -279,6 +307,13 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 // Get returns the object, if it exists from the store
 func (s *storeImpl) Get(ctx context.Context, id string) (*storage.SignatureIntegration, bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "SignatureIntegration")
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(resources.SignatureIntegration)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return nil, false, err
+	} else if !ok {
+		return nil, false, nil
+	}
 
 	conn, release, err := s.acquireConn(ctx, ops.Get, "SignatureIntegration")
 	if err != nil {
@@ -312,6 +347,13 @@ func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pg
 func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "SignatureIntegration")
 
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(resources.SignatureIntegration)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
 	conn, release, err := s.acquireConn(ctx, ops.Remove, "SignatureIntegration")
 	if err != nil {
 		return err
@@ -327,6 +369,13 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 // GetIDs returns all the IDs for the store
 func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "storage.SignatureIntegrationIDs")
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(resources.SignatureIntegration)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, nil
+	}
 
 	rows, err := s.db.Query(ctx, getIDsStmt)
 	if err != nil {
@@ -347,6 +396,13 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 // GetMany returns the objects specified by the IDs or the index in the missing indices slice
 func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.SignatureIntegration, []int, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "SignatureIntegration")
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(resources.SignatureIntegration)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return nil, nil, err
+	} else if !ok {
+		return nil, nil, nil
+	}
 
 	conn, release, err := s.acquireConn(ctx, ops.GetMany, "SignatureIntegration")
 	if err != nil {
@@ -395,6 +451,13 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Signa
 // Delete removes the specified IDs from the store
 func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.RemoveMany, "SignatureIntegration")
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(resources.SignatureIntegration)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
 
 	conn, release, err := s.acquireConn(ctx, ops.RemoveMany, "SignatureIntegration")
 	if err != nil {

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -40,7 +40,7 @@ var (
 	LocalImageScanning = registerFeature("Enable OpenShift local-image scanning", "ROX_LOCAL_IMAGE_SCANNING", true)
 
 	// ImageSignatureVerification enables image signature verification.
-	ImageSignatureVerification = registerFeature("Enable Image Signature Verification workflow", "ROX_VERIFY_IMAGE_SIGNATURE", false)
+	ImageSignatureVerification = registerFeature("Enable Image Signature Verification workflow", "ROX_VERIFY_IMAGE_SIGNATURE", true)
 
 	// PostgresDatastore enables Postgres datastore.
 	PostgresDatastore = registerFeature("Enable Postgres Datastore", "ROX_POSTGRES_DATASTORE", false)

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -575,6 +575,10 @@ func (e *enricherImpl) enrichWithSignature(ctx context.Context, enrichmentContex
 
 	matchingRegistries, err := getMatchingRegistries(registrySet.GetAll(), img)
 	if err != nil {
+		// Do not return an error for internal images when no integration is found.
+		if enrichmentContext.Internal {
+			return false, nil
+		}
 		return false, errors.Wrapf(err, "getting matching registries for image %q", imgName)
 	}
 

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -453,16 +453,18 @@ func TestCVESuppression(t *testing.T) {
 	mockReporter.EXPECT().UpdateIntegrationHealthAsync(gomock.Any()).AnyTimes()
 
 	enricherImpl := &enricherImpl{
-		cvesSuppressor:            &fakeCVESuppressor{},
-		cvesSuppressorV2:          &fakeCVESuppressorV2{},
-		integrations:              set,
-		errorsPerScanner:          map[scannertypes.ImageScannerWithDataSource]int32{fsr: 0},
-		errorsPerRegistry:         map[types.ImageRegistry]int32{fsr: 0},
-		integrationHealthReporter: mockReporter,
-		metadataLimiter:           rate.NewLimiter(rate.Every(50*time.Millisecond), 1),
-		metadataCache:             expiringcache.NewExpiringCache(1 * time.Minute),
-		metrics:                   newMetrics(pkgMetrics.CentralSubsystem),
-		imageGetter:               emptyImageGetter,
+		cvesSuppressor:             &fakeCVESuppressor{},
+		cvesSuppressorV2:           &fakeCVESuppressorV2{},
+		integrations:               set,
+		errorsPerScanner:           map[scannertypes.ImageScannerWithDataSource]int32{fsr: 0},
+		errorsPerRegistry:          map[types.ImageRegistry]int32{fsr: 0},
+		integrationHealthReporter:  mockReporter,
+		metadataLimiter:            rate.NewLimiter(rate.Every(50*time.Millisecond), 1),
+		metadataCache:              expiringcache.NewExpiringCache(1 * time.Minute),
+		metrics:                    newMetrics(pkgMetrics.CentralSubsystem),
+		imageGetter:                emptyImageGetter,
+		signatureIntegrationGetter: emptySignatureIntegrationGetter,
+		signatureFetcher:           &fakeSigFetcher{},
 	}
 
 	img := &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}}
@@ -498,7 +500,10 @@ func TestZeroIntegrations(t *testing.T) {
 	img := &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}}
 	results, err := enricherImpl.EnrichImage(emptyCtx, EnrichmentContext{}, img)
 	assert.Error(t, err)
-	expectedErrMsg := "image enrichment errors: [error getting metadata for image:  error: not found: no image registries are integrated: please add an image integration, error scanning image:  error: no image scanners are integrated]"
+	expectedErrMsg := "image enrichment errors: [error getting metadata for image:  error: not found: no image " +
+		"registries are integrated: please add an image integration, error scanning image:  error: no image scanners " +
+		"are integrated, getting registries for context: not found: no image registries are integrated: please add " +
+		"an image integration]"
 	assert.Equal(t, expectedErrMsg, err.Error())
 	assert.False(t, results.ImageUpdated)
 	assert.Equal(t, ScanNotDone, results.ScanResult)
@@ -557,8 +562,10 @@ func TestRegistryMissingFromImage(t *testing.T) {
 	img := &storage.Image{Id: "id", Name: &storage.ImageName{FullName: "testimage"}}
 	results, err := enricherImpl.EnrichImage(emptyCtx, EnrichmentContext{}, img)
 	assert.Error(t, err)
-	expectedErrMsg := fmt.Sprintf("image enrichment error: error getting metadata for image: "+
-		"testimage error: invalid arguments: no registry is indicated for image %q", img.GetName().GetFullName())
+	expectedErrMsg := fmt.Sprintf("image enrichment errors: [error getting metadata for image: testimage "+
+		"error: invalid arguments: no registry is indicated for image %q, checking registry for image %q: "+
+		"invalid arguments: no registry is indicated for image %q]",
+		img.GetName().GetFullName(), img.GetName().GetFullName(), img.GetName().GetFullName())
 	assert.Equal(t, expectedErrMsg, err.Error())
 	assert.True(t, results.ImageUpdated)
 	assert.Equal(t, ScanSucceeded, results.ScanResult)
@@ -568,7 +575,7 @@ func TestZeroRegistryIntegrations(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	registrySet := registryMocks.NewMockSet(ctrl)
-	registrySet.EXPECT().IsEmpty().Return(true)
+	registrySet.EXPECT().IsEmpty().Return(true).AnyTimes()
 	registrySet.EXPECT().GetAll().Return([]types.ImageRegistry{}).AnyTimes()
 
 	fsr := newFakeRegistryScanner(opts{})
@@ -591,7 +598,9 @@ func TestZeroRegistryIntegrations(t *testing.T) {
 	img := &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}}
 	results, err := enricherImpl.EnrichImage(emptyCtx, EnrichmentContext{}, img)
 	assert.Error(t, err)
-	expectedErrMsg := "image enrichment error: error getting metadata for image:  error: not found: no image registries are integrated: please add an image integration"
+	expectedErrMsg := "image enrichment errors: [error getting metadata for image:  error: not found: no image " +
+		"registries are integrated: please add an image integration, getting registries for context: not found: " +
+		"no image registries are integrated: please add an image integration]"
 	assert.Equal(t, expectedErrMsg, err.Error())
 	assert.True(t, results.ImageUpdated)
 	assert.Equal(t, ScanSucceeded, results.ScanResult)
@@ -625,7 +634,9 @@ func TestNoMatchingRegistryIntegration(t *testing.T) {
 	img := &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}}
 	results, err := enricherImpl.EnrichImage(emptyCtx, EnrichmentContext{}, img)
 	assert.Error(t, err)
-	expectedErrMsg := "image enrichment error: error getting metadata for image:  error: no matching image registries found: please add an image integration for reg"
+	expectedErrMsg := "image enrichment errors: [error getting metadata for image:  error: no matching image " +
+		"registries found: please add an image integration for reg, getting matching registries for image \"\": " +
+		"not found: no matching registries found: please add an image integration for \"\"]"
 	assert.Equal(t, expectedErrMsg, err.Error())
 	assert.False(t, results.ImageUpdated)
 	assert.Equal(t, ScanNotDone, results.ScanResult)

--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -11,7 +11,6 @@ import orchestratormanager.OrchestratorTypes
 import org.junit.experimental.categories.Category
 import services.PolicyService
 import services.SignatureIntegrationService
-import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Unroll
 import util.Env

--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -16,7 +16,6 @@ import spock.lang.Shared
 import spock.lang.Unroll
 import util.Env
 
-@IgnoreIf({ Env.get("ROX_VERIFY_IMAGE_SIGNATURE", "false") == "false" })
 class ImageSignatureVerificationTest extends BaseSpecification {
     // https://issues.redhat.com/browse/ROX-6891
     static final private Integer WAIT_FOR_VIOLATION_TIMEOUT =

--- a/scale/launch_workload.sh
+++ b/scale/launch_workload.sh
@@ -24,13 +24,8 @@ if ! kubectl -n stackrox get pvc/stackrox-db > /dev/null; then
   exit 1
 fi
 
-if [[ "$ROX_VERIFY_IMAGE_SIGNATURE" == "true" ]]; then
-  # Set environment variables.
-  kubectl -n stackrox set env deploy/central ROX_VERIFY_IMAGE_SIGNATURE=true
-  kubectl -n stackrox set env deploy/sensor ROX_VERIFY_IMAGE_SIGNATURE=true
-  # Create signature integrations to verify image signatures.
-  "${DIR}"/signatures/create-signature-integrations.sh
-fi
+# Create signature integrations to verify image signatures.
+"${DIR}"/signatures/create-signature-integrations.sh
 
 kubectl -n "${namespace}" delete deploy/admission-control
 kubectl -n "${namespace}" delete daemonset collector


### PR DESCRIPTION
## Description

Enable the `ROX_VERIFY_IMAGE_SIGNATURE` feature flag by default.
Remove paths where it was used to conditionally i.e. skip tests / create integrations.

For now, not removing all the code paths, in a case any blocking issues occur during the release testing, we will be able to roll back.

## Testing Performed
- CI (`race-condition-tests` should execute `ImageSignatureVerificationTest` and be successful)
