### PR TITLE
Create amd64 roxctl binary on M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ build-prep: deps
 
 .PHONY: cli-build
 cli-build: build-prep
-	RACE=0 CGO_ENABLED=0 GOOS=darwin $(GOBUILD) ./roxctl
+	RACE=0 CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) ./roxctl
 	RACE=0 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) ./roxctl
 ifdef CI
 	RACE=0 CGO_ENABLED=0 GOOS=windows $(GOBUILD) ./roxctl
@@ -366,7 +366,7 @@ cli-linux: build-prep
 	RACE=0 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) ./roxctl
 
 cli-darwin: build-prep
-	RACE=0 CGO_ENABLED=0 GOOS=darwin $(GOBUILD) ./roxctl
+	RACE=0 CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) ./roxctl
 
 upgrader: bin/$(HOST_OS)/upgrader
 

--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,7 @@ build-prep: deps
 .PHONY: cli-build
 cli-build: build-prep
 	RACE=0 CGO_ENABLED=0 GOOS=darwin $(GOBUILD) ./roxctl
-	RACE=0 CGO_ENABLED=0 GOOS=linux $(GOBUILD) ./roxctl
+	RACE=0 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) ./roxctl
 ifdef CI
 	RACE=0 CGO_ENABLED=0 GOOS=windows $(GOBUILD) ./roxctl
 endif
@@ -363,7 +363,7 @@ cli: cli-build
 	chmod u+w $(GOPATH)/bin/roxctl
 
 cli-linux: build-prep
-	RACE=0 CGO_ENABLED=0 GOOS=linux $(GOBUILD) ./roxctl
+	RACE=0 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) ./roxctl
 
 cli-darwin: build-prep
 	RACE=0 CGO_ENABLED=0 GOOS=darwin $(GOBUILD) ./roxctl


### PR DESCRIPTION
## Description
On arm64 architecture, roxctl binary was created by default for arm64. This diff adds the flag to make sure it is created for amd64 architecture. 

This is helpful in local dev and private images.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs]~(https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
CI and local build
