### PR TITLE
[ROX-10202] : Add top level GraphQL resolvers for node vulnerabilities

### DIFF
--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -1,0 +1,100 @@
+package resolvers
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/metrics"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+func init() {
+	schema := getBuilder()
+	utils.Must(
+		schema.AddType("EmbeddedNodeVulnerability", []string{
+			"id: ID!",
+			"cve: String!",
+			"cvss: Float!",
+			"scoreVersion: String!",
+			"vectors: EmbeddedVulnerabilityVectors",
+			"link: String!",
+			"summary: String!",
+			"fixedByVersion: String!",
+			"isFixable(query: String): Boolean!",
+			"lastScanned: Time",
+			"createdAt: Time", // Discovered At System
+			"components(query: String, pagination: Pagination): [EmbeddedImageScanComponent!]!",
+			"componentCount(query: String): Int!",
+			"nodes(query: String, pagination: Pagination): [Node!]!",
+			"nodeCount(query: String): Int!",
+			"envImpact: Float!",
+			"severity: String!",
+			"publishedOn: Time",
+			"lastModified: Time",
+			"impactScore: Float!",
+			"vulnerabilityType: String!",
+			"vulnerabilityTypes: [String!]!",
+			"suppressed: Boolean!",
+			"suppressActivation: Time",
+			"suppressExpiry: Time",
+			"activeState(query: String): ActiveState",
+			"vulnerabilityState: String!",
+			"effectiveVulnerabilityRequest: VulnerabilityRequest",
+		}),
+		schema.AddQuery("nodeVulnerability(id: ID): EmbeddedNodeVulnerability"),
+		schema.AddQuery("nodeVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [EmbeddedNodeVulnerability!]!"),
+		schema.AddQuery("nodeVulnerabilityCount(query: String): Int!"),
+		schema.AddExtraResolver("EmbeddedNodeVulnerability", `unusedVarSink(query: String): Int`),
+	)
+}
+
+// NodeVulnerability resolves a single vulnerability based on an id (the CVE value).
+func (resolver *Resolver) NodeVulnerability(ctx context.Context, args IDQuery) (VulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "NodeVulnerability")
+	if !features.PostgresDatastore.Enabled() {
+		return resolver.vulnerabilityV2(ctx, args)
+	}
+	// TODO : Add postgres support
+	return nil, errors.New("Resolver NodeVulnerability does not support postgres yet")
+}
+
+// NodeVulnerabilities resolves a set of vulnerabilities based on a query.
+func (resolver *Resolver) NodeVulnerabilities(ctx context.Context, q PaginatedQuery) ([]VulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "NodeVulnerabilities")
+	if !features.PostgresDatastore.Enabled() {
+		query := search.AddRawQueriesAsConjunction(q.String(),
+			search.NewQueryBuilder().AddExactMatches(search.CVEType, storage.CVE_NODE_CVE.String()).Query())
+		return resolver.vulnerabilitiesV2(ctx, PaginatedQuery{Query: &query, Pagination: q.Pagination})
+	}
+	// TODO : Add postgres support
+	return nil, errors.New("Resolver NodeVulnerabilities does not support postgres yet")
+}
+
+// NodeVulnerabilityCount returns count of all clusters across infrastructure
+func (resolver *Resolver) NodeVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "NodeVulnerabilityCount")
+	if !features.PostgresDatastore.Enabled() {
+		query := search.AddRawQueriesAsConjunction(args.String(),
+			search.NewQueryBuilder().AddExactMatches(search.CVEType, storage.CVE_NODE_CVE.String()).Query())
+		return resolver.vulnerabilityCountV2(ctx, RawQuery{Query: &query})
+	}
+	// TODO : Add postgres support
+	return 0, errors.New("Resolver NodeVulnerabilityCount does not support postgres yet")
+}
+
+// NodeVulnCounter returns a VulnerabilityCounterResolver for the input query.s
+func (resolver *Resolver) NodeVulnCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "NodeVulnCounter")
+	if !features.PostgresDatastore.Enabled() {
+		query := search.AddRawQueriesAsConjunction(args.String(),
+			search.NewQueryBuilder().AddExactMatches(search.CVEType, storage.CVE_NODE_CVE.String()).Query())
+		return resolver.vulnCounterV2(ctx, RawQuery{Query: &query})
+	}
+	// TODO : Add postgres support
+	return nil, errors.New("Resolver NodeVulnCounter does not support postgres yet")
+}

--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -43,15 +43,15 @@ func init() {
 			"activeState(query: String): ActiveState",
 			"vulnerabilityState: String!",
 			"effectiveVulnerabilityRequest: VulnerabilityRequest",
+			"unusedVarSink(query: String): Int",
 		}),
 		schema.AddQuery("nodeVulnerability(id: ID): NodeVulnerability"),
 		schema.AddQuery("nodeVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [NodeVulnerability!]!"),
 		schema.AddQuery("nodeVulnerabilityCount(query: String): Int!"),
-		schema.AddExtraResolver("NodeVulnerability", `unusedVarSink(query: String): Int`),
 	)
 }
 
-// NodeVulnerability resolves a single vulnerability based on an id (the CVE value).
+// NodeVulnerability resolves a single vulnerability based on an id
 func (resolver *Resolver) NodeVulnerability(ctx context.Context, args IDQuery) (VulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "NodeVulnerability")
 	if !features.PostgresDatastore.Enabled() {


### PR DESCRIPTION
## Description

Added top level graphQL resolvers for `NodeVulnerabilities`, `NodeVulnerability` and `NodeVulnerabilityCount`. The resolvers currently create a conjunction query with `CVEType: NODE_CVE` for querying against RocksDB, and error out on Postgres enabled. Resolution logic for Postgres will be added after Postgres datastores are implemented.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- Manually tested by querying the resolvers to see if they return node vulnerabilities (and no other vulns) and that they contain expected fields, when Postgres is disabled.
- e2e/unit tests will be added in a separate task.