### PR TITLE
Replace cypress server and route with intercept in search

### DIFF
--- a/ui/apps/platform/cypress/constants/SearchPage.js
+++ b/ui/apps/platform/cypress/constants/SearchPage.js
@@ -1,13 +1,8 @@
 import scopeSelectors from '../helpers/scopeSelectors';
-import tab from '../selectors/tab';
 import search from '../selectors/search';
-
-const viewOnLabelChip = '[data-testid="view-on-label-chip"]';
-const filterOnLabelChip = '[data-testid="filter-on-label-chip"]';
 
 export const selectors = {
     globalSearchButton: 'button:contains("Search")',
-    pageSearchSuggestions: 'div.Select-menu-outer',
     pageSearch: scopeSelectors('[data-testid="page-header"]', {
         input: search.input,
         options: search.input,
@@ -16,23 +11,18 @@ export const selectors = {
         input: search.input,
         options: search.input,
     }),
-    allTab: `${tab.tabs}:contains("All")`,
-    violationsTab: `${tab.tabs}:contains("Violations")`,
-    policiesTab: `${tab.tabs}:contains("Policies")`,
-    deploymentsTab: `${tab.tabs}:contains("Deployments")`,
-    imagesTab: `${tab.tabs}:contains("Images")`,
-    secretsTab: `${tab.tabs}:contains("Secrets")`,
+    empty: scopeSelectors('.pf-c-empty-state', {
+        head: 'h1',
+        body: '.pf-c-empty-state__body',
+    }),
+    tab: 'li.pf-c-tabs__item',
     globalSearchResults: scopeSelectors('[data-testid="global-search-results"]', {
         header: 'h1',
     }),
-    viewOnRiskLabelChip: `${viewOnLabelChip}:contains("RISK")`,
-    viewOnViolationsLabelChip: `${viewOnLabelChip}:contains("VIOLATIONS")`,
-    viewOnPoliciesLabelChip: `${viewOnLabelChip}:contains("POLICIES")`,
-    viewOnImagesLabelChip: `${viewOnLabelChip}:contains("IMAGES")`,
-    viewOnSecretsLabelChip: `${viewOnLabelChip}:contains("SECRETS")`,
-    filterOnRiskLabelChip: `${filterOnLabelChip}:contains("RISK")`,
-    filterOnViolationsLabelChip: `${filterOnLabelChip}:contains("VIOLATIONS")`,
-    filterOnNetworkLabelChip: `${filterOnLabelChip}:contains("NETWORK")`,
+
+    // Include ancestor selector like section#All to match only the table for the active tab.
+    viewOnChip: 'td[data-label="View On:"] button',
+    filterOnChip: 'td[data-label="Filter On:"] button',
 };
 
 export default selectors;

--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -55,8 +55,7 @@ export const general = {
 };
 
 export const search = {
-    globalSearchWithResults: '/v1/search?query=Cluster:remote',
-    globalSearchWithNoResults: '/v1/search?query=Cluster:',
+    results: '/v1/search?query=*',
     options: '/v1/search/metadata/options*',
     autocomplete: 'v1/search/autocomplete*',
     autocompleteBySearch: (searchObj, category) =>

--- a/ui/apps/platform/cypress/integration/search.test.js
+++ b/ui/apps/platform/cypress/integration/search.test.js
@@ -1,63 +1,67 @@
 import { selectors } from '../constants/SearchPage';
 import * as api from '../constants/apiEndpoints';
 import withAuth from '../helpers/basicAuth';
+import { visitMainDashboard } from '../helpers/main';
 
-// TODO: Fix for ROX-6826
-describe.skip('Global Search Modal', () => {
-    withAuth();
+function visitSearch() {
+    visitMainDashboard();
 
-    beforeEach(() => {
-        cy.server();
-        cy.fixture('search/globalSearchResults.json').as('globalSearchResultsJson');
-        cy.route('GET', api.search.globalSearchWithResults, '@globalSearchResultsJson').as(
-            'globalSearchResults'
-        );
-        cy.fixture('search/metadataOptions.json').as('metadataOptionsJson');
-        cy.route('GET', api.search.options, '@metadataOptionsJson').as('globalSearchOptions');
-        cy.visit('/main/dashboard');
-        cy.get(selectors.globalSearchButton).click();
+    cy.get(selectors.globalSearchButton).click();
+}
+
+function searchWithFixture(searchTuples, fixture) {
+    cy.intercept('GET', api.search.results, { fixture }).as('getSearchResults');
+
+    cy.get(selectors.globalSearch.input).clear();
+    searchTuples.forEach(([category, value]) => {
+        cy.get(selectors.globalSearch.input).type(`${category}{enter}`);
+        cy.get(selectors.globalSearch.input).type(`${value}{enter}`);
     });
 
-    // TODO: Fix for ROX-6826
-    xit('Should have 6 tabs with the "All" tab selected by default', () => {
-        cy.wait('@globalSearchOptions');
-        cy.get(selectors.globalSearch.input).type('Cluster:{enter}', {
-            force: true,
-        });
-        cy.get(selectors.globalSearch.input).type('remote{enter}', {
-            force: true,
-        });
-        cy.wait('@globalSearchResults');
-        cy.get(selectors.allTab).should('have.class', 'border-primary-400');
-        cy.get(selectors.violationsTab).should('not.have.class', 'border-primary-400');
-        cy.get(selectors.policiesTab).should('not.have.class', 'border-primary-400');
-        cy.get(selectors.deploymentsTab).should('not.have.class', 'border-primary-400');
-        cy.get(selectors.imagesTab).should('not.have.class', 'border-primary-400');
-        cy.get(selectors.secretsTab).should('not.have.class', 'border-primary-400');
+    cy.wait('@getSearchResults');
+}
+
+describe('Global Search Modal', () => {
+    withAuth();
+
+    it('should have empty state instead of count and tabs if search filter is empty', () => {
+        visitSearch();
+
+        cy.get(`${selectors.empty.head}:contains("Search all data")`).should('exist');
+        cy.get(
+            `${selectors.empty.body}:contains("Choose one or more filter values to search")`
+        ).should('exist');
+
+        cy.get(selectors.globalSearchResults.header).should('not.exist');
+        cy.get(selectors.tab).should('not.exist');
+    });
+
+    it('Should have 6 tabs with the "All" tab selected by default', () => {
+        visitSearch();
+        searchWithFixture([['Cluster:', 'remote']], 'search/globalSearchResults.json');
+
+        cy.get(`${selectors.tab}:contains("All")`).should('have.class', 'pf-m-current');
+        cy.get(`${selectors.tab}:contains("Violations")`).should('not.have.class', 'pf-m-current');
+        cy.get(`${selectors.tab}:contains("Policies")`).should('not.have.class', 'pf-m-current');
+        cy.get(`${selectors.tab}:contains("Deployments")`).should('not.have.class', 'pf-m-current');
+        cy.get(`${selectors.tab}:contains("Images")`).should('not.have.class', 'pf-m-current');
+        cy.get(`${selectors.tab}:contains("Secrets")`).should('not.have.class', 'pf-m-current');
     });
 
     it('Should filter search results', () => {
-        cy.wait('@globalSearchOptions');
-        cy.get(selectors.globalSearch.input).type('Cluster:{enter}', {
-            force: true,
-        });
-        cy.get(selectors.globalSearch.input).type('remote{enter}', {
-            force: true,
-        });
-        cy.wait('@globalSearchResults');
-        cy.get(selectors.globalSearchResults.header).should('not.have.text', '0 search results');
+        visitSearch();
+        searchWithFixture([['Cluster:', 'remote']], 'search/globalSearchResults.json');
+
+        cy.get(selectors.globalSearchResults.header).should('have.text', '4 search results');
     });
 
     it('Should send you to the Violations page', () => {
-        cy.wait('@globalSearchOptions');
-        cy.get(selectors.globalSearch.input).type('Cluster:{enter}', {
-            force: true,
-        });
-        cy.get(selectors.globalSearch.input).type('remote{enter}', {
-            force: true,
-        });
-        cy.wait('@globalSearchResults');
-        cy.get(selectors.viewOnViolationsLabelChip).click();
+        visitSearch();
+        searchWithFixture([['Cluster:', 'remote']], 'search/globalSearchResults.json');
+
+        cy.get(`section#All ${selectors.viewOnChip}:contains("VIOLATIONS")`).click();
+        // TODO because 404 for /v1/alerts/6f68ef75-a96d-4121-ad89-92cf8cde0062
+        // replace button with anchor and assert on href attribute?
         cy.location('pathname').should(
             'eq',
             '/main/violations/6f68ef75-a96d-4121-ad89-92cf8cde0062'
@@ -65,41 +69,32 @@ describe.skip('Global Search Modal', () => {
     });
 
     it('Should send you to the Risk page', () => {
-        cy.wait('@globalSearchOptions');
-        cy.get(selectors.globalSearch.input).type('Cluster:{enter}', {
-            force: true,
-        });
-        cy.get(selectors.globalSearch.input).type('remote{enter}', {
-            force: true,
-        });
-        cy.wait('@globalSearchResults');
-        cy.get(selectors.viewOnRiskLabelChip).click();
+        visitSearch();
+        searchWithFixture([['Cluster:', 'remote']], 'search/globalSearchResults.json');
+
+        cy.get(`section#All ${selectors.viewOnChip}:contains("RISK")`).click();
+        // TODO because 404 for /v1/deploymentswithrisk/ppqqu24i8x16j7annv2bjphyy
+        // replace button with anchor and assert on href attribute?
         cy.location('pathname').should('eq', '/main/risk/ppqqu24i8x16j7annv2bjphyy');
     });
 
     it('Should send you to the Policies page', () => {
-        cy.wait('@globalSearchOptions');
-        cy.get(selectors.globalSearch.input).type('Cluster:{enter}', {
-            force: true,
-        });
-        cy.get(selectors.globalSearch.input).type('remote{enter}', {
-            force: true,
-        });
-        cy.wait('@globalSearchResults');
-        cy.get(selectors.viewOnPoliciesLabelChip).click();
+        visitSearch();
+        searchWithFixture([['Cluster:', 'remote']], 'search/globalSearchResults.json');
+
+        cy.get(`section#All ${selectors.viewOnChip}:contains("POLICIES")`).click();
+        // TODO because 404 for /v1/policies/0ea8d235-b02a-41ee-a61d-edcb2c1b0eac
+        // replace button with anchor and assert on href attribute?
         cy.location('pathname').should('eq', '/main/policies/0ea8d235-b02a-41ee-a61d-edcb2c1b0eac');
     });
 
     it('Should send you to the Images page', () => {
-        cy.wait('@globalSearchOptions');
-        cy.get(selectors.globalSearch.input).type('Cluster:{enter}', {
-            force: true,
-        });
-        cy.get(selectors.globalSearch.input).type('remote{enter}', {
-            force: true,
-        });
-        cy.wait('@globalSearchResults');
-        cy.get(selectors.viewOnImagesLabelChip).click();
+        visitSearch();
+        searchWithFixture([['Cluster:', 'remote']], 'search/globalSearchResults.json');
+
+        cy.get(`section#All ${selectors.viewOnChip}:contains("IMAGES")`).click();
+        // TODO because could not find image for id
+        // replace button with anchor and assert on href attribute?
         cy.location('pathname').should(
             'eq',
             '/main/vulnerability-management/images/sha256:9342f82b178a4325aec19f997400e866bf7c6bf9d59dd74e1358f971159dd7b8'


### PR DESCRIPTION
## Description

> In a future release, support for `cy.server()` and `cy.route()` will be removed.

* Find `cy.server` in cypress/integration: from 7 results in 5 files to 6 results in 4 files.
* Find `cy.route` in cypress/integration: from 20 results in 6 files to 18 results in 5 files.

### Generic changes

https://docs.cypress.io/guides/references/migration-guide#Migrating-cy-route-to-cy-intercept

* Delete `cy.server()` and `beforeEach`
* Replace `cy.route(method, url)` with `cy.intercept(method, url)` in helper functions
* Replace `cy.route(method, url, '@fixtureAlias')` with `cy.intercept(method, url, { fixture: 'fixtureUrl' })`

### Specific changes

1. Edit cypress/constants/SearchPage.js
    * Delete unused `pageSearchSuggestions` selector
    * Add `empty` selectors
    * Replace classic tab selectors with generic `tab` selector for PatternFly
    * Replace classic chip selectors with generic `viewOnChip` and `filterOnChip` selectors for PatternFly

2. Edit cypress/constants/apiEndpoints.js
    * Replace `globalSearchWithResults` and `globalSearchWithNoResults` with `results` endpoint

3. Edit cypress/integration/search.test.js
    * Replace `beforeEach` with `visitSearch` and `searchWithFixture` functions
    * Omit intercept for search options (but leave the fixture, because auth.text.js uses it)
    * Add `clear` method and delete `{ force: true }` options
    * Add `'should have empty state instead of count and tabs if search filter is empty'` test
    * Replace negative with positive assertion in `'Should filter search results'` test

### Residue

* Replace global Search modal with Search page on /main/search route
* See if **View On** and **Filter On** buttons can become links, to avoid 404 status for requests
* See if it is possible to add tests for **Filter On** links
* Replace **Should** with **should** in test names when tests are updated for Search page (leave it for now to help alignment in **Changed files**)

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Ran tests one at a time in local deployment