### PR TITLE
ROX-10664: Precise that `errox.CausedBy(err)` drops the `err` class

### DIFF
--- a/pkg/errox/roxerror.go
+++ b/pkg/errox/roxerror.go
@@ -91,6 +91,10 @@ func (e *RoxError) Newf(format string, args ...interface{}) *RoxError {
 // CausedBy adds a cause to the RoxError. The resulting message is a combination
 // of the rox error and the cause following a colon.
 //
+// Note, that if cause is an error chain, the chain is collapsed to the message
+// and the cause class is dropped, i.e.:
+//     errors.Is(err.CausedBy(cause), cause) == false
+//
 // Example:
 //     return errox.InvalidArgument.CausedBy(err)
 // or

--- a/pkg/errox/roxerror_test.go
+++ b/pkg/errox/roxerror_test.go
@@ -68,8 +68,11 @@ func TestCausedBy(t *testing.T) {
 	}
 
 	{
-		assert.Equal(t, "not found: your fault",
-			NotFound.CausedBy(errors.New("your fault")).Error())
+		cause := errors.New("your fault")
+		err := NotFound.CausedBy(cause)
+		assert.Equal(t, "not found: your fault", err.Error())
+		assert.ErrorIs(t, err, NotFound)
+		assert.NotErrorIs(t, err, cause)
 	}
 
 	{


### PR DESCRIPTION
## Description

A comment and an explicit test case to tell and show that `roxerr.CausedBy(err)` would drop the class of `err` and keep only the one of `roxerr` in the resulting chain.

This is due to the decision to implement both the classification and the causation via standard error chaining by wrapping, so the chain of sentinel based classes, that supports the classification, overtakes here the chain of the cause.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

A unit test updated to explicitly show the effect: `errors.Is(err.CausedBy(cause), cause) == false`.