### PR TITLE
Add size and row count metrics

### DIFF
--- a/central/globaldb/metrics/metrics.go
+++ b/central/globaldb/metrics/metrics.go
@@ -44,6 +44,11 @@ func init() {
 		InlineBucketInuse,
 		BoltDBSize,
 		RocksDBSize,
+		PostgresTableCounts,
+		PostgresIndexSize,
+		PostgresTableTotalSize,
+		PostgresTableDataSize,
+		PostgresToastSize,
 	)
 }
 
@@ -137,6 +142,41 @@ var (
 		Name:      "rocksdb_db_size",
 		Help:      "bytes being used by RocksDB",
 	})
+
+	PostgresTableCounts = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_table_size",
+		Help:      "estimated number of rows in the table",
+	}, []string{"Table"})
+
+	PostgresIndexSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_table_index_bytes",
+		Help:      "bytes being used by indexes for a table",
+	}, []string{"Table"})
+
+	PostgresTableTotalSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_table_total_bytes",
+		Help:      "bytes being used by the table overall",
+	}, []string{"Table"})
+
+	PostgresTableDataSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_table_data_bytes",
+		Help:      "bytes being used by the data for a table",
+	}, []string{"Table"})
+
+	PostgresToastSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_table_toast_bytes",
+		Help:      "bytes being used by toast for a table",
+	}, []string{"Table"})
 )
 
 // SetGaugeInt sets a value for a gauge from an int

--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -56,8 +56,7 @@ SELECT TABLE_NAME
              LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE nspname = 'public'
   ) a
   WHERE oid = parent
-) a
-ORDER BY total_bytes DESC;`
+) a;'`
 )
 
 var (

--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/central/globaldb/metrics"
 	"github.com/stackrox/rox/pkg/config"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/retry"
@@ -15,6 +17,47 @@ import (
 
 const (
 	dbPasswordFile = "/run/secrets/stackrox.io/db-password/password"
+
+	tableQuery = `WITH RECURSIVE pg_inherit(inhrelid, inhparent) AS
+    (select inhrelid, inhparent
+    FROM pg_inherits
+    UNION
+    SELECT child.inhrelid, parent.inhparent
+    FROM pg_inherit child, pg_inherits parent
+    WHERE child.inhparent = parent.inhrelid),
+pg_inherit_short AS (SELECT * FROM pg_inherit WHERE inhparent NOT IN (SELECT inhrelid FROM pg_inherit))
+SELECT TABLE_NAME
+    , row_estimate
+    , total_bytes AS total
+    , index_bytes AS INDEX
+    , toast_bytes AS toast
+    , table_bytes AS TABLE
+  FROM (
+    SELECT *, total_bytes-index_bytes-COALESCE(toast_bytes,0) AS table_bytes
+    FROM (
+         SELECT c.oid
+              , relname AS TABLE_NAME
+              , SUM(c.reltuples) OVER (partition BY parent) AS row_estimate
+              , SUM(pg_total_relation_size(c.oid)) OVER (partition BY parent) AS total_bytes
+              , SUM(pg_indexes_size(c.oid)) OVER (partition BY parent) AS index_bytes
+              , SUM(pg_total_relation_size(reltoastrelid)) OVER (partition BY parent) AS toast_bytes
+              , parent
+          FROM (
+                SELECT pg_class.oid
+                    , reltuples
+                    , relname
+                    , relnamespace
+                    , pg_class.reltoastrelid
+                    , COALESCE(inhparent, pg_class.oid) parent
+                FROM pg_class
+                    LEFT JOIN pg_inherit_short ON inhrelid = oid
+                WHERE relkind IN ('r', 'p')
+             ) c
+             LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE nspname = 'public'
+  ) a
+  WHERE oid = parent
+) a
+ORDER BY total_bytes DESC;`
 )
 
 var (
@@ -24,6 +67,8 @@ var (
 	postgresTimeBetweenRetries = 10 * time.Second
 	postgresDB                 *pgxpool.Pool
 	pgSync                     sync.Once
+
+	postgresQueryTimeout = 10 * time.Second
 )
 
 // RegisterTable maps a table to an object type for the purposes of metrics gathering
@@ -66,9 +111,51 @@ func GetPostgres() *pgxpool.Pool {
 		if err != nil {
 			log.Errorf("Could not create pg_stat_statements extension: %v", err)
 		}
+		go startMonitoringPostgres(postgresDB)
 
 	})
 	return postgresDB
+}
+
+func collectPostgresStats(db *pgxpool.Pool) {
+	ctx, cancel := context.WithTimeout(context.Background(), postgresQueryTimeout)
+	defer cancel()
+	row, err := db.Query(ctx, tableQuery)
+	if err != nil {
+		log.Errorf("error fetching object counts: %v", err)
+		return
+	}
+
+	defer row.Close()
+	for row.Next() {
+		var (
+			tableName   string
+			rowEstimate int
+			totalSize   int
+			indexSize   int
+			toastSize   int
+			tableSize   int
+		)
+		if err := row.Scan(&tableName, &rowEstimate, &totalSize, &indexSize, &toastSize, &tableSize); err != nil {
+			log.Errorf("error scanning row: %v", err)
+			return
+		}
+
+		tableLabel := prometheus.Labels{"Table": tableName}
+		metrics.PostgresTableCounts.With(tableLabel).Set(float64(rowEstimate))
+		metrics.PostgresTableTotalSize.With(tableLabel).Set(float64(totalSize))
+		metrics.PostgresIndexSize.With(tableLabel).Set(float64(indexSize))
+		metrics.PostgresToastSize.With(tableLabel).Set(float64(toastSize))
+		metrics.PostgresTableDataSize.With(tableLabel).Set(float64(tableSize))
+	}
+}
+
+func startMonitoringPostgres(db *pgxpool.Pool) {
+	t := time.NewTicker(1 * time.Minute)
+	defer t.Stop()
+	for range t.C {
+		collectPostgresStats(db)
+	}
 }
 
 // GetSchemaForTable return the schema registered for specified table name.


### PR DESCRIPTION
## Description

Adds row count estimation based on statistics (so not exact count), table size, index size, toast size, total size

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Will run locally and paste metrics

```
prometheus-metric-parser single --file metrics-1 | grep -i postgres_table | grep -i pods
postgres_table_data_bytes Table=pods                                             237568
postgres_table_data_bytes Table=pods_liveinstances                               73728
postgres_table_index_bytes Table=pods                                            16384
postgres_table_index_bytes Table=pods_liveinstances                              32768
postgres_table_size Table=pods                                                   -1
postgres_table_size Table=pods_liveinstances                                     65
postgres_table_toast_bytes Table=pods                                            8192
postgres_table_toast_bytes Table=pods_liveinstances                              8192
postgres_table_total_bytes Table=pods                                            262144
postgres_table_total_bytes Table=pods_liveinstances                              114688
```