### PR TITLE
Implement error screen for fatal errors sent from backend in netgraph

### DIFF
--- a/ui/apps/platform/cypress/constants/NetworkPage.js
+++ b/ui/apps/platform/cypress/constants/NetworkPage.js
@@ -64,4 +64,9 @@ export const selectors = {
         namespaceSelect: '.namespace-select > button',
         filterSelect: search.multiSelectInput,
     }),
+    errorOverlay: {
+        heading: 'h2:contains("An error has prevented the Network Graph from loading")',
+        message: (messageText) =>
+            `${selectors.errorOverlay.heading} + div *:contains("${messageText}")`,
+    },
 };

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -92,5 +92,6 @@ describe('Network Graph Search', () => {
         cy.wait('@networkGraph');
 
         cy.get(networkPageSelectors.errorOverlay.heading).should('not.exist');
+        cy.get(networkPageSelectors.cytoscapeContainer);
     });
 });

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -74,7 +74,8 @@ describe('Network Graph Search', () => {
         visitNetworkGraph();
 
         // Stub out an error response from the server
-        const error = 'Number of deployments (220) exceeds maximum allowed for Network Graph: 200';
+        const error =
+            'Number of deployments (2200) exceeds maximum allowed for Network Graph: 2000';
         cy.intercept('GET', api.network.networkGraph, {
             statusCode: 500,
             body: { error, message: error },

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -74,7 +74,7 @@ describe('Network Graph Search', () => {
         visitNetworkGraph();
 
         // Stub out an error response from the server
-        const error = 'number of deployments (220) exceeds maximum allowed for Network Graph: 200';
+        const error = 'Number of deployments (220) exceeds maximum allowed for Network Graph: 200';
         cy.intercept('GET', api.network.networkGraph, {
             statusCode: 500,
             body: { error, message: error },

--- a/ui/apps/platform/src/Components/PatternFly/EmptyStateTemplate/EmptyStateTemplate.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/EmptyStateTemplate/EmptyStateTemplate.tsx
@@ -12,16 +12,18 @@ type EmptyStateTemplateProps = {
     children?: ReactNode;
     title: string;
     headingLevel: 'h1' | 'h2' | 'h3' | 'h4';
+    icon?: React.ComponentType;
 };
 
 function EmptyStateTemplate({
     children,
     title,
     headingLevel,
+    icon = CubesIcon,
 }: EmptyStateTemplateProps): ReactElement {
     return (
         <EmptyState variant={EmptyStateVariant.large}>
-            <EmptyStateIcon icon={CubesIcon} />
+            <EmptyStateIcon icon={icon} />
             <Title headingLevel={headingLevel} size="lg">
                 {title}
             </Title>

--- a/ui/apps/platform/src/Containers/Network/GraphLoadErrorState.tsx
+++ b/ui/apps/platform/src/Containers/Network/GraphLoadErrorState.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Flex, FlexItem, Text } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+
+type GraphLoadErrorStateProps = {
+    /** The direct error message returned from the server */
+    error: string;
+    /** A user friendly message to describe how to resolve the error */
+    userMessage: string;
+};
+
+function GraphLoadErrorState({ error, userMessage }: GraphLoadErrorStateProps) {
+    return (
+        <Flex className="pf-u-flex-grow-1 pf-u-pt-2xl">
+            <FlexItem grow={{ default: 'grow' }}>
+                <EmptyStateTemplate
+                    headingLevel="h2"
+                    title="An error has prevented the Network Graph from loading."
+                    icon={ExclamationCircleIcon}
+                >
+                    <Text className="pf-u-font-weight-bold">{error}</Text>
+                    <Text className="pf-u-mt-lg">{userMessage}</Text>
+                </EmptyStateTemplate>
+            </FlexItem>
+        </Flex>
+    );
+}
+
+export default GraphLoadErrorState;

--- a/ui/apps/platform/src/Containers/Network/GraphLoadErrorState.tsx
+++ b/ui/apps/platform/src/Containers/Network/GraphLoadErrorState.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flex, FlexItem, Text } from '@patternfly/react-core';
+import { capitalize, Flex, FlexItem, Text, Title } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
@@ -14,13 +14,13 @@ type GraphLoadErrorStateProps = {
 function GraphLoadErrorState({ error, userMessage }: GraphLoadErrorStateProps) {
     return (
         <Flex className="pf-u-flex-grow-1 pf-u-pt-2xl">
-            <FlexItem grow={{ default: 'grow' }}>
+            <FlexItem className="pf-u-color-100" grow={{ default: 'grow' }}>
                 <EmptyStateTemplate
                     headingLevel="h2"
                     title="An error has prevented the Network Graph from loading."
                     icon={ExclamationCircleIcon}
                 >
-                    <Text className="pf-u-font-weight-bold">{error}</Text>
+                    <Title headingLevel="h3">{capitalize(error)}</Title>
                     <Text className="pf-u-mt-lg">{userMessage}</Text>
                 </EmptyStateTemplate>
             </FlexItem>

--- a/ui/apps/platform/src/Containers/Network/Page.js
+++ b/ui/apps/platform/src/Containers/Network/Page.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { useRouteMatch } from 'react-router-dom';
-import { createSelector, createStructuredSelector } from 'reselect';
+import { createStructuredSelector } from 'reselect';
 
 import { selectors } from 'reducers';
 import useLocalStorage from 'hooks/useLocalStorage';
@@ -18,8 +18,10 @@ import Graph from 'Containers/Network/Graph/Graph';
 import SidePanel from 'Containers/Network/SidePanel/SidePanel';
 import SimulationFrame from 'Components/SimulationFrame';
 import { fetchDeployment } from 'services/DeploymentsService';
+import { getErrorMessageFromServerResponse } from 'utils/networkGraphUtils';
 import Header from './Header/Header';
 import NoSelectedNamespace from './NoSelectedNamespace';
+import GraphLoadErrorState from './GraphLoadErrorState';
 
 function GraphFrame() {
     const [showNamespaceFlows, setShowNamespaceFlows] = useLocalStorage(
@@ -74,7 +76,13 @@ const networkPageContentSelector = createStructuredSelector({
     selectedNamespaceFilters: selectors.getSelectedNamespaceFilters,
 });
 
-function NetworkPage({ closeSidePanel, setDialogueStage, setNetworkModification }) {
+function NetworkPage({
+    getNetworkFlowGraphState,
+    serverErrorMessage,
+    closeSidePanel,
+    setDialogueStage,
+    setNetworkModification,
+}) {
     const { isNetworkSimulationOn } = useNetworkPolicySimulation();
     const { isBaselineSimulationOn } = useNetworkBaselineSimulation();
     const isSimulationOn = isNetworkSimulationOn || isBaselineSimulationOn;
@@ -120,20 +128,28 @@ function NetworkPage({ closeSidePanel, setDialogueStage, setNetworkModification 
         };
     }, [closeSidePanel, setDialogueStage, setNetworkModification]);
 
-    const isGraphDisabled = selectedNamespaceFilters.length === 0;
+    const hasNoSelectedNamespace = selectedNamespaceFilters.length === 0;
+    const hasGraphLoadError = getNetworkFlowGraphState === 'ERROR';
+
+    let content;
+    if (hasNoSelectedNamespace) {
+        content = <NoSelectedNamespace clusterName={clusterName} />;
+    } else if (hasGraphLoadError) {
+        const userMessage = getErrorMessageFromServerResponse(serverErrorMessage);
+        content = <GraphLoadErrorState error={serverErrorMessage} userMessage={userMessage} />;
+    } else {
+        content = <GraphFrame />;
+    }
 
     return (
         <>
-            <Header isGraphDisabled={isGraphDisabled} isSimulationOn={isSimulationOn} />
+            <Header
+                isGraphDisabled={hasNoSelectedNamespace || hasGraphLoadError}
+                isSimulationOn={isSimulationOn}
+            />
             <section className="flex flex-1 h-full w-full">
                 <div className="flex flex-1 flex-col w-full overflow-hidden">
-                    <div className="flex flex-1 flex-col relative">
-                        {isGraphDisabled ? (
-                            <NoSelectedNamespace clusterName={clusterName} />
-                        ) : (
-                            <GraphFrame />
-                        )}
-                    </div>
+                    <div className="flex flex-1 flex-col relative">{content}</div>
                 </div>
                 <Dialogue />
             </section>
@@ -141,13 +157,9 @@ function NetworkPage({ closeSidePanel, setDialogueStage, setNetworkModification 
     );
 }
 
-const isViewFiltered = createSelector(
-    [selectors.getNetworkSearchOptions],
-    (searchOptions) => searchOptions.length !== 0
-);
-
 const mapStateToProps = createStructuredSelector({
-    isViewFiltered,
+    getNetworkFlowGraphState: selectors.getNetworkFlowGraphState,
+    serverErrorMessage: selectors.getNetworkFlowErrorMessage,
 });
 
 const mapDispatchToProps = {

--- a/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/Simulator.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/Simulator.tsx
@@ -61,7 +61,7 @@ function Simulator({
 }
 
 const mapStateToProps = createStructuredSelector({
-    errorMessage: selectors.getNetworkErrorMessage,
+    errorMessage: selectors.getNetworkPolicyErrorMessage,
     modificationState: selectors.getNetworkPolicyModificationState,
     policyGraphState: selectors.getNetworkPolicyGraphState,
 });

--- a/ui/apps/platform/src/reducers/network/backend.js
+++ b/ui/apps/platform/src/reducers/network/backend.js
@@ -38,10 +38,24 @@ const nodeUpdatesEpoch = (state = null, action) => {
     return state;
 };
 
-const networkErrorMessage = (state = '', action) => {
+const networkPolicyErrorMessage = (state = '', action) => {
     if (action.type === types.FETCH_NETWORK_POLICY_GRAPH.FAILURE) {
         const { message } = action.error.response.data;
         return message;
+    }
+    if (action.type === types.FETCH_NETWORK_POLICY_GRAPH.SUCCESS) {
+        return '';
+    }
+    return state;
+};
+
+const networkFlowErrorMessage = (state = '', action) => {
+    if (action.type === types.FETCH_NETWORK_FLOW_GRAPH.FAILURE) {
+        const { message } = action.error.response.data;
+        return message;
+    }
+    if (action.type === types.FETCH_NETWORK_FLOW_GRAPH.SUCCESS) {
+        return '';
     }
     return state;
 };
@@ -91,7 +105,8 @@ const networkPolicyApplicationState = (state = 'INITIAL', action) => {
 const reducer = combineReducers({
     networkPolicyGraph,
     nodeUpdatesEpoch,
-    networkErrorMessage,
+    networkPolicyErrorMessage,
+    networkFlowErrorMessage,
     networkPolicyGraphState,
     networkFlowGraphState,
     networkPolicyApplicationState,
@@ -101,7 +116,8 @@ const reducer = combineReducers({
 
 const getNetworkPolicyGraph = (state) => state.networkPolicyGraph;
 const getNodeUpdatesEpoch = (state) => state.nodeUpdatesEpoch;
-const getNetworkErrorMessage = (state) => state.networkErrorMessage;
+const getNetworkPolicyErrorMessage = (state) => state.networkPolicyErrorMessage;
+const getNetworkFlowErrorMessage = (state) => state.networkFlowErrorMessage;
 const getNetworkPolicyGraphState = (state) => state.networkPolicyGraphState;
 const getNetworkFlowGraphState = (state) => state.networkFlowGraphState;
 const getNetworkPolicyApplicationState = (state) => state.networkPolicyApplicationState;
@@ -109,7 +125,8 @@ const getNetworkPolicyApplicationState = (state) => state.networkPolicyApplicati
 export const selectors = {
     getNetworkPolicyGraph,
     getNodeUpdatesEpoch,
-    getNetworkErrorMessage,
+    getNetworkPolicyErrorMessage,
+    getNetworkFlowErrorMessage,
     getNetworkPolicyGraphState,
     getNetworkFlowGraphState,
     getNetworkPolicyApplicationState,

--- a/ui/apps/platform/src/sagas/networkSagas.js
+++ b/ui/apps/platform/src/sagas/networkSagas.js
@@ -29,50 +29,70 @@ import timeWindowToDate from 'utils/timeWindows';
 import queryService from 'utils/queryService';
 import { filterModes } from 'constants/networkFilterModes';
 
-// get generators
+function* getFlowGraph(clusterId, namespaces, query, timeWindow, includePorts) {
+    let flowGraph;
+    try {
+        flowGraph = (yield call(
+            service.fetchNetworkFlowGraph,
+            clusterId,
+            namespaces,
+            query,
+            timeWindowToDate(timeWindow),
+            includePorts
+        )).response;
+    } catch (error) {
+        yield put(backendNetworkActions.fetchNetworkFlowGraph.failure(error));
+    }
+
+    return flowGraph;
+}
+
+function* getPolicyGraph(clusterId, namespaces, query, modification, includePorts) {
+    let policyGraph;
+    try {
+        policyGraph = (yield call(
+            service.fetchNetworkPolicyGraph,
+            clusterId,
+            namespaces,
+            query,
+            modification,
+            includePorts
+        )).response;
+    } catch (error) {
+        // On error, such as when an applied yaml is invalid, attempt to revert to the
+        // previous successful policyGraph response
+        yield put(notificationActions.addNotification(error.response.data.error));
+        yield put(notificationActions.removeOldestNotification());
+        policyGraph = yield select(selectors.getNetworkPolicyGraph);
+    }
+
+    return policyGraph;
+}
+
 function* getNetworkGraphs(clusterId, namespaces, query) {
     // Do not query the backend for network graph updates if no namespace is selected
     if (!namespaces.length) {
         return;
     }
 
-    try {
-        const timeWindow = yield select(selectors.getNetworkActivityTimeWindow);
-        const modification = yield select(selectors.getNetworkPolicyModification);
+    const timeWindow = yield select(selectors.getNetworkActivityTimeWindow);
+    const modification = yield select(selectors.getNetworkPolicyModification);
 
-        const includePorts = true;
+    const flowGraph = yield getFlowGraph(clusterId, namespaces, query, timeWindow, true);
+    const policyGraph = yield getPolicyGraph(clusterId, namespaces, query, modification, true);
 
-        const [{ response: flowGraph }, { response: policyGraph }] = yield all([
-            call(
-                service.fetchNetworkFlowGraph,
-                clusterId,
-                namespaces,
-                query,
-                timeWindowToDate(timeWindow),
-                includePorts
-            ),
-            call(
-                service.fetchNetworkPolicyGraph,
-                clusterId,
-                namespaces,
-                query,
-                modification,
-                includePorts
-            ),
-        ]);
+    if (flowGraph) {
+        yield put(backendNetworkActions.fetchNetworkFlowGraph.success(flowGraph));
+    }
+
+    if (policyGraph) {
+        yield put(backendNetworkActions.fetchNetworkPolicyGraph.success(policyGraph));
+    }
+
+    if (policyGraph && flowGraph) {
         yield put(graphNetworkActions.setNetworkEdgeMap(flowGraph, policyGraph));
         yield put(graphNetworkActions.setNetworkNodeMap(flowGraph, policyGraph));
         yield put(graphNetworkActions.updateNetworkGraphTimestamp(new Date()));
-        yield put(backendNetworkActions.fetchNetworkPolicyGraph.success(policyGraph));
-        yield put(backendNetworkActions.fetchNetworkFlowGraph.success(flowGraph));
-    } catch (error) {
-        yield put(notificationActions.addNotification(error.response.data.error));
-        yield put(notificationActions.removeOldestNotification());
-        // if network flow graph fails
-        const policyGraph = yield select(selectors.getNetworkPolicyGraph);
-        if (policyGraph) {
-            yield put(backendNetworkActions.fetchNetworkPolicyGraph.success(policyGraph));
-        }
     }
 }
 

--- a/ui/apps/platform/src/sagas/networkSagas.js
+++ b/ui/apps/platform/src/sagas/networkSagas.js
@@ -91,11 +91,11 @@ function* getNetworkGraphs(clusterId, namespaces, query) {
     );
 
     if (policyGraph && flowGraph) {
-        yield put(backendNetworkActions.fetchNetworkFlowGraph.success(flowGraph));
-        yield put(backendNetworkActions.fetchNetworkPolicyGraph.success(policyGraph));
         yield put(graphNetworkActions.setNetworkEdgeMap(flowGraph, policyGraph));
         yield put(graphNetworkActions.setNetworkNodeMap(flowGraph, policyGraph));
         yield put(graphNetworkActions.updateNetworkGraphTimestamp(new Date()));
+        yield put(backendNetworkActions.fetchNetworkFlowGraph.success(flowGraph));
+        yield put(backendNetworkActions.fetchNetworkPolicyGraph.success(policyGraph));
     } else if (policyGraph) {
         yield put(backendNetworkActions.fetchNetworkPolicyGraph.success(policyGraph));
     }

--- a/ui/apps/platform/src/sagas/networkSagas.js
+++ b/ui/apps/platform/src/sagas/networkSagas.js
@@ -78,8 +78,15 @@ function* getNetworkGraphs(clusterId, namespaces, query) {
     const timeWindow = yield select(selectors.getNetworkActivityTimeWindow);
     const modification = yield select(selectors.getNetworkPolicyModification);
 
-    const flowGraph = yield getFlowGraph(clusterId, namespaces, query, timeWindow, true);
-    const policyGraph = yield getPolicyGraph(clusterId, namespaces, query, modification, true);
+    const flowGraph = yield call(getFlowGraph, clusterId, namespaces, query, timeWindow, true);
+    const policyGraph = yield call(
+        getPolicyGraph,
+        clusterId,
+        namespaces,
+        query,
+        modification,
+        true
+    );
 
     if (flowGraph) {
         yield put(backendNetworkActions.fetchNetworkFlowGraph.success(flowGraph));

--- a/ui/apps/platform/src/utils/networkGraphUtils.js
+++ b/ui/apps/platform/src/utils/networkGraphUtils.js
@@ -1268,3 +1268,24 @@ export function getIsNodeHoverable(type) {
         type === nodeTypes.CIDR_BLOCK
     );
 }
+
+/**
+ * Attempt to get a more descriptive error message based on the text of the server
+ * response, otherwise return a standard error message.
+ *
+ * @param {string} serverError The error message sent from the server.
+ * @param {string=} defaultMessage A default message to use as a fallback for non-specific error cases.
+ *
+ * @returns {string} The user facing error message to display.
+ */
+export function getErrorMessageFromServerResponse(
+    serverError,
+    defaultMessage = 'Please refresh the page. If this problem continues, please contact support.'
+) {
+    // Attempt to detect scale issues from the server error. This typically occurs when filters
+    // are selected that create a graph too large for the backend to calculate efficiently.
+    if (serverError.includes('exceeds maximum')) {
+        return 'To reload the graph, try updating the filters at the top of the page.';
+    }
+    return defaultMessage;
+}


### PR DESCRIPTION
## Description

This changes the behavior of the Network Graph so that errors sent from the server on flow graph (`/networkgraph/`) requests cause the graph to stop rendering and display an error message. The previous behavior was to display a toast with the error message while continuing to render the graph. This would result in a rendering that may be inaccurate, as the latest fetch from the server had failed.

The new behavior is to replace the graph rendering with the error state display until a successful request has been returned from the server. The toast message is no longer displayed when an error occurs.

Previously, error handling on the network graph page was based only on a [failure of the policy graph](https://github.com/stackrox/stackrox/pull/1415/files#diff-714e7b67bf8421defcbec33cd521f8162fa0f9e8bf3ba76739875a26a8ab93bdR41) request, failures of the flow graph were ignored. The new behavior separates error handling for the two requests:

- Errors in flow graph requests will now stop the rendering of the graph and display the error component (e.g. the server responds with a 500 error due to too many nodes)
- Errors in policy graph requests will allow rendering to continue using the most recent successful policy graph, but pop up a toast message with the most recent error (e.g. A simulated network policy was provided with an invalid yaml patch)


## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added

If any of these don't apply, please comment below.

## Testing Performed

A recent change to the backend will return an error message if a request attempts to render the graph with > 2000 nodes. This value is configurable via environment variable. For the below tests I set a very low number on this threshold so that this could be tested against a gke-default cluster:

```bash
# use a persistent volume for the `central` database so that it will persist when the pod is recreated
STORAGE=pvc yarn deploy-local
kubectl -n stackrox set env deployment central ROX_MAX_DEPLOYMENTS_NETWORK_GRAPH=10
```

Test that clean visit to the Network Graph page displays the "select namespace" component.
![image](https://user-images.githubusercontent.com/1292638/165130750-f0fa0646-65c4-4d84-9dde-1565342785ce.png)

Test that the graph renders normally when no errors occur:
![image](https://user-images.githubusercontent.com/1292638/165130932-5954a3a8-b9a7-4cd2-9205-45563e651dee.png)

Test that an error in a request removes the display of the graph, replacing it with an error screen. This error state should also disable the CIDR and Net Simulator buttons.
![image](https://user-images.githubusercontent.com/1292638/165131079-826a1c40-b489-4104-ba5e-7d59dbd4b85a.png)

Test that a change in state that results in a successful network request renders the graph with the correct data:
![image](https://user-images.githubusercontent.com/1292638/165131274-8450cd74-c8b6-4bd2-9bb9-aa44083fe31c.png)

Test that an error in a policy graph request continues to render the graph, but displays a toast message with the error:
![image](https://user-images.githubusercontent.com/1292638/165316613-186edaeb-2873-4921-93d0-c98ea694a51a.png)


