### PR TITLE
Add deterministic method of awaiting Network Graph rerender in flaky tests.

### DIFF
--- a/ui/apps/platform/cypress/constants/NetworkPage.js
+++ b/ui/apps/platform/cypress/constants/NetworkPage.js
@@ -16,6 +16,7 @@ export const selectors = {
     cytoscapeContainer: '#cytoscapeContainer',
     simulatorSuccessMessage: 'div[data-testid="message-body"]:contains("Policies processed")',
     panels: networkPanels,
+    nodesUpdateSection: 'div[data-testid="nodes-update-section"]',
     legend: {
         deployments: '[data-testid="deployment-legend"] div',
         namespaces: '[data-testid="namespace-legend"] div',

--- a/ui/apps/platform/src/Containers/Network/Graph/Overlays/NodesUpdateSection.tsx
+++ b/ui/apps/platform/src/Containers/Network/Graph/Overlays/NodesUpdateSection.tsx
@@ -42,7 +42,11 @@ const NodesUpdateSection = ({
     lastUpdatedTimestamp,
 }: NodeUpdateSectionProps) => {
     return (
-        <div className="absolute top-0 pin-network-update-label-left mt-2 mr-2 p-2 bg-base-100 rounded-sm border-2 border-base-400 text-base-500 text-xs font-700">
+        <div
+            data-testid="nodes-update-section"
+            data-test-updated={dateFns.format(lastUpdatedTimestamp, 'hhmmssSSSS')}
+            className="absolute top-0 pin-network-update-label-left mt-2 mr-2 p-2 bg-base-100 rounded-sm border-2 border-base-400 text-base-500 text-xs font-700"
+        >
             <div className="uppercase">{`Last Updated: ${dateFns.format(
                 lastUpdatedTimestamp,
                 'hh:mm:ssA'


### PR DESCRIPTION
## Description

The problem:

Network Graph tests were occasionally flaking when the gap in time between the network response for the policy and flow graphs and the re-render of the graph was too large. https://app.circleci.com/pipelines/github/stackrox/stackrox/9032/workflows/2a4f8f60-afe8-4fce-b859-b805cacdf392/jobs/402968

The affected tests waited for a network response with the Cypress command `cy.wait(['@networkGraph', '@networkPolicies']);` which was followed by a query for the Cytoscape container and immediate assertions on the data. If there was a gap in time between the `cy.wait` triggering and the assertions, the tests would fail. We cannot use Cypress's built in retry mechanism here because the changes we are waiting for are not query-able in the DOM; they are rendered in an HTML Canvas.

This was easily reproducible across tests if an artificial wait was added in the network saga right after the network request completed [here](https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/sagas/networkSagas.js#L65). Both an async `yield delay(2000)` and blocking `while(new Date().getTime() < now + sleepDuration)` wait would cause the tests to fail.

The propose fix instead watches the "Last Updated" element overlay on the graph to detect when an update was made. An additional `data-test` property was added so we could get to a granularity that would make flakes very unlikely. (In my first iteration of this I used the "Last Updated" text directly, but that could cause failures if the time between updates was < one second.)


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
