### PR TITLE
Create resource properties holder for pg template

### DIFF
--- a/tools/generate-helpers/pg-table-bindings/list.go
+++ b/tools/generate-helpers/pg-table-bindings/list.go
@@ -62,20 +62,20 @@ func resourceMetadataFromString(resource string) permissions.ResourceMetadata {
 	panic("unknown resource: " + resource)
 }
 
-func clusterGetter(schema *walker.Schema) string {
+func clusterGetter(prefix string, schema *walker.Schema) string {
 	for _, f := range schema.Fields {
 		if strings.Contains(f.Search.FieldName, "Cluster ID") {
-			return f.Getter("obj")
+			return f.Getter(prefix)
 		}
 	}
 	panic(schema.TypeName + "has no cluster. Is it directly scoped?")
 }
 
-func namespaceGetter(schema *walker.Schema) string {
+func namespaceGetter(prefix string, schema *walker.Schema) string {
 	for _, f := range schema.Fields {
 		if strings.Contains(f.Search.FieldName, "Namespace") {
-			return f.Getter("obj")
+			return f.Getter(prefix)
 		}
 	}
-	return ""
+	panic(schema.TypeName + "has no cluster. Is it directly and namespace scoped?")
 }

--- a/tools/generate-helpers/pg-table-bindings/list_test.go
+++ b/tools/generate-helpers/pg-table-bindings/list_test.go
@@ -30,27 +30,30 @@ func TestClusterGetter(t *testing.T) {
 		&storage.ProcessBaseline{}: "obj.GetKey().GetClusterId()",
 	} {
 		t.Run(fmt.Sprintf("%T -> %s", typ, getter), func(t *testing.T) {
-			assert.Equal(t, getter, clusterGetter(walker.Walk(reflect.TypeOf(typ), "")))
+			assert.Equal(t, getter, clusterGetter("obj", walker.Walk(reflect.TypeOf(typ), "")))
 		})
 	}
 
 	t.Run("panics for not directly scoped type", func(t *testing.T) {
-		assert.Panics(t, func() { clusterGetter(walker.Walk(reflect.TypeOf(&storage.CVE{}), "")) })
-		assert.Panics(t, func() { clusterGetter(walker.Walk(reflect.TypeOf(&storage.Email{}), "")) })
+		assert.Panics(t, func() { clusterGetter("obj", walker.Walk(reflect.TypeOf(&storage.CVE{}), "")) })
+		assert.Panics(t, func() { clusterGetter("obj", walker.Walk(reflect.TypeOf(&storage.Email{}), "")) })
 	})
 }
 
 func TestNamespaceGetter(t *testing.T) {
 	for typ, getter := range map[proto.Message]string{
-		&storage.Email{}:             "",
-		&storage.Cluster{}:           "",
 		&storage.NamespaceMetadata{}: "obj.GetId()",
 		&storage.Deployment{}:        "obj.GetNamespace()",
 		&storage.ProcessBaseline{}:   "obj.GetKey().GetNamespace()",
 		&storage.Risk{}:              "obj.GetSubject().GetNamespace()",
 	} {
 		t.Run(fmt.Sprintf("%T -> %s", typ, getter), func(t *testing.T) {
-			assert.Equal(t, getter, namespaceGetter(walker.Walk(reflect.TypeOf(typ), "")))
+			assert.Equal(t, getter, namespaceGetter("obj", walker.Walk(reflect.TypeOf(typ), "")))
 		})
 	}
+
+	t.Run("panics for not directly & ns scoped type", func(t *testing.T) {
+		assert.Panics(t, func() { namespaceGetter("obj", walker.Walk(reflect.TypeOf(&storage.Email{}), "")) })
+		assert.Panics(t, func() { namespaceGetter("obj", walker.Walk(reflect.TypeOf(&storage.Cluster{}), "")) })
+	})
 }

--- a/tools/generate-helpers/pg-table-bindings/main.go
+++ b/tools/generate-helpers/pg-table-bindings/main.go
@@ -129,7 +129,6 @@ func main() {
 		compileFKArgAndAttachToSchema(schema, props.Refs)
 
 		permissionCheckerEnabled := props.PermissionChecker != ""
-		resourceType := getResourceType(props.Type, schema, permissionCheckerEnabled, props.JoinTable)
 		templateMap := map[string]interface{}{
 			"Type":              props.Type,
 			"TrimmedType":       stringutils.GetAfter(props.Type, "."),
@@ -139,11 +138,12 @@ func main() {
 			"OptionsPath":       path.Join(packagenames.Rox, props.OptionsPath),
 			"JoinTable":         props.JoinTable,
 			"PermissionChecker": props.PermissionChecker,
-			"ResourceType":      resourceType.String(),
-		}
-		if resourceType == directlyScoped {
-			templateMap["ClusterGetter"] = clusterGetter(schema)
-			templateMap["NamespaceGetter"] = namespaceGetter(schema)
+			"Obj": object{
+				storageType:              props.Type,
+				permissionCheckerEnabled: permissionCheckerEnabled,
+				isJoinTable:              props.JoinTable,
+				schema:                   schema,
+			},
 		}
 
 		if err := generateSchema(schema); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/object.go
+++ b/tools/generate-helpers/pg-table-bindings/object.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/postgres/walker"
+)
+
+type object struct {
+	storageType              string
+	permissionCheckerEnabled bool
+	isJoinTable              bool
+	schema                   *walker.Schema
+}
+
+func (o object) GetClusterID(name string) string {
+	return clusterGetter(name, o.schema)
+}
+
+func (o object) GetNamespace(name string) string {
+	return namespaceGetter(name, o.schema)
+}
+
+func (o object) IsDirectlyScoped() bool {
+	return o.isResourceType(directlyScoped)
+}
+
+func (o object) IsGloballyScoped() bool {
+	return o.isResourceType(globallyScoped)
+}
+
+func (o object) IsJoinTable() bool {
+	return o.isJoinTable
+}
+
+func (o object) HasPermissionChecker() bool {
+	return o.permissionCheckerEnabled
+}
+
+func (o object) IsNamespaceScope() bool {
+	return o.isScope(permissions.NamespaceScope)
+}
+
+func (o object) IsClusterScope() bool {
+	return o.isScope(permissions.ClusterScope)
+}
+
+func (o object) IsGlobalScope() bool {
+	return o.isScope(permissions.GlobalScope)
+}
+
+func (o object) isScope(scope permissions.ResourceScope) bool {
+	if o.isJoinTable || o.permissionCheckerEnabled {
+		return false
+	}
+	resource := storageToResource(o.storageType)
+	metadata := resourceMetadataFromString(resource)
+	return metadata.GetScope() == scope
+}
+
+func (o object) isResourceType(resourceType ResourceType) bool {
+	return getResourceType(o.storageType, o.schema, o.permissionCheckerEnabled, o.isJoinTable) == resourceType
+}

--- a/tools/generate-helpers/pg-table-bindings/object.go
+++ b/tools/generate-helpers/pg-table-bindings/object.go
@@ -44,10 +44,6 @@ func (o object) IsClusterScope() bool {
 	return o.isScope(permissions.ClusterScope)
 }
 
-func (o object) IsGlobalScope() bool {
-	return o.isScope(permissions.GlobalScope)
-}
-
 func (o object) isScope(scope permissions.ResourceScope) bool {
 	if o.isJoinTable || o.permissionCheckerEnabled {
 		return false

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -17,7 +17,7 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
-    {{- if (or (eq .ResourceType "globallyScoped") (eq .ResourceType "permissionChecker")) }}
+    {{- if (or (.Obj.IsGloballyScoped) (.Obj.HasPermissionChecker)) }}
     "github.com/stackrox/rox/pkg/sac"{{- end }}
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/testutils/envisolator"
@@ -49,7 +49,7 @@ func (s *{{$namePrefix}}StoreSuite) TearDownTest() {
 }
 
 func (s *{{$namePrefix}}StoreSuite) TestStore() {
-    {{- if or (eq .ResourceType "globallyScoped") (eq .ResourceType "permissionChecker") }}
+    {{- if or (.Obj.IsGloballyScoped) (.Obj.HasPermissionChecker) }}
     ctx := sac.WithAllAccess(context.Background())
     {{- else -}}
     ctx := context.Background()
@@ -74,7 +74,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 	s.Nil(found{{.TrimmedType|upperCamelCase}})
 
     {{if not .JoinTable -}}
-    {{- if or (eq .ResourceType "globallyScoped") (eq .ResourceType "permissionChecker") }}
+    {{- if or (.Obj.IsGloballyScoped) (.Obj.HasPermissionChecker) }}
     withNoAccessCtx := sac.WithNoAccess(ctx)
     {{- end }}
 
@@ -88,7 +88,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal({{$name}}Count, 1)
 
-    {{- if or (eq .ResourceType "globallyScoped") (eq .ResourceType "permissionChecker") }}
+    {{- if or (.Obj.IsGloballyScoped) (.Obj.HasPermissionChecker) }}
     {{$name}}Count, err = store.Count(withNoAccessCtx)
     s.NoError(err)
     s.Zero({{$name}}Count)
@@ -98,7 +98,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 	s.NoError(err)
 	s.True({{$name}}Exists)
 	s.NoError(store.Upsert(ctx, {{$name}}))
-    {{- if or (eq .ResourceType "globallyScoped") (eq .ResourceType "permissionChecker") }}
+    {{- if or (.Obj.IsGloballyScoped) (.Obj.HasPermissionChecker) }}
 	s.ErrorIs(store.Upsert(withNoAccessCtx, {{$name}}), sac.ErrResourceAccessDenied)
     {{- end }}
 
@@ -113,7 +113,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 	s.False(exists)
 	s.Nil(found{{.TrimmedType|upperCamelCase}})
 
-    {{- if or (eq .ResourceType "globallyScoped") (eq .ResourceType "permissionChecker") }}
+    {{- if or (.Obj.IsGloballyScoped) (.Obj.HasPermissionChecker) }}
     s.ErrorIs(store.Delete(withNoAccessCtx, {{template "paramList" $}}), sac.ErrResourceAccessDenied)
     {{- end }}
 


### PR DESCRIPTION
## Description

This PR creates `object` which is handy holder for all resource properties. The main reason to have it is to avoid writing complicated conditions, repeat common constructs in template and use strings for enums (numbers are not descriptive anyway).

## Testing Performed
CI