### PR TITLE
ROX-10208: integrate branding env into ci attempt 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -942,7 +942,7 @@ commands:
 
       - run:
           name: Build main image
-          command: make docker-build-main-image
+          command: make docker-build-main-image ROX_PRODUCT_BRANDING="<< parameters.branding >>"
 
       - run:
           name: Check debugger presence in the main image

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ endif
 # 3. Otherwise set it to "development_build" by default, e.g. for developers running the Makefile locally.
 ROX_IMAGE_FLAVOR ?= $(shell if [[ "$(GOTAGS)" == *"$(RELEASE_GOTAGS)"* ]]; then echo "stackrox.io"; else echo "development_build"; fi)
 
+ROX_PRODUCT_BRANDING ?= STACKROX_BRANDING
 DEFAULT_IMAGE_REGISTRY := quay.io/stackrox-io
 BUILD_IMAGE_VERSION=$(shell sed 's/\s*\#.*//' BUILD_IMAGE_VERSION)
 BUILD_IMAGE := $(DEFAULT_IMAGE_REGISTRY)/apollo-ci:$(BUILD_IMAGE_VERSION)
@@ -508,6 +509,7 @@ docker-build-main-image: copy-binaries-to-image-dir docker-build-data-image $(CU
 		-t stackrox/main:$(TAG) \
 		-t $(DEFAULT_IMAGE_REGISTRY)/main:$(TAG) \
 		--build-arg ROX_IMAGE_FLAVOR=$(ROX_IMAGE_FLAVOR) \
+		--build-arg ROX_PRODUCT_BRANDING=$(ROX_PRODUCT_BRANDING) \
 		--file image/rhel/Dockerfile \
 		--label version=$(TAG) \
 		--label release=$(TAG) \

--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -17,10 +17,12 @@ LABEL name="main" \
       description="This image contains components required to operate the StackRox Kubernetes Security Platform."
 
 ARG ROX_IMAGE_FLAVOR
+ARG ROX_PRODUCT_BRANDING
 
 ENV PATH="/stackrox:$PATH" \
     ROX_ROXCTL_IN_MAIN_IMAGE="true" \
-    ROX_IMAGE_FLAVOR=${ROX_IMAGE_FLAVOR}
+    ROX_IMAGE_FLAVOR=${ROX_IMAGE_FLAVOR} \
+    ROX_PRODUCT_BRANDING=${ROX_PRODUCT_BRANDING}
 
 COPY signatures/RPM-GPG-KEY-CentOS-Official /
 COPY scripts /stackrox/

--- a/pkg/branding/brandedtext_test.go
+++ b/pkg/branding/brandedtext_test.go
@@ -45,10 +45,9 @@ func (s *BrandedTextTestSuite) TestGetBrandedProductName() {
 			productBrandingEnv: "STACKROX_BRANDING",
 			brandedProductName: brandedProductNameStackrox,
 		},
-		// TODO(ROX-10208): Set brandedProductNameShort to brandedProductNameStackrox
 		"Unset env": {
 			productBrandingEnv: "",
-			brandedProductName: brandedProductNameRHACS,
+			brandedProductName: brandedProductNameStackrox,
 		},
 	}
 	for name, tt := range tests {
@@ -73,10 +72,9 @@ func (s *BrandedTextTestSuite) TestGetBrandedProductNameShort() {
 			productBrandingEnv:      "STACKROX_BRANDING",
 			brandedProductNameShort: brandedProductNameStackrox,
 		},
-		// TODO(ROX-10208): Set brandedProductNameShort to brandedProductNameStackrox
 		"Unset env": {
 			productBrandingEnv:      "",
-			brandedProductNameShort: productNameRHACSShort,
+			brandedProductNameShort: brandedProductNameStackrox,
 		},
 	}
 	for name, tt := range tests {

--- a/pkg/branding/env.go
+++ b/pkg/branding/env.go
@@ -11,8 +11,7 @@ const (
 )
 
 var (
-	// TODO(ROX-10208): Remove the default in the followup task of adding the new env variable to CI
-	productBrandingSetting = env.RegisterSetting(ProductBrandingEnvName, env.WithDefault("RHACS_BRANDING"))
+	productBrandingSetting = env.RegisterSetting(ProductBrandingEnvName)
 )
 
 // getProductBrandingEnv returns a value of the environment variable that defines the product branding.


### PR DESCRIPTION
## Description

ROX-9929 introduced a new environment variable `ProductBrandingEnvName` which defines product branding. The goal of ROX-10208 was to integrate this new environment variable into the Makefile, circleci/config.yml and Dockerfile so that builds have the env variable set correctly, eg. "RHACS_BRANDING" or "STACKROX_BRANDING"

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] ~Determined and documented upgrade steps~ // not applicable
- [ ] ~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~ // not applicable

If any of these don't apply, please comment below.

## Testing Performed

I'm actually unsure on how to test this properly. We would need a way to ensure that build behavior is consistent with how it was previously; "RHACS_BRANDING" is what used to be the default. Consider testing a work in progress for now, will update with further steps here.
