### PR TITLE
Disable monitoring support in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3414,7 +3414,7 @@ jobs:
       name: custom
       resource_class: medium
     environment:
-      - MONITORING_SUPPORT: true
+      - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - LOAD_BALANCER: lb
       - ROX_PLAINTEXT_ENDPOINTS: "8080,grpc@8081"
@@ -3570,7 +3570,7 @@ jobs:
       name: custom
       resource_class: medium+
     environment:
-      - MONITORING_SUPPORT: true
+      - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - LOAD_BALANCER: lb
       - OUTPUT_FORMAT: helm
@@ -3635,7 +3635,7 @@ jobs:
       - LOCAL_PORT: 443
       - COLLECTION_METHOD: ebpf
       - GCP_IMAGE_TYPE: "COS"
-      - MONITORING_SUPPORT: true
+      - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - ROX_BASELINE_GENERATION_DURATION: 1m
       - LOAD_BALANCER: lb
@@ -3657,7 +3657,7 @@ jobs:
       - LOCAL_PORT: 443
       - COLLECTION_METHOD: ebpf
       - GCP_IMAGE_TYPE: "COS"
-      - MONITORING_SUPPORT: true
+      - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - ROX_BASELINE_GENERATION_DURATION: 1m
       - LOAD_BALANCER: lb
@@ -3682,7 +3682,7 @@ jobs:
     environment:
       - LOCAL_PORT: 443
       - COLLECTION_METHOD: kernel-module
-      - MONITORING_SUPPORT: true
+      - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - ROX_BASELINE_GENERATION_DURATION: 1m
       - LOAD_BALANCER: lb
@@ -3743,7 +3743,7 @@ jobs:
   gke-api-scale-tests:
     executor: custom
     environment:
-      - MONITORING_SUPPORT: true
+      - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - STORAGE: pvc
       - STORAGE_CLASS: faster
@@ -3821,7 +3821,7 @@ jobs:
   gke-postgres-api-scale-tests:
     executor: custom
     environment:
-    - MONITORING_SUPPORT: true
+    - MONITORING_SUPPORT: false
     - SCANNER_SUPPORT: true
     - STORAGE: pvc
     - STORAGE_CLASS: faster
@@ -3891,7 +3891,7 @@ jobs:
     environment:
       - LOCAL_PORT: 8000
       - COLLECTION_METHOD: kernel-module
-      - MONITORING_SUPPORT: true
+      - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - ADMISSION_CONTROLLER: true
       - ADMISSION_CONTROLLER_UPDATES: true
@@ -3934,7 +3934,7 @@ jobs:
       - EKS_AUTOMATION_VERSION: 0.2.17
       - LOCAL_PORT: 8000
       - COLLECTION_METHOD: kernel-module
-      - MONITORING_SUPPORT: true
+      - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - ROX_BASELINE_GENERATION_DURATION: 1m
       - ADMISSION_CONTROLLER: true
@@ -4022,7 +4022,7 @@ jobs:
     environment:
       - LOCAL_PORT: 443
       - COLLECTION_METHOD: ebpf
-      - MONITORING_SUPPORT: true
+      - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - ROX_WHITELIST_GENERATION_DURATION: 1m
       - LOAD_BALANCER: lb
@@ -4058,7 +4058,7 @@ jobs:
     environment:
       - LOCAL_PORT: 443
       - COLLECTION_METHOD: ebpf
-      - MONITORING_SUPPORT: true
+      - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - ROX_WHITELIST_GENERATION_DURATION: 1m
       - LOAD_BALANCER: lb
@@ -4282,7 +4282,7 @@ jobs:
       LOCAL_PORT: 443
       COLLECTION_METHOD: ebpf
       GCP_IMAGE_TYPE: "COS"
-      MONITORING_SUPPORT: "true"
+      MONITORING_SUPPORT: "false"
       SCANNER_SUPPORT: "true"
       ROX_BASELINE_GENERATION_DURATION: 1m
       LOAD_BALANCER: lb
@@ -4631,7 +4631,7 @@ jobs:
     environment:
       - LOCAL_PORT: 443
       - COLLECTION_METHOD: ebpf
-      - MONITORING_SUPPORT: true
+      - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - ROX_WHITELIST_GENERATION_DURATION: 1m
       - LOAD_BALANCER: lb
@@ -4670,7 +4670,7 @@ jobs:
     environment:
       - LOCAL_PORT: 443
       - COLLECTION_METHOD: ebpf
-      - MONITORING_SUPPORT: true
+      - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - ROX_WHITELIST_GENERATION_DURATION: 1m
       - LOAD_BALANCER: lb
@@ -4708,7 +4708,7 @@ jobs:
     environment:
       - LOCAL_PORT: 443
       - COLLECTION_METHOD: ebpf
-      - MONITORING_SUPPORT: true
+      - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - ROX_WHITELIST_GENERATION_DURATION: 1m
       - LOAD_BALANCER: lb
@@ -4753,7 +4753,7 @@ jobs:
     environment:
       - LOCAL_PORT: 443
       - COLLECTION_METHOD: ebpf
-      - MONITORING_SUPPORT: true
+      - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - ROX_WHITELIST_GENERATION_DURATION: 1m
       - LOAD_BALANCER: lb

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -81,7 +81,6 @@ test_preamble() {
         export MAIN_TAG
     fi
 
-    export MONITORING_SUPPORT=true
     export SCANNER_SUPPORT=true
     export LOAD_BALANCER=lb
     export ROX_PLAINTEXT_ENDPOINTS="8080,grpc@8081"
@@ -91,8 +90,6 @@ test_preamble() {
     export SENSOR_HELM_DEPLOY=true
     export ROX_ACTIVE_VULN_MANAGEMENT=true
     export ROX_ACTIVE_VULN_REFRESH_INTERVAL=1m
-    MONITORING_IMAGE="$REGISTRY/monitoring:$(cat "$TEST_ROOT"/MONITORING_VERSION)"
-    export MONITORING_IMAGE
     SCANNER_IMAGE="$REGISTRY/scanner:$(cat "$TEST_ROOT"/SCANNER_VERSION)"
     export SCANNER_IMAGE
     SCANNER_DB_IMAGE="$REGISTRY/scanner-db:$(cat "$TEST_ROOT"/SCANNER_VERSION)"


### PR DESCRIPTION
## Description

If `MONITORING_SUPPORT=true`, then the deployment will include an
instance of Prometheus and Grafana, which is intended be used for
development and debugging purposes. The current CI jobs do not access
Prometheus or Grafana anymore - therefore the deployment is unnecessary
overhead and can be safely disabled.

The monitoring services can also lead to failed or flaky tests
due to CVE scanning of the container images, as was observed in ROX-10212.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.
