### PR TITLE
Delete unused sagas/reducers for network graph.

### DIFF
--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -30,9 +30,7 @@ export function clickOnNodeByName(cytoscape, node) {
 }
 
 export function clickOnDeploymentNodeByName(cytoscape, name) {
-    cy.intercept('GET', api.network.deployment).as('getDeployment');
     clickOnNodeByName(cytoscape, { type: 'DEPLOYMENT', name });
-    cy.wait('@getDeployment');
 }
 
 export function mouseOverNodeById(cytoscape, node) {

--- a/ui/apps/platform/cypress/helpers/risk.js
+++ b/ui/apps/platform/cypress/helpers/risk.js
@@ -18,9 +18,8 @@ export function viewRiskDeploymentByName(deploymentName) {
 
 export function viewRiskDeploymentInNetworkGraph() {
     // Assume location is risk deployment panel.
-    cy.intercept('GET', api.network.deployment).as('getDeployment');
     cy.intercept('GET', api.network.networkGraph).as('getNetworkGraphCluster');
     cy.intercept('GET', api.network.networkPoliciesGraph).as('getNetworkPoliciesCluster');
     cy.get(riskPageSelectors.viewDeploymentsInNetworkGraphButton).click();
-    cy.wait(['@getDeployment', '@getNetworkGraphCluster', '@getNetworkPoliciesCluster']);
+    cy.wait(['@getNetworkGraphCluster', '@getNetworkPoliciesCluster']);
 }

--- a/ui/apps/platform/src/Containers/Network/Graph/Graph.js
+++ b/ui/apps/platform/src/Containers/Network/Graph/Graph.js
@@ -10,7 +10,6 @@ import { actions as backendActions } from 'reducers/network/backend';
 import { actions as graphActions } from 'reducers/network/graph';
 import { actions as pageActions } from 'reducers/network/page';
 import { actions as sidepanelActions } from 'reducers/network/sidepanel';
-import { actions as deploymentActions } from 'reducers/deployments';
 import NetworkGraph from 'Components/NetworkGraph';
 import NoResultsMessage from 'Components/NoResultsMessage';
 import { filterModes } from 'constants/networkFilterModes';
@@ -39,7 +38,6 @@ class Graph extends Component {
             id: PropTypes.string,
             deployments: PropTypes.arrayOf(PropTypes.shape({})),
         }),
-        fetchDeployment: PropTypes.func.isRequired,
         clusters: PropTypes.arrayOf(PropTypes.object).isRequired,
         selectedClusterId: PropTypes.string,
         showNamespaceFlows: PropTypes.string.isRequired,
@@ -109,7 +107,6 @@ class Graph extends Component {
             return;
         }
         this.props.setSelectedNode(node);
-        this.props.fetchDeployment(node.deploymentId);
         this.props.fetchNetworkPolicies([...node.policyIds]);
         this.props.setSidePanelStage(sidepanelStages.details);
         this.props.openSidePanel();
@@ -212,7 +209,6 @@ const mapStateToProps = createStructuredSelector({
 const mapDispatchToProps = {
     setSelectedNode: graphActions.setSelectedNode,
     setSelectedNamespace: graphActions.setSelectedNamespace,
-    fetchDeployment: deploymentActions.fetchDeployment.request,
     fetchNetworkPolicies: backendActions.fetchNetworkPolicies.request,
     openSidePanel: pageActions.openSidePanel,
     setSidePanelStage: sidepanelActions.setSidePanelStage,

--- a/ui/apps/platform/src/reducers/deployments.js
+++ b/ui/apps/platform/src/reducers/deployments.js
@@ -16,7 +16,6 @@ import {
 
 export const types = {
     FETCH_DEPLOYMENTS: createFetchingActionTypes('deployments/FETCH_DEPLOYMENTS'),
-    FETCH_DEPLOYMENT: createFetchingActionTypes('deployments/FETCH_DEPLOYMENT'),
     ...searchTypes('deployments'),
 };
 
@@ -24,7 +23,6 @@ export const types = {
 
 export const actions = {
     fetchDeployments: createFetchingActions(types.FETCH_DEPLOYMENTS),
-    fetchDeployment: createFetchingActions(types.FETCH_DEPLOYMENT),
     ...getSearchActions('deployments'),
 };
 

--- a/ui/apps/platform/src/reducers/deployments.test.js
+++ b/ui/apps/platform/src/reducers/deployments.test.js
@@ -51,19 +51,6 @@ describe('Deployments Reducer', () => {
         expect(nextState.filteredIds).toEqual(Object.keys(deploymentsById));
     });
 
-    it('should enrich existing deployment', () => {
-        const prevState = {
-            ...initialState,
-            byId: deploymentsById,
-        };
-        const nextState = reducer(prevState, actions.fetchDeployment.success(deploymentResponse));
-
-        expect(nextState.byId).toEqual({
-            ...deploymentsById,
-            [singleDeployment.id]: singleDeployment,
-        });
-    });
-
     it('should cleanup non-existing deployments when received new list of deployments', () => {
         const prevState = {
             ...initialState,

--- a/ui/apps/platform/src/reducers/deployments.test.js
+++ b/ui/apps/platform/src/reducers/deployments.test.js
@@ -19,15 +19,6 @@ const deploymentsResponse = {
     result: Object.keys(deploymentsById),
 };
 
-const singleDeployment = { id: 'dep1', data: 'data' };
-const deploymentResponse = {
-    entities: {
-        deployment: {
-            [singleDeployment.id]: singleDeployment,
-        },
-    },
-};
-
 describe('Deployments Reducer', () => {
     it('should return the initial state', () => {
         expect(reducer(undefined, {})).toEqual(initialState);

--- a/ui/apps/platform/src/reducers/network/sidepanel.js
+++ b/ui/apps/platform/src/reducers/network/sidepanel.js
@@ -1,7 +1,5 @@
 import { combineReducers } from 'redux';
-import isEqual from 'lodash/isEqual';
 import sidepanelStages from 'Containers/Network/SidePanel/sidepanelStages';
-import { types as deploymentTypes } from 'reducers/deployments';
 
 // Action types
 //-------------
@@ -100,19 +98,6 @@ const networkPolicyExcludePortsProtocolsState = (state = false, action) => {
     return state;
 };
 
-const selectedNodeDeployment = (state = {}, action) => {
-    if (action.response && action.response.entities) {
-        const { entities, result } = action.response;
-        if (entities && entities.deployment && result) {
-            const deploymentsById = { ...entities.deployment[result] };
-            if (action.type === deploymentTypes.FETCH_DEPLOYMENT.SUCCESS) {
-                return isEqual(deploymentsById, state) ? state : deploymentsById;
-            }
-        }
-    }
-    return state;
-};
-
 const reducer = combineReducers({
     networkSidePanelStage,
     networkPolicyModification,
@@ -120,7 +105,6 @@ const reducer = combineReducers({
     networkPolicyModificationSource,
     networkPolicyModificationState,
     networkPolicyExcludePortsProtocolsState,
-    selectedNodeDeployment,
 });
 
 export default reducer;
@@ -136,7 +120,6 @@ const getNetworkPolicyModificationSource = (state) => state.networkPolicyModific
 const getNetworkPolicyModificationState = (state) => state.networkPolicyModificationState;
 const getNetworkPolicyExcludePortsProtocolsState = (state) =>
     state.networkPolicyExcludePortsProtocolsState;
-const getNodeDeployment = (state) => state.selectedNodeDeployment;
 
 export const selectors = {
     getSidePanelStage,
@@ -145,5 +128,4 @@ export const selectors = {
     getNetworkPolicyModificationSource,
     getNetworkPolicyModificationState,
     getNetworkPolicyExcludePortsProtocolsState,
-    getNodeDeployment,
 };

--- a/ui/apps/platform/src/sagas/deploymentSagas.js
+++ b/ui/apps/platform/src/sagas/deploymentSagas.js
@@ -1,10 +1,7 @@
 import { all, takeLatest, call, fork, put, select } from 'redux-saga/effects';
 
 import { dashboardPath, policiesPath } from 'routePaths';
-import {
-    fetchDeploymentsLegacy as fetchDeployments,
-    fetchDeploymentLegacy as fetchDeployment,
-} from 'services/DeploymentsService';
+import { fetchDeploymentsLegacy as fetchDeployments } from 'services/DeploymentsService';
 import { actions } from 'reducers/deployments';
 import { types as dashboardTypes } from 'reducers/dashboard';
 import { selectors } from 'reducers';
@@ -16,15 +13,6 @@ export function* getDeployments({ options = [] }) {
         yield put(actions.fetchDeployments.success(result.response, { options }));
     } catch (error) {
         yield put(actions.fetchDeployments.failure(error));
-    }
-}
-
-export function* getDeployment(id) {
-    try {
-        const result = yield call(fetchDeployment, id);
-        yield put(actions.fetchDeployment.success(result.response, { id }));
-    } catch (error) {
-        yield put(actions.fetchDeployment.failure(error));
     }
 }
 

--- a/ui/apps/platform/src/sagas/networkSagas.js
+++ b/ui/apps/platform/src/sagas/networkSagas.js
@@ -23,13 +23,11 @@ import { actions as clusterActions } from 'reducers/clusters';
 import { actions as notificationActions } from 'reducers/notifications';
 import { selectors } from 'reducers';
 import { takeEveryNewlyMatchedLocation } from 'utils/sagaEffects';
-import { types as deploymentTypes } from 'reducers/deployments';
 import { types as locationActionTypes } from 'reducers/routes';
 import searchOptionsToQuery from 'services/searchOptionsToQuery';
 import timeWindowToDate from 'utils/timeWindows';
 import queryService from 'utils/queryService';
 import { filterModes } from 'constants/networkFilterModes';
-import { getDeployment } from './deploymentSagas';
 
 // get generators
 function* getNetworkGraphs(clusterId, namespaces, query) {
@@ -76,10 +74,6 @@ function* getNetworkGraphs(clusterId, namespaces, query) {
             yield put(backendNetworkActions.fetchNetworkPolicyGraph.success(policyGraph));
         }
     }
-}
-
-function* getSelectedDeployment({ params }) {
-    yield call(getDeployment, params);
 }
 
 export function* getNetworkPolicies({ params }) {
@@ -291,10 +285,6 @@ function* watchNetworkSearchOptions() {
     yield takeLatest(searchNetworkTypes.SET_SEARCH_OPTIONS, filterNetworkPageBySearch);
 }
 
-function* watchFetchDeploymentRequest() {
-    yield takeLatest(deploymentTypes.FETCH_DEPLOYMENT.REQUEST, getSelectedDeployment);
-}
-
 function* watchNetworkPoliciesRequest() {
     yield takeLatest(backendNetworkTypes.FETCH_NETWORK_POLICIES.REQUEST, getNetworkPolicies);
 }
@@ -372,7 +362,6 @@ export default function* network() {
         takeEveryNewlyMatchedLocation(networkPath, loadNetworkPage),
         fork(watchNetworkSearchOptions),
         fork(watchNetworkPoliciesRequest),
-        fork(watchFetchDeploymentRequest),
         fork(watchActiveNetworkModification),
         fork(watchUndoNetworkModification),
         fork(watchGenerateNetworkModification),

--- a/ui/apps/platform/src/services/DeploymentsService.ts
+++ b/ui/apps/platform/src/services/DeploymentsService.ts
@@ -132,22 +132,3 @@ export function fetchDeploymentsLegacy(options: RestSearchOption[]): Promise<{
             response: normalize(response?.data?.deployments ?? [], [deploymentSchema]),
         }));
 }
-
-/**
- * Fetches a deployment by its ID.
- *
- * TODO: Delete after (its only call in) deploymentSagas has been deleted.
- */
-export function fetchDeploymentLegacy(id: string): Promise<{
-    response: {
-        entities: { deployment: Record<string, Deployment> };
-        result: string;
-    };
-}> {
-    if (!id) {
-        throw new Error('Deployment ID must be specified');
-    }
-    return axios.get<Deployment>(`${deploymentByIdUrl}/${id}`).then((response) => ({
-        response: normalize({ deployment: response.data }, deploymentDetail),
-    }));
-}

--- a/ui/apps/platform/src/services/DeploymentsService.ts
+++ b/ui/apps/platform/src/services/DeploymentsService.ts
@@ -10,7 +10,7 @@ import {
     orchestratorComponentOption,
 } from 'Containers/Navigation/OrchestratorComponentsToggle';
 import axios from './instance';
-import { deployment as deploymentSchema, deploymentDetail } from './schemas';
+import { deployment as deploymentSchema } from './schemas';
 
 const deploymentsUrl = '/v1/deploymentswithprocessinfo';
 const deploymentByIdUrl = '/v1/deployments';


### PR DESCRIPTION
## Description

This PR is the result of a discovery by @pedrottimark that clicking a node in the Network Graph causes two sets of network requests to be sent to both `/deployments/:id` and `/networkpolicies/:pid`. Each set of requests originates from the following cause:
~~[a `useEffect` in the Network <Page> component](https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Network/Page.js#L91) (used to enable the namespace of a deployment when visiting from the Risk page)~~ It turns out this request was unrelated.
- A click on a Cytoscape node, that dispatches a FETCH_DEPLOYMENT.request action to Redux

In looking for a way to remove the duplicate requests I found that the above ends up storing data that is unused, and that much of the reducer/action/saga plumbing it flows through is deprecated dead code.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

If there are additional areas that should be manually tested that I did not account for below, please give me a heads up and I will check them as well.

I followed the deprecated flow in the following order:
- [a node click event](https://github.com/stackrox/stackrox/pull/1271/files#diff-144cd6c670b6b13a7cc59d07defe2e153b976aacf39f65446eccf1f2c36842c7L112) dispatches the initial `fetchDeployment.request` action that was created [here](https://github.com/stackrox/stackrox/pull/1271/files#diff-c11ed6479fb56727b2f3f66d0898db4a8b12fe1b773c75765437dc79584cd241L27)
- This action is picked up by the [NetworkSaga](https://github.com/stackrox/stackrox/pull/1271/files#diff-165272c1231ca7d39e1f7ce98c4e0cdb9f85a52de5e755471a68186667376288L294) that in turn calls a `getDeployment` saga from [DeploymentSagas](https://github.com/stackrox/stackrox/pull/1271/files#diff-42ad6572e73ab66fa03c4bfcb7a975723671fdac63a7d77aa44a8f101600d792L22)
- A search for the `getDeployment` saga reveals that it is only imported and used in the NetworkSaga file and can be deleted.
- The deleted `getDeployment` saga called the final instance of [this service function](https://github.com/stackrox/stackrox/pull/1271/files#diff-c7429905b7316ce086314b9fd82cc0f07e6cf1777080d22ebceb0ba825b10bb6L141), which can also be deleted
- The above flow is only used in [this reducer](https://github.com/stackrox/stackrox/pull/1271/files#diff-67e56bd97af5d59480b6cd11a17b1654dd529d8d9e73399ed4b8cc5974579fd4L103) when it detects the `FETCH_DEPLOYMENT.SUCCESS` action type.
- The state object returned by the above reducer is available through the [`getNodeDeployment` selector,](https://github.com/stackrox/stackrox/pull/1271/files#diff-67e56bd97af5d59480b6cd11a17b1654dd529d8d9e73399ed4b8cc5974579fd4L139) which is not called anywhere in the code base.

Key imports and search strings that are not available anywhere else in the code:
- getDeployment (the one called from deploymentSagas.js at least)
- fetchDeployment.request, fetchDeployment.success, fetchDeployment.failure
- FETCH_DEPLOYMENT (the action type, separate from FETCH_DEPLOYMENT**S**)

Tested that visiting the Network Graph via a Risk Page deployment works as expected:
![image](https://user-images.githubusercontent.com/1292638/163020842-40f86a05-ca9d-4034-bcc4-b1421774d709.png)

Tested that visiting the Network Graph directly and clicking a node in the visualization opens the sidebar as expected:
![image](https://user-images.githubusercontent.com/1292638/163020985-69f46fd4-8bd8-4d68-b45f-2148ba29d511.png)

Tested that a single request is sent to the  deployments API when visiting the Network Graph with a deployment id in the URL: (Note that this removes _both_ of the duplicate `v1/deployments/:id` calls when clicking a node, but _neither_ of the `v1/networkpolicies/:pid` calls)
<img width="1033" alt="image" src="https://user-images.githubusercontent.com/1292638/163021633-ec2d36ad-a8a9-4a85-94a3-43c00095a732.png">

