### PR TITLE
ROX-9476: Change start behavior of the Sensor components

### DIFF
--- a/sensor/kubernetes/localscanner/tls_issuer.go
+++ b/sensor/kubernetes/localscanner/tls_issuer.go
@@ -124,8 +124,7 @@ func (i *localScannerTLSIssuerImpl) Start() error {
 func (i *localScannerTLSIssuerImpl) abortStart(err error) error {
 	log.Errorf("local scanner TLS issuer start aborted due to error: %s", err)
 	i.Stop(err)
-	// This component should never stop Sensor.
-	return nil
+	return err
 }
 
 func (i *localScannerTLSIssuerImpl) Stop(_ error) {

--- a/sensor/kubernetes/localscanner/tls_issuer_test.go
+++ b/sensor/kubernetes/localscanner/tls_issuer_test.go
@@ -131,7 +131,7 @@ func TestLocalScannerTLSIssuerRefresherFailureStartFailure(t *testing.T) {
 
 	startErr := fixture.tlsIssuer.Start()
 
-	assert.NoError(t, startErr)
+	assert.Error(t, startErr)
 	fixture.assertMockExpectations(t)
 }
 
@@ -145,7 +145,7 @@ func TestLocalScannerTLSIssuerStartAlreadyStartedFailure(t *testing.T) {
 	secondStartErr := fixture.tlsIssuer.Start()
 
 	assert.NoError(t, startErr)
-	assert.NoError(t, secondStartErr)
+	assert.Error(t, secondStartErr)
 	fixture.assertMockExpectations(t)
 }
 
@@ -164,7 +164,7 @@ func TestLocalScannerTLSIssuerFetchSensorDeploymentOwnerRefErrorStartFailure(t *
 
 			startErr := fixture.tlsIssuer.Start()
 
-			assert.NoError(t, startErr)
+			assert.Error(t, startErr)
 			fixture.assertMockExpectations(t)
 		})
 	}

--- a/sensor/kubernetes/localscanner/tls_issuer_test.go
+++ b/sensor/kubernetes/localscanner/tls_issuer_test.go
@@ -131,7 +131,7 @@ func TestLocalScannerTLSIssuerRefresherFailureStartFailure(t *testing.T) {
 
 	startErr := fixture.tlsIssuer.Start()
 
-	assert.Error(t, startErr)
+	require.Error(t, startErr)
 	fixture.assertMockExpectations(t)
 }
 
@@ -145,7 +145,7 @@ func TestLocalScannerTLSIssuerStartAlreadyStartedFailure(t *testing.T) {
 	secondStartErr := fixture.tlsIssuer.Start()
 
 	assert.NoError(t, startErr)
-	assert.Error(t, secondStartErr)
+	require.Error(t, secondStartErr)
 	fixture.assertMockExpectations(t)
 }
 
@@ -164,7 +164,7 @@ func TestLocalScannerTLSIssuerFetchSensorDeploymentOwnerRefErrorStartFailure(t *
 
 			startErr := fixture.tlsIssuer.Start()
 
-			assert.Error(t, startErr)
+			require.Error(t, startErr)
 			fixture.assertMockExpectations(t)
 		})
 	}


### PR DESCRIPTION
## Description

Change startup behavior of the sensor components.

Current behavior: log error, not panic
Expected behavior: panic in development build, log in release build (using #1444)


## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed
Unit tests