### PR TITLE
Dashboard test enhancements and flake reduction

### DIFF
--- a/ui/apps/platform/cypress/constants/ViolationsPage.js
+++ b/ui/apps/platform/cypress/constants/ViolationsPage.js
@@ -11,6 +11,8 @@ export const selectors = {
     firstTableRowLink: 'tbody tr:nth(0) a',
     lastTableRow: 'tbody tr:last',
     lastTableRowLink: 'tbody tr:last a',
+    resultsFoundHeader: (number) =>
+        `h2:contains("${number} result${number === 1 ? '' : 's'} found")`,
     actions: {
         btn: 'td.pf-c-table__action button',
         excludeDeploymentBtn: 'button:contains("Exclude deployment")',

--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -3,7 +3,7 @@ import { url } from '../constants/DashboardPage';
 
 // eslint-disable-next-line import/prefer-default-export
 export function visitMainDashboard() {
-    cy.intercept('POST', api.dashboard.summaryCounts).as('summaryCounts');
+    cy.intercept('GET', api.risks.riskyDeployments).as('riskyDeployments');
     cy.visit(url);
-    cy.wait('@summaryCounts');
+    cy.wait('@riskyDeployments');
 }

--- a/ui/apps/platform/cypress/integration/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/dashboard.test.js
@@ -20,10 +20,9 @@ describe('Dashboard page', () => {
     it('should display system violations tiles', () => {
         cy.intercept('GET', api.alerts.countsByCluster, {
             fixture: 'alerts/countsByCluster-single.json',
-        }).as('alertsByCluster');
+        });
 
-        cy.visit(dashboardUrl);
-        cy.wait('@alertsByCluster');
+        visitMainDashboard();
 
         cy.get(selectors.sectionHeaders.systemViolations).next('div').children().as('riskTiles');
 
@@ -36,7 +35,7 @@ describe('Dashboard page', () => {
     });
 
     it('should not navigate to the violations page when clicking the critical severity risk tile', () => {
-        cy.visit(dashboardUrl);
+        visitMainDashboard();
         cy.get(selectors.sectionHeaders.systemViolations).next('div').children().as('riskTiles');
 
         cy.get('@riskTiles').first().click();
@@ -58,7 +57,7 @@ describe('Dashboard page', () => {
     });
 
     it('should navigate to compliance standards page when clicking on standard', () => {
-        cy.visit(dashboardUrl);
+        visitMainDashboard();
         cy.get(selectors.sectionHeaders.compliance).should('exist');
         cy.get(selectors.chart.legendLink).click();
         cy.location().should((location) => {
@@ -70,10 +69,9 @@ describe('Dashboard page', () => {
     it('should display violations by cluster chart for single cluster', () => {
         cy.intercept('GET', api.alerts.countsByCluster, {
             fixture: 'alerts/countsByCluster-single.json',
-        }).as('alertsByCluster');
+        });
 
-        cy.visit(dashboardUrl);
-        cy.wait('@alertsByCluster');
+        visitMainDashboard();
 
         cy.get(selectors.sectionHeaders.violationsByClusters).next().as('chart');
 
@@ -97,10 +95,9 @@ describe('Dashboard page', () => {
     it('should display violations by cluster chart for two clusters', () => {
         cy.intercept('GET', api.alerts.countsByCluster, {
             fixture: 'alerts/countsByCluster-couple.json',
-        }).as('alertsByCluster');
+        });
 
-        cy.visit(dashboardUrl);
-        cy.wait('@alertsByCluster');
+        visitMainDashboard();
 
         cy.get(selectors.sectionHeaders.violationsByClusters)
             .next()
@@ -111,19 +108,17 @@ describe('Dashboard page', () => {
     it('should display events by time charts', () => {
         cy.intercept('GET', api.dashboard.timeseries, {
             fixture: 'alerts/alertsByTimeseries.json',
-        }).as('alertsByTimeseries');
-        cy.visit(dashboardUrl);
-        cy.wait('@alertsByTimeseries');
+        });
+        visitMainDashboard();
         cy.get(selectors.sectionHeaders.eventsByTime).next().find(selectors.timeseries);
     });
 
     it('should display violations category chart', () => {
         cy.intercept('GET', api.alerts.countsByCategory, {
             fixture: 'alerts/countsByCategory.json',
-        }).as('alertsByCategory');
+        });
 
-        cy.visit(dashboardUrl);
-        cy.wait('@alertsByCategory');
+        visitMainDashboard();
 
         cy.get(selectors.sectionHeaders.securityBestPractices).next().as('chart');
         cy.get('@chart').find(selectors.chart.legendItem).should('have.text', 'Low');
@@ -134,10 +129,9 @@ describe('Dashboard page', () => {
     it('should display top risky deployments', () => {
         cy.intercept('GET', api.risks.riskyDeployments, {
             fixture: 'risks/riskyDeployments.json',
-        }).as('riskyDeployments');
+        });
 
-        cy.visit(dashboardUrl);
-        cy.wait('@riskyDeployments');
+        visitMainDashboard();
 
         cy.get(selectors.sectionHeaders.topRiskyDeployments).next().as('list');
 
@@ -166,9 +160,7 @@ describe('Dashboard page', () => {
             body: { groups: [] },
         }).as('alertsByCluster');
 
-        cy.visit(dashboardUrl);
-        cy.wait('@alertsByCategory');
-        cy.wait('@alertsByCluster');
+        visitMainDashboard();
 
         cy.get(selectors.sectionHeaders.securityBestPractices).should('not.exist');
         cy.get(selectors.sectionHeaders.devopsBestPractices).should('not.exist');

--- a/ui/apps/platform/cypress/integration/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/dashboard.test.js
@@ -1,4 +1,5 @@
 import { url as dashboardUrl, selectors } from '../constants/DashboardPage';
+import { url as riskUrl } from '../constants/RiskPage';
 
 import {
     url as violationsUrl,
@@ -145,7 +146,7 @@ describe('Dashboard page', () => {
         // see that the order matches on the Risk page.
         cy.get(`${selectors.sectionHeaders.topRiskyDeployments} + div li`).then(($deployments) => {
             cy.get(selectors.buttons.viewAll).click();
-            cy.url().should('match', /\/main\/risk/);
+            cy.location('pathname').should('eq', riskUrl);
 
             $deployments.each((i, elem) => {
                 const deploymentName = elem.innerText.replace(/\n.*/, '');

--- a/ui/apps/platform/cypress/selectors/table.js
+++ b/ui/apps/platform/cypress/selectors/table.js
@@ -1,5 +1,7 @@
 const table = {
     header: '[data-testid="filtered-header"]',
+    body: '.rt-tbody',
+    group: '.rt-tr-group',
     column: {
         name: 'div.rt-th div:contains("Name")',
         priority: 'div.rt-th div:contains("Priority")',


### PR DESCRIPTION
## Description

This aims to reduce some of the flaky-ness in the Dashboard tests introduced by the move from Redux Sagas to local network calls, as well as make the test criteria of a couple of test more robust.

## Changes

1. The `visitMainDashboard` helper function now waits for the "riskyDeployments" request instead of the "summaryCounts" request. The reordering due to the move away from redux-sagas means that "riskyDeployments" is the last request this page will make to fetch data the impacts rendering. Since the helper function waits for this request by default, other tests in this file that used `cy.wait()` on specific data providing calls were changed to used the `visitMainDashboard` wait instead.

2. The functionality of the `should navigate to violations page when clicking the low severity tile` test was changed. Previously this test would click on the last severity tile on the page and then check that the URL on the Violations page contained a filter. The new behavior is to explicitly look for the "Low" severity tile, click it, and ensure the count from the dashboard page matches the number of violations displayed after navigation. This addressed the regression that was fixed in #1366.

3. The functionality of the `should display top risky deployments` test was changed. Previously this test would check that the top risky deployments list contained `n` elements. The new behavior is to get the names of the deployments in this list, navigate to the Risk page, and verify that the ordering of the top risky deployments is the same.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

If any of these don't apply, please comment below.

## Testing Performed

All changes were in Cypress code, and e2e tests passed locally.
