### PR TITLE
[ROX-10089] : Change AllowPrivilegeEscalation policy criteria name in UI to match fieldnames list on backend

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Form/descriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Form/descriptors.tsx
@@ -734,9 +734,9 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         canBooleanLogic: false,
     },
     {
-        label: 'Allow privilege escalation',
-        name: 'Allow privilege escalation',
-        shortName: 'Allow privilege escalation',
+        label: 'Privilege escalation',
+        name: 'Allow Privilege Escalation',
+        shortName: 'Privilege escalation',
         longName: 'Privilege escalation on container',
         category: policyCriteriaCategories.CONTAINER_CONFIGURATION,
         type: 'radioGroup',


### PR DESCRIPTION
## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [stackrox/openshift-docs]~(https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.
- Performed manual UI testing

## Testing Performed

Manual UI testing by creating a policy to match `Privilege escalation : allowed` and checking if it matches a deployment with `allowPrivilegeEscalation` set to true.

![59409B00-E7B8-4367-95B2-1941EF61D155](https://user-images.githubusercontent.com/101146970/163269323-18d1ef2c-af1c-4fc4-b5eb-ae82384cf022.jpeg)

![0DEC1227-C13A-4364-82F6-FB02855171EE_1_105_c](https://user-images.githubusercontent.com/101146970/163269921-4bb7c9b0-2103-4c57-8bf4-5e44cb53ee5a.jpeg)

![40524025-CA32-47C0-8B66-F00E491E2BFB_1_105_c](https://user-images.githubusercontent.com/101146970/163269970-e521d14f-af82-4e9a-be1c-5e6b1cbe740b.jpeg)

![38B009A3-C9BF-4A02-893C-624424AB370C_1_105_c](https://user-images.githubusercontent.com/101146970/163273292-3631752a-efee-487a-8526-90c8fa37f178.jpeg)

