### PR TITLE
ROX-9964: Mount memory tmpfs as share memory

### DIFF
--- a/image/postgres/postgresql.conf
+++ b/image/postgres/postgresql.conf
@@ -135,6 +135,8 @@ ssl_key_file = '/run/secrets/stackrox.io/certs/server.key'
 # - Memory -
 
 #shared_buffers = 128MB			# min 128kB
+# Keep this in sync with shared-memory in
+# image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
 shared_buffers = 2GB			# StackRox customized
 					# (change requires restart)
 #huge_pages = try			# on, off, or try

--- a/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
@@ -106,6 +106,7 @@ spec:
       - name: shared-memory
         emptyDir:
           medium: Memory
+          {{- /* Keep this in sync with shared_buffers in /Users/cong/go/src/github.com/stackrox/rox/image/postgres/postgresql.conf */}}
           sizeLimit: 2Gi
 ---
 apiVersion: v1

--- a/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
@@ -77,6 +77,8 @@ spec:
           name: disk
         - name: central-db-tls-volume
           mountPath: /run/secrets/stackrox.io/certs
+        - mountPath: /dev/shm
+          name: shared-memory
       securityContext:
         fsGroup: 70
       volumes:
@@ -101,6 +103,10 @@ spec:
             path: server.key
           - key: ca.pem
             path: root.crt
+      - name: shared-memory
+        emptyDir:
+          medium: Memory
+          sizeLimit: 2Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Description

Mount memory for /dev/shm.
/dev/shm is by default mounted 64M.
This PR mount shared memory as emptyDir with upper sizeLimit.
The 2GB upper bind is by-default enabled for kubernetes 1.22+


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
- CI
- Tested on kubernetes 1.22.5.
- Tested on kubernetes 1.20.15(gke) with no side effect. Upper limit is half of available RAM. 
