### PR TITLE
ROX-10095: Do not use fixture for networkGraph integration test

### DIFF
--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -1,4 +1,3 @@
-import * as api from '../../constants/apiEndpoints';
 import { selectors as networkPageSelectors } from '../../constants/NetworkPage';
 import withAuth from '../../helpers/basicAuth';
 import {
@@ -6,7 +5,6 @@ import {
     filterDeployments,
     filterNamespaces,
     selectDeploymentFilter,
-    visitNetworkGraphWithMockedData,
     visitNetworkGraphWithNamespaceFilters,
 } from '../../helpers/networkGraph';
 
@@ -14,17 +12,13 @@ describe('Network Deployment Details', () => {
     withAuth();
 
     it('should open up the Deployments Side Panel when a deployment is clicked', () => {
-        visitNetworkGraphWithMockedData();
+        visitNetworkGraphWithNamespaceFilters('stackrox');
 
         cy.getCytoscape(networkPageSelectors.cytoscapeContainer).then((cytoscape) => {
-            cy.intercept('GET', api.network.deployment, {
-                fixture: 'network/centralDeployment.json',
-            }).as('centralDeployment');
             clickOnNodeByName(cytoscape, {
                 type: 'DEPLOYMENT',
                 name: 'central',
             });
-            cy.wait('@centralDeployment');
             cy.get(`${networkPageSelectors.networkEntityTabbedOverlay.header}:contains("central")`);
         });
     });


### PR DESCRIPTION
## Description

Fixture is not needed and now causes requests to fail after clean up in #1271

Integration tests passed for its branch build but failed for its master build.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed

1. `yarn cypress-open` in ui/apps/platform
    * cypress/integration/networkGraph/networkGraph.test.js

        See 404 status with fixture
        <img width="1348" alt="cypress-404" src="https://user-images.githubusercontent.com/11862657/163466093-fe4dccf1-0632-4bdd-ba95-eab9fd1bd327.png">

        See 200 status without fixture
        <img width="1348" alt="cypress-200" src="https://user-images.githubusercontent.com/11862657/163466072-38059d44-cb82-4322-9f8c-42e707d64a81.png">

