### PR TITLE
Delete leftover resources from Redux reducers in ui

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -1,11 +1,7 @@
-import React from 'react';
-import { connect } from 'react-redux';
+import React, { ReactElement } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
-import { createStructuredSelector } from 'reselect';
-import PropTypes from 'prop-types';
 
-import { selectors } from 'reducers';
-import { actions, getHasReadPermission } from 'reducers/roles';
+import usePermissions from 'hooks/usePermissions';
 
 import { accessControlBasePath, accessControlPath, getEntityPath } from './accessControlPaths';
 
@@ -18,14 +14,15 @@ import Roles from './Roles/Roles';
 
 const paramId = ':entityId?';
 
-function AccessControl({ userRolePermissions }) {
+function AccessControl(): ReactElement {
     // TODO is read access required for all routes in improved Access Control?
     // TODO Is write access required anywhere in classic Access Control?
-    const hasReadAccess = getHasReadPermission('AuthProvider', userRolePermissions);
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForAuthProvider = hasReadAccess('AuthProvider');
 
     return (
         <>
-            {hasReadAccess ? (
+            {hasReadAccessForAuthProvider ? (
                 <Switch>
                     <Route exact path={accessControlBasePath}>
                         <Redirect to={getEntityPath('AUTH_PROVIDER')} />
@@ -57,18 +54,4 @@ function AccessControl({ userRolePermissions }) {
     );
 }
 
-AccessControl.propTypes = {
-    userRolePermissions: PropTypes.shape({
-        resourceToAccess: PropTypes.shape({ AuthProvider: PropTypes.string }),
-    }).isRequired,
-};
-
-const mapStateToProps = createStructuredSelector({
-    userRolePermissions: selectors.getUserRolePermissions,
-});
-
-const mapDispatchToProps = {
-    fetchResources: actions.fetchResources.request,
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(AccessControl);
+export default AccessControl;

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
@@ -20,7 +20,7 @@ import {
     createPermissionSet,
     deletePermissionSet,
     fetchPermissionSets,
-    fetchResourcesAsArray,
+    fetchResources,
     fetchRolesAsArray,
     updatePermissionSet,
 } from 'services/RolesService';
@@ -83,7 +83,7 @@ function PermissionSets(): ReactElement {
 
         setCounterFetching((counterPrev) => counterPrev + 1);
         setAlertResources(null);
-        fetchResourcesAsArray()
+        fetchResources()
             .then((resourcesFetched) => {
                 setResources(resourcesFetched);
             })

--- a/ui/apps/platform/src/reducers/roles.js
+++ b/ui/apps/platform/src/reducers/roles.js
@@ -15,7 +15,6 @@ export const types = {
     SELECTED_ROLE: 'roles/SELECTED_ROLE',
     SAVE_ROLE: 'roles/SAVE_ROLE',
     DELETE_ROLE: 'roles/DELETE_ROLE',
-    FETCH_RESOURCES: createFetchingActionTypes('roles/FETCH_RESOURCES'),
 };
 
 export const actions = {
@@ -33,19 +32,11 @@ export const actions = {
         type: types.DELETE_ROLE,
         id,
     }),
-    fetchResources: createFetchingActions(types.FETCH_RESOURCES),
 };
 
 const roles = (state = [], action) => {
     if (action.type === types.FETCH_ROLES.SUCCESS) {
         return isEqual(action.response.roles, state) ? state : action.response.roles;
-    }
-    return state;
-};
-
-const resources = (state = [], action) => {
-    if (action.type === types.FETCH_RESOURCES.SUCCESS) {
-        return isEqual(action.response.resources, state) ? state : action.response.resources;
     }
     return state;
 };
@@ -101,7 +92,6 @@ const isLoading = (state = true, action) => {
 
 const reducer = combineReducers({
     roles,
-    resources,
     selectedRole,
     userRolePermissions,
     error,
@@ -109,7 +99,6 @@ const reducer = combineReducers({
 });
 
 const getRoles = (state) => state.roles;
-const getResources = (state) => state.resources;
 const getSelectedRole = (state) => state.selectedRole;
 const getUserRolePermissions = (state) => state.userRolePermissions;
 const getUserRolePermissionsError = (state) => state.error;
@@ -135,7 +124,6 @@ export const getHasReadWritePermission = (resource, userRolePermissionsArg) => {
 
 export const selectors = {
     getRoles,
-    getResources,
     getSelectedRole,
     getUserRolePermissions,
     getUserRolePermissionsError,

--- a/ui/apps/platform/src/reducers/roles.test.js
+++ b/ui/apps/platform/src/reducers/roles.test.js
@@ -4,7 +4,6 @@ describe('roles reducer', () => {
     it('should return the initial state', () => {
         const expected = {
             roles: [],
-            resources: [],
             selectedRole: null,
             userRolePermissions: null,
             error: null,

--- a/ui/apps/platform/src/sagas/roleSagas.js
+++ b/ui/apps/platform/src/sagas/roleSagas.js
@@ -61,15 +61,6 @@ function* selectRole(action) {
     }
 }
 
-function* fetchResources() {
-    try {
-        const result = yield call(service.fetchResources);
-        yield put(actions.fetchResources.success(result.response));
-    } catch (error) {
-        Raven.captureException(error);
-    }
-}
-
 function* watchSaveRole() {
     yield takeLatest(types.SAVE_ROLE, saveRole);
 }
@@ -82,10 +73,6 @@ function* watchSelectRole() {
     yield takeLatest(types.SELECTED_ROLE, selectRole);
 }
 
-function* watchFetchResources() {
-    yield takeLatest(types.FETCH_RESOURCES.REQUEST, fetchResources);
-}
-
 export default function* integrations() {
     yield all([
         takeEveryNewlyMatchedLocation(accessControlPath, getRoles),
@@ -93,6 +80,5 @@ export default function* integrations() {
         fork(watchSaveRole),
         fork(watchDeleteRole),
         fork(watchSelectRole),
-        fork(watchFetchResources),
     ]);
 }

--- a/ui/apps/platform/src/services/RolesService.ts
+++ b/ui/apps/platform/src/services/RolesService.ts
@@ -2,16 +2,7 @@ import axios from './instance';
 
 const resourcesUrl = '/v1/resources';
 
-export function fetchResources(): Promise<{ response: { resources: string[] } }> {
-    return axios.get<{ resources: string[] }>(resourcesUrl).then((response) => ({
-        response: response.data,
-    }));
-}
-
-// TODO After classic Access Control code has been deleted,
-// delete preceding function fetchResources also its Redux support,
-// and then rename the following function as fetchResources.
-export function fetchResourcesAsArray(): Promise<string[]> {
+export function fetchResources(): Promise<string[]> {
     return axios
         .get<{ resources: string[] }>(resourcesUrl)
         .then((response) => response?.data?.resources ?? []);


### PR DESCRIPTION
## Description

1. While investigating an integration test failure, I noticed `"resources": [],` in logimbue-data.json file
2. and no `FETCH_RESOURCES_REQUEST` in Redux actions
2. and then `// TODO After classic Access Control code has been deleted` comment in RolesService.js file

### Changed files

1. Rewrite Containers/AccessControl/AccessControl.js as TypeScript
    * Replace `userRolePermissions` in props with `usePermissions` hook
    * Delete unused `fetchResources` from props

2. Edit Containers/AccessControl/PermissionSets/PermissionSets.tsx
    * Replace `fetchResourcesAsArray` with `FetchResources`

3. Edit reducers/roles.js
    * Delete `FETCH_RESOURCES` type
    * Delete `fetchResources` action
    * Delete `resources` reducer
    * Delete `getResources` selector

4. Edit sagas/roleSagas.js
    * Delete `fetchResources` function
    * Delete `watchFetchResources` function
    * Delete `watchFetchResources` function call

5. Edit services/RolesService.ts
    * Delete `fetchResources` function
    * Rename `fetchResourcesAsArray` function as `FetchResources`

### Residue

* Fix incorrect logic for access to access control routes!

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited unit test

## Testing Performed

1. `yarn build` in ui
2. `yarn start` in ui
3. `yarn cypress-open` in ui/apps/platform and see that `'displays alert if no permission'` tests still pass
    * accessControl/accessControlAccessScopes.test.js
    * accessControl/accessControlAuthProviders.test.js
    * accessControl/accessControlPermissionSets.test.js
    * accessControl/accessControlRoles.test.js