### PR TITLE
Wait before cytoscape assertions in Network Graph integration tests

### DIFF
--- a/ui/apps/platform/cypress/support/commands.js
+++ b/ui/apps/platform/cypress/support/commands.js
@@ -2,6 +2,7 @@
 import 'cypress-file-upload';
 
 Cypress.Commands.add('getCytoscape', (containerId) => {
+    cy.wait(100);
     cy.get(containerId).then(() => {
         cy.window().then((win) => {
             return win.cytoscape;


### PR DESCRIPTION
## Description

### Problem

> Network Graph Search should filter to show only the stackrox namespace and deployments connected to stackrox namespace

> AssertionError: expected 0 to equal 1

https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js#L52

* https://app.circleci.com/pipelines/github/stackrox/stackrox/8633/workflows/3462b23e-18eb-436c-971b-e9955af2f651/jobs/381699
* https://app.circleci.com/pipelines/github/stackrox/stackrox/9032/workflows/2a4f8f60-afe8-4fce-b859-b805cacdf392/jobs/402968
* https://app.circleci.com/pipelines/github/stackrox/stackrox/9396/workflows/261df960-87d4-464b-8443-df34136ace14/jobs/422685
* https://app.circleci.com/pipelines/github/stackrox/stackrox/9449/workflows/9b4a19ac-69c1-4641-9d23-290c35d8e37e/jobs/425868
* https://app.circleci.com/pipelines/github/stackrox/stackrox/9493/workflows/37350729-28b1-440d-8dd3-a2228ca2600f/jobs/427973

![cypress-expected-0-to-equal-1](https://user-images.githubusercontent.com/11862657/163062861-b5e610d5-796b-405c-9df4-8d0325e8e234.png)

### Short-term solution

Because `getCytoscape` does not have retry like cypress `get` for DOM elements, add `wait(100)` in case the test sometimes accesses the cytoscape data before it has been updated.

The test has failed often enough recently to evaluate the effect of this change.

There might be better long-term solutions.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

1. `yarn cypress-open` in ui/apps/platform
    * cypress/integration/networkGraph/connections.test.js
    * cypress/integration/networkGraph/externalEntities.test.js
    * cypress/integration/networkGraph/networkFlows.test.js
    * cypress/integration/networkGraph/networkGraph.test.js
    * cypress/integration/networkGraph/tooltip.test.js
    * cypress/integration/network.test.js