### PR TITLE
RS-481: make style under OpenShift CI

### DIFF
--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -8,6 +8,7 @@ import subprocess
 
 from common import popen_graceful_kill
 
+QA_TESTS_OUTPUT_DIR = "/tmp/qa-tests-backend-logs"
 
 class BaseTest:
     def __init__(self):
@@ -30,7 +31,7 @@ class UpgradeTest(BaseTest):
             ["tests/upgrade/run.sh", UpgradeTest.TEST_OUTPUT_DIR]
         ) as cmd:
 
-            self.test_output_dirs = [UpgradeTest.TEST_OUTPUT_DIR]
+            self.test_output_dirs = [UpgradeTest.TEST_OUTPUT_DIR, QA_TESTS_OUTPUT_DIR]
 
             try:
                 exitstatus = cmd.wait(UpgradeTest.TEST_TIMEOUT)

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -30,6 +30,9 @@ case "$ci_job" in
     gke-upgrade-tests)
         "$ROOT/.openshift-ci/gke_upgrade_test.py"
         ;;
+    style-checks)
+        make style
+        ;;
     *)
         # For ease of initial integration this function does not fail when the
         # job is unknown.

--- a/Makefile
+++ b/Makefile
@@ -145,11 +145,11 @@ ifdef CI
 	@echo 'The environment indicates we are in CI; running linters in check mode.'
 	@echo 'If this fails, run `make style`.'
 	@echo "Running with no tags..."
-	golangci-lint run --timeout 4m0s
+	golangci-lint run --timeout 8m0s
 	@echo "Running with release tags..."
 	@# We use --tests=false because some unit tests don't compile with release tags,
 	@# since they use functions that we don't define in the release build. That's okay.
-	golangci-lint run --timeout 4m0s --build-tags "$(subst $(comma),$(space),$(RELEASE_GOTAGS))" --tests=false
+	golangci-lint run --timeout 8m0s --build-tags "$(subst $(comma),$(space),$(RELEASE_GOTAGS))" --tests=false
 else
 	golangci-lint run --fix
 	golangci-lint run --fix --build-tags "$(subst $(comma),$(space),$(RELEASE_GOTAGS))" --tests=false

--- a/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
@@ -37,7 +37,7 @@ class PolicyFieldsTest extends BaseSpecification {
     static final private Deployment DEP_A =
             createAndRegisterDeployment()
                     .setName("deployment-a")
-                    .setImage("us.gcr.io/stackrox-ci/qa/trigger-policy-violations/more:0.3")
+                    .setImage("us.gcr.io/stackrox-ci/qa/trigger-policy-violations/more:0.39.io/stackrox-ci/qa/trigger-policy-violations/more:0.39.io/stackrox-ci/qa/trigger-policy-violations/more:0.39.io/stackrox-ci/qa/trigger-policy-violations/more:0.39.io/stackrox-ci/qa/trigger-policy-violations/more:0.39")
                     .setCapabilities(["NET_ADMIN", "SYSLOG"], ["IPC_LOCK", "WAKE_ALARM"])
                     .addLimits("cpu", "0.5")
                     .addRequest("cpu", "0.25")

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -429,12 +429,6 @@ openshift_ci_mods() {
     info "HOME ${HOME:-}"
     export GRADLE_USER_HOME="${HOME}"
     info "GRADLE_USER_HOME ${GRADLE_USER_HOME:-}"
-    # For OpenJDK
-    set -x
-    mkdir -p "/tmp/.java/.userPrefs"
-    chmod -R 0777 "/tmp/.java"
-    ls -laR "/tmp/.java"
-    set +x
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then


### PR DESCRIPTION
## Description

Per title.
- Added `make style`.
- Gave golang-lint more time.
- Removed useless JDK prefs setting.
- Captured debug from QA tests.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] OSCI with a [forced failure](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_rox-openshift-ci-mirror/8/pull-ci-stackrox-rox-openshift-ci-mirror-master-style-checks/1513701872299413504)
- [x] OSCI [happy path](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_rox-openshift-ci-mirror/8/pull-ci-stackrox-rox-openshift-ci-mirror-master-style-checks/1513670790615142400)