### PR TITLE
Scan images in quay only on rc release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5109,13 +5109,9 @@ workflows:
             - ui-unit-tests
 
       - scan-images-in-quay:
+          <<: *runOnlyOnReleaseCandidateBuilds
           context:
           - quay-rhacs-eng-readonly
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
           requires:
             - build-stackrox
             - build-rhacs


### PR DESCRIPTION
## Description

Currently quay needs at least 3 days to perform a scan so there is no point in doing nightly scan as it will fail.

## Testing Performed

CI