### PR TITLE
Add `errox.CausedByf`

### DIFF
--- a/pkg/errox/roxerror.go
+++ b/pkg/errox/roxerror.go
@@ -98,3 +98,13 @@ func (e *RoxError) Newf(format string, args ...interface{}) *RoxError {
 func (e *RoxError) CausedBy(cause interface{}) error {
 	return fmt.Errorf("%w: %v", e, cause)
 }
+
+// CausedByf adds a cause to the RoxError. The resulting message is a
+// combination of the rox error and the cause message, formatted based on the
+// provided format specifier and arguments, following a colon.
+//
+// Example:
+//     return errox.InvalidArgument.CausedByf("unknown parameter %v", p)
+func (e *RoxError) CausedByf(format string, args ...interface{}) error {
+	return e.CausedBy(fmt.Sprintf(format, args...))
+}

--- a/pkg/errox/roxerror_test.go
+++ b/pkg/errox/roxerror_test.go
@@ -76,4 +76,10 @@ func TestCausedBy(t *testing.T) {
 		err := NotFound.New("lost forever").CausedBy("swallowed by Kraken")
 		assert.ErrorIs(t, err, NotFound)
 	}
+
+	{
+		err := NotFound.New("absolute disaster").CausedByf("out of %v", "sense")
+		assert.Equal(t, "absolute disaster: out of sense", err.Error())
+		assert.ErrorIs(t, err, NotFound)
+	}
 }


### PR DESCRIPTION
## Description

Introduce a handy wrapper for `errox.CausedBy`. Inspired by #1389.

[x] Unittest
