### PR TITLE
OSCI: Build central-db

### DIFF
--- a/.openshift-ci/build/Dockerfile.build-main-and-bundles
+++ b/.openshift-ci/build/Dockerfile.build-main-and-bundles
@@ -3,4 +3,4 @@ FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.35
 COPY stackrox /go/src/github.com/stackrox/stackrox
 WORKDIR /go/src/github.com/stackrox/stackrox
 
-RUN ./.openshift-ci/build/build-main-and-bundle.sh
+RUN ./.openshift-ci/build/build-main-and-bundles.sh

--- a/.openshift-ci/build/build-main-and-bundles.sh
+++ b/.openshift-ci/build/build-main-and-bundles.sh
@@ -87,7 +87,7 @@ create_main_bundle_and_scripts() {
 }
 
 create_central_db_bundle() {
-    "$ROOT/image/rhel/create-bundle.sh" image/postgres image/postgres "true"
+    "$ROOT/image/postgres/create-bundle.sh" image/postgres image/postgres "true"
 }
 
 cleanup_image() {

--- a/.openshift-ci/build/build-main-and-bundles.sh
+++ b/.openshift-ci/build/build-main-and-bundles.sh
@@ -71,8 +71,8 @@ make_stackrox_data() {
     cp image/docs/api/v1/swagger.json /stackrox-data/docs/api/v1/swagger.json
 }
 
-create_bundle_and_scripts() {
-    info "Creating bundle.tar.gz"
+create_main_bundle_and_scripts() {
+    info "Creating main bundle.tar.gz"
 
     if [[ -z "${DEBUG_BUILD:-}" ]]; then
         if [[ "$(git rev-parse --abbrev-ref HEAD)" =~ "-debug" ]]; then
@@ -84,6 +84,10 @@ create_bundle_and_scripts() {
 
     DEBUG_BUILD="${DEBUG_BUILD}" \
        "$ROOT/image/rhel/create-bundle.sh" image "local" "local" image/rhel
+}
+
+create_central_db_bundle() {
+    "$ROOT/image/rhel/create-bundle.sh" image/postgres image/postgres "true"
 }
 
 cleanup_image() {
@@ -113,7 +117,7 @@ cleanup_image() {
     mv roxctl-linux image/bin/
 }
 
-build() {
+build_main_and_bundles() {
     # TODO(RS-509) Submodules are not initialized in migration but they should
     # be in the 'src' delivered by OSCI in the final env so this can then be removed.
     git submodule update --init
@@ -137,9 +141,10 @@ build() {
 
     make_stackrox_data
 
-    create_bundle_and_scripts
+    create_main_bundle_and_scripts
+    create_central_db_bundle
 
     cleanup_image
 }
 
-build
+build_main_and_bundles

--- a/image/postgres/create-bundle.sh
+++ b/image/postgres/create-bundle.sh
@@ -36,7 +36,7 @@ pg_rhel_version="8.5"
 
 if [[ "${NATIVE_PG_INSTALL}" == "true" ]]; then
     dnf install -y "${postgres_repo_url}"
-    postgres_minor="$(dnf list -y "postgresql${postgres_major}-devel.x86_64" | tail -n 1 | awk '{print $2}')"
+    postgres_minor="$(dnf list -y "postgresql${postgres_major}-devel.x86_64" | tail -n 1 | awk '{print $2}').x86_64"
     echo "PG minor version: ${postgres_minor}"
 else
     build_dir="$(mktemp -d)"

--- a/image/postgres/create-bundle.sh
+++ b/image/postgres/create-bundle.sh
@@ -10,6 +10,8 @@ die() {
 
 INPUT_ROOT="$1"
 OUTPUT_DIR="$2"
+# Install the PG repo natively if true (versus using a container)
+NATIVE_PG_INSTALL="${3:-false}"
 
 [[ -n "$INPUT_ROOT" && -n "$OUTPUT_DIR" ]] \
     || die "Usage: $0 <input-root-dir> <output-dir>"
@@ -32,14 +34,20 @@ postgres_repo_url="https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x
 postgres_major="14"
 pg_rhel_version="8.5"
 
-build_dir="$(mktemp -d)"
-docker build -q -t postgres-minor-image "${build_dir}" -f - <<EOF
+if [[ "${NATIVE_PG_INSTALL}" == "true" ]]; then
+    dnf install -y "${postgres_repo_url}"
+    postgres_minor="$(dnf list -y "postgresql${postgres_major}-devel.x86_64" | tail -n 1 | awk '{print $2}')"
+    echo "PG minor version: ${postgres_minor}"
+else
+    build_dir="$(mktemp -d)"
+    docker build -q -t postgres-minor-image "${build_dir}" -f - <<EOF
 FROM registry.access.redhat.com/ubi8/ubi:${pg_rhel_version}
 RUN dnf install -y "${postgres_repo_url}"
 ENTRYPOINT dnf list -y postgresql${postgres_major}-server.x86_64 | tail -n 1 | awk '{print \$2}'
 EOF
-postgres_minor="$(docker run --rm postgres-minor-image).x86_64"
-rm -rf "${build_dir}"
+    postgres_minor="$(docker run --rm postgres-minor-image).x86_64"
+    rm -rf "${build_dir}"
+fi
 
 # =============================================================================
 
@@ -78,4 +86,3 @@ sha512sum --check "${OUTPUT_BUNDLE}.sha512"
 
 # Clean up after success
 rm -r "${bundle_root}"
-


### PR DESCRIPTION
## Description

This PR makes changes required to build the central-db image in OpenShift CI. Specifically it relies on a local postgres rpm install to determine the `postgres_minor` value due to OpenShift CI docker run limitations. Companion PR is: https://github.com/openshift/release/pull/28146.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI and:
- [x] deploy the central-db created by OpenShift CI and check it is operational.
