### PR TITLE
ROX-8715: refactor generation of network baselines to occur after observation period ends

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3537,6 +3537,7 @@ jobs:
       - ROX_POLICIES_PATTERNFLY: true
       - ROX_NEW_POLICY_CATEGORIES: true
       - ROX_SECURITY_METRICS_PHASE_ONE: true
+      - ROX_NETWORK_BASELINE_OBSERVATION_PERIOD: 2m
 
     steps:
       - checkout

--- a/central/deployment/queue/mocks/observation_queue.go
+++ b/central/deployment/queue/mocks/observation_queue.go
@@ -34,6 +34,20 @@ func (m *MockDeploymentObservationQueue) EXPECT() *MockDeploymentObservationQueu
 	return m.recorder
 }
 
+// GetObservationDetails mocks base method.
+func (m *MockDeploymentObservationQueue) GetObservationDetails(deploymentID string) *queue.DeploymentObservation {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetObservationDetails", deploymentID)
+	ret0, _ := ret[0].(*queue.DeploymentObservation)
+	return ret0
+}
+
+// GetObservationDetails indicates an expected call of GetObservationDetails.
+func (mr *MockDeploymentObservationQueueMockRecorder) GetObservationDetails(deploymentID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObservationDetails", reflect.TypeOf((*MockDeploymentObservationQueue)(nil).GetObservationDetails), deploymentID)
+}
+
 // InObservation mocks base method.
 func (m *MockDeploymentObservationQueue) InObservation(deploymentID string) bool {
 	m.ctrl.T.Helper()
@@ -86,6 +100,18 @@ func (m *MockDeploymentObservationQueue) Push(observation *queue.DeploymentObser
 func (mr *MockDeploymentObservationQueueMockRecorder) Push(observation interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Push", reflect.TypeOf((*MockDeploymentObservationQueue)(nil).Push), observation)
+}
+
+// PutBackInObservation mocks base method.
+func (m *MockDeploymentObservationQueue) PutBackInObservation(observation *queue.DeploymentObservation) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "PutBackInObservation", observation)
+}
+
+// PutBackInObservation indicates an expected call of PutBackInObservation.
+func (mr *MockDeploymentObservationQueueMockRecorder) PutBackInObservation(observation interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutBackInObservation", reflect.TypeOf((*MockDeploymentObservationQueue)(nil).PutBackInObservation), observation)
 }
 
 // RemoveDeployment mocks base method.

--- a/central/deployment/queue/observation_queue.go
+++ b/central/deployment/queue/observation_queue.go
@@ -21,8 +21,10 @@ type DeploymentObservationQueue interface {
 	Pull() *DeploymentObservation
 	Peek() *DeploymentObservation
 	Push(observation *DeploymentObservation)
+	PutBackInObservation(observation *DeploymentObservation)
 	RemoveDeployment(deploymentID string)
 	RemoveFromObservation(deploymentID string)
+	GetObservationDetails(deploymentID string) *DeploymentObservation
 }
 
 // deploymentObservationQueue queue for deployments in observation window
@@ -93,14 +95,28 @@ func (q *deploymentObservationQueueImpl) Push(observation *DeploymentObservation
 	depObj := q.queue.PushBack(observation)
 	// Reference the list object in the deployment map
 	q.deploymentMap[observation.DeploymentID] = depObj
-
 }
 
-// RemoveDeployment removes a deployment from the list and the map
-func (q *deploymentObservationQueueImpl) RemoveDeployment(deploymentID string) {
+// PutBackInObservation attempts to add an item to the queue, and does nothing if object already exists.
+func (q *deploymentObservationQueueImpl) PutBackInObservation(observation *DeploymentObservation) {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
+	// Currently observing this deployment.  Need to update the time and position in the queue
+	if depObj, found := q.deploymentMap[observation.DeploymentID]; found && depObj != nil {
+		// Remove it from the queue so we can add it back to the end
+		q.queue.Remove(depObj)
+	}
+
+	// We have either never observed this deployment OR we already completed observing.  So we simply add it to the
+	// end of the queue and replace the object in the map.
+	depObj := q.queue.PushBack(observation)
+	// Reference the list object in the deployment map
+	q.deploymentMap[observation.DeploymentID] = depObj
+}
+
+// removeListItem removes the list item associated with a deployment
+func (q *deploymentObservationQueueImpl) removeListItem(deploymentID string) {
 	// The deployment is kept in the map after it has been processed to ensure we
 	// do not process it again.  In that case the depObj will be nil
 	depObj, found := q.deploymentMap[deploymentID]
@@ -112,7 +128,22 @@ func (q *deploymentObservationQueueImpl) RemoveDeployment(deploymentID string) {
 	if depObj != nil {
 		q.queue.Remove(depObj)
 	}
+}
+
+// removeDeployment removes a deployment from the list and the map
+func (q *deploymentObservationQueueImpl) removeDeployment(deploymentID string) {
+	// remove the corresponding list items
+	q.removeListItem(deploymentID)
+
 	delete(q.deploymentMap, deploymentID)
+}
+
+// RemoveDeployment removes a deployment from the list and the map
+func (q *deploymentObservationQueueImpl) RemoveDeployment(deploymentID string) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	q.removeDeployment(deploymentID)
 }
 
 // RemoveFromObservation removes a deployment from observation
@@ -133,4 +164,19 @@ func (q *deploymentObservationQueueImpl) RemoveFromObservation(deploymentID stri
 	}
 	// Keep the deployment in the map, so we know that we have processed this deployment.
 	q.deploymentMap[deploymentID] = nil
+}
+
+// GetObservationDetails gets the observations details of the deployment
+func (q *deploymentObservationQueueImpl) GetObservationDetails(deploymentID string) *DeploymentObservation {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	// The deployment is kept in the map after it has been processed to ensure we
+	// do not process it again.  In that case the depObj will be nil
+	depObj, found := q.deploymentMap[deploymentID]
+	if !found || depObj == nil {
+		return nil
+	}
+
+	return depObj.Value.(*DeploymentObservation)
 }

--- a/central/networkbaseline/manager/manager.go
+++ b/central/networkbaseline/manager/manager.go
@@ -14,8 +14,14 @@ import (
 // The Manager manages network baselines.
 // ALL writes to network baselines MUST go through the manager.
 type Manager interface {
-	// ProcessDeploymentCreate notifies the baseline manager of a deployment create.
+	// CreateNetworkBaseline creates a network baseline if one does not exit
 	// The baseline manager then creates a baseline for this deployment if it does not already exist.
+	// It must only be called by trusted code, since it assumes the caller has full access to modify
+	// network baselines in the datastore.
+	CreateNetworkBaseline(deploymentID string) error
+	// ProcessDeploymentCreate notifies the baseline manager of a deployment create.
+	// The baseline manager then puts the deployment into observation mode so that the baseline will be created
+	// when the observation period ends.
 	// It must only be called by trusted code, since it assumes the caller has full access to modify
 	// network baselines in the datastore.
 	ProcessDeploymentCreate(deploymentID, deploymentName, clusterID, namespace string) error
@@ -31,7 +37,7 @@ type Manager interface {
 	ProcessFlowUpdate(flows map[networkgraph.NetworkConnIndicator]timestamp.MicroTS) error
 	// ProcessPostClusterDelete is called during post cluster delete. It cleans up all the baselines that belonged to
 	// this cluster, including the edges pointing towards these baselines.
-	ProcessPostClusterDelete(clusterID string) error
+	ProcessPostClusterDelete(deploymentIDs []string) error
 
 	// ProcessBaselineStatusUpdate processes a user-filed request to modify the baseline status.
 	// The error it returns will be a status.Error.

--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -2,11 +2,15 @@ package manager
 
 import (
 	"context"
+	"time"
 
+	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	deploymentDS "github.com/stackrox/rox/central/deployment/datastore"
+	"github.com/stackrox/rox/central/deployment/queue"
 	"github.com/stackrox/rox/central/networkbaseline/datastore"
 	networkEntityDS "github.com/stackrox/rox/central/networkgraph/entity/datastore"
+	networkFlowDS "github.com/stackrox/rox/central/networkgraph/flow/datastore"
 	networkPolicyDS "github.com/stackrox/rox/central/networkpolicies/datastore"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/central/sensor/service/connection"
@@ -20,6 +24,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/networkgraph/networkbaseline"
+	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
@@ -28,12 +33,18 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 )
 
+const (
+	baselineFlushTickerDuration = 5 * time.Second
+)
+
 var (
 	managerCtx = sac.WithAllAccess(context.Background())
 
 	networkBaselineSAC = sac.ForResource(resources.NetworkBaseline)
 
 	log = logging.LoggerForModule()
+
+	observationDuration = env.NetworkBaselineObservationPeriod.DurationSetting()
 )
 
 type manager struct {
@@ -41,18 +52,23 @@ type manager struct {
 	networkEntities   networkEntityDS.EntityDataStore
 	deploymentDS      deploymentDS.DataStore
 	networkPolicyDS   networkPolicyDS.DataStore
+	clusterFlows      networkFlowDS.ClusterDataStore
 	connectionManager connection.Manager
 
 	baselinesByDeploymentID map[string]*networkbaseline.BaselineInfo
 	seenNetworkPolicies     set.Uint64Set
 	lock                    sync.Mutex
+
+	deploymentObservationQueue queue.DeploymentObservationQueue
+	baselineFlushTicker        *time.Ticker
 }
 
 func getNewObservationPeriodEnd() timestamp.MicroTS {
-	return timestamp.Now().Add(env.NetworkBaselineObservationPeriod.DurationSetting())
+	return timestamp.Now().Add(observationDuration)
 }
 
-func (m *manager) shouldUpdate(conn *networkgraph.NetworkConnIndicator, updateTS timestamp.MicroTS) bool {
+// shouldUpdate -- looks at the baselines and flows to determine if the flow should be added to the baseline.
+func (m *manager) shouldUpdate(conn *networkgraph.NetworkConnIndicator, updateTS timestamp.MicroTS, initialLoad bool) bool {
 	var atLeastOneBaselineInObservationPeriod bool
 	for _, entity := range []*networkgraph.Entity{&conn.SrcEntity, &conn.DstEntity} {
 		if _, valid := networkbaseline.ValidBaselinePeerEntityTypes[entity.Type]; !valid {
@@ -65,16 +81,35 @@ func (m *manager) shouldUpdate(conn *networkgraph.NetworkConnIndicator, updateTS
 			continue
 		}
 		baselineInfo, found := m.baselinesByDeploymentID[entity.ID]
-		// This likely means the deployment has been deleted.
-		// We can avoid processing this flow altogether.
-		if !found {
+		// This case occurs when the deployment has been deleted OR the deployment is being controlled by the
+		// observation queue and as such we have not created a baseline for it yet.
+		// We can avoid processing this flow altogether at this time.
+		if !found || baselineInfo == nil {
 			return false
 		}
+
 		// If even one baseline is user-locked, no updates based on flows.
 		if baselineInfo.UserLocked {
 			return false
 		}
-		if baselineInfo.ObservationPeriodEnd.After(updateTS) {
+
+		// It is possible that the last time stamp on the flow is nil if the connection is initial and still open
+		// In those cases updateTS will be 0 because that is the nil value of a MicroTS.  So all flows in such a state
+		// would think the baseline is out of observation or not when we compare the time as we do below.  To resolve
+		// these cases we compare to now if the timestamp is 0 to ensure we don't add a flow to a baseline that is
+		// no longer being observed.
+		compareTime := updateTS
+		if compareTime == 0 {
+			compareTime = timestamp.Now()
+		}
+
+		// If the last time the flow was seen is nil, then updateTS will be 0 and thus
+		// the baseline will always report being in observation.
+		// Additionally, we could be in an initial load state where Deployment Observation expired
+		// OR user requested a baseline; so we shouldUpdate the deployments involved.
+		// Additionally, it is possible that by the time we get the flow from sensor that the observation window
+		// has ended.  So we still need to compare based on the time of the flow vs just checking the observation queue.
+		if baselineInfo.ObservationPeriodEnd.After(compareTime) || initialLoad {
 			atLeastOneBaselineInObservationPeriod = true
 		}
 	}
@@ -82,6 +117,10 @@ func (m *manager) shouldUpdate(conn *networkgraph.NetworkConnIndicator, updateTS
 }
 
 func (m *manager) maybeAddPeer(deploymentID string, p *networkbaseline.Peer, modifiedDeploymentIDs set.StringSet) {
+	if baseline, found := m.baselinesByDeploymentID[deploymentID]; !found || baseline == nil {
+		return
+	}
+
 	_, isForbidden := m.baselinesByDeploymentID[deploymentID].ForbiddenPeers[*p]
 	if isForbidden {
 		return
@@ -101,6 +140,10 @@ func (m *manager) persistNetworkBaselines(deploymentIDs set.StringSet, baselines
 	baselines := make([]*storage.NetworkBaseline, 0, len(deploymentIDs))
 	for deploymentID := range deploymentIDs {
 		baselineInfo := m.baselinesByDeploymentID[deploymentID]
+		if baselineInfo == nil {
+			continue
+		}
+
 		peers, err := networkbaseline.ConvertPeersToProto(baselineInfo.BaselinePeers)
 		if err != nil {
 			return err
@@ -156,7 +199,7 @@ func (m *manager) lookUpPeerName(entity networkgraph.Entity) string {
 	case storage.NetworkEntityInfo_DEPLOYMENT:
 		// If the peer is a deployment, just look it up from the baselines
 		peerBaseline, ok := m.baselinesByDeploymentID[entity.ID]
-		if !ok {
+		if !ok || peerBaseline == nil {
 			// Unexpected but the chance of this happening should be very slim.
 			// - created deployment A and B
 			// - created baseline for A
@@ -189,10 +232,10 @@ func (m *manager) lookUpPeerName(entity networkgraph.Entity) string {
 	}
 }
 
-func (m *manager) processFlowUpdate(flows map[networkgraph.NetworkConnIndicator]timestamp.MicroTS) error {
+func (m *manager) processFlowUpdate(flows map[networkgraph.NetworkConnIndicator]timestamp.MicroTS, initialLoad bool) (set.StringSet, error) {
 	modifiedDeploymentIDs := set.NewStringSet()
 	for conn, updateTS := range flows {
-		if !m.shouldUpdate(&conn, updateTS) {
+		if !m.shouldUpdate(&conn, updateTS, initialLoad) {
 			continue
 		}
 		if conn.SrcEntity.Type == storage.NetworkEntityInfo_DEPLOYMENT {
@@ -220,30 +263,41 @@ func (m *manager) processFlowUpdate(flows map[networkgraph.NetworkConnIndicator]
 			}
 		}
 	}
-	return m.persistNetworkBaselines(modifiedDeploymentIDs, nil)
+
+	err := m.persistNetworkBaselines(modifiedDeploymentIDs, nil)
+	if err != nil {
+		return nil, err
+	}
+	return modifiedDeploymentIDs, nil
 }
 
-func (m *manager) processDeploymentCreate(deploymentID, deploymentName, clusterID, namespace string) error {
+func (m *manager) processDeploymentCreate(deploymentID, clusterID string) error {
+	// Deployment has already had a baseline created.  Nothing to do in this case.
 	if _, exists := m.baselinesByDeploymentID[deploymentID]; exists {
 		return nil
 	}
 
-	m.baselinesByDeploymentID[deploymentID] = &networkbaseline.BaselineInfo{
-		ClusterID:            clusterID,
-		Namespace:            namespace,
-		DeploymentName:       deploymentName,
-		ObservationPeriodEnd: getNewObservationPeriodEnd(),
-		UserLocked:           false,
-		BaselinePeers:        make(map[networkbaseline.Peer]struct{}),
-		ForbiddenPeers:       make(map[networkbaseline.Peer]struct{}),
-	}
-	return m.persistNetworkBaselines(set.NewStringSet(deploymentID), nil)
+	// We don't want to process the deployment until the observation window expires OR the user requests a
+	// baseline.  But the cache needs to know the deployment exists.  So map this deployment to nil.
+	m.baselinesByDeploymentID[deploymentID] = nil
+
+	// Push the new deployment on to the observation queue.  When Observation ends, flows for this deployment
+	// will be pulled and placed into a baseline.
+	m.deploymentObservationQueue.Push(
+		&queue.DeploymentObservation{
+			DeploymentID:   deploymentID,
+			InObservation:  true,
+			ObservationEnd: getNewObservationPeriodEnd().GogoProtobuf(),
+		})
+
+	return nil
 }
 
 func (m *manager) ProcessDeploymentCreate(deploymentID, deploymentName, clusterID, namespace string) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	return m.processDeploymentCreate(deploymentID, deploymentName, clusterID, namespace)
+
+	return m.processDeploymentCreate(deploymentID, clusterID)
 }
 
 func (m *manager) processDeploymentDelete(deploymentID string) error {
@@ -253,44 +307,52 @@ func (m *manager) processDeploymentDelete(deploymentID string) error {
 		return nil
 	}
 
-	modifiedDeployments := set.NewStringSet()
-	for peer := range deletingBaseline.BaselinePeers {
-		// Delete the edge from that deployment to this deployment
-		peerBaseline, peerFound := m.baselinesByDeploymentID[peer.Entity.ID]
-		if !peerFound {
-			// Probably the peer is not a deployment
-			continue
+	// If the deployment is being tracked, but the baseline is not yet created, we cannot look at hte peers.  If we
+	// have a peer at all, then the peer will have been created
+	if deletingBaseline != nil {
+		modifiedDeployments := set.NewStringSet()
+		for peer := range deletingBaseline.BaselinePeers {
+			// Delete the edge from that deployment to this deployment
+			peerBaseline, peerFound := m.baselinesByDeploymentID[peer.Entity.ID]
+			if !peerFound || peerBaseline == nil {
+				// Probably the peer is not a deployment
+				continue
+			}
+			reversedPeer := networkbaseline.ReversePeerView(deploymentID, deletingBaseline.DeploymentName, &peer)
+			delete(peerBaseline.BaselinePeers, reversedPeer)
+			modifiedDeployments.Add(peer.Entity.ID)
 		}
-		reversedPeer := networkbaseline.ReversePeerView(deploymentID, deletingBaseline.DeploymentName, &peer)
-		delete(peerBaseline.BaselinePeers, reversedPeer)
-		modifiedDeployments.Add(peer.Entity.ID)
-	}
-	// For now delete this deployment record from the forbidden peers as well. If we need
-	// the records to be sticky for any reason, remove the following lines
-	for forbiddenPeer := range deletingBaseline.ForbiddenPeers {
-		forbiddenPeerBaseline, found := m.baselinesByDeploymentID[forbiddenPeer.Entity.ID]
-		if !found {
-			// Probably the forbidden peer is not a deployment
-			continue
+		// For now delete this deployment record from the forbidden peers as well. If we need
+		// the records to be sticky for any reason, remove the following lines
+		for forbiddenPeer := range deletingBaseline.ForbiddenPeers {
+			forbiddenPeerBaseline, found := m.baselinesByDeploymentID[forbiddenPeer.Entity.ID]
+			if !found || forbiddenPeerBaseline == nil {
+				// Probably the forbidden peer is not a deployment
+				continue
+			}
+			reversedPeer := networkbaseline.ReversePeerView(deploymentID, deletingBaseline.DeploymentName, &forbiddenPeer)
+			delete(forbiddenPeerBaseline.ForbiddenPeers, reversedPeer)
+			modifiedDeployments.Add(forbiddenPeer.Entity.ID)
 		}
-		reversedPeer := networkbaseline.ReversePeerView(deploymentID, deletingBaseline.DeploymentName, &forbiddenPeer)
-		delete(forbiddenPeerBaseline.ForbiddenPeers, reversedPeer)
-		modifiedDeployments.Add(forbiddenPeer.Entity.ID)
+
+		// Delete the records from other baselines first, then delete the wanted baseline after
+		err := m.persistNetworkBaselines(modifiedDeployments, nil)
+		if err != nil {
+			return errors.Wrapf(err, "deleting baseline of deployment %q", deletingBaseline.DeploymentName)
+		}
 	}
 
-	// Delete the records from other baselines first, then delete the wanted baseline after
-	err := m.persistNetworkBaselines(modifiedDeployments, nil)
-	if err != nil {
-		return errors.Wrapf(err, "deleting baseline of deployment %q", deletingBaseline.DeploymentName)
-	}
-
-	err = m.ds.DeleteNetworkBaseline(managerCtx, deploymentID)
+	err := m.ds.DeleteNetworkBaseline(managerCtx, deploymentID)
 	if err != nil {
 		return errors.Wrapf(err, "deleting baseline of deployment %q", deletingBaseline.DeploymentName)
 	}
 
 	// Clean up cache
 	delete(m.baselinesByDeploymentID, deploymentID)
+
+	// Remove the deployment from the observation queue
+	m.deploymentObservationQueue.RemoveDeployment(deploymentID)
+
 	return nil
 }
 
@@ -303,7 +365,9 @@ func (m *manager) ProcessDeploymentDelete(deploymentID string) error {
 func (m *manager) ProcessFlowUpdate(flows map[networkgraph.NetworkConnIndicator]timestamp.MicroTS) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	return m.processFlowUpdate(flows)
+
+	_, err := m.processFlowUpdate(flows, false)
+	return err
 }
 
 func (m *manager) validatePeers(peers []*v1.NetworkBaselinePeerStatus) error {
@@ -339,7 +403,7 @@ func (m *manager) ProcessBaselineStatusUpdate(ctx context.Context, modifyRequest
 	defer m.lock.Unlock()
 
 	baseline, found := m.baselinesByDeploymentID[deploymentID]
-	if !found {
+	if !found || baseline == nil {
 		return errors.Wrapf(errox.InvalidArgs, "no baseline found for deployment id %q", deploymentID)
 	}
 	if err := m.validatePeers(modifyRequest.GetPeers()); err != nil {
@@ -379,9 +443,11 @@ func (m *manager) ProcessBaselineStatusUpdate(ctx context.Context, modifyRequest
 				reversePeer := networkbaseline.ReversePeerView(deploymentID, baseline.DeploymentName, &peer)
 
 				otherBaseline := m.baselinesByDeploymentID[peer.Entity.ID]
-				otherBaseline.BaselinePeers[reversePeer] = struct{}{}
-				delete(otherBaseline.ForbiddenPeers, reversePeer)
-				modifiedDeploymentIDs.Add(peer.Entity.ID)
+				if otherBaseline != nil {
+					otherBaseline.BaselinePeers[reversePeer] = struct{}{}
+					delete(otherBaseline.ForbiddenPeers, reversePeer)
+					modifiedDeploymentIDs.Add(peer.Entity.ID)
+				}
 			}
 		case v1.NetworkBaselinePeerStatus_ANOMALOUS:
 			if !inBaseline && inForbidden {
@@ -395,9 +461,11 @@ func (m *manager) ProcessBaselineStatusUpdate(ctx context.Context, modifyRequest
 				reversePeer := networkbaseline.ReversePeerView(deploymentID, baseline.DeploymentName, &peer)
 
 				otherBaseline := m.baselinesByDeploymentID[peer.Entity.ID]
-				delete(otherBaseline.BaselinePeers, reversePeer)
-				otherBaseline.ForbiddenPeers[reversePeer] = struct{}{}
-				modifiedDeploymentIDs.Add(peer.Entity.ID)
+				if otherBaseline != nil {
+					delete(otherBaseline.BaselinePeers, reversePeer)
+					otherBaseline.ForbiddenPeers[reversePeer] = struct{}{}
+					modifiedDeploymentIDs.Add(peer.Entity.ID)
+				}
 			}
 		default:
 			return utils.Should(errors.Errorf("unknown status: %v", peerAndStatus.GetStatus()))
@@ -421,23 +489,43 @@ func (m *manager) processNetworkPolicyUpdate(
 
 	// This is a network policy we have not yet processed before. Process it.
 	// First get all the relevant deployments
-	deploymentIDs, err := m.getDeploymentIDsAffectedByNetworkPolicy(ctx, policy)
+	deployments, err := m.getDeploymentIDsAffectedByNetworkPolicy(ctx, policy)
 	if err != nil {
 		return err
 	}
 
 	// For each of the affected deployments, reset the corresponding baseline's observation period
 	modifiedDeploymentIDs := set.NewStringSet()
-	for _, deploymentID := range deploymentIDs {
-		baseline, found := m.baselinesByDeploymentID[deploymentID]
+	for _, deployment := range deployments {
+		baseline, found := m.baselinesByDeploymentID[deployment.GetId()]
+
 		if !found {
 			// Maybe somehow the network policy update came first before the deployment create event.
 			// In this case do nothing and trust that the deployment create flow should just
-			// take care of setting the observation period
+			// take care of setting the observation period.  This could also occur if the deployment was
+			// still in observation without the user having requested a baseline.  Thus we account for this
+			// by updating the observation period in the observation queue above.
 			continue
 		}
-		baseline.ObservationPeriodEnd = getNewObservationPeriodEnd()
-		modifiedDeploymentIDs.Add(deploymentID)
+
+		// Regardless of whether the baseline has already been created or not, we need to update the observation
+		// period of the observation queue.  This could entail putting the object back on the list.
+		newObservationPeriodEnd := getNewObservationPeriodEnd()
+
+		// If the baseline is nil then we have seen the deployment but haven't yet processed it from the observation
+		// queue, so move it to the back of the observation queue.
+		if baseline == nil {
+			m.deploymentObservationQueue.PutBackInObservation(
+				&queue.DeploymentObservation{
+					DeploymentID:   deployment.GetId(),
+					InObservation:  true,
+					ObservationEnd: newObservationPeriodEnd.GogoProtobuf(),
+				})
+		} else {
+			baseline.ObservationPeriodEnd = newObservationPeriodEnd
+		}
+
+		modifiedDeploymentIDs.Add(deployment.GetId())
 	}
 
 	err = m.persistNetworkBaselines(modifiedDeploymentIDs, nil)
@@ -452,7 +540,7 @@ func (m *manager) processNetworkPolicyUpdate(
 func (m *manager) getDeploymentIDsAffectedByNetworkPolicy(
 	ctx context.Context,
 	policy *storage.NetworkPolicy,
-) ([]string, error) {
+) ([]*storage.Deployment, error) {
 	deploymentQuery :=
 		search.
 			NewQueryBuilder().
@@ -466,10 +554,10 @@ func (m *manager) getDeploymentIDsAffectedByNetworkPolicy(
 
 	// Filter out the deployments that we don't want. aka check the policy's pod selectors and
 	// namespace selectors.
-	var result []string
+	var result []*storage.Deployment
 	for _, deployment := range deploymentsInSameClusterAndNamespace {
 		if m.isDeploymentAffectedByNetworkPolicy(deployment, policy) {
-			result = append(result, deployment.GetId())
+			result = append(result, deployment)
 		}
 	}
 
@@ -507,7 +595,7 @@ type clusterNamespacePair struct {
 
 func (m *manager) processBaselineLockUpdate(ctx context.Context, deploymentID string, lockBaseline bool) error {
 	baseline, found := m.baselinesByDeploymentID[deploymentID]
-	if !found {
+	if !found || baseline == nil {
 		return errors.Wrap(errox.InvalidArgs, "no baseline with given deployment ID found")
 	}
 	// Permission check before modifying in-memory data structures
@@ -538,20 +626,26 @@ func (m *manager) ProcessBaselineLockUpdate(ctx context.Context, deploymentID st
 	return m.processBaselineLockUpdate(ctx, deploymentID, lockBaseline)
 }
 
-func (m *manager) processPostClusterDelete(clusterID string) error {
-	deletingBaselines := set.NewStringSet()
-	for deploymentID, baseline := range m.baselinesByDeploymentID {
-		if baseline.ClusterID == clusterID {
-			deletingBaselines.Add(deploymentID)
-		}
-	}
+func (m *manager) processPostClusterDelete(deploymentIDs []string) error {
+	// NOTE:  This process could have invoked processDeploymentDelete repeatedly,
+	// but for doing deletes in bulk it is more efficient to do the work in
+	// the map than reach out to the database like that function does.
+
+	// Putting in a set to make it easy to check if the various peers are
+	// also being deleted.
+	deletingBaselines := set.NewStringSet(deploymentIDs...)
 
 	// Clean up edges in other baselines
 	modifiedBaselines := set.NewStringSet()
 	for deploymentID, baseline := range m.baselinesByDeploymentID {
-		if deletingBaselines.Contains(deploymentID) {
+		// We need to delete any peers that reference deleted deployments.
+		// If we are deleting the baseline we are looking at OR if we are
+		// looking at a baseline that has not been processed yet, we do not
+		// need to look for peers.
+		if deletingBaselines.Contains(deploymentID) || baseline == nil {
 			continue
 		}
+
 		// Baselines that are not deleted. Need to update their edges in case
 		// they are pointing to the deleting baselines.
 		for p := range baseline.BaselinePeers {
@@ -579,17 +673,21 @@ func (m *manager) processPostClusterDelete(clusterID string) error {
 	if err != nil {
 		return err
 	}
+
 	// Delete from cache
 	for deploymentID := range deletingBaselines {
 		delete(m.baselinesByDeploymentID, deploymentID)
+		// Remove from the observation queue
+		m.deploymentObservationQueue.RemoveDeployment(deploymentID)
 	}
+
 	return nil
 }
 
-func (m *manager) ProcessPostClusterDelete(clusterID string) error {
+func (m *manager) ProcessPostClusterDelete(deploymentIDs []string) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	return m.processPostClusterDelete(clusterID)
+	return m.processPostClusterDelete(deploymentIDs)
 }
 
 func (m *manager) initFromStore() error {
@@ -600,6 +698,7 @@ func (m *manager) initFromStore() error {
 		if err != nil {
 			return err
 		}
+
 		m.baselinesByDeploymentID[baseline.GetDeploymentId()] = baselineInfo
 
 		// Try loading all the network policies to build the seen network policies cache
@@ -626,24 +725,187 @@ func (m *manager) initFromStore() error {
 	})
 }
 
+func (m *manager) flushBaselineQueue() {
+	for {
+		// ObservationEnd is in the future so we have nothing to do at this time
+		head := m.deploymentObservationQueue.Peek()
+		if head == nil || protoutils.After(head.ObservationEnd, types.TimestampNow()) {
+			return
+		}
+
+		// Grab the first deployment to baseline.
+		// NOTE:  This is the only place from which Pull is being called.
+		observedDep := m.deploymentObservationQueue.Pull()
+
+		// Get the details about the deployment.
+		deployment, exists, err := m.deploymentDS.GetDeployment(managerCtx, observedDep.DeploymentID)
+		if !exists {
+			log.Error(errors.Wrapf(errox.NotFound, "deployment with id %q does not exist", observedDep.DeploymentID))
+			continue
+		}
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+
+		err = m.addBaseline(deployment.GetId(), deployment.GetName(), deployment.GetClusterId(), deployment.GetNamespace(), timestamp.FromProtobuf(observedDep.ObservationEnd))
+		if err != nil {
+			log.Error(err)
+		}
+	}
+}
+
+func (m *manager) flushBaselineQueuePeriodically() {
+	defer m.baselineFlushTicker.Stop()
+	for range m.baselineFlushTicker.C {
+		m.flushBaselineQueue()
+	}
+}
+
+func (m *manager) getFlowStore(ctx context.Context, clusterID string) (networkFlowDS.FlowDataStore, error) {
+	flowStore, err := m.clusterFlows.GetFlowStore(ctx, clusterID)
+	if err != nil {
+		return nil, errors.Errorf("could not obtain flow store for cluster %s: %v", clusterID, err)
+	}
+	if flowStore == nil {
+		return nil, errors.Wrapf(errox.NotFound, "no flow store found for cluster %s", clusterID)
+	}
+	return flowStore, nil
+}
+
+func (m *manager) addBaseline(deploymentID, deploymentName, clusterID, namespace string, observationEnd timestamp.MicroTS) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	// We have already created a baseline for this deployment.  Nothing necessary to do.
+	if baseline, found := m.baselinesByDeploymentID[deploymentID]; found && baseline != nil {
+		return nil
+	}
+
+	writeEmpty := true
+
+	flowStore, _ := m.getFlowStore(managerCtx, clusterID)
+
+	// Create an empty baseline entry in the map.  This will put this deployment in a state where it will be updated until
+	// its observation end time.
+	m.baselinesByDeploymentID[deploymentID] = &networkbaseline.BaselineInfo{
+		ClusterID:            clusterID,
+		Namespace:            namespace,
+		DeploymentName:       deploymentName,
+		ObservationPeriodEnd: observationEnd,
+		UserLocked:           false,
+		BaselinePeers:        make(map[networkbaseline.Peer]struct{}),
+		ForbiddenPeers:       make(map[networkbaseline.Peer]struct{}),
+	}
+
+	// Grab flows related to deployment
+	flows, err := flowStore.GetFlowsForDeployment(managerCtx, deploymentID, false)
+	if err != nil {
+		return err
+	}
+
+	// If we have flows then process them.  If we don't persist an empty baseline
+	if len(flows) > 0 {
+		// package them into a map of flows like comes in
+		// when packaging the flows up in that map, I think the timestamp has to be now
+		flowMap := m.putFlowsInMap(flows)
+
+		// then simply call processFlowUpdate with the map of flows.
+		modifiedDeployments, err := m.processFlowUpdate(flowMap, true)
+		if err != nil {
+			return err
+		}
+		// If the modified list contains our deployment it was persisted with flows
+		// If it does not then that means all peers were locked or not yet written to a baseline so we will
+		// need to persist an empty baseline object for this deployment.  As subsequent deployments are processed,
+		// flows will be added.
+		if modifiedDeployments.Contains(deploymentID) {
+			writeEmpty = false
+		}
+	}
+
+	// If there are no flows OR the peers were all locked, we need to write an empty baseline.
+	if writeEmpty {
+		// Save the empty baseline because we may not be able to update it if all its connections are locked.
+		err := m.persistNetworkBaselines(set.NewStringSet(deploymentID), nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Since the manager holds a cache of network baselines, we know longer need to hold it in the observation queue after processing it
+	m.deploymentObservationQueue.RemoveDeployment(deploymentID)
+
+	return nil
+}
+
+func (m *manager) CreateNetworkBaseline(deploymentID string) error {
+	deployment, exists, err := m.deploymentDS.GetDeployment(managerCtx, deploymentID)
+	if !exists {
+		return errors.Wrapf(errox.NotFound, "deployment with id %q does not exist", deploymentID)
+	}
+	if err != nil {
+		return err
+	}
+
+	// Need the details from the Observation Queue to grab the proper Observation Time
+	depDetails := m.deploymentObservationQueue.GetObservationDetails(deploymentID)
+	var t timestamp.MicroTS
+	if depDetails == nil {
+		t = getNewObservationPeriodEnd()
+	} else {
+		t = timestamp.FromProtobuf(depDetails.ObservationEnd)
+	}
+
+	// Now build the baseline
+	err = m.addBaseline(deployment.GetId(), deployment.GetName(), deployment.GetClusterId(), deployment.GetNamespace(), t)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *manager) putFlowsInMap(newFlows []*storage.NetworkFlow) map[networkgraph.NetworkConnIndicator]timestamp.MicroTS {
+	out := make(map[networkgraph.NetworkConnIndicator]timestamp.MicroTS, len(newFlows))
+	now := timestamp.Now()
+	for _, newFlow := range newFlows {
+		t := timestamp.FromProtobuf(newFlow.LastSeenTimestamp)
+		if newFlow.LastSeenTimestamp == nil {
+			t = now
+		}
+
+		out[networkgraph.GetNetworkConnIndicator(newFlow)] = t
+	}
+	return out
+}
+
 // New returns an initialized manager, and starts the manager's processing loop in the background.
 func New(
 	ds datastore.DataStore,
 	networkEntities networkEntityDS.EntityDataStore,
 	deploymentDS deploymentDS.DataStore,
 	networkPolicyDS networkPolicyDS.DataStore,
+	clusterFlows networkFlowDS.ClusterDataStore,
 	connectionManager connection.Manager,
 ) (Manager, error) {
 	m := &manager{
-		ds:                  ds,
-		networkEntities:     networkEntities,
-		deploymentDS:        deploymentDS,
-		networkPolicyDS:     networkPolicyDS,
-		connectionManager:   connectionManager,
-		seenNetworkPolicies: set.NewUint64Set(),
+		ds:                         ds,
+		networkEntities:            networkEntities,
+		deploymentDS:               deploymentDS,
+		networkPolicyDS:            networkPolicyDS,
+		clusterFlows:               clusterFlows,
+		connectionManager:          connectionManager,
+		seenNetworkPolicies:        set.NewUint64Set(),
+		deploymentObservationQueue: queue.New(),
+		baselineFlushTicker:        time.NewTicker(baselineFlushTickerDuration),
 	}
 	if err := m.initFromStore(); err != nil {
 		return nil, err
 	}
+
+	// Start the flush baseline process
+	go m.flushBaselineQueuePeriodically()
+
 	return m, nil
 }

--- a/central/networkbaseline/manager/mocks/manager.go
+++ b/central/networkbaseline/manager/mocks/manager.go
@@ -39,6 +39,20 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
+// CreateNetworkBaseline mocks base method.
+func (m *MockManager) CreateNetworkBaseline(deploymentID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNetworkBaseline", deploymentID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateNetworkBaseline indicates an expected call of CreateNetworkBaseline.
+func (mr *MockManagerMockRecorder) CreateNetworkBaseline(deploymentID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkBaseline", reflect.TypeOf((*MockManager)(nil).CreateNetworkBaseline), deploymentID)
+}
+
 // ProcessBaselineLockUpdate mocks base method.
 func (m *MockManager) ProcessBaselineLockUpdate(ctx context.Context, deploymentID string, lockBaseline bool) error {
 	m.ctrl.T.Helper()
@@ -124,15 +138,15 @@ func (mr *MockManagerMockRecorder) ProcessNetworkPolicyUpdate(ctx, action, polic
 }
 
 // ProcessPostClusterDelete mocks base method.
-func (m *MockManager) ProcessPostClusterDelete(clusterID string) error {
+func (m *MockManager) ProcessPostClusterDelete(deploymentIDs []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessPostClusterDelete", clusterID)
+	ret := m.ctrl.Call(m, "ProcessPostClusterDelete", deploymentIDs)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ProcessPostClusterDelete indicates an expected call of ProcessPostClusterDelete.
-func (mr *MockManagerMockRecorder) ProcessPostClusterDelete(clusterID interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) ProcessPostClusterDelete(deploymentIDs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessPostClusterDelete", reflect.TypeOf((*MockManager)(nil).ProcessPostClusterDelete), clusterID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessPostClusterDelete", reflect.TypeOf((*MockManager)(nil).ProcessPostClusterDelete), deploymentIDs)
 }

--- a/central/networkbaseline/manager/singleton.go
+++ b/central/networkbaseline/manager/singleton.go
@@ -4,6 +4,7 @@ import (
 	deploymentDS "github.com/stackrox/rox/central/deployment/datastore"
 	"github.com/stackrox/rox/central/networkbaseline/datastore"
 	networkEntityDS "github.com/stackrox/rox/central/networkgraph/entity/datastore"
+	nfDS "github.com/stackrox/rox/central/networkgraph/flow/datastore"
 	networkPolicyDS "github.com/stackrox/rox/central/networkpolicies/datastore"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	"github.com/stackrox/rox/pkg/sync"
@@ -25,6 +26,7 @@ func Singleton() Manager {
 				networkEntityDS.Singleton(),
 				deploymentDS.Singleton(),
 				networkPolicyDS.Singleton(),
+				nfDS.Singleton(),
 				connection.ManagerSingleton())
 		utils.CrashOnError(err)
 	})

--- a/central/networkbaseline/service/service_impl.go
+++ b/central/networkbaseline/service/service_impl.go
@@ -53,6 +53,7 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 	return ctx, authorizer.Authorized(ctx, fullMethodName)
 }
 
+// GetNetworkBaselineStatusForFlows - gets the status of the flows within the baseline.
 func (s *serviceImpl) GetNetworkBaselineStatusForFlows(
 	ctx context.Context,
 	request *v1.NetworkBaselineStatusRequest,
@@ -63,7 +64,10 @@ func (s *serviceImpl) GetNetworkBaselineStatusForFlows(
 		return nil, err
 	}
 	if !found {
-		return nil, errox.NotFound.New("network baseline for the deployment does not exist")
+		baseline, err = s.createBaseline(ctx, request.GetDeploymentId())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Got the baseline, check status of each passed in peer
@@ -71,19 +75,42 @@ func (s *serviceImpl) GetNetworkBaselineStatusForFlows(
 	return &v1.NetworkBaselineStatusResponse{Statuses: statuses}, nil
 }
 
+// GetNetworkBaseline -- gets the network baseline assocated with the deployment.
 func (s *serviceImpl) GetNetworkBaseline(
 	ctx context.Context,
 	request *v1.ResourceByID,
 ) (*storage.NetworkBaseline, error) {
 	if request.GetId() == "" {
-		return nil, errors.Wrap(errox.InvalidArgs, "Network baseline id must be provided")
+		return nil, errors.Wrap(errox.InvalidArgs, "Deployment id for the network baseline must be provided")
 	}
 	baseline, found, err := s.datastore.GetNetworkBaseline(ctx, request.GetId())
 	if err != nil {
 		return nil, err
 	}
 	if !found {
-		return nil, errors.Wrapf(errox.NotFound, "network baseline with id %q does not exist", request.GetId())
+		baseline, err = s.createBaseline(ctx, request.GetId())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return baseline, nil
+}
+
+func (s *serviceImpl) createBaseline(ctx context.Context, deploymentID string) (*storage.NetworkBaseline, error) {
+	// We didn't find one but user asked for one.  Let's try to build one
+	err := s.manager.CreateNetworkBaseline(deploymentID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Grab the newly created baseline
+	baseline, found, err := s.datastore.GetNetworkBaseline(ctx, deploymentID)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.Wrapf(errox.NotFound, "Network baseline for deployment id %q does not exist", deploymentID)
 	}
 
 	return baseline, nil

--- a/central/networkgraph/flow/datastore/flow.go
+++ b/central/networkgraph/flow/datastore/flow.go
@@ -13,6 +13,9 @@ import (
 type FlowDataStore interface {
 	GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error)
 	GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error)
+	// GetFlowsForDeployment returns all flows referencing a specific deployment id
+	GetFlowsForDeployment(ctx context.Context, deploymentID string, adjustForGraph bool) ([]*storage.NetworkFlow, error)
+
 	// UpsertFlows upserts the given flows to the store. The flows slice might be modified by this function, so if you
 	// need to use it afterwards, create a copy.
 	UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) error

--- a/central/networkgraph/flow/datastore/flow_impl.go
+++ b/central/networkgraph/flow/datastore/flow_impl.go
@@ -54,6 +54,21 @@ func (fds *flowDataStoreImpl) GetMatchingFlows(ctx context.Context, pred func(*s
 	return flows, ts, nil
 }
 
+func (fds *flowDataStoreImpl) GetFlowsForDeployment(ctx context.Context, deploymentID string, adjustForGraph bool) ([]*storage.NetworkFlow, error) {
+	flows, err := fds.storage.GetFlowsForDeployment(ctx, deploymentID)
+	if err != nil {
+		return nil, err
+	}
+
+	if adjustForGraph {
+		flows, err = fds.adjustFlowsForGraphConfig(ctx, flows)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return flows, nil
+}
+
 func (fds *flowDataStoreImpl) adjustFlowsForGraphConfig(ctx context.Context, flows []*storage.NetworkFlow) ([]*storage.NetworkFlow, error) {
 	graphConfigReadCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),

--- a/central/networkgraph/flow/datastore/internal/store/flow.go
+++ b/central/networkgraph/flow/datastore/internal/store/flow.go
@@ -13,6 +13,8 @@ import (
 type FlowStore interface {
 	GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error)
 	GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error)
+	// GetFlowsForDeployment returns all flows referencing a specific deployment id
+	GetFlowsForDeployment(ctx context.Context, deploymentID string) ([]*storage.NetworkFlow, error)
 
 	UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) error
 	RemoveFlow(ctx context.Context, props *storage.NetworkFlowProperties) error

--- a/central/networkgraph/flow/datastore/internal/store/mocks/flow.go
+++ b/central/networkgraph/flow/datastore/internal/store/mocks/flow.go
@@ -53,6 +53,21 @@ func (mr *MockFlowStoreMockRecorder) GetAllFlows(ctx, since interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllFlows", reflect.TypeOf((*MockFlowStore)(nil).GetAllFlows), ctx, since)
 }
 
+// GetFlowsForDeployment mocks base method.
+func (m *MockFlowStore) GetFlowsForDeployment(ctx context.Context, deploymentID string) ([]*storage.NetworkFlow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFlowsForDeployment", ctx, deploymentID)
+	ret0, _ := ret[0].([]*storage.NetworkFlow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFlowsForDeployment indicates an expected call of GetFlowsForDeployment.
+func (mr *MockFlowStoreMockRecorder) GetFlowsForDeployment(ctx, deploymentID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlowsForDeployment", reflect.TypeOf((*MockFlowStore)(nil).GetFlowsForDeployment), ctx, deploymentID)
+}
+
 // GetMatchingFlows mocks base method.
 func (m *MockFlowStore) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error) {
 	m.ctrl.T.Helper()

--- a/central/networkgraph/flow/datastore/mocks/flow.go
+++ b/central/networkgraph/flow/datastore/mocks/flow.go
@@ -53,6 +53,21 @@ func (mr *MockFlowDataStoreMockRecorder) GetAllFlows(ctx, since interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllFlows", reflect.TypeOf((*MockFlowDataStore)(nil).GetAllFlows), ctx, since)
 }
 
+// GetFlowsForDeployment mocks base method.
+func (m *MockFlowDataStore) GetFlowsForDeployment(ctx context.Context, deploymentID string, adjustForGraph bool) ([]*storage.NetworkFlow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFlowsForDeployment", ctx, deploymentID, adjustForGraph)
+	ret0, _ := ret[0].([]*storage.NetworkFlow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFlowsForDeployment indicates an expected call of GetFlowsForDeployment.
+func (mr *MockFlowDataStoreMockRecorder) GetFlowsForDeployment(ctx, deploymentID, adjustForGraph interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlowsForDeployment", reflect.TypeOf((*MockFlowDataStore)(nil).GetFlowsForDeployment), ctx, deploymentID, adjustForGraph)
+}
+
 // GetMatchingFlows mocks base method.
 func (m *MockFlowDataStore) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error) {
 	m.ctrl.T.Helper()

--- a/central/sensor/service/pipeline/deploymentevents/pipeline.go
+++ b/central/sensor/service/pipeline/deploymentevents/pipeline.go
@@ -206,7 +206,7 @@ func (s *pipelineImpl) runGeneralPipeline(ctx context.Context, deployment *stora
 		return err
 	}
 
-	// Add network baseline for this deployment if it does not exist yet
+	// Inform network baseline manager that a new deployment has been created
 	if err := s.networkBaselines.ProcessDeploymentCreate(
 		deployment.GetId(),
 		deployment.GetName(),

--- a/pkg/metrics/op_string.go
+++ b/pkg/metrics/op_string.go
@@ -16,24 +16,25 @@ func _() {
 	_ = x[Get-5]
 	_ = x[GetAll-6]
 	_ = x[GetMany-7]
-	_ = x[GetGrouped-8]
-	_ = x[List-9]
-	_ = x[Prune-10]
-	_ = x[Reset-11]
-	_ = x[Rename-12]
-	_ = x[Remove-13]
-	_ = x[RemoveMany-14]
-	_ = x[RemoveFlowsByDeployment-15]
-	_ = x[Search-16]
-	_ = x[Update-17]
-	_ = x[UpdateMany-18]
-	_ = x[Upsert-19]
-	_ = x[UpsertAll-20]
+	_ = x[GetFlowsForDeployment-8]
+	_ = x[GetGrouped-9]
+	_ = x[List-10]
+	_ = x[Prune-11]
+	_ = x[Reset-12]
+	_ = x[Rename-13]
+	_ = x[Remove-14]
+	_ = x[RemoveMany-15]
+	_ = x[RemoveFlowsByDeployment-16]
+	_ = x[Search-17]
+	_ = x[Update-18]
+	_ = x[UpdateMany-19]
+	_ = x[Upsert-20]
+	_ = x[UpsertAll-21]
 }
 
-const _Op_name = "AddAddManyCountDedupeExistsGetGetAllGetManyGetGroupedListPruneResetRenameRemoveRemoveManyRemoveFlowsByDeploymentSearchUpdateUpdateManyUpsertUpsertAll"
+const _Op_name = "AddAddManyCountDedupeExistsGetGetAllGetManyGetFlowsForDeploymentGetGroupedListPruneResetRenameRemoveRemoveManyRemoveFlowsByDeploymentSearchUpdateUpdateManyUpsertUpsertAll"
 
-var _Op_index = [...]uint8{0, 3, 10, 15, 21, 27, 30, 36, 43, 53, 57, 62, 67, 73, 79, 89, 112, 118, 124, 134, 140, 149}
+var _Op_index = [...]uint8{0, 3, 10, 15, 21, 27, 30, 36, 43, 64, 74, 78, 83, 88, 94, 100, 110, 133, 139, 145, 155, 161, 170}
 
 func (i Op) String() string {
 	if i < 0 || i >= Op(len(_Op_index)-1) {

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -18,6 +18,7 @@ const (
 	Get
 	GetAll
 	GetMany
+	GetFlowsForDeployment
 
 	// Special operation currently used only for processes.
 	GetGrouped

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -4,21 +4,24 @@ import io.stackrox.proto.storage.NetworkFlowOuterClass
 import objects.Deployment
 import org.junit.experimental.categories.Category
 import services.NetworkBaselineService
-import spock.lang.Ignore
 import spock.lang.Retry
+import spock.lang.Unroll
 import util.NetworkGraphUtil
 
 @Retry(count = 0)
 class NetworkBaselineTest extends BaseSpecification {
     static final private String SERVER_DEP_NAME = "net-bl-server"
     static final private String BASELINED_CLIENT_DEP_NAME = "net-bl-client-baselined"
+    static final private String USER_DEP_NAME = "net-bl-user-server"
+    static final private String BASELINED_USER_CLIENT_DEP_NAME = "net-bl-user-client-baselined"
     static final private String ANOMALOUS_CLIENT_DEP_NAME = "net-bl-client-anomalous"
     static final private String DEFERRED_BASELINED_CLIENT_DEP_NAME = "net-bl-client-deferred-baselined"
+    static final private String DEFERRED_POST_LOCK_DEP_NAME = "net-bl-client-post-lock"
 
     static final private String NGINX_IMAGE = "quay.io/rhacs-eng/qa:nginx-1.19-alpine"
 
     // The baseline generation duration must be changed from the default for this test to succeed.
-    static final private int EXPECTED_BASELINE_DURATION_SECONDS = 120
+    static final private int EXPECTED_BASELINE_DURATION_SECONDS = 240
 
     static final private int CLOCK_SKEW_ALLOWANCE_SECONDS = 15
 
@@ -40,12 +43,28 @@ class NetworkBaselineTest extends BaseSpecification {
                     ["for i in \$(seq 1 10); do wget -S http://${SERVER_DEP_NAME}; sleep 1; done; sleep 1000" as String]
                 )
 
+    static final private USER_DEP = createAndRegisterDeployment()
+                    .setName(USER_DEP_NAME)
+                    .setImage(NGINX_IMAGE)
+                    .addLabel("app", USER_DEP_NAME)
+                    .addPort(80)
+                    .setExposeAsService(true)
+
+    static final private BASELINED_USER_CLIENT_DEP = createAndRegisterDeployment()
+                .setName(BASELINED_USER_CLIENT_DEP_NAME)
+                .setImage(NGINX_IMAGE)
+                .addLabel("app", BASELINED_USER_CLIENT_DEP_NAME)
+                .setCommand(["/bin/sh", "-c",])
+                .setArgs(
+                    ["for i in \$(seq 1 10); do wget -S http://${USER_DEP_NAME}; sleep 1; done; sleep 1000" as String]
+                )
+
     static final private ANOMALOUS_CLIENT_DEP = createAndRegisterDeployment()
         .setName(ANOMALOUS_CLIENT_DEP_NAME)
         .setImage(NGINX_IMAGE)
         .addLabel("app", ANOMALOUS_CLIENT_DEP_NAME)
         .setCommand(["/bin/sh", "-c",])
-        .setArgs(["echo sleeping; sleep ${EXPECTED_BASELINE_DURATION_SECONDS+30}; echo sleep done; " +
+        .setArgs(["echo sleeping; date; sleep ${EXPECTED_BASELINE_DURATION_SECONDS+30}; echo sleep done; date;" +
                       "for i in \$(seq 1 10); do wget -S http://${SERVER_DEP_NAME}; sleep 1; done;" +
                       "sleep 1000" as String,])
 
@@ -53,6 +72,15 @@ class NetworkBaselineTest extends BaseSpecification {
         .setName(DEFERRED_BASELINED_CLIENT_DEP_NAME)
         .setImage(NGINX_IMAGE)
         .addLabel("app", DEFERRED_BASELINED_CLIENT_DEP_NAME)
+        .setCommand(["/bin/sh", "-c",])
+        .setArgs(["while sleep 1; " +
+                      "do wget -S http://${SERVER_DEP_NAME}; " +
+                      "done" as String,])
+
+    static final private DEFERRED_POST_LOCK_CLIENT_DEP = createAndRegisterDeployment()
+        .setName(DEFERRED_POST_LOCK_DEP_NAME)
+        .setImage(NGINX_IMAGE)
+        .addLabel("app", DEFERRED_POST_LOCK_DEP_NAME)
         .setCommand(["/bin/sh", "-c",])
         .setArgs(["while sleep 1; " +
                       "do wget -S http://${SERVER_DEP_NAME}; " +
@@ -102,13 +130,13 @@ class NetworkBaselineTest extends BaseSpecification {
         }
     }
 
+    @Unroll
     @Category(NetworkBaseline)
-    @Ignore("Skip test for now, we're working on fixing it.")
     def "Verify network baseline functionality"() {
         when:
         "Create initial set of deployments, wait for baseline to populate"
         def beforeDeploymentCreate = System.currentTimeSeconds()
-        batchCreate([SERVER_DEP, BASELINED_CLIENT_DEP, ANOMALOUS_CLIENT_DEP])
+        batchCreate([SERVER_DEP, BASELINED_CLIENT_DEP])
         def justAfterDeploymentCreate = System.currentTimeSeconds()
 
         def serverDeploymentID = SERVER_DEP.deploymentUid
@@ -117,16 +145,20 @@ class NetworkBaselineTest extends BaseSpecification {
         def baselinedClientDeploymentID = BASELINED_CLIENT_DEP.deploymentUid
         assert baselinedClientDeploymentID != null
 
+        assert NetworkGraphUtil.checkForEdge(baselinedClientDeploymentID, serverDeploymentID, null, 180)
+
+        // Now create the anomalous deployment
+        batchCreate([ANOMALOUS_CLIENT_DEP])
+
         def anomalousClientDeploymentID = ANOMALOUS_CLIENT_DEP.deploymentUid
         assert anomalousClientDeploymentID != null
         log.info "Deployment IDs Server: ${serverDeploymentID}, " +
             "Baselined client: ${baselinedClientDeploymentID}, Anomalous client: ${anomalousClientDeploymentID}"
 
-        assert NetworkGraphUtil.checkForEdge(baselinedClientDeploymentID, serverDeploymentID, null, 180)
         assert NetworkGraphUtil.checkForEdge(anomalousClientDeploymentID, serverDeploymentID, null,
             EXPECTED_BASELINE_DURATION_SECONDS + 180)
 
-        def serverBaseline = evaluateWithRetry(20, 3) {
+        def serverBaseline = evaluateWithRetry(30, 4) {
             def baseline = NetworkBaselineService.getNetworkBaseline(serverDeploymentID)
             if (baseline.getPeersCount() == 0) {
                 throw new RuntimeException(
@@ -138,6 +170,7 @@ class NetworkBaselineTest extends BaseSpecification {
         assert serverBaseline
         def anomalousClientBaseline = NetworkBaselineService.getNetworkBaseline(anomalousClientDeploymentID)
         assert anomalousClientBaseline
+        log.info "Anomalous Baseline: ${anomalousClientBaseline}"
         def baselinedClientBaseline = NetworkBaselineService.getNetworkBaseline(baselinedClientDeploymentID)
         assert baselinedClientDeploymentID
 
@@ -160,9 +193,24 @@ class NetworkBaselineTest extends BaseSpecification {
 
         def deferredBaselinedClientDeploymentID = DEFERRED_BASELINED_CLIENT_DEP.deploymentUid
         assert deferredBaselinedClientDeploymentID != null
+        log.info "Deferred Baseline: ${deferredBaselinedClientDeploymentID}"
 
-        assert NetworkGraphUtil.checkForEdge(anomalousClientDeploymentID, serverDeploymentID, null, 180)
-        serverBaseline = evaluateWithRetry(20, 3) {
+        // Waiting on it to come out of observation.
+        def deferredBaselinedClientBaseline = evaluateWithRetry(30, 4) {
+            def baseline = NetworkBaselineService.getNetworkBaseline(deferredBaselinedClientDeploymentID)
+            def now = System.currentTimeSeconds()
+            if (baseline.getObservationPeriodEnd().getSeconds() > now) {
+                throw new RuntimeException(
+                    "Baseline ${deferredBaselinedClientDeploymentID} is in observation. Baseline is ${baseline}"
+                )
+            }
+            return baseline
+        }
+        assert deferredBaselinedClientBaseline
+
+        assert NetworkGraphUtil.checkForEdge(deferredBaselinedClientDeploymentID, serverDeploymentID, null, 180)
+        // Make sure peers have been added to the serverBaseline
+        serverBaseline = evaluateWithRetry(30, 4) {
             def baseline = NetworkBaselineService.getNetworkBaseline(serverDeploymentID)
             if (baseline.getPeersCount() < 2) {
                 throw new RuntimeException(
@@ -172,11 +220,6 @@ class NetworkBaselineTest extends BaseSpecification {
             return baseline
         }
         assert serverBaseline
-
-        def deferredBaselinedClientBaseline = NetworkBaselineService.getNetworkBaseline(
-            deferredBaselinedClientDeploymentID
-        )
-        assert deferredBaselinedClientDeploymentID
 
         then:
         "Validate the updated baselines"
@@ -191,5 +234,97 @@ class NetworkBaselineTest extends BaseSpecification {
         )
         validateBaseline(deferredBaselinedClientBaseline, beforeDeferredCreate, justAfterDeferredCreate,
             [new Tuple2<String, Boolean>(serverDeploymentID, false)])
+
+        when:
+        "Create another deployment, ensure it DOES NOT get added to serverDeploymentID due to user lock"
+        NetworkBaselineService.lockNetworkBaseline(serverDeploymentID)
+
+        batchCreate([DEFERRED_POST_LOCK_CLIENT_DEP])
+
+        def postLockClientDeploymentID = DEFERRED_POST_LOCK_CLIENT_DEP.deploymentUid
+        assert postLockClientDeploymentID != null
+        log.info "Post Lock Deployment: ${postLockClientDeploymentID}"
+
+        // Waiting on it to come out of observation.
+        def postLockClientBaseline = evaluateWithRetry(30, 4) {
+            def baseline = NetworkBaselineService.getNetworkBaseline(postLockClientDeploymentID)
+            def now = System.currentTimeSeconds()
+            if (baseline.getObservationPeriodEnd().getSeconds() > now) {
+                throw new RuntimeException(
+                    "Baseline ${postLockClientDeploymentID} is not out of observation yet. Baseline is ${baseline}"
+                )
+            }
+            return baseline
+        }
+        assert postLockClientBaseline
+
+        assert NetworkGraphUtil.checkForEdge(postLockClientDeploymentID, serverDeploymentID, null, 180)
+
+        // Grab the latest server baseline for validation
+        serverBaseline = NetworkBaselineService.getNetworkBaseline(serverDeploymentID)
+        assert serverBaseline
+
+        then:
+        "Validate the locked baselines"
+        // Post lock should not be added as a peer because serverBaseline is locked.
+        validateBaseline(serverBaseline, beforeDeploymentCreate, justAfterDeploymentCreate,
+            [new Tuple2<String, Boolean>(baselinedClientDeploymentID, true),
+             new Tuple2<String, Boolean>(deferredBaselinedClientDeploymentID, true),
+            ]
+        )
+        validateBaseline(postLockClientBaseline, beforeDeferredCreate, justAfterDeferredCreate,
+            [])
+    }
+
+    @Unroll
+    @Category(NetworkBaseline)
+    def "Verify user get for non-existent baseline"() {
+        when:
+        "Create initial set of deployments, wait for baseline to populate"
+        def beforeDeploymentCreate = System.currentTimeSeconds()
+        batchCreate([USER_DEP, BASELINED_USER_CLIENT_DEP])
+        def justAfterDeploymentCreate = System.currentTimeSeconds()
+
+        def serverDeploymentID = USER_DEP.deploymentUid
+        assert serverDeploymentID != null
+
+        def baselinedClientDeploymentID = BASELINED_USER_CLIENT_DEP.deploymentUid
+        assert baselinedClientDeploymentID != null
+
+        log.info "Deployment IDs Server: ${serverDeploymentID}, " +
+                    "Baselined client: ${baselinedClientDeploymentID}"
+
+        def serverBaseline = NetworkBaselineService.getNetworkBaseline(serverDeploymentID)
+        log.info "Requested Baseline: ${serverBaseline}"
+        assert serverBaseline
+
+        def baselinedClientBaseline = NetworkBaselineService.getNetworkBaseline(baselinedClientDeploymentID)
+        assert baselinedClientBaseline
+
+        assert NetworkGraphUtil.checkForEdge(baselinedClientDeploymentID, serverDeploymentID, null, 180)
+
+        // Waiting on it to come out of observation.
+        serverBaseline = evaluateWithRetry(30, 4) {
+            def baseline = NetworkBaselineService.getNetworkBaseline(serverDeploymentID)
+            def now = System.currentTimeSeconds()
+            if (baseline.getPeersCount() == 0 && baseline.getObservationPeriodEnd().getSeconds() > now) {
+                throw new RuntimeException(
+                    "No peers in baseline for deployment ${serverDeploymentID} yet. Baseline is ${baseline}"
+                )
+            }
+            return baseline
+        }
+
+        baselinedClientBaseline = NetworkBaselineService.getNetworkBaseline(baselinedClientDeploymentID)
+
+        then:
+        "Validate user requested server baseline"
+        // The client->server connection should be baselined since the client as the
+        // connection occurred during the observation window.
+        validateBaseline(serverBaseline, beforeDeploymentCreate, justAfterDeploymentCreate,
+            [new Tuple2<String, Boolean>(baselinedClientDeploymentID, true)])
+        validateBaseline(baselinedClientBaseline, beforeDeploymentCreate, justAfterDeploymentCreate,
+            [new Tuple2<String, Boolean>(serverDeploymentID, false)]
+        )
     }
 }


### PR DESCRIPTION
## Description
NOTE:  The failures on gke-postgres-api-e2e-tests seem to be related to search.  As such I will proceed with review while I try to figure that nonsense out.

We are moving to a model where we do not build network baselines by default as flows come in.  We will be a network baseline under 2 circumstances:
1. The observation window for a deployment expires
2. The user requests to view a network baseline

Once a baseline is created updates or risks will be processed as the flows come in as is done prior to this change.  If the user does not request a baseline, a baseline will be built from all the existing flows for a deployment once the observation window for that deployment expires.  We are controlling that using the observation queue that will allow us to go through the deployments sequentially as their observations end.  This is similar to the updates to process baselines.  

One key difference from process baselines is that network baselines keep the entire baseline in a cache in memory.  So the observation queue is only used for initial tracking of when to process the deployment and once a deployment is processed we no longer utilize the observation queue and rely on the local cache for all logic on how to update the baselines.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [stackrox/openshift-docs]~~(https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

For testing I update the various test files, primarily the manager_impl_test and service_impl_test.  
Additionally I turned off the ignore flag and added tests to the QA test NetworkBaselineTest.groovy.  That covers a few more cases of a user creating a baseline, order of flows and processes, etc.
I also ran long running and scale jobs to ensure things worked as expected.
