### PR TITLE
ROX-10694 Fix "Filter On" links in global search for Violations, Risk

### DIFF
--- a/ui/apps/platform/src/Containers/Search/SearchResults.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchResults.tsx
@@ -14,7 +14,12 @@ import {
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
-import { addSearchModifier, addSearchKeyword } from 'utils/searchUtils';
+import {
+    addSearchModifier,
+    addSearchKeyword,
+    getUrlQueryStringForSearchFilter,
+    searchOptionsToSearchFilter,
+} from 'utils/searchUtils';
 import { selectors } from 'reducers';
 import { actions as globalSearchActions } from 'reducers/globalSearch';
 import { GlobalSearchOption } from 'types/search';
@@ -195,18 +200,40 @@ function SearchResults({
         setGlobalSearchCategory(selectedTab.category);
     }
 
+    const amendSearchOptions = (searchCategory: string, category: string, name: string) => {
+        let searchOptions = [...globalSearchOptions];
+        if (name) {
+            searchOptions = addSearchModifier(
+                searchOptions,
+                `${mapping[searchCategory].name as string}:`
+            );
+            searchOptions = addSearchKeyword(searchOptions, name);
+        }
+        return searchOptions;
+    };
+
     const onLinkHandler =
         (searchCategory: string, category: string, toURL: string, name: string) => () => {
-            let searchOptions = globalSearchOptions.slice();
-            if (name) {
-                searchOptions = addSearchModifier(
-                    searchOptions,
-                    `${mapping[searchCategory].name as string}:`
-                );
-                searchOptions = addSearchKeyword(searchOptions, name);
-            }
+            const searchOptions = amendSearchOptions(searchCategory, category, name);
             passthroughGlobalSearchOptions(searchOptions, category);
             onClose(toURL);
+        };
+
+    const onFilterLinkHandler =
+        (searchCategory: string, category: string, toURL: string, name: string) => () => {
+            const searchOptions = amendSearchOptions(searchCategory, category, name);
+            passthroughGlobalSearchOptions(searchOptions, category);
+            const searchFilter = searchOptionsToSearchFilter(searchOptions);
+            let queryString = '';
+            // TODO Once Violations, Risk, and Network Graph are all using URL Search Params this can be simplified
+            if (category === 'ALERTS' || category === 'DEPLOYMENTS') {
+                queryString = getUrlQueryStringForSearchFilter(searchFilter);
+            } else if (category === 'NETWORK') {
+                // Do nothing, until Network Graph moves from Redux to URL Params
+            } else {
+                // This should never happen, the only three "filter on" pages are the ones listed above
+            }
+            onClose(`${toURL}?${queryString}`);
         };
 
     const contents = sortedRows.length ? (
@@ -314,7 +341,7 @@ function SearchResults({
                                                 <RelatedLink
                                                     data-testid="filter-on-label-chip"
                                                     id={id}
-                                                    onClick={onLinkHandler(
+                                                    onClick={onFilterLinkHandler(
                                                         category,
                                                         filterOnMapping[item],
                                                         getLink(item),

--- a/ui/apps/platform/src/Containers/Search/SearchResults.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchResults.tsx
@@ -14,12 +14,7 @@ import {
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
-import {
-    addSearchModifier,
-    addSearchKeyword,
-    getUrlQueryStringForSearchFilter,
-    searchOptionsToSearchFilter,
-} from 'utils/searchUtils';
+import { getUrlQueryStringForSearchFilter, searchOptionsToSearchFilter } from 'utils/searchUtils';
 import { selectors } from 'reducers';
 import { actions as globalSearchActions } from 'reducers/globalSearch';
 import { GlobalSearchOption } from 'types/search';
@@ -200,28 +195,36 @@ function SearchResults({
         setGlobalSearchCategory(selectedTab.category);
     }
 
-    const amendSearchOptions = (searchCategory: string, category: string, name: string) => {
-        let searchOptions = [...globalSearchOptions];
+    const amendSearchOptions = (searchCategory: string, name: string) => {
         if (name) {
-            searchOptions = addSearchModifier(
-                searchOptions,
-                `${mapping[searchCategory].name as string}:`
-            );
-            searchOptions = addSearchKeyword(searchOptions, name);
+            const searchModifier = `${mapping[searchCategory].name as string}:`;
+            return [
+                ...globalSearchOptions,
+                {
+                    value: searchModifier,
+                    label: searchModifier,
+                    type: 'categoryOption',
+                },
+                {
+                    value: name,
+                    label: name,
+                    className: 'Select-create-option-placeholder',
+                } as GlobalSearchOption,
+            ];
         }
-        return searchOptions;
+        return [...globalSearchOptions];
     };
 
     const onLinkHandler =
         (searchCategory: string, category: string, toURL: string, name: string) => () => {
-            const searchOptions = amendSearchOptions(searchCategory, category, name);
+            const searchOptions = amendSearchOptions(searchCategory, name);
             passthroughGlobalSearchOptions(searchOptions, category);
             onClose(toURL);
         };
 
     const onFilterLinkHandler =
         (searchCategory: string, category: string, toURL: string, name: string) => () => {
-            const searchOptions = amendSearchOptions(searchCategory, category, name);
+            const searchOptions = amendSearchOptions(searchCategory, name);
             passthroughGlobalSearchOptions(searchOptions, category);
             const searchFilter = searchOptionsToSearchFilter(searchOptions);
             let queryString = '';

--- a/ui/apps/platform/src/utils/searchUtils.test.js
+++ b/ui/apps/platform/src/utils/searchUtils.test.js
@@ -4,6 +4,7 @@ import {
     convertToRestSearch,
     convertSortToGraphQLFormat,
     convertSortToRestFormat,
+    searchOptionsToSearchFilter,
 } from './searchUtils';
 
 describe('searchUtils', () => {
@@ -259,6 +260,52 @@ describe('searchUtils', () => {
                 field: 'Priority',
                 reversed: true,
             });
+        });
+    });
+
+    describe('searchOptionsToSearchFilter', () => {
+        it('should translate an array of SearchEntries to a SearchFilter object', () => {
+            expect(
+                searchOptionsToSearchFilter([
+                    { type: 'categoryOption', value: 'Image', label: 'Image' },
+                    { value: 'nginx:latest', label: 'nginx:latest' },
+                    { type: 'categoryOption', value: 'Status', label: 'Status' },
+                    { type: 'categoryOption', value: 'Severity', label: 'Severity' },
+                    { value: 'LOW_SEVERITY', label: 'LOW_SEVERITY' },
+                    { value: 'HIGH_SEVERITY', label: 'HIGH_SEVERITY' },
+                ])
+            ).toEqual({
+                Image: 'nginx:latest',
+                Status: '',
+                Severity: ['LOW_SEVERITY', 'HIGH_SEVERITY'],
+            });
+        });
+
+        it('should return an empty string value when no search options is provided for a category', () => {
+            expect(
+                searchOptionsToSearchFilter([
+                    { type: 'categoryOption', value: 'Status', label: 'Status' },
+                ])
+            ).toEqual({ Status: '' });
+        });
+
+        it('should return a string value when a single search options is provided for a category', () => {
+            expect(
+                searchOptionsToSearchFilter([
+                    { type: 'categoryOption', value: 'Image', label: 'Image' },
+                    { value: 'nginx:latest', label: 'nginx:latest' },
+                ])
+            ).toEqual({ Image: 'nginx:latest' });
+        });
+
+        it('should return an array value when multiple search options are provided for a category', () => {
+            expect(
+                searchOptionsToSearchFilter([
+                    { type: 'categoryOption', value: 'Severity', label: 'Severity' },
+                    { value: 'LOW_SEVERITY', label: 'LOW_SEVERITY' },
+                    { value: 'HIGH_SEVERITY', label: 'HIGH_SEVERITY' },
+                ])
+            ).toEqual({ Severity: ['LOW_SEVERITY', 'HIGH_SEVERITY'] });
         });
     });
 });

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -116,6 +116,33 @@ export function convertSortToRestFormat(graphqlSort: GraphQLSortOption[]): Parti
     };
 }
 
+/**
+ * Function to convert the legacy SearchEntry array format to the
+ * SearchFilter format.
+ */
+export function searchOptionsToSearchFilter(searchOptions: GlobalSearchOption[]): SearchFilter {
+    const searchFilter = {};
+    let currentOption = '';
+    searchOptions.forEach(({ value, type }) => {
+        if (type === 'categoryOption') {
+            // categoryOption represents the key of a search filter
+            const option = value.replace(':', '');
+            searchFilter[option] = '';
+            currentOption = option;
+        } else if (searchFilter[currentOption].length === 0) {
+            // If this is the first search value for this category, store it as a string
+            searchFilter[currentOption] = value;
+        } else if (!Array.isArray(searchFilter[currentOption])) {
+            // If this is not the first search value for this category, store it in a new array
+            searchFilter[currentOption] = [searchFilter[currentOption], value];
+        } else {
+            // If we already have an array, simply add the next value
+            searchFilter[currentOption].push(value);
+        }
+    });
+    return searchFilter;
+}
+
 /*
  * Return request query string for search filter. Omit filter criterion:
  * If option does not have value.

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -8,36 +8,6 @@ import {
 } from 'types/search';
 
 /**
- *  Adds a search modifier to the searchOptions
- *
- *  @param searchOptions an array of search options
- *  @param modifier a modifier term (ie. 'Cluster:')
- *  @returns the modified search options
- */
-export function addSearchModifier(
-    searchOptions: GlobalSearchOption[],
-    modifier: string
-): GlobalSearchOption[] {
-    const chip = { value: modifier, label: modifier, type: 'categoryOption' };
-    return [...searchOptions, chip];
-}
-
-/**
- *  Adds a search keyword to the searchOptions
- *
- *  @param searchOptions an array of search options
- *  @param keyword a keyword term (ie. 'remote')
- *  @returns the modified search options
- */
-export function addSearchKeyword(
-    searchOptions: GlobalSearchOption[],
-    keyword: string
-): GlobalSearchOption[] {
-    const chip = { value: keyword, label: keyword, className: 'Select-create-option-placeholder' };
-    return [...searchOptions, chip];
-}
-
-/**
  *  Checks if the modifier exists in the searchOptions
  *
  *  @param {!Object[]} searchOptions an array of search options


### PR DESCRIPTION
## Description

In working through URL search parameters, I found that when doing a global search the "Filter On" buttons in the search results no longer worked for some categories. The only three pages that can currently be visited via these buttons are:

- Risk (filter was not applied)
- Violations (filter was not applied)
- Network (filter _is_ applied, but UX needs work due to new namespace filter)

This PR updates the buttons to pass search options through the URL instead of using Redux for the Risk and Violations pages. Network still uses Redux until that page can be converted to use URL params.

## Follow up work
- ~Risk page should be updated to use `search` instead of `s` for the URL parameter, and have the special case here removed ([ROX-10693](https://issues.redhat.com/browse/ROX-10693))~
- Network should be updated to use URL parameters instead of Redux, and have the special case here removed ([ROX-10300](https://issues.redhat.com/browse/ROX-10300))
- The GlobalSearchOption and SearchFilter types are likely duplicates, so one can be removed

## Checklist
- [ ] Investigated and inspected CI test results

If any of these don't apply, please comment below.

## Testing Performed

Perform a global search with query options that match some entity. Various search options should provide a list of search results with "Filter On" links to Violations, Network, and Risk.

Test that search options are applied when clicking Filter On: Violations (`Image:` search, note that `Image:` is filtered out by the Violations page but `Deployment:` is valid)
![image](https://user-images.githubusercontent.com/1292638/166236834-9b681394-4b65-475a-805b-b1caff1cdef9.png)

Test that search options are applied when clicking Filter On: Network (`Image:` search, note that a namespace must be selected when visiting the Network page.)
![image](https://user-images.githubusercontent.com/1292638/166237090-cf755693-2ff9-4ab3-b7f2-73a125bbd825.png)

Test that search options are applied when clicking Filter On: Risk
![image](https://user-images.githubusercontent.com/1292638/166237164-cccbaa3e-c904-4f99-8aaa-a4e89904659c.png)


