### PR TITLE
OSCI: Build roxctl

### DIFF
--- a/.openshift-ci/build/build-main-and-bundle.sh
+++ b/.openshift-ci/build/build-main-and-bundle.sh
@@ -94,6 +94,9 @@ cleanup_image() {
 
     info "Reducing the image size"
 
+    # Save for image/roxctl.Dockerfile
+    cp image/bin/roxctl-linux .
+
     set +e
     rm -rf /go/{bin,pkg}
     rm -rf /root/{.cache,.npm}
@@ -104,6 +107,10 @@ cleanup_image() {
     rm -rf image/{THIRD_PARTY_NOTICES,bin,ui}
     rm -rf ui/build ui/node_modules ui/**/node_modules
     set -e
+
+    # Restore for image/roxctl.Dockerfile
+    mkdir -p image/bin
+    mv roxctl-linux image/bin/
 }
 
 build() {

--- a/image/roxctl.Dockerfile
+++ b/image/roxctl.Dockerfile
@@ -1,9 +1,12 @@
-FROM alpine:latest as certs
-RUN apk --update add ca-certificates
+ARG BASE_REGISTRY=registry.access.redhat.com
+ARG BASE_IMAGE=ubi8-minimal
+ARG BASE_TAG=8.5
+
+FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS certs
 
 FROM scratch
 COPY ./bin/roxctl-linux /roxctl
-COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
 ENV ROX_ROXCTL_IN_MAIN_IMAGE="true"
 
 USER 65534:65534

--- a/image/roxctl.Dockerfile
+++ b/image/roxctl.Dockerfile
@@ -1,12 +1,9 @@
-ARG BASE_REGISTRY=registry.access.redhat.com
-ARG BASE_IMAGE=ubi8-minimal
-ARG BASE_TAG=8.5
-
-FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS certs
+FROM alpine:latest as certs
+RUN apk --update add ca-certificates
 
 FROM scratch
 COPY ./bin/roxctl-linux /roxctl
-COPY --from=certs /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ENV ROX_ROXCTL_IN_MAIN_IMAGE="true"
 
 USER 65534:65534


### PR DESCRIPTION
## Description

A minor change to the build and bundle script so that a roxctl image can be built in OpenShift CI. Companion PR in https://github.com/openshift/release/pull/28139

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient