### PR TITLE
ROX-10217: Remove format validation from URL field of generic webhook integration form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - Added AllowPrivilegeEscalation as a new policy criteria.
 - ROX-10038: Removed limit of 10 inclusions and 10 exclusions from policy form
 - ROX-10090: Made the username and password optional on the Artifactory integration form
+- ROX-10217: Remove format validation from the URL field of the generic webhook integration form
 
 ## [69.1]
 

--- a/ui/apps/platform/cypress/integration/integrations/notifiers.test.js
+++ b/ui/apps/platform/cypress/integration/integrations/notifiers.test.js
@@ -183,8 +183,7 @@ describe('Notifiers Test', () => {
             cy.get(selectors.buttons.save).should('be.disabled');
 
             // Step 2, check fields for invalid formats, or conditional validation
-            getInputByLabel('Endpoint').type('example').blur();
-            getHelperElementByLabel('Endpoint').contains('Endpoint must be a valid URL');
+            getInputByLabel('Endpoint').type('example.com:3000/hooks/123').blur();
 
             getInputByLabel('Username').type('neo').blur();
             getInputByLabel('Password').type(' ').blur();
@@ -200,7 +199,7 @@ describe('Notifiers Test', () => {
 
             // Step 3, check valid from and save
             getInputByLabel('Integration name').clear().type(integrationName);
-            getInputByLabel('Endpoint').clear().type('example.com:3000/hooks/123');
+            getInputByLabel('Endpoint').clear().type('service-name');
             getInputByLabel('CA certificate (optional)').type(sampleCert, { delay: 1 });
             getInputByLabel('Skip TLS verification').click();
             getInputByLabel('Enable audit logging').click();

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GenericWebhookIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GenericWebhookIntegrationForm.tsx
@@ -53,18 +53,11 @@ export type GenericWebhookIntegrationFormValues = {
     updatePassword: boolean;
 };
 
-const validEndpointRegex =
-    /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=.]+$/;
-
 export const validationSchema = yup.object().shape({
     notifier: yup.object().shape({
         name: yup.string().trim().required('Name is required'),
         generic: yup.object().shape({
-            endpoint: yup
-                .string()
-                .trim()
-                .required('Endpoint is required')
-                .matches(validEndpointRegex, 'Endpoint must be a valid URL'),
+            endpoint: yup.string().trim().required('Endpoint is required'),
             skipTlsVerify: yup.bool(),
             auditLoggingEnabled: yup.bool(),
             username: yup


### PR DESCRIPTION
## Description

1. Customer had an issue with a webhook URL that had previously worked when we had no front-end validation of the URL field in Generic Webhook integration form. After upgrading to a version that has the new form, they cannot edit or create new integrations. Based on a sanitized version, it appears that their URL was failing due to the presence of a `%` character, as part of URL encoding.
2. There have been other issues, on other forms' endpoint fields, where customers have used a variety of formats, including Kubernetes service names instead of traditional URL formats.

Rather than only address the immediate issue in #1 above, by adding `%` to the validation regex, I decided to allow for #2 as well. Therefore, I removed all specific validation, and just made the field required.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required

## Testing Performed

* Updated e2e test
* Manual testing

![Screen Shot 2022-04-19 at 11 24 25 AM](https://user-images.githubusercontent.com/715729/164051741-20e48d97-2cdd-4484-8109-eebf3ab0c466.png)
