### PR TITLE
ROX-9535: Effective access scope merge - merge cluster ID to cluster name map as well

### DIFF
--- a/pkg/sac/effectiveaccessscope/effective_access_scope.go
+++ b/pkg/sac/effectiveaccessscope/effective_access_scope.go
@@ -308,6 +308,12 @@ func (root *ScopeTree) Merge(tree *ScopeTree) {
 	if root.Clusters == nil {
 		root.Clusters = map[string]*clustersScopeSubTree{}
 	}
+	if len(tree.clusterIDToName) > 0 && root.clusterIDToName == nil {
+		root.clusterIDToName = make(map[string]string)
+	}
+	for clusterID, clusterName := range tree.clusterIDToName {
+		root.clusterIDToName[clusterID] = clusterName
+	}
 	for key, cluster := range tree.Clusters {
 		rootCluster := root.Clusters[key]
 		if rootCluster == nil || cluster.State == Included {

--- a/pkg/sac/effectiveaccessscope/effective_access_scope_test.go
+++ b/pkg/sac/effectiveaccessscope/effective_access_scope_test.go
@@ -823,6 +823,11 @@ func TestMergeScopeTree(t *testing.T) {
 			name: "merge namespaces and clusters",
 			a: &ScopeTree{
 				State: Partial,
+				clusterIDToName: map[string]string{
+					"clusterid.earth":    "Earth",
+					"clusterid.arrakis":  "Arrakis",
+					"clusterid.notfound": "Not Found",
+				},
 				Clusters: map[string]*clustersScopeSubTree{
 					"Earth": {
 						State: Excluded,
@@ -842,6 +847,10 @@ func TestMergeScopeTree(t *testing.T) {
 			},
 			b: &ScopeTree{
 				State: Partial,
+				clusterIDToName: map[string]string{
+					"clusterid.earth":   "Earth",
+					"clusterid.arrakis": "Arrakis",
+				},
 				Clusters: map[string]*clustersScopeSubTree{
 					"Earth": {
 						State: Partial,
@@ -860,6 +869,11 @@ func TestMergeScopeTree(t *testing.T) {
 			},
 			c: &ScopeTree{
 				State: Partial,
+				clusterIDToName: map[string]string{
+					"clusterid.earth":    "Earth",
+					"clusterid.arrakis":  "Arrakis",
+					"clusterid.notfound": "Not Found",
+				},
 				Clusters: map[string]*clustersScopeSubTree{
 					"Arrakis": {
 						State: Partial,
@@ -879,6 +893,10 @@ func TestMergeScopeTree(t *testing.T) {
 			name: "short circuit when cluster is included",
 			a: &ScopeTree{
 				State: Partial,
+				clusterIDToName: map[string]string{
+					"clusterid.earth":   "Earth",
+					"clusterid.arrakis": "Arrakis",
+				},
 				Clusters: map[string]*clustersScopeSubTree{
 					"Earth": {
 						State: Included,
@@ -896,6 +914,11 @@ func TestMergeScopeTree(t *testing.T) {
 			},
 			b: &ScopeTree{
 				State: Partial,
+				clusterIDToName: map[string]string{
+					"clusterid.earth":    "Earth",
+					"clusterid.arrakis":  "Arrakis",
+					"clusterid.notfound": "Not Found",
+				},
 				Clusters: map[string]*clustersScopeSubTree{
 					"Earth": {
 						State: Excluded,
@@ -915,6 +938,11 @@ func TestMergeScopeTree(t *testing.T) {
 			},
 			c: &ScopeTree{
 				State: Partial,
+				clusterIDToName: map[string]string{
+					"clusterid.earth":    "Earth",
+					"clusterid.arrakis":  "Arrakis",
+					"clusterid.notfound": "Not Found",
+				},
 				Clusters: map[string]*clustersScopeSubTree{
 					"Arrakis": {
 						State: Partial,
@@ -930,6 +958,10 @@ func TestMergeScopeTree(t *testing.T) {
 			a:    DenyAllEffectiveAccessScope(),
 			b: &ScopeTree{
 				State: Partial,
+				clusterIDToName: map[string]string{
+					"clusterid.earth":   "Earth",
+					"clusterid.arrakis": "Arrakis",
+				},
 				Clusters: map[string]*clustersScopeSubTree{
 					"Earth": {
 						State: Partial,
@@ -948,6 +980,10 @@ func TestMergeScopeTree(t *testing.T) {
 			},
 			c: &ScopeTree{
 				State: Partial,
+				clusterIDToName: map[string]string{
+					"clusterid.earth":   "Earth",
+					"clusterid.arrakis": "Arrakis",
+				},
 				Clusters: map[string]*clustersScopeSubTree{
 					"Earth": {
 						State: Partial,
@@ -969,6 +1005,9 @@ func TestMergeScopeTree(t *testing.T) {
 			a:    DenyAllEffectiveAccessScope(),
 			b: &ScopeTree{
 				State: Partial,
+				clusterIDToName: map[string]string{
+					"clusterid.earth": "Earth",
+				},
 				Clusters: map[string]*clustersScopeSubTree{
 					"Earth": {
 						State: Included,
@@ -977,6 +1016,9 @@ func TestMergeScopeTree(t *testing.T) {
 			},
 			c: &ScopeTree{
 				State: Partial,
+				clusterIDToName: map[string]string{
+					"clusterid.earth": "Earth",
+				},
 				Clusters: map[string]*clustersScopeSubTree{
 					"Earth": {
 						State: Included,
@@ -1003,6 +1045,9 @@ func TestMergeScopeTree(t *testing.T) {
 			},
 			b: &ScopeTree{
 				State: Partial,
+				clusterIDToName: map[string]string{
+					"clusterid.earth": "Earth",
+				},
 				Clusters: map[string]*clustersScopeSubTree{
 					"Earth": {
 						State: Included,
@@ -1011,6 +1056,9 @@ func TestMergeScopeTree(t *testing.T) {
 			},
 			c: &ScopeTree{
 				State: Partial,
+				clusterIDToName: map[string]string{
+					"clusterid.earth": "Earth",
+				},
 				Clusters: map[string]*clustersScopeSubTree{
 					"Earth": {
 						State: Included,


### PR DESCRIPTION
## Description

Trying to set up some end to end tests for scoped access control, it was discovered that the effective access scope merge missed the merge of some attributes.
The change includes the cluster ID to name map in the effective access scope merge in order to ensure proper 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Manual E2E tests on secret list and secret retrieval against postgres

Added unit tests for the missing part