### PR TITLE
Update type signature for setSearchFilter props to accept a single object value.

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferralsSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferralsSearchFilter.tsx
@@ -16,7 +16,7 @@ import SelectSingle from 'Components/SelectSingle';
 
 export type ApprovedDeferralsSearchFilterProps = {
     searchFilter: SearchFilter;
-    setSearchFilter: React.Dispatch<React.SetStateAction<SearchFilter>>;
+    setSearchFilter: (newFilter: SearchFilter) => void;
 };
 
 function ApprovedDeferralsSearchFilter({

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferralsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferralsTable.tsx
@@ -37,7 +37,7 @@ export type ApprovedDeferralsTableProps = {
     isLoading: boolean;
     itemCount: number;
     searchFilter: SearchFilter;
-    setSearchFilter: React.Dispatch<React.SetStateAction<SearchFilter>>;
+    setSearchFilter: (newFilter: SearchFilter) => void;
 } & UsePaginationResult;
 
 function ApprovedDeferralsTable({

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositivesSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositivesSearchFilter.tsx
@@ -6,7 +6,7 @@ import { SearchFilter } from 'types/search';
 
 export type ApprovedFalsePositivesSearchFilterProps = {
     searchFilter: SearchFilter;
-    setSearchFilter: React.Dispatch<React.SetStateAction<SearchFilter>>;
+    setSearchFilter: (newFilter: SearchFilter) => void;
 };
 
 function ApprovedFalsePositivesSearchFilter({

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositivesTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositivesTable.tsx
@@ -35,7 +35,7 @@ export type ApprovedFalsePositivesTableProps = {
     isLoading: boolean;
     itemCount: number;
     searchFilter: SearchFilter;
-    setSearchFilter: React.Dispatch<React.SetStateAction<SearchFilter>>;
+    setSearchFilter: (newFilter: SearchFilter) => void;
 } & UsePaginationResult;
 
 function ApprovedFalsePositivesTable({

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovalsSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovalsSearchFilter.tsx
@@ -16,7 +16,7 @@ import SelectSingle from 'Components/SelectSingle';
 
 export type PendingApprovalsSearchFilterProps = {
     searchFilter: SearchFilter;
-    setSearchFilter: React.Dispatch<React.SetStateAction<SearchFilter>>;
+    setSearchFilter: (newFilter: SearchFilter) => void;
 };
 
 function PendingApprovalsSearchFilter({

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovalsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovalsTable.tsx
@@ -41,7 +41,7 @@ export type PendingApprovalsTableProps = {
     isLoading: boolean;
     itemCount: number;
     searchFilter: SearchFilter;
-    setSearchFilter: React.Dispatch<React.SetStateAction<SearchFilter>>;
+    setSearchFilter: (newFilter: SearchFilter) => void;
 } & UsePaginationResult;
 
 function PendingApprovalsTable({

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/SearchFilterResults.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/SearchFilterResults.tsx
@@ -5,7 +5,7 @@ import { SearchFilter } from 'types/search';
 
 export type VulnerabilityRequestSearchResultsProps = {
     searchFilter: SearchFilter;
-    setSearchFilter: React.Dispatch<React.SetStateAction<SearchFilter>>;
+    setSearchFilter: (newFilter: SearchFilter) => void;
 };
 
 function VulnerabilityRequestSearchResults({

--- a/ui/apps/platform/src/hooks/useURLSearch.ts
+++ b/ui/apps/platform/src/hooks/useURLSearch.ts
@@ -1,7 +1,8 @@
+import { SearchFilter } from 'types/search';
 import useURLParameter from './useURLParameter';
 
 function useURLSearch(keyPrefix = 'search') {
-    const [searchFilter, setSearchFilter] = useURLParameter(keyPrefix, {});
+    const [searchFilter, setSearchFilter] = useURLParameter<SearchFilter>(keyPrefix, {});
     return { searchFilter, setSearchFilter };
 }
 


### PR DESCRIPTION
## Description

This is a type-level only change that reduces the type signature of many `setSearchFilter` props from `(filter: SearchFilter | ((prev: SearchFilter) => SearchFilter)) => void` to just `(filter: SearchFilter) => void`.

This was needed because the generic type in `useURLSearch` required `<SearchFilter>` explicitly, otherwise TS inferred the return type of that hook to always be an empty object `{}`.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Type level change only, so CI should be sufficient.
