### PR TITLE
ROX-10661: Add metrics for monitoring network policy store

### DIFF
--- a/sensor/common/detector/metrics/metrics.go
+++ b/sensor/common/detector/metrics/metrics.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -15,6 +16,30 @@ var (
 		Help:      "Time spent in exponential backoff for the ImageScanInternal endpoint",
 		Buckets:   prometheus.ExponentialBuckets(4, 2, 8),
 	})
+	networkPoliciesStored = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "num_network_policies_in_store",
+		Help:      "Number of network policies (per namespace) currently stored in the in-memory store in sensor.",
+	},
+		[]string{
+			// Which namespace the network policy belongs to
+			"K8sNamespace",
+		})
+	networkPoliciesStoreEvents = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "events_network_policy_store_total",
+		Help:      "Events affecting the state of network policy currently stored in the in-memory store in sensor.",
+	},
+		[]string{
+			// What event caused an update of the metric value
+			"updateEvent",
+			// Namespace of the network policy that triggered the metric update
+			"K8sNamespace",
+			// Number of selector terms on the network policy that triggered the metric update
+			"NumSelectors",
+		})
 )
 
 // ObserveTimeSpentInExponentialBackoff observes the metric.
@@ -22,6 +47,20 @@ func ObserveTimeSpentInExponentialBackoff(t time.Duration) {
 	timeSpentInExponentialBackoff.Observe(t.Seconds())
 }
 
+// ObserveNetworkPolicyStoreState observes the metric.
+func ObserveNetworkPolicyStoreState(ns string, num int) {
+	networkPoliciesStored.WithLabelValues("K8sNamespace", ns).Set(float64(num))
+}
+
+// ObserveNetworkPolicyStoreEvent observes the metric.
+func ObserveNetworkPolicyStoreEvent(event, namespace string, numSelectors int) {
+	networkPoliciesStoreEvents.WithLabelValues(
+		"updateEvent", event,
+		"K8sNamespace", namespace,
+		"NumSelectors", fmt.Sprintf("%d", numSelectors),
+	).Inc()
+}
+
 func init() {
-	prometheus.MustRegister(timeSpentInExponentialBackoff)
+	prometheus.MustRegister(timeSpentInExponentialBackoff, networkPoliciesStored, networkPoliciesStoreEvents)
 }

--- a/sensor/common/detector/metrics/metrics.go
+++ b/sensor/common/detector/metrics/metrics.go
@@ -49,16 +49,16 @@ func ObserveTimeSpentInExponentialBackoff(t time.Duration) {
 
 // ObserveNetworkPolicyStoreState observes the metric.
 func ObserveNetworkPolicyStoreState(ns string, num int) {
-	networkPoliciesStored.WithLabelValues("K8sNamespace", ns).Set(float64(num))
+	networkPoliciesStored.With(prometheus.Labels{"K8sNamespace": ns}).Set(float64(num))
 }
 
 // ObserveNetworkPolicyStoreEvent observes the metric.
 func ObserveNetworkPolicyStoreEvent(event, namespace string, numSelectors int) {
-	networkPoliciesStoreEvents.WithLabelValues(
-		"updateEvent", event,
-		"K8sNamespace", namespace,
-		"NumSelectors", fmt.Sprintf("%d", numSelectors),
-	).Inc()
+	networkPoliciesStoreEvents.With(prometheus.Labels{
+		"updateEvent":  event,
+		"K8sNamespace": namespace,
+		"NumSelectors": fmt.Sprintf("%d", numSelectors),
+	}).Inc()
 }
 
 func init() {

--- a/sensor/common/detector/metrics/metrics.go
+++ b/sensor/common/detector/metrics/metrics.go
@@ -20,7 +20,7 @@ var (
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
 		Name:      "num_network_policies_in_store",
-		Help:      "Number of network policies (per namespace) currently stored in the in-memory store in sensor.",
+		Help:      "Number of network policies (per namespace) currently stored in the sensor's memory.",
 	},
 		[]string{
 			// Which namespace the network policy belongs to
@@ -30,7 +30,7 @@ var (
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
 		Name:      "events_network_policy_store_total",
-		Help:      "Events affecting the state of network policy currently stored in the in-memory store in sensor.",
+		Help:      "Events affecting the state of network policies currently stored in the sensor's memory.",
 	},
 		[]string{
 			// What event caused an update of the metric value

--- a/sensor/common/detector/metrics/metrics.go
+++ b/sensor/common/detector/metrics/metrics.go
@@ -24,7 +24,7 @@ var (
 	},
 		[]string{
 			// Which namespace the network policy belongs to
-			"K8sNamespace",
+			"k8sNamespace",
 		})
 	networkPoliciesStoreEvents = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
@@ -34,11 +34,11 @@ var (
 	},
 		[]string{
 			// What event caused an update of the metric value
-			"updateEvent",
+			"event",
 			// Namespace of the network policy that triggered the metric update
-			"K8sNamespace",
+			"k8sNamespace",
 			// Number of selector terms on the network policy that triggered the metric update
-			"NumSelectors",
+			"numSelectors",
 		})
 )
 
@@ -49,15 +49,15 @@ func ObserveTimeSpentInExponentialBackoff(t time.Duration) {
 
 // ObserveNetworkPolicyStoreState observes the metric.
 func ObserveNetworkPolicyStoreState(ns string, num int) {
-	networkPoliciesStored.With(prometheus.Labels{"K8sNamespace": ns}).Set(float64(num))
+	networkPoliciesStored.With(prometheus.Labels{"k8sNamespace": ns}).Set(float64(num))
 }
 
 // ObserveNetworkPolicyStoreEvent observes the metric.
 func ObserveNetworkPolicyStoreEvent(event, namespace string, numSelectors int) {
 	networkPoliciesStoreEvents.With(prometheus.Labels{
-		"updateEvent":  event,
-		"K8sNamespace": namespace,
-		"NumSelectors": fmt.Sprintf("%d", numSelectors),
+		"event":        event,
+		"k8sNamespace": namespace,
+		"numSelectors": fmt.Sprintf("%d", numSelectors),
 	}).Inc()
 }
 

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -122,8 +122,8 @@ func (n *networkPolicyStoreImpl) updateStateMetric() {
 // Delete removes network policy from the store
 func (n *networkPolicyStoreImpl) Delete(ID, ns string) {
 	n.lock.Lock()
-	defer n.updateStateMetric()
 	defer n.lock.Unlock()
+	defer n.updateStateMetric()
 	if policies, nsFound := n.data[ns]; nsFound {
 		if policy, policyFound := policies[ID]; policyFound {
 			metrics.ObserveNetworkPolicyStoreEvent("delete", ns, len(policy.GetSpec().GetPodSelector().GetMatchLabels()))
@@ -138,8 +138,8 @@ func (n *networkPolicyStoreImpl) Delete(ID, ns string) {
 // Upsert adds or updates network policy based on the namespace and ID
 func (n *networkPolicyStoreImpl) Upsert(np *storage.NetworkPolicy) {
 	n.lock.Lock()
-	defer n.updateStateMetric()
 	defer n.lock.Unlock()
+	defer n.updateStateMetric()
 
 	if _, nsFound := n.data[np.GetNamespace()]; !nsFound {
 		n.data[np.GetNamespace()] = make(map[string]*storage.NetworkPolicy)

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"github.com/stackrox/rox/pkg/labels"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/detector/metrics"
 	"github.com/stackrox/rox/sensor/common/store"
 
 	"github.com/stackrox/rox/generated/storage"
@@ -112,11 +113,21 @@ func (n *networkPolicyStoreImpl) All() map[string]*storage.NetworkPolicy {
 	return result
 }
 
+func (n *networkPolicyStoreImpl) updateStateMetric() {
+	for ns, m := range n.data {
+		metrics.ObserveNetworkPolicyStoreState(ns, len(m))
+	}
+}
+
 // Delete removes network policy from the store
 func (n *networkPolicyStoreImpl) Delete(ID, ns string) {
 	n.lock.Lock()
+	defer n.updateStateMetric()
 	defer n.lock.Unlock()
-	if _, nsFound := n.data[ns]; nsFound {
+	if policies, nsFound := n.data[ns]; nsFound {
+		if policy, policyFound := policies[ID]; policyFound {
+			metrics.ObserveNetworkPolicyStoreEvent("delete", ns, len(policy.GetSpec().GetPodSelector().GetMatchLabels()))
+		}
 		delete(n.data[ns], ID)
 		if len(n.data[ns]) == 0 {
 			delete(n.data, ns)
@@ -127,11 +138,17 @@ func (n *networkPolicyStoreImpl) Delete(ID, ns string) {
 // Upsert adds or updates network policy based on the namespace and ID
 func (n *networkPolicyStoreImpl) Upsert(np *storage.NetworkPolicy) {
 	n.lock.Lock()
+	defer n.updateStateMetric()
 	defer n.lock.Unlock()
 
 	if _, nsFound := n.data[np.GetNamespace()]; !nsFound {
 		n.data[np.GetNamespace()] = make(map[string]*storage.NetworkPolicy)
 	}
+	event := "add"
+	if _, exists := n.data[np.GetNamespace()][np.GetId()]; exists {
+		event = "update"
+	}
+	metrics.ObserveNetworkPolicyStoreEvent(event, np.GetNamespace(), len(np.GetSpec().GetPodSelector().GetMatchLabels()))
 	n.data[np.GetNamespace()][np.GetId()] = np
 }
 


### PR DESCRIPTION
## Description

We want to be able to observe the number of network policies currently stored in sensor's memory. This should give us overview of the potential memory consumption in case any OOM would happen.

There is a tiny cost related with adding the metrics - we are open for suggestions - for example: to place it behind a feature-flag.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

This PR is adding two metrics - existing unit tests should cover the changes.

## Testing Performed

- [x] CI
- [x] Manual deployment and looking at the metrics


## Example view over the metrics

(note that labels has been renamed since the moment the screenshot was taken)
![Screenshot 2022-04-29 at 10 31 10](https://user-images.githubusercontent.com/114479/165911727-c28682c0-1db6-447b-9801-d3623d225003.png)

