### PR TITLE
Remove unsafe typecast used in parsing query parameters.

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportSinglePage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportSinglePage.tsx
@@ -7,7 +7,6 @@ import useFetchReport from 'hooks/useFetchReport';
 import usePermissions from 'hooks/usePermissions';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { getQueryObject } from 'utils/queryStringUtils';
-import { VulnMgmtReportQueryObject } from './VulnMgmtReport.utils';
 import VulnMgmtReportDetail from './Detail/VulnMgmtReportDetail';
 import VulnMgmtEditReportPage from './Detail/VulnMgmtEditReportPage';
 
@@ -22,7 +21,7 @@ function VulnMgmtReportPage(): ReactElement {
     const { hasReadWriteAccess } = usePermissions();
     const hasVulnReportWriteAccess = hasReadWriteAccess('VulnerabilityReports');
 
-    const queryObject = getQueryObject<VulnMgmtReportQueryObject>(search);
+    const queryObject = getQueryObject(search);
     const { action } = queryObject;
     const { reportId } = useParams();
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportsBasePage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportsBasePage.tsx
@@ -5,11 +5,10 @@ import { useLocation } from 'react-router-dom';
 import { getQueryObject } from 'utils/queryStringUtils';
 import VulnMgmtCreateReportPage from './VulnMgmtCreateReportPage';
 import VulnMgmtReportTablePage from './VulnMgmtReportTablePage';
-import { VulnMgmtReportQueryObject } from './VulnMgmtReport.utils';
 
 function VulnMgmtReportsMainPage(): ReactElement {
     const { search } = useLocation();
-    const queryObject = getQueryObject<VulnMgmtReportQueryObject>(search);
+    const queryObject = getQueryObject(search);
     const { action } = queryObject;
 
     if (action === 'create') {

--- a/ui/apps/platform/src/hooks/useURLPagination.ts
+++ b/ui/apps/platform/src/hooks/useURLPagination.ts
@@ -11,7 +11,7 @@ type UseURLPaginationResult = {
 function safeNumber(val: unknown, defaultVal: number) {
     const parsed = Number(val);
 
-    return Number.isNaN(parsed) ? defaultVal : parsed;
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : defaultVal;
 }
 
 function useURLPagination(defaultPerPage: number): UseURLPaginationResult {

--- a/ui/apps/platform/src/hooks/useURLPagination.ts
+++ b/ui/apps/platform/src/hooks/useURLPagination.ts
@@ -8,12 +8,15 @@ type UseURLPaginationResult = {
     setPerPage: (perPage: number) => void;
 };
 
+function safeNumber(val: unknown, defaultVal: number) {
+    const parsed = Number(val);
+
+    return Number.isNaN(parsed) ? defaultVal : parsed;
+}
+
 function useURLPagination(defaultPerPage: number): UseURLPaginationResult {
-    const [page, setPageString] = useURLParameter<string | undefined>('page', '1');
-    const [perPage, setPerPageString] = useURLParameter<string | undefined>(
-        'perPage',
-        `${defaultPerPage}`
-    );
+    const [page, setPageString] = useURLParameter('page', '1');
+    const [perPage, setPerPageString] = useURLParameter('perPage', `${defaultPerPage}`);
     const setPage = useCallback(
         (num: number) => setPageString(num > 1 ? String(num) : undefined),
         [setPageString]
@@ -23,8 +26,8 @@ function useURLPagination(defaultPerPage: number): UseURLPaginationResult {
         [setPerPageString, defaultPerPage]
     );
     return {
-        page: Number(page),
-        perPage: Number(perPage),
+        page: safeNumber(page, 1),
+        perPage: safeNumber(perPage, defaultPerPage),
         setPage,
         setPerPage,
     };

--- a/ui/apps/platform/src/hooks/useURLParameter.ts
+++ b/ui/apps/platform/src/hooks/useURLParameter.ts
@@ -3,9 +3,9 @@ import { useLocation, useHistory } from 'react-router-dom';
 import isEqual from 'lodash/isEqual';
 import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
 
-type QueryValue = undefined | string | string[] | qs.ParsedQs | qs.ParsedQs[];
+export type QueryValue = undefined | string | string[] | qs.ParsedQs | qs.ParsedQs[];
 
-type UseURLParameterResult<T> = [T, (newValue: T) => void];
+type UseURLParameterResult = [QueryValue, (newValue: QueryValue) => void];
 
 /**
  * Hook to handle reading and writing of a piece of state in the page's URL query parameters.
@@ -22,20 +22,17 @@ type UseURLParameterResult<T> = [T, (newValue: T) => void];
  *
  * @returns [value, setterFn]
  */
-function useURLParameter<ParsedValueType extends QueryValue>(
-    keyPrefix: string,
-    defaultValue: ParsedValueType
-): UseURLParameterResult<ParsedValueType> {
+function useURLParameter(keyPrefix: string, defaultValue: QueryValue): UseURLParameterResult {
     const history = useHistory();
     const location = useLocation();
     // We use an internal Ref here so that calling code that depends on the
     // value returned by this hook can detect updates. e.g. When used in the
     // dependency array of a `useEffect`.
-    const internalValue = useRef<ParsedValueType>(defaultValue);
+    const internalValue = useRef(defaultValue);
     // memoize the setter function to retain referential equality as long
     // as the URL parameters do not change
     const setValue = useCallback(
-        (newValue: ParsedValueType) => {
+        (newValue: QueryValue) => {
             const previousQuery = getQueryObject(location.search) || {};
             const newQueryString = getQueryString({
                 ...previousQuery,
@@ -54,8 +51,7 @@ function useURLParameter<ParsedValueType extends QueryValue>(
         [keyPrefix, history, location.search]
     );
 
-    const nextValue =
-        getQueryObject<Record<string, ParsedValueType>>(location.search)[keyPrefix] || defaultValue;
+    const nextValue = getQueryObject(location.search)[keyPrefix] || defaultValue;
 
     // If the search filter has changed, replace the object reference.
     if (!isEqual(internalValue.current, nextValue)) {

--- a/ui/apps/platform/src/hooks/useURLSearch.ts
+++ b/ui/apps/platform/src/hooks/useURLSearch.ts
@@ -1,9 +1,48 @@
-import { SearchFilter } from 'types/search';
-import useURLParameter from './useURLParameter';
+import { useRef } from 'react';
+import isEqual from 'lodash/isEqual';
 
-function useURLSearch(keyPrefix = 'search') {
-    const [searchFilter, setSearchFilter] = useURLParameter<SearchFilter>(keyPrefix, {});
-    return { searchFilter, setSearchFilter };
+import { SearchFilter } from 'types/search';
+import { isParsedQs } from 'utils/queryStringUtils';
+import useURLParameter, { QueryValue } from './useURLParameter';
+
+type UseUrlSearchReturn = {
+    searchFilter: SearchFilter;
+    setSearchFilter: (newFilter: SearchFilter) => void;
+};
+
+function parseFilter(rawFilter: QueryValue): SearchFilter {
+    const parsedFilter = {};
+
+    if (!rawFilter || !isParsedQs(rawFilter)) {
+        return parsedFilter;
+    }
+
+    Object.entries(rawFilter).forEach(([searchKey, searchVal]) => {
+        if (typeof searchVal === 'string') {
+            parsedFilter[searchKey] = searchVal;
+        } else if (Array.isArray(searchVal)) {
+            parsedFilter[searchKey] = [];
+            searchVal.forEach((searchArrayEntry) => {
+                if (typeof searchArrayEntry === 'string') {
+                    parsedFilter[searchKey].push(searchArrayEntry);
+                }
+            });
+        }
+    });
+
+    return parsedFilter;
+}
+
+function useURLSearch(keyPrefix = 'search'): UseUrlSearchReturn {
+    const [rawFilter, setSearchFilter] = useURLParameter(keyPrefix, {});
+    const searchFilterRef = useRef<SearchFilter>({});
+    const sanitizedFilter = parseFilter(rawFilter);
+
+    if (!isEqual(searchFilterRef.current, sanitizedFilter)) {
+        searchFilterRef.current = sanitizedFilter;
+    }
+
+    return { searchFilter: searchFilterRef.current, setSearchFilter };
 }
 
 export default useURLSearch;

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import useURLParameter from 'hooks/useURLParameter';
 import { SortDirection, SortOption, ThProps } from 'types/table';
 import { ApiSortOption } from 'types/search';
+import { isParsedQs } from 'utils/queryStringUtils';
 
 export type GetSortParams = (field: string) => ThProps['sort'] | undefined;
 
@@ -22,16 +23,23 @@ function tableSortOption(field: string, direction: SortDirection): ApiSortOption
     };
 }
 
-function useURLSort({ sortFields, defaultSortOption }: UseTableSortProps): UseTableSortResult {
-    const [sortOption, setSortOption] = useURLParameter<SortOption>(
-        'sortOption',
-        defaultSortOption
-    );
+function isDirection(val: unknown): val is 'asc' | 'desc' {
+    return val === 'asc' || val === 'desc';
+}
 
-    // get the sort option values from the URL, if available
+function useURLSort({ sortFields, defaultSortOption }: UseTableSortProps): UseTableSortResult {
+    const [sortOption, setSortOption] = useURLParameter('sortOption', defaultSortOption);
+
+    // get the parsed sort option values from the URL, if available
     // otherwise, use the default sort option values
-    const activeSortField = sortOption?.field || defaultSortOption.field;
-    const activeSortDirection = sortOption?.direction || defaultSortOption.direction;
+    const activeSortField =
+        isParsedQs(sortOption) && typeof sortOption?.field === 'string'
+            ? sortOption.field
+            : defaultSortOption.field;
+    const activeSortDirection =
+        isParsedQs(sortOption) && isDirection(sortOption?.direction)
+            ? sortOption.direction
+            : defaultSortOption.direction;
 
     const internalSortResultOption = useRef<ApiSortOption>(
         tableSortOption(activeSortField, activeSortDirection)

--- a/ui/apps/platform/src/utils/queryStringUtils.ts
+++ b/ui/apps/platform/src/utils/queryStringUtils.ts
@@ -1,13 +1,18 @@
 import qs from 'qs';
+import isPlainObject from 'lodash/isPlainObject';
 
 export type BasePageAction = 'create' | 'edit';
 
 export type ExtendedPageAction = BasePageAction | 'clone' | 'generate';
 
-export function getQueryObject<T extends qs.ParsedQs>(search: string): T {
-    return qs.parse(search, { ignoreQueryPrefix: true }) as T;
+export function getQueryObject(search: string): qs.ParsedQs {
+    return qs.parse(search, { ignoreQueryPrefix: true });
 }
 
 export function getQueryString<T>(searchObject: T): string {
     return qs.stringify(searchObject, { encode: false, addQueryPrefix: true });
+}
+
+export function isParsedQs(s: unknown): s is qs.ParsedQs {
+    return isPlainObject(s);
 }


### PR DESCRIPTION
## Description

This removes an unsafe cast from the `getQueryObject()` function that is used in a handful of places for URL parsing. This cast could cause a page to crash if a malformed query parameter was passed in the URL.

For example, if the Violations page was visited with the URL `/main/violations?search[Severity]=HIGH_SEVERITY&search[Category][bogus]=Privileges`, the search parameter would be parsed into an object that looked like
```js
{
  Severity: 'HIGH_SEVERITY',
  Category: {
    bogus: 'Privileges'
  }
}
```
which would be assigned to a TS `SearchFilter` variable with the type
```typescript
export type SearchFilter = Record<string, string | string[]>;
```
causing runtime errors when iterating over the values.

I noticed the potential for error when converting the policies page to use the new hook and seeing [these validation functions](https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Policies/policies.utils.ts#L44).

## Impact

- The `useURLParameter` hook no longer accepts a generic parameter, and just returns `qs.ParsedQs` directly.
- Code that calls this hook directly or hooks that are based on this hook must handle parsing into a narrowed type on their own.
- Invalid parameters in the URL will be ignored when using the `useURLSearch` hook.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

If any of these don't apply, please comment below.

## Testing Performed

Test that invalid parameters in the URL are ignored, and do not cause errors on the page:
(URL for the screenshot below: `https://localhost:3000/main/violations?search[Severity]=HIGH_SEVERITY&search[Category][bogus]=Privileges&search=test`)
![image](https://user-images.githubusercontent.com/1292638/165591143-29c4d504-6ab8-43ad-ba26-43d5a937e4f1.png)

Test that sorting and pagination work as expected:
![image](https://user-images.githubusercontent.com/1292638/165591283-6483b398-7891-4507-b77d-2ba23b44ff4a.png)

Test that multiple search options work on Violations page:
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/165592792-62b53671-ae97-4f5b-89e1-62ed42e2c9c2.png">

Test that multiple search options work on Risk Acceptance pages:
![image](https://user-images.githubusercontent.com/1292638/165592675-0435e6ca-9096-4f62-b52a-06ee6c1b4642.png)

