### PR TITLE
ROX-10084: Add dirty tag filter for operator installation

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -80,8 +80,8 @@ ENABLE_WEBHOOKS ?= false
 # Use the value figured in the parent directory Makefile, unless provided explicitly in the environment.
 ROX_IMAGE_FLAVOR ?= $(shell $(MAKE) --quiet --no-print-directory -C .. image-flavor)
 
-# ALLOW_DIRTY_TAG_INSTALLATION determines if OLM installation should proceed with -dirty prefixed operator image tag.
-# -dirty prefix shows that current branch changes are not committed
+# ALLOW_DIRTY_TAG_INSTALLATION determines if OLM installation should proceed with -dirty suffixed operator image tag.
+# -dirty suffix shows that current branch changes are not committed
 # therefore CI has not built and pushed image with current changes to the registry.
 ALLOW_DIRTY_TAG_INSTALLATION ?= false
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -331,7 +331,7 @@ deploy-via-olm: ## Deploy operator image to the cluster using OLM.
 .PHONY: deploy-dirty-tag-via-olm
 deploy-dirty-tag-via-olm: ## Deploy operator dirty tagged image to the cluster using OLM.
 # This command ignores filter for dirty tagged images.
-	ALLOW_DIRTY_TAG_INSTALLATION ?=true KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(VERSION) true
+	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(VERSION) true
 
 .PHONY: deploy-previous-via-olm
 deploy-previous-via-olm: kuttl bundle-post-process ## Deploy replaced version of operator image to the cluster using OLM.

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -80,6 +80,11 @@ ENABLE_WEBHOOKS ?= false
 # Use the value figured in the parent directory Makefile, unless provided explicitly in the environment.
 ROX_IMAGE_FLAVOR ?= $(shell $(MAKE) --quiet --no-print-directory -C .. image-flavor)
 
+# ALLOW_DIRTY_TAG_INSTALLATION determines if OLM installation should proceed with -dirty prefixed operator image tag.
+# -dirty prefix shows that current branch changes are not committed
+# therefore CI has not built and pushed image with current changes to the registry.
+ALLOW_DIRTY_TAG_INSTALLATION ?= false
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -321,7 +326,12 @@ undeploy: check-ci-setup kustomize ## Undeploy operator image from the K8s clust
 deploy-via-olm: ## Deploy operator image to the cluster using OLM.
 # This requires operator, bundle and index images to already be pushed, but we do not depend on the
 # target(s) that do it here, because CI does it in a separate job, in parallel with cluster deployment.
-	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(VERSION)
+	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(VERSION) $(ALLOW_DIRTY_TAG_INSTALLATION)
+
+.PHONY: deploy-dirty-tag-via-olm
+deploy-dirty-tag-via-olm: ## Deploy operator dirty tagged image to the cluster using OLM.
+# This command ignores filter for dirty tagged images.
+	ALLOW_DIRTY_TAG_INSTALLATION ?=true KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(VERSION) true
 
 .PHONY: deploy-previous-via-olm
 deploy-previous-via-olm: kuttl bundle-post-process ## Deploy replaced version of operator image to the cluster using OLM.
@@ -329,11 +339,15 @@ deploy-previous-via-olm: kuttl bundle-post-process ## Deploy replaced version of
 # target(s) that do it here, because CI does it in a separate job, in parallel with cluster deployment.
 	@replaced_version_no_v=$$(sed -E -n 's/^[[:space:]]*replaces:[[:space:]]*[^.]+\.v(.*)$$/\1/p' build/bundle/manifests/rhacs-operator.clusterserviceversion.yaml) ;\
 	set -x ;\
-	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(VERSION) $${replaced_version_no_v}
+	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(VERSION) $(ALLOW_DIRTY_TAG_INSTALLATION) $${replaced_version_no_v}
 
 .PHONY: upgrade-via-olm
 upgrade-via-olm: kuttl
-	KUTTL=$(KUTTL) ./hack/olm-operator-upgrade.sh $(TEST_NAMESPACE) $(VERSION)
+	KUTTL=$(KUTTL) ./hack/olm-operator-upgrade.sh $(TEST_NAMESPACE) $(VERSION) $(ALLOW_DIRTY_TAG_INSTALLATION)
+
+.PHONY: upgrade-dirty-tag-via-olm
+upgrade-via-olm: kuttl
+	KUTTL=$(KUTTL) ./hack/olm-operator-upgrade.sh $(TEST_NAMESPACE) $(VERSION) true
 
 ##@ Bundle and Index build
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -346,7 +346,7 @@ upgrade-via-olm: kuttl
 	KUTTL=$(KUTTL) ./hack/olm-operator-upgrade.sh $(TEST_NAMESPACE) $(VERSION) $(ALLOW_DIRTY_TAG_INSTALLATION)
 
 .PHONY: upgrade-dirty-tag-via-olm
-upgrade-via-olm: kuttl
+upgrade-dirty-tag-via-olm: kuttl
 	KUTTL=$(KUTTL) ./hack/olm-operator-upgrade.sh $(TEST_NAMESPACE) $(VERSION) true
 
 ##@ Bundle and Index build

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -80,11 +80,6 @@ ENABLE_WEBHOOKS ?= false
 # Use the value figured in the parent directory Makefile, unless provided explicitly in the environment.
 ROX_IMAGE_FLAVOR ?= $(shell $(MAKE) --quiet --no-print-directory -C .. image-flavor)
 
-# ALLOW_DIRTY_TAG_INSTALLATION determines if OLM installation should proceed with -dirty suffixed operator image tag.
-# -dirty suffix shows that current branch changes are not committed
-# therefore CI has not built and pushed image with current changes to the registry.
-ALLOW_DIRTY_TAG_INSTALLATION ?= false
-
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -326,12 +321,12 @@ undeploy: check-ci-setup kustomize ## Undeploy operator image from the K8s clust
 deploy-via-olm: ## Deploy operator image to the cluster using OLM.
 # This requires operator, bundle and index images to already be pushed, but we do not depend on the
 # target(s) that do it here, because CI does it in a separate job, in parallel with cluster deployment.
-	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(VERSION) $(ALLOW_DIRTY_TAG_INSTALLATION)
+	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(VERSION)
 
 .PHONY: deploy-dirty-tag-via-olm
 deploy-dirty-tag-via-olm: ## Deploy operator dirty tagged image to the cluster using OLM.
 # This target ignores filter for dirty tagged images.
-	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(VERSION) true
+	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh --allow-dirty-tag $(TEST_NAMESPACE) $(VERSION)
 
 .PHONY: deploy-previous-via-olm
 deploy-previous-via-olm: kuttl bundle-post-process ## Deploy replaced version of operator image to the cluster using OLM.
@@ -339,15 +334,15 @@ deploy-previous-via-olm: kuttl bundle-post-process ## Deploy replaced version of
 # target(s) that do it here, because CI does it in a separate job, in parallel with cluster deployment.
 	@replaced_version_no_v=$$(sed -E -n 's/^[[:space:]]*replaces:[[:space:]]*[^.]+\.v(.*)$$/\1/p' build/bundle/manifests/rhacs-operator.clusterserviceversion.yaml) ;\
 	set -x ;\
-	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(VERSION) $(ALLOW_DIRTY_TAG_INSTALLATION) $${replaced_version_no_v}
+	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(VERSION) $${replaced_version_no_v}
 
 .PHONY: upgrade-via-olm
 upgrade-via-olm: kuttl
-	KUTTL=$(KUTTL) ./hack/olm-operator-upgrade.sh $(TEST_NAMESPACE) $(VERSION) $(ALLOW_DIRTY_TAG_INSTALLATION)
+	KUTTL=$(KUTTL) ./hack/olm-operator-upgrade.sh $(TEST_NAMESPACE) $(VERSION)
 
 .PHONY: upgrade-dirty-tag-via-olm
 upgrade-dirty-tag-via-olm: kuttl
-	KUTTL=$(KUTTL) ./hack/olm-operator-upgrade.sh $(TEST_NAMESPACE) $(VERSION) true
+	KUTTL=$(KUTTL) ./hack/olm-operator-upgrade.sh --allow-dirty-tag $(TEST_NAMESPACE) $(VERSION)
 
 ##@ Bundle and Index build
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -330,7 +330,7 @@ deploy-via-olm: ## Deploy operator image to the cluster using OLM.
 
 .PHONY: deploy-dirty-tag-via-olm
 deploy-dirty-tag-via-olm: ## Deploy operator dirty tagged image to the cluster using OLM.
-# This command ignores filter for dirty tagged images.
+# This target ignores filter for dirty tagged images.
 	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(VERSION) true
 
 .PHONY: deploy-previous-via-olm

--- a/operator/README.md
+++ b/operator/README.md
@@ -246,3 +246,25 @@ kubectl delete index-test
 
 Instructions and best practices on how to extend the StackRox CRDs is contained in the separate file
 [EXTENDING_CRDS.md](./EXTENDING_CRDS.md).
+
+## Installing operator via OLM
+
+The following command will install operator to the currently selected kubernetes cluster.
+
+```bash
+ make kuttl deploy-via-olm
+```
+
+If operator image has a `-dirty` suffix then the following command has to be used instead:
+
+```bash
+make kuttle deploy-dirty-tag-via-olm
+```
+
+For upgrading an existing operator:
+
+```bash
+make kuttle upgrade-via-olm
+
+```
+Note ерфе there is a specific command for upgrading `-dirty` suffixed tags `upgrade-dirty-tag-via-olm`

--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -70,7 +70,7 @@ function check_version_tag() {
   local -r allow_dirty_tag="$2"
 
   echo $IMAGE_TAG_BASE
-  if docker manifest inspect $IMAGE_TAG_BASE:$version_tag ; then
+  if docker manifest inspect "$IMAGE_TAG_BASE:$version_tag" ; then
     return 0
   else
     log "Cannot find $IMAGE_TAG_BASE:$version_tag image tag in the registry."

--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -77,7 +77,7 @@ function check_version_tag() {
   fi
 
 
-  if [[ $version_tag == *-dirty ]] && [[ $allow_dirty_tag = false ]]; then
+  if [[ "$version_tag" == *-dirty ]] && [[ "$allow_dirty_tag" == false ]]; then
     log "Cannot install from *-dirty image tag. Please, use 'deploy-dirty-tag-via-olm' command instead if you need to install dirty tagged image"
     return 1
   fi

--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -65,6 +65,15 @@ function retry() {
   return 1
 }
 
+function check_version_tag() {
+  local -r version_tag="$1"
+
+    if [[ $version_tag == *-dirty ]]; then
+      log "Cannot install from *-dirty image tag. Dirty tag images are not supposed to be pushed to the registry"
+      return 1
+    fi
+}
+
 function approve_install_plan() {
   local -r operator_ns="$1"
   local -r version_tag="$2"

--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -69,12 +69,6 @@ function check_version_tag() {
   local -r version_tag="$1"
   local -r allow_dirty_tag="$2"
 
-  if docker manifest inspect "$IMAGE_TAG_BASE:$version_tag" ; then
-    return 0
-  else
-    log "Cannot find $IMAGE_TAG_BASE:$version_tag image tag in the registry."
-  fi
-
   if [[ "$version_tag" == *-dirty ]]; then
     log "Target image tag has -dirty suffix."
     if [[ "$allow_dirty_tag" == false ]]; then

--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -68,10 +68,10 @@ function retry() {
 function check_version_tag() {
   local -r version_tag="$1"
 
-    if [[ $version_tag == *-dirty ]]; then
-      log "Cannot install from *-dirty image tag. Dirty tag images are not supposed to be pushed to the registry"
-      return 1
-    fi
+  if [[ $version_tag == *-dirty ]]; then
+    log "Cannot install from *-dirty image tag. Dirty tag images are not supposed to be pushed to the registry."
+    return 1
+  fi
 }
 
 function approve_install_plan() {

--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -69,7 +69,6 @@ function check_version_tag() {
   local -r version_tag="$1"
   local -r allow_dirty_tag="$2"
 
-  echo $IMAGE_TAG_BASE
   if docker manifest inspect "$IMAGE_TAG_BASE:$version_tag" ; then
     return 0
   else

--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -76,7 +76,6 @@ function check_version_tag() {
     log "Cannot find $IMAGE_TAG_BASE:$version_tag image tag in the registry."
   fi
 
-
   if [[ "$version_tag" == *-dirty ]] && [[ "$allow_dirty_tag" == false ]]; then
     log "Cannot install from *-dirty image tag. Please, use 'deploy-dirty-tag-via-olm' command instead if you need to install dirty tagged image"
     return 1

--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -67,11 +67,22 @@ function retry() {
 
 function check_version_tag() {
   local -r version_tag="$1"
+  local -r allow_dirty_tag="$2"
 
-  if [[ $version_tag == *-dirty ]]; then
-    log "Cannot install from *-dirty image tag. Dirty tag images are not supposed to be pushed to the registry."
+  echo $IMAGE_TAG_BASE
+  if docker manifest inspect $IMAGE_TAG_BASE:$version_tag ; then
+    return 0
+  else
+    log "Cannot find $IMAGE_TAG_BASE:$version_tag image tag in the registry."
+  fi
+
+
+  if [[ $version_tag == *-dirty ]] && [[ $allow_dirty_tag = false ]]; then
+    log "Cannot install from *-dirty image tag. Please, use 'deploy-dirty-tag-via-olm' command instead if you need to install dirty tagged image"
     return 1
   fi
+
+  return 0
 }
 
 function approve_install_plan() {

--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -76,9 +76,12 @@ function check_version_tag() {
     log "Cannot find $IMAGE_TAG_BASE:$version_tag image tag in the registry."
   fi
 
-  if [[ "$version_tag" == *-dirty ]] && [[ "$allow_dirty_tag" == false ]]; then
-    log "Cannot install from *-dirty image tag. Please, use 'deploy-dirty-tag-via-olm' command instead if you need to install dirty tagged image"
-    return 1
+  if [[ "$version_tag" == *-dirty ]]; then
+    log "Target image tag has -dirty suffix."
+    if [[ "$allow_dirty_tag" == false ]]; then
+      log "Cannot install from *-dirty image tag. Please, use 'deploy-dirty-tag-via-olm' command or add '--allow-dirty-tag' flag if you need to install dirty tagged image."
+      return 1
+    fi
   fi
 
   return 0

--- a/operator/hack/olm-operator-install.sh
+++ b/operator/hack/olm-operator-install.sh
@@ -21,6 +21,7 @@ function main() {
     ;;
   esac
 
+  check_version_tag "${operator_version}"
   create_namespace "${operator_ns}"
   create_pull_secret "${operator_ns}"
   apply_operator_manifests "${operator_ns}" "${index_version}" "${operator_version}"

--- a/operator/hack/olm-operator-install.sh
+++ b/operator/hack/olm-operator-install.sh
@@ -7,21 +7,23 @@ source "$(dirname "$0")/common.sh"
 function main() {
   local -r operator_ns="${1:-}"
   case $# in
-  2)
-    local -r index_version="${2:-}"
-    local -r operator_version="${2:-}"
-    ;;
   3)
     local -r index_version="${2:-}"
-    local -r operator_version="${3:-}"
+    local -r operator_version="${2:-}"
+    local -r allow_dirty_tag="${3:-}"
+    ;;
+  4)
+    local -r index_version="${2:-}"
+    local -r allow_dirty_tag="${3:-}"
+    local -r operator_version="${4:-}"
     ;;
   *)
-    echo "Usage: $0 <operator_ns> <index-version> [<install-version>]" >&2
+    echo "Usage: $0 <operator_ns> <index-version> <allow-dirty-tag> [<install-version>]" >&2
     exit 1
     ;;
   esac
 
-  check_version_tag "${operator_version}"
+  check_version_tag "${operator_version}" "${allow_dirty_tag}"
   create_namespace "${operator_ns}"
   create_pull_secret "${operator_ns}"
   apply_operator_manifests "${operator_ns}" "${index_version}" "${operator_version}"

--- a/operator/hack/olm-operator-install.sh
+++ b/operator/hack/olm-operator-install.sh
@@ -4,21 +4,29 @@ set -eu -o pipefail
 
 source "$(dirname "$0")/common.sh"
 
+declare allow_dirty_tag=false
+
 function main() {
+  case "$1" in
+  -d | --allow-dirty-tag)
+    allow_dirty_tag=true
+    shift
+    ;;
+  esac
+
   local -r operator_ns="${1:-}"
+
   case $# in
-  3)
+  2)
     local -r index_version="${2:-}"
     local -r operator_version="${2:-}"
-    local -r allow_dirty_tag="${3:-}"
     ;;
-  4)
+  3)
     local -r index_version="${2:-}"
-    local -r allow_dirty_tag="${3:-}"
-    local -r operator_version="${4:-}"
+    local -r operator_version="${3:-}"
     ;;
   *)
-    echo "Usage: $0 <operator_ns> <index-version> <allow-dirty-tag> [<install-version>]" >&2
+    echo "Usage: $0 [--allow-dirty-tag | -d] <operator_ns> <index-version> [<install-version>]" >&2
     exit 1
     ;;
   esac

--- a/operator/hack/olm-operator-upgrade.sh
+++ b/operator/hack/olm-operator-upgrade.sh
@@ -5,15 +5,23 @@ set -eu -o pipefail
 
 source "$(dirname "$0")/common.sh"
 
+declare allow_dirty_tag=false
+
 function main() {
-  if [[ $# -ne 3 ]]; then
-    echo "Usage: $0 <operator_ns> <operator-version> <allow-dirty-tag>" >&2
+  case "$1" in
+  -d | --allow-dirty-tag)
+    allow_dirty_tag=true
+    shift
+    ;;
+  esac
+
+  if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 [-d | --allow-dirty-tag] <operator_ns> <operator-version>" >&2
     exit 1
   fi
 
   local -r operator_ns="${1:-}"
   local -r operator_version="${2:-}"
-  local -r allow_dirty_tag="${3:-}"
 
   # Unfortunately simply changing to automatic approval does not work:
   # https://github.com/operator-framework/operator-lifecycle-manager/issues/2341

--- a/operator/hack/olm-operator-upgrade.sh
+++ b/operator/hack/olm-operator-upgrade.sh
@@ -20,6 +20,7 @@ function main() {
   #  --type=json -p '[{"op": "remove", "path": "/spec/startingCSV"}, {"op": "replace", "path": "/spec/installPlanApproval", "value": "Automatic"}]'
 
   # However OLM happens to create an install plan for the latest version anyway, as soon as the old one is done, so we just have to approve it:
+  check_version_tag "${operator_version}"
   approve_install_plan "${operator_ns}" "${operator_version}"
   nurse_deployment_until_available "${operator_ns}" "${operator_version}"
 }

--- a/operator/hack/olm-operator-upgrade.sh
+++ b/operator/hack/olm-operator-upgrade.sh
@@ -6,13 +6,14 @@ set -eu -o pipefail
 source "$(dirname "$0")/common.sh"
 
 function main() {
-  if [[ $# -ne 2 ]]; then
-    echo "Usage: $0 <operator_ns> <operator-version>" >&2
+  if [[ $# -ne 3 ]]; then
+    echo "Usage: $0 <operator_ns> <operator-version> <allow-dirty-tag>" >&2
     exit 1
   fi
 
   local -r operator_ns="${1:-}"
   local -r operator_version="${2:-}"
+  local -r allow_dirty_tag="${3:-}"
 
   # Unfortunately simply changing to automatic approval does not work:
   # https://github.com/operator-framework/operator-lifecycle-manager/issues/2341
@@ -20,7 +21,7 @@ function main() {
   #  --type=json -p '[{"op": "remove", "path": "/spec/startingCSV"}, {"op": "replace", "path": "/spec/installPlanApproval", "value": "Automatic"}]'
 
   # However OLM happens to create an install plan for the latest version anyway, as soon as the old one is done, so we just have to approve it:
-  check_version_tag "${operator_version}"
+  check_version_tag "${operator_version}" "${allow_dirty_tag}"
   approve_install_plan "${operator_ns}" "${operator_version}"
   nurse_deployment_until_available "${operator_ns}" "${operator_version}"
 }


### PR DESCRIPTION
## Description

[Ticket description](https://issues.redhat.com/browse/ROX-10084)

Dirty tag helps to spot if there are some changes since last commit. Such tags are not pushed to the image registry. Running `olm-operator-install` with dirty tag stuck operator in `ImagePullBackOff` loop because there is no such image in the registry. I think it makes sense to fail fast dirty tag olm installation and give developer a hint why this is not going to work.



## Checklist
- [x] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

No need, it is just a quality of life improvement

## Testing Performed

Run locally with dirty tag against remote cluster and it failed immediately 
