### PR TITLE
ROX-10647: Change Scanner node affinity

### DIFF
--- a/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
+++ b/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
@@ -50,18 +50,18 @@ spec:
         {{- if ._rox.env.openshift }}
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: In
+                    values:
+                    - "true"
             - weight: 25
               preference:
                 matchExpressions:
                   - key: node-role.kubernetes.io/compute
                     operator: In
-                    values:
-                    - "true"
-            - weight: 75
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/infra
-                    operator: NotIn
                     values:
                     - "true"
             - weight: 100
@@ -218,18 +218,18 @@ spec:
                     values:
                     - "true"
             {{ if ._rox.env.openshift }}
+            - weight: 50
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: In
+                    values:
+                    - "true"
             - weight: 25
               preference:
                 matchExpressions:
                   - key: node-role.kubernetes.io/compute
                     operator: In
-                    values:
-                    - "true"
-            - weight: 75
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/infra
-                    operator: NotIn
                     values:
                     - "true"
             - weight: 100

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
@@ -98,6 +98,36 @@ tests:
     .securitycontextconstraints["stackrox-scanner"] | assertThat(. == null)
     .deployments["scanner-db"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 4)
     .deployments["scanner"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 3)
+    .deployments["scanner"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution[]
+      | select(.preference.matchExpressions[0].key == "node-role.kubernetes.io/infra" ) | [
+        assertThat(.weight == 50),
+        assertThat(.preference.matchExpressions[0].operator == "In")
+      ]
+    .deployments["scanner"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution[]
+      | select(.preference.matchExpressions[0].key == "node-role.kubernetes.io/compute" ) | [
+        assertThat(.weight == 25),
+        assertThat(.preference.matchExpressions[0].operator == "In")
+      ]
+    .deployments["scanner"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution[]
+      | select(.preference.matchExpressions[0].key == "node-role.kubernetes.io/master" ) | [
+        assertThat(.weight == 100),
+        assertThat(.preference.matchExpressions[0].operator == "NotIn")
+      ]
+    .deployments["scanner-db"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution[]
+      | select(.preference.matchExpressions[0].key == "node-role.kubernetes.io/infra" ) | [
+        assertThat(.weight == 50),
+        assertThat(.preference.matchExpressions[0].operator == "In")
+      ]
+    .deployments["scanner-db"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution[]
+      | select(.preference.matchExpressions[0].key == "node-role.kubernetes.io/compute" ) | [
+        assertThat(.weight == 25),
+        assertThat(.preference.matchExpressions[0].operator == "In")
+      ]
+    .deployments["scanner-db"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution[]
+      | select(.preference.matchExpressions[0].key == "node-role.kubernetes.io/master" ) | [
+        assertThat(.weight == 100),
+        assertThat(.preference.matchExpressions[0].operator == "NotIn")
+      ]
     .networkpolicys["scanner"].spec.ingress | assertThat(length == 2)
     .networkpolicys["scanner"].spec.ingress[1] | .from[0].podSelector.matchLabels.app | assertThat(. == "sensor")
 


### PR DESCRIPTION
## Description

[Ticket link](https://issues.redhat.com/browse/ROX-10647)

Scanner is recommended to run on Infra node if possible, thus affinity looks as follow: `infra > worker > master`

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

only update yml unit test based on helmtest
