### PR TITLE
ROX-9476: Improve error handling on sensor start - use utils.Should

### DIFF
--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -208,7 +208,7 @@ func (s *Sensor) Start() {
 
 	for _, component := range s.components {
 		if err := component.Start(); err != nil {
-			_ = utils.Should(errors.Wrapf(err, "Sensor component %T failed to start", component))
+			_ = utils.Should(errors.Wrapf(err, "sensor component %T failed to start", component))
 		}
 	}
 

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -208,7 +208,7 @@ func (s *Sensor) Start() {
 
 	for _, component := range s.components {
 		if err := component.Start(); err != nil {
-			log.Panicf("Sensor component %T failed to start: %v", component, err)
+			_ = utils.Should(errors.Wrapf(err, "Sensor component %T failed to start", component))
 		}
 	}
 


### PR DESCRIPTION
## Description

Use utils.Should instead of logging the error during the sensor start. This will lead to a component crash when it is started in dev environment (non release build).

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Manual dev test
