### PR TITLE
[ROX-10608] Align image-cve relation datastore for postgres

### DIFF
--- a/central/graphql/resolvers/vulnerabilities.go
+++ b/central/graphql/resolvers/vulnerabilities.go
@@ -50,7 +50,6 @@ func init() {
 			"vulnerabilityState: String!",
 			"effectiveVulnerabilityRequest: VulnerabilityRequest",
 		}),
-
 		schema.AddQuery("vulnerability(id: ID): EmbeddedVulnerability"),
 		schema.AddQuery("vulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [EmbeddedVulnerability!]!"),
 		schema.AddQuery("vulnerabilityCount(query: String): Int!"),

--- a/central/graphql/resolvers/vulnerabilities.go
+++ b/central/graphql/resolvers/vulnerabilities.go
@@ -50,6 +50,7 @@ func init() {
 			"vulnerabilityState: String!",
 			"effectiveVulnerabilityRequest: VulnerabilityRequest",
 		}),
+
 		schema.AddQuery("vulnerability(id: ID): EmbeddedVulnerability"),
 		schema.AddQuery("vulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [EmbeddedVulnerability!]!"),
 		schema.AddQuery("vulnerabilityCount(query: String): Int!"),

--- a/central/graphql/resolvers/vulnerability_requests_test.go
+++ b/central/graphql/resolvers/vulnerability_requests_test.go
@@ -35,10 +35,7 @@ import (
 	imageComponentEdgeDackBox "github.com/stackrox/rox/central/imagecomponentedge/dackbox"
 	imageComponentEdgeIndex "github.com/stackrox/rox/central/imagecomponentedge/index"
 	imageCVEEdgeDackBox "github.com/stackrox/rox/central/imagecveedge/dackbox"
-	imageCVEEdgeDS "github.com/stackrox/rox/central/imagecveedge/datastore"
 	imageCVEEdgeIndex "github.com/stackrox/rox/central/imagecveedge/index"
-	imageCVEEdgeSearcher "github.com/stackrox/rox/central/imagecveedge/search"
-	imageCVEEdgeStore "github.com/stackrox/rox/central/imagecveedge/store/dackbox"
 	nodeIndex "github.com/stackrox/rox/central/node/index"
 	nodeComponentEdgeIndex "github.com/stackrox/rox/central/nodecomponentedge/index"
 	notifierMocks "github.com/stackrox/rox/central/notifier/processor/mocks"
@@ -161,7 +158,6 @@ type VulnRequestResolverTestSuite struct {
 	cveDataStore          cveDS.DataStore
 	imageDataStore        imageDS.DataStore
 	componentCVEDataStore componentCVEEdgeDS.DataStore
-	imageCVEDataStore     imageCVEEdgeDS.DataStore
 	sensorConnMgrMocks    *sensorConnMgrMocks.MockManager
 	riskManager           *riskManager.MockManager
 	reprocessor           *reprocessorMocks.MockLoop
@@ -202,7 +198,6 @@ func (s *VulnRequestResolverTestSuite) SetupTest() {
 	pendingReqCache, activeReqCache := vulnReqCache.New(), vulnReqCache.New()
 	s.createImageDataStore(dacky)
 	s.createCVEDataStore(dacky)
-	s.createImageCVEDataStore(dacky)
 	s.createComponentCVEDataStore(dacky)
 	s.createVulnRequestDataStore(pendingReqCache, activeReqCache)
 	s.deployments = deploymentMockDS.NewMockDataStore(s.mockCtrl)
@@ -232,7 +227,6 @@ func (s *VulnRequestResolverTestSuite) SetupTest() {
 		pendingReqCache,
 		vulnReqCache.New(),
 		s.imageDataStore,
-		s.imageCVEDataStore,
 		s.cveDataStore,
 		s.componentCVEDataStore,
 		s.sensorConnMgrMocks,
@@ -267,23 +261,6 @@ func (s *VulnRequestResolverTestSuite) createCVEDataStore(dacky *dackbox.DackBox
 	)
 	s.Require().NoError(err)
 	s.cveDataStore = cveDataStore
-}
-
-func (s *VulnRequestResolverTestSuite) createImageCVEDataStore(dacky *dackbox.DackBox) {
-	imageCVEEdgeStore := imageCVEEdgeStore.New(dacky, concurrency.NewKeyFence())
-	s.imageCVEDataStore = imageCVEEdgeDS.New(dacky,
-		imageCVEEdgeStore,
-		imageCVEEdgeSearcher.New(imageCVEEdgeStore,
-			cveIndex.New(s.bleveIndex),
-			imageCVEEdgeIndex.New(s.bleveIndex),
-			componentCVEEdgeIndex.New(s.bleveIndex),
-			componentIndex.New(s.bleveIndex),
-			imageComponentEdgeIndex.New(s.bleveIndex),
-			imageIndex.New(s.bleveIndex),
-			deploymentIndex.New(s.bleveIndex, nil),
-			clusterIndex.New(s.bleveIndex),
-		),
-	)
 }
 
 func (s *VulnRequestResolverTestSuite) createComponentCVEDataStore(dacky *dackbox.DackBox) {

--- a/central/image/datastore/datastore.go
+++ b/central/image/datastore/datastore.go
@@ -40,6 +40,7 @@ type DataStore interface {
 	GetImagesBatch(ctx context.Context, shas []string) ([]*storage.Image, error)
 
 	UpsertImage(ctx context.Context, image *storage.Image) error
+	UpdateVulnerabilityState(ctx context.Context, cve string, images []string, state storage.VulnerabilityState) error
 
 	DeleteImages(ctx context.Context, ids ...string) error
 	Exists(ctx context.Context, id string) (bool, error)

--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -278,6 +278,7 @@ func (ds *datastoreImpl) UpdateVulnerabilityState(ctx context.Context, cve strin
 	}
 	return nil
 }
+
 func (ds *datastoreImpl) initializeRankers() {
 	readCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(

--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -266,6 +266,18 @@ func (ds *datastoreImpl) Exists(ctx context.Context, id string) (bool, error) {
 	return ds.storage.Exists(ctx, id)
 }
 
+func (ds *datastoreImpl) UpdateVulnerabilityState(ctx context.Context, cve string, images []string, state storage.VulnerabilityState) error {
+	if ok, err := imagesSAC.WriteAllowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	if err := ds.storage.UpdateVulnState(ctx, cve, images, state); err != nil {
+		return err
+	}
+	return nil
+}
 func (ds *datastoreImpl) initializeRankers() {
 	readCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(

--- a/central/image/datastore/internal/store/dackbox/store_impl_test.go
+++ b/central/image/datastore/internal/store/dackbox/store_impl_test.go
@@ -167,10 +167,12 @@ func (suite *ImageStoreTestSuite) TestImages() {
 	suite.Equal(images[0].GetLastUpdated(), vuln.GetCreatedAt())
 
 	// Check that the Image CVE Edges were written with the correct timestamp.
-	imageCVEEdge, _, err := suite.imageCVEEdgeStore.Get(edges.EdgeID{ParentID: "sha256:sha1", ChildID: "cve1"}.ToString())
+	// This test relies on dackbox that does not require the primary keys.
+	imageCVEEdge, _, err := suite.imageCVEEdgeStore.Get(allAccessCtx, edges.EdgeID{ParentID: "sha256:sha1", ChildID: "cve1"}.ToString(), "", "", "", "")
 	suite.NoError(err)
 	suite.Equal(images[0].GetLastUpdated(), imageCVEEdge.GetFirstImageOccurrence())
-	imageCVEEdge, _, err = suite.imageCVEEdgeStore.Get(edges.EdgeID{ParentID: "sha256:sha1", ChildID: "cve1"}.ToString())
+	// This test relies on dackbox that does not require the primary keys.
+	imageCVEEdge, _, err = suite.imageCVEEdgeStore.Get(allAccessCtx, edges.EdgeID{ParentID: "sha256:sha1", ChildID: "cve1"}.ToString(), "", "", "", "")
 	suite.NoError(err)
 	suite.Equal(images[0].GetLastUpdated(), imageCVEEdge.GetFirstImageOccurrence())
 
@@ -298,7 +300,7 @@ func (suite *ImageStoreTestSuite) TestImages() {
 	suite.Equal(0, count)
 
 	// Check that the Image CVE Edges are removed.
-	count, err = suite.imageCVEEdgeStore.Count()
+	count, err = suite.imageCVEEdgeStore.Count(allAccessCtx)
 	suite.NoError(err)
 	suite.Equal(0, count)
 }

--- a/central/image/datastore/internal/store/mocks/store.go
+++ b/central/image/datastore/internal/store/mocks/store.go
@@ -161,6 +161,20 @@ func (mr *MockStoreMockRecorder) GetMany(ctx, ids interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMany", reflect.TypeOf((*MockStore)(nil).GetMany), ctx, ids)
 }
 
+// UpdateVulnState mocks base method.
+func (m *MockStore) UpdateVulnState(ctx context.Context, cve string, images []string, state storage.VulnerabilityState) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateVulnState", ctx, cve, images, state)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateVulnState indicates an expected call of UpdateVulnState.
+func (mr *MockStoreMockRecorder) UpdateVulnState(ctx, cve, images, state interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateVulnState", reflect.TypeOf((*MockStore)(nil).UpdateVulnState), ctx, cve, images, state)
+}
+
 // Upsert mocks base method.
 func (m *MockStore) Upsert(ctx context.Context, image *storage.Image) error {
 	m.ctrl.T.Helper()

--- a/central/image/datastore/internal/store/store.go
+++ b/central/image/datastore/internal/store/store.go
@@ -20,6 +20,8 @@ type Store interface {
 	Upsert(ctx context.Context, image *storage.Image) error
 	Delete(ctx context.Context, id string) error
 
+	UpdateVulnState(ctx context.Context, cve string, images []string, state storage.VulnerabilityState) error
+
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 }

--- a/central/image/datastore/mocks/datastore.go
+++ b/central/image/datastore/mocks/datastore.go
@@ -224,6 +224,20 @@ func (mr *MockDataStoreMockRecorder) SearchRawImages(ctx, q interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchRawImages", reflect.TypeOf((*MockDataStore)(nil).SearchRawImages), ctx, q)
 }
 
+// UpdateVulnerabilityState mocks base method.
+func (m *MockDataStore) UpdateVulnerabilityState(ctx context.Context, cve string, images []string, state storage.VulnerabilityState) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateVulnerabilityState", ctx, cve, images, state)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateVulnerabilityState indicates an expected call of UpdateVulnerabilityState.
+func (mr *MockDataStoreMockRecorder) UpdateVulnerabilityState(ctx, cve, images, state interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateVulnerabilityState", reflect.TypeOf((*MockDataStore)(nil).UpdateVulnerabilityState), ctx, cve, images, state)
+}
+
 // UpsertImage mocks base method.
 func (m *MockDataStore) UpsertImage(ctx context.Context, image *storage.Image) error {
 	m.ctrl.T.Helper()

--- a/central/imagecveedge/datastore/datastore.go
+++ b/central/imagecveedge/datastore/datastore.go
@@ -18,7 +18,6 @@ type DataStore interface {
 	SearchEdges(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)
 	SearchRawEdges(ctx context.Context, q *v1.Query) ([]*storage.ImageCVEEdge, error)
 	Get(ctx context.Context, id string) (*storage.ImageCVEEdge, bool, error)
-	UpdateVulnerabilityState(ctx context.Context, cve string, images []string, state storage.VulnerabilityState) error
 }
 
 // New returns a new instance of a DataStore.

--- a/central/imagecveedge/datastore/mocks/datastore.go
+++ b/central/imagecveedge/datastore/mocks/datastore.go
@@ -97,17 +97,3 @@ func (mr *MockDataStoreMockRecorder) SearchRawEdges(ctx, q interface{}) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchRawEdges", reflect.TypeOf((*MockDataStore)(nil).SearchRawEdges), ctx, q)
 }
-
-// UpdateVulnerabilityState mocks base method.
-func (m *MockDataStore) UpdateVulnerabilityState(ctx context.Context, cve string, images []string, state storage.VulnerabilityState) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateVulnerabilityState", ctx, cve, images, state)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateVulnerabilityState indicates an expected call of UpdateVulnerabilityState.
-func (mr *MockDataStoreMockRecorder) UpdateVulnerabilityState(ctx, cve, images, state interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateVulnerabilityState", reflect.TypeOf((*MockDataStore)(nil).UpdateVulnerabilityState), ctx, cve, images, state)
-}

--- a/central/imagecveedge/datastore/singleton.go
+++ b/central/imagecveedge/datastore/singleton.go
@@ -5,13 +5,14 @@ import (
 	componentCVEEdgeIndexer "github.com/stackrox/rox/central/componentcveedge/index"
 	cveIndexer "github.com/stackrox/rox/central/cve/index"
 	deploymentIndexer "github.com/stackrox/rox/central/deployment/index"
-	globaldb "github.com/stackrox/rox/central/globaldb/dackbox"
+	globalDackbox "github.com/stackrox/rox/central/globaldb/dackbox"
 	"github.com/stackrox/rox/central/globalindex"
 	imageIndexer "github.com/stackrox/rox/central/image/index"
 	componentIndexer "github.com/stackrox/rox/central/imagecomponent/index"
 	imageComponentEdgeIndexer "github.com/stackrox/rox/central/imagecomponentedge/index"
 	imageCVEEdgeIndexer "github.com/stackrox/rox/central/imagecveedge/index"
 	"github.com/stackrox/rox/central/imagecveedge/search"
+	"github.com/stackrox/rox/central/imagecveedge/store"
 	"github.com/stackrox/rox/central/imagecveedge/store/dackbox"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -23,9 +24,21 @@ var (
 )
 
 func initialize() {
-	storage := dackbox.New(globaldb.GetGlobalDackBox(), globaldb.GetKeyFence())
-	var searcher = search.New(storage, cveIndexer.New(globalindex.GetGlobalIndex()),
-		imageCVEEdgeIndexer.New(globalindex.GetGlobalIndex()),
+	var storage store.Store
+	var indexer imageCVEEdgeIndexer.Indexer
+	var searcher search.Searcher
+
+	// TODO: Wire up.
+	// if features.PostgresDatastore.Enabled() {
+	//	storage = postgres.New(context.TODO(), globaldb.GetPostgres())
+	//	indexer = postgres.NewIndexer(globaldb.GetPostgres())
+	//	searcher = search.NewV2(storage, indexer)
+	//}
+
+	storage = dackbox.New(globalDackbox.GetGlobalDackBox(), globalDackbox.GetKeyFence())
+	indexer = imageCVEEdgeIndexer.New(globalindex.GetGlobalIndex())
+	searcher = search.New(storage, cveIndexer.New(globalindex.GetGlobalIndex()),
+		indexer,
 		componentCVEEdgeIndexer.New(globalindex.GetGlobalIndex()),
 		componentIndexer.New(globalindex.GetGlobalIndex()),
 		imageComponentEdgeIndexer.New(globalindex.GetGlobalIndex()),
@@ -33,7 +46,7 @@ func initialize() {
 		deploymentIndexer.New(globalindex.GetGlobalIndex(), globalindex.GetProcessIndex()),
 		clusterIndexer.New(globalindex.GetGlobalIndex()))
 
-	ad = New(globaldb.GetGlobalDackBox(), storage, searcher)
+	ad = New(globalDackbox.GetGlobalDackBox(), storage, searcher)
 }
 
 // Singleton provides the interface for non-service external interaction.

--- a/central/imagecveedge/search/searcher_impl_v2.go
+++ b/central/imagecveedge/search/searcher_impl_v2.go
@@ -1,0 +1,97 @@
+package search
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/central/imagecveedge/index"
+	"github.com/stackrox/rox/central/imagecveedge/store"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/blevesearch"
+	"github.com/stackrox/rox/pkg/search/scoped/postgres"
+)
+
+// NewV2 returns a new instance of Searcher for the given storage and indexer.
+func NewV2(storage store.Store, indexer index.Indexer) Searcher {
+	return &searcherImplV2{
+		storage:  storage,
+		indexer:  indexer,
+		searcher: postgres.WithScoping(blevesearch.WrapUnsafeSearcherAsSearcher(indexer)),
+	}
+}
+
+type searcherImplV2 struct {
+	storage  store.Store
+	indexer  index.Indexer
+	searcher search.Searcher
+}
+
+// SearchEdges returns the search results from indexed edges for the query.
+func (ds *searcherImplV2) SearchEdges(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
+	results, err := ds.Search(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	return ds.resultsToSearchResults(ctx, results)
+}
+
+// Search returns the raw search results from the query
+func (ds *searcherImplV2) Search(ctx context.Context, q *v1.Query) (res []search.Result, err error) {
+	return ds.searcher.Search(ctx, q)
+}
+
+// Count returns the number of search results from the query
+func (ds *searcherImplV2) Count(ctx context.Context, q *v1.Query) (count int, err error) {
+	return ds.searcher.Count(ctx, q)
+}
+
+// SearchRawEdges retrieves edges from the indexer and storage
+func (ds *searcherImplV2) SearchRawEdges(ctx context.Context, q *v1.Query) ([]*storage.ImageCVEEdge, error) {
+	return ds.searchImageComponentEdges(ctx, q)
+}
+
+func (ds *searcherImplV2) resultsToEdges(ctx context.Context, results []search.Result) ([]*storage.ImageCVEEdge, []int, error) {
+	return ds.storage.GetMany(ctx, search.ResultsToIDs(results))
+}
+
+func (ds *searcherImplV2) resultsToSearchResults(ctx context.Context, results []search.Result) ([]*v1.SearchResult, error) {
+	cves, missingIndices, err := ds.resultsToEdges(ctx, results)
+	if err != nil {
+		return nil, err
+	}
+	results = search.RemoveMissingResults(results, missingIndices)
+	return convertMany(cves, results), nil
+}
+
+func convertMany(cves []*storage.ImageCVEEdge, results []search.Result) []*v1.SearchResult {
+	outputResults := make([]*v1.SearchResult, len(cves))
+	for index, sar := range cves {
+		outputResults[index] = convertOne(sar, &results[index])
+	}
+	return outputResults
+}
+
+func convertOne(obj *storage.ImageCVEEdge, result *search.Result) *v1.SearchResult {
+	return &v1.SearchResult{
+		Category:       v1.SearchCategory_IMAGE_VULN_EDGE,
+		Id:             obj.GetId(),
+		Name:           obj.GetId(),
+		FieldToMatches: search.GetProtoMatchesMap(result.Matches),
+		Score:          result.Score,
+	}
+}
+
+func (ds *searcherImplV2) searchImageComponentEdges(ctx context.Context, q *v1.Query) ([]*storage.ImageCVEEdge, error) {
+	results, err := ds.Search(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := search.ResultsToIDs(results)
+	cves, _, err := ds.storage.GetMany(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	return cves, nil
+}

--- a/central/imagecveedge/store/dackbox/store_impl.go
+++ b/central/imagecveedge/store/dackbox/store_impl.go
@@ -1,10 +1,9 @@
 package dackbox
 
 import (
+	"context"
 	"time"
 
-	cveDackBox "github.com/stackrox/rox/central/cve/dackbox"
-	imgDackBox "github.com/stackrox/rox/central/image/dackbox"
 	edgeDackBox "github.com/stackrox/rox/central/imagecveedge/dackbox"
 	"github.com/stackrox/rox/central/imagecveedge/store"
 	"github.com/stackrox/rox/central/metrics"
@@ -12,7 +11,6 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/dackbox"
 	"github.com/stackrox/rox/pkg/dackbox/crud"
-	"github.com/stackrox/rox/pkg/dackbox/edges"
 	ops "github.com/stackrox/rox/pkg/metrics"
 )
 
@@ -36,7 +34,7 @@ func New(dacky *dackbox.DackBox, keyFence concurrency.KeyFence) store.Store {
 	}
 }
 
-func (b *storeImpl) Exists(id string) (bool, error) {
+func (b *storeImpl) Exists(_ context.Context, id string, _ string, _ string, _ string, _ string) (bool, error) {
 	dackTxn, err := b.dacky.NewReadOnlyTransaction()
 	if err != nil {
 		return false, err
@@ -51,7 +49,7 @@ func (b *storeImpl) Exists(id string) (bool, error) {
 	return exists, nil
 }
 
-func (b *storeImpl) Count() (int, error) {
+func (b *storeImpl) Count(_ context.Context) (int, error) {
 	defer metrics.SetDackboxOperationDurationTime(time.Now(), ops.Count, "ImageCVEEdge")
 
 	dackTxn, err := b.dacky.NewReadOnlyTransaction()
@@ -68,28 +66,7 @@ func (b *storeImpl) Count() (int, error) {
 	return count, nil
 }
 
-func (b *storeImpl) GetAll() ([]*storage.ImageCVEEdge, error) {
-	defer metrics.SetDackboxOperationDurationTime(time.Now(), ops.GetAll, "ImageCVEEdge")
-
-	dackTxn, err := b.dacky.NewReadOnlyTransaction()
-	if err != nil {
-		return nil, err
-	}
-	defer dackTxn.Discard()
-
-	msgs, err := b.reader.ReadAllIn(edgeDackBox.Bucket, dackTxn)
-	if err != nil {
-		return nil, err
-	}
-	ret := make([]*storage.ImageCVEEdge, 0, len(msgs))
-	for _, msg := range msgs {
-		ret = append(ret, msg.(*storage.ImageCVEEdge))
-	}
-
-	return ret, nil
-}
-
-func (b *storeImpl) Get(id string) (cve *storage.ImageCVEEdge, exists bool, err error) {
+func (b *storeImpl) Get(_ context.Context, id string, _ string, _ string, _ string, _ string) (cve *storage.ImageCVEEdge, exists bool, err error) {
 	defer metrics.SetDackboxOperationDurationTime(time.Now(), ops.Get, "ImageCVEEdge")
 
 	dackTxn, err := b.dacky.NewReadOnlyTransaction()
@@ -106,7 +83,7 @@ func (b *storeImpl) Get(id string) (cve *storage.ImageCVEEdge, exists bool, err 
 	return msg.(*storage.ImageCVEEdge), true, err
 }
 
-func (b *storeImpl) GetMany(ids []string) ([]*storage.ImageCVEEdge, []int, error) {
+func (b *storeImpl) GetMany(_ context.Context, ids []string) ([]*storage.ImageCVEEdge, []int, error) {
 	defer metrics.SetDackboxOperationDurationTime(time.Now(), ops.GetMany, "ImageCVEEdge")
 
 	dackTxn, err := b.dacky.NewReadOnlyTransaction()
@@ -130,55 +107,4 @@ func (b *storeImpl) GetMany(ids []string) ([]*storage.ImageCVEEdge, []int, error
 	}
 
 	return ret, missing, nil
-}
-
-func (b *storeImpl) UpdateVulnState(cve string, images []string, state storage.VulnerabilityState) error {
-	defer metrics.SetDackboxOperationDurationTime(time.Now(), ops.UpdateMany, "ImageCVEEdge")
-
-	edgeIDs := getEdgeIDs(cve, images...)
-	graphKeys := gatherKeysForEdge(cve, images...)
-	// Lock nodes in the graph and update the image-cve edge in the db.
-	return b.keyFence.DoStatusWithLock(concurrency.DiscreteKeySet(graphKeys...), func() error {
-		dackTxn, err := b.dacky.NewTransaction()
-		if err != nil {
-			return err
-		}
-		defer dackTxn.Discard()
-
-		for _, edgeID := range edgeIDs {
-			msg, err := b.reader.ReadIn(edgeDackBox.BucketHandler.GetKey(edgeID), dackTxn)
-			if err != nil {
-				return err
-			}
-			if msg == nil {
-				continue
-			}
-			edge := msg.(*storage.ImageCVEEdge)
-			if edge.GetState() == state {
-				continue
-			}
-			edge.State = state
-			if err := b.upserter.UpsertIn(nil, edge, dackTxn); err != nil {
-				return err
-			}
-		}
-		return dackTxn.Commit()
-	})
-}
-
-func getEdgeIDs(cve string, imageIDs ...string) []string {
-	ids := make([]string, 0, len(imageIDs))
-	for _, imgID := range imageIDs {
-		ids = append(ids, edges.EdgeID{ParentID: imgID, ChildID: cve}.ToString())
-	}
-	return ids
-}
-
-func gatherKeysForEdge(cve string, imageIDs ...string) [][]byte {
-	allKeys := make([][]byte, 0, len(imageIDs)+1)
-	for _, imgID := range imageIDs {
-		allKeys = append(allKeys, imgDackBox.BucketHandler.GetKey(imgID))
-	}
-	allKeys = append(allKeys, cveDackBox.BucketHandler.GetKey(cve))
-	return allKeys
 }

--- a/central/imagecveedge/store/mocks/store.go
+++ b/central/imagecveedge/store/mocks/store.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -35,39 +36,39 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 }
 
 // Count mocks base method.
-func (m *MockStore) Count() (int, error) {
+func (m *MockStore) Count(ctx context.Context) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Count")
+	ret := m.ctrl.Call(m, "Count", ctx)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Count indicates an expected call of Count.
-func (mr *MockStoreMockRecorder) Count() *gomock.Call {
+func (mr *MockStoreMockRecorder) Count(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockStore)(nil).Count))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockStore)(nil).Count), ctx)
 }
 
 // Exists mocks base method.
-func (m *MockStore) Exists(id string) (bool, error) {
+func (m *MockStore) Exists(ctx context.Context, id, imageID, imageCveID, imageCve, imageCveOperatingSystem string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exists", id)
+	ret := m.ctrl.Call(m, "Exists", ctx, id, imageID, imageCveID, imageCve, imageCveOperatingSystem)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Exists indicates an expected call of Exists.
-func (mr *MockStoreMockRecorder) Exists(id interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) Exists(ctx, id, imageID, imageCveID, imageCve, imageCveOperatingSystem interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockStore)(nil).Exists), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockStore)(nil).Exists), ctx, id, imageID, imageCveID, imageCve, imageCveOperatingSystem)
 }
 
 // Get mocks base method.
-func (m *MockStore) Get(id string) (*storage.ImageCVEEdge, bool, error) {
+func (m *MockStore) Get(ctx context.Context, id, imageID, imageCveID, imageCve, imageCveOperatingSystem string) (*storage.ImageCVEEdge, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", id)
+	ret := m.ctrl.Call(m, "Get", ctx, id, imageID, imageCveID, imageCve, imageCveOperatingSystem)
 	ret0, _ := ret[0].(*storage.ImageCVEEdge)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -75,30 +76,15 @@ func (m *MockStore) Get(id string) (*storage.ImageCVEEdge, bool, error) {
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockStoreMockRecorder) Get(id interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) Get(ctx, id, imageID, imageCveID, imageCve, imageCveOperatingSystem interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), id)
-}
-
-// GetAll mocks base method.
-func (m *MockStore) GetAll() ([]*storage.ImageCVEEdge, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAll")
-	ret0, _ := ret[0].([]*storage.ImageCVEEdge)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAll indicates an expected call of GetAll.
-func (mr *MockStoreMockRecorder) GetAll() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockStore)(nil).GetAll))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id, imageID, imageCveID, imageCve, imageCveOperatingSystem)
 }
 
 // GetMany mocks base method.
-func (m *MockStore) GetMany(ids []string) ([]*storage.ImageCVEEdge, []int, error) {
+func (m *MockStore) GetMany(ctx context.Context, ids []string) ([]*storage.ImageCVEEdge, []int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMany", ids)
+	ret := m.ctrl.Call(m, "GetMany", ctx, ids)
 	ret0, _ := ret[0].([]*storage.ImageCVEEdge)
 	ret1, _ := ret[1].([]int)
 	ret2, _ := ret[2].(error)
@@ -106,21 +92,7 @@ func (m *MockStore) GetMany(ids []string) ([]*storage.ImageCVEEdge, []int, error
 }
 
 // GetMany indicates an expected call of GetMany.
-func (mr *MockStoreMockRecorder) GetMany(ids interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetMany(ctx, ids interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMany", reflect.TypeOf((*MockStore)(nil).GetMany), ids)
-}
-
-// UpdateVulnState mocks base method.
-func (m *MockStore) UpdateVulnState(cve string, images []string, state storage.VulnerabilityState) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateVulnState", cve, images, state)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateVulnState indicates an expected call of UpdateVulnState.
-func (mr *MockStoreMockRecorder) UpdateVulnState(cve, images, state interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateVulnState", reflect.TypeOf((*MockStore)(nil).UpdateVulnState), cve, images, state)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMany", reflect.TypeOf((*MockStore)(nil).GetMany), ctx, ids)
 }

--- a/central/imagecveedge/store/store.go
+++ b/central/imagecveedge/store/store.go
@@ -1,17 +1,17 @@
 package store
 
 import (
+	"context"
+
 	"github.com/stackrox/rox/generated/storage"
 )
 
 // Store provides storage functionality for ImageCVEEdges.
 //go:generate mockgen-wrapper
 type Store interface {
-	Count() (int, error)
-	Exists(id string) (bool, error)
+	Count(ctx context.Context) (int, error)
+	Exists(ctx context.Context, id string, imageID string, imageCveID string, imageCve string, imageCveOperatingSystem string) (bool, error)
 
-	GetAll() ([]*storage.ImageCVEEdge, error)
-	Get(id string) (*storage.ImageCVEEdge, bool, error)
-	GetMany(ids []string) ([]*storage.ImageCVEEdge, []int, error)
-	UpdateVulnState(cve string, images []string, state storage.VulnerabilityState) error
+	Get(ctx context.Context, id string, imageID string, imageCveID string, imageCve string, imageCveOperatingSystem string) (*storage.ImageCVEEdge, bool, error)
+	GetMany(ctx context.Context, ids []string) ([]*storage.ImageCVEEdge, []int, error)
 }

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -10,7 +10,6 @@ import (
 	cveDataStore "github.com/stackrox/rox/central/cve/datastore"
 	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
 	imgDataStore "github.com/stackrox/rox/central/image/datastore"
-	imgCVEEdgeDataStore "github.com/stackrox/rox/central/imagecveedge/datastore"
 	"github.com/stackrox/rox/central/reprocessor"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/central/sensor/service/connection"
@@ -48,7 +47,6 @@ var (
 type managerImpl struct {
 	deployments       deploymentDataStore.DataStore
 	images            imgDataStore.DataStore
-	imageCVEEdges     imgCVEEdgeDataStore.DataStore
 	cves              cveDataStore.DataStore
 	componentCVEEdges componentCVEEdgeDataStore.DataStore
 	vulnReqs          vulnReqDataStore.DataStore
@@ -198,7 +196,7 @@ func (m *managerImpl) SnoozeVulnerabilityOnRequest(_ context.Context, request *s
 		// Determine the effective for the cves in the image scope.
 		cveStateMap := m.activeReqCache.GetEffectiveVulnStateForImage(request.GetCves().GetIds(), img.GetName().GetRegistry(), img.GetName().GetRemote(), img.GetName().GetTag())
 		for _, cve := range request.GetCves().GetIds() {
-			if err := m.imageCVEEdges.UpdateVulnerabilityState(allAccessCtx, cve, []string{imageID}, cveStateMap[cve]); err != nil {
+			if err := m.images.UpdateVulnerabilityState(allAccessCtx, cve, []string{imageID}, cveStateMap[cve]); err != nil {
 				return errors.Wrapf(err, "could not un-snooze vulnerabilities for request %s", request.GetId())
 			}
 		}
@@ -237,7 +235,7 @@ func (m *managerImpl) UnSnoozeVulnerabilityOnRequest(_ context.Context, request 
 		// Determine the effective for the cves in the image scope.
 		cveStateMap := m.activeReqCache.GetEffectiveVulnStateForImage(request.GetCves().GetIds(), img.GetName().GetRegistry(), img.GetName().GetRemote(), img.GetName().GetTag())
 		for _, cve := range request.GetCves().GetIds() {
-			if err := m.imageCVEEdges.UpdateVulnerabilityState(allAccessCtx, cve, []string{imageID}, cveStateMap[cve]); err != nil {
+			if err := m.images.UpdateVulnerabilityState(allAccessCtx, cve, []string{imageID}, cveStateMap[cve]); err != nil {
 				return errors.Wrapf(err, "could not un-snooze vulnerabilities for request %s", request.GetId())
 			}
 		}

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
@@ -163,7 +163,6 @@ func (s *VulnRequestManagerTestSuite) SetupTest() {
 	s.manager = &managerImpl{
 		deployments:                           s.deployments,
 		images:                                s.imageDataStore,
-		imageCVEEdges:                         s.imageCVEDataStore,
 		vulnReqs:                              s.vulnReqDataStore,
 		cves:                                  s.cveDataStore,
 		componentCVEEdges:                     s.componentCVEDataStore,

--- a/central/vulnerabilityrequest/manager/requestmgr/singleton.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/singleton.go
@@ -5,7 +5,6 @@ import (
 	cveDataStore "github.com/stackrox/rox/central/cve/datastore"
 	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
 	imageDataStore "github.com/stackrox/rox/central/image/datastore"
-	imageCVEDataStore "github.com/stackrox/rox/central/imagecveedge/datastore"
 	"github.com/stackrox/rox/central/reprocessor"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	"github.com/stackrox/rox/central/vulnerabilityrequest/cache"
@@ -30,7 +29,6 @@ func initialize() {
 		cache.PendingReqsCacheSingleton(),
 		cache.ActiveReqsCacheSingleton(),
 		imageDataStore.Singleton(),
-		imageCVEDataStore.Singleton(),
 		cveDataStore.Singleton(),
 		componentCVEEdgeDataStore.Singleton(),
 		connection.ManagerSingleton(),
@@ -51,7 +49,6 @@ func New(
 	pendingVulnReqsCache cache.VulnReqCache,
 	activeVulnReqsCache cache.VulnReqCache,
 	images imageDataStore.DataStore,
-	imageCVEEdges imageCVEDataStore.DataStore,
 	cves cveDataStore.DataStore,
 	componentCVEEdges componentCVEEdgeDataStore.DataStore,
 	sensorConnMgr connection.Manager,
@@ -60,7 +57,6 @@ func New(
 	return &managerImpl{
 		deployments:       deployments,
 		images:            images,
-		imageCVEEdges:     imageCVEEdges,
 		cves:              cves,
 		componentCVEEdges: componentCVEEdges,
 		vulnReqs:          vulnReqs,


### PR DESCRIPTION
## Description

- Align image-cve datastore for postgres
- Image-CVE searcher for postgres
- Moved `UpdateVulnState()` from image-cve to image store. Relation tables should not have update functions anyways.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required
- ~Determined and documented upgrade steps
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
