### PR TITLE
Update initials 3.1.2 dependencies in UI

### DIFF
--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -41,7 +41,7 @@
     "dependencies": {
         "@tippyjs/react": "^4.2.5",
         "formik": "^2.2.9",
-        "initials": "^3.1.1",
+        "initials": "^3.1.2",
         "lodash": "^4.17.21",
         "react-feather": "^2.0.9",
         "tippy.js": "^6.3.7"

--- a/ui/packages/ui-components/src/Avatar/Avatar.tsx
+++ b/ui/packages/ui-components/src/Avatar/Avatar.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { find as createInitials } from 'initials';
+import createInitials from 'initials';
 
 export type AvatarProps = {
     /* URL to the avatar image */

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -10940,10 +10940,10 @@ init-package-json@^1.10.3:
     validate-npm-package-license "^3.0.1"
     validate-npm-package-name "^3.0.0"
 
-initials@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/initials/-/initials-3.1.1.tgz#a63395b2c46bc56207b4b964a6eb185dbd8458e6"
-  integrity sha512-imRkwIpCUer+w9NB41dTENhJrTQTGOJthRa3URF0O9+L7MOMBPmN8njwkiX4u8YnzxbjEp4Is0ohiW6NSA8ZCw==
+initials@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/initials/-/initials-3.1.2.tgz#30a0f9f149f0654ddf1c6b36b588b525f882a4f8"
+  integrity sha512-Sltg35nx8+GX1w4U86rmbxFEmqFiSuMJviS6cB2KChB+jcT2/8Td+nlImXD74HkqpZF5PMv8hN57AyrA/7ltXw==
 
 inline-source-map@~0.6.0:
   version "0.6.2"


### PR DESCRIPTION
## Description

https://github.com/gr2m/initials/releases/tag/v3.1.2

* types: set return type based on parameter
    fixes https://github.com/gr2m/initials/issues/81 opened by **Ivan Kornienko**

TypeScript correctly infers return type for `initials` default export, therefore named export is no longer needed as work-around.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~a

## Testing Performed

1. `yarn test` in ui/packages/ui-components
2. `yarn build` in ui
3. `yarn start` in ui
    ![initials](https://user-images.githubusercontent.com/11862657/162846757-a7af370a-edb0-4b10-ac47-7cf4aeda670d.png)