### PR TITLE
Fix false negative for User Cert auth provider e2e test

### DIFF
--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -27,10 +27,10 @@ const h2 = 'Auth providers';
 describe('Access Control Auth providers', () => {
     withAuth();
 
-    function visitAuthProviders() {
+    function visitAuthProviders(saveProviderMock = {}) {
         cy.intercept('GET', authProvidersApi.list).as('GetAuthProviders');
         cy.intercept('GET', mypermissionApi).as('GetMyPermissions');
-        cy.intercept('POST', authProvidersApi.create, {}).as('CreateAuthProvider');
+        cy.intercept('POST', authProvidersApi.create, saveProviderMock).as('CreateAuthProvider');
         cy.visit(authProvidersUrl);
         cy.wait('@GetAuthProviders');
         cy.wait('@GetMyPermissions');
@@ -241,10 +241,26 @@ describe('Access Control Auth providers', () => {
     });
 
     it('add User Certificates', () => {
-        visitAuthProviders();
+        const newProviderName = generateNameWithDate('User Cert Test Provide');
+
+        const mockUserCertResponse = {
+            id: '21b1003e-8f24-447f-a92e-0f8ff4a1274e',
+            name: newProviderName,
+            type: 'userpki',
+            uiEndpoint: 'localhost:3000',
+            enabled: true,
+            config: {
+                keys: '-----BEGIN CERTIFICATE-----\nMIICEjCCAXsCAg36MA0GCSqGSIb3DQEBBQUAMIGbMQswCQYDVQQGEwJKUDEOMAwG\nA1UECBMFVG9reW8xEDAOBgNVBAcTB0NodW8ta3UxETAPBgNVBAoTCEZyYW5rNERE\nMRgwFgYDVQQLEw9XZWJDZXJ0IFN1cHBvcnQxGDAWBgNVBAMTD0ZyYW5rNEREIFdl\nYiBDQTEjMCEGCSqGSIb3DQEJARYUc3VwcG9ydEBmcmFuazRkZC5jb20wHhcNMTIw\nODIyMDUyNjU0WhcNMTcwODIxMDUyNjU0WjBKMQswCQYDVQQGEwJKUDEOMAwGA1UE\nCAwFVG9reW8xETAPBgNVBAoMCEZyYW5rNEREMRgwFgYDVQQDDA93d3cuZXhhbXBs\nZS5jb20wXDANBgkqhkiG9w0BAQEFAANLADBIAkEAm/xmkHmEQrurE/0re/jeFRLl\n8ZPjBop7uLHhnia7lQG/5zDtZIUC3RVpqDSwBuw/NTweGyuP+o8AG98HxqxTBwID\nAQABMA0GCSqGSIb3DQEBBQUAA4GBABS2TLuBeTPmcaTaUW/LCB2NYOy8GMdzR1mx\n8iBIu2H6/E2tiY3RIevV2OW61qY2/XRQg7YPxx3ffeUugX9F4J/iPnnu1zAxxyBy\n2VguKv4SWjRFoRkIfIlHX0qVviMhSlNy2ioFLy7JcPZb+v3ftDGywUqcBiVDoea0\nHn+GmxZA\n-----END CERTIFICATE-----',
+            },
+            loginUrl: '/sso/login/21b1003e-8f24-447f-a92e-0f8ff4a1274e',
+            validated: false,
+            extraUiEndpoints: [],
+            active: false,
+        };
+
+        visitAuthProviders(mockUserCertResponse);
 
         const type = 'User Certificates';
-        const newProviderName = generateNameWithDate('User Cert Test Provide');
 
         cy.get(selectors.list.addButton).click();
         cy.get(`${selectors.list.authProviders.addDropdownItem}:contains("${type}")`).click();
@@ -281,6 +297,7 @@ describe('Access Control Auth providers', () => {
         cy.wait('@GetAuthProviders'); // wait for GET to finish, which means redirect back to list page
         cy.location().should((loc) => {
             expect(loc.pathname).to.eq('/main/access-control/auth-providers');
+            expect(loc.search).to.eq('');
         });
     });
 


### PR DESCRIPTION
## Description

Mark Pedrotti noticed that this test was passing, but was a "false negative" because the POST call to save the new auth provider was failing, but the test was not doing the correct assertions to catch that.

I investigated and found that the API call was failing because of an unrelated change in the mocking.

1. Fixed the mocking for this test, which also allows for more thorough tests of other auth providers types in the future. (I resisted the urge to do more in this PR.)
2. Added the assertion that Mark suggested as a better way to catch regressions like this in the test in the future. (Namely, making sure there is no query param, thus ensuring that the redirect back to the table view happened, after a successful save.)

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added


## Testing Performed

* Verified this test, and whole suite, by running locally
* Inspected this suite on video recording of CI run

<img width="2203" alt="Screen Shot 2022-04-25 at 11 49 11 AM" src="https://user-images.githubusercontent.com/715729/165127142-a19b2114-ff64-45f4-aa77-f778457c16e3.png">

