### PR TITLE
ROX-9745: Making the policy boltdb store less bespoke, and ensuring it has interface parity with the generated postgres store (categories methods TBD).

### DIFF
--- a/central/policy/datastore/datastore_impl.go
+++ b/central/policy/datastore/datastore_impl.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	errorsPkg "github.com/pkg/errors"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
@@ -20,11 +21,17 @@ import (
 	searchPkg "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/uuid"
 )
 
 var (
 	log       = logging.LoggerForModule()
 	policySAC = sac.ForResource(resources.Policy)
+
+	policyCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Policy)))
 )
 
 type datastoreImpl struct {
@@ -38,7 +45,7 @@ type datastoreImpl struct {
 }
 
 func (ds *datastoreImpl) buildIndex() error {
-	policies, err := ds.storage.GetAllPolicies()
+	policies, err := ds.storage.GetAll(policyCtx)
 	if err != nil {
 		return err
 	}
@@ -75,7 +82,7 @@ func (ds *datastoreImpl) GetPolicy(ctx context.Context, id string) (*storage.Pol
 		return nil, false, err
 	}
 
-	policy, exists, err := ds.storage.GetPolicy(id)
+	policy, exists, err := ds.storage.Get(ctx, id)
 	if err != nil || !exists {
 		return nil, false, err
 	}
@@ -87,7 +94,7 @@ func (ds *datastoreImpl) GetPolicies(ctx context.Context, ids []string) ([]*stor
 		return nil, nil, nil, err
 	}
 
-	policies, missingIndices, policyErrors, err := ds.storage.GetPolicies(ids...)
+	policies, missingIndices, policyErrors, err := ds.storage.GetMany(ctx, ids...)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -99,7 +106,7 @@ func (ds *datastoreImpl) GetAllPolicies(ctx context.Context) ([]*storage.Policy,
 		return nil, err
 	}
 
-	policies, err := ds.storage.GetAllPolicies()
+	policies, err := ds.storage.GetAll(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -133,17 +140,38 @@ func (ds *datastoreImpl) AddPolicy(ctx context.Context, policy *storage.Policy) 
 		return "", sac.ErrResourceAccessDenied
 	}
 
+	if policy.Id == "" {
+		policy.Id = uuid.NewV4().String()
+	}
+
+	ds.policyMutex.Lock()
+	defer ds.policyMutex.Unlock()
+
+	allPolicies, err := ds.GetAllPolicies(ctx)
+	if err != nil {
+		return "", errorsPkg.Wrap(err, "getting all policies")
+	}
+	policyNameIDMap := make(map[string]string, len(allPolicies))
+	for _, policy := range allPolicies {
+		policyNameIDMap[policy.GetName()] = policy.GetId()
+	}
+
+	if ds.policyNameIsNotUnique(policyNameIDMap, policy.GetName()) {
+		return "", fmt.Errorf("Could not add policy due to name validation, policy with name %s already exists", policy.GetName())
+	}
 	utils.FillSortHelperFields(policy)
 	// Any policy added after statup must be marked custom policy.
 	markPoliciesAsCustom(policy)
 
 	// No need to lock here because nobody can update the policy
 	// until this function returns and they receive the id.
-	id, err := ds.storage.AddPolicy(policy, true)
+	err = ds.storage.Upsert(ctx, policy)
+
 	if err != nil {
-		return id, err
+		return policy.Id, err
 	}
-	return id, ds.indexer.AddPolicy(policy)
+
+	return policy.Id, ds.indexer.AddPolicy(policy)
 }
 
 // UpdatePolicy updates a policy from the storage and the indexer
@@ -154,11 +182,15 @@ func (ds *datastoreImpl) UpdatePolicy(ctx context.Context, policy *storage.Polic
 		return sac.ErrResourceAccessDenied
 	}
 
+	if policy.Id == "" {
+		return errors.New("policy id not specified")
+	}
+
 	utils.FillSortHelperFields(policy)
 
 	ds.policyMutex.Lock()
 	defer ds.policyMutex.Unlock()
-	if err := ds.storage.UpdatePolicy(policy); err != nil {
+	if err := ds.storage.Upsert(ctx, policy); err != nil {
 		return err
 	}
 	return ds.indexer.AddPolicy(policy)
@@ -175,11 +207,11 @@ func (ds *datastoreImpl) RemovePolicy(ctx context.Context, id string) error {
 	ds.policyMutex.Lock()
 	defer ds.policyMutex.Unlock()
 
-	return ds.removePolicyNoLock(id)
+	return ds.removePolicyNoLock(ctx, id)
 }
 
-func (ds *datastoreImpl) removePolicyNoLock(id string) error {
-	if err := ds.storage.RemovePolicy(id); err != nil {
+func (ds *datastoreImpl) removePolicyNoLock(ctx context.Context, id string) error {
+	if err := ds.storage.Delete(ctx, id); err != nil {
 		return err
 	}
 	return ds.indexer.DeletePolicy(id)
@@ -191,6 +223,8 @@ func (ds *datastoreImpl) RenamePolicyCategory(ctx context.Context, request *v1.R
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
+	ds.policyMutex.Lock()
+	defer ds.policyMutex.Unlock()
 
 	return ds.storage.RenamePolicyCategory(request)
 }
@@ -238,7 +272,7 @@ func (ds *datastoreImpl) ImportPolicies(ctx context.Context, importPolicies []*s
 	allSucceeded := true
 	responses := make([]*v1.ImportPolicyResponse, len(importPolicies))
 	for i, policy := range importPolicies {
-		response := ds.importPolicy(policy, overwrite, policyNameIDMap)
+		response := ds.importPolicy(ctx, policy, overwrite, policyNameIDMap)
 		if !response.Succeeded {
 			allSucceeded = false
 		}
@@ -255,15 +289,43 @@ func (ds *datastoreImpl) ImportPolicies(ctx context.Context, importPolicies []*s
 	return responses, allSucceeded, nil
 }
 
-func (ds *datastoreImpl) importPolicy(policy *storage.Policy, overwrite bool, policyNameIDMap map[string]string) *v1.ImportPolicyResponse {
+func (ds *datastoreImpl) importPolicy(ctx context.Context, policy *storage.Policy, overwrite bool, policyNameIDMap map[string]string) *v1.ImportPolicyResponse {
 	result := &v1.ImportPolicyResponse{
 		Policy: policy,
 	}
 	var err error
 	if overwrite {
-		err = ds.importOverwrite(policy, policyNameIDMap)
+		err = ds.importOverwrite(ctx, policy, policyNameIDMap)
 	} else {
-		_, err = ds.storage.AddPolicy(policy, true)
+		existingPolicy, exists, storeErr := ds.storage.Get(ctx, policy.GetId())
+		if storeErr != nil {
+			result.Errors = getImportErrorsFromError(storeErr)
+			return result
+		}
+		importErrors := make([]*v1.ImportPolicyError, 0)
+		if exists {
+			importErrors = append(result.Errors, &v1.ImportPolicyError{
+				Message: fmt.Sprintf("policy with id '%s' already exists, unable to import policy", policy.GetId()),
+				Type:    policiesPkg.ErrImportDuplicateID,
+				Metadata: &v1.ImportPolicyError_DuplicateName{
+					DuplicateName: existingPolicy.GetName(),
+				},
+			})
+		}
+		if ds.policyNameIsNotUnique(policyNameIDMap, policy.GetName()) {
+			importErrors = append(importErrors, &v1.ImportPolicyError{
+				Message: fmt.Sprintf("policy with name '%s' already exists, unable to import policy", policy.GetName()),
+				Type:    policiesPkg.ErrImportDuplicateName,
+				Metadata: &v1.ImportPolicyError_DuplicateName{
+					DuplicateName: policy.GetName(),
+				},
+			})
+		}
+		if len(importErrors) > 0 {
+			result.Errors = importErrors
+			return result
+		}
+		err = ds.storage.Upsert(ctx, policy)
 	}
 	if err != nil {
 		result.Errors = getImportErrorsFromError(err)
@@ -278,28 +340,36 @@ func (ds *datastoreImpl) importPolicy(policy *storage.Policy, overwrite bool, po
 	return result
 }
 
-func (ds *datastoreImpl) importOverwrite(policy *storage.Policy, policyNameIDMap map[string]string) error {
+func (ds *datastoreImpl) policyNameIsNotUnique(policyNameIDMap map[string]string, name string) bool {
+	for n := range policyNameIDMap {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (ds *datastoreImpl) importOverwrite(ctx context.Context, policy *storage.Policy, policyNameIDMap map[string]string) error {
 	if policy.GetId() != "" {
-		_, exists, err := ds.storage.GetPolicy(policy.GetId())
+		_, exists, err := ds.storage.Get(ctx, policy.GetId())
 		if err != nil {
 			return errorsPkg.Wrapf(err, "getting policy %s", policy.GetId())
 		}
 		if exists {
-			if err := ds.removePolicyNoLock(policy.GetId()); err != nil {
+			if err := ds.removePolicyNoLock(ctx, policy.GetId()); err != nil {
 				return errorsPkg.Wrapf(err, "removing policy %s", policy.GetId())
 			}
 		}
 	}
 
 	if otherPolicyID, ok := policyNameIDMap[policy.GetName()]; ok && otherPolicyID != policy.GetId() {
-		if err := ds.removePolicyNoLock(otherPolicyID); err != nil {
+		if err := ds.removePolicyNoLock(ctx, otherPolicyID); err != nil {
 			return errorsPkg.Wrapf(err, "removing policy %s", otherPolicyID)
 		}
 	}
 
 	// This should never create a name violation because we just removed any ID/name conflicts
-	_, err := ds.storage.AddPolicy(policy, true)
-	return err
+	return ds.storage.Upsert(ctx, policy)
 }
 
 func getImportErrorsFromError(err error) []*v1.ImportPolicyError {

--- a/central/policy/datastore/datastore_impl.go
+++ b/central/policy/datastore/datastore_impl.go
@@ -25,9 +25,13 @@ import (
 )
 
 var (
-	log          = logging.LoggerForModule()
-	policySAC    = sac.ForResource(resources.Policy)
-	allAccessCtx = sac.WithAllAccess(context.Background())
+	log       = logging.LoggerForModule()
+	policySAC = sac.ForResource(resources.Policy)
+
+	policyCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Policy)))
 )
 
 type datastoreImpl struct {
@@ -41,7 +45,7 @@ type datastoreImpl struct {
 }
 
 func (ds *datastoreImpl) buildIndex() error {
-	policies, err := ds.storage.GetAll(allAccessCtx)
+	policies, err := ds.storage.GetAll(policyCtx)
 	if err != nil {
 		return err
 	}

--- a/central/policy/datastore/datastore_impl_test.go
+++ b/central/policy/datastore/datastore_impl_test.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -79,8 +80,9 @@ func (s *PolicyDatastoreTestSuite) TestImportPolicySucceeds() {
 	}
 
 	s.clusterDatastore.EXPECT().GetClusters(s.ctx).Return(nil, nil)
-	s.store.EXPECT().GetAllPolicies().Return(nil, nil)
-	s.store.EXPECT().AddPolicy(policy, true).Return(policy.GetId(), nil)
+	s.store.EXPECT().Get(s.ctx, policy.GetId()).Return(nil, false, nil)
+	s.store.EXPECT().GetAll(s.ctx).Return(nil, nil)
+	s.store.EXPECT().Upsert(s.ctx, policy).Return(nil)
 	s.indexer.EXPECT().AddPolicy(policy).Return(nil)
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.ctx, []*storage.Policy{policy.Clone()}, false)
 	s.NoError(err)
@@ -97,25 +99,21 @@ func (s *PolicyDatastoreTestSuite) TestImportPolicyDuplicateID() {
 		SORTName: "test policy",
 	}
 
-	otherName := "Joseph Rules"
-	errString := "some error string"
-	storeError := &store.PolicyStoreErrorList{
-		Errors: []error{
-			&store.IDConflictError{
-				ErrString:          errString,
-				ExistingPolicyName: otherName,
-			},
-		},
-	}
+	errString1 := "policy with id 'test-policy-1' already exists, unable to import policy"
+	errString2 := "policy with name 'test policy' already exists, unable to import policy"
+
 	s.clusterDatastore.EXPECT().GetClusters(s.ctx).Return(nil, nil)
-	s.store.EXPECT().GetAllPolicies().Return(nil, nil)
-	s.store.EXPECT().AddPolicy(policy, true).Return(policy.GetId(), storeError)
+	s.store.EXPECT().Get(s.ctx, policy.GetId()).Return(policy, true, nil)
+	s.store.EXPECT().GetAll(s.ctx).Return([]*storage.Policy{
+		policy,
+	}, nil)
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.ctx, []*storage.Policy{policy.Clone()}, false)
 	s.NoError(err)
 	s.False(allSucceeded)
 	s.Require().Len(responses, 1)
 
-	s.testImportFailResponse(policy, []string{policies.ErrImportDuplicateID}, []string{errString}, []string{otherName}, responses[0])
+	s.testImportFailResponse(policy, []string{policies.ErrImportDuplicateID, policies.ErrImportDuplicateName},
+		[]string{errString1, errString2}, []string{policy.GetName(), policy.GetName()}, responses[0])
 }
 
 func (s *PolicyDatastoreTestSuite) TestImportPolicyDuplicateName() {
@@ -126,56 +124,23 @@ func (s *PolicyDatastoreTestSuite) TestImportPolicyDuplicateName() {
 		SORTName: name,
 	}
 
-	errString := "some error string"
-	storeError := &store.PolicyStoreErrorList{
-		Errors: []error{
-			&store.NameConflictError{
-				ErrString:          errString,
-				ExistingPolicyName: name,
-			},
-		},
-	}
+	errString := fmt.Sprintf("policy with name '%s' already exists, unable to import policy", name)
+
 	s.clusterDatastore.EXPECT().GetClusters(s.ctx).Return(nil, nil)
-	s.store.EXPECT().GetAllPolicies().Return(nil, nil)
-	s.store.EXPECT().AddPolicy(policy, true).Return(policy.GetId(), storeError)
+	s.store.EXPECT().Get(s.ctx, policy.GetId()).Return(nil, false, nil)
+	s.store.EXPECT().GetAll(s.ctx).Return([]*storage.Policy{
+		{
+			Name:     name,
+			Id:       "some-other-id",
+			SORTName: name,
+		},
+	}, nil)
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.ctx, []*storage.Policy{policy.Clone()}, false)
 	s.NoError(err)
 	s.False(allSucceeded)
 	s.Require().Len(responses, 1)
 
 	s.testImportFailResponse(policy, []string{policies.ErrImportDuplicateName}, []string{errString}, []string{name}, responses[0])
-}
-
-func (s *PolicyDatastoreTestSuite) TestImportPolicyDuplicateNameAndDuplicateID() {
-	name := "another-duplicate-name"
-	policy := &storage.Policy{
-		Name:     name,
-		Id:       "another-duplicate-id",
-		SORTName: name,
-	}
-
-	errString := "some error string"
-	storeError := &store.PolicyStoreErrorList{
-		Errors: []error{
-			&store.NameConflictError{
-				ErrString:          errString,
-				ExistingPolicyName: name,
-			},
-			&store.IDConflictError{
-				ErrString:          errString,
-				ExistingPolicyName: name,
-			},
-		},
-	}
-	s.clusterDatastore.EXPECT().GetClusters(s.ctx).Return(nil, nil)
-	s.store.EXPECT().GetAllPolicies().Return(nil, nil)
-	s.store.EXPECT().AddPolicy(policy, true).Return(policy.GetId(), storeError)
-	responses, allSucceeded, err := s.datastore.ImportPolicies(s.ctx, []*storage.Policy{policy.Clone()}, false)
-	s.NoError(err)
-	s.False(allSucceeded)
-	s.Require().Len(responses, 1)
-
-	s.testImportFailResponse(policy, []string{policies.ErrImportDuplicateName, policies.ErrImportDuplicateID}, []string{errString, errString}, []string{name, name}, responses[0])
 }
 
 func (s *PolicyDatastoreTestSuite) TestImportPolicyMixedSuccessAndFailure() {
@@ -218,13 +183,14 @@ func (s *PolicyDatastoreTestSuite) TestImportPolicyMixedSuccessAndFailure() {
 
 	s.clusterDatastore.EXPECT().GetClusters(s.ctx).Return(nil, nil)
 
-	s.store.EXPECT().GetAllPolicies().Return(nil, nil)
+	s.store.EXPECT().GetAll(s.ctx).Return(nil, nil)
 
-	s.store.EXPECT().AddPolicy(policySucceed, true).Return(policySucceed.GetId(), nil)
+	s.store.EXPECT().Upsert(s.ctx, policySucceed).Return(nil)
 	s.indexer.EXPECT().AddPolicy(policySucceed).Return(nil)
+	s.store.EXPECT().Get(s.ctx, gomock.Any()).Return(nil, false, nil).AnyTimes()
 
-	s.store.EXPECT().AddPolicy(policyFail1, true).Return(policyFail1.GetId(), errorFail1)
-	s.store.EXPECT().AddPolicy(policyFail2, true).Return(policyFail2.GetId(), errorFail2)
+	s.store.EXPECT().Upsert(s.ctx, policyFail1).Return(errorFail1)
+	s.store.EXPECT().Upsert(s.ctx, policyFail2).Return(errorFail2)
 
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.ctx, []*storage.Policy{policySucceed.Clone(), policyFail1.Clone(), policyFail2.Clone()}, false)
 	s.NoError(err)
@@ -246,12 +212,13 @@ func (s *PolicyDatastoreTestSuite) TestUnknownError() {
 		SORTName: name,
 	}
 
-	errString := "This is not a structured error type"
+	errString := "this is not a structured error type"
 	storeError := errors.New(errString)
 
 	s.clusterDatastore.EXPECT().GetClusters(s.ctx).Return(nil, nil)
-	s.store.EXPECT().GetAllPolicies().Return(nil, nil)
-	s.store.EXPECT().AddPolicy(policy, true).Return(policy.GetId(), storeError)
+	s.store.EXPECT().Get(s.ctx, policy.GetId()).Return(nil, false, nil)
+	s.store.EXPECT().GetAll(s.ctx).Return(nil, nil)
+	s.store.EXPECT().Upsert(s.ctx, policy).Return(storeError)
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.ctx, []*storage.Policy{policy.Clone()}, false)
 	s.NoError(err)
 	s.False(allSucceeded)
@@ -286,18 +253,18 @@ func (s *PolicyDatastoreTestSuite) TestImportOverwrite() {
 
 	s.clusterDatastore.EXPECT().GetClusters(s.ctx).Return(nil, nil)
 
-	s.store.EXPECT().GetAllPolicies().Return([]*storage.Policy{existingPolicy1, existingPolicy2}, nil)
+	s.store.EXPECT().GetAll(s.ctx).Return([]*storage.Policy{existingPolicy1, existingPolicy2}, nil)
 
-	s.store.EXPECT().GetPolicy(existingPolicy1.GetId()).Return(nil, true, nil)
-	s.store.EXPECT().RemovePolicy(existingPolicy1.GetId()).Return(nil)
+	s.store.EXPECT().Get(s.ctx, existingPolicy1.GetId()).Return(nil, true, nil)
+	s.store.EXPECT().Delete(s.ctx, existingPolicy1.GetId()).Return(nil)
 	s.indexer.EXPECT().DeletePolicy(existingPolicy1.GetId()).Return(nil)
-	s.store.EXPECT().AddPolicy(policy1, true).Return("", nil)
+	s.store.EXPECT().Upsert(s.ctx, policy1).Return(nil)
 	s.indexer.EXPECT().AddPolicy(policy1).Return(nil)
 
-	s.store.EXPECT().GetPolicy(policy2.GetId()).Return(nil, false, nil)
-	s.store.EXPECT().RemovePolicy(existingPolicy2.GetId()).Return(nil)
+	s.store.EXPECT().Get(s.ctx, policy2.GetId()).Return(nil, false, nil)
+	s.store.EXPECT().Delete(s.ctx, existingPolicy2.GetId()).Return(nil)
 	s.indexer.EXPECT().DeletePolicy(existingPolicy2.GetId()).Return(nil)
-	s.store.EXPECT().AddPolicy(policy2, true).Return("", nil)
+	s.store.EXPECT().Upsert(s.ctx, policy2).Return(nil)
 	s.indexer.EXPECT().AddPolicy(policy2).Return(nil)
 
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.ctx, []*storage.Policy{policy1.Clone(), policy2.Clone()}, true)
@@ -341,8 +308,9 @@ func (s *PolicyDatastoreTestSuite) TestRemoveScopesAndNotifiers() {
 
 	s.clusterDatastore.EXPECT().GetClusters(s.ctx).Return(nil, nil)
 	s.notifierDatastore.EXPECT().GetNotifier(s.ctx, notifierName).Return(nil, false, nil)
-	s.store.EXPECT().GetAllPolicies().Return(nil, nil)
-	s.store.EXPECT().AddPolicy(policy, true).Return(policy.GetId(), nil)
+	s.store.EXPECT().Get(s.ctx, policy.GetId()).Return(nil, false, nil)
+	s.store.EXPECT().GetAll(s.ctx).Return(nil, nil)
+	s.store.EXPECT().Upsert(s.ctx, policy).Return(nil)
 	s.indexer.EXPECT().AddPolicy(policy).Return(nil)
 
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.ctx, []*storage.Policy{policy}, false)
@@ -390,8 +358,9 @@ func (s *PolicyDatastoreTestSuite) TestDoesNotRemoveScopesAndNotifiers() {
 	}
 	s.clusterDatastore.EXPECT().GetClusters(s.ctx).Return(mockClusters, nil)
 	s.notifierDatastore.EXPECT().GetNotifier(s.ctx, notifierName).Return(nil, true, nil)
-	s.store.EXPECT().GetAllPolicies().Return(nil, nil)
-	s.store.EXPECT().AddPolicy(policy, true).Return(policy.GetId(), nil)
+	s.store.EXPECT().GetAll(s.ctx).Return(nil, nil)
+	s.store.EXPECT().Get(s.ctx, policy.Id).Return(nil, false, nil)
+	s.store.EXPECT().Upsert(s.ctx, policy).Return(nil)
 	s.indexer.EXPECT().AddPolicy(policy).Return(nil)
 
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.ctx, []*storage.Policy{policy.Clone()}, false)

--- a/central/policy/datastore/datastore_impl_test.go
+++ b/central/policy/datastore/datastore_impl_test.go
@@ -99,7 +99,7 @@ func (s *PolicyDatastoreTestSuite) TestImportPolicyDuplicateID() {
 		SORTName: "test policy",
 	}
 
-	errString1 := "policy with id 'test-policy-1' already exists, unable to import policy"
+	errString1 := "policy with id '\"test-policy-1\"' already exists, unable to import policy"
 	errString2 := "policy with name 'test policy' already exists, unable to import policy"
 
 	s.clusterDatastore.EXPECT().GetClusters(s.ctx).Return(nil, nil)

--- a/central/policy/search/searcher_impl.go
+++ b/central/policy/search/searcher_impl.go
@@ -59,7 +59,7 @@ func (ds *searcherImpl) searchPolicies(ctx context.Context, q *v1.Query) ([]*sto
 	var policies []*storage.Policy
 	var newResults []search.Result
 	for _, result := range results {
-		policy, exists, err := ds.storage.GetPolicy(result.ID)
+		policy, exists, err := ds.storage.Get(ctx, result.ID)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/central/policy/store/mocks/store.go
+++ b/central/policy/store/mocks/store.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -35,19 +36,51 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
-// AddPolicy mocks base method.
-func (m *MockStore) AddPolicy(policy *storage.Policy, removePolicyTombstone bool) (string, error) {
+// AckKeysIndexed mocks base method.
+func (m *MockStore) AckKeysIndexed(ctx context.Context, keys ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddPolicy", policy, removePolicyTombstone)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	varargs := []interface{}{ctx}
+	for _, a := range keys {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AckKeysIndexed", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// AddPolicy indicates an expected call of AddPolicy.
-func (mr *MockStoreMockRecorder) AddPolicy(policy, removePolicyTombstone interface{}) *gomock.Call {
+// AckKeysIndexed indicates an expected call of AckKeysIndexed.
+func (mr *MockStoreMockRecorder) AckKeysIndexed(ctx interface{}, keys ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPolicy", reflect.TypeOf((*MockStore)(nil).AddPolicy), policy, removePolicyTombstone)
+	varargs := append([]interface{}{ctx}, keys...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AckKeysIndexed", reflect.TypeOf((*MockStore)(nil).AckKeysIndexed), varargs...)
+}
+
+// Delete mocks base method.
+func (m *MockStore) Delete(ctx context.Context, id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockStoreMockRecorder) Delete(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+}
+
+// DeleteMany mocks base method.
+func (m *MockStore) DeleteMany(ctx context.Context, ids []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteMany", ctx, ids)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteMany indicates an expected call of DeleteMany.
+func (mr *MockStoreMockRecorder) DeleteMany(ctx, ids interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockStore)(nil).DeleteMany), ctx, ids)
 }
 
 // DeletePolicyCategory mocks base method.
@@ -64,29 +97,75 @@ func (mr *MockStoreMockRecorder) DeletePolicyCategory(request interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePolicyCategory", reflect.TypeOf((*MockStore)(nil).DeletePolicyCategory), request)
 }
 
-// GetAllPolicies mocks base method.
-func (m *MockStore) GetAllPolicies() ([]*storage.Policy, error) {
+// Get mocks base method.
+func (m *MockStore) Get(ctx context.Context, id string) (*storage.Policy, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllPolicies")
+	ret := m.ctrl.Call(m, "Get", ctx, id)
+	ret0, _ := ret[0].(*storage.Policy)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockStoreMockRecorder) Get(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
+}
+
+// GetAll mocks base method.
+func (m *MockStore) GetAll(ctx context.Context) ([]*storage.Policy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAll", ctx)
 	ret0, _ := ret[0].([]*storage.Policy)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllPolicies indicates an expected call of GetAllPolicies.
-func (mr *MockStoreMockRecorder) GetAllPolicies() *gomock.Call {
+// GetAll indicates an expected call of GetAll.
+func (mr *MockStoreMockRecorder) GetAll(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllPolicies", reflect.TypeOf((*MockStore)(nil).GetAllPolicies))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockStore)(nil).GetAll), ctx)
 }
 
-// GetPolicies mocks base method.
-func (m *MockStore) GetPolicies(ids ...string) ([]*storage.Policy, []int, []error, error) {
+// GetIDs mocks base method.
+func (m *MockStore) GetIDs(ctx context.Context) ([]string, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{}
+	ret := m.ctrl.Call(m, "GetIDs", ctx)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIDs indicates an expected call of GetIDs.
+func (mr *MockStoreMockRecorder) GetIDs(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIDs", reflect.TypeOf((*MockStore)(nil).GetIDs), ctx)
+}
+
+// GetKeysToIndex mocks base method.
+func (m *MockStore) GetKeysToIndex(ctx context.Context) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKeysToIndex", ctx)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetKeysToIndex indicates an expected call of GetKeysToIndex.
+func (mr *MockStoreMockRecorder) GetKeysToIndex(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeysToIndex", reflect.TypeOf((*MockStore)(nil).GetKeysToIndex), ctx)
+}
+
+// GetMany mocks base method.
+func (m *MockStore) GetMany(ctx context.Context, ids ...string) ([]*storage.Policy, []int, []error, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx}
 	for _, a := range ids {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "GetPolicies", varargs...)
+	ret := m.ctrl.Call(m, "GetMany", varargs...)
 	ret0, _ := ret[0].([]*storage.Policy)
 	ret1, _ := ret[1].([]int)
 	ret2, _ := ret[2].([]error)
@@ -94,40 +173,11 @@ func (m *MockStore) GetPolicies(ids ...string) ([]*storage.Policy, []int, []erro
 	return ret0, ret1, ret2, ret3
 }
 
-// GetPolicies indicates an expected call of GetPolicies.
-func (mr *MockStoreMockRecorder) GetPolicies(ids ...interface{}) *gomock.Call {
+// GetMany indicates an expected call of GetMany.
+func (mr *MockStoreMockRecorder) GetMany(ctx interface{}, ids ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPolicies", reflect.TypeOf((*MockStore)(nil).GetPolicies), ids...)
-}
-
-// GetPolicy mocks base method.
-func (m *MockStore) GetPolicy(id string) (*storage.Policy, bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPolicy", id)
-	ret0, _ := ret[0].(*storage.Policy)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetPolicy indicates an expected call of GetPolicy.
-func (mr *MockStoreMockRecorder) GetPolicy(id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPolicy", reflect.TypeOf((*MockStore)(nil).GetPolicy), id)
-}
-
-// RemovePolicy mocks base method.
-func (m *MockStore) RemovePolicy(id string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemovePolicy", id)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemovePolicy indicates an expected call of RemovePolicy.
-func (mr *MockStoreMockRecorder) RemovePolicy(id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePolicy", reflect.TypeOf((*MockStore)(nil).RemovePolicy), id)
+	varargs := append([]interface{}{ctx}, ids...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMany", reflect.TypeOf((*MockStore)(nil).GetMany), varargs...)
 }
 
 // RenamePolicyCategory mocks base method.
@@ -144,16 +194,30 @@ func (mr *MockStoreMockRecorder) RenamePolicyCategory(request interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenamePolicyCategory", reflect.TypeOf((*MockStore)(nil).RenamePolicyCategory), request)
 }
 
-// UpdatePolicy mocks base method.
-func (m *MockStore) UpdatePolicy(arg0 *storage.Policy) error {
+// Upsert mocks base method.
+func (m *MockStore) Upsert(ctx context.Context, policy *storage.Policy) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdatePolicy", arg0)
+	ret := m.ctrl.Call(m, "Upsert", ctx, policy)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdatePolicy indicates an expected call of UpdatePolicy.
-func (mr *MockStoreMockRecorder) UpdatePolicy(arg0 interface{}) *gomock.Call {
+// Upsert indicates an expected call of Upsert.
+func (mr *MockStoreMockRecorder) Upsert(ctx, policy interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePolicy", reflect.TypeOf((*MockStore)(nil).UpdatePolicy), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*MockStore)(nil).Upsert), ctx, policy)
+}
+
+// UpsertMany mocks base method.
+func (m *MockStore) UpsertMany(ctx context.Context, objs []*storage.Policy) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertMany", ctx, objs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertMany indicates an expected call of UpsertMany.
+func (mr *MockStoreMockRecorder) UpsertMany(ctx, objs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertMany", reflect.TypeOf((*MockStore)(nil).UpsertMany), ctx, objs)
 }

--- a/central/policy/store/store_impl.go
+++ b/central/policy/store/store_impl.go
@@ -33,11 +33,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	err := s.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(policyBucket)
 		return b.ForEach(func(k, v []byte) error {
-			var policy storage.Policy
-			if err := proto.Unmarshal(v, &policy); err != nil {
-				return err
-			}
-			policyIDs = append(policyIDs, policy.GetId())
+			policyIDs = append(policyIDs, string(k))
 			return nil
 		})
 	})

--- a/central/policy/store/store_impl.go
+++ b/central/policy/store/store_impl.go
@@ -1,8 +1,8 @@
 package store
 
 import (
+	"context"
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"sort"
 	"time"
@@ -14,12 +14,10 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/dberrors"
 	"github.com/stackrox/rox/pkg/errorhelpers"
-	"github.com/stackrox/rox/pkg/errox"
 	ops "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/secondarykey"
 	"github.com/stackrox/rox/pkg/sync"
-	"github.com/stackrox/rox/pkg/uuid"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -27,6 +25,43 @@ type storeImpl struct {
 	*bolt.DB
 
 	mutex sync.Mutex
+}
+
+func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
+	defer metrics.SetBoltOperationDurationTime(time.Now(), ops.GetMany, "Policy")
+	var policyIDs []string
+	err := s.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(policyBucket)
+		return b.ForEach(func(k, v []byte) error {
+			var policy storage.Policy
+			if err := proto.Unmarshal(v, &policy); err != nil {
+				return err
+			}
+			policyIDs = append(policyIDs, policy.GetId())
+			return nil
+		})
+	})
+	return policyIDs, err
+}
+
+func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) error {
+	return errors.New("not implemented")
+}
+
+func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
+	return errors.New("not implemented")
+}
+
+//// Stubs for satisfying legacy interfaces
+
+// AckKeysIndexed acknowledges the passed keys were indexed
+func (s *storeImpl) AckKeysIndexed(ctx context.Context, keys ...string) error {
+	return nil
+}
+
+// GetKeysToIndex returns the keys that need to be indexed
+func (s *storeImpl) GetKeysToIndex(ctx context.Context) ([]string, error) {
+	return nil, nil
 }
 
 func (s *storeImpl) wasDefaultPolicyRemoved(id string) (bool, error) {
@@ -56,8 +91,8 @@ func (s *storeImpl) getPolicy(id string, bucket *bolt.Bucket) (policy *storage.P
 	return
 }
 
-// GetPolicy returns policy with given id.
-func (s *storeImpl) GetPolicy(id string) (policy *storage.Policy, exists bool, err error) {
+// Get returns policy with given id.
+func (s *storeImpl) Get(_ context.Context, id string) (policy *storage.Policy, exists bool, err error) {
 	defer metrics.SetBoltOperationDurationTime(time.Now(), ops.Get, "Policy")
 	policy = new(storage.Policy)
 	err = s.View(func(tx *bolt.Tx) error {
@@ -73,8 +108,8 @@ func (s *storeImpl) GetPolicy(id string) (policy *storage.Policy, exists bool, e
 	return
 }
 
-// GetAllPolicies retrieves policies matching the request from bolt
-func (s *storeImpl) GetAllPolicies() ([]*storage.Policy, error) {
+// GetAll retrieves policies matching the request from bolt
+func (s *storeImpl) GetAll(_ context.Context) ([]*storage.Policy, error) {
 	defer metrics.SetBoltOperationDurationTime(time.Now(), ops.GetMany, "Policy")
 	var policies []*storage.Policy
 	err := s.View(func(tx *bolt.Tx) error {
@@ -91,7 +126,7 @@ func (s *storeImpl) GetAllPolicies() ([]*storage.Policy, error) {
 	return policies, err
 }
 
-func (s *storeImpl) GetPolicies(ids ...string) ([]*storage.Policy, []int, []error, error) {
+func (s *storeImpl) GetMany(_ context.Context, ids ...string) ([]*storage.Policy, []int, []error, error) {
 	defer metrics.SetBoltOperationDurationTime(time.Now(), ops.GetMany, "Policy")
 	var policies []*storage.Policy
 	var missingIndices []int
@@ -119,38 +154,23 @@ func (s *storeImpl) GetPolicies(ids ...string) ([]*storage.Policy, []int, []erro
 	return policies, missingIndices, errorList, err
 }
 
-// AddPolicy adds a policy to bolt
-func (s *storeImpl) AddPolicy(policy *storage.Policy, removePolicyTombstone bool) (string, error) {
-	defer metrics.SetBoltOperationDurationTime(time.Now(), ops.Add, "Policy")
+// Upsert updates a policy to bolt
+func (s *storeImpl) Upsert(_ context.Context, policy *storage.Policy) error {
+	defer metrics.SetBoltOperationDurationTime(time.Now(), ops.Update, "Policy")
 
-	if policy.Id == "" {
-		policy.Id = uuid.NewV4().String()
-	}
-
-	// Lock here so we can check whether the policy exists outside of the Bolt write lock.  This can race with
-	// update/delete but I don't think this results in any problems.
+	// Have to lock here because this is an upsert, not an update.
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	if removePolicyTombstone {
-		if err := s.Update(func(tx *bolt.Tx) error {
-			return tx.Bucket(removedDefaultPolicyBucket).Delete([]byte(policy.GetId()))
-		}); err != nil {
-			return "", err
-		}
-	} else {
-		wasRemoved, err := s.wasDefaultPolicyRemoved(policy.GetId())
-		if err != nil {
-			return "", err
-		}
-		if wasRemoved {
-			return "", errors.Errorf("default policy %s was previously removed", policy.GetId())
-		}
+	wasRemoved, err := s.wasDefaultPolicyRemoved(policy.GetId())
+	if err != nil {
+		return err
 	}
-
+	if wasRemoved {
+		return errors.Errorf("default policy %s was previously removed", policy.GetId())
+	}
 	equalPolicyExists := false
-	err := s.View(func(tx *bolt.Tx) error {
-		var errs []error
+	err = s.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(policyBucket)
 
 		// Check whether a policy with this ID already exists
@@ -164,67 +184,16 @@ func (s *storeImpl) AddPolicy(policy *storage.Policy, removePolicyTombstone bool
 				equalPolicyExists = true
 				return nil
 			}
-			errs = append(errs,
-				&IDConflictError{
-					ErrString:          fmt.Sprintf("Policy %v (%v) cannot be added because it already exists", policy.GetName(), policy.GetId()),
-					ExistingPolicyName: existingPolicy.GetName(),
-				},
-			)
-		}
-
-		// Check whether a policy with this name already exists
-		if exists := secondarykey.CheckUniqueKeyExists(tx, policyBucket, policy.GetName()); exists {
-			errs = append(errs,
-				&NameConflictError{
-					ErrString:          "Could not add policy due to name validation",
-					ExistingPolicyName: policy.GetName(),
-				},
-			)
-		}
-
-		// If we had any ID or name conflicts return both here
-		if len(errs) > 0 {
-			return &PolicyStoreErrorList{
-				Errors: errs,
-			}
 		}
 		return nil
 	})
+
 	if err != nil {
-		return policy.GetId(), err
+		return err
 	}
-
 	if equalPolicyExists {
-		return policy.GetId(), nil
+		return nil
 	}
-
-	if err = s.Update(func(tx *bolt.Tx) error {
-		// We've already checked for duplicate IDs and names, we can just write here.
-		if err := secondarykey.InsertUniqueKey(tx, policyBucket, policy.GetId(), policy.GetName()); err != nil {
-			return err
-		}
-
-		bucket := tx.Bucket(policyBucket)
-		bytes, err := proto.Marshal(policy)
-		if err != nil {
-			return err
-		}
-		return bucket.Put([]byte(policy.GetId()), bytes)
-	}); err != nil {
-		return "", err
-	}
-
-	return policy.GetId(), nil
-}
-
-// UpdatePolicy updates a policy to bolt
-func (s *storeImpl) UpdatePolicy(policy *storage.Policy) error {
-	defer metrics.SetBoltOperationDurationTime(time.Now(), ops.Update, "Policy")
-
-	// Have to lock here because this is an upsert, not an update.  AddPolicy should not re-create a policy which is
-	// created here.
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
 
 	// Verify that policy's settings flags are not updated. If the lock flags are set to read-only,
 	// verify that the corresponding fields are not updated.
@@ -232,14 +201,15 @@ func (s *storeImpl) UpdatePolicy(policy *storage.Policy) error {
 		return err
 	}
 
-	err := s.Update(func(tx *bolt.Tx) error {
+	err = s.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(policyBucket)
 		// If the update is changing the name, check if the name has already been taken
 		val, ok := secondarykey.GetCurrentUniqueKey(tx, policyBucket, policy.GetId())
 		if !ok {
-			return errox.NotFound
-		}
-		if val != policy.GetName() {
+			if err := secondarykey.InsertUniqueKey(tx, policyBucket, policy.GetId(), policy.GetName()); err != nil {
+				return err
+			}
+		} else if val != policy.GetName() {
 			if err := secondarykey.UpdateUniqueKey(tx, policyBucket, policy.GetId(), policy.GetName()); err != nil {
 				return errors.Wrap(err, "Could not update policy due to name validation")
 			}
@@ -267,8 +237,8 @@ func (s *storeImpl) UpdatePolicy(policy *storage.Policy) error {
 	})
 }
 
-// RemovePolicy removes a policy.
-func (s *storeImpl) RemovePolicy(id string) error {
+// Delete removes a policy.
+func (s *storeImpl) Delete(_ context.Context, id string) error {
 	defer metrics.SetBoltOperationDurationTime(time.Now(), ops.Remove, "Policy")
 	var policy storage.Policy
 	err := s.Update(func(tx *bolt.Tx) error {
@@ -301,21 +271,7 @@ func (s *storeImpl) RemovePolicy(id string) error {
 		return nil
 	}
 
-	return s.updatePolicyTombstone(id, true, false)
-}
-
-func (s *storeImpl) updatePolicyTombstone(id string, tombstoned bool, addIfNotFound bool) error {
-	return s.Update(func(tx *bolt.Tx) error {
-		if tx.Bucket(removedDefaultPolicyBucket).Get([]byte(id)) == nil && !addIfNotFound {
-			return nil
-		}
-
-		bytes, err := json.Marshal(tombstoned)
-		if err != nil {
-			return err
-		}
-		return tx.Bucket(removedDefaultPolicyBucket).Put([]byte(id), bytes)
-	})
+	return nil
 }
 
 // RenamePolicyCategory renames all occurrence of a policy category to the new requested category.
@@ -396,12 +352,12 @@ func (s *storeImpl) verifySettingFieldsAreUnchanged(newPolicy *storage.Policy) e
 		}
 
 		if oldPolicy.GetIsDefault() != newPolicy.GetIsDefault() {
-			log.Warnf("'isDefault' is read-only fields. Setting it to previous value for policy %q.", newPolicy.GetName())
+			log.Warnf("'isDefault' is a read-only field. Setting it to previous value for policy %q.", newPolicy.GetName())
 			newPolicy.IsDefault = oldPolicy.GetIsDefault()
 		}
 
 		if oldPolicy.GetCriteriaLocked() != newPolicy.GetCriteriaLocked() {
-			log.Warnf("'criteriaLocked' is read-only fields. Setting it to previous value for policy %q.", newPolicy.GetName())
+			log.Warnf("'criteriaLocked' is a read-only field. Setting it to previous value for policy %q.", newPolicy.GetName())
 			newPolicy.CriteriaLocked = oldPolicy.GetCriteriaLocked()
 		}
 

--- a/central/search/service/service_impl_test.go
+++ b/central/search/service/service_impl_test.go
@@ -221,9 +221,11 @@ func (s *SearchOperationsTestSuite) TestAutocomplete() {
 }
 
 func (s *SearchOperationsTestSuite) TestAutocompleteForEnums() {
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowAllAccessScopeChecker())
+
 	// Create Policy Searcher
 	policyStore := policyStoreMocks.NewMockStore(s.mockCtrl)
-	policyStore.EXPECT().GetAllPolicies()
+	policyStore.EXPECT().GetAll(gomock.Any())
 	idx, err := globalindex.MemOnlyIndex()
 	s.NoError(err)
 	policyIndexer := policyIndex.New(idx)
@@ -248,7 +250,6 @@ func (s *SearchOperationsTestSuite) TestAutocompleteForEnums() {
 		WithAggregator(nil).
 		Build().(*serviceImpl)
 
-	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowAllAccessScopeChecker())
 	results, err := service.autocomplete(ctx, fmt.Sprintf("%s:", search.Severity), []v1.SearchCategory{v1.SearchCategory_POLICIES})
 	s.NoError(err)
 	s.Equal([]string{fixtures.GetPolicy().GetSeverity().String()}, results)

--- a/tests/policy_test.go
+++ b/tests/policy_test.go
@@ -34,7 +34,6 @@ func TestImportExportPolicies(t *testing.T) {
 	verifyExportExistentSucceeds(t)
 	verifyMixedExportFails(t)
 	verifyImportSucceeds(t)
-	verifyDuplicateImportSucceeds(t)
 	verifyDefaultPolicyDuplicateImportFails(t)
 	verifyImportInvalidFails(t)
 	verifyImportDuplicateNameFails(t)
@@ -277,23 +276,6 @@ func verifyImportSucceeds(t *testing.T) {
 	policy := exportPolicy(t, service, knownPolicyID)
 	policy.Name = "A new name"
 	policy.Id = "integrationtestpolicy"
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	importResp, err := service.ImportPolicies(ctx, &v1.ImportPoliciesRequest{
-		Policies: []*storage.Policy{policy},
-	})
-	cancel()
-	require.NoError(t, err)
-	// All imported policies are treated as custom policies.
-	markPolicyAsCustom(policy)
-	validateImportPoliciesSuccess(t, importResp, []*storage.Policy{policy}, false)
-}
-
-func verifyDuplicateImportSucceeds(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
-	service := v1.NewPolicyServiceClient(conn)
-
-	// Create an existing policy so we don't change default policies
-	policy := createUniquePolicy(t, service)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	importResp, err := service.ImportPolicies(ctx, &v1.ImportPoliciesRequest{
 		Policies: []*storage.Policy{policy},


### PR DESCRIPTION
## Description
The goal of this PR to make the policy boltdb store less bespoke and get as much interface parity as possible with the generated postgres store. This PR does _not_ ensure complete interface parity - since that will require deprecating the policy category related endpoints which will happen only 2 releases from now.  The `CHANGELOG` to deprecate these methods is in a separate PR.

Very important: This is as much as we can do now. 

1. Removed policy tombstoning logic since default policies are no longer editable/deletable.
2. Renamed methods to match those in postgres generated store interfaces.
3. Combined Add and Update into an Upsert
4. Moved a lot of logic out of the store into the datastore layer - error checking, id and name collisions during import and such.
5. Modified tests and removed a couple of incorrect tests after a discussion with @vjwilson about expected behavior for imports. Thanks Van!

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [stackrox/openshift-docs]~(https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))


## Testing Performed
All automated tests pass. Manual TBD.