### PR TITLE
[Rox-9435] : Always perform a dry-run even if the policy is marked disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-10038: Removed limit of 10 inclusions and 10 exclusions from policy form
 - ROX-10090: Made the username and password optional on the Artifactory integration form
 - ROX-10217: Remove format validation from the URL field of the generic webhook integration form
+- ROX-9435: Updated dryrun API to generate preview violations for disabled policies
 
 ## [69.1]
 

--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -452,10 +452,6 @@ func (s *serviceImpl) predicateBasedDryRunPolicy(ctx context.Context, cancelCtx 
 				<-pChan
 			}()
 
-			if compiledPolicy.Policy().GetDisabled() {
-				return
-			}
-
 			deployment, exists, err := s.deployments.GetDeployment(ctx, depId)
 			if !exists || err != nil {
 				return

--- a/qa-tests-backend/src/main/groovy/services/PolicyService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/PolicyService.groovy
@@ -48,6 +48,10 @@ class PolicyService extends BaseService {
         }
     }
 
+    static PolicyServiceOuterClass.DryRunResponse dryRunPolicy(PolicyOuterClass.Policy policy) {
+            return getPolicyClient().dryRunPolicy(policy)
+    }
+
     static patchPolicy(PolicyServiceOuterClass.PatchPolicyRequest pr) {
         try {
             getPolicyClient().patchPolicy(pr).newBuilder().build()

--- a/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
@@ -1,5 +1,3 @@
-import io.stackrox.proto.api.v1.PolicyServiceOuterClass
-
 import static Services.checkForNoViolations
 import static Services.waitForViolation
 
@@ -17,6 +15,7 @@ import common.Constants
 import objects.Volume
 import io.stackrox.proto.storage.Rbac
 import io.stackrox.proto.storage.NodeOuterClass
+import io.stackrox.proto.api.v1.PolicyServiceOuterClass.DryRunResponse
 import io.stackrox.proto.storage.PolicyOuterClass.Policy
 import io.stackrox.proto.storage.PolicyOuterClass.PolicyFields
 import io.stackrox.proto.storage.PolicyOuterClass.ImageNamePolicy
@@ -784,21 +783,21 @@ class PolicyConfigurationTest extends BaseSpecification {
     def "Verify dryRun on a disabled policy generates violations for matching deployments"() {
         when:
         "Initialize a new disabled policy that will match an existing deployment"
-        Policy.Builder policy = Policy.newBuilder()
-                                                    .setName("TestPrivilegedPolicy")
-                                                    .setDescription("TestPrivileged")
-                                                    .setRationale("TestPrivileged")
-                                                    .addLifecycleStages(LifecycleStage.DEPLOY)
-                                                    .addCategories("DevOps Best Practices")
-                                                    .setDisabled(true)
-                                                    .setSeverityValue(2)
-                                                    .setFields(PolicyFields.newBuilder()
-                                                        .setPrivileged(true))
-                                                    .build()
+        Policy policy = Policy.newBuilder()
+                                .setName("TestPrivilegedPolicy")
+                                .setDescription("TestPrivileged")
+                                .setRationale("TestPrivileged")
+                                .addLifecycleStages(LifecycleStage.DEPLOY)
+                                .addCategories("DevOps Best Practices")
+                                .setDisabled(true)
+                                .setSeverityValue(2)
+                                .setFields(PolicyFields.newBuilder()
+                                        .setPrivileged(true))
+                                .build()
 
         and:
         "dryRun is called on the policy"
-        PolicyServiceOuterClass.DryRunResponse dryRunResponse = PolicyService.dryRunPolicy(policy)
+        DryRunResponse dryRunResponse = PolicyService.dryRunPolicy(policy)
 
         then:
         "Verify dryRun response contains alert/s for matching deployments"

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PreviewViolations.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PreviewViolations.tsx
@@ -14,6 +14,7 @@ function PreviewViolations({ alertsFromDryRun }: PreviewViolationsProps): ReactE
 
     return (
         <div>
+            <Title headingLevel="h2">Deployment results</Title>
             {alertsFromDryRun.map(({ deployment, violations }, alertIndex) => {
                 /*
                  * pf-u-mb-sm separates deployment name from first list item with same spacing as subsequent list items.

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PreviewViolations.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PreviewViolations.tsx
@@ -14,7 +14,9 @@ function PreviewViolations({ alertsFromDryRun }: PreviewViolationsProps): ReactE
 
     return (
         <div>
-            <Title headingLevel="h2">Deployment results</Title>
+            <Title className="pf-u-mb-sm" headingLevel="h2">
+                Deployment results
+            </Title>
             {alertsFromDryRun.map(({ deployment, violations }, alertIndex) => {
                 /*
                  * pf-u-mb-sm separates deployment name from first list item with same spacing as subsequent list items.

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/ReviewPolicyForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/ReviewPolicyForm.tsx
@@ -167,9 +167,10 @@ function ReviewPolicyForm({
                                 variant="info"
                                 title="Policy disabled"
                             >
-                                <p>Violations will not generate unless policy is enabled</p>
+                                <p>Violations will not be generated unless the policy is enabled</p>
                             </Alert>
                         )}
+                        <Divider component="div" />
                         {isRunningDryRun ? (
                             <Flex justifyContent={{ default: 'justifyContentCenter' }}>
                                 <FlexItem>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/ReviewPolicyForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/ReviewPolicyForm.tsx
@@ -161,10 +161,14 @@ function ReviewPolicyForm({
                             Before you save the policy, verify that the violations seem accurate.
                         </div>
                         {values.disabled && (
-                            <div className="pf-u-mb-md">
-                                Note that this policy is disabled and any violations in this preview
-                                will not be generated unless policy is enabled.
-                            </div>
+                            <Alert
+                                className="pf-u-mb-md"
+                                isInline
+                                variant="info"
+                                title="Policy disabled"
+                            >
+                                <p>Violations will not generate unless policy is enabled</p>
+                            </Alert>
                         )}
                         {isRunningDryRun ? (
                             <Flex justifyContent={{ default: 'justifyContentCenter' }}>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/ReviewPolicyForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/ReviewPolicyForm.tsx
@@ -160,6 +160,12 @@ function ReviewPolicyForm({
                         <div className="pf-u-mb-md">
                             Before you save the policy, verify that the violations seem accurate.
                         </div>
+                        {values.disabled && (
+                            <div className="pf-u-mb-md">
+                                Note that this policy is disabled and any violations in this preview
+                                will not be generated unless policy is enabled.
+                            </div>
+                        )}
                         {isRunningDryRun ? (
                             <Flex justifyContent={{ default: 'justifyContentCenter' }}>
                                 <FlexItem>


### PR DESCRIPTION
## Description

Updated `dryrun` APIs to generate preview violations for disabled policies. For disabled policies, 'Preview violations' in the UI will show an info alert indicating that the policy is disabled.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed
- CI testing
- Added a new e2e test
- Manual testing on UI by editing a disabled policy

![80067DAA-68E8-4575-8F20-7E45327F3A97_1_105_c](https://user-images.githubusercontent.com/101146970/164512258-4f4e558c-d38c-4d65-be2d-b385d54459d5.jpeg)

![BECE6BE4-057F-4186-8F66-7B82C0313ED8_1_105_c](https://user-images.githubusercontent.com/101146970/164512298-1464f677-be01-4c7e-9b99-0976794a647b.jpeg)

