### PR TITLE
ROX-9988: Introduce OSS flavor

### DIFF
--- a/pkg/images/defaults/env.go
+++ b/pkg/images/defaults/env.go
@@ -11,6 +11,8 @@ const (
 	ImageFlavorNameStackRoxIORelease = "stackrox.io"
 	// ImageFlavorNameRHACSRelease is a name for image flavor (image defaults) for images released to registry.redhat.io.
 	ImageFlavorNameRHACSRelease = "rhacs"
+	// ImageFlavorNameOpenSourceRelease is a name for image flavor (image defaults) for images released to quay.io/stackrox-io.
+	ImageFlavorNameOpenSourceRelease = "opensource"
 )
 
 var (

--- a/pkg/images/defaults/flavor.go
+++ b/pkg/images/defaults/flavor.go
@@ -207,9 +207,9 @@ func OpenSourceReleaseImageFlavor() ImageFlavor {
 
 		CollectorRegistry:      "quay.io/stackrox-io",
 		CollectorImageName:     "collector",
-		CollectorImageTag:      v.CollectorVersion + "-latest",
-		CollectorSlimImageName: "collector",
-		CollectorSlimImageTag:  v.CollectorVersion + "-slim",
+		CollectorImageTag:      v.CollectorVersion,
+		CollectorSlimImageName: "collector-slim",
+		CollectorSlimImageTag:  v.CollectorVersion,
 
 		ScannerImageName:       "scanner",
 		ScannerSlimImageName:   "scanner-slim",

--- a/pkg/images/defaults/flavor.go
+++ b/pkg/images/defaults/flavor.go
@@ -42,6 +42,11 @@ var (
 			isAllowedInReleaseBuild: true,
 			constructorFunc:         RHACSReleaseImageFlavor,
 		},
+		{
+			imageFlavorName:         ImageFlavorNameOpenSourceRelease,
+			isAllowedInReleaseBuild: true,
+			constructorFunc:         OpenSourceReleaseImageFlavor,
+		},
 	}
 
 	// imageFlavorMap contains allImageFlavors keyed by ImageFlavorName.
@@ -182,6 +187,38 @@ func RHACSReleaseImageFlavor() ImageFlavor {
 
 		ChartRepo: ChartRepo{
 			URL: "https://mirror.openshift.com/pub/rhacs/charts",
+		},
+		ImagePullSecrets: ImagePullSecrets{
+			AllowNone: true,
+		},
+		Versions: v,
+	}
+}
+
+// OpensourceReleaseImageFlavor returns image values for `opensource` flavor.
+func OpenSourceReleaseImageFlavor() ImageFlavor {
+	v := version.GetAllVersionsDevelopment()
+	return ImageFlavor{
+		MainRegistry:       "quay.io/stackrox-io",
+		MainImageName:      "main",
+		MainImageTag:       v.MainVersion,
+		CentralDBImageTag:  v.MainVersion,
+		CentralDBImageName: "central-db",
+
+		CollectorRegistry:      "quay.io/stackrox-io",
+		CollectorImageName:     "collector",
+		CollectorImageTag:      v.CollectorVersion + "-latest",
+		CollectorSlimImageName: "collector",
+		CollectorSlimImageTag:  v.CollectorVersion + "-slim",
+
+		ScannerImageName:       "scanner",
+		ScannerSlimImageName:   "scanner-slim",
+		ScannerImageTag:        v.ScannerVersion,
+		ScannerDBImageName:     "scanner-db",
+		ScannerDBSlimImageName: "scanner-db-slim",
+
+		ChartRepo: ChartRepo{
+			URL: "https://charts.stackrox.io",
 		},
 		ImagePullSecrets: ImagePullSecrets{
 			AllowNone: true,

--- a/pkg/images/defaults/flavor.go
+++ b/pkg/images/defaults/flavor.go
@@ -197,7 +197,7 @@ func RHACSReleaseImageFlavor() ImageFlavor {
 
 // OpenSourceReleaseImageFlavor returns image values for `opensource` flavor.
 func OpenSourceReleaseImageFlavor() ImageFlavor {
-	v := version.GetAllVersionsDevelopment()
+	v := version.GetAllVersionsUnified()
 	return ImageFlavor{
 		MainRegistry:       "quay.io/stackrox-io",
 		MainImageName:      "main",

--- a/pkg/images/defaults/flavor.go
+++ b/pkg/images/defaults/flavor.go
@@ -195,7 +195,7 @@ func RHACSReleaseImageFlavor() ImageFlavor {
 	}
 }
 
-// OpensourceReleaseImageFlavor returns image values for `opensource` flavor.
+// OpenSourceReleaseImageFlavor returns image values for `opensource` flavor.
 func OpenSourceReleaseImageFlavor() ImageFlavor {
 	v := version.GetAllVersionsDevelopment()
 	return ImageFlavor{

--- a/pkg/images/defaults/flavor.go
+++ b/pkg/images/defaults/flavor.go
@@ -218,6 +218,7 @@ func OpenSourceReleaseImageFlavor() ImageFlavor {
 		ScannerDBSlimImageName: "scanner-db-slim",
 
 		ChartRepo: ChartRepo{
+			// TODO(ROX-10079): establish a place where open source users will be able to download Helm charts.
 			URL: "https://charts.stackrox.io",
 		},
 		ImagePullSecrets: ImagePullSecrets{

--- a/pkg/images/defaults/flavor_test.go
+++ b/pkg/images/defaults/flavor_test.go
@@ -53,6 +53,9 @@ func (s *imageFlavorTestSuite) TestGetImageFlavorFromEnv() {
 		"rhacs": {
 			expectedFlavor: RHACSReleaseImageFlavor(),
 		},
+		"opensource": {
+			expectedFlavor: OpenSourceReleaseImageFlavor(),
+		},
 		"wrong_value": {
 			shouldPanicAlways: true,
 		},
@@ -97,6 +100,9 @@ func (s *imageFlavorTestSuite) TestGetImageFlavorByName() {
 		"rhacs": {
 			expectedFlavor: RHACSReleaseImageFlavor(),
 		},
+		"opensource": {
+			expectedFlavor: OpenSourceReleaseImageFlavor(),
+		},
 		"wrong_value": {
 			expectedErrorRelease:    "unexpected value 'wrong_value'",
 			expectedErrorNonRelease: "unexpected value 'wrong_value'",
@@ -132,8 +138,8 @@ func TestGetAllowedImageFlavorNames(t *testing.T) {
 		isRelease bool
 		want      []string
 	}{
-		{"development", false, []string{"development_build", "stackrox.io", "rhacs"}},
-		{"release", true, []string{"stackrox.io", "rhacs"}},
+		{"development", false, []string{"development_build", "stackrox.io", "rhacs", "opensource"}},
+		{"release", true, []string{"stackrox.io", "rhacs", "opensource"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tests/roxctl/bats-tests/local/central-generate-interactive-flavors-postgres.bats
+++ b/tests/roxctl/bats-tests/local/central-generate-interactive-flavors-postgres.bats
@@ -44,11 +44,11 @@ bitfield_to_failure() {
 }
 
 assert_flavor_prompt_development() {
-  assert_line --partial 'Enter default container images settings (development_build, stackrox.io, rhacs); it controls repositories from where to download the images, image names and tags format (default: "development_build"):'
+  assert_line --partial 'Enter default container images settings (development_build, stackrox.io, rhacs, opensource); it controls repositories from where to download the images, image names and tags format (default: "development_build"):'
 }
 
 assert_flavor_prompt_release() {
-  assert_line --partial 'Enter default container images settings (stackrox.io, rhacs); it controls repositories from where to download the images, image names and tags format (default: "rhacs"):'
+  assert_line --partial 'Enter default container images settings (stackrox.io, rhacs, opensource); it controls repositories from where to download the images, image names and tags format (default: "rhacs"):'
 }
 
 assert_prompts_development() {

--- a/tests/roxctl/bats-tests/local/central-generate-interactive-flavors.bats
+++ b/tests/roxctl/bats-tests/local/central-generate-interactive-flavors.bats
@@ -42,11 +42,11 @@ bitfield_to_failure() {
 }
 
 assert_flavor_prompt_development() {
-  assert_line --partial 'Enter default container images settings (development_build, stackrox.io, rhacs); it controls repositories from where to download the images, image names and tags format (default: "development_build"):'
+  assert_line --partial 'Enter default container images settings (development_build, stackrox.io, rhacs, opensource); it controls repositories from where to download the images, image names and tags format (default: "development_build"):'
 }
 
 assert_flavor_prompt_release() {
-  assert_line --partial 'Enter default container images settings (stackrox.io, rhacs); it controls repositories from where to download the images, image names and tags format (default: "rhacs"):'
+  assert_line --partial 'Enter default container images settings (stackrox.io, rhacs, opensource); it controls repositories from where to download the images, image names and tags format (default: "rhacs"):'
 }
 
 assert_prompts_development() {

--- a/tests/roxctl/bats-tests/local/roxctl-helm-output-central-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-helm-output-central-development.bats
@@ -58,7 +58,7 @@ teardown() {
 @test "roxctl-development helm output central-services --image-defaults=dummy should fail" {
   run roxctl-development helm output central-services --image-defaults=dummy --output-dir "$out_dir"
   assert_failure
-  assert_line --regexp "ERROR:[[:space:]]+unable to get chart meta values: '--image-defaults': unexpected value 'dummy', allowed values are \[development_build stackrox.io rhacs\]"
+  assert_line --regexp "ERROR:[[:space:]]+unable to get chart meta values: '--image-defaults': unexpected value 'dummy', allowed values are \[development_build stackrox.io rhacs opensource\]"
 }
 
 @test "roxctl-development helm output central-services --image-defaults=stackrox.io should use stackrox.io registry" {

--- a/tests/roxctl/bats-tests/local/roxctl-helm-output-central-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-helm-output-central-development.bats
@@ -36,7 +36,7 @@ teardown() {
 @test "roxctl-development helm output help-text should state default value for --image-defaults flag" {
   run roxctl-development helm output central-services -h
   assert_success
-  assert_line --regexp "--image-defaults.*\(development_build, stackrox.io, rhacs\).*default \"development_build\""
+  assert_line --regexp "--image-defaults.*\(development_build, stackrox.io, rhacs, opensource\).*default \"development_build\""
 }
 
 @test "roxctl-development helm output central-services should use docker.io registry" {

--- a/tests/roxctl/bats-tests/local/roxctl-helm-output-central-release.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-helm-output-central-release.bats
@@ -22,7 +22,7 @@ teardown() {
 @test "roxctl-release helm output help-text should state default value for --image-defaults flag" {
   run roxctl-release helm output central-services -h
   assert_success
-  assert_line --regexp "--image-defaults.*\(stackrox.io, rhacs\).*default \"rhacs\""
+  assert_line --regexp "--image-defaults.*\(stackrox.io, rhacs, opensource\).*default \"rhacs\""
 }
 
 @test "roxctl-release helm output central-services should use registry.redhat.io registry" {

--- a/tests/roxctl/bats-tests/local/roxctl-helm-output-central-release.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-helm-output-central-release.bats
@@ -61,13 +61,13 @@ teardown() {
 @test "roxctl-release helm output central-services --image-defaults=development_build should fail" {
   run roxctl-release helm output central-services --image-defaults=development_build --output-dir "$out_dir"
   assert_failure
-  assert_line --regexp "ERROR:[[:space:]]+unable to get chart meta values: '--image-defaults': unexpected value 'development_build', allowed values are \[stackrox.io rhacs\]"
+  assert_line --regexp "ERROR:[[:space:]]+unable to get chart meta values: '--image-defaults': unexpected value 'development_build', allowed values are \[stackrox.io rhacs opensource\]"
 }
 
 @test "roxctl-release helm output central-services --image-defaults='' should fail with unexpected value of --image-defaults" {
   run roxctl-release helm output central-services --image-defaults='' --output-dir "$out_dir"
   assert_failure
-  assert_line --regexp "ERROR:[[:space:]]+unable to get chart meta values: '--image-defaults': unexpected value '', allowed values are \[stackrox.io rhacs\]"
+  assert_line --regexp "ERROR:[[:space:]]+unable to get chart meta values: '--image-defaults': unexpected value '', allowed values are \[stackrox.io rhacs opensource\]"
 }
 
 @test "roxctl-release helm output central-services --rhacs --image-defaults=stackrox.io should return error about --rhacs colliding with --image-defaults" {


### PR DESCRIPTION
## Description

Introducing a new image flavor, `opensource`, which points to `quay.io/stackrox-io`.
This addresses ROX-9988.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [ ] ~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
- [ ] Document user facing changes in [dev-docs](https://github.com/stackrox/dev-docs) repo (as it's OSS-related usage changes)

If any of these don't apply, please comment below.

## Testing Performed

Testing was conducted by generating helm charts through `roxctl` and ensuring that it pulls the images from our public quay org:

```bash
# Generate charts
roxctl helm output central-services --image-defaults=opensource
roxctl helm output secured-cluster-services --image-defaults=opensource

# Install central chart - afterwards, generate & download cluster init bundle
helm install -n stackrox --create-namespace stackrox-central-services stackrox-central-services-chart --set imagePullSecrets.allowNone=true

# Install secured cluster chart by providing it the downloaded cluster init bundle
helm install -n stackrox --create-namespace stackrox-secured-cluster-services stackrox-secured-cluster-services-chart -f ./maincluster-cluster-init-bundle.yaml --set centralEndpoint=central.stackrox:443 --set clusterName=maincluster
```
