### PR TITLE
ROX-10043: Mark deployments to be reprocessed on NetworkPolicy updates

### DIFF
--- a/sensor/kubernetes/listener/resources/networkpolicy.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy.go
@@ -69,8 +69,9 @@ func (h *networkPolicyDispatcher) getSelector(np, oldNp *storage.NetworkPolicy) 
 }
 
 func (h *networkPolicyDispatcher) updateDeploymentsFromStore(np *storage.NetworkPolicy, sel selector) {
-	var idsRequireReprocessing []string
-	for _, deploymentWrap := range h.deploymentStore.getMatchingDeployments(np.GetNamespace(), sel) {
+	deployments := h.deploymentStore.getMatchingDeployments(np.GetNamespace(), sel)
+	idsRequireReprocessing := make([]string, 0, len(deployments))
+	for _, deploymentWrap := range deployments {
 		idsRequireReprocessing = append(idsRequireReprocessing, deploymentWrap.GetId())
 	}
 	h.detector.ReprocessDeployments(idsRequireReprocessing...)

--- a/sensor/kubernetes/listener/resources/networkpolicy.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy.go
@@ -69,7 +69,9 @@ func (h *networkPolicyDispatcher) getSelector(np, oldNp *storage.NetworkPolicy) 
 }
 
 func (h *networkPolicyDispatcher) updateDeploymentsFromStore(np *storage.NetworkPolicy, sel selector) {
+	var idsRequireReprocessing []string
 	for _, deploymentWrap := range h.deploymentStore.getMatchingDeployments(np.GetNamespace(), sel) {
-		h.detector.ProcessDeployment(deploymentWrap.GetDeployment(), central.ResourceAction_UPDATE_RESOURCE)
+		idsRequireReprocessing = append(idsRequireReprocessing, deploymentWrap.GetId())
 	}
+	h.detector.ReprocessDeployments(idsRequireReprocessing...)
 }

--- a/sensor/kubernetes/listener/resources/networkpolicy_test.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_test.go
@@ -392,7 +392,7 @@ func (suite *NetworkPolicyDispatcherSuite) Test_ProcessEvent() {
 	for name, c := range cases {
 		suite.T().Run(name, func(t *testing.T) {
 			c.expectedEvents = createSensorEvent(c.netpol.(*networkingV1.NetworkPolicy), c.action)
-			deps := set.StringSet{}
+			deps := set.NewStringSet()
 			reprocessDeploymentMock := suite.detector.EXPECT().ReprocessDeployments(gomock.Any()).DoAndReturn(func(ids ...string) {
 				deps.AddAll(ids...)
 			})


### PR DESCRIPTION
## Description

The current implementation checks if the deployment changed on `update` events before triggering the evaluation. Since we're forcing the retrigger by sending the same deployment to detector, the evaluation is never re-triggered. 

[This is the relevant part of the code](https://github.com/stackrox/stackrox/blob/7c666b96fd87825424804e91def8e30ade606fb5/sensor/common/detector/detector.go#L433-L437):
```go
// Check if the deployment has changes that require detection, which is more expensive than hashing
// If not, then just return
if !d.deduper.needsProcessing(deployment) {
	return
}
```

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests ~~added~~ updated
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- CI
- Created simple `nginx` deployment and `allow-all` ingress network policy. Upon removing the policy it takes ~1 min for the resync to happen and the violation appears. 