### PR TITLE
ROX-8392: Add clarifying comments

### DIFF
--- a/image/static-bin/import-additional-cas
+++ b/image/static-bin/import-additional-cas
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# The function copies everything that could be found under the path provided in
+# the first argument, ignoring files starting with '..' which are created by
+# kubernetes secret volume mount process.
 copy_existing () {
     src=$1
     if [ -d "$src" ] && [ "$(ls -A -I "..*" "$src")" ]; then
@@ -12,6 +15,8 @@ copy_existing () {
 }
 
 copy_existing /usr/local/share/ca-certificates
+
+# Copy the custom trusted CA bundles injected by the Openshift Network Operator.
 copy_existing /etc/pki/injected-ca-trust
 
-update-ca-trust
+update-ca-trust extract


### PR DESCRIPTION
## Description

Minor changes: comments and explicit `extract` argument for verbosity.

(Copying back the `import-additional-cas` script from scanner (#712) for consistency.)

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Testing on the script performed in #1088. This PR doesn't bring any testable changes.

The `extract` argument is actually ignored today by the `update-ca-trust` script, but that may change in the future according to the comment:
```sh
$ cat /usr/bin/update-ca-trust
#!/bin/sh

#set -vx

# At this time, while this script is trivial, we ignore any parameters given.
# However, for backwards compatibility reasons, future versions of this script must
# support the syntax "update-ca-trust extract" trigger the generation of output
# files in $DEST.
...
```
