### PR TITLE
ROX-10291: Provision default service account pull secrets on new namespaces

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
@@ -36,6 +36,7 @@ class OpenShift extends Kubernetes {
         try {
             oClient.projectrequests().create(projectRequest)
             log.debug "Created namespace ${ns}"
+            provisionDefaultServiceAccount(ns)
         } catch (KubernetesClientException kce) {
             if (kce.code != 409) {
                 throw kce


### PR DESCRIPTION
## Description

Some docker.io images used in test were moved to quay.io to avoid rate limiting. This has caused an increase in deployment failures e.g. ROX-10291. Looking at this I noticed that the same pullSecret addition to the default service account that is done for Kubernetes.groovy is not done in OpenShift.groovy. Adding it may fix the problem or it may not but it cannot hurt.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

All QA tests + OpenShift-4
