### PR TITLE
Replace cypress server and route with intercept in auth

### DIFF
--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -67,7 +67,7 @@ export const search = {
 };
 
 export const alerts = {
-    countsByCluster: 'v1/alerts/summary/counts?*group_by=CLUSTER*',
+    countsByCluster: '/v1/alerts/summary/counts?*group_by=CLUSTER*',
     countsByCategory: '/v1/alerts/summary/counts?*group_by=CATEGORY*',
     alerts: '/v1/alerts?(\\?*)',
     alertById: '/v1/alerts/*',

--- a/ui/apps/platform/cypress/integration/auth.test.js
+++ b/ui/apps/platform/cypress/integration/auth.test.js
@@ -12,15 +12,12 @@ const UNAUTHENTICATED = false;
 
 describe('Authentication', () => {
     const setupAuth = (landingUrl, authStatusValid, authStatusResponse = {}) => {
-        cy.server();
-        cy.route('GET', api.auth.loginAuthProviders, 'fixture:auth/authProviders.json').as(
+        cy.intercept('GET', api.auth.loginAuthProviders, { fixture: 'auth/authProviders.json' }).as(
             'authProviders'
         );
-        cy.route({
-            method: 'GET',
-            url: api.auth.authStatus,
-            status: authStatusValid ? 200 : 401,
-            response: authStatusResponse,
+        cy.intercept('GET', api.auth.authStatus, {
+            statusCode: authStatusValid ? 200 : 401,
+            body: authStatusResponse,
         }).as('authStatus');
 
         cy.visit(landingUrl);
@@ -28,35 +25,30 @@ describe('Authentication', () => {
     };
 
     const stubAPIs = () => {
-        cy.server();
         // Cypress routes have an override behaviour, so defining this first makes it the fallback.
-        cy.route(/.*/, {}).as('everythingElse');
-        cy.route('GET', api.clusters.list, 'fixture:clusters/couple.json').as('clusters');
-        cy.route('GET', api.search.options, 'fixture:search/metadataOptions.json').as(
+        // Replace /.*/ RegExp for route method with '/v1/*' string for intercept method
+        // because it is not limited to XHR, there matches HTML requests too!
+        cy.intercept('/v1/*', { body: {} }).as('everythingElse');
+        cy.intercept('GET', api.clusters.list, { fixture: 'clusters/couple.json' }).as('clusters');
+        cy.intercept('GET', api.search.options, { fixture: 'search/metadataOptions.json' }).as(
             'searchOptions'
         );
-        cy.route('GET', api.alerts.countsByCluster, {}).as('countsByCluster');
-        cy.route('GET', api.alerts.countsByCategory, {}).as('countsByCategory');
-        cy.route('GET', api.dashboard.timeseries, {}).as('alertsByTimeseries');
-        cy.route('GET', api.risks.riskyDeployments, {}).as('deployments');
-        cy.route('POST', api.logs, {}).as('logs');
+        cy.intercept('GET', api.alerts.countsByCluster, { body: {} }).as('countsByCluster');
+        cy.intercept('GET', api.alerts.countsByCategory, { body: {} }).as('countsByCategory');
+        cy.intercept('GET', api.dashboard.timeseries, { body: {} }).as('alertsByTimeseries');
+        cy.intercept('GET', api.risks.riskyDeployments, { body: {} }).as('deployments');
+        cy.intercept('POST', api.logs, { body: {} }).as('logs');
     };
 
     it('should redirect user to login page, authenticate and redirect to the requested page', () => {
         stubAPIs();
         setupAuth(dashboardURL, AUTHENTICATED);
-        cy.server();
-        cy.route('GET', api.clusters.list, 'fixture:clusters/couple.json').as('clusters');
-        cy.route('GET', api.search.options, 'fixture:search/metadataOptions.json').as(
-            'searchOptions'
-        );
-        cy.url().should('contain', loginUrl);
+        cy.location('pathname').should('eq', loginUrl);
         cy.get(selectors.providerSelect).should('have.text', 'auth-provider-name');
         cy.get(selectors.loginButton).click(); // stubbed auth provider will simulate redirect with 'my-token'
-        cy.wait('@authStatus').then((xhr) => {
-            expect(xhr.request.headers.Authorization).to.eq('Bearer my-token');
-        });
-        cy.url().should('contain', dashboardURL);
+        // Replace Authorization for route method with authorization for intercept method.
+        cy.wait('@authStatus').its('request.headers.authorization').should('eq', 'Bearer my-token');
+        cy.location('pathname').should('eq', dashboardURL);
     });
 
     it('should allow authenticated user to enter', () => {
@@ -66,7 +58,7 @@ describe('Authentication', () => {
 
         cy.wait('@authStatus');
 
-        cy.url().should('contain', dashboardURL);
+        cy.location('pathname').should('eq', dashboardURL);
     });
 
     it('should logout previously authenticated user with invalid token', () => {
@@ -76,13 +68,13 @@ describe('Authentication', () => {
 
         cy.wait('@authStatus');
 
-        cy.url().should('contain', loginUrl);
+        cy.location('pathname').should('eq', loginUrl);
     });
 
     // TODO: Fix it, see ROX-4983 for more explanation
     it.skip('should request token refresh 30 sec in advance', () => {
         stubAPIs();
-        cy.route('POST', api.auth.tokenRefresh, {}).as('tokenRefresh');
+        cy.intercept('POST', api.auth.tokenRefresh, { body: {} }).as('tokenRefresh');
         localStorage.setItem('access_token', 'my-token'); // authenticated user
 
         const expiryDate = addSeconds(Date.now(), 33); // +3 sec should be enough
@@ -102,15 +94,14 @@ describe('Authentication', () => {
         // turning off for now, because of an issue with Cypress
         // see https://srox.slack.com/archives/C7ERNFL0M/p1596839383218700
         it.skip('should logout user by request', () => {
-            cy.server();
-            cy.route('POST', api.auth.logout, {}).as('logout');
+            cy.intercept('POST', api.auth.logout, { body: {} }).as('logout');
 
             cy.visit(dashboardURL);
 
             cy.get(navSelectors.menuButton).click();
             cy.get(navSelectors.menuList.logoutButton).click();
             cy.wait('@logout');
-            cy.url().should('contain', loginUrl);
+            cy.location('pathname').should('eq', loginUrl);
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/auth.test.js
+++ b/ui/apps/platform/cypress/integration/auth.test.js
@@ -27,7 +27,7 @@ describe('Authentication', () => {
     const stubAPIs = () => {
         // Cypress routes have an override behaviour, so defining this first makes it the fallback.
         // Replace /.*/ RegExp for route method with '/v1/*' string for intercept method
-        // because it is not limited to XHR, there matches HTML requests too!
+        // because it is not limited to XHR, therefore it matches HTML requests too!
         cy.intercept('/v1/*', { body: {} }).as('everythingElse');
         cy.intercept('GET', api.clusters.list, { fixture: 'clusters/couple.json' }).as('clusters');
         cy.intercept('GET', api.search.options, { fixture: 'search/metadataOptions.json' }).as(


### PR DESCRIPTION
## Description

> In a future release, support for `cy.server()` and `cy.route()` will be removed.

* Find `cy.server` in cypress/integration: from 11 results in 6 files to 7 results in 5 files.
* Find `cy.route` in cypress/integration: from 34 results in 7 files to 20 results in 6 files.

### Generic changes

https://docs.cypress.io/guides/references/migration-guide#Migrating-cy-route-to-cy-intercept

* Delete `cy.server()`
* Replace `cy.route(method, url)` with `cy.intercept(method, url)`
* Replace `cy.route(method, url, 'fixture:fixtureUrl')` with `cy.intercept(method, url, { fixture: 'fixtureUrl' })`
* Replace `cy.route(method, url, data)` with `cy.intercept(method, url, { body: data })`
* Replace `cy.route({ method, url, status, response })` with `cy.intercept(method, url, { body, statusCode })`
* Replace `cy.route(/.*/, {})` with `cy.intercept('/v1/*')` and write comment
* Replace `cy.url()` with `cy.location('pathname')` to make assertion more precise
* Replace `cy.wait(…).then((xhr) => {…})` with `cy.wait(…).its(…).should('eq', …)` and write comment


### Specific changes

1. cypress/constants/apiEndpoints.js
    * Add slash at beginning of `countsByCluster` under `alerts`

2. cypress/integration/auth.test.js
    * Delete 2 `cy.route` calls that are redundant with `stubAPIs` function in `'should redirect user to login page, authenticate and redirect to the requested page'` test

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

1. Ran auth tests one at a time in local deployment
    * The 2 skipped tests passed, but I left them skipped in case they are still flakey
2. Ran dashboard.test.js because it refers to `countsByCluster` endpoint