### PR TITLE
Delete ROX_VULN_REPORTING feature flag

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -326,6 +326,8 @@ func servicesToRegister(registry authproviders.Registry, authzTraceSink observe.
 		processIndicatorService.Singleton(),
 		processBaselineService.Singleton(),
 		rbacService.Singleton(),
+		reportConfigurationService.Singleton(),
+		reportService.Singleton(),
 		roleService.Singleton(),
 		sacService.Singleton(),
 		searchService.Singleton(),
@@ -339,12 +341,6 @@ func servicesToRegister(registry authproviders.Registry, authzTraceSink observe.
 		telemetryService.Singleton(),
 		userService.Singleton(),
 		vulnRequestService.Singleton(),
-	}
-
-	if features.VulnReporting.Enabled() {
-		servicesToRegister = append(servicesToRegister,
-			reportConfigurationService.Singleton(),
-			reportService.Singleton())
 	}
 
 	if features.ImageSignatureVerification.Enabled() {
@@ -709,11 +705,8 @@ func waitForTerminationSignal() {
 		{suppress.Singleton(), "cve unsuppress loop"},
 		{pruning.Singleton(), "gargage collector"},
 		{gatherer.Singleton(), "network graph default external sources gatherer"},
+		{vulnReportScheduleManager.Singleton(), "vuln reports schedule manager"},
 		{vulnRequestManager.Singleton(), "vuln deferral requests expiry loop"},
-	}
-
-	if features.VulnReporting.Enabled() {
-		stoppables = append(stoppables, stoppableWithName{vulnReportScheduleManager.Singleton(), "vuln reports schedule manager"})
 	}
 
 	var wg sync.WaitGroup

--- a/central/reports/manager/manager_impl.go
+++ b/central/reports/manager/manager_impl.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/contextutil"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sac"
 )
 
@@ -65,9 +64,6 @@ func (m *managerImpl) RunReport(ctx context.Context, reportConfig *storage.Repor
 }
 
 func (m *managerImpl) Start() {
-	if !features.VulnReporting.Enabled() {
-		return
-	}
 	m.scheduler.Start()
 }
 

--- a/central/reports/manager/singleton.go
+++ b/central/reports/manager/singleton.go
@@ -8,7 +8,6 @@ import (
 	reportConfigDS "github.com/stackrox/rox/central/reportconfigurations/datastore"
 	"github.com/stackrox/rox/central/reports/scheduler"
 	roleDataStore "github.com/stackrox/rox/central/role/datastore"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -35,9 +34,6 @@ func initialize() {
 
 // Singleton provides the instance of Manager to use.
 func Singleton() Manager {
-	if !features.VulnReporting.Enabled() {
-		return nil
-	}
 	once.Do(initialize)
 	return instance
 }

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -23,7 +23,6 @@ import (
 	roleDataStore "github.com/stackrox/rox/central/role/datastore"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/protoconv/schedule"
@@ -374,9 +373,6 @@ func (s *scheduler) runPaginatedQuery(ctx context.Context, scopeQuery, cveQuery 
 }
 
 func (s *scheduler) Start() {
-	if !features.VulnReporting.Enabled() {
-		return
-	}
 	go s.runReports()
 }
 

--- a/central/role/datastore/singleton.go
+++ b/central/role/datastore/singleton.go
@@ -48,10 +48,8 @@ func Singleton() DataStore {
 		// Which role format is used is determined solely by the feature flag.
 		ds = New(roleStorage, permissionSetStorage, accessScopeStorage)
 
-		if features.VulnReporting.Enabled() {
-			for r, a := range vulnReportingDefaultRoles {
-				defaultRoles[r] = a
-			}
+		for r, a := range vulnReportingDefaultRoles {
+			defaultRoles[r] = a
 		}
 
 		ctx := sac.WithGlobalAccessScopeChecker(context.Background(),

--- a/central/role/resources/list.go
+++ b/central/role/resources/list.go
@@ -70,7 +70,7 @@ var (
 	User                             = newResourceMetadata("User", permissions.GlobalScope)
 	VulnerabilityManagementApprovals = newResourceMetadata("VulnerabilityManagementApprovals", permissions.GlobalScope)
 	VulnerabilityManagementRequests  = newResourceMetadata("VulnerabilityManagementRequests", permissions.GlobalScope)
-	VulnerabilityReports             = newResourceMetadataWithFeatureFlag("VulnerabilityReports", permissions.GlobalScope, features.VulnReporting)
+	VulnerabilityReports             = newResourceMetadata("VulnerabilityReports", permissions.GlobalScope)
 	WatchedImage                     = newResourceMetadata("WatchedImage", permissions.GlobalScope)
 
 	// Internal Resources

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -30,9 +30,6 @@ var (
 	// PoliciesPatternFly enables the PatternFly version of Policies. (used in the front-end app only)
 	PoliciesPatternFly = registerFeature("Enable PatternFly version of Policies", "ROX_POLICIES_PATTERNFLY", true)
 
-	// VulnReporting enables scheduled vulnerability reporting workflow, that allows the creation and management of vulnerability reporting configurations.
-	VulnReporting = registerFeature("Enable creation of scheduled vulnerability reports to be sent via email notifier", "ROX_VULN_REPORTING", true)
-
 	// LocalImageScanning enables OpenShift local-image scanning.
 	LocalImageScanning = registerFeature("Enable OpenShift local-image scanning", "ROX_LOCAL_IMAGE_SCANNING", true)
 

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -30,6 +30,9 @@ var (
 	// PoliciesPatternFly enables the PatternFly version of Policies. (used in the front-end app only)
 	PoliciesPatternFly = registerFeature("Enable PatternFly version of Policies", "ROX_POLICIES_PATTERNFLY", true)
 
+	// VulnReporting enables scheduled vulnerability reporting workflow, that allows the creation and management of vulnerability reporting configurations.
+	VulnReporting = registerFeature("Enable creation of scheduled vulnerability reports to be sent via email notifier", "ROX_VULN_REPORTING", true)
+
 	// LocalImageScanning enables OpenShift local-image scanning.
 	LocalImageScanning = registerFeature("Enable OpenShift local-image scanning", "ROX_LOCAL_IMAGE_SCANNING", true)
 

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -90,7 +90,6 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
     const isSystemHealthPatternFlyEnabled = isFeatureFlagEnabled(
         knownBackendFlags.ROX_SYSTEM_HEALTH_PF
     );
-    const isVulnReportingEnabled = isFeatureFlagEnabled(knownBackendFlags.ROX_VULN_REPORTING);
 
     const hasVulnerabilityReportsPermission = hasReadAccess('VulnerabilityReports');
 
@@ -114,7 +113,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     <Route path={apidocsPath} component={AsyncApiDocsPage} />
                     <Route path={userBasePath} component={AsyncUserPage} />
                     <Route path={systemConfigPath} component={AsyncSystemConfigPage} />
-                    {isVulnReportingEnabled && hasVulnerabilityReportsPermission && (
+                    {hasVulnerabilityReportsPermission && (
                         <Route path={vulnManagementReportsPath} component={AsyncVulnMgmtReports} />
                     )}
                     <Route

--- a/ui/apps/platform/src/Containers/Navigation/NavigationSideBar/NavigationSideBar.tsx
+++ b/ui/apps/platform/src/Containers/Navigation/NavigationSideBar/NavigationSideBar.tsx
@@ -4,7 +4,7 @@ import { Nav, NavList, NavExpandable, PageSidebar } from '@patternfly/react-core
 
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import { HasReadAccess } from 'hooks/usePermissions';
-import { knownBackendFlags } from 'utils/featureFlags';
+// import { knownBackendFlags } from 'utils/featureFlags';
 
 import {
     basePathToLabelMap,
@@ -38,15 +38,12 @@ const platformConfigurationPaths = [
 
 type NavigationSideBarProps = {
     hasReadAccess: HasReadAccess;
+    // eslint-disable-next-line react/no-unused-prop-types
     isFeatureFlagEnabled: IsFeatureFlagEnabled;
 };
 
-function NavigationSideBar({
-    hasReadAccess,
-    isFeatureFlagEnabled,
-}: NavigationSideBarProps): ReactElement {
+function NavigationSideBar({ hasReadAccess }: NavigationSideBarProps): ReactElement {
     const location: Location = useLocation();
-    const isVulnReportingEnabled = isFeatureFlagEnabled(knownBackendFlags.ROX_VULN_REPORTING);
 
     const vulnerabilityManagementPaths = [vulnManagementPath];
     if (
@@ -55,7 +52,7 @@ function NavigationSideBar({
     ) {
         vulnerabilityManagementPaths.push(vulnManagementRiskAcceptancePath);
     }
-    if (isVulnReportingEnabled && hasReadAccess('VulnerabilityReports')) {
+    if (hasReadAccess('VulnerabilityReports')) {
         vulnerabilityManagementPaths.push(vulnManagementReportsPath);
     }
 

--- a/ui/apps/platform/src/Containers/Navigation/NavigationSideBar/NavigationSideBar.tsx
+++ b/ui/apps/platform/src/Containers/Navigation/NavigationSideBar/NavigationSideBar.tsx
@@ -4,6 +4,7 @@ import { Nav, NavList, NavExpandable, PageSidebar } from '@patternfly/react-core
 
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import { HasReadAccess } from 'hooks/usePermissions';
+// The following import is for feature flags in isFeatureFlagEnabled function calls.
 // import { knownBackendFlags } from 'utils/featureFlags';
 
 import {

--- a/ui/apps/platform/src/Containers/SystemConfig/ConfigDataRetentionDetailWidget.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/ConfigDataRetentionDetailWidget.tsx
@@ -13,8 +13,6 @@ import {
 } from '@patternfly/react-core';
 
 import { PrivateConfig } from './SystemConfigTypes';
-import useFeatureFlagEnabled from '../../hooks/useFeatureFlagEnabled';
-import { knownBackendFlags } from '../../utils/featureFlags';
 
 const UNKNOWN_FLAG = -1;
 
@@ -42,8 +40,6 @@ export type DataRetentionDetailWidgetProps = {
 const DataRetentionDetailWidget = ({
     privateConfig,
 }: DataRetentionDetailWidgetProps): ReactElement => {
-    const isVulnReportingEnabled = useFeatureFlagEnabled(knownBackendFlags.ROX_VULN_REPORTING);
-
     return (
         <Card data-testid="data-retention-config">
             <CardTitle>Data Retention Configuration</CardTitle>
@@ -94,15 +90,13 @@ const DataRetentionDetailWidget = ({
                             suffix="Day"
                         />
                     </GalleryItem>
-                    {isVulnReportingEnabled && (
-                        <GalleryItem>
-                            <NumberBox
-                                label="Expired Vulnerability Requests"
-                                value={privateConfig?.expiredVulnReqRetentionDurationDays}
-                                suffix="Day"
-                            />
-                        </GalleryItem>
-                    )}
+                    <GalleryItem>
+                        <NumberBox
+                            label="Expired Vulnerability Requests"
+                            value={privateConfig?.expiredVulnReqRetentionDurationDays}
+                            suffix="Day"
+                        />
+                    </GalleryItem>
                 </Gallery>
             </CardBody>
         </Card>

--- a/ui/apps/platform/src/Containers/SystemConfig/SystemConfigForm/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/SystemConfigForm/SystemConfigForm.tsx
@@ -23,8 +23,6 @@ import { getProductBranding } from 'constants/productBranding';
 import { ConfigTelemetryDetailContent } from '../ConfigTelemetryDetailWidget';
 import { PrivateConfig, PublicConfig, TelemetryConfig } from '../SystemConfigTypes';
 import FormSelect from './FormSelect';
-import useFeatureFlagEnabled from '../../../hooks/useFeatureFlagEnabled';
-import { knownBackendFlags } from '../../../utils/featureFlags';
 
 export type SystemConfigFormProps = {
     values: {
@@ -51,8 +49,6 @@ const SystemConfigForm = ({
     function onCustomChange(value, id) {
         return setFieldValue(id, value, false);
     }
-
-    const isVulnReportingEnabled = useFeatureFlagEnabled(knownBackendFlags.ROX_VULN_REPORTING);
 
     return (
         <Form id="system-config-edit-form" onSubmit={onSubmitForm}>
@@ -182,27 +178,25 @@ const SystemConfigForm = ({
                                             />
                                         </FormGroup>
                                     </GridItem>
-                                    {isVulnReportingEnabled && (
-                                        <GridItem>
-                                            <FormGroup
-                                                label="Expired Vulnerability Requests"
+                                    <GridItem>
+                                        <FormGroup
+                                            label="Expired Vulnerability Requests"
+                                            isRequired
+                                            fieldId="privateConfig.expiredVulnReqRetentionDurationDays"
+                                        >
+                                            <TextInput
                                                 isRequired
-                                                fieldId="privateConfig.expiredVulnReqRetentionDurationDays"
-                                            >
-                                                <TextInput
-                                                    isRequired
-                                                    type="number"
-                                                    id="privateConfig.expiredVulnReqRetentionDurationDays"
-                                                    name="privateConfig.expiredVulnReqRetentionDurationDays"
-                                                    value={
-                                                        values?.privateConfig
-                                                            ?.expiredVulnReqRetentionDurationDays
-                                                    }
-                                                    onChange={onChange}
-                                                />
-                                            </FormGroup>
-                                        </GridItem>
-                                    )}
+                                                type="number"
+                                                id="privateConfig.expiredVulnReqRetentionDurationDays"
+                                                name="privateConfig.expiredVulnReqRetentionDurationDays"
+                                                value={
+                                                    values?.privateConfig
+                                                        ?.expiredVulnReqRetentionDurationDays
+                                                }
+                                                onChange={onChange}
+                                            />
+                                        </FormGroup>
+                                    </GridItem>
                                 </Grid>
                             </FormSection>
                         </CardBody>

--- a/ui/apps/platform/src/utils/featureFlags.ts
+++ b/ui/apps/platform/src/utils/featureFlags.ts
@@ -16,7 +16,6 @@ export const knownBackendFlags = {
     ROX_NETWORK_DETECTION_BLOCKED_FLOWS: 'ROX_NETWORK_DETECTION_BLOCKED_FLOWS',
     ROX_POLICIES_PATTERNFLY: 'ROX_POLICIES_PATTERNFLY',
     ROX_SYSTEM_HEALTH_PF: 'ROX_SYSTEM_HEALTH_PF',
-    ROX_VULN_REPORTING: 'ROX_VULN_REPORTING',
 };
 
 // isBackendFeatureFlagEnabled returns whether a feature flag retrieved from the backend is enabled.


### PR DESCRIPTION
## Description

Delete leftover feature flags is a prerequisite to replace `useFeatureFlagEnabled` with `useFeatureFlags` hook

1. pkg/features/list.go
    * Leave feature flag for now because some backend code still refers to `VulnReporting` /cc @clickboo

2. ui/apps/platform/src/Containers/MainPage/Body.tsx
    * Delete feature flag from conditional rendering for `VulnMgmtReports` element

3. ui/apps/platform/src/Containers/Navigation/NavigationSideBar/NavigationSideBar.tsx
    * Delete feature flag from conditional rendering for `vulnManagementReportsPath` path
    * Comment out `import` statement for `knownBackendFlags` as hint for people who add feature flags
    * Add disable comment for `isFeatureFlagEnabled` prop so `MainPage` continues to render the element with it

    Too bad, so sad prettier does not allow the following:

    ```tsx
    function NavigationSideBar({
        hasReadAccess,
        // isFeatureFlagEnabled,
    }: NavigationSideBarProps): ReactElement {
    ```

4. ui/apps/platform/src/Containers/SystemConfig/ConfigDataRetentionDetailWidget.tsx
    * Delete feature flags from conditional rendering for `expiredVulnReqRetentionDurationDays` property

5. ui/apps/platform/src/Containers/SystemConfig/SystemConfigForm/SystemConfigForm.tsx
    * Delete feature flags from conditional rendering for `expiredVulnReqRetentionDurationDays` property

6. ui/apps/platform/src/utils/featureFlags.ts
    * Delete frontend definition of feature flag

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### manual testing

/main/systemconfig
![systemconfig](https://user-images.githubusercontent.com/11862657/163829346-2e0f3888-d4d3-4dad-bcae-9e721abda8e0.png)

### integration testing

1. `yarn build` in ui
2. `yarn cypress` in ui/apps/platform
    * vulnmanagement/reporting/displayReports.test.js (does not depend on feature flag)
    * vulnmanagement/reporting/manageReports.test.js (does not depend on feature flag)