### PR TITLE
Fix prop type errors for port and state in NetworkBaselinesSearch

### DIFF
--- a/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/Flows/NetworkBaselines/NetworkBaselinesSearch.js
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/Flows/NetworkBaselines/NetworkBaselinesSearch.js
@@ -78,10 +78,10 @@ NetworkBaselinesSearch.propTypes = {
                     name: PropTypes.string,
                     namespace: PropTypes.string,
                 }),
-                port: PropTypes.string.isRequired,
+                port: PropTypes.number.isRequired,
                 protocol: PropTypes.string.isRequired,
                 ingress: PropTypes.bool.isRequired,
-                state: PropTypes.string.isRequired,
+                state: PropTypes.string,
             }),
             status: PropTypes.oneOf(Object.values(networkFlowStatus)).isRequired,
         })

--- a/ui/apps/platform/src/types/networkBaseline.proto.ts
+++ b/ui/apps/platform/src/types/networkBaseline.proto.ts
@@ -1,0 +1,45 @@
+import { L4Protocol, NetworkEntity } from './networkFlow.proto';
+
+export type NetworkBaselineConnectionProperties = {
+    // Whether this connection is an ingress/egress, from the PoV of the deployment whose baseline this is in
+    ingress: boolean;
+
+    // May be 0 if not applicable (e.g., icmp), and denotes the destination port
+    port: number; // uint32
+    protocol: L4Protocol;
+};
+
+export type NetworkBaselinePeer = {
+    entity: NetworkEntity;
+
+    // Will always have at least one element
+    properties: NetworkBaselineConnectionProperties[];
+};
+
+// NetworkBaseline represents a network baseline of a deployment. It contains all
+// the baseline peers and their respective connections.
+// next available tag: 8
+export type NetworkBaseline = {
+    // This is the ID of the baseline.
+    deploymentId: string;
+
+    clusterId: string;
+    namespace: string;
+
+    peers: NetworkBaselinePeer[];
+
+    // A list of peers that will never be added to the baseline.
+    // For now, this contains peers that the user has manually removed.
+    // This is used to ensure we don't add it back in the event we see the flow again.
+    forbiddenPeers: NetworkBaselinePeer[];
+
+    observationPeriodEnd: string; // ISO 8601 date string
+
+    // Indicates if this baseline has been locked by user.
+    // Here locking means:
+    // 1: Do not let system automatically add any allowed peer to baseline
+    // 2: Start reporting violations on flows that are not in the baseline
+    locked: boolean;
+
+    deploymentName: string;
+};

--- a/ui/apps/platform/src/types/networkFlow.proto.ts
+++ b/ui/apps/platform/src/types/networkFlow.proto.ts
@@ -25,7 +25,7 @@ export type NetworkEndpointProperties = {
 
 export type NetworkEntity = {
     info: NetworkEntityInfo;
-    scope: NetworkEntityScope;
+    scope: NetworkEntityScope | null;
 };
 
 /*


### PR DESCRIPTION
## Description

Follow up error found while testing #1255

Prop type for `port` is `string` but type is number `uint32 port` https://github.com/stackrox/stackrox/blob/master/proto/storage/network_baseline.proto#L20
Prop `state` is required on **Network Flows** tab but not on **Network Baselines** tab

1. Edit src/Containers/Network/SidePanel/NetworkDeploymentOverlay/Flows/NetworkBaselines/NetworkBaselinesSearch.js
    * Replace `string` with `number` for `port`
    * Delete `isRequired` from `state`

2. Add src/types/networkBaseline.proto.ts for future use

3. Edit src/types/networkFlow.proto.ts
    * Add `| null` because of response

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. Visit /main/network
2. Select a namespace (for example, stackrox)
3. Click a deployment (for example, scanner-db)

    * Warning: Failed prop type: Invalid prop `networkBaselines[0].peer.port` of type `number` supplied to `NetworkBaselinesSearch`, expected `string`.
        at NetworkBaselinesSearch
        at NetworkBaselines
        at NetworkFlows
        ![console](https://user-images.githubusercontent.com/11862657/162996510-92e0455d-666e-48c5-9885-66cb625bba1f.png)

    * But `port: 5432` in /v1/networkbaseline response
        ![network](https://user-images.githubusercontent.com/11862657/162996585-efdfed52-4db6-469f-861c-fa9dead75722.png)

4. Click the **Baseline Settings** tab

    * Warning: Failed prop type: The prop `networkBaselines[0].peer.state` is marked as required in `NetworkBaselinesSearch`, but its value is `undefined`.
        at NetworkBaselinesSearch
        at NetworkBaselines

    * `state` is in https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/Flows/NetworkFlows/useFetchNetworkBaselines.ts#L35-L49
    * `state` is not in https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/Flows/BaselineSettings/useFetchNetworkBaselines.ts#L54-L64
