### PR TITLE
RS-519 CI Migration: port unit-* jobs

### DIFF
--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -31,6 +31,9 @@ case "$ci_job" in
     gke-upgrade-tests)
         "$ROOT/.openshift-ci/gke_upgrade_test.py"
         ;;
+    shell-unit-tests)
+        make shell-unit-tests
+        ;;
     style-checks)
         make style
         ;;

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -33,7 +33,6 @@ case "$ci_job" in
         ;;
     shell-unit-tests)
         make shell-unit-tests
-	# TODO: null change to trigger build
         ;;
     style-checks)
         make style

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -33,6 +33,7 @@ case "$ci_job" in
         ;;
     shell-unit-tests)
         make shell-unit-tests
+	# TODO: null change to trigger build
         ;;
     style-checks)
         make style

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -76,11 +76,13 @@ create_cluster() {
     if is_OPENSHIFT_CI; then
         require_environment "JOB_NAME"
         require_environment "BUILD_ID"
+
         local job_name_limit50=${JOB_NAME:0:50}
         job_name_limit50=${job_name_limit50/%-/x}  # replace trailing - with x
         local job_name_limit63=${JOB_NAME:0:50}
         job_name_limit63=${job_name_limit63/%-/x}  # replace trailing - with x
         local build_id_limit63=${BUILD_ID:0:63}
+        build_id_limit63=${build_id_limit63/%-/x}  # replace trailing - with x
 
         tags="${tags},stackrox-ci-$job_name_limit50"
         labels="${labels},stackrox-ci-job=$job_name_limit63,stackrox-ci-build-id=$build_id_limit63"
@@ -88,11 +90,13 @@ create_cluster() {
     elif is_CIRCLECI; then
         require_environment "CIRCLE_JOB"
         require_environment "CIRCLE_WORKFLOW_ID"
+
         local circle_job_limit50=${CIRCLE_JOB:0:50}
         circle_job_limit50=${circle_job_limit50/%-/x}  # replace trailing - with x
         local circle_job_limit63=${CIRCLE_JOB:0:63}
         circle_job_limit63=${circle_job_limit63/%-/x}  # replace trailing - with x
         local circle_workflow_id_limit63=${CIRCLE_WORKFLOW_ID:0:63}
+        circle_workflow_id_limit63=${circle_workflow_id_limit63/%-/x}  # replace trailing - with x
 
         tags="${tags},stackrox-ci-$circle_job_limit50"
         labels="${labels},stackrox-ci-job=$circle_job_limit63,stackrox-ci-workflow=$circle_workflow_id_limit63"

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -79,7 +79,7 @@ create_cluster() {
 
         local job_name_limit50=${JOB_NAME:0:50}
         job_name_limit50=${job_name_limit50/%-/x}  # replace trailing - with x
-        local job_name_limit63=${JOB_NAME:0:50}
+        local job_name_limit63=${JOB_NAME:0:63}
         job_name_limit63=${job_name_limit63/%-/x}  # replace trailing - with x
         local build_id_limit63=${BUILD_ID:0:63}
         build_id_limit63=${build_id_limit63/%-/x}  # replace trailing - with x


### PR DESCRIPTION
https://issues.redhat.com/browse/RS-519

* Fix GKE resource tag and label names to ensure they end in a word character 
* Add OpenShift CI job `shell-unit-tests`
* Add OpenShift CI job `go-unit-tests`  [TODO]
* Add OpenShift CI job `go-postgres-unit-tests`  [TODO]
* Add OpenShift CI job `integration-unit-tests`  [TODO]

### Testing

OpenShift CI  [TODO: how to link test result set?]
* https://prow.ci.openshift.org/?author=sbostick
* https://github.com/stackrox/stackrox-osci/pull/3

CircleCI  [TODO: update after adding remaining jobs targeted in this porting effort]
* https://app.circleci.com/pipelines/github/stackrox/stackrox/10713/workflows/1c0cc668-59f4-4c7c-87a4-ad35ef91874c
