### PR TITLE
ROX-10014: Update preferred node affinity for central

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            # Central is single-homed, so avoid preemptive nodes.
+            # Central is single-homed, so avoid preemptible nodes.
             - weight: 100
               preference:
                 matchExpressions:

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            # Central is single-homed, so avoid preemptible nodes.
+            # Central is single-homed, so avoid preemptive nodes.
             - weight: 100
               preference:
                 matchExpressions:
@@ -48,18 +48,18 @@ spec:
                     values:
                     - "true"
             {{- if ._rox.env.openshift }}
+            - weight: 50
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: In
+                    values:
+                    - "true"
             - weight: 25
               preference:
                 matchExpressions:
                   - key: node-role.kubernetes.io/compute
                     operator: In
-                    values:
-                    - "true"
-            - weight: 75
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/infra
-                    operator: NotIn
                     values:
                     - "true"
             - weight: 100

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
@@ -1,0 +1,90 @@
+values:
+  ca:
+    cert: ""
+    key: ""
+  central:
+    serviceTLS:
+      cert: ""
+      key: ""
+    dbServiceTLS:
+      cert: ""
+      key: ""
+tests:
+- name: "central with default settings"
+  expect: |
+    .podsecuritypolicys["stackrox-central"] | assertThat(. != null)
+    .rolebindings["stackrox-central-psp"] | assertThat(. != null)
+    .clusterroles["stackrox-central-psp"] | assertThat(. != null)
+    .serviceaccounts["central"] | assertThat(. != null)
+    .secrets["central-htpasswd"].stringData.htpasswd | assertThat(length != 0)
+    .configmaps["central-config"].data.["central-config.yaml"] | assertThat(length != 0)
+    .networkpolicies["central"] | assertThat(length != null)
+    .networkpolicies["central-db"] | assertThat(length != null)
+    .deployments["central"] | assertThat(. != null)
+    .services["central"] | assertThat(. != null)
+
+- name: "central with OpenShift 3 and enabled SCCs"
+  server:
+    visibleSchemas:
+    - openshift-3.11.0
+    availableSchemas:
+    - openshift-3.11.0
+  values:
+    env:
+      openshift: 3
+    system:
+      createSCCs: true
+  expect: |
+    .securitycontextconstraints["stackrox-central"] | .users[0] | assertThat(contains("system:serviceaccount:stackrox:central"))
+    .roles["use-central-scc"] | assertThat(. == null)
+    .rolebindings["central-use-scc"] | assertThat(. == null)
+    .deployments["central"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 4)
+    .deployments["central"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution[]
+      | select(.preference.matchExpressions[0].key == "node-role.kubernetes.io/infra" ) | [
+        assertThat(.weight == 50),
+        assertThat(.preference.matchExpressions[0].operator == "In")
+      ]
+    .deployments["central"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution[]
+      | select(.preference.matchExpressions[0].key == "node-role.kubernetes.io/compute" ) | [
+        assertThat(.weight == 25),
+        assertThat(.preference.matchExpressions[0].operator == "In")
+      ]
+    .deployments["central"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution[]
+      | select(.preference.matchExpressions[0].key == "node-role.kubernetes.io/master" ) | [
+        assertThat(.weight == 100),
+        assertThat(.preference.matchExpressions[0].operator == "NotIn")
+      ]
+    .networkpolicys["central"].spec.ingress | assertThat(length == 0)
+
+- name: "central with OpenShift 4 and disabled SCCs"
+  server:
+    visibleSchemas:
+    - openshift-4.1.0
+    availableSchemas:
+    - openshift-4.1.0
+  values:
+    env:
+      openshift: 4
+    system:
+      createSCCs: false
+  expect: |
+    .roles["use-central-scc"] | assertThat(. != null)
+    .rolebindings["central-use-scc"] | assertThat(. != null)
+    .securitycontextconstraints["stackrox-central"] | assertThat(. == null)
+    .deployments["central"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 4)
+    .deployments["central"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution[]
+      | select(.preference.matchExpressions[0].key == "node-role.kubernetes.io/infra" ) | [
+        assertThat(.weight == 50),
+        assertThat(.preference.matchExpressions[0].operator == "In")
+      ]
+    .deployments["central"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution[]
+      | select(.preference.matchExpressions[0].key == "node-role.kubernetes.io/compute" ) | [
+        assertThat(.weight == 25),
+        assertThat(.preference.matchExpressions[0].operator == "In")
+      ]
+    .deployments["central"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution[]
+      | select(.preference.matchExpressions[0].key == "node-role.kubernetes.io/master" ) | [
+        assertThat(.weight == 100),
+        assertThat(.preference.matchExpressions[0].operator == "NotIn")
+      ]
+    .networkpolicys["central"].spec.ingress | assertThat(length == 0)


### PR DESCRIPTION
## Description

[Ticket link](https://issues.redhat.com/browse/ROX-10014)

Central is recommended to run on infra or master nodes because Central is considered part of the OpenShift infrastructure.
Thus, Central `nodeAffinity` have to be switched to Infra->Compute->Master from Compute->Infra->Master

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

Please, let me know if this change worth a documentation upgrade. I think that it's not important enough.

## Testing Performed

Only unit tests
