### PR TITLE
Adding code ownership areas for the core workflows team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,21 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners
 # This will automatically assign a team / people as reviewers for PRs based on the files changed within the PR.
 
+# Core Workflows team's main responsibilities include policies including default policies and policy management workflows,
+# detection and alerting, integrations and notifiers, risk, vulnerability management and reporting.
+pkg/detection/**/*                  @stackrox/core-workflows
+pkg/booleanpolicy/**/*              @stackrox/core-workflows
+pkg/defaults/policies/**/*          @stackrox/core-workflows
+central/policy/**/*                 @stackrox/core-workflows
+central/reports/**/*                @stackrox/core-workflows
+central/reportconfiguration/**/*    @stackrox/core-workflows
+central/vulnerabilityrequest/**/*   @stackrox/core-workflows
+proto/storage/policy.proto          @stackrox/core-workflows
+proto/storage/image.proto           @stackrox/core-workflows
+proto/storage/cve.proto             @stackrox/core-workflows
+proto/storage/alert.proto           @stackrox/core-workflows
+proto/storage/risk.proto            @stackrox/core-workflows
+
 # Merlin's main responsibilities include roxctl, authN (authproviders), authZ (SAC).
 roxctl/**/*     @stackrox/merlin
 pkg/auth/**/*   @stackrox/merlin


### PR DESCRIPTION
## Description
This is a starting point for code ownership for our team and my first take of areas of interest for our team. Always a balance between adding too much vs too little (for instance, we'd definitely like to know of changes in protos - but all protos? maybe not).

Would love to hear your thoughts.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [stackrox/openshift-docs]~(https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed
None required.