### PR TITLE
ROX-10097: Update nginx base image for docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-9435: Updated dryrun API to generate preview violations for disabled policies
 - Support for security policies that do not have a policyVersion or have versions prior to 1.1 will be removed. If you have externally stored older policies, they cannot be imported.
 - ROX-10021: RHCOS node support is dropped until major improvements are made in ROX-8944.
+- ROX-10097: Updated the base for the docs image from `nginx-118:1-46` to `nginx-120:latest`.
 
 ## [69.1]
 

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -10,7 +10,7 @@ COPY Makefile ./
 RUN npm install -g npm@8.1.4 && npm install -g yarn@1.22.17
 RUN make
 
-FROM registry.access.redhat.com/ubi8/nginx-118:1-46
+FROM registry.access.redhat.com/ubi8/nginx-120:1
 
 # Delete unnecessary things from the content directory.
 RUN find . -mindepth 1 -delete

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -10,7 +10,7 @@ COPY Makefile ./
 RUN npm install -g npm@8.1.4 && npm install -g yarn@1.22.17
 RUN make
 
-FROM registry.access.redhat.com/ubi8/nginx-120:1
+FROM registry.access.redhat.com/ubi8/nginx-120:latest
 
 # Delete unnecessary things from the content directory.
 RUN find . -mindepth 1 -delete


### PR DESCRIPTION
## Description

`nginx` is used to serve static docs for the /air gapped/ clients. Currently used image shows [the following scan results](https://quay.io/repository/rhacs-eng/docs/manifest/sha256:c11ee57382b2b772723447113f0187ae0620d46ddb228f340970bcca72eff7c1?tab=vulnerabilities&fixable=true):

```
Quay Security Scanner has detected 58 vulnerabilities.
Patches are available for 54 vulnerabilities.
 12 High-level vulnerabilities.
 46 Medium-level vulnerabilities.
```

The newer version promises today only [1 important vulnerability](https://catalog.redhat.com/software/containers/ubi8/nginx-120/6156abfac739c0a4123a86fd?container-tabs=security#security).

Note the suggested use of the more generic tag `:latest`, as only the basic static resource service is required from nginx.

## Testing Done

Running the local image with `docker run -p 8888:8080 docs:test`, and navigating to `localhost:8888` shows the docs with images, CSS and scripts.
