### PR TITLE
Fix sorting of Violations page by Enforcement count.

### DIFF
--- a/ui/apps/platform/src/Containers/Violations/violationTableColumnDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Violations/violationTableColumnDescriptors.tsx
@@ -107,7 +107,7 @@ const tableColumnDescriptor = [
     {
         Header: 'Enforced',
         accessor: 'enforcementCount',
-        sortField: 'Policy',
+        sortField: 'Enforcement',
         Cell: EnforcementColumn,
     },
     {


### PR DESCRIPTION
## Description

Prior to this change, the Violations table would be sorted by "Policy" when clicking the sort header for the "Enforced" column or the "Policy" column. In each case, both columns would be highlighted.

The "Enforcement" key used for sorting was pulled from https://github.com/stackrox/stackrox/blob/master/pkg/search/options.go#L39

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Test that "Enforced" sorts by only the "Enforced" column.
![image](https://user-images.githubusercontent.com/1292638/163251383-f5945fb6-b835-4530-a3a4-4340db14c11b.png)
![image](https://user-images.githubusercontent.com/1292638/163251409-b17c8c25-a1f9-4ed2-9d59-b267751d2e22.png)

Test that "Policy" sorts by only the "Policy" columns.
![image](https://user-images.githubusercontent.com/1292638/163251462-9eee6bb0-8f2b-43cf-ab90-fdf687578aa8.png)
![image](https://user-images.githubusercontent.com/1292638/163251497-9bc8dc4d-6030-47a1-9aba-63cd1b3e4538.png)

