### PR TITLE
Remove dnf cache in portable way

### DIFF
--- a/image/postgres/Dockerfile
+++ b/image/postgres/Dockerfile
@@ -35,7 +35,7 @@ RUN groupadd -g 70 postgres && \
         /tmp/postgres-libs.rpm /tmp/postgres-server.rpm /tmp/postgres.rpm /tmp/postgres-contrib.rpm && \
     dnf clean all && \
     rpm -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
-    rm -rf /var/cache/dnf && \
+    rm -rf /var/cache/dnf /var/cache/yum && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     chown postgres:postgres /usr/local/bin/docker-entrypoint.sh && \
     chmod +x /usr/local/bin/docker-entrypoint.sh && \

--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -45,7 +45,7 @@ RUN ln -s entrypoint-wrapper.sh /stackrox/admission-control && \
     rm /tmp/snappy.rpm RPM-GPG-KEY-CentOS-Official && \
     # (Optional) Remove line below to keep package management utilities
     rpm -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
-    rm -rf /var/cache/dnf && \
+    rm -rf /var/cache/dnf /var/cache/yum && \
     # The contents of paths mounted as emptyDir volumes in Kubernetes are saved
     # by the script `save-dir-contents` during the image build. The directory
     # contents are then restored by the script `restore-all-dir-contents`


### PR DESCRIPTION
## Description

As Ross pointed out in https://github.com/stackrox/stackrox/pull/1315 there is no `/var/cache/dnf` in images based on ubi-minimal. There's `/var/cache/yum` instead.
This change will delete either directory if it exists so that our cache cleanup is independent from the type of the underlying UBI image we use.

Interestingly, our downstream-released images contain `/var/cache/yum`, but it's tiny.
```
$ docker run --rm -it --entrypoint=/bin/bash registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.69.1
bash-4.4$ find /var/cache/yum -ls
 19677886      4 drwxr-xr-x   3  root     root         4096 Apr  5 12:53 /var/cache/yum
 19677887      4 drwxr-xr-x   2  root     root         4096 Apr  5 12:53 /var/cache/yum/lock
bash-4.4$ find /var/cache/dnf -ls
find: '/var/cache/dnf': No such file or directory
```

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~ - no need to test this in automated way.
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ - I don't think the change deserves it.
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- Relying on CI.
- [ ] `/var/cache` in built image is such that there's no `dnf` or `yum` directory.