### PR TITLE
Add visit function to wait on featureflags and mypermissions in integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/ClustersPage.js
+++ b/ui/apps/platform/cypress/constants/ClustersPage.js
@@ -5,7 +5,8 @@ export const clustersUrl = '/main/clusters';
 export const selectors = {
     configure: 'ul.pf-c-nav__list li button:contains("Platform Configuration")',
     navLink: 'ul.pf-c-nav__list li a.pf-c-nav__link:contains("Clusters")',
-    header: '[data-testid="header-text"]',
+    clustersListHeading: 'h1:contains("Clusters")',
+    clusterSidePanelHeading: '[data-testid="clusters-side-panel-header"]',
     autoUpgradeInput: '[id="enableAutoUpgrade"]',
     clusters: scopeSelectors('[data-testid="clusters-table"]', {
         // Ignore the first checkbox column and last delete column.

--- a/ui/apps/platform/cypress/constants/NetworkPage.js
+++ b/ui/apps/platform/cypress/constants/NetworkPage.js
@@ -14,6 +14,9 @@ const networkEntityTabbedOverlay = '[data-testid="network-entity-tabbed-overlay"
 
 export const selectors = {
     cytoscapeContainer: '#cytoscapeContainer',
+    networkGraphHeading: 'h1:contains("Network Graph")',
+    emptyStateSubheading:
+        '.pf-c-empty-state h2:contains("Please select at least one namespace from your cluster")',
     simulatorSuccessMessage: 'div[data-testid="message-body"]:contains("Policies processed")',
     panels: networkPanels,
     legend: {

--- a/ui/apps/platform/cypress/helpers/clusters.js
+++ b/ui/apps/platform/cypress/helpers/clusters.js
@@ -1,35 +1,32 @@
 import * as api from '../constants/apiEndpoints';
-import { clustersUrl } from '../constants/ClustersPage';
-import { url as dashboardUrl } from '../constants/DashboardPage';
-import navigation from '../selectors/navigation';
+import { clustersUrl, selectors } from '../constants/ClustersPage';
+
+import { visitFromLeftNavExpandable } from './nav';
+import { visit } from './visit';
 
 // Navigation
 
 export function visitClustersFromLeftNav() {
-    cy.intercept('POST', api.graphql(api.general.graphqlOps.summaryCounts)).as('getSummaryCounts');
-    cy.visit(dashboardUrl);
-    cy.wait('@getSummaryCounts');
-
     cy.intercept('GET', api.clusters.list).as('getClusters');
-    cy.get(navigation.navExpandablePlatformConfiguration).click();
-    cy.get(
-        `${navigation.navExpandablePlatformConfiguration} + ${navigation.nestedNavLinks}:contains("Clusters")`
-    ).click();
+    visitFromLeftNavExpandable('Platform Configuration', 'Clusters');
     cy.wait('@getClusters');
+    cy.get(selectors.clustersListHeading).contains('Clusters');
 }
 
 export function visitClusters() {
     cy.intercept('GET', api.clusters.list).as('getClusters');
-    cy.visit(clustersUrl);
+    visit(clustersUrl);
     cy.wait('@getClusters');
+    cy.get(selectors.clustersListHeading).contains('Clusters');
 }
 
 export function visitClustersWithFixture(fixturePath) {
     cy.intercept('GET', api.clusters.list, {
         fixture: fixturePath,
     }).as('getClusters');
-    cy.visit(clustersUrl);
+    visit(clustersUrl);
     cy.wait('@getClusters');
+    cy.get(selectors.clustersListHeading).contains('Clusters');
 }
 
 export function visitClustersWithFixtureMetadataDatetime(fixturePath, metadata, datetimeISOString) {
@@ -57,8 +54,9 @@ export function visitClusterByNameWithFixture(clusterName, fixturePath) {
             body: { cluster },
         }).as('getCluster');
 
-        cy.visit(`${clustersUrl}/${cluster.id}`);
+        visit(`${clustersUrl}/${cluster.id}`);
         cy.wait(['@getClusters', '@getCluster']);
+        cy.get(selectors.clusterSidePanelHeading).contains(clusterName);
     });
 }
 
@@ -85,7 +83,8 @@ export function visitClusterByNameWithFixtureMetadataDatetime(
         const currentDatetime = new Date(datetimeISOString);
         cy.clock(currentDatetime.getTime(), ['Date', 'setInterval']);
 
-        cy.visit(`${clustersUrl}/${cluster.id}`);
+        visit(`${clustersUrl}/${cluster.id}`);
         cy.wait(['@getClusters', '@getCluster', '@getMetadata']);
+        cy.get(selectors.clusterSidePanelHeading).contains(clusterName);
     });
 }

--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -1,9 +1,10 @@
 import * as api from '../constants/apiEndpoints';
 import { url } from '../constants/DashboardPage';
+import { visit } from './visit';
 
 // eslint-disable-next-line import/prefer-default-export
 export function visitMainDashboard() {
     cy.intercept('GET', api.risks.riskyDeployments).as('riskyDeployments');
-    cy.visit(url);
+    visit(url);
     cy.wait('@riskyDeployments');
 }

--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -1,6 +1,7 @@
 import * as api from '../constants/apiEndpoints';
 import { selectors as networkGraphSelectors, url as networkUrl } from '../constants/NetworkPage';
 import { visitFromLeftNav } from './nav';
+import { visit } from './visit';
 import selectSelectors from '../selectors/select';
 
 const getNodeErrorMessage = (node) => `Could not find node "${node.name}" of type "${node.type}"`;
@@ -147,12 +148,16 @@ export function visitNetworkGraphFromLeftNav() {
     cy.intercept('GET', api.clusters.list).as('clusters');
     visitFromLeftNav('Network');
     cy.wait('@clusters');
+    cy.get(networkGraphSelectors.networkGraphHeading);
+    cy.get(networkGraphSelectors.emptyStateSubheading);
 }
 
 export function visitNetworkGraph() {
     cy.intercept('GET', api.clusters.list).as('clusters');
-    cy.visit(networkUrl);
+    visit(networkUrl);
     cy.wait('@clusters');
+    cy.get(networkGraphSelectors.networkGraphHeading);
+    cy.get(networkGraphSelectors.emptyStateSubheading);
 }
 
 export function visitNetworkGraphWithNamespaceFilters(...namespaces) {
@@ -174,6 +179,5 @@ export function visitNetworkGraphWithMockedData() {
 
     visitNetworkGraph();
     selectNamespaceFilters('stackrox');
-
     cy.wait(['@networkGraph', '@networkPolicies']);
 }

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -1,0 +1,12 @@
+import * as api from '../constants/apiEndpoints';
+
+/*
+ * Wait for prerequisite requests to render container components.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function visit(url) {
+    cy.intercept('GET', api.featureFlags).as('getFeatureFlags');
+    cy.intercept('GET', api.roles.mypermissions).as('getMyPermissions');
+    cy.visit(url);
+    cy.wait(['@getFeatureFlags', '@getMyPermissions']);
+}

--- a/ui/apps/platform/cypress/integration/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/clusters.test.js
@@ -18,7 +18,6 @@ describe('Clusters page', () => {
     describe('smoke tests', () => {
         it('should be linked in the Platform Configuration menu', () => {
             visitClustersFromLeftNav();
-            cy.get(selectors.header).contains('Clusters');
         });
 
         it('should have a toggle control for the auto-upgrade setting', () => {


### PR DESCRIPTION
## Description

### Problem

> Network Graph connections filter allowed appears in namespace edge tooltip

> AssertionError: Timed out retrying after 4000ms: Expected to find element: `[data-testid="network-graph-toolbar"] .namespace-select > button`, but never found it.

* https://app.circleci.com/pipelines/github/stackrox/stackrox/10378/workflows/605b8220-0db9-4001-b984-1f508f94e978/jobs/475064

Timeout of 4 seconds exceeded for `button` element even though network graph is not yet rendered.
![featureflags](https://user-images.githubusercontent.com/11862657/165563390-d4caf1f9-1fd3-4a05-af5c-f33b4f91376d.png)

Especially when sagas make container-specific requests based on page address, wait on those responses does not guarantee that component is able to render, because `Main` component must wait on the following prerequisite requests:
* /v1/featureflags
* /v1/mypermissions

### Solution

**Goal**: Generic or container-specific helper functions encapsulate the improvements so test files require minimal changes.

1. Because cypress allows 5 seconds to make a request, and then 30 seconds to receive a response, replace `cy.visit` with `visit` helper function that waits on prerequisite requests to render container components, so that element timeout does not false start.

    Even though this problem might decrease as use of sagas decrease, replacing `cy.visit` with `visit` (which provides a generic wait) is a low-cost way to improve reliability of classic tests (which do not wait on container-specific requests).

2. Wait for an expected element on the page (for example, heading) in container-specific visit helper functions to add an extra 4 seconds before timeout for test-specific elements.

### Changed files

1. Edit constants/ClustersPage.js
    * Replace `header` with `clustersListHeading` selector which is compatible with markup in PatternFly
    * Add `sidePanelHeading` selector

2. Edit constants/NetworkPage.js
    * Add `networkGraphHeading` selector
    * Add `emptyStateSubheading` selector

3. Edit helpers/clusters.js
    * Replace repeated code with `visitFromLeftNavExpandable` helper function
    * Replace `cy.visit` with `visit` in helper functions
    * Add to helper functions: assertion for heading of clusters list or side panel

4. Edit helpers/main.js
    * Replace `cy.visit` with `visit` in helper function

5. Edit helpers/networkGraph.js
    * Replace `cy.visit` with `visit` in helper functions
    * Add to helper functions: assertions for heading and empty state

6. Add helpers/visit.js

7. Edit integration/clusters.test.js
    * Delete header assertion because included in helper functions

### Residue

1. Investigate `"Cannot read properties of undefined (reading 'subject')"` in logimbue-date.json file which is unrelated to this problem, but apparently from integration/configmanagement/usersandgroups.test.js
2. Remove skip in clusters tests after investigating whether to refactor the following:
    * clusters fixture
    * metadata fixture for sensor upgrade
    * clock for certificate expiration
3. See if improvements supersede `cy.wait(100)` added to `getCytoscape` in #1278
4. Investigate whether it is possible to clean up after `'should be able to toggle status of a single flow'` test, because it is not repeatable in local deployment.
5. Investigate whether it is possible to remove skip from networkGraph/tooltip.test.js

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

1. `yarn lint` in ui
2. `yarn start` in ui
3. `yarn cypress-open` in ui/apps/platform
    * clusters.test.js
    * network.test.js
    * networkGraph/connections.test.js
    * networkGraph/externalEntities.test.js
    * networkGraph/networkFlows.test.js
    * networkGraph/networkGraph.test.js