### PR TITLE
ROX-10012: Added e2e tests for roxctl scanner upload-db

### DIFF
--- a/tests/roxctl/bats-tests/cluster/scanner-upload-db.bats
+++ b/tests/roxctl/bats-tests/cluster/scanner-upload-db.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load "../helpers.bash"
+
+temp_dir=""
+
+setup_file() {
+  local -r roxctl_version="$(roxctl-development version || true)"
+  echo "Testing roxctl version: '${roxctl_version}'" >&3
+
+  command -v curl || skip "Command 'curl' required."
+  [[ -n "${API_ENDPOINT}" ]] || fail "Environment variable 'API_ENDPOINT' required"
+  [[ -n "${ROX_PASSWORD}" ]] || fail "Environment variable 'ROX_PASSWORD' required"
+}
+
+setup() {
+  temp_dir="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "${temp_dir}"
+}
+
+@test "[no-option] roxctl scanner upload-db" {
+  run roxctl_authenticated scanner upload-db
+  assert_failure
+  assert_output --partial '"scanner-db-file" not set'
+}
+
+@test "[non-zip] roxctl scanner upload-db" {
+  echo 'Just text' > "${temp_dir}/test-invalid-scanner-vuln-updates.zip"
+
+  run roxctl_authenticated scanner upload-db --scanner-db-file "${temp_dir}/test-invalid-scanner-vuln-updates.zip"
+  assert_failure
+  assert_output --partial 'not a valid zip file'
+}
+
+@test "[zip] roxctl scanner upload-db" {
+  run curl --silent --fail --output "${temp_dir}/test-scanner-vuln-updates.zip" --location 'https://install.stackrox.io/scanner/scanner-vuln-updates.zip'
+  assert_success
+
+  run roxctl_authenticated scanner upload-db --scanner-db-file "${temp_dir}/test-scanner-vuln-updates.zip"
+  assert_success
+}


### PR DESCRIPTION
## Description

Added end-to-end test for `roxctl scanner upload-db` command. The following options are tested:
- required flag is not used
- file is not a valid format (not zip format)
- valid zip file upload

The non-existing file is covered with unit tests.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ - nothing relevant
- ~~[ ] Determined and documented upgrade steps~~ - nothing to update on client side
- ~~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~ - nothing changed on user facing

## Testing Performed

Required environment:
- cluster has to be up and running
- `API_ENDPOINT` and `ROX_PASSWORD` environment variables set

The following command can be executed from the repo root directory:
```
tests/roxctl/bats-tests/cluster/scanner-upload-db.bats
```
