### PR TITLE
ROX-10090: Remove UI validation for Artifactory integration auth in form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-9946: Fixed default permissions for the default Vuln Reporter role to exclude the modify permission on notifiers, since it is not needed for report creation.
 - Added AllowPrivilegeEscalation as a new policy criteria.
 - ROX-10038: Removed limit of 10 inclusions and 10 exclusions from policy form
+- ROX-10090: Made the username and password optional on the Artifactory integration form
 
 ## [69.1]
 

--- a/ui/apps/platform/cypress/integration/integrations/imageIntegrations.test.js
+++ b/ui/apps/platform/cypress/integration/integrations/imageIntegrations.test.js
@@ -239,12 +239,10 @@ describe('Image Integrations Test', () => {
 
         // Step 1, check empty fields
         getInputByLabel('Integration name').type(' ');
-        getInputByLabel('Endpoint').type(' ');
-        getInputByLabel('Password').type(' ').blur();
+        getInputByLabel('Endpoint').type(' ').blur();
 
         getHelperElementByLabel('Integration name').contains('An integration name is required');
         getHelperElementByLabel('Endpoint').contains('An endpoint is required');
-        getHelperElementByLabel('Password').contains('A password is required');
         cy.get(selectors.buttons.test).should('be.disabled');
         cy.get(selectors.buttons.save).should('be.disabled');
 

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ArtifactoryIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ArtifactoryIntegrationForm.tsx
@@ -42,25 +42,7 @@ export const validationSchema = yup.object().shape({
         docker: yup.object().shape({
             endpoint: yup.string().trim().required('An endpoint is required'),
             username: yup.string(),
-            password: yup
-                .string()
-                .test(
-                    'password-test',
-                    'A password is required',
-                    (value, context: yup.TestContext) => {
-                        const requirePasswordField =
-                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                            // @ts-ignore
-                            context?.from[2]?.value?.updatePassword || false;
-
-                        if (!requirePasswordField) {
-                            return true;
-                        }
-
-                        const trimmedValue = value?.trim();
-                        return !!trimmedValue;
-                    }
-                ),
+            password: yup.string(),
             insecure: yup.bool(),
         }),
         skipTestIntegration: yup.bool(),
@@ -171,13 +153,11 @@ function ArtifactoryIntegrationForm({
                     </FormLabelGroup>
                     <FormLabelGroup
                         label="Username"
-                        isRequired
                         fieldId="config.docker.username"
                         touched={touched}
                         errors={errors}
                     >
                         <TextInput
-                            isRequired
                             type="text"
                             id="config.docker.username"
                             value={values.config.docker.username}
@@ -205,7 +185,6 @@ function ArtifactoryIntegrationForm({
                         </FormLabelGroup>
                     )}
                     <FormLabelGroup
-                        isRequired={values.updatePassword}
                         label="Password"
                         fieldId="config.docker.password"
                         touched={touched}
@@ -222,7 +201,7 @@ function ArtifactoryIntegrationForm({
                             placeholder={
                                 values.updatePassword
                                     ? ''
-                                    : 'Currently-stored password will be used.'
+                                    : 'Any currently-stored password will be used.'
                             }
                         />
                     </FormLabelGroup>


### PR DESCRIPTION
## Description

Remove the required validations, visual indicators, and disabled settings for username and password on the Artifactory integration form.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required


## Testing Performed

Manually verified creating an Artifactory integration without username or password, and also still with a username and password.

<img width="1569" alt="Screen Shot 2022-04-18 at 1 56 35 PM" src="https://user-images.githubusercontent.com/715729/163863543-5b6f483f-ab67-4641-8e04-316198083b31.png">
<img width="1569" alt="Screen Shot 2022-04-18 at 1 56 43 PM" src="https://user-images.githubusercontent.com/715729/163863547-30433152-0de7-46cb-b366-d54694570dce.png">
<img width="1569" alt="Screen Shot 2022-04-18 at 3 20 04 PM" src="https://user-images.githubusercontent.com/715729/163863545-351b2617-fb3b-4e7c-97fe-1d41e17ec2e7.png">
