### PR TITLE
ROX-10289 ROX-10616: Fix permission issue when provision openshift

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1641,6 +1641,7 @@ commands:
           name: Create cloud resources
           command: |
             mkdir -p openshift
+            chmod 777 openshift
             set +e
             try=0
             max_attempts=2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1641,8 +1641,6 @@ commands:
           name: Create cloud resources
           command: |
             mkdir -p openshift
-            export UID=$(id -u)
-            export GID=$(id -g)
             set +e
             try=0
             max_attempts=2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1640,8 +1640,7 @@ commands:
       - run:
           name: Create cloud resources
           command: |
-            mkdir -p openshift
-            chmod 777 openshift
+            mkdir -m 777 -p openshift
             set +e
             try=0
             max_attempts=2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1658,7 +1658,7 @@ commands:
                     --dns-project=stackrox-ci \
                     --dns-zone=openshift-ci-rox-systems \
                     --zone=us-central1-a \
-                    2>&1 | scripts/ci/monitor-output.sh 60 && chmod -R 777 openshift
+                    2>&1 | scripts/ci/monitor-output.sh 60 && sudo chmod -R +r openshift
                 rc=$?
                 if [[ ${rc} == 0 ]]; then
                     echo "============= Openshift provision succeeded ============="

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1502,7 +1502,7 @@ commands:
           command: |
             if [[ "<< parameters.orchestrator-flavor >>" == "openshift" ]]; then
               export CLUSTER=OPENSHIFT
-              oc apply -f "qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
+              oc get scc qatest-anyuid || oc create -f "qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
             else
               export CLUSTER=K8S
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1502,7 +1502,7 @@ commands:
           command: |
             if [[ "<< parameters.orchestrator-flavor >>" == "openshift" ]]; then
               export CLUSTER=OPENSHIFT
-              oc apply -f "qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
+              oc patch -f "qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
             else
               export CLUSTER=K8S
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1502,7 +1502,7 @@ commands:
           command: |
             if [[ "<< parameters.orchestrator-flavor >>" == "openshift" ]]; then
               export CLUSTER=OPENSHIFT
-              oc patch -f "qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
+              oc apply -f "qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
             else
               export CLUSTER=K8S
             fi
@@ -1640,7 +1640,7 @@ commands:
       - run:
           name: Create cloud resources
           command: |
-            mkdir -p openshift
+            mkdir -m 777 -p openshift
             set +e
             try=0
             max_attempts=2
@@ -1648,7 +1648,6 @@ commands:
                 try=$((try + 1))
                 echo "============= Openshift provision try ${try} ============="
                 docker run --rm -t -v "$PWD/openshift:/well-known" \
-                  --user $UID:$GID \
                   -e GOOGLE_CREDENTIALS="$GCLOUD_SERVICE_ACCOUNT_CIRCLECI_ROX" \
                   "gcr.io/stackrox-infra/automation-flavors/openshift-multi:<< parameters.version >>" \
                   create \
@@ -1659,7 +1658,7 @@ commands:
                     --dns-project=stackrox-ci \
                     --dns-zone=openshift-ci-rox-systems \
                     --zone=us-central1-a \
-                    2>&1 | scripts/ci/monitor-output.sh 60
+                    2>&1 | scripts/ci/monitor-output.sh 60 && chmod -R 777 openshift
                 rc=$?
                 if [[ ${rc} == 0 ]]; then
                     echo "============= Openshift provision succeeded ============="

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1640,7 +1640,9 @@ commands:
       - run:
           name: Create cloud resources
           command: |
-            mkdir -m 777 -p openshift
+            mkdir -p openshift
+            export UID=$(id -u)
+            export GID=$(id -g)
             set +e
             try=0
             max_attempts=2
@@ -1648,6 +1650,7 @@ commands:
                 try=$((try + 1))
                 echo "============= Openshift provision try ${try} ============="
                 docker run --rm -t -v "$PWD/openshift:/well-known" \
+                  --user $UID:$GID \
                   -e GOOGLE_CREDENTIALS="$GCLOUD_SERVICE_ACCOUNT_CIRCLECI_ROX" \
                   "gcr.io/stackrox-infra/automation-flavors/openshift-multi:<< parameters.version >>" \
                   create \


### PR DESCRIPTION
## Description

It looks like we have issue with file permissions. Docker container could not write in `/well-known` dir. After adding permissions to write the next job could not read the content so it was necessary to add read permissions.  This should be treated as a quickfix to enable nightly tests to run on openshift.

## Testing Performed

CI