### PR TITLE
Compile groovy on make style

### DIFF
--- a/qa-tests-backend/Makefile
+++ b/qa-tests-backend/Makefile
@@ -17,7 +17,7 @@ style: compile
 	exit $$STATUS
 
 .PHONY: compile
-compile:
+compile: proto-generated-srcs
 	@echo "+ $@"
 	@$(GRADLE) assemble testClasses
 
@@ -39,57 +39,57 @@ clean-generated-srcs:
 	git clean -xdf build/generated
 
 .PHONY: test
-test: proto-generated-srcs
+test: compile
 	@echo "+ $@"
 	$(GRADLE) test -Dgroups=-Upgrade,-SensorBounce,-SensorBounceNext
 
 .PHONY: bat-test
-bat-test: proto-generated-srcs
+bat-test: compile
 	@echo "+ $@"
 	$(GRADLE) test -Dgroups=BAT
 
 .PHONY: smoke-test
-smoke-test: proto-generated-srcs
+smoke-test: compile
 	@echo "+ $@"
 	$(GRADLE) test -Dgroups=SMOKE
 
 .PHONY: runtime-test
-runtime-test: proto-generated-srcs
+runtime-test: compile
 	@echo "+ $@"
 	$(GRADLE) test -Dgroups=RUNTIME
 
 .PHONY: enforcement-test
-enforcement-test: proto-generated-srcs
+enforcement-test: compile
 	@echo "+ $@"
 	$(GRADLE) test -Dgroups=PolicyEnforcement
 
 .PHONY: integration-test
-integration-test: proto-generated-srcs
+integration-test: compile
 	@echo "+ $@"
 	$(GRADLE) test -Dgroups=Integration
 
 .PHONY: networkpolicy-simulator-test
-networkpolicy-simulator-test: proto-generated-srcs
+networkpolicy-simulator-test: compile
 	@echo "+ $@"
 	$(GRADLE) test -Dgroups=NetworkPolicySimulation
 
 .PHONY: non-bat-test
-non-bat-test: proto-generated-srcs
+non-bat-test: compile
 	@echo "+ $@"
 	$(GRADLE) test -Dgroups=-BAT,-Upgrade,-SensorBounce,-SensorBounceNext
 
 .PHONY: upgrade-test
-upgrade-test: proto-generated-srcs
+upgrade-test: compile
 	@echo "+ $@"
 	$(GRADLE) test -Dgroups=Upgrade
 
 .PHONY: graphql-test
-graphql-test: proto-generated-srcs
+graphql-test: compile
 	@echo "+ $@"
 	$(GRADLE) test -Dgroups=GraphQL
 
 .PHONY: sensor-bounce-test
-sensor-bounce-test: proto-generated-srcs
+sensor-bounce-test: compile
 	@echo "+ $@"
 	$(GRADLE) test -Dgroups=SensorBounce
 	$(GRADLE) test -Dgroups=SensorBounceNext

--- a/qa-tests-backend/Makefile
+++ b/qa-tests-backend/Makefile
@@ -7,7 +7,7 @@ GRADLE := ./gradlew
 ## Style ##
 ###########
 .PHONY: style
-style:
+style: compile
 	@echo "+ $@"
 	@$(GRADLE) --continue codenarcMain codenarcTest ; \
 	STATUS=$$? ; \
@@ -15,6 +15,11 @@ style:
 	    cat build/reports/codenarc/main.txt build/reports/codenarc/test.txt >&2 2>/dev/null ; \
 	fi ; \
 	exit $$STATUS
+
+.PHONY: compile
+compile:
+	@echo "+ $@"
+	@$(GRADLE) assemble testClasses
 
 .PHONY: style-fix
 style-fix:

--- a/qa-tests-backend/Makefile
+++ b/qa-tests-backend/Makefile
@@ -17,7 +17,7 @@ style: compile
 	exit $$STATUS
 
 .PHONY: compile
-compile: proto-generated-srcs
+compile: build/generated
 	@echo "+ $@"
 	@$(GRADLE) assemble testClasses
 
@@ -27,11 +27,16 @@ style-fix:
 	@scripts/fix_lint.py .
 
 .PHONY: proto-generated-srcs
-proto-generated-srcs:
+proto-generated-srcs: build/generated
+
+build/generated: src/main/proto
 	@echo "+ $@"
+	$(GRADLE) generateProto generateTestProto
+
+src/main/proto: ../proto
+	@echo "+ migrate protos"
 	-rm -r src/main/proto
 	@scripts/migrate_protos.sh
-	$(GRADLE) generateProto generateTestProto
 
 .PHONY: clean-generated-srcs
 clean-generated-srcs:


### PR DESCRIPTION
## Description

Currently on `make style` we run only codenarc check. It detects when there are too many imports but not when import is missing or code does not compile. This PR compile tests before running codenarc to prevent situation when we run tests but they fail due to missing import or compilation error. 

## Testing Performed

CI