### PR TITLE
OSCI: Build roxctl (redux)

### DIFF
--- a/image/roxctl-osci.Dockerfile
+++ b/image/roxctl-osci.Dockerfile
@@ -1,0 +1,8 @@
+# Under OpenShift CI CA certificates are in context already.
+FROM scratch
+COPY ./bin/roxctl-linux /roxctl
+COPY ./tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
+ENV ROX_ROXCTL_IN_MAIN_IMAGE="true"
+
+USER 65534:65534
+ENTRYPOINT [ "/roxctl" ]

--- a/image/roxctl-osci.Dockerfile
+++ b/image/roxctl-osci.Dockerfile
@@ -1,7 +1,8 @@
-# Under OpenShift CI CA certificates are in context already.
+FROM registry.access.redhat.com/ubi8-minimal:8.5 AS certs
+
 FROM scratch
 COPY ./bin/roxctl-linux /roxctl
-COPY ./tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
 ENV ROX_ROXCTL_IN_MAIN_IMAGE="true"
 
 USER 65534:65534

--- a/image/roxctl-osci.Dockerfile
+++ b/image/roxctl-osci.Dockerfile
@@ -1,9 +1,0 @@
-FROM registry.access.redhat.com/ubi8-minimal:8.5 AS certs
-
-FROM scratch
-COPY ./bin/roxctl-linux /roxctl
-COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
-ENV ROX_ROXCTL_IN_MAIN_IMAGE="true"
-
-USER 65534:65534
-ENTRYPOINT [ "/roxctl" ]

--- a/image/roxctl.Dockerfile
+++ b/image/roxctl.Dockerfile
@@ -1,9 +1,8 @@
-FROM alpine:latest as certs
-RUN apk --update add ca-certificates
+FROM registry.access.redhat.com/ubi8-minimal:latest AS certs
 
 FROM scratch
 COPY ./bin/roxctl-linux /roxctl
-COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
 ENV ROX_ROXCTL_IN_MAIN_IMAGE="true"
 
 USER 65534:65534


### PR DESCRIPTION
## Description

PR #1435 created and OpenShift CI roxctl image build using an embedded Dockerfile in openshift/release because I thought it had to be that way. I've since learnt that using precise image.inputs is possible for the image that provides the certs in this multi-stage build and so this PR arrives to remove the duplication. UBI is used in place of alpine because alpine images are not available in OpenShift CI. The openshift companion PR is: https://github.com/openshift/release/pull/28169

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient