### PR TITLE
ROX-9974: Allow Sensor reconnects faster during scale test

### DIFF
--- a/pkg/env/scale.go
+++ b/pkg/env/scale.go
@@ -1,0 +1,6 @@
+package env
+
+var (
+	// ScaleTestEnabled signifies that a scale test is being run
+	ScaleTestEnabled = RegisterBooleanSetting("ROX_SCALE_TEST", false)
+)

--- a/scale/launch_workload.sh
+++ b/scale/launch_workload.sh
@@ -31,7 +31,7 @@ kubectl -n "${namespace}" delete deploy/admission-control
 kubectl -n "${namespace}" delete daemonset collector
 
 kubectl -n "${namespace}" set env deploy/sensor MUTEX_WATCHDOG_TIMEOUT_SECS=0
-kubectl -n "${namespace}" set env deploy/central MUTEX_WATCHDOG_TIMEOUT_SECS=0
+kubectl -n "${namespace}" set env deploy/central MUTEX_WATCHDOG_TIMEOUT_SECS=0  ROX_SCALE_TEST=true
 kubectl -n "${namespace}" delete configmap scale-workload-config || true
 kubectl -n "${namespace}" create configmap scale-workload-config --from-file=workload.yaml="$file"
 kubectl -n "${namespace}" patch deploy/sensor -p '{"spec":{"template":{"spec":{"containers":[{"name":"sensor","volumeMounts":[{"name":"scale-workload-config","mountPath":"/var/scale/stackrox"}]}],"volumes":[{"name":"scale-workload-config","configMap":{"name": "scale-workload-config"}}]}}}}'


### PR DESCRIPTION
## Description

More of a quick workaround. In general, I think I should rework this so the scale test can be run at deploy time. The issue is that sensor restarts after the deployment occurs if the deploy.sh works too quickly for the patch to take place 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
