### PR TITLE
Update Grafana image

### DIFF
--- a/deploy/charts/monitoring/values.yaml
+++ b/deploy/charts/monitoring/values.yaml
@@ -1,5 +1,5 @@
 image: null
-grafanaImage: grafana/grafana:8.4.5
+grafanaImage: grafana/grafana:8.4.7
 prometheusImage: prom/prometheus:v2.34.0
 password: stackrox
 


### PR DESCRIPTION
`grafana:8.4.5` is affected by CVE-2022-28391. An update of the
underlying Alpine image fixes that in `grafana:8.4.7`.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.
