### PR TITLE
Update Policies to use URL search hook

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PoliciesPage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PoliciesPage.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 
 import usePermissions from 'hooks/usePermissions';
-import { policiesBasePath } from 'routePaths';
-import { SearchFilter } from 'types/search';
+import useURLSearch from 'hooks/useURLSearch';
 
 import NotFoundMessage from 'Components/NotFoundMessage';
-import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
 import { parsePoliciesSearchString } from './policies.utils';
 import PoliciesTablePage from './Table/PoliciesTablePage';
 import PolicyPage from './PolicyPage';
@@ -20,27 +18,19 @@ function PoliciesPage() {
      *
      * Examples of urls for PolicyTablePage:
      * /main/policies
-     * /main/policies?s[Lifecycle Stage]=BUILD
-     * /main/policies?s[Lifecycle Stage]=BUILD&s[Lifecycle State]=DEPLOY
-     * /main/policies?s[Lifecycle State]=RUNTIME&s[Severity]=CRITICAL_SEVERITY
+     * /main/policies?search[Lifecycle Stage]=BUILD
+     * /main/policies?search[Lifecycle Stage]=BUILD&search[Lifecycle State]=DEPLOY
+     * /main/policies?search[Lifecycle State]=RUNTIME&search[Severity]=CRITICAL_SEVERITY
      */
-    const history = useHistory();
     const location = useLocation();
     const { search } = location;
-    const { pageAction, searchFilter } = parsePoliciesSearchString(search);
+    const { searchFilter, setSearchFilter } = useURLSearch();
+    const { pageAction } = parsePoliciesSearchString(search);
     const { policyId } = useParams();
 
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
     const hasReadAccessForPolicy = hasReadAccess('Policy');
     const hasWriteAccessForPolicy = hasReadWriteAccess('Policy');
-
-    function handleChangeSearchFilter(changedSearchFilter: SearchFilter) {
-        // Browser history has only the most recent search filter.
-        history.replace({
-            pathname: policiesBasePath,
-            search: getUrlQueryStringForSearchFilter(changedSearchFilter, 's'),
-        });
-    }
 
     if (!hasReadAccessForPolicy) {
         return <NotFoundMessage title="404: We couldn't find that page" />;
@@ -59,7 +49,7 @@ function PoliciesPage() {
     return (
         <PoliciesTablePage
             hasWriteAccessForPolicy={hasWriteAccessForPolicy}
-            handleChangeSearchFilter={handleChangeSearchFilter}
+            handleChangeSearchFilter={setSearchFilter}
             searchFilter={searchFilter}
         />
     );

--- a/ui/apps/platform/src/Containers/Policies/PoliciesPage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PoliciesPage.tsx
@@ -18,9 +18,9 @@ function PoliciesPage() {
      *
      * Examples of urls for PolicyTablePage:
      * /main/policies
-     * /main/policies?search[Lifecycle Stage]=BUILD
-     * /main/policies?search[Lifecycle Stage]=BUILD&search[Lifecycle State]=DEPLOY
-     * /main/policies?search[Lifecycle State]=RUNTIME&search[Severity]=CRITICAL_SEVERITY
+     * /main/policies?s[Lifecycle Stage]=BUILD
+     * /main/policies?s[Lifecycle Stage]=BUILD&s[Lifecycle State]=DEPLOY
+     * /main/policies?s[Lifecycle State]=RUNTIME&s[Severity]=CRITICAL_SEVERITY
      */
     const location = useLocation();
     const { search } = location;

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -1,6 +1,5 @@
-import isPlainObject from 'lodash/isPlainObject';
 import pluralize from 'pluralize';
-import qs, { ParsedQs } from 'qs';
+import qs from 'qs';
 import cloneDeep from 'lodash/cloneDeep';
 
 import integrationsList from 'Containers/Integrations/utils/integrationsList';
@@ -25,47 +24,23 @@ function isValidAction(action: unknown): action is ExtendedPageAction {
     return action === 'clone' || action === 'create' || action === 'edit' || action === 'generate';
 }
 
-function isParsedQs(s: unknown): s is ParsedQs {
-    return isPlainObject(s);
-}
-
-function isValidFilterValue(value: unknown): value is string | string[] {
-    if (typeof value === 'string') {
-        return true;
-    }
-
-    if (Array.isArray(value) && value.every((item) => typeof item === 'string')) {
-        return true;
-    }
-
-    return false;
-}
-
-function isValidFilter(s: unknown): s is SearchFilter {
-    return isParsedQs(s) && Object.values(s).every((value) => isValidFilterValue(value));
-}
-
 export type PoliciesSearch = {
     pageAction?: ExtendedPageAction;
     searchFilter?: SearchFilter;
 };
 
 /*
- * Given search query string from location, return validated action string and filter object.
+ * Given search query string from location, return validated action string.
  *
  * Examples of search query string:
  * ?action=create
  * ?action=edit
- * ?s[Lifecycle Stage]=BUILD
- * ?s[Lifecycle Stage]=BUILD&s[Lifecycle State]=DEPLOY
- * ?s[Lifecycle State]=RUNTIME&s[Severity]=CRITICAL_SEVERITY
  */
 export function parsePoliciesSearchString(search: string): PoliciesSearch {
-    const { action, s } = qs.parse(search, { ignoreQueryPrefix: true });
+    const { action } = qs.parse(search, { ignoreQueryPrefix: true });
 
     return {
         pageAction: isValidAction(action) ? action : undefined,
-        searchFilter: isValidFilter(s) ? s : undefined,
     };
 }
 


### PR DESCRIPTION
## Description

This updates the Policies page to use the useURLSearch hook to manage search state in the browser's URL. This is a non-functional change to add consistency in the way URL search is handled.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

Test that applying a search filter successfully filters the table and track parameter usage in the URL.
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/1292638/165953175-4cbb5152-2505-4520-9db7-c3ab074945a8.png">

Test that applying a search filter with multiple values works as expected.
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/1292638/165953351-ac78d61a-4172-4272-8b73-629ac2d7e1c7.png">

Test that multiple search filter options works as expected.
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/1292638/165953431-5bd35d3b-605b-4571-980e-a2ebb98d830c.png">

Test that visiting the page directly with all of the above URLs works identically to entering the search parameters in the filter bar.