### PR TITLE
ROX-7999: Fix SACv2 flake.

### DIFF
--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -82,9 +82,9 @@ class SACTest extends BaseSpecification {
         deployments.each {
             def depID = it.id
             try {
-                withRetry(30, 2, {
+                withRetry(30, 2) {
                     assert DeploymentService.getDeploymentWithRisk(depID).hasRisk()
-                })
+                }
             } catch (Exception e) {
                 if (strictIntegrationTesting) {
                     throw (e)

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -1,11 +1,10 @@
-import io.stackrox.proto.storage.DeploymentOuterClass
-
 import static Services.waitForViolation
 import static services.ClusterService.DEFAULT_CLUSTER_NAME
 
 import io.stackrox.proto.api.v1.ApiTokenService.GenerateTokenResponse
 import io.stackrox.proto.api.v1.NamespaceServiceOuterClass
 import io.stackrox.proto.api.v1.SearchServiceOuterClass as SSOC
+import io.stackrox.proto.storage.DeploymentOuterClass
 
 import groups.BAT
 import objects.Deployment

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -1,3 +1,5 @@
+import io.stackrox.proto.storage.DeploymentOuterClass
+
 import static Services.waitForViolation
 import static services.ClusterService.DEFAULT_CLUSTER_NAME
 
@@ -78,7 +80,7 @@ class SACTest extends BaseSpecification {
 
         // Make sure each deployment has a risk score.
         def deployments = DeploymentService.listDeployments()
-        deployments.each { ListDeployment dep ->
+        deployments.each { DeploymentOuterClass.ListDeployment dep ->
             try {
                 withRetry(30, 2) {
                     assert DeploymentService.getDeploymentWithRisk(dep.id).hasRisk()


### PR DESCRIPTION
## Description

Previously, we only triggered a blocking image scan, but missed to verify that the deployment has a risk calculated.

This led to flakes where the risk was not yet calculated at the point of asserting within the test.

Now, we ensure that the image is pre-scanned (which will cover a scan result being there and the risk upserting being faster) as well as that the deployment has a risk score calculated. 


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
- CI (SACv2 tests should not flake anymore)
