### PR TITLE
Increase timeout for SAC when run in race condition tests.

### DIFF
--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -62,6 +62,10 @@ class SACTest extends BaseSpecification {
 
     static final private Integer WAIT_FOR_VIOLATION_TIMEOUT = isRaceBuild() ? 600 : 60
 
+    // Increase the timeout for race-condition tests. By default, we will wait 60 seconds, on race-condition tests
+    // we will wait 600 seconds.
+    static final private Integer WAIT_FOR_RISK_RETRIES = isRaceBuild() ? 300 : 30
+
     def setupSpec() {
         // Make sure we scan the image initially to make reprocessing faster.
         def img = Services.scanImage(TEST_IMAGE)
@@ -81,7 +85,7 @@ class SACTest extends BaseSpecification {
         def deployments = DeploymentService.listDeployments()
         deployments.each { DeploymentOuterClass.ListDeployment dep ->
             try {
-                withRetry(30, 2) {
+                withRetry(WAIT_FOR_RISK_RETRIES, 2) {
                     assert DeploymentService.getDeploymentWithRisk(dep.id).hasRisk()
                 }
             } catch (Exception e) {


### PR DESCRIPTION
## Description

Tests are flaking when waiting for a deployment's risk within the `race-condition-tests`, see [here as an example](https://app.circleci.com/pipelines/github/stackrox/stackrox/10104/workflows/77eff0e7-08af-48bf-8b1e-4c3486a4763f/jobs/460455/tests).

Increased the timeout to match what we already are doing for violations, conditionally increasing the timeout when a race-build is used.