### PR TITLE
Fix unintended invalid command execution

### DIFF
--- a/image/templates/sensor/openshift/sensor.sh
+++ b/image/templates/sensor/openshift/sensor.sh
@@ -13,7 +13,7 @@ else
     count="$(${KUBE_COMMAND} api-resources | grep "securitycontextconstraints" -c || true)"
     if [[ "${count}" -eq 0 ]]; then
        echo >&2 "Detected an attempt to deploy a cluster bundle designed to be deployed on OpenShift, \\
-        on a vanilla Kubernetes cluster. Please regenerate the cluster bundle using cluster type `k8s` and redeploy. \\
+        on a vanilla Kubernetes cluster. Please regenerate the cluster bundle using cluster type 'k8s' and redeploy. \\
         If you think this message is in error, and would like to continue deploying the cluster bundle, please rerun \\
         the script using 'SKIP_ORCHESTRATOR_CHECK=true ./sensor.sh'"
         exit 1


### PR DESCRIPTION
## Description

Noticed when run on a nonexisting cluster by mistake.

```
$ ./sensor.sh 
Unable to connect to the server: dial tcp: lookup api.jephilli-4-11-04-21-0636.devcluster.openshift.com on 192.168.192.1:53: no such host
./sensor.sh: line 15: k8s: command not found
Detected an attempt to deploy a cluster bundle designed to be deployed on OpenShift, \
        on a vanilla Kubernetes cluster. Please regenerate the cluster bundle using cluster type  and redeploy. \
        If you think this message is in error, and would like to continue deploying the cluster bundle, please rerun \
        the script using 'SKIP_ORCHESTRATOR_CHECK=true ./sensor.sh'
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

None.