### PR TITLE
ROX-10307: Converting Policy Import utils to typescript

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Modal/DuplicatePolicyForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/DuplicatePolicyForm.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, ReactElement } from 'react';
 import { Form, Radio } from '@patternfly/react-core';
 import { Field } from 'formik';
 
-import { POLICY_DUPE_ACTIONS } from './PolicyImport.utils';
 import RenamePolicySection from './RenamePolicySection';
 import KeepBothSection from './KeepBothSection';
 
@@ -48,12 +47,8 @@ function DuplicatePolicyForm({
                         value="overwrite"
                         label="Overwrite existing policy"
                         id="policy-overwrite-radio-1"
-                        isChecked={field.value === POLICY_DUPE_ACTIONS.OVERWRITE}
-                        onChange={changeRadio(
-                            field.onChange,
-                            field.name,
-                            POLICY_DUPE_ACTIONS.OVERWRITE
-                        )}
+                        isChecked={field.value === 'overwrite'}
+                        onChange={changeRadio(field.onChange, field.name, 'overwrite')}
                     />
                 )}
             </Field>

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModal.tsx
@@ -2,25 +2,20 @@ import React, { ReactElement, useState } from 'react';
 import { Modal, ModalVariant } from '@patternfly/react-core';
 
 import { importPolicies } from 'services/PoliciesService';
-import { ListPolicy } from 'types/policy.proto';
+import { Policy } from 'types/policy.proto';
 import {
     parsePolicyImportErrors,
     getResolvedPolicies,
     getErrorMessages,
     checkDupeOnlyErrors,
+    PolicyImportDuplicateError,
+    PolicyResolution,
 } from './PolicyImport.utils';
 import ImportPolicyJSONSuccess from './ImportPolicyJSONSuccess';
 import ImportPolicyJSONModalError from './ImportPolicyJSONModalError';
 import ImportPolicyJSONUpload from './ImportPolicyJSONUpload';
 
-const RESOLUTION = { resolution: '', newName: '' };
-
-type DuplicateErrors = {
-    type: string;
-    incomingName: string;
-    incomingId: string;
-    duplicateName: string;
-};
+const RESOLUTION = { resolution: null, newName: '' };
 
 type ImportPolicyJSONModalType = 'upload' | 'success' | 'error';
 
@@ -35,9 +30,9 @@ function ImportPolicyJSONModal({
     isOpen,
     fetchPoliciesWithQuery,
 }: ImportPolicyJSONModalProps): ReactElement {
-    const [policies, setPolicies] = useState<ListPolicy[]>([]);
-    const [duplicateErrors, setDuplicateErrors] = useState<DuplicateErrors[]>([]);
-    const [duplicateResolution, setDuplicateResolution] = useState(RESOLUTION);
+    const [policies, setPolicies] = useState<Policy[]>([]);
+    const [duplicateErrors, setDuplicateErrors] = useState<PolicyImportDuplicateError[]>([]);
+    const [duplicateResolution, setDuplicateResolution] = useState<PolicyResolution>(RESOLUTION);
     const [modalType, setModalType] = useState<ImportPolicyJSONModalType>('upload');
     const [errorMessages, setErrorMessages] = useState<string[]>([]);
 
@@ -66,9 +61,7 @@ function ImportPolicyJSONModal({
                     if (onlyHasDupeErrors) {
                         setDuplicateErrors(errors[0]);
                     }
-                    const errorMessageArray = getErrorMessages(errors[0]).map(
-                        ({ msg }) => msg as string
-                    );
+                    const errorMessageArray = getErrorMessages(errors[0]).map(({ msg }) => msg);
                     setErrorMessages(errorMessageArray);
                     setModalType('error');
                 }

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModal.tsx
@@ -8,7 +8,7 @@ import {
     getResolvedPolicies,
     getErrorMessages,
     checkDupeOnlyErrors,
-    PolicyImportDuplicateError,
+    PolicyImportError,
     PolicyResolution,
 } from './PolicyImport.utils';
 import ImportPolicyJSONSuccess from './ImportPolicyJSONSuccess';
@@ -31,7 +31,7 @@ function ImportPolicyJSONModal({
     fetchPoliciesWithQuery,
 }: ImportPolicyJSONModalProps): ReactElement {
     const [policies, setPolicies] = useState<Policy[]>([]);
-    const [duplicateErrors, setDuplicateErrors] = useState<PolicyImportDuplicateError[]>([]);
+    const [duplicateErrors, setDuplicateErrors] = useState<PolicyImportError[]>([]);
     const [duplicateResolution, setDuplicateResolution] = useState<PolicyResolution>(RESOLUTION);
     const [modalType, setModalType] = useState<ImportPolicyJSONModalType>('upload');
     const [errorMessages, setErrorMessages] = useState<string[]>([]);

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModalError.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModalError.tsx
@@ -6,28 +6,22 @@ import * as yup from 'yup';
 import { ListPolicy } from 'types/policy.proto';
 import {
     MIN_POLICY_NAME_LENGTH,
-    POLICY_DUPE_ACTIONS,
     hasDuplicateIdOnly,
     checkForBlockedSubmit,
+    PolicyImportDuplicateError,
+    PolicyResolution,
 } from './PolicyImport.utils';
 import DuplicatePolicyForm from './DuplicatePolicyForm';
 
 const RESOLUTION = { resolution: '', newName: '' };
 
-type DuplicateErrors = {
-    type: string;
-    incomingName: string;
-    incomingId: string;
-    duplicateName: string;
-};
-
 type ImportPolicyJSONErrorProps = {
     handleCancelModal: () => void;
     startImportPolicies: () => void;
     policies: ListPolicy[];
-    duplicateErrors: DuplicateErrors[];
+    duplicateErrors: PolicyImportDuplicateError[];
     errorMessages: string[];
-    duplicateResolution: { resolution: string; newName: string };
+    duplicateResolution: PolicyResolution;
     setDuplicateResolution: (duplicateResolution) => void;
 };
 
@@ -59,7 +53,7 @@ function ImportPolicyJSONError({
             onSubmit={() => {}}
             validationSchema={yup.object({
                 newName: yup.string().when('resolution', {
-                    is: POLICY_DUPE_ACTIONS.RENAME,
+                    is: 'rename',
                     then: (newNameSchema) =>
                         newNameSchema
                             .trim()

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModalError.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModalError.tsx
@@ -3,12 +3,12 @@ import { Button, ModalBoxBody, ModalBoxFooter, Alert } from '@patternfly/react-c
 import { Formik } from 'formik';
 import * as yup from 'yup';
 
-import { ListPolicy } from 'types/policy.proto';
+import { Policy } from 'types/policy.proto';
 import {
     MIN_POLICY_NAME_LENGTH,
     hasDuplicateIdOnly,
     checkForBlockedSubmit,
-    PolicyImportDuplicateError,
+    PolicyImportError,
     PolicyResolution,
 } from './PolicyImport.utils';
 import DuplicatePolicyForm from './DuplicatePolicyForm';
@@ -18,8 +18,8 @@ const RESOLUTION = { resolution: '', newName: '' };
 type ImportPolicyJSONErrorProps = {
     handleCancelModal: () => void;
     startImportPolicies: () => void;
-    policies: ListPolicy[];
-    duplicateErrors: PolicyImportDuplicateError[];
+    policies: Policy[];
+    duplicateErrors: PolicyImportError[];
     errorMessages: string[];
     duplicateResolution: PolicyResolution;
     setDuplicateResolution: (duplicateResolution) => void;

--- a/ui/apps/platform/src/Containers/Policies/Modal/KeepBothSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/KeepBothSection.tsx
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import { Field } from 'formik';
 import { Radio } from '@patternfly/react-core';
 
-import { POLICY_DUPE_ACTIONS } from './PolicyImport.utils';
-
 const KeepBothSection = ({ changeRadio }) => {
     return (
         <Field name="resolution">
@@ -13,12 +11,8 @@ const KeepBothSection = ({ changeRadio }) => {
                     name={field.name}
                     id="keep-both-radio"
                     value="keepBoth"
-                    checked={field.value === POLICY_DUPE_ACTIONS.KEEP_BOTH}
-                    onChange={changeRadio(
-                        field.onChange,
-                        field.name,
-                        POLICY_DUPE_ACTIONS.KEEP_BOTH
-                    )}
+                    checked={field.value === 'keepBoth'}
+                    onChange={changeRadio(field.onChange, field.name, 'keepBoth')}
                     label="Keep both policies (imported policy will be assigned a new ID)"
                 />
             )}

--- a/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.test.ts
@@ -1,13 +1,18 @@
 // system under test (SUT)
 import {
-    POLICY_DUPE_ACTIONS,
     parsePolicyImportErrors,
     isDuplicateResolved,
     getResolvedPolicies,
     getErrorMessages,
     hasDuplicateIdOnly,
     checkForBlockedSubmit,
-} from './PolicyImport.utils';
+    PolicyImportError,
+    PolicyResolutionType,
+    PolicyImportErrorDuplicateName,
+    PolicyImportErrorDuplicateId,
+    PolicyImportErrorInvalidPolicy,
+} from '@stackrox/platform-app/src/Containers/Policies/Modal/PolicyImport.utils';
+import { ImportPoliciesResponse, ImportPolicyError } from '@stackrox/platform-app/src/services/PoliciesService';
 
 describe('PolicyImport.utils', () => {
     describe('parsePolicyImportErrors', () => {
@@ -24,16 +29,14 @@ describe('PolicyImport.utils', () => {
             const response = getPolicy(errors);
 
             const errorList = parsePolicyImportErrors(response.responses);
+            const duplicateName = response.responses[0].errors[0].type === 'duplicate_name' ? response.responses[0].errors[0].duplicateName : null;
 
             expect(errorList).toEqual([
                 [
                     {
-                        duplicateName: response.responses[0].errors[0].duplicateName,
-                        incomingId: response.responses[0].policy.id,
-                        incomingName: response.responses[0].policy.name,
+                        duplicateName: duplicateName,
                         type: 'duplicate_name',
                         message: 'Could not add policy due to name validation',
-                        validationError: null,
                     },
                 ],
             ]);
@@ -44,17 +47,17 @@ describe('PolicyImport.utils', () => {
             const response = getPolicy(errors);
 
             const errorList = parsePolicyImportErrors(response.responses);
+            const duplicateName = response.responses[0].errors[0].type === 'duplicate_id' ? response.responses[0].errors[0].duplicateName : null;
 
             expect(errorList).toEqual([
                 [
                     {
-                        duplicateName: response.responses[0].errors[0].duplicateName,
+                        duplicateName: duplicateName,
                         incomingId: response.responses[0].policy.id,
                         incomingName: response.responses[0].policy.name,
                         type: 'duplicate_id',
                         message:
                             'Policy Fixable CVSS >= 9 (f09f8da1-6111-4ca0-8f49-294a76c65117) cannot be added because it already exists',
-                        validationError: null,
                     },
                 ],
             ]);
@@ -65,25 +68,22 @@ describe('PolicyImport.utils', () => {
             const response = getPolicy(errors);
 
             const errorList = parsePolicyImportErrors(response.responses);
+            const duplicateName = response.responses[0].errors[0].type === 'duplicate_name' ? response.responses[0].errors[0].duplicateName : null;
 
             expect(errorList).toEqual([
                 [
                     {
-                        duplicateName: response.responses[0].errors[0].duplicateName,
-                        incomingId: response.responses[0].policy.id,
-                        incomingName: response.responses[0].policy.name,
+                        duplicateName: duplicateName,
                         type: 'duplicate_name',
                         message: 'Could not add policy due to name validation',
-                        validationError: null,
                     },
                     {
-                        duplicateName: response.responses[0].errors[0].duplicateName,
+                        duplicateName: duplicateName,
                         incomingId: response.responses[0].policy.id,
                         incomingName: response.responses[0].policy.name,
                         type: 'duplicate_id',
                         message:
                             'Policy Fixable CVSS >= 9 (f09f8da1-6111-4ca0-8f49-294a76c65117) cannot be added because it already exists',
-                        validationError: null,
                     },
                 ],
             ]);
@@ -92,7 +92,7 @@ describe('PolicyImport.utils', () => {
 
     describe('isDuplicateResolved', () => {
         it('should return false for a pristine (yet-to-be-resolved) object', () => {
-            const resolutionObj = { resolution: '', newName: '' };
+            const resolutionObj = { resolution: null, newName: '' };
 
             const isResolved = isDuplicateResolved(resolutionObj);
 
@@ -100,7 +100,7 @@ describe('PolicyImport.utils', () => {
         });
 
         it('should return false if rename is chosen, but name is empty', () => {
-            const resolutionObj = { resolution: POLICY_DUPE_ACTIONS.RENAME, newName: '' };
+            const resolutionObj = { resolution: 'rename' as PolicyResolutionType, newName: '' };
 
             const isResolved = isDuplicateResolved(resolutionObj);
 
@@ -108,7 +108,7 @@ describe('PolicyImport.utils', () => {
         });
 
         it('should return false if rename is chosen, but name is too short', () => {
-            const resolutionObj = { resolution: POLICY_DUPE_ACTIONS.RENAME, newName: '1234' };
+            const resolutionObj = { resolution: 'rename' as PolicyResolutionType, newName: '1234' };
 
             const isResolved = isDuplicateResolved(resolutionObj);
 
@@ -116,7 +116,7 @@ describe('PolicyImport.utils', () => {
         });
 
         it('should return true if rename is chosen, and name is minimum length', () => {
-            const resolutionObj = { resolution: POLICY_DUPE_ACTIONS.RENAME, newName: '12345' };
+            const resolutionObj = { resolution: 'rename' as PolicyResolutionType, newName: '12345' };
 
             const isResolved = isDuplicateResolved(resolutionObj);
 
@@ -124,7 +124,7 @@ describe('PolicyImport.utils', () => {
         });
 
         it('should return true if overwrite is chosen', () => {
-            const resolutionObj = { resolution: POLICY_DUPE_ACTIONS.OVERWRITE, newName: '' };
+            const resolutionObj = { resolution: 'overwrite' as PolicyResolutionType, newName: '' };
 
             const isResolved = isDuplicateResolved(resolutionObj);
 
@@ -148,7 +148,8 @@ describe('PolicyImport.utils', () => {
                     incomingId: '1234-5678-9012-3456',
                     incomingName: 'A policy name',
                     type: 'duplicate_name',
-                },
+                    message: '',
+                } as PolicyImportErrorDuplicateName,
             ];
 
             const errStr = getErrorMessages(policyErrors);
@@ -168,7 +169,8 @@ describe('PolicyImport.utils', () => {
                     incomingId: '1234-5678-9012-3456',
                     incomingName: 'A policy name',
                     type: 'duplicate_id',
-                },
+                    message: '',
+                } as PolicyImportErrorDuplicateId,
             ];
 
             const errStr = getErrorMessages(policyErrors);
@@ -185,16 +187,14 @@ describe('PolicyImport.utils', () => {
             const policyErrors = [
                 {
                     duplicateName: 'A policy name',
-                    incomingId: '9876-5432-1098-7654',
-                    incomingName: 'A policy name',
                     type: 'duplicate_name',
-                },
+                } as PolicyImportErrorDuplicateName,
                 {
                     duplicateName: 'Another policy name',
                     incomingId: '1234-5678-9012-3456',
                     incomingName: 'A policy name',
                     type: 'duplicate_id',
-                },
+                } as PolicyImportErrorDuplicateId,
             ];
 
             const errStr = getErrorMessages(policyErrors);
@@ -214,13 +214,11 @@ describe('PolicyImport.utils', () => {
         it('should return a message for invalid policy error', () => {
             const policyErrors = [
                 {
-                    incomingId: '1234-5678-9012-3456',
-                    incomingName: 'A policy name',
                     type: 'invalid_policy',
                     message: 'Invalid policy',
                     validationError:
                         'policy invalid error: error validating lifecycle stage error: deploy time policy cannot contain runtime fields',
-                },
+                } as PolicyImportErrorInvalidPolicy,
             ];
 
             const errStr = getErrorMessages(policyErrors);
@@ -238,8 +236,8 @@ describe('PolicyImport.utils', () => {
         it('should just return the policies array as-is if there are no errors', () => {
             const response = getPolicy();
             const policies = [response.responses[0].policy];
-            const errors = null;
-            const duplicateResolution = null;
+            const errors = [];
+            const duplicateResolution = { resolution: null, newName: '' };
 
             const [resolvedPolicies, metadata] = getResolvedPolicies(
                 policies,
@@ -248,7 +246,7 @@ describe('PolicyImport.utils', () => {
             );
 
             expect(resolvedPolicies).toEqual(policies);
-            expect(metadata).toEqual({});
+            expect(metadata).toEqual({ overwrite: false });
         });
 
         it('should return metadata object with overwrite, if errors are present and overwrite is selected', () => {
@@ -257,12 +255,10 @@ describe('PolicyImport.utils', () => {
             const errors = [
                 {
                     duplicateName: 'A policy name',
-                    incomingId: '9876-5432-1098-7654',
-                    incomingName: 'A policy name',
                     type: 'duplicate_name',
-                },
+                } as PolicyImportErrorDuplicateName,
             ];
-            const duplicateResolution = { resolution: POLICY_DUPE_ACTIONS.OVERWRITE, newName: '' };
+            const duplicateResolution = { resolution: 'overwrite' as PolicyResolutionType, newName: '' };
 
             const [resolvedPolicies, metadata] = getResolvedPolicies(
                 policies,
@@ -282,13 +278,11 @@ describe('PolicyImport.utils', () => {
             const errors = [
                 {
                     duplicateName: 'A policy name',
-                    incomingId: '9876-5432-1098-7654',
-                    incomingName: 'A policy name',
                     type: 'duplicate_name',
-                },
+                } as PolicyImportErrorDuplicateName,
             ];
             const duplicateResolution = {
-                resolution: POLICY_DUPE_ACTIONS.RENAME,
+                resolution: 'rename' as PolicyResolutionType,
                 newName: coolNewName,
             };
 
@@ -300,7 +294,7 @@ describe('PolicyImport.utils', () => {
 
             expect(resolvedPolicies[0].name).toEqual(coolNewName);
             expect(resolvedPolicies[0].id).toEqual(policies[0].id);
-            expect(metadata).toEqual({});
+            expect(metadata).toEqual({ overwrite: false });
         });
 
         it('should return metadata object with rename, if name AND ID errors present and rename is selected', () => {
@@ -311,19 +305,17 @@ describe('PolicyImport.utils', () => {
             const errors = [
                 {
                     duplicateName: 'A policy name',
-                    incomingId: '9876-5432-1098-7654',
-                    incomingName: 'A policy name',
                     type: 'duplicate_name',
-                },
+                } as PolicyImportErrorDuplicateName,
                 {
                     duplicateName: 'Another policy name',
                     incomingId: '1234-5678-9012-3456',
                     incomingName: 'A policy name',
                     type: 'duplicate_id',
-                },
+                } as PolicyImportErrorDuplicateId,
             ];
             const duplicateResolution = {
-                resolution: POLICY_DUPE_ACTIONS.RENAME,
+                resolution: 'rename' as PolicyResolutionType,
                 newName: coolNewName,
             };
 
@@ -335,7 +327,7 @@ describe('PolicyImport.utils', () => {
 
             expect(resolvedPolicies[0].name).toEqual(coolNewName);
             expect(resolvedPolicies[0].id).toEqual('');
-            expect(metadata).toEqual({});
+            expect(metadata).toEqual({ overwrite: false });
         });
     });
 
@@ -349,7 +341,7 @@ describe('PolicyImport.utils', () => {
         });
 
         it('should return false if there is only a duplicate name error', () => {
-            const errors = [{ type: 'duplicate name', value: 'Really strict policy' }];
+            const errors = [{ type: 'duplicate_name', message: 'Really strict policy' } as PolicyImportErrorDuplicateName];
 
             const onlyDupeId = hasDuplicateIdOnly(errors);
 
@@ -363,7 +355,7 @@ describe('PolicyImport.utils', () => {
                     incomingId: '1234-5678-9012-3456',
                     incomingName: 'A policy name',
                     type: 'duplicate_id',
-                },
+                } as PolicyImportErrorDuplicateId,
             ];
 
             const onlyDupeId = hasDuplicateIdOnly(errors);
@@ -375,16 +367,14 @@ describe('PolicyImport.utils', () => {
             const errors = [
                 {
                     duplicateName: 'A policy name',
-                    incomingId: '9876-5432-1098-7654',
-                    incomingName: 'A policy name',
                     type: 'duplicate_name',
-                },
+                } as PolicyImportErrorDuplicateName,
                 {
                     duplicateName: 'Another policy name',
                     incomingId: '1234-5678-9012-3456',
                     incomingName: 'A policy name',
                     type: 'duplicate_id',
-                },
+                } as PolicyImportErrorDuplicateId,
             ];
 
             const onlyDupeId = hasDuplicateIdOnly(errors);
@@ -396,13 +386,13 @@ describe('PolicyImport.utils', () => {
     describe('checkForBlockedSubmit', () => {
         it('should return true if no policies selected yet', () => {
             const policies = [];
-            const messageObj = null;
+            const messageObj = { message: '', type: '' };
             const duplicateErrors = null;
-            const duplicateResolution = { resolution: '', newName: '' };
+            const duplicateResolution = { resolution: null, newName: '' };
 
             const isBlocked = checkForBlockedSubmit({
                 numPolicies: policies?.length || 0,
-                messageType: messageObj?.type,
+                messageType: messageObj.type,
                 hasDuplicateErrors: !!duplicateErrors,
                 duplicateResolution,
             });
@@ -412,9 +402,9 @@ describe('PolicyImport.utils', () => {
 
         it('should return false if nothing blocks policy submission', () => {
             const policies = [{ name: 'Snafu' }];
-            const messageObj = null;
+            const messageObj = { message: '', type: '' };
             const duplicateErrors = null;
-            const duplicateResolution = { resolution: '', newName: '' };
+            const duplicateResolution = { resolution: null, newName: '' };
 
             const isBlocked = checkForBlockedSubmit({
                 numPolicies: policies?.length || 0,
@@ -430,7 +420,7 @@ describe('PolicyImport.utils', () => {
             const policies = [{ name: 'Snafu' }];
             const messageObj = { type: 'info' };
             const duplicateErrors = null;
-            const duplicateResolution = { resolution: '', newName: '' };
+            const duplicateResolution = { resolution: null, newName: '' };
 
             const isBlocked = checkForBlockedSubmit({
                 numPolicies: policies?.length || 0,
@@ -446,7 +436,7 @@ describe('PolicyImport.utils', () => {
             const policies = [{ name: 'Snafu' }];
             const messageObj = { type: 'error' };
             const duplicateErrors = null;
-            const duplicateResolution = { resolution: '', newName: '' };
+            const duplicateResolution = { resolution: null, newName: '' };
 
             const isBlocked = checkForBlockedSubmit({
                 numPolicies: policies?.length || 0,
@@ -462,7 +452,7 @@ describe('PolicyImport.utils', () => {
             const policies = [{ name: 'CVE >= 7' }];
             const messageObj = { type: 'error' };
             const duplicateErrors = [{ dupeName: 'CVE >= 7' }];
-            const duplicateResolution = { resolution: '', newName: '' };
+            const duplicateResolution = { resolution: null, newName: '' };
 
             const isBlocked = checkForBlockedSubmit({
                 numPolicies: policies?.length || 0,
@@ -479,7 +469,7 @@ describe('PolicyImport.utils', () => {
             const messageObj = { type: 'error' };
             const duplicateErrors = [{ dupeName: 'CVE >= 7' }];
             const duplicateResolution = {
-                resolution: POLICY_DUPE_ACTIONS.OVERWRITE,
+                resolution: 'overwrite' as PolicyResolutionType,
                 newName: '',
             };
 
@@ -495,8 +485,8 @@ describe('PolicyImport.utils', () => {
     });
 });
 
-function getPolicy(errors = {}) {
-    const errorResponse = [];
+function getPolicy(errors: { id?: boolean; name?: boolean; } = {}): ImportPoliciesResponse {
+    const errorResponse = [] as ImportPolicyError[];
     if (errors.name) {
         errorResponse.push({
             message: 'Could not add policy due to name validation',
@@ -528,36 +518,6 @@ function getPolicy(errors = {}) {
                         'Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.',
                     disabled: false,
                     categories: ['Vulnerability Management'],
-                    fields: {
-                        imageName: null,
-                        lineRule: null,
-                        cvss: {
-                            op: 'GREATER_THAN_OR_EQUALS',
-                            value: 9,
-                        },
-                        cve: '',
-                        component: null,
-                        env: null,
-                        command: '',
-                        args: '',
-                        directory: '',
-                        user: '',
-                        volumePolicy: null,
-                        portPolicy: null,
-                        requiredLabel: null,
-                        requiredAnnotation: null,
-                        disallowedAnnotation: null,
-                        dropCapabilities: [],
-                        addCapabilities: [],
-                        containerResourcePolicy: null,
-                        processPolicy: null,
-                        fixedBy: '.*',
-                        portExposurePolicy: null,
-                        permissionPolicy: null,
-                        hostMountPolicy: null,
-                        requiredImageLabel: null,
-                        disallowedImageLabel: null,
-                    },
                     lifecycleStages: ['BUILD', 'DEPLOY'],
                     exclusions: [],
                     scope: [],
@@ -565,11 +525,19 @@ function getPolicy(errors = {}) {
                     enforcementActions: ['FAIL_BUILD_ENFORCEMENT'],
                     notifiers: [],
                     lastUpdated: null,
-                    SORTName: 'Fixable CVSS >= 9',
-                    SORTLifecycleStage: 'BUILD,DEPLOY',
-                    SORTEnforcement: true,
+                    SORT_name: 'Fixable CVSS >= 9',
+                    SORT_lifecycleStage: 'BUILD,DEPLOY',
+                    SORT_enforcement: true,
                     policyVersion: '',
                     policySections: [],
+                    mitreAttackVectors: [],
+                    excludedImageNames: [],
+                    excludedDeploymentScopes: [],
+                    isDefault: true,
+                    serverPolicySections: [],
+                    criteriaLocked: false,
+                    mitreVectorsLocked: false,
+                    eventSource: 'NOT_APPLICABLE',
                 },
                 errors: errorResponse,
             },

--- a/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.test.ts
@@ -1,4 +1,5 @@
 // system under test (SUT)
+import { ImportPoliciesResponse, ImportPolicyError } from 'services/PoliciesService';
 import {
     parsePolicyImportErrors,
     isDuplicateResolved,
@@ -6,13 +7,11 @@ import {
     getErrorMessages,
     hasDuplicateIdOnly,
     checkForBlockedSubmit,
-    PolicyImportError,
     PolicyResolutionType,
     PolicyImportErrorDuplicateName,
     PolicyImportErrorDuplicateId,
     PolicyImportErrorInvalidPolicy,
-} from '@stackrox/platform-app/src/Containers/Policies/Modal/PolicyImport.utils';
-import { ImportPoliciesResponse, ImportPolicyError } from '@stackrox/platform-app/src/services/PoliciesService';
+} from './PolicyImport.utils';
 
 describe('PolicyImport.utils', () => {
     describe('parsePolicyImportErrors', () => {
@@ -29,12 +28,15 @@ describe('PolicyImport.utils', () => {
             const response = getPolicy(errors);
 
             const errorList = parsePolicyImportErrors(response.responses);
-            const duplicateName = response.responses[0].errors[0].type === 'duplicate_name' ? response.responses[0].errors[0].duplicateName : null;
+            const duplicateName =
+                response.responses[0].errors[0].type === 'duplicate_name'
+                    ? response.responses[0].errors[0].duplicateName
+                    : null;
 
             expect(errorList).toEqual([
                 [
                     {
-                        duplicateName: duplicateName,
+                        duplicateName,
                         type: 'duplicate_name',
                         message: 'Could not add policy due to name validation',
                     },
@@ -47,12 +49,15 @@ describe('PolicyImport.utils', () => {
             const response = getPolicy(errors);
 
             const errorList = parsePolicyImportErrors(response.responses);
-            const duplicateName = response.responses[0].errors[0].type === 'duplicate_id' ? response.responses[0].errors[0].duplicateName : null;
+            const duplicateName =
+                response.responses[0].errors[0].type === 'duplicate_id'
+                    ? response.responses[0].errors[0].duplicateName
+                    : null;
 
             expect(errorList).toEqual([
                 [
                     {
-                        duplicateName: duplicateName,
+                        duplicateName,
                         incomingId: response.responses[0].policy.id,
                         incomingName: response.responses[0].policy.name,
                         type: 'duplicate_id',
@@ -68,17 +73,20 @@ describe('PolicyImport.utils', () => {
             const response = getPolicy(errors);
 
             const errorList = parsePolicyImportErrors(response.responses);
-            const duplicateName = response.responses[0].errors[0].type === 'duplicate_name' ? response.responses[0].errors[0].duplicateName : null;
+            const duplicateName =
+                response.responses[0].errors[0].type === 'duplicate_name'
+                    ? response.responses[0].errors[0].duplicateName
+                    : null;
 
             expect(errorList).toEqual([
                 [
                     {
-                        duplicateName: duplicateName,
+                        duplicateName,
                         type: 'duplicate_name',
                         message: 'Could not add policy due to name validation',
                     },
                     {
-                        duplicateName: duplicateName,
+                        duplicateName,
                         incomingId: response.responses[0].policy.id,
                         incomingName: response.responses[0].policy.name,
                         type: 'duplicate_id',
@@ -116,7 +124,10 @@ describe('PolicyImport.utils', () => {
         });
 
         it('should return true if rename is chosen, and name is minimum length', () => {
-            const resolutionObj = { resolution: 'rename' as PolicyResolutionType, newName: '12345' };
+            const resolutionObj = {
+                resolution: 'rename' as PolicyResolutionType,
+                newName: '12345',
+            };
 
             const isResolved = isDuplicateResolved(resolutionObj);
 
@@ -258,7 +269,10 @@ describe('PolicyImport.utils', () => {
                     type: 'duplicate_name',
                 } as PolicyImportErrorDuplicateName,
             ];
-            const duplicateResolution = { resolution: 'overwrite' as PolicyResolutionType, newName: '' };
+            const duplicateResolution = {
+                resolution: 'overwrite' as PolicyResolutionType,
+                newName: '',
+            };
 
             const [resolvedPolicies, metadata] = getResolvedPolicies(
                 policies,
@@ -341,7 +355,12 @@ describe('PolicyImport.utils', () => {
         });
 
         it('should return false if there is only a duplicate name error', () => {
-            const errors = [{ type: 'duplicate_name', message: 'Really strict policy' } as PolicyImportErrorDuplicateName];
+            const errors = [
+                {
+                    type: 'duplicate_name',
+                    message: 'Really strict policy',
+                } as PolicyImportErrorDuplicateName,
+            ];
 
             const onlyDupeId = hasDuplicateIdOnly(errors);
 
@@ -485,7 +504,7 @@ describe('PolicyImport.utils', () => {
     });
 });
 
-function getPolicy(errors: { id?: boolean; name?: boolean; } = {}): ImportPoliciesResponse {
+function getPolicy(errors: { id?: boolean; name?: boolean } = {}): ImportPoliciesResponse {
     const errorResponse = [] as ImportPolicyError[];
     if (errors.name) {
         errorResponse.push({

--- a/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.ts
@@ -3,19 +3,19 @@ import { ImportPolicyResponse } from 'services/PoliciesService';
 
 export const MIN_POLICY_NAME_LENGTH = 5;
 
-type PolicyImportErrorDuplicateName = {
+export type PolicyImportErrorDuplicateName = {
     type: 'duplicate_name';
     duplicateName: string;
 } & PolicyImportErrorBase;
 
-type PolicyImportErrorDuplicateId = {
+export type PolicyImportErrorDuplicateId = {
     type: 'duplicate_id';
     duplicateName: string;
     incomingName: string;
     incomingId: string;
 } & PolicyImportErrorBase;
 
-type PolicyImportErrorInvalidPolicy = {
+export type PolicyImportErrorInvalidPolicy = {
     type: 'invalid_policy';
     validationError: string;
 } & PolicyImportErrorBase;
@@ -69,8 +69,10 @@ export function parsePolicyImportErrors(responses: ImportPolicyResponse[]): Poli
     return errors;
 }
 
+export type PolicyResolutionType = 'rename' | 'overwrite' | 'keepBoth';
+
 export type PolicyResolution = {
-    resolution: 'rename' | 'overwrite' | 'keepBoth' | null;
+    resolution: PolicyResolutionType | null;
     newName: string;
 };
 

--- a/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.ts
@@ -1,26 +1,43 @@
+import { Policy } from 'types/policy.proto';
+
 export const MIN_POLICY_NAME_LENGTH = 5;
 
-export const POLICY_DUPE_ACTIONS = {
-    KEEP_BOTH: 'keepBoth',
-    RENAME: 'rename',
-    OVERWRITE: 'overwrite',
-};
+type PolicyImportError = {
+    type: string;
+    duplicateName: string;
+    validationError?: string;
+    message: string;
+}
+
+type PolicyImportResponse = { 
+    succeeded: boolean; 
+    policy?: {
+        name: string;
+        id: string;
+    }; 
+    errors?: PolicyImportError[];
+}
+
+type PolicyImportErrorListItem = {
+    type: string;
+    incomingName?: string;
+    incomingId?: string;
+    duplicateName: string;
+    validationError?: string | null;
+    message: string;
+}
 
 /**
  * parsePolicyImportErrors extracts any errors from the array of policies in the import, for ease-of-use in the UI
- *
- * @param   {array}  responses  a list of objects { succeeded: boolean, policy: object, errors: Array<object> }
- *
- * @return  {[array]}           Array< Array<{ type: string, incomingName: string, incomingId: string. duplicateName: string } > >
  */
-export function parsePolicyImportErrors(responses = []) {
-    const errors = responses.reduce((acc, res) => {
-        if (res?.errors?.length) {
-            const errorItems = res.errors.reduce((errList, err) => {
+export function parsePolicyImportErrors(responses: PolicyImportResponse[]): PolicyImportErrorListItem[][] {
+    const errors = responses.reduce((acc: PolicyImportErrorListItem[][], res) => {
+        if (res.errors?.length) {
+            const errorItems = res.errors.reduce((errList: PolicyImportErrorListItem[], err: PolicyImportError) => {
                 const thisErr = {
                     type: err.type,
-                    incomingName: res?.policy?.name,
-                    incomingId: res?.policy?.id,
+                    incomingName: res.policy?.name,
+                    incomingId: res.policy?.id,
                     duplicateName: err.duplicateName,
                     validationError: err?.validationError || null,
                     message: err.message,
@@ -37,32 +54,34 @@ export function parsePolicyImportErrors(responses = []) {
     return errors;
 }
 
+type PolicyResolution = {
+    resolution: 'rename'| 'overwrite' | 'keepBoth';
+    newName: string;
+}
+
 /**
  * isDuplicateResolved performs a check of the object for a Duplicate Policy Form,
  *   and determines if user has chosen a combination of inputs that will resolve
  *   the duplication if the policy is re-submitted
- *
- * @param   {object}  resolutionObj  { resolution: oneOf(POLICY_DUPE_ACTIONS.RENAME|POLICY_DUPE_ACTIONS.OVERWRITE), newName: string }
- *
- * @return  {boolean}                 true if policy can be re-submitted, false otherwise
  */
-export function isDuplicateResolved(resolutionObj) {
+export function isDuplicateResolved(resolutionObj: PolicyResolution): boolean {
     return (
-        resolutionObj.resolution === POLICY_DUPE_ACTIONS.OVERWRITE ||
-        resolutionObj.resolution === POLICY_DUPE_ACTIONS.KEEP_BOTH ||
-        (resolutionObj.resolution === POLICY_DUPE_ACTIONS.RENAME &&
+        resolutionObj.resolution === 'overwrite' ||
+        resolutionObj.resolution === 'keepBoth' ||
+        (resolutionObj.resolution === 'rename' &&
             resolutionObj?.newName?.length >= MIN_POLICY_NAME_LENGTH)
     );
 }
 
+type PolicyErrorMessage = {
+    type: string;
+    msg: string;
+}
+
 /**
  * stringify any import errors to display to the user
- *
- * @param   {array}  policyErrors  Array< { type: string, value: string } >
- *
- * @return  {array}               each array and value, joined by "and"
  */
-export function getErrorMessages(policyErrors) {
+export function getErrorMessages(policyErrors: PolicyImportErrorListItem[]): PolicyErrorMessage[] {
     const errorMessages = policyErrors.map((err) => {
         let msg = '';
         switch (err.type) {
@@ -92,23 +111,19 @@ export function getErrorMessages(policyErrors) {
 
 /**
  * modify the import payload to reflect the duplicate resolution chosen by the user
- *
- * @param   {array}  policies             Array< policy{object} >
- * @param   {array}  errors               Array < type: string, value: string } >
- * @param   {object} duplicateResolution  < resolution: string, newName: string } >
- *
- * @return  {tuple}                       First element: Array< object[policy], second element: metadata{ overwrite?: boolean }
  */
-export function getResolvedPolicies(policies, errors, duplicateResolution) {
+export function getResolvedPolicies(policies: Policy[], errors: PolicyImportErrorListItem[], duplicateResolution: PolicyResolution): [Policy[], { overwrite?: boolean }] {
     const resolvedPolicies = [...policies];
-    const metadata = {};
+    const metadata = {
+        overwrite: false
+    };
 
     if (errors) {
-        if (duplicateResolution?.resolution === POLICY_DUPE_ACTIONS.OVERWRITE) {
+        if (duplicateResolution?.resolution === 'overwrite') {
             metadata.overwrite = true;
-        } else if (duplicateResolution?.resolution === POLICY_DUPE_ACTIONS.KEEP_BOTH) {
+        } else if (duplicateResolution?.resolution === 'keepBoth') {
             resolvedPolicies[0].id = '';
-        } else if (duplicateResolution?.resolution === POLICY_DUPE_ACTIONS.RENAME) {
+        } else if (duplicateResolution?.resolution === 'rename') {
             resolvedPolicies[0].name = duplicateResolution?.newName;
 
             if (errors.some((err) => err.type === 'duplicate_id')) {
@@ -127,19 +142,15 @@ export function getResolvedPolicies(policies, errors, duplicateResolution) {
  *
  * @return  {boolean}              true if the only error is a duplicate policy ID
  */
-export function hasDuplicateIdOnly(importErrors) {
+export function hasDuplicateIdOnly(importErrors: PolicyImportErrorListItem[]): boolean {
     return importErrors?.length === 1 && importErrors[0].type === 'duplicate_id';
 }
 
 /**
  * simple function to abstract the test for only duplicate errors
- *
- * @param   {array}  importErrors  Array< type: string, value: string } >
- *
- * @return  {boolean}              true if there are only dupe errors, no validation errors
  */
-export function checkDupeOnlyErrors(importErrors) {
-    return (
+export function checkDupeOnlyErrors(importErrors: PolicyImportErrorListItem[][]): boolean {
+    return !!(
         importErrors?.length &&
         importErrors.every((policyErrors) => {
             const hasInvalidPolicy = policyErrors.some((err) => err.type === 'invalid_policy');
@@ -152,23 +163,18 @@ export function checkDupeOnlyErrors(importErrors) {
 
 /**
  * function to abstract checks for whether importing is currently blocked
- *
- * @param   {object}  settings  Object{ numPolicies: number,
- *                                      messageType: string
- *                                      hasDuplicateErrors: boolean,
- *                                      duplicateResolution: Object{ resolution: string,
- *                                                           newName?: string
- *                                                         }
- *                                    }
- *
- * @return  {boolean}              true if submission blocked by current state, false otherwise
  */
 export function checkForBlockedSubmit({
     numPolicies,
     messageType,
     hasDuplicateErrors,
     duplicateResolution,
-}) {
+}: {
+    numPolicies: number;
+    messageType: string;
+    hasDuplicateErrors: boolean;
+    duplicateResolution: PolicyResolution;
+}): boolean {
     return (
         numPolicies < 1 || // at least one policy must be in selected file
         messageType === 'info' || // an info message means upload has already succeeded

--- a/ui/apps/platform/src/Containers/Policies/Modal/RenamePolicySection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/RenamePolicySection.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { FormGroup, Radio, TextInput } from '@patternfly/react-core';
 import { Field } from 'formik';
 
-import { POLICY_DUPE_ACTIONS } from './PolicyImport.utils';
+type RenamePolicySectionProps = {
+    changeRadio: (handler, name, value) => () => void;
+    changeText: (handler, name) => (value) => void;
+};
 
-const RenamePolicySection = ({ changeRadio, changeText }) => {
+const RenamePolicySection = ({ changeRadio, changeText }: RenamePolicySectionProps) => {
     return (
         <div>
             <Field name="resolution">
@@ -15,18 +17,14 @@ const RenamePolicySection = ({ changeRadio, changeText }) => {
                         value="overwrite"
                         label="Rename incoming policy"
                         id="policy-rename-radio"
-                        isChecked={field.value === POLICY_DUPE_ACTIONS.RENAME}
-                        onChange={changeRadio(
-                            field.onChange,
-                            field.name,
-                            POLICY_DUPE_ACTIONS.RENAME
-                        )}
+                        isChecked={field.value === 'rename'}
+                        onChange={changeRadio(field.onChange, field.name, 'rename')}
                     />
                 )}
             </Field>
             <Field name="newName">
                 {({ field, form }) => {
-                    const isDisabled = form.values.resolution !== POLICY_DUPE_ACTIONS.RENAME;
+                    const isDisabled = form.values.resolution !== 'rename';
                     const validated =
                         form.touched.newName && form.errors.newName ? 'error' : 'default';
                     return (
@@ -52,11 +50,6 @@ const RenamePolicySection = ({ changeRadio, changeText }) => {
             </Field>
         </div>
     );
-};
-
-RenamePolicySection.propTypes = {
-    changeRadio: PropTypes.func.isRequired,
-    changeText: PropTypes.func.isRequired,
 };
 
 export default RenamePolicySection;


### PR DESCRIPTION
## Description

As the title suggests. The policy import functionality on the policies page should be the same as before.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
