### PR TITLE
ROX-9598 Revert "Cleanup allowed_vulns.json"

### DIFF
--- a/release/scripts/allowed_vulns.json
+++ b/release/scripts/allowed_vulns.json
@@ -1,5 +1,17 @@
 [
     {
+        "vuln": "CVE-2020-28928",
+        "image": "^scanner.*$",
+        "tag": ".*",
+        "reason": "This is a Quay false positive on musl:1.2.2_pre2-r0, scanner has musl:1.2.2-r0"
+    },
+    {
+        "vuln": "CVE-2020-28928",
+        "image": "^main.*$",
+        "tag": ".*",
+        "reason": "This is a Quay false positive on musl:1.2.2_pre2-r0, main starting from at least 3.64.0 has musl:1.2.2-r3"
+    },
+    {
         "vuln": "CVE-XXXX-YYYY",
         "image": ".*",
         "tag": ".*",
@@ -10,5 +22,35 @@
         "image": "^docs.*",
         "tag": ".*",
         "reason": "The docs image is not deployed in production"
+    },
+    {
+        "vuln": "SNYK-PYTHON-URLLIB3-174323",
+        "image": ".*",
+        "tag": ".*",
+        "reason": "This is a Quay false fixable on ubi8:8.5"
+    },
+    {
+        "vuln": "SNYK-PYTHON-URLLIB3-1014645",
+        "image": ".*",
+        "tag": ".*",
+        "reason": "This is a Quay false fixable on ubi8:8.5"
+    },
+    {
+        "vuln": "SNYK-PYTHON-URLLIB3-1533435",
+        "image": ".*",
+        "tag": ".*",
+        "reason": "This is a Quay false fixable on ubi8:8.5"
+    },
+    {
+        "vuln": "pyup.io-38834 (CVE-2020-26137)",
+        "image": ".*",
+        "tag": ".*",
+        "reason": "This is a Quay false fixable on ubi8:8.5"
+    },
+    {
+        "vuln": "pyup.io-43975 (CVE-2021-33503)",
+        "image": ".*",
+        "tag": ".*",
+        "reason": "This is a Quay false fixable on ubi8:8.5"
     }
 ]


### PR DESCRIPTION
Reverts stackrox/stackrox#1061

This seems to have been a bit premature, since only main image is fixed (by switching to UBI-minimal).
These errors are still raised for the scanner and collector images.
We can re-apply this once we migrate those images too - we have [ROX-10096](https://issues.redhat.com/browse/ROX-10096) to track that.

cc @msugakov @janisz @0x656b694d 