### PR TITLE
ROX-10038: Remove limit on inclusions and exclusions in policy form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - Fixed permissions checks in the UI that prevented users with certain limited permissions from creating report configurations.
 - ROX-9946: Fixed default permissions for the default Vuln Reporter role to exclude the modify permission on notifiers, since it is not needed for report creation.
 - Added AllowPrivilegeEscalation as a new policy criteria.
+- ROX-10038: Removed limit of 10 inclusions and 10 exclusions from policy form
 
 ## [69.1]
 

--- a/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step4/PolicyScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PatternFly/Wizard/Step4/PolicyScopeForm.tsx
@@ -23,9 +23,6 @@ import { fetchImages } from 'services/ImagesService';
 import { fetchDeployments } from 'services/DeploymentsService';
 import PolicyScopeCard from './PolicyScopeCard';
 
-const MAX_INCLUSION_SCOPES = 10;
-const MAX_EXCLUSION_SCOPES = 10;
-
 function PolicyScopeForm() {
     const [isExcludeImagesOpen, setIsExcludeImagesOpen] = React.useState(false);
     const [images, setImages] = React.useState<Image[]>([]);
@@ -40,9 +37,7 @@ function PolicyScopeForm() {
         values.lifecycleStages.includes('DEPLOY') || values.lifecycleStages.includes('RUNTIME');
 
     function addNewInclusionScope() {
-        if (scope.length < MAX_INCLUSION_SCOPES) {
-            setFieldValue('scope', [...scope, {}]);
-        }
+        setFieldValue('scope', [...scope, {}]);
     }
 
     function deleteInclusionScope(index) {
@@ -51,9 +46,7 @@ function PolicyScopeForm() {
     }
 
     function addNewExclusionDeploymentScope() {
-        if (excludedDeploymentScopes.length < MAX_EXCLUSION_SCOPES) {
-            setFieldValue('excludedDeploymentScopes', [...excludedDeploymentScopes, {}]);
-        }
+        setFieldValue('excludedDeploymentScopes', [...excludedDeploymentScopes, {}]);
     }
 
     function deleteExclusionDeploymentScope(index) {


### PR DESCRIPTION
## Description

Customer reported that the limit of 10 inclusions and 10 exclusions does not allow them enough inclusions/exclusions.

This removes that limit for both.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Evaluated and added CHANGELOG entry if required


## Testing Performed

Manual testing

Successfully entered 12 inclusions and 12 exclusions (first and second half of Greek alphabet, respectively) in the policy form
<img width="1541" alt="Screen Shot 2022-04-15 at 8 07 01 AM" src="https://user-images.githubusercontent.com/715729/163580688-149ad417-d781-4a26-9d54-db91a573d1b3.png">
<img width="1541" alt="Screen Shot 2022-04-15 at 8 07 05 AM" src="https://user-images.githubusercontent.com/715729/163580689-7032ba9c-bb56-4e9c-9a0f-329107866eb7.png">



Saved the policy with those inclusions and exclusions to verify that numbers higher than 10 were persisted in the backend.
<img width="1541" alt="Screen Shot 2022-04-15 at 8 07 29 AM" src="https://user-images.githubusercontent.com/715729/163580699-f5822591-7717-471d-9b0c-325b9b8a7d61.png">
<img width="1541" alt="Screen Shot 2022-04-15 at 8 07 31 AM" src="https://user-images.githubusercontent.com/715729/163580700-ba97a3f0-7406-4598-8a25-0723e27aca6a.png">

