### PR TITLE
Enable feature flag for upgrade test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3774,7 +3774,6 @@ jobs:
     executor: custom
     environment:
       LOAD_BALANCER: "lb"
-      ROX_NETPOL_FIELDS: "true"
     steps:
       - checkout
       - check-backend-changes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3774,6 +3774,7 @@ jobs:
     executor: custom
     environment:
       LOAD_BALANCER: "lb"
+      ROX_NETPOL_FIELDS: "true"
     steps:
       - checkout
       - check-backend-changes

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,3 +28,5 @@ area/postgres:
 - pkg/search/postgres/**/*
 - tools/generate-helpers/pg-table-bindings/**/*
 - tools/generate-helpers/pg-table-bindings-wrapper
+ci-upgrade-tests:
+- pkg/defaults/policies/**/*

--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -727,13 +727,11 @@ func (s *serviceImpl) ExportPolicies(ctx context.Context, request *v1.ExportPoli
 		return nil, err
 	}
 	if len(policyErrors) > 0 {
+		errDetails := &v1.ExportPoliciesErrorList{}
 		for i, missingIndex := range missingIndices {
 			policyError := policyErrors[i].Error()
 			policyID := request.PolicyIds[missingIndex]
 			log.Warnf("A policy error ocurred for id %s: '%v'", policyID, policyError)
-		}
-		errDetails := &v1.ExportPoliciesErrorList{}
-		for i, missingIndex := range missingIndices {
 			errDetails.Errors = append(errDetails.Errors, &v1.ExportPolicyError{
 				PolicyId: request.PolicyIds[missingIndex],
 				Error: &v1.PolicyError{

--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -729,8 +729,8 @@ func (s *serviceImpl) ExportPolicies(ctx context.Context, request *v1.ExportPoli
 	if len(policyErrors) > 0 {
 		for i, missingIndex := range missingIndices {
 			policyError := policyErrors[i].Error()
-			policyId := request.PolicyIds[missingIndex]
-			log.Warnf("a policy error from %s: %v", policyId, policyError)
+			policyID := request.PolicyIds[missingIndex]
+			log.Warnf("A policy error ocurred for id %s: '%v'", policyID, policyError)
 		}
 		errDetails := &v1.ExportPoliciesErrorList{}
 		for i, missingIndex := range missingIndices {

--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -727,6 +727,11 @@ func (s *serviceImpl) ExportPolicies(ctx context.Context, request *v1.ExportPoli
 		return nil, err
 	}
 	if len(policyErrors) > 0 {
+		for i, missingIndex := range missingIndices {
+			policyError := policyErrors[i].Error()
+			policyId := request.PolicyIds[missingIndex]
+			log.Warnf("a policy error from %s: %v", policyId, policyError)
+		}
 		errDetails := &v1.ExportPoliciesErrorList{}
 		for i, missingIndex := range missingIndices {
 			errDetails.Errors = append(errDetails.Errors, &v1.ExportPolicyError{

--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -212,9 +212,8 @@ class UpgradesTest extends BaseSpecification {
                             build()
             ).getPoliciesList()
         } catch (StatusRuntimeException e) {
-            println "Exception in exportPolicies(): ${e}"
-            println "Status: ${e.getStatus()}"
-            println "Trailers: ${e.getTrailers()}"
+            println "Exception in exportPolicies(): ${e.getStatus()}"
+            println "See central log for more details."
             throw(e)
         }
 

--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -18,6 +18,8 @@ class UpgradesTest extends BaseSpecification {
     private final static String CLUSTERID = Env.mustGet("UPGRADE_CLUSTER_ID")
     private final static String POLICIES_JSON_PATH =
             Env.get("POLICIES_JSON_RELATIVE_PATH", "../pkg/defaults/policies/files")
+    // As policies are added they will be missing from the original version used in the upgrade test
+    private final static List<String> POLICIES_MISSING_FROM_ORIGINAL = ["38bf79e7-48bf-4ab1-b72f-38e8ad8b4ec3"]
 
     private static final COMPLIANCE_QUERY = """query getAggregatedResults(
         \$groupBy: [ComplianceAggregation_Scope!],
@@ -197,7 +199,9 @@ class UpgradesTest extends BaseSpecification {
                 JsonFormat.parser().merge(file.text, builder)
                 def policy = builder.build()
 
-                defaultPolicies[policy.id] = policy
+                if (!POLICIES_MISSING_FROM_ORIGINAL.contains(policy.id)) {
+                    defaultPolicies[policy.id] = policy
+                }
             }
         }
 

--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -1,6 +1,7 @@
 import com.google.protobuf.util.JsonFormat
 import groovy.io.FileType
 import groups.Upgrade
+import io.grpc.StatusRuntimeException
 import io.stackrox.proto.api.v1.PolicyServiceOuterClass
 import io.stackrox.proto.api.v1.SummaryServiceOuterClass
 import io.stackrox.proto.storage.PolicyOuterClass
@@ -202,11 +203,18 @@ class UpgradesTest extends BaseSpecification {
 
         when:
         "Upgraded default policies are fetched from central"
-        def upgradedPolicies = PolicyService.getPolicyClient().exportPolicies(
-                PolicyServiceOuterClass.ExportPoliciesRequest.newBuilder().
-                        addAllPolicyIds(defaultPolicies.keySet()).
-                        build()
-        ).getPoliciesList()
+        def upgradedPolicies
+        try {
+            println("Exporting policies: ${defaultPolicies.keySet().join(", ")}")
+            upgradedPolicies = PolicyService.getPolicyClient().exportPolicies(
+                    PolicyServiceOuterClass.ExportPoliciesRequest.newBuilder().
+                            addAllPolicyIds(defaultPolicies.keySet()).
+                            build()
+            ).getPoliciesList()
+        } catch (StatusRuntimeException e) {
+            println "Exception in exportPolicies(): ${e}"
+            throw(e)
+        }
 
         def knownPolicyDifferences = [
                 "2e90874a-3521-44de-85c6-5720f519a701": new KnownPolicyDiffs()

--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -213,6 +213,8 @@ class UpgradesTest extends BaseSpecification {
             ).getPoliciesList()
         } catch (StatusRuntimeException e) {
             println "Exception in exportPolicies(): ${e}"
+            println "Status: ${e.getStatus()}"
+            println "Trailers: ${e.getTrailers()}"
             throw(e)
         }
 

--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -18,8 +18,6 @@ class UpgradesTest extends BaseSpecification {
     private final static String CLUSTERID = Env.mustGet("UPGRADE_CLUSTER_ID")
     private final static String POLICIES_JSON_PATH =
             Env.get("POLICIES_JSON_RELATIVE_PATH", "../pkg/defaults/policies/files")
-    // As policies are added they will be missing from the original version used in the upgrade test
-    private final static List<String> POLICIES_MISSING_FROM_ORIGINAL = ["38bf79e7-48bf-4ab1-b72f-38e8ad8b4ec3"]
 
     private static final COMPLIANCE_QUERY = """query getAggregatedResults(
         \$groupBy: [ComplianceAggregation_Scope!],
@@ -199,9 +197,7 @@ class UpgradesTest extends BaseSpecification {
                 JsonFormat.parser().merge(file.text, builder)
                 def policy = builder.build()
 
-                if (!POLICIES_MISSING_FROM_ORIGINAL.contains(policy.id)) {
-                    defaultPolicies[policy.id] = policy
-                }
+                defaultPolicies[policy.id] = policy
             }
         }
 

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -336,6 +336,7 @@ test_upgrade_paths() {
 
     cd "$TEST_ROOT"
 
+    kubectl -n stackrox set env deploy/central ROX_NETPOL_FIELDS="true"
     kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:$(make --quiet tag)"
     wait_for_api
 


### PR DESCRIPTION
## Description

ROX_NETPOL_FIELDS needs to be enabled for the upgrade test so that `deployment_has_ingress_network_policy` exists as a default policy. This changes fixes: https://circleci.com/gh/stackrox/stackrox/427975, etc.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient
