### PR TITLE
Delete leftover clusters selected and wizard reducers in UI

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
@@ -1,8 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { generatePath } from 'react-router-dom';
-import { connect } from 'react-redux';
-import { createStructuredSelector } from 'reselect';
 import { useQuery } from '@apollo/client';
 import { HashLink } from 'react-router-hash-link';
 
@@ -11,8 +9,6 @@ import URLSearchInput from 'Components/URLSearchInput';
 import entityTypes, { searchCategories } from 'constants/entityTypes';
 import workflowStateContext from 'Containers/workflowStateContext';
 import { SEARCH_OPTIONS_QUERY } from 'queries/search';
-import { actions as clustersActions } from 'reducers/clusters';
-import { selectors } from 'reducers';
 import { clustersBasePath, clustersPathWithParam, integrationsPath } from 'routePaths';
 import parseURL from 'utils/URLParser';
 
@@ -115,12 +111,4 @@ ClustersPage.propTypes = {
     match: ReactRouterPropTypes.match.isRequired,
 };
 
-const mapStateToProps = createStructuredSelector({
-    searchOptions: selectors.getClustersSearchOptions,
-});
-
-const mapDispatchToProps = {
-    setSearchOptions: clustersActions.setClustersSearchOptions,
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(ClustersPage);
+export default ClustersPage;

--- a/ui/apps/platform/src/reducers/clusters.js
+++ b/ui/apps/platform/src/reducers/clusters.js
@@ -4,26 +4,18 @@ import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 
 import { createFetchingActionTypes, createFetchingActions } from 'utils/fetchingReduxRoutines';
-import {
-    types as searchTypes,
-    getActions as getSearchActions,
-    reducers as searchReducers,
-    getSelectors as getSearchSelectors,
-} from 'reducers/pageSearch';
 import mergeEntitiesById from 'utils/mergeEntitiesById';
 
 // Action types
 
 export const types = {
     FETCH_CLUSTERS: createFetchingActionTypes('clusters/FETCH_CLUSTERS'),
-    ...searchTypes('clusters'),
 };
 
 // Actions
 
 export const actions = {
     fetchClusters: createFetchingActions(types.FETCH_CLUSTERS),
-    ...getSearchActions('clusters'),
 };
 
 // Reducers
@@ -43,7 +35,6 @@ const byId = (state = {}, { type, response }) => {
 
 const reducer = combineReducers({
     byId,
-    ...searchReducers('clusters'),
 });
 
 export default reducer;
@@ -56,5 +47,4 @@ const getClusters = createSelector([getClustersById], (clusters) => Object.value
 export const selectors = {
     getClustersById,
     getClusters,
-    ...getSearchSelectors('clusters'),
 };

--- a/ui/apps/platform/src/reducers/clusters.js
+++ b/ui/apps/platform/src/reducers/clusters.js
@@ -12,34 +12,10 @@ import {
 } from 'reducers/pageSearch';
 import mergeEntitiesById from 'utils/mergeEntitiesById';
 
-export const clusterFormId = 'cluster-form';
-
-export const clusterTypes = [
-    'SWARM_CLUSTER',
-    'OPENSHIFT_CLUSTER',
-    'OPENSHIFT4_CLUSTER',
-    'KUBERNETES_CLUSTER',
-];
-
-export const wizardPages = Object.freeze({
-    FORM: 'FORM',
-    DEPLOYMENT: 'DEPLOYMENT',
-});
-
 // Action types
 
 export const types = {
     FETCH_CLUSTERS: createFetchingActionTypes('clusters/FETCH_CLUSTERS'),
-    FETCH_CLUSTER: createFetchingActionTypes('clusters/FETCH_CLUSTER'),
-    SELECT_CLUSTER: 'clusters/SELECT_CLUSTER',
-    START_WIZARD: 'clusters/START_WIZARD',
-    NEXT_WIZARD_PAGE: 'clusters/NEXT_WIZARD_PAGE',
-    PREV_WIZARD_PAGE: 'clusters/NEXT_WIZARD_PAGE',
-    UPDATE_WIZARD_STATE: 'clusters/UPDATE_WIZARD_STATE',
-    FINISH_WIZARD: 'clusters/FINISH_WIZARD',
-    SAVE_CLUSTER: createFetchingActionTypes('clusters/SAVE_CLUSTER'),
-    DELETE_CLUSTERS: 'clusters/DELETE_CLUSTERS',
-    DOWNLOAD_CLUSTER_YAML: 'clusters/DOWNLOAD_CLUSTER_YAML',
     ...searchTypes('clusters'),
 };
 
@@ -47,16 +23,6 @@ export const types = {
 
 export const actions = {
     fetchClusters: createFetchingActions(types.FETCH_CLUSTERS),
-    fetchCluster: createFetchingActions(types.FETCH_CLUSTER),
-    selectCluster: (clusterId) => ({ type: types.SELECT_CLUSTER, clusterId }),
-    startWizard: (clusterId) => ({ type: types.START_WIZARD, clusterId }),
-    nextWizardPage: () => ({ type: types.NEXT_WIZARD_PAGE }),
-    prevWizardPage: () => ({ type: types.PREV_WIZARD_PAGE }),
-    updateWizardState: (page, clusterId) => ({ type: types.UPDATE_WIZARD_STATE, page, clusterId }),
-    finishWizard: () => ({ type: types.FINISH_WIZARD }),
-    saveCluster: createFetchingActions(types.SAVE_CLUSTER),
-    deleteClusters: (clusterIds) => ({ type: types.DELETE_CLUSTERS, clusterIds }),
-    downloadClusterYaml: (clusterId) => ({ type: types.DOWNLOAD_CLUSTER_YAML, clusterId }),
     ...getSearchActions('clusters'),
 };
 
@@ -72,48 +38,11 @@ const byId = (state = {}, { type, response }) => {
         const onlyExisting = pick(newState, Object.keys(clustersById));
         return isEqual(onlyExisting, state) ? state : onlyExisting;
     }
-    if (type === types.SAVE_CLUSTER.SUCCESS || type === types.FETCH_CLUSTER.SUCCESS) {
-        const clustersById = response.entities.cluster;
-        return mergeEntitiesById(state, clustersById);
-    }
     return state;
-};
-
-const selectedCluster = (state = null, action) => {
-    if (action.type === types.SELECT_CLUSTER) {
-        return action.clusterId;
-    }
-    if (state && action.type === types.FETCH_CLUSTERS.SUCCESS) {
-        const clusters = action.response.entities.cluster;
-        // received a new list of clusters and it doesn't contain selected cluster: unselect
-        if (!clusters[state]) {
-            return null;
-        }
-    }
-    if (state && action.type === types.START_WIZARD) {
-        // started add / edit wizard, deselect cluster if we're adding a new one
-        return state === action.clusterId ? state : null;
-    }
-    return state;
-};
-
-const wizard = (state = null, { type, clusterId, page }) => {
-    switch (type) {
-        case types.START_WIZARD:
-            return { page: wizardPages.FORM, clusterId };
-        case types.UPDATE_WIZARD_STATE:
-            return { page, clusterId };
-        case types.FINISH_WIZARD:
-            return null;
-        default:
-            return state;
-    }
 };
 
 const reducer = combineReducers({
     byId,
-    selectedCluster,
-    wizard,
     ...searchReducers('clusters'),
 });
 
@@ -123,15 +52,9 @@ export default reducer;
 
 const getClustersById = (state) => state.byId;
 const getClusters = createSelector([getClustersById], (clusters) => Object.values(clusters));
-const getSelectedClusterId = (state) => state.selectedCluster;
-const getWizardCurrentPage = (state) => (state.wizard ? state.wizard.page : null);
-const getWizardClusterId = (state) => (state.wizard ? state.wizard.clusterId : null);
 
 export const selectors = {
     getClustersById,
     getClusters,
-    getSelectedClusterId,
-    getWizardCurrentPage,
-    getWizardClusterId,
     ...getSearchSelectors('clusters'),
 };

--- a/ui/apps/platform/src/sagas/clusterSagas.js
+++ b/ui/apps/platform/src/sagas/clusterSagas.js
@@ -1,12 +1,7 @@
-import { take, takeLatest, call, fork, put, all, select, race } from 'redux-saga/effects';
-import { delay } from 'redux-saga';
-import { getFormValues } from 'redux-form';
-import Raven from 'raven-js';
+import { takeLatest, call, fork, put, all } from 'redux-saga/effects';
 
 import * as service from 'services/ClustersService';
-import { actions, types, wizardPages, clusterFormId } from 'reducers/clusters';
-import { actions as notificationActions } from 'reducers/notifications';
-import { selectors } from 'reducers';
+import { actions, types } from 'reducers/clusters';
 
 function* getClusters() {
     try {
@@ -17,105 +12,10 @@ function* getClusters() {
     }
 }
 
-function* getCluster(clusterId) {
-    try {
-        const result = yield call(service.fetchCluster, clusterId);
-        yield put(actions.fetchCluster.success(result.response));
-    } catch (error) {
-        yield put(actions.fetchCluster.failure(error));
-    }
-}
-
-function* saveCluster(cluster) {
-    try {
-        const result = yield call(service.saveCluster, cluster);
-        yield put(actions.saveCluster.success(result.response));
-        return result.response.result.cluster; // that will be cluster ID
-    } catch (error) {
-        if (error.response) {
-            yield put(notificationActions.addNotification(error.response.data.error));
-            yield put(notificationActions.removeOldestNotification());
-        }
-        yield put(actions.saveCluster.failure(error));
-        Raven.captureException(error);
-    }
-    return null;
-}
-
-function* deleteClusters({ clusterIds }) {
-    try {
-        yield call(service.deleteClusters, clusterIds);
-        yield fork(getClusters);
-    } catch (error) {
-        if (error.response) {
-            yield put(notificationActions.addNotification(error.response.data.error));
-            yield put(notificationActions.removeOldestNotification());
-        }
-        Raven.captureException(error);
-    }
-}
-
-function* downloadClusterYaml() {
-    try {
-        const clusterId = yield select(selectors.getWizardClusterId);
-        yield call(service.downloadClusterYaml, clusterId);
-    } catch (error) {
-        yield put(notificationActions.addNotification('Error while downloading a file'));
-        yield put(notificationActions.removeOldestNotification());
-        Raven.captureException(error);
-    }
-}
-
 function* watchFetchRequest() {
     yield takeLatest(types.FETCH_CLUSTERS.REQUEST, getClusters);
 }
 
-function* watchDeleteRequest() {
-    yield takeLatest(types.DELETE_CLUSTERS, deleteClusters);
-}
-
-function* pollCluster(clusterId) {
-    while (true) {
-        yield call(getCluster, clusterId);
-        yield delay(3000); // every 3 sec
-    }
-}
-
-function* watchDownloadRequest() {
-    yield takeLatest(types.DOWNLOAD_CLUSTER_YAML, downloadClusterYaml);
-}
-
-function* watchWizard() {
-    while (true) {
-        const action = yield take([types.NEXT_WIZARD_PAGE, types.PREV_WIZARD_PAGE]);
-        const currentPage = yield select(selectors.getWizardCurrentPage);
-        const clusterId = yield select(selectors.getWizardClusterId);
-
-        if (action.type === types.NEXT_WIZARD_PAGE && currentPage === wizardPages.FORM) {
-            const formData = yield select(getFormValues(clusterFormId));
-            const savedClusterId = yield call(saveCluster, { id: clusterId, ...formData });
-            yield fork(getClusters);
-            if (savedClusterId) {
-                yield put(actions.updateWizardState(wizardPages.DEPLOYMENT, savedClusterId));
-                yield race([
-                    call(pollCluster, savedClusterId),
-                    take([types.FINISH_WIZARD, types.PREV_WIZARD_PAGE]),
-                ]);
-            }
-        } else if (
-            action.type === types.PREV_WIZARD_PAGE &&
-            currentPage === wizardPages.DEPLOYMENT
-        ) {
-            yield put(actions.updateWizardState(wizardPages.FORM, clusterId));
-        }
-    }
-}
-
 export default function* clusters() {
-    yield all([
-        fork(watchFetchRequest),
-        fork(watchDeleteRequest),
-        fork(watchWizard),
-        fork(watchDownloadRequest),
-    ]);
+    yield all([fork(watchFetchRequest)]);
 }

--- a/ui/apps/platform/src/sagas/searchSagas.js
+++ b/ui/apps/platform/src/sagas/searchSagas.js
@@ -1,15 +1,7 @@
 import { all, put, call } from 'redux-saga/effects';
 
-import {
-    mainPath,
-    clustersPathWithParam,
-    policiesPath,
-    imagesPath,
-    secretsPath,
-    networkPath,
-} from 'routePaths';
+import { mainPath, policiesPath, imagesPath, secretsPath, networkPath } from 'routePaths';
 import { takeEveryNewlyMatchedLocation } from 'utils/sagaEffects';
-import { actions as clustersActions } from 'reducers/clusters';
 import { actions as policiesActions } from 'reducers/policies/search';
 import { actions as imagesActions } from 'reducers/images';
 import { actions as secretsActions } from 'reducers/secrets';
@@ -82,14 +74,6 @@ export default function* searches() {
             globalSearchActions.setGlobalSearchSuggestions,
             null,
             ''
-        ),
-        takeEveryNewlyMatchedLocation(
-            clustersPathWithParam,
-            getSearchOptions,
-            clustersActions.setClustersSearchModifiers,
-            clustersActions.setClustersSearchSuggestions,
-            clustersActions.setClustersSearchOptions,
-            `categories=CLUSTERS`
         ),
         // TODO: remove once policies is fully migrated over to PF
         takeEveryNewlyMatchedLocation(


### PR DESCRIPTION
## Description

Noticed in logimbue-data.json file while investigating integration test failures.

### Goals
1. Reserve global store for authentication, authorization, and feature flags.
2. Delete leftover requests in sagas for unused container-specific data in global store.
3. Delete unused container-specific data from global store.
4. Move container-specific data from global store, so cause-and-effect is clearer within containers and as prerequisite for future container plugins.

### Residue

1. Investigate unrelated error in local deployment several seconds after clicking Next when creating new cluster.
2. Investigate whether there are any references to search reducers:
    * searchOptions
    * searchModifiers
    * searchSuggestions
3. Although cluster sagas are not strictly needed, because network sagas request clusters directly instead of indirectly via action, wait to delete (see next point).
4. Delete clusters reducer after Network Graph makes its own request instead of the following references:
    * Containers/Network/Page.js
    * Containers/Network/Graph/Graph.js
    * Containers/Network/Header/ClusterSelect.tsx

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn build` in ui
2. `wc build/static/js/*.chunk.js` in ui
    * branch - master: -6343 = 9493869 - 9500212
3. `yarn start` in ui

### manual testing

1. /main/network
    * See /v1/clusters request
    * See no temporary console log, because network sagas request clusters directly instead of indirectly via action

2. /main/clusters
    * See change from empty array to non-empty array for `searchModifiers` and `searchSuggestions` but not `searchOptions`
    * Create cluster (see residue)