### PR TITLE
Run operator tests when it was changed

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -37,3 +37,5 @@ ci-postgres-tests:
 - tools/generate-helpers/pg-table-bindings-wrapper
 ci-upgrade-tests:
 - pkg/defaults/policies/**/*
+ci-openshift-4-operator-tests:
+- operator/**/*


### PR DESCRIPTION
## Description

Currently the operator test is skipped by default. Since circleci has no notion of skipped test check is green resulting in false belief that everything is fine. This PR adds label to run operator test whenever operator code was changed.

## Testing Performed

N/A
