### PR TITLE
Remove /var/cache/yum

### DIFF
--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -45,7 +45,7 @@ RUN ln -s entrypoint-wrapper.sh /stackrox/admission-control && \
     rm /tmp/snappy.rpm RPM-GPG-KEY-CentOS-Official && \
     # (Optional) Remove line below to keep package management utilities
     rpm -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
-    rm -rf /var/cache/dnf && \
+    rm -rf /var/cache/yum && \
     # The contents of paths mounted as emptyDir volumes in Kubernetes are saved
     # by the script `save-dir-contents` during the image build. The directory
     # contents are then restored by the script `restore-all-dir-contents`


### PR DESCRIPTION
## Description

`microdnf`'s cache is `/var/cache/yum` instead of `/var/cache/dnf`, so the cache was never actually deleted.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Ensure both `/var/cache/dnf` and `/var/cache/yum` do not exist in the `main` image.
