### PR TITLE
Fix links to Violations page from Dashboard severity tiles.

### DIFF
--- a/ui/apps/platform/cypress/integration/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/dashboard.test.js
@@ -53,7 +53,7 @@ describe('Dashboard page', () => {
         cy.get('@riskTiles').last().click();
         cy.location().should((location) => {
             expect(location.pathname).to.eq(violationsUrl);
-            expect(location.search).to.eq('?severity=LOW_SEVERITY');
+            expect(location.search).to.eq('?search[Severity]=LOW_SEVERITY');
         });
     });
 

--- a/ui/apps/platform/src/Containers/Dashboard/DashboardPage.js
+++ b/ui/apps/platform/src/Containers/Dashboard/DashboardPage.js
@@ -104,7 +104,10 @@ const DashboardPage = () => {
                         className={`flex flex-wrap ${!isDarkMode ? 'bg-base-300' : 'bg-base-100'}`}
                     >
                         <div className="w-full lg:w-1/2 p-6 z-1">
-                            <EnvironmentRisk globalViolationsCounts={globalViolationsCounts} />
+                            <EnvironmentRisk
+                                globalViolationsCounts={globalViolationsCounts}
+                                clusters={filteredClusters}
+                            />
                         </div>
                         <div className="w-full lg:w-1/2 p-6 z-1 border-l border-base-400">
                             <DashboardCompliance />

--- a/ui/apps/platform/src/Containers/Dashboard/EnvironmentRisk.js
+++ b/ui/apps/platform/src/Containers/Dashboard/EnvironmentRisk.js
@@ -5,9 +5,10 @@ import PropTypes from 'prop-types';
 import SeverityTile from 'Containers/Dashboard/SeverityTile';
 import { severityColorMap } from 'constants/severityColors';
 import { useTheme } from 'Containers/ThemeProvider';
+import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
 import severityPropType from './severityPropTypes';
 
-const EnvironmentRisk = ({ globalViolationsCounts }) => {
+const EnvironmentRisk = ({ globalViolationsCounts, clusters }) => {
     const { isDarkMode } = useTheme();
     const counts = {
         CRITICAL_SEVERITY: 0,
@@ -43,15 +44,24 @@ const EnvironmentRisk = ({ globalViolationsCounts }) => {
                 </Link>
             </h2>
             <div className="flex">
-                {severities.map((severity, i) => (
-                    <SeverityTile
-                        severity={severity}
-                        count={counts[severity]}
-                        color={severityColorMap[severity]}
-                        index={i}
-                        key={severity}
-                    />
-                ))}
+                {severities.map((severity, i) => {
+                    const searchFilter = {
+                        Severity: severity,
+                        Cluster: clusters,
+                    };
+                    const searchString = getUrlQueryStringForSearchFilter(searchFilter);
+                    const link = `/main/violations?${searchString}`;
+                    return (
+                        <SeverityTile
+                            severity={severity}
+                            count={counts[severity]}
+                            color={severityColorMap[severity]}
+                            index={i}
+                            key={severity}
+                            link={link}
+                        />
+                    );
+                })}
             </div>
         </div>
     );
@@ -69,6 +79,11 @@ EnvironmentRisk.propTypes = {
             group: PropTypes.string.isRequired,
         })
     ).isRequired,
+    clusters: PropTypes.arrayOf(PropTypes.string),
+};
+
+EnvironmentRisk.defaultProps = {
+    clusters: [],
 };
 
 export default EnvironmentRisk;

--- a/ui/apps/platform/src/Containers/Dashboard/SeverityTile.js
+++ b/ui/apps/platform/src/Containers/Dashboard/SeverityTile.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { severityLabels } from 'messages/common';
 import { useTheme } from 'Containers/ThemeProvider';
 
-const SeverityTile = ({ severity, count, index, color }) => {
+const SeverityTile = ({ severity, count, index, color, link }) => {
     const { isDarkMode } = useTheme();
     function renderTileContent() {
         const backgroundStyle = {
@@ -46,7 +46,7 @@ const SeverityTile = ({ severity, count, index, color }) => {
             }  flex flex-1 flex-col border-3 p-4 text-center relative cursor-pointer rounded-sm no-underline hover:bg-primary-200 hover:shadow hover:bg-base-200 ${
                 index !== 0 ? 'ml-4' : ''
             }`}
-            to={`/main/violations?severity=${severity}`}
+            to={link}
             data-testid="severity-tile"
         >
             {renderTileContent()}
@@ -59,6 +59,7 @@ SeverityTile.propTypes = {
     count: PropTypes.number.isRequired,
     index: PropTypes.number.isRequired,
     color: PropTypes.string.isRequired,
+    link: PropTypes.string.isRequired,
 };
 
 export default SeverityTile;


### PR DESCRIPTION
## Description

Fixes the links from the "# System Violations" tiles on the dashboard to the Violations page.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Cypress test updated to check correct URL parameters.

Test that visiting the Dashboard and clicking a tile loads the Violations page with the correct severity filter applied:
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/1292638/164462662-d935c067-8ca1-48d4-b6fb-e8fd3a2dd30a.png">

Test that applying a cluster filter on the dashboard and clicking a tile loads the Violations page with both a severity filter and a cluster filter:
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/1292638/164462816-a5028024-3f4f-4bc2-bb47-0ca81160ec56.png">
