### PR TITLE
ROX-8331: Increase the front-end limit on rendered nodes in the Network Graph from 1100 to 2000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - Registry integrations for ECR are now auto-generated if the cluster's cloud provider is AWS, and the nodes' Instance IAM Role has policies granting access to ECR.  Customers can turn this feature off by disabling the EC2 instance metadata service in their nodes.
 - A new default policy added to detect Spring Cloud Function RCE vulnerability (CVE-2022-22963) and Spring Framework Spring4Shell RCE vulnerability (CVE-2022-22965).
 - Fixed permissions checks in the UI that prevented users with certain limited permissions from creating report configurations.
+- ROX-8331: Increase the front-end limit on rendered nodes in the Network Graph from 1100 to 2000
 - ROX-9946: Fixed default permissions for the default Vuln Reporter role to exclude the modify permission on notifiers, since it is not needed for report creation.
 - Added AllowPrivilegeEscalation as a new policy criteria.
 - ROX-10038: Removed limit of 10 inclusions and 10 exclusions from policy form

--- a/ui/apps/platform/src/Containers/Network/Graph/Graph.js
+++ b/ui/apps/platform/src/Containers/Network/Graph/Graph.js
@@ -132,8 +132,8 @@ class Graph extends Component {
             simulatedBaselines,
         } = this.props;
 
-        // If we have more than 1100 nodes, display a message instead of the graph.
-        const nodeLimit = 1100;
+        // If we have more than 2000 nodes, display a message instead of the graph.
+        const nodeLimit = 2000;
         if (Object.keys(networkNodeMap).length > nodeLimit) {
             // hopefully a temporal solution
             return (


### PR DESCRIPTION
## Description

Customer has said that even limiting the Network Graph to a single namespace, the graph refuses to render because it would contain more than 1100 nodes (points on the graph).

A quick fix to allow the frontend to attempt to render more nodes. 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Evaluated and added CHANGELOG entry if required

## Testing Performed

Manual testing that the Network Graph still works as expected for fewer nodes.

![Screen Shot 2022-04-19 at 1 50 53 PM](https://user-images.githubusercontent.com/715729/164069548-ed808669-7d77-4523-9cb1-1a6698980d05.png)
