### PR TITLE
ROX-10249: Enable network policy system policy and update changelog 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   `ROX_ALLOW_MISDIRECTED_REQUESTS=true`.
 - Registry integrations for ECR are now auto-generated if the cluster's cloud provider is AWS, and the nodes' Instance IAM Role has policies granting access to ECR.  Customers can turn this feature off by disabling the EC2 instance metadata service in their nodes.
 - A new default policy added to detect Spring Cloud Function RCE vulnerability (CVE-2022-22963) and Spring Framework Spring4Shell RCE vulnerability (CVE-2022-22965).
+- A new default policy added to detect missing ingress NetworkPolicy associated with deployments. The policy is disabled by default.
+- Two new policy criteria were added to alert on missing ingress or egress NetworkPolicy associations. 
 - Fixed permissions checks in the UI that prevented users with certain limited permissions from creating report configurations.
 - ROX-8789: Change operator catalog format from deprecated SQLite database format to new file-based format.
 - ROX-8331: Increase the front-end limit on rendered nodes in the Network Graph from 1100 to 2000

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -44,5 +44,5 @@ var (
 	NetworkPolicySystemPolicy = registerFeature("Enable NetworkPolicy-related system policy fields", "ROX_NETPOL_FIELDS", false)
 
 	// NewPolicyCategories enables new policy categories as first-class entities.
-	NewPolicyCategories = registerFeature("Enable new policy categories as first-class entities", "ROX_NEW_POLICY_CATEGORIES", false)
+	NewPolicyCategories = registerFeature("Enable new policy categories as first-class entities", "ROX_NEW_POLICY_CATEGORIES", true)
 )

--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -189,10 +189,7 @@ class UpgradesTest extends BaseSpecification {
         given:
         "Default policies in code"
 
-        def policiesGuardedByFeatureFlags = [
-                // @TODO(ROX-10249): Remove when policy is no longer guarded by a feature flag
-                "38bf79e7-48bf-4ab1-b72f-38e8ad8b4ec3"
-        ]
+        def policiesGuardedByFeatureFlags = []
         Map<String, PolicyOuterClass.Policy> defaultPolicies = [:]
         def policiesDir = new File(POLICIES_JSON_PATH)
         policiesDir.eachFileRecurse (FileType.FILES) { file ->


### PR DESCRIPTION
## Description

This PR enables the feature flag for the MVP of epic [ROX-8957](https://issues.redhat.com/browse/ROX-8957). 

This should be merged after #1371

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [x] Evaluated and added CHANGELOG entry if required
- [ ] ~~Determined and documented upgrade steps~~
- [x] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

Docs are being handled by @gaurav-nelson 


