### PR TITLE
ROX-10211: quickfix to skip policy if feature flag is enabled

### DIFF
--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -189,8 +189,8 @@ class UpgradesTest extends BaseSpecification {
         given:
         "Default policies in code"
 
-        // @TODO(ROX-10249): Policy is no longer guarded by a feature flag
         def policiesGuardedByFeatureFlags = [
+                // @TODO(ROX-10249): Remove when policy is no longer guarded by a feature flag
                 "38bf79e7-48bf-4ab1-b72f-38e8ad8b4ec3"
         ]
         Map<String, PolicyOuterClass.Policy> defaultPolicies = [:]

--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -189,6 +189,10 @@ class UpgradesTest extends BaseSpecification {
         given:
         "Default policies in code"
 
+        // @TODO(ROX-10249): Policy is no longer guarded by a feature flag
+        def policiesGuardedByFeatureFlags = [
+                "38bf79e7-48bf-4ab1-b72f-38e8ad8b4ec3"
+        ]
         Map<String, PolicyOuterClass.Policy> defaultPolicies = [:]
         def policiesDir = new File(POLICIES_JSON_PATH)
         policiesDir.eachFileRecurse (FileType.FILES) { file ->
@@ -196,8 +200,9 @@ class UpgradesTest extends BaseSpecification {
                 def builder = PolicyOuterClass.Policy.newBuilder()
                 JsonFormat.parser().merge(file.text, builder)
                 def policy = builder.build()
-
-                defaultPolicies[policy.id] = policy
+                if (!policiesGuardedByFeatureFlags.contains(policy.id)) {
+                    defaultPolicies[policy.id] = policy
+                }
             }
         }
 


### PR DESCRIPTION
## Description

Upgrade tests are failing because nightly does not have feature flag `ROX_NETPOL_FIELDS` enabled. The quickfix before having the feature flag enabled is to skip that policy in the test based on a hardcoded list of skippable ids. 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~~Unit test and regression tests added~~
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

- `gke-api-upgrade-tests` ✅ 