### PR TITLE
Bugfix: Instances of TeardownTest() --> TearDownTest()

### DIFF
--- a/central/apitoken/datastore/datastore_test.go
+++ b/central/apitoken/datastore/datastore_test.go
@@ -46,7 +46,7 @@ func (s *apiTokenDataStoreTestSuite) SetupTest() {
 	s.dataStore = New(s.storage)
 }
 
-func (s *apiTokenDataStoreTestSuite) TeardownTest() {
+func (s *apiTokenDataStoreTestSuite) TearDownTest() {
 	s.mockCtrl.Finish()
 }
 

--- a/central/notifier/datastore/datastsore_test.go
+++ b/central/notifier/datastore/datastsore_test.go
@@ -47,7 +47,7 @@ func (s *notifierDataStoreTestSuite) SetupTest() {
 	s.dataStore = New(s.storage)
 }
 
-func (s *notifierDataStoreTestSuite) TeardownTest() {
+func (s *notifierDataStoreTestSuite) TearDownTest() {
 	s.mockCtrl.Finish()
 }
 

--- a/pkg/helm/charts/tests/securedclusterservices/base_suite_test.go
+++ b/pkg/helm/charts/tests/securedclusterservices/base_suite_test.go
@@ -110,7 +110,7 @@ func (s *baseSuite) SetupTest() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 }
 
-func (s *baseSuite) TeardownTest() {
+func (s *baseSuite) TearDownTest() {
 	s.envIsolator.RestoreAll()
 }
 


### PR DESCRIPTION
## Description

Fixed 3 instances of TeardownTest() being used instead of TearDownTest() as I made that mistake myself and then searched if it happened anywhere else in the codebase.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~ // not applicable
- [x] ~Evaluated and added CHANGELOG entry if required~ // not applicable
- [x] ~Determined and documented upgrade steps~ // not applicable
- [x] ~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~// not applicable

If any of these don't apply, please comment below.

## Testing Performed

No tests performed, just let CI run through. If tests suddenly fail because a TearDownTest() function that wasn't called before is called now that's something to look into.
