### PR TITLE
Edit cve proto and add node and vulnerability proto to types in UI

### DIFF
--- a/ui/apps/platform/src/types/cve.proto.ts
+++ b/ui/apps/platform/src/types/cve.proto.ts
@@ -1,73 +1,11 @@
 export type VulnerabilitySeverity =
+    // | 'UNKNOWN_VULNERABILITY_SEVERITY'
     | 'LOW_VULNERABILITY_SEVERITY'
     | 'MODERATE_VULNERABILITY_SEVERITY'
     | 'IMPORTANT_VULNERABILITY_SEVERITY'
     | 'CRITICAL_VULNERABILITY_SEVERITY';
 
 export type VulnerabilityState = 'OBSERVED' | 'DEFERRED' | 'FALSE_POSITIVE';
-
-export type CVE = {
-    id: string;
-    cve: string;
-    operatingSystem: string;
-    cvss: number; // float
-    impactScore: number; // float
-
-    // For internal purposes only. This will only be populated prior to upsert into datastore.
-    // Cluster cves are split between k8s and istio. The type info is a relationship attribute and not a property of cve itself.
-    // TODO: Move type to relationship objects.
-
-    type: CVEType;
-    types: CVEType[];
-
-    summary: string;
-    link: string;
-    // This indicates the timestamp when the cve was first published in the cve feeds.
-    publishedOn: string; // ISO 8601 date string
-    // Time when the CVE was first seen in the system.
-    createdAt: string; // ISO 8601 date string
-    lastModified: string; // ISO 8601 date string
-    references: CVEReference[];
-
-    scoreVersion: CVEScoreVersion;
-    cvssV2: CVSSV2;
-    cvssV3: CVSSV3;
-
-    // TODO: Move suppression field out of CVE object. Maybe create equivalent dummy vulnerability requests.
-    // Unfortunately, although there exists image SAC check on legacy suppress APIs,
-    // one can snooze node and cluster type vulns, so we will have to carry over the support for node and cluster cves.
-
-    suppressed: boolean;
-    suppressActivation: string; // ISO 8601 date string
-    suppressExpiry: string; // ISO 8601 date string
-
-    distroSpecifics: Record<string, CVEDistroSpecific>;
-    severity: VulnerabilitySeverity;
-};
-
-export type CVEDistroSpecific = {
-    severity: VulnerabilitySeverity;
-    cvss: number; // float
-    scoreVersion: CVEScoreVersion;
-    cvssV2: CVSSV2;
-    cvssV3: CVSSV3;
-};
-
-export type CVEReference = {
-    URI: string;
-    tags: string[];
-};
-
-// No unset for automatic backwards compatibility
-export type CVEScoreVersion = 'V2' | 'V3' | 'UNKNOWN';
-
-export type CVEType =
-    | 'UNKNOWN_CVE'
-    | 'IMAGE_CVE'
-    | 'K8S_CVE'
-    | 'ISTIO_CVE'
-    | 'NODE_CVE'
-    | 'OPENSHIFT_CVE';
 
 export type CVSSV2 = {
     vector: string;
@@ -98,7 +36,7 @@ export type CVSSV3 = {
     exploitabilityScore: number; // float
     impactScore: number; // float
     attackVector: AttackVectorV3;
-    attackComplexity: ComplexityV3;
+    attackComplexity: AttackComplexityV3;
     privilegesRequired: PrivilegesV3;
     userInteraction: UserInteractionV3;
     scope: ScopeV3;
@@ -115,7 +53,7 @@ export type AttackVectorV3 =
     | 'ATTACK_NETWORK'
     | 'ATTACK_PHYSICAL';
 
-export type ComplexityV3 = 'COMPLEXITY_LOW' | 'COMPLEXITY_HIGH';
+export type AttackComplexityV3 = 'COMPLEXITY_LOW' | 'COMPLEXITY_HIGH';
 
 export type ImpactV3 = 'IMPACT_NONE' | 'IMPACT_LOW' | 'IMPACT_HIGH';
 

--- a/ui/apps/platform/src/types/cve.proto.ts
+++ b/ui/apps/platform/src/types/cve.proto.ts
@@ -5,3 +5,124 @@ export type VulnerabilitySeverity =
     | 'CRITICAL_VULNERABILITY_SEVERITY';
 
 export type VulnerabilityState = 'OBSERVED' | 'DEFERRED' | 'FALSE_POSITIVE';
+
+export type CVE = {
+    id: string;
+    cve: string;
+    operatingSystem: string;
+    cvss: number; // float
+    impactScore: number; // float
+
+    // For internal purposes only. This will only be populated prior to upsert into datastore.
+    // Cluster cves are split between k8s and istio. The type info is a relationship attribute and not a property of cve itself.
+    // TODO: Move type to relationship objects.
+
+    type: CVEType;
+    types: CVEType[];
+
+    summary: string;
+    link: string;
+    // This indicates the timestamp when the cve was first published in the cve feeds.
+    publishedOn: string; // ISO 8601 date string
+    // Time when the CVE was first seen in the system.
+    createdAt: string; // ISO 8601 date string
+    lastModified: string; // ISO 8601 date string
+    references: CVEReference[];
+
+    scoreVersion: CVEScoreVersion;
+    cvssV2: CVSSV2;
+    cvssV3: CVSSV3;
+
+    // TODO: Move suppression field out of CVE object. Maybe create equivalent dummy vulnerability requests.
+    // Unfortunately, although there exists image SAC check on legacy suppress APIs,
+    // one can snooze node and cluster type vulns, so we will have to carry over the support for node and cluster cves.
+
+    suppressed: boolean;
+    suppressActivation: string; // ISO 8601 date string
+    suppressExpiry: string; // ISO 8601 date string
+
+    distroSpecifics: Record<string, CVEDistroSpecific>;
+    severity: VulnerabilitySeverity;
+};
+
+export type CVEDistroSpecific = {
+    severity: VulnerabilitySeverity;
+    cvss: number; // float
+    scoreVersion: CVEScoreVersion;
+    cvssV2: CVSSV2;
+    cvssV3: CVSSV3;
+};
+
+export type CVEReference = {
+    URI: string;
+    tags: string[];
+};
+
+// No unset for automatic backwards compatibility
+export type CVEScoreVersion = 'V2' | 'V3' | 'UNKNOWN';
+
+export type CVEType =
+    | 'UNKNOWN_CVE'
+    | 'IMAGE_CVE'
+    | 'K8S_CVE'
+    | 'ISTIO_CVE'
+    | 'NODE_CVE'
+    | 'OPENSHIFT_CVE';
+
+export type CVSSV2 = {
+    vector: string;
+    attackVector: AttackVectorV2;
+    accessComplexity: AccessComplexityV2;
+    authentication: AuthenticationV2;
+    confidentiality: ImpactV2;
+    integrity: ImpactV2;
+    availability: ImpactV2;
+    exploitabilityScore: number; // float
+    impactScore: number; // float
+    score: number; // float
+    severity: SeverityV2;
+};
+
+export type AccessComplexityV2 = 'ACCESS_HIGH' | 'ACCESS_MEDIUM' | 'ACCESS_LOW';
+
+export type AttackVectorV2 = 'ATTACK_LOCAL' | 'ATTACK_ADJACENT' | 'ATTACK_NETWORK';
+
+export type AuthenticationV2 = 'AUTH_MULTIPLE' | 'AUTH_SINGLE' | 'AUTH_NONE';
+
+export type ImpactV2 = 'IMPACT_NONE' | 'IMPACT_PARTIAL' | 'IMPACT_COMPLETE';
+
+export type SeverityV2 = 'UNKNOWN' | 'LOW' | 'MEDIUM' | 'HIGH';
+
+export type CVSSV3 = {
+    vector: string;
+    exploitabilityScore: number; // float
+    impactScore: number; // float
+    attackVector: AttackVectorV3;
+    attackComplexity: ComplexityV3;
+    privilegesRequired: PrivilegesV3;
+    userInteraction: UserInteractionV3;
+    scope: ScopeV3;
+    confidentiality: ImpactV3;
+    integrity: ImpactV3;
+    availability: ImpactV3;
+    score: number; // float
+    severity: SeverityV3;
+};
+
+export type AttackVectorV3 =
+    | 'ATTACK_LOCAL'
+    | 'ATTACK_ADJACENT'
+    | 'ATTACK_NETWORK'
+    | 'ATTACK_PHYSICAL';
+
+export type ComplexityV3 = 'COMPLEXITY_LOW' | 'COMPLEXITY_HIGH';
+
+export type ImpactV3 = 'IMPACT_NONE' | 'IMPACT_LOW' | 'IMPACT_HIGH';
+
+export type PrivilegesV3 = 'PRIVILEGE_NONE' | 'PRIVILEGE_LOW' | 'PRIVILEGE_HIGH';
+
+export type ScopeV3 = 'UNCHANGED' | 'CHANGED';
+
+export type SeverityV3 = 'UNKNOWN' | 'NONE' | 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+
+export type UserInteractionV3 = 'UI_NONE' | 'UI_REQUIRED';

--- a/ui/apps/platform/src/types/node.proto.ts
+++ b/ui/apps/platform/src/types/node.proto.ts
@@ -1,0 +1,82 @@
+import { ContainerRuntimeInfo } from './containerRuntime.proto';
+import { Taint } from './taints.proto';
+import { EmbeddedVulnerability } from './vulnerability.proto';
+
+// Node represents information about a node in the cluster.
+export type Node = {
+    // A unique ID identifying this node.
+    id: string;
+    // The (host)name of the node. Might or might not be the same as ID.
+    name: string;
+    // Taints on the host
+    taints: Taint[];
+    clusterId: string;
+    clusterName: string;
+    // TODO(ROX-6895): "Label" search term is ambiguous.
+    labels: Record<string, string>;
+    annotations: Record<string, string>;
+    // When the cluster reported the node was added
+    joinedAt: string; // ISO 8601 date string
+    // node internal IP addresses
+    internalIpAddresses: string[];
+    // node external IP addresses
+    external_ip_addresses: string[];
+    // From NodeInfo
+    containerRuntimeVersion: string; // deprecated, use containerRuntime.version
+    containerRuntime: ContainerRuntimeInfo;
+    kernelVersion: string;
+    // From NodeInfo. Operating system reported by the node (ex: linux).
+    operatingSystem: string;
+    // From NodeInfo. OS image reported by the node from /etc/os-release.
+    osImage: string;
+    kubeletVersion: string;
+    kubeProxyVersion: string;
+
+    lastUpdated: string; // ISO 8601 date string
+    // Time we received an update from Kubernetes.
+    k8sUpdated: string; // ISO 8601 date string
+
+    scan: NodeScan;
+    // oneof set_components {
+    components: number; // int32
+    // }
+    // oneof set_cves {
+    cves: number; // int32
+    // }
+    // oneof set_fixable {
+    fixableCves: number; // int32
+    // }
+    priority: number; // int64
+    riskScore: number; // float
+    // oneof set_top_cvss {
+    topCvss: number; // float
+    // }
+};
+
+export type NodeScan = {
+    scanTime: string; // ISO 8601 date string
+    operatingSystem: string;
+    components: EmbeddedNodeScanComponent[];
+};
+
+export type EmbeddedNodeScanComponent = {
+    name: string;
+    version: string;
+    vulns: EmbeddedVulnerability[];
+    priority: number; // int64
+    // oneof set_top_cvss {
+    topCvss: number; // float
+    // }
+    riskScore: number; // float
+};
+
+export type NodeComponentEdge = {
+    // base 64 encoded Node:Component ids.
+    id: string;
+};
+
+export type NodeCVEEdge = {
+    // base 64 encoded Node:CVE ids.
+    id: string;
+    firstNodeOccurrence: string; // ISO 8601 date string
+};

--- a/ui/apps/platform/src/types/node.proto.ts
+++ b/ui/apps/platform/src/types/node.proto.ts
@@ -12,15 +12,12 @@ export type Node = {
     taints: Taint[];
     clusterId: string;
     clusterName: string;
-    // TODO(ROX-6895): "Label" search term is ambiguous.
     labels: Record<string, string>;
     annotations: Record<string, string>;
     // When the cluster reported the node was added
     joinedAt: string; // ISO 8601 date string
-    // node internal IP addresses
     internalIpAddresses: string[];
-    // node external IP addresses
-    external_ip_addresses: string[];
+    externalIpAddresses: string[];
     // From NodeInfo
     containerRuntimeVersion: string; // deprecated, use containerRuntime.version
     containerRuntime: ContainerRuntimeInfo;
@@ -31,26 +28,15 @@ export type Node = {
     osImage: string;
     kubeletVersion: string;
     kubeProxyVersion: string;
-
     lastUpdated: string; // ISO 8601 date string
-    // Time we received an update from Kubernetes.
     k8sUpdated: string; // ISO 8601 date string
-
     scan: NodeScan;
-    // oneof set_components {
-    components: number; // int32
-    // }
-    // oneof set_cves {
-    cves: number; // int32
-    // }
-    // oneof set_fixable {
-    fixableCves: number; // int32
-    // }
-    priority: number; // int64
+    components?: number; // int32
+    cves?: number; // int32
+    fixableCves?: number; // int32
+    priority: string; // int64
     riskScore: number; // float
-    // oneof set_top_cvss {
-    topCvss: number; // float
-    // }
+    topCvss?: number; // float
 };
 
 export type NodeScan = {
@@ -63,20 +49,7 @@ export type EmbeddedNodeScanComponent = {
     name: string;
     version: string;
     vulns: EmbeddedVulnerability[];
-    priority: number; // int64
-    // oneof set_top_cvss {
-    topCvss: number; // float
-    // }
+    priority: string; // int64
+    topCvss?: number; // float
     riskScore: number; // float
-};
-
-export type NodeComponentEdge = {
-    // base 64 encoded Node:Component ids.
-    id: string;
-};
-
-export type NodeCVEEdge = {
-    // base 64 encoded Node:CVE ids.
-    id: string;
-    firstNodeOccurrence: string; // ISO 8601 date string
 };

--- a/ui/apps/platform/src/types/vulnerability.proto.ts
+++ b/ui/apps/platform/src/types/vulnerability.proto.ts
@@ -1,0 +1,42 @@
+import { CVSSV2, CVSSV3, VulnerabilitySeverity, VulnerabilityState } from './cve.proto';
+
+export type VulnerabilityType =
+    | 'UNKNOWN_VULNERABILITY'
+    | 'IMAGE_VULNERABILITY'
+    | 'K8S_VULNERABILITY'
+    | 'ISTIO_VULNERABILITY'
+    | 'NODE_VULNERABILITY'
+    | 'OPENSHIFT_VULNERABILITY';
+
+// No unset for automatic backwards compatibility
+export type EmbeddedVulnerabilityScoreVersion = 'V2' | 'V3';
+
+export type EmbeddedVulnerability = {
+    cve: string;
+    cvss: number; // float
+    summary: string;
+    link: string;
+    // oneof set_fixed_by {
+    fixedBy: string;
+    // }
+    scoreVersion: EmbeddedVulnerabilityScoreVersion;
+    cvssV2: CVSSV2;
+    cvssV3: CVSSV3;
+    publishedOn: string; // ISO 8601 date string
+    lastModified: string; // ISO 8601 date string
+    // For internal purposes only.
+    vulnerabilityType: VulnerabilityType;
+    vulnerabilityTypes: VulnerabilityType[];
+    suppressed: boolean;
+    suppressActivation: string; // ISO 8601 date string
+    suppressExpiry: string; // ISO 8601 date string
+    // Time when the CVE was first seen in the system.
+    firstSystemOccurrence: string; // ISO 8601 date string
+    // Time when the CVE was first seen in the image.
+    firstImageOccurrence: string; // ISO 8601 date string
+    // Time when the CVE was first seen in the node.
+    firstNodeOccurrence: string; // ISO 8601 date string
+
+    severity: VulnerabilitySeverity;
+    state: VulnerabilityState;
+};

--- a/ui/apps/platform/src/types/vulnerability.proto.ts
+++ b/ui/apps/platform/src/types/vulnerability.proto.ts
@@ -16,9 +16,7 @@ export type EmbeddedVulnerability = {
     cvss: number; // float
     summary: string;
     link: string;
-    // oneof set_fixed_by {
-    fixedBy: string;
-    // }
+    fixedBy?: string;
     scoreVersion: EmbeddedVulnerabilityScoreVersion;
     cvssV2: CVSSV2;
     cvssV3: CVSSV3;
@@ -28,15 +26,14 @@ export type EmbeddedVulnerability = {
     vulnerabilityType: VulnerabilityType;
     vulnerabilityTypes: VulnerabilityType[];
     suppressed: boolean;
-    suppressActivation: string; // ISO 8601 date string
-    suppressExpiry: string; // ISO 8601 date string
+    suppressActivation: string | null; // ISO 8601 date string
+    suppressExpiry: string | null; // ISO 8601 date string
     // Time when the CVE was first seen in the system.
-    firstSystemOccurrence: string; // ISO 8601 date string
+    firstSystemOccurrence: string | null; // ISO 8601 date string
     // Time when the CVE was first seen in the image.
-    firstImageOccurrence: string; // ISO 8601 date string
+    firstImageOccurrence: string | null; // ISO 8601 date string
     // Time when the CVE was first seen in the node.
-    firstNodeOccurrence: string; // ISO 8601 date string
-
+    firstNodeOccurrence: string | null; // ISO 8601 date string
     severity: VulnerabilitySeverity;
     state: VulnerabilityState;
 };


### PR DESCRIPTION
## Description

Related to #1273 and #1275 which adds to proto/storage/node.proto

```proto
    enum Note {
        UNSET              = 0;
        UNSUPPORTED        = 1;
        KERNEL_UNSUPPORTED = 2;
    }
```

So there is a known file where to add the corresponding string union type:

```ts
export NodeScanNote = 'UNSET' | 'UNSUPPORTED' | 'KERNEL_UNSUPPORTED';
```

@sachaudh @vjwilson

TypeScript TS2741 Property 'UNKNOWN_VULNERABILITY_SEVERITY' is missing

* https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/constants/reportConstants.ts#L4-L11
* https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/messages/common.ts#L17-L22

Is there any reason not to include a property for this key?

For example, in the following classic code, `switch` statement has a default case:

https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Components/CVSSSeverityLabel.js#L7-L20

See below that `"severity": "UNKNOWN_VULNERABILITY_SEVERITY"` can occur in response to /v1/nodes/:clusterId request, although UI uses graphQL queries instead.

```js
          {
            "name": "kernel",
            "version": "5.10.25-linuxkit",
            "vulns": [
              {
                "cve": "CVE-2018-1000026",
                "cvss": 7.7,
                "summary": "Linux Linux kernel version at least v4.8 onwards, probably well before contains a Insufficient input validation vulnerability in bnx2x network card driver that can result in DoS: Network card firmware assertion takes card off-line. This attack appear to be exploitable via An attacker on a must pass a very large, specially crafted packet to the bnx2x card. This can be done from an untrusted guest VM..",
                "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000026",
                "scoreVersion": "V3",
                "cvssV2": {
                  "vector": "AV:N/AC:L/Au:S/C:N/I:N/A:C",
                  "attackVector": "ATTACK_NETWORK",
                  "accessComplexity": "ACCESS_LOW",
                  "authentication": "AUTH_SINGLE",
                  "confidentiality": "IMPACT_NONE",
                  "integrity": "IMPACT_NONE",
                  "availability": "IMPACT_COMPLETE",
                  "exploitabilityScore": 8,
                  "impactScore": 6.9,
                  "score": 6.8,
                  "severity": "MEDIUM"
                },
                "cvssV3": {
                  "vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:N/A:H",
                  "exploitabilityScore": 3.1,
                  "impactScore": 4,
                  "attackVector": "ATTACK_NETWORK",
                  "attackComplexity": "COMPLEXITY_LOW",
                  "privilegesRequired": "PRIVILEGE_LOW",
                  "userInteraction": "UI_NONE",
                  "scope": "CHANGED",
                  "confidentiality": "IMPACT_NONE",
                  "integrity": "IMPACT_NONE",
                  "availability": "IMPACT_HIGH",
                  "score": 7.7,
                  "severity": "HIGH"
                },
                "publishedOn": "2018-02-09T23:29:00Z",
                "lastModified": "2020-10-15T13:28:00Z",
                "vulnerabilityType": "UNKNOWN_VULNERABILITY",
                "vulnerabilityTypes": ["NODE_VULNERABILITY"],
                "suppressed": false,
                "suppressActivation": null,
                "suppressExpiry": null,
                "firstSystemOccurrence": "2022-04-14T15:28:06.130408200Z",
                "firstImageOccurrence": null,
                "firstNodeOccurrence": "2022-04-14T15:28:06.130408200Z",
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "state": "OBSERVED"
              },
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Temporarily request /v1/nodes/:clusterId and make sure proto is consistent with response