### PR TITLE
Update postgres and rhel images with dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -74,3 +74,21 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
     - "stackrox/backend-dep-updaters"
+
+  - package-ecosystem: 'docker'
+    directory: 'image/rhel'
+    schedule:
+      interval: 'weekly'
+      day: 'wednesday'
+    open-pull-requests-limit: 1
+    reviewers:
+    - "stackrox/backend-dep-updaters"
+
+  - package-ecosystem: 'docker'
+    directory: 'image/postgres'
+    schedule:
+      interval: 'weekly'
+      day: 'wednesday'
+    open-pull-requests-limit: 1
+    reviewers:
+    - "stackrox/backend-dep-updaters"


### PR DESCRIPTION
## Description

Currently we are monitoring only operator base image with dependabot. 
This PR configure dependabot for postgres and rhel image.

## Testing Performed

N/A