### PR TITLE
Replace redirect with unmatched path for Not Found page

### DIFF
--- a/ui/apps/platform/src/Containers/AppPage.tsx
+++ b/ui/apps/platform/src/Containers/AppPage.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
-import { Route, Switch, Redirect } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 
-import { mainPath, loginPath, testLoginResultsPath, authResponsePrefix } from 'routePaths';
+import { loginPath, testLoginResultsPath, authResponsePrefix } from 'routePaths';
 import LoadingSection from 'Components/PatternFly/LoadingSection';
 import AuthenticatedRoutes from 'Containers/MainPage/AuthenticatedRoutes';
 import LoginPage from 'Containers/Login/LoginPage';
@@ -15,11 +15,10 @@ function AppPage(): ReactElement {
             <AppPageTitle />
             <AppPageFavicon />
             <Switch>
-                <Route path={mainPath} component={AuthenticatedRoutes} />
                 <Route path={loginPath} component={LoginPage} />
                 <Route path={testLoginResultsPath} component={TestLoginResultsPage} />
                 <Route path={authResponsePrefix} component={LoadingSection} />
-                <Route path="/" render={() => <Redirect to={mainPath} />} />
+                <Route component={AuthenticatedRoutes} />
             </Switch>
         </>
     );

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -4,7 +4,6 @@ import { PageSection } from '@patternfly/react-core';
 
 import {
     mainPath,
-    notFoundPath,
     dashboardPath,
     networkPath,
     violationsPath,
@@ -102,7 +101,8 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
         >
             <ErrorBoundary>
                 <Switch>
-                    <Route path={notFoundPath} component={NotFoundPage} />
+                    <Route path="/" exact render={() => <Redirect to={dashboardPath} />} />
+                    <Route path={mainPath} exact render={() => <Redirect to={dashboardPath} />} />
                     <Route path={dashboardPath} component={AsyncDashboardPage} />
                     <Route path={networkPath} component={AsyncNetworkPage} />
                     <Route path={violationsPath} component={AsyncViolationsPage} />
@@ -131,8 +131,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     {isSystemHealthPatternFlyEnabled && (
                         <Route path={systemHealthPathPF} component={AsyncSystemHealthPagePF} />
                     )}
-                    <Route path={mainPath} exact render={() => <Redirect to={dashboardPath} />} />
-                    <Route path={mainPath} render={() => <Redirect to={notFoundPath} />} />
+                    <Route component={NotFoundPage} />
                 </Switch>
             </ErrorBoundary>
         </div>

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -9,7 +9,6 @@ export const loginPath = '/login';
 export const testLoginResultsPath = '/test-login-results';
 export const authResponsePrefix = '/auth/response/';
 
-export const notFoundPath = `${mainPath}/404`;
 export const dashboardPath = `${mainPath}/dashboard`;
 export const networkBasePath = `${mainPath}/network`;
 export const networkPath = `${networkBasePath}/:deploymentId?/:externalType?`;


### PR DESCRIPTION
## Description

Follow up after discussion about #1213

### Goals

1. Instead of redirect, render `NotFoundPage` element at the unmatched path, so people can investigate why the path is unavailable:
    * feature flag
    * user role permissions
    * incorrect link

2. Continue to increase cohesion and reduce coupling between components:
    * `AppPage`
    * `AuthenticatedRoutes`
    * `MainPage`
    * `Body`

### Changed files

1. Edit src/Containers/AppPage.tsx
    * Delegate to `Body` element the responsibility for redirect from /
    * Render `AuthenticatedRoutes` as default for unmatched paths

2. Edit src/Containers/MainPage/Body.tsx
    * Redirect directly from / to /main/dashboard instead of indirectly from / to /main and then to /main/dashboard
    * Render `NotFoundPage` as default for unmatched paths

3. Edit src/routePaths.js
    * Delete `notFoundPath`

### Residue

If path does match generic pattern
* but second-level resource is not available because of feature flag or role permissions, page title is **Reporting** (for example) instead of **Not Found**
* but second-level resource does not match a specific pattern, page title is empty instead of **Not Found**

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### redirected paths

* https://localhost:3000 redirects to /main/dashboard
* https://localhost:3000/main redirects to /main/dashboard

### matched paths

* /main/dashboard renders `AsyncDashboardPage`

* https://localhost:3000/main/vulnerability-management renders Vulnerability Management - Dashboard
* https://localhost:3000/main/vulnerability-management/cves renders Vulnerability Management - Cves
* https://localhost:3000/main/vulnerability-management/cves?workflowState[0][t]=CVE&workflowState[0][i]=… renders Vulnerability Management - Cve
* https://localhost:3000/main/vulnerability-management/reports with access renders Vulnerability Management - Reporting
* https://localhost:3000/main/system-health-pf with feature flag renders System Health

# unmatched paths

* https://localhost:3000/unknown renders `NotFoundPage`
* https://localhost:3000/main/unknown renders `NotFoundPage`
* https://localhost:3000/main/vulnerability-management/unknown renders `PageNotFound`
* https://localhost:3000/main/vulnerability-management/reports without access renders `PageNotFound`
* https://localhost:3000/main/system-health-pf without feature flag renders `NotFoundPage`