### PR TITLE
CI: Avoid docker rate limits (again)

### DIFF
--- a/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
@@ -29,8 +29,8 @@ class AttemptedAlertsTest extends BaseSpecification {
             (DEP_NAMES[1]): createDeployment(DEP_NAMES[1], "nginx:latest"),
             (DEP_NAMES[2]): createDeployment(DEP_NAMES[2], "nginx:latest"),
             (DEP_NAMES[3]): createDeployment(DEP_NAMES[3], "nginx:latest"),
-            (DEP_NAMES[4]): createDeployment(DEP_NAMES[4], "nginx:1.14-alpine"),
-            (DEP_NAMES[5]): createDeployment(DEP_NAMES[5], "nginx:1.14-alpine"),
+            (DEP_NAMES[4]): createDeployment(DEP_NAMES[4], "quay.io/rhacs-eng/qa:nginx-1-14-alpine"),
+            (DEP_NAMES[5]): createDeployment(DEP_NAMES[5], "quay.io/rhacs-eng/qa:nginx-1-14-alpine"),
     ]
 
     static final private String LATEST_TAG_POLICY_NAME = "Latest tag"

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -39,7 +39,7 @@ import java.text.SimpleDateFormat
 @OnFailure(handler = { Helpers.collectDebugForFailure(delegate as Throwable) })
 class BaseSpecification extends Specification {
 
-    static final String TEST_IMAGE = "nginx:1.7.9"
+    static final String TEST_IMAGE = "quay.io/rhacs-eng/qa:nginx-1-7-9"
 
     static final String RUN_ID
 

--- a/qa-tests-backend/src/test/groovy/CSVTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CSVTest.groovy
@@ -75,11 +75,11 @@ class CSVTest extends BaseSpecification {
 
     static final private Deployment CVE_DEPLOYMENT = new Deployment()
             .setName("nginx-deployment")
-            .setImage("nginx:1.9")
+            .setImage("quay.io/rhacs-eng/qa:nginx-1-9")
             .addLabel("app", "test")
 
     def setupSpec() {
-        ImageService.scanImage("nginx:1.9")
+        ImageService.scanImage("quay.io/rhacs-eng/qa:nginx-1-9")
         orchestrator.createDeployment(CVE_DEPLOYMENT)
         assert Services.waitForDeployment(CVE_DEPLOYMENT)
     }

--- a/qa-tests-backend/src/test/groovy/CSVTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CSVTest.groovy
@@ -172,13 +172,13 @@ class CSVTest extends BaseSpecification {
 
         graphQLQuery                    | graphQLPayload | csvQuery
         FIXABLE_CVES_IN_IMAGE_QUERY     | [
-                id        : "sha256:54313b5c376892d55205f13d620bc3dcccc8e70e596d083953f95e94f071f6db",
+                id        : "sha256:c8c29d842c09d6c61f537843808e01c0af4079e9e74079616f57dfcfa91d4e25",
                 query: "",
                 // must scope without scope query since graphQL is hitting sub-resolver
                 scopeQuery: "",
                 vulnQuery : "Fixable:true",
                 vulnPagination: new Pagination(0, 0, new SortOption("cvss", true)),
-        ] | "Image Sha:sha256:54313b5c376892d55205f13d620bc3dcccc8e70e596d083953f95e94f071f6db+Fixable:true"
+        ] | "Image Sha:sha256:c8c29d842c09d6c61f537843808e01c0af4079e9e74079616f57dfcfa91d4e25+Fixable:true"
         FIXABLE_CVES_IN_COMPONENT_QUERY | [
                 // openssl 1.0.1k-3+deb8u5
                 id        : "b3BlbnNzbA:MS4wLjFrLTMrZGViOHU1",

--- a/qa-tests-backend/src/test/groovy/CSVTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CSVTest.groovy
@@ -172,13 +172,13 @@ class CSVTest extends BaseSpecification {
 
         graphQLQuery                    | graphQLPayload | csvQuery
         FIXABLE_CVES_IN_IMAGE_QUERY     | [
-                id        : "sha256:c8c29d842c09d6c61f537843808e01c0af4079e9e74079616f57dfcfa91d4e25",
+                id        : "sha256:e18c5814a9f7ddd5fe410f17417a48d2de562325e9d71337274134f4a6654e3f",
                 query: "",
                 // must scope without scope query since graphQL is hitting sub-resolver
                 scopeQuery: "",
                 vulnQuery : "Fixable:true",
                 vulnPagination: new Pagination(0, 0, new SortOption("cvss", true)),
-        ] | "Image Sha:sha256:c8c29d842c09d6c61f537843808e01c0af4079e9e74079616f57dfcfa91d4e25+Fixable:true"
+        ] | "Image Sha:sha256:e18c5814a9f7ddd5fe410f17417a48d2de562325e9d71337274134f4a6654e3f+Fixable:true"
         FIXABLE_CVES_IN_COMPONENT_QUERY | [
                 // openssl 1.0.1k-3+deb8u5
                 id        : "b3BlbnNzbA:MS4wLjFrLTMrZGViOHU1",

--- a/qa-tests-backend/src/test/groovy/CVETest.groovy
+++ b/qa-tests-backend/src/test/groovy/CVETest.groovy
@@ -163,7 +163,7 @@ class CVETest extends BaseSpecification {
 
     static final private Deployment CVE_DEPLOYMENT = new Deployment()
             .setName(CVE_DEPLOYMENT_NAME)
-            .setImage("us.gcr.io/stackrox-ci/quay.io/rhacs-eng/qa:nginx-1-9")
+            .setImage("us.gcr.io/stackrox-ci/nginx:1.9")
             .addLabel("app", "test")
 
     static final private NGINX_1_10_2_IMAGE = "us.gcr.io/stackrox-ci/nginx:1.10.2"
@@ -185,7 +185,7 @@ class CVETest extends BaseSpecification {
             "docker.io/library/debian@${UNFIXABLE_VULN_IMAGE_DIGEST}"
 
     def setupSpec() {
-        ImageService.scanImage("us.gcr.io/stackrox-ci/quay.io/rhacs-eng/qa:nginx-1-9")
+        ImageService.scanImage("us.gcr.io/stackrox-ci/nginx:1.9")
         ImageService.scanImage(NGINX_1_10_2_IMAGE)
         ImageService.scanImage(RED_HAT_IMAGE)
         ImageService.scanImage(UBUNTU_IMAGE)

--- a/qa-tests-backend/src/test/groovy/CVETest.groovy
+++ b/qa-tests-backend/src/test/groovy/CVETest.groovy
@@ -163,7 +163,7 @@ class CVETest extends BaseSpecification {
 
     static final private Deployment CVE_DEPLOYMENT = new Deployment()
             .setName(CVE_DEPLOYMENT_NAME)
-            .setImage("us.gcr.io/stackrox-ci/nginx:1.9")
+            .setImage("us.gcr.io/stackrox-ci/quay.io/rhacs-eng/qa:nginx-1-9")
             .addLabel("app", "test")
 
     static final private NGINX_1_10_2_IMAGE = "us.gcr.io/stackrox-ci/nginx:1.10.2"
@@ -185,7 +185,7 @@ class CVETest extends BaseSpecification {
             "docker.io/library/debian@${UNFIXABLE_VULN_IMAGE_DIGEST}"
 
     def setupSpec() {
-        ImageService.scanImage("us.gcr.io/stackrox-ci/nginx:1.9")
+        ImageService.scanImage("us.gcr.io/stackrox-ci/quay.io/rhacs-eng/qa:nginx-1-9")
         ImageService.scanImage(NGINX_1_10_2_IMAGE)
         ImageService.scanImage(RED_HAT_IMAGE)
         ImageService.scanImage(UBUNTU_IMAGE)
@@ -273,13 +273,20 @@ class CVETest extends BaseSpecification {
         where:
         "data inputs"
 
-        query                                                                  | cve             | checkImageCount
-        "Deployment:${CVE_DEPLOYMENT_NAME}+Image:nginx:1.9+CVE:CVE-2005-2541"  | "CVE-2005-2541" | true
-        "Label:name=cve-deployment+CVE:CVE-2005-2541"                          | "CVE-2005-2541" | true
-        "Image:nginx:1.9+CVE:CVE-2005-2541"                                    | "CVE-2005-2541" | true
-        "CVSS:10+CVE:CVE-2005-2541"                                            | "CVE-2005-2541" | false
-        "Component:tar+CVE:CVE-2005-2541"                                      | "CVE-2005-2541" | false
-        "CVE:CVE-2005-2541"                                                    | "CVE-2005-2541" | false
+        query                                                                  |
+                cve             | checkImageCount
+        "Deployment:${CVE_DEPLOYMENT_NAME}+Image:quay.io/rhacs-eng/qa:nginx-1-9+CVE:CVE-2005-2541"  |
+                "CVE-2005-2541" | true
+        "Label:name=cve-deployment+CVE:CVE-2005-2541"                          |
+                "CVE-2005-2541" | true
+        "Image:quay.io/rhacs-eng/qa:nginx-1-9+CVE:CVE-2005-2541"               |
+                "CVE-2005-2541" | true
+        "CVSS:10+CVE:CVE-2005-2541"                                            |
+                "CVE-2005-2541" | false
+        "Component:tar+CVE:CVE-2005-2541"                                      |
+                "CVE-2005-2541" | false
+        "CVE:CVE-2005-2541"                                                    |
+                "CVE-2005-2541" | false
     }
 
     @Unroll

--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -813,7 +813,7 @@ class ComplianceTest extends BaseSpecification {
         "create Deployment that forces checks to fail"
         Deployment deployment = new Deployment()
                 .setName("compliance-deployment")
-                .setImage("nginx:1.15.4-alpine")
+                .setImage("quay.io/rhacs-eng/qa:nginx-1-15-4-alpine")
                 .addPort(80, "UDP")
                 .setCommand(["/bin/sh", "-c",])
                 .setArgs(["dd if=/dev/zero of=/dev/null & yes"])

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -95,7 +95,7 @@ class DefaultPoliciesTest extends BaseSpecification {
             .setCommand(["sleep", "600"]),
         new Deployment()
             .setName(NGINX_1_10)
-            .setImage("docker.io/nginx:1.10")
+            .setImage("quay.io/rhacs-eng/qa:docker-io-nginx-1-10")
             .addLabel("app", "test"),
         new Deployment()
             .setName(GCR_NGINX)

--- a/qa-tests-backend/src/test/groovy/Enforcement.groovy
+++ b/qa-tests-backend/src/test/groovy/Enforcement.groovy
@@ -170,7 +170,7 @@ class Enforcement extends BaseSpecification {
                             .setSkipReplicaWait(true),
             (SCALE_DOWN_ENFORCEMENT_BUILD_DEPLOY_SEVERITY):
                     new Deployment()
-                            .setImage("us.gcr.io/stackrox-ci/quay.io/rhacs-eng/qa:nginx-1-9-1")
+                            .setImage("us.gcr.io/stackrox-ci/nginx:1.9.1")
                             .addPort(22)
                             .setSkipReplicaWait(true)
                             .setCommand(["sleep", "600"]),

--- a/qa-tests-backend/src/test/groovy/Enforcement.groovy
+++ b/qa-tests-backend/src/test/groovy/Enforcement.groovy
@@ -170,7 +170,7 @@ class Enforcement extends BaseSpecification {
                             .setSkipReplicaWait(true),
             (SCALE_DOWN_ENFORCEMENT_BUILD_DEPLOY_SEVERITY):
                     new Deployment()
-                            .setImage("us.gcr.io/stackrox-ci/nginx:1.9.1")
+                            .setImage("us.gcr.io/stackrox-ci/quay.io/rhacs-eng/qa:nginx-1-9-1")
                             .addPort(22)
                             .setSkipReplicaWait(true)
                             .setCommand(["sleep", "600"]),

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -36,7 +36,7 @@ class ImageScanningTest extends BaseSpecification {
     static final private String RHEL7_IMAGE =
             "richxsl/rhel7@sha256:8f3aae325d2074d2dc328cb532d6e7aeb0c588e15ddf847347038fe0566364d6"
     static final private String GCR_IMAGE   = "us.gcr.io/stackrox-ci/qa/registry-image:0.2"
-    static final private String NGINX_IMAGE = "nginx:1.12.1"
+    static final private String NGINX_IMAGE = "quay.io/rhacs-eng/qa:nginx-1-12-1"
     static final private String OCI_IMAGE   = "quay.io/rhacs-eng/qa:oci-manifest"
     static final private String AR_IMAGE    = "us-west1-docker.pkg.dev/stackrox-ci/artifact-registry-test1/nginx:1.17"
     static final private String CENTOS_IMAGE = "quay.io/rhacs-eng/qa:centos7-base"

--- a/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
@@ -110,7 +110,7 @@ class K8sRbacTest extends BaseSpecification {
                 .setName(DEPLOYMENT_NAME)
                 .setNamespace(Constants.ORCHESTRATOR_NAMESPACE)
                 .setServiceAccountName(SERVICE_ACCOUNT_NAME)
-                .setImage("nginx:1.15.4-alpine")
+                .setImage("quay.io/rhacs-eng/qa:nginx-1-15-4-alpine")
                 .setSkipReplicaWait(true)
         orchestrator.createDeployment(deployment)
         assert Services.waitForDeployment(deployment)

--- a/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
@@ -271,7 +271,7 @@ class PolicyConfigurationTest extends BaseSpecification {
                         .setFields(PolicyFields.newBuilder()
                                 .setImageName(
                                         ImageNamePolicy.newBuilder()
-                                                .setRemote("library/nginx")
+                                                .setRemote("quay.io/rhacs-eng/qa")
                                                 .build())
                                 .build())
                         .build()                       | DEPLOYMENTNGINX | null

--- a/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
@@ -111,7 +111,7 @@ class PolicyConfigurationTest extends BaseSpecification {
                     .setName(DEPLOYMENT_RBAC)
                     .setNamespace(Constants.ORCHESTRATOR_NAMESPACE)
                     .setServiceAccountName(SERVICE_ACCOUNT_NAME)
-                    .setImage("nginx:1.15.4-alpine")
+                    .setImage("quay.io/rhacs-eng/qa:nginx-1-15-4-alpine")
                     .setSkipReplicaWait(true),
     ]
 

--- a/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
@@ -271,7 +271,7 @@ class PolicyConfigurationTest extends BaseSpecification {
                         .setFields(PolicyFields.newBuilder()
                                 .setImageName(
                                         ImageNamePolicy.newBuilder()
-                                                .setRemote("quay.io/rhacs-eng/qa")
+                                                .setRemote("rhacs-eng/qa")
                                                 .build())
                                 .build())
                         .build()                       | DEPLOYMENTNGINX | null

--- a/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
@@ -254,7 +254,7 @@ class PolicyConfigurationTest extends BaseSpecification {
                         .setFields(PolicyFields.newBuilder()
                                 .setImageName(
                                         ImageNamePolicy.newBuilder()
-                                                .setTag("1.7.9")
+                                                .setTag("nginx-1-7-9")
                                                 .build())
                                 .build())
                         .build()                       | DEPLOYMENTNGINX | null

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -30,7 +30,7 @@ class SACTest extends BaseSpecification {
     static final private String NAMESPACE_QA1 = "qa-test1"
     static final private String DEPLOYMENTNGINX_NAMESPACE_QA2 = "sac-deploymentnginx-qa2"
     static final private String NAMESPACE_QA2 = "qa-test2"
-    static final private String TEST_IMAGE = "nginx:1.7.9"
+    static final private String TEST_IMAGE = "quay.io/rhacs-eng/qa:nginx-1-7-9"
     static final private String TESTROLE = "Continuous Integration"
     static final private String SECRETNAME = "sac-secret"
     static final protected String ALLACCESSTOKEN = "allAccessToken"

--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -187,7 +187,7 @@ class TLSChallengeTest extends BaseSpecification {
         loadBalancerDeployment.setNamespace(PROXY_NAMESPACE)
                 .setName("nginx-loadbalancer")
                 .setExposeAsService(true)
-                .setImage("nginx:1.17.1")
+                .setImage("quay.io/rhacs-eng/qa:nginx-1-17-1")
                 .addVolumeFromConfigMap(nginxConfigMap, "/etc/nginx/conf.d/")
                 .addVolumeFromSecret(tlsConfSecret, "/run/secrets/tls/")
                 .setTargetPort(8443)

--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -33,7 +33,8 @@ class TLSChallengeTest extends BaseSpecification {
 
     def setupSpec() {
         originalCentralEndpoint = orchestrator.getDeploymentEnv("stackrox", "sensor", "ROX_CENTRAL_ENDPOINT")
-        orchestrator.createNamespace(PROXY_NAMESPACE)
+        orchestrator.ensureNamespaceExists(PROXY_NAMESPACE)
+        addStackroxImagePullSecret(PROXY_NAMESPACE)
 
         ByteArrayOutputStream out = new ByteArrayOutputStream()
         out.write(LEAF_CERT_CONTENT)


### PR DESCRIPTION
## Description

Moves some test image refs to quay.io/rhacs-eng/qa to avoid docker.io rate limit test [failures](https://app.circleci.com/pipelines/github/stackrox/stackrox/9501/workflows/b6b7a08c-5a94-45fb-ab9e-3f6b1ce7ae6d/jobs/428298/steps). If we continue to hit rate limits we'll need to consider other options e.g. creating a pull secret with an unlimited account.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient - all tests + openshift-4.