### PR TITLE
ROX-9976: Don't assume kubectl

### DIFF
--- a/deploy/common/env.sh
+++ b/deploy/common/env.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-export KUBE_COMMAND=${KUBE_COMMAND:-kubectl}
-echo "KUBE_COMMAND set to ${KUBE_COMMAND}"
-
 export STACKROX_NAMESPACE="${STACKROX_NAMESPACE:-stackrox}"
 echo "STACKROX_NAMESPACE set to ${STACKROX_NAMESPACE}"
 

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -239,8 +239,8 @@ function launch_central {
 
     echo "Deploying Central..."
 
-    ${KUBE_COMMAND} get namespace "${STACKROX_NAMESPACE}" &>/dev/null || \
-      ${KUBE_COMMAND} create namespace "${STACKROX_NAMESPACE}"
+    ${KUBE_COMMAND:-kubectl} get namespace "${STACKROX_NAMESPACE}" &>/dev/null || \
+      ${KUBE_COMMAND:-kubectl} create namespace "${STACKROX_NAMESPACE}"
 
     if [[ -f "$unzip_dir/values-public.yaml" ]]; then
       if [[ -n "${REGISTRY_USERNAME}" ]]; then


### PR DESCRIPTION
## Description

PR #1121 was overly assumptive that the `KUBE_COMMAND` env should default to `kubectl` for all `deploy/*` scripts. It really only needs to be set in `k8sbased.sh` in cases where it is not set.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient - deployment now succeeds under openshift-crio.
