### PR TITLE
Use different key for go.mod cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,12 +92,15 @@ saveGoLintCache: &saveGoLintCache
     - /home/circleci/.cache/golangci-lint
     - /go/pkg/mod
 
-goModCacheKey: &goModCacheKey 'rox-go-pkg-mod-v3-{{ checksum "go.sum" }}'
 restoreGoModCache: &restoreGoModCache
   restore_cache:
     name: Restore Go module cache
     keys:
-      - *goModCacheKey
+      - rox-go-pkg-mod-v3-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
+      - rox-go-pkg-mod-v3-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-
+      - rox-go-pkg-mod-v3-{{ .Environment.CIRCLE_JOB }}-master-
+      - rox-go-pkg-mod-v3-{{ .Environment.CIRCLE_JOB }}-
+      - rox-go-pkg-mod-v3-
 
 goModTidy: &goModTidy
   run:
@@ -108,7 +111,7 @@ goModTidy: &goModTidy
 saveGoModCache: &saveGoModCache
   save_cache:
     name: Saving Go module cache
-    key: *goModCacheKey
+    key: rox-go-pkg-mod-v3-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - /go/pkg/mod
 


### PR DESCRIPTION
## Description

Currently we use hash of go.sum as a cache key. Although it looks like a perfect candidate to use it comes with drawback. Whenever anything changes in go.sum we need to download all modules again. Changing cache key will allow us to use cached modules from master branch build and then download only missing modules resulting in faster build and less failures.

Failures:
- https://app.circleci.com/pipelines/github/stackrox/stackrox/10506/workflows/d07c4137-f5e9-4158-962d-47764d0005b0/jobs/481623
- https://app.circleci.com/pipelines/github/stackrox/stackrox/10626/workflows/480efa42-e8bf-4bee-a9eb-ecf88bad12d7/jobs/487753


## Testing Performed

CI
