### PR TITLE
Replace assertion for exposure and label with name in network integration test

### DIFF
--- a/ui/apps/platform/cypress/integration/network.test.js
+++ b/ui/apps/platform/cypress/integration/network.test.js
@@ -147,14 +147,14 @@ describe('Network page', () => {
 describe('Network Deployment Details', () => {
     withAuth();
 
-    it('should show the port exposure levels using port configuration labels', () => {
+    it('should show the deployment name and namespace', () => {
         visitRiskDeployments();
         viewRiskDeploymentByName('central');
         viewRiskDeploymentInNetworkGraph();
 
         cy.get(`${selectors.tab.tabs}:contains('Details')`).click();
-        cy.get(`[data-testid="exposure"]:contains('ClusterIP')`);
-        cy.get(`[data-testid="level"]:contains('ClusterIP')`);
+        cy.get(`[data-testid="Deployment Name"]:contains('central')`);
+        cy.get(`[data-testid="Namespace"]:contains('stackrox')`);
     });
 });
 


### PR DESCRIPTION
## Description

Network Deployment Details should show the port exposure levels using port configuration labels

AssertionError: Timed out retrying after 4000ms: Expected to find element: `[data-testid="exposure"]:contains('ClusterIP')`, but never found it.

* https://app.circleci.com/pipelines/github/stackrox/stackrox/9929/workflows/c079f47a-708a-4797-95c8-6b02200f1053/jobs/451171
* https://app.circleci.com/pipelines/github/stackrox/stackrox/9924/workflows/aa5a0feb-a720-43c4-87a4-950f3e31d1a1/jobs/451006
* https://app.circleci.com/pipelines/github/stackrox/stackrox/9926/workflows/35be3ee2-d075-478d-a8ac-06d5409c38b7/jobs/451117
* https://app.circleci.com/pipelines/github/stackrox/stackrox/9928/workflows/2142dd11-3ff2-448d-addf-1238160a2b88/jobs/451187
* https://app.circleci.com/pipelines/github/stackrox/stackrox/9929/workflows/c079f47a-708a-4797-95c8-6b02200f1053/jobs/451171
* https://app.circleci.com/pipelines/github/stackrox/stackrox/9934/workflows/7e1f8815-8b5f-4482-8a91-51062f3a1ba8/jobs/451500
* https://app.circleci.com/pipelines/github/stackrox/stackrox/9938/workflows/18e9a65f-670d-48d9-a7b3-f1732664ae34/jobs/451648

Unfortunately the screenshot for the failing integration test does not show what is rendered instead of expected value of ClusterIP which corresponds to INTERNAL.
![exposure-level-fail](https://user-images.githubusercontent.com/11862657/164258144-635c1f26-093d-4fa1-a4ac-8c9ccef56d43.png)

Here is screenshot for local deployment where the test passes
![exposure-level-ClusterIP](https://user-images.githubusercontent.com/11862657/164257382-5c8ba30a-473f-4ec1-a6bf-fdf41c968066.png)

Replace assertions with details that are visible without scrolling:
* replace exposure with Deployment Name
* replace label with Namespace

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

1. `yarn cypress-open` in ui/apps/platform
    * Ran original test locally to see it pass
    * Ran edited test locally to see it pass