### PR TITLE
Prevent redundant clusters request if no search filter in UI

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
@@ -81,10 +81,9 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
         });
     }
 
+    const filteredSearch = filterAllowedSearch(searchOptions, pageSearch || {});
+    const restSearch = convertToRestSearch(filteredSearch || {});
     useDeepCompareEffect(() => {
-        const filteredSearch = filterAllowedSearch(searchOptions, pageSearch || {});
-        const restSearch = convertToRestSearch(filteredSearch || {});
-
         if (restSearch.length) {
             setIsViewFiltered(true);
         } else {
@@ -92,7 +91,7 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
         }
 
         refreshClusterList(restSearch);
-    }, [pageSearch, searchOptions, pollingCount]);
+    }, [restSearch, pollingCount]);
 
     // use a custom hook to set up polling, thanks Dan Abramov and Rob Stark
     useInterval(() => {


### PR DESCRIPTION
## Description

### Problem

> Cluster management should indicate which clusters are managed by Helm and the Operator

> Error: The following error originated from your application code, not from Cypress. It was caused by an unhandled promise rejection.

> Network Error

In failure before #1429 clusters list incorrectly renders response from **actual** request
![cypress-ci-clusters-04-25](https://user-images.githubusercontent.com/11862657/165846502-cbfcb31c-780b-4be2-a6c8-d076aed63695.png)

https://app.circleci.com/pipelines/github/stackrox/stackrox/10288/workflows/85211755-5702-44f5-8f5b-2a66a0bfc258/jobs/470401

logimbue-data.json has the following which does not seem correct:

```json
        {
          "timestamp": 1650910006.213,
          "category": "navigation",
          "data": { "to": "/main/clusters", "from": "/main/clusters" }
        },
```

and following request with status code 200, there is request with status code 0:

```json
        {
          "timestamp": 1650910006.497,
          "type": "http",
          "category": "xhr",
          "data": { "method": "GET", "url": "/v1/clusters", "status_code": 0 }
        },
```

In failure after #1429 clusters list correctly renders fixture from **mock** request
![cypress-NetworkError-04-28](https://user-images.githubusercontent.com/11862657/165846556-4d45f5e1-2ab5-4213-8f16-e9ffcf92ef6c.png)

https://app.circleci.com/pipelines/github/stackrox/stackrox/10638/workflows/662c21c7-c7d7-468b-af30-1c5ed278a059/jobs/488535

logimbue-data.json also has the following which does not seem correct:

```json
        {
          "timestamp": 1651156888.382,
          "category": "navigation",
          "data": { "to": "/main/clusters", "from": "/main/clusters" }
        },
```

but following request with status code 200, there is not a request with status code 0

### Analysis

Because `searchOptions` is in dependencies, there is an initial clusters request, and then a second clusters request after response to searchOptions request:

```js
    useDeepCompareEffect(() => {
        const filteredSearch = filterAllowedSearch(searchOptions, pageSearch || {});
        const restSearch = convertToRestSearch(filteredSearch || {});

        if (restSearch.length) {
            setIsViewFiltered(true);
        } else {
            setIsViewFiltered(false);
        }

        refreshClusterList(restSearch);
    }, [pageSearch, searchOptions, pollingCount]);
```

When there is no search filter, the second clusters request is redundant.

### Solution

The next step forward is to refactor the hook to depend only on `restSearch` and `pollingCount`

```js
    const filteredSearch = filterAllowedSearch(searchOptions, pageSearch || {});
    const restSearch = convertToRestSearch(filteredSearch || {});
    useDeepCompareEffect(() => {
        if (restSearch.length) {
            setIsViewFiltered(true);
        } else {
            setIsViewFiltered(false);
        }

        refreshClusterList(restSearch);
    }, [restSearch, pollingCount]);
```

### Residue

1. Replace `restSearch` array of objects with `filteredSearch` object as argument of `fetchClustersAsArray` service function.
2. Discuss whether to replace `useDeepCompareEffect` for query array/object with `useEffect` for query string.
3. Refactor carefully to prevent incorrect initial request when visiting by page address with search query string causes 2 clusters requests, first incorrect without filter before `searchOptions` and second correct with filter after `searchOptions`
4. Catch error and render message if request fails (after failures have stopped).
5. Investigate redundant `history.push` which seems to be independent of this problem.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn build` in ui
2. `yarn start` in ui

### manual testing

Add temporary `console.log` in ClustersTablePanel.js in `useDeepCompareEffect`
* `pollingCount`
* `restSearch`
* `searchOptions`

Scenarios

1. Platform Configuration > Clusters

    * does have redundant second request with `pageSearch, restSearch` in dependencies

        useDeepCompareEffect 0 [] []
        useDeepCompareEffect 0 [] ['Admission Control Status', 'Cluster', 'Cluster Label', 'Cluster Status', 'Collector Status', 'Sensor Status']
        useDeepCompareEffect 1 [] ['Admission Control Status', 'Cluster', 'Cluster Label', 'Cluster Status', 'Collector Status', 'Sensor Status']

        1.07s /v1/clusters 80.70ms
        1.07s /v1/cluster-defaults 123.62ms
        1.07s /api/graphql?opname=searchOptions 54.38ms
        1.14s /v1/clusters 66.81ms
        6.06s /v1/clusters 29.68ms

    * does not have redundant second request with `restSearch` in dependencies

        useDeepCompareEffect 0 [] []
        useDeepCompareEffect 1 [] ['Admission Control Status', 'Cluster', 'Cluster Label', 'Cluster Status', 'Collector Status', 'Sensor Status']

        3.16s /v1/clusters 83.97ms
        3.16s /v1/cluster-defaults 271.16ms
        3.16s /api/graphql?opname=searchOptions 97.77ms
        8.14s /v1/clusters 33.19ms

2. Paste address which has cluster id

    * does have redundant second request with `pageSearch, restSearch` in dependencies

        2.54s /v1/clusters 83.71ms
        2.54s /v1/cluster-defaults 238.23ms
        2.54s /v1/clusters/id 72.08ms
        2.54s /api/graphql?opname=searchOptions 66.20ms
        2.63s /v1/clusters 39.20ms
        7.58s /v1/clusters 33.65ms

    * does not have redundant second request with `restSearch` in dependencies

        2.45s /v1/clusters 67.94ms
        2.45s /v1/cluster-defaults 271.03ms
        2.45s /v1/clusters/id 79.22ms
        2.45s /api/graphql?opname=searchOptions 83.43ms
        7.48s /v1/clusters 25.16ms

3. Paste address which has search query /main/clusters?s[Cluster%20Status]=HEALTHY

    * does have incorrect first request with `pageSearch, restSearch` in dependencies

        useDeepCompareEffect 0 [] []
        useDeepCompareEffect 0 [{…}, {…}] ['Admission Control Status', 'Cluster', 'Cluster Label', 'Cluster Status', 'Collector Status', 'Sensor Status']
        useDeepCompareEffect 1 [{…}, {…}] ['Admission Control Status', 'Cluster', 'Cluster Label', 'Cluster Status', 'Collector Status', 'Sensor Status']

        2.93s /v1/clusters 91.51ms
        2.94s /v1/cluster-defaults 162.29ms
        2.94s /api/graphql?opname=searchOptions 105.05ms
        3.15s /v1/clusters?query=Cluster%20Status%3AHEALTHY 51.54ms
        7.87s /v1/clusters?query=Cluster%20Status%3AHEALTHY 25.64ms

    * does have incorrect first request with `restSearch` in dependencies

        2.60s /v1/clusters 75.42ms
        2.60s /v1/cluster-defaults 276.57ms
        2.60s /api/graphql?opname=searchOptions 58.29ms
        2.71s /v1/clusters?query=Cluster%20Status%3AHEALTHY 35.41ms
        7.57s /v1/clusters?query=Cluster%20Status%3AHEALTHY 34.19ms

### integration testing

1. `yarn cypress-open` in ui/apps/platform
    * clusters.test.js