### PR TITLE
ROX-10096: Fix `vuln_check.sh` to ignore non-fixable vulnerabilities

### DIFF
--- a/release/scripts/vuln_check.sh
+++ b/release/scripts/vuln_check.sh
@@ -53,7 +53,7 @@ function compare_fixable_vulns {
     FAIL_SCRIPT=true
   else
     echo "Trying to get any fixable vulns for ${image_name}"
-    CURRENT_FIXABLE=$(quay_curl "${image_name}/manifest/${CURRENT_IMAGE}/security?vulnerabilities=true" | jq -r '.data.Layer.Features | .[] | select(.Vulnerabilities != null) | .Vulnerabilities | .[] | select(.FixedBy != null) | .Name')
+    CURRENT_FIXABLE=$(quay_curl "${image_name}/manifest/${CURRENT_IMAGE}/security?vulnerabilities=true" | jq -r '.data.Layer.Features | .[] | select(.Vulnerabilities != null) | .Vulnerabilities | .[] | select(.FixedBy | . != null and . != "") | .Name')
 
     # fail the check if fixable vulns are found that are not allowed
     if [[ -n "$CURRENT_FIXABLE" ]]; then


### PR DESCRIPTION
## Description

`Quay.io` returns today empty `FixedBy` for vulnerabilities without available fixes.

Local testing against [images with known non-fixable vulnerabilities](https://quay.io/repository/rhacs-eng/scanner-db/manifest/sha256:4039acc33be3250e5fa87818377195b234ecc30cd6275f89b12a46094422ef03?tab=vulnerabilities):
```
✗ SCANNER_TAG=3.69.x-480-gf8c811f553-rcd-amd64 release/scripts/vuln_check.sh
Fetching current image SHA from quay for scanner:2.23.0-31-g460993206e
Getting scan status for scanner
Trying to get any fixable vulns for scanner
scanner:2.23.0-31-g460993206e has no fixable vulns
Fetching current image SHA from quay for scanner-db:2.23.0-31-g460993206e
Getting scan status for scanner-db
Trying to get any fixable vulns for scanner-db
scanner-db:2.23.0-31-g460993206e has no fixable vulns
```