### PR TITLE
Request deployment only if needed for filters in Network Graph

### DIFF
--- a/ui/apps/platform/cypress/helpers/risk.js
+++ b/ui/apps/platform/cypress/helpers/risk.js
@@ -12,7 +12,9 @@ export function visitRiskDeployments() {
 export function viewRiskDeploymentByName(deploymentName) {
     // Assume location is risk deployments table.
     cy.intercept('GET', api.risks.fetchDeploymentWithRisk).as('getDeploymentWithRisk');
-    cy.get(`${selectors.table.rows}:contains("${deploymentName}")`).click();
+    cy.get(
+        `${selectors.table.rows} ${selectors.table.cells}:nth-child(1):contains("${deploymentName}")`
+    ).click();
     cy.wait('@getDeploymentWithRisk');
 }
 

--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -116,7 +116,7 @@ describe('Risk page', () => {
             viewRiskDeploymentByName('central');
             viewRiskDeploymentInNetworkGraph();
 
-            cy.location('pathname').should('match', /^\/main\/network\/[0-9a-z]+/);
+            cy.location('pathname').should('match', /^\/main\/network\/[0-9a-z]+$/);
         });
     });
 

--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -2,6 +2,11 @@ import { selectors as RiskPageSelectors, url, errorMessages } from '../../consta
 import { selectors as searchSelectors } from '../../constants/SearchPage';
 import * as api from '../../constants/apiEndpoints';
 import withAuth from '../../helpers/basicAuth';
+import {
+    visitRiskDeployments,
+    viewRiskDeploymentByName,
+    viewRiskDeploymentInNetworkGraph,
+} from '../../helpers/risk';
 
 describe('Risk page', () => {
     withAuth();
@@ -103,14 +108,15 @@ describe('Risk page', () => {
             cy.get(searchSelectors.pageSearch.input).type('{esc}'); // close the drop-down menu
             cy.get(RiskPageSelectors.sidePanel.tabs).should('not.exist');
         });
+    });
 
+    describe('with actual API', () => {
         it('should navigate to network page with selected deployment', () => {
-            mockGetDeployment();
-            cy.get(RiskPageSelectors.table.row.firstRow).click({ force: true });
-            cy.wait('@firstDeployment');
+            visitRiskDeployments();
+            viewRiskDeploymentByName('central');
+            viewRiskDeploymentInNetworkGraph();
 
-            cy.get(RiskPageSelectors.viewDeploymentsInNetworkGraphButton).click({ force: true });
-            cy.url().should('contain', '/main/network');
+            cy.location('pathname').should('match', /^\/main\/network\/[0-9a-z]+/);
         });
     });
 

--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -116,7 +116,7 @@ describe('Risk page', () => {
             viewRiskDeploymentByName('central');
             viewRiskDeploymentInNetworkGraph();
 
-            cy.location('pathname').should('match', /^\/main\/network\/[0-9a-z]+$/);
+            cy.location('pathname').should('match', /^\/main\/network\/[-0-9a-z]+$/);
         });
     });
 

--- a/ui/apps/platform/src/Containers/Network/Page.js
+++ b/ui/apps/platform/src/Containers/Network/Page.js
@@ -89,7 +89,11 @@ function NetworkPage({ closeSidePanel, setDialogueStage, setNetworkModification 
     const dispatch = useDispatch();
 
     useEffect(() => {
-        if (!deploymentId || !isInitialRender) {
+        if (!isInitialRender) {
+            return;
+        }
+        setIsInitialRender(false);
+        if (!deploymentId) {
             return;
         }
         // If the page is visited with a deployment id, we need to enable that deployment's
@@ -103,7 +107,6 @@ function NetworkPage({ closeSidePanel, setDialogueStage, setNetworkModification 
                 dispatch(graphActions.setSelectedNamespaceFilters(newFilters));
             }
         });
-        setIsInitialRender(false);
     }, [dispatch, deploymentId, selectedClusterId, selectedNamespaceFilters, isInitialRender]);
 
     const clusterName = clusters.find((c) => c.id === selectedClusterId)?.name;


### PR DESCRIPTION
## Description

### Problem

> If the page is visited with a deployment id, we need to enable that deployment's namespace filter and switch to the correct cluster

https://github.com/stackrox/stackrox/blame/master/ui/apps/platform/src/Containers/Network/Page.js#L91-L107

If the initial render is **without** a deployment id, the next render **with** a deployment id makes deployment request, however
* its cluster has already been selected
* its namespace has already been selected

### Solution

1. Separate conditions for early return from hook
2. Move `setIsInitialRender` function call

```diff
     useEffect(() => {
-        if (!deploymentId || !isInitialRender) {
+        if (!isInitialRender) {
             return;
         }
+        setIsInitialRender(false);
+        if (!deploymentId) {
+            return;
+        }
         fetchDeployment(deploymentId).then(({ clusterId, namespace }) => { … });
-        setIsInitialRender(false);
     }, [dispatch, deploymentId, selectedClusterId, selectedNamespaceFilters, isInitialRender]);
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### manual testing

Observe deployment requests in the following interactions:

1. Visit **Network Graph** and then click deployment

    * /main/network
        GET /v1/deploymentswithprocessinfo?query=Orchestrator%20Component%3Afalse (request both before and after solution)
    * Filter **stackrox** namespace
    * Click **central** deployment
        /main/network/:centralId
        GET /v1/deployments/:centralId (unneeded request before but not after solution)

2. And then click a different deployment (no request before nor after solution)

    * Click **scanner** deployment
        /main/network/:scannerId

3. Paste network address which does not have deployment id (no request before nor after solution)

    * /main/network

4. Paste network address which does have deployment id

    * /main/network/:sensorId
        GET /v1/deployments/:sensorId (needed request before and after solution)

5. View from Risk

    * /main/risk
        GET /v1/deploymentswithprocessinfo?pagination.offset=0&pagination.limit=50&pagination.sortOption.field=Deployment%20Risk%20Priority&pagination.sortOption.reversed=false&query=Orchestrator%20Component%3Afalse
        GET /v1/deploymentscount?query=Orchestrator%20Component%3Afalse
    * Click **collector** row in the deployments table
        /main/risk/:collectorId
        GET /v1/deploymentswithrisk/:collectorId
    * Click **View deployment in Network Graph** in the deployment side panel
        /main/network/:collectorId
        GET /v1/deployments/:collectorId (needed request before and after solution)

### integration testing

1. `yarn start` in ui
2. `yarn cypress-open` in ui/apps/platform
    * network.test.js
    * networkGraph/externalEntities.test.js
    * networkGraph/networkFlows.test.js
    * networkGraph/networkGraph.test.js
    * risk/risk.test.js

<img width="1348" alt="deployment-404" src="https://user-images.githubusercontent.com/11862657/164032406-524c7e96-e892-4dc6-ba63-1bb975b91b70.png">

Edit `'should navigate to network page with selected deployment'` test so it uses actual API to prevent unneeded 404 status for deployment request