### PR TITLE
ROX-9931: Fix NetworkFlowTest flake

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -431,13 +431,14 @@ class NetworkFlowTest extends BaseSpecification {
         assert targetUid != null
 
         when:
-        "Network graph is filtered by deployment A"
-        def graph = NetworkGraphService.getNetworkGraph(null, "Deployment:\"${TCPCONNECTIONSOURCE}\"", "")
+        "Check for edge in network graph"
+        println "Checking for edge between ${TCPCONNECTIONSOURCE} and ${TCPCONNECTIONTARGET}"
+        List<Edge> edges = NetworkGraphUtil.checkForEdge(sourceUid, targetUid)
+        assert edges
 
         then:
-        "Edge between A and B should exist in network graph"
-        List<Edge> edges = NetworkGraphUtil.findEdges(graph, sourceUid, targetUid)
-        assert edges && edges.size() > 0
+        "Wait for collector update and fetch graph again to confirm short interval connections remain"
+        assert waitForEdgeUpdate(edges.get(0), 90)
     }
 
     @Category([NetworkFlowVisualization])


### PR DESCRIPTION
## Description

Seems like it is a pattern for other NetworkFlow test cases to wait for the collector to resync.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~


## Testing Performed

- Tested with infra cluster and I was able to reproduce the error when running the test individually. When debugging the test and waiting for a few seconds before getting the graph the test would pass. 