### PR TITLE
Remove duplicate type definition for old style global search option

### DIFF
--- a/ui/apps/platform/src/Containers/Search/SearchResults.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchResults.tsx
@@ -17,7 +17,7 @@ import { TableComposable, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-tab
 import { getUrlQueryStringForSearchFilter, searchOptionsToSearchFilter } from 'utils/searchUtils';
 import { selectors } from 'reducers';
 import { actions as globalSearchActions } from 'reducers/globalSearch';
-import { GlobalSearchOption } from 'types/search';
+import { SearchEntry } from 'types/search';
 import { SortDirection } from 'types/table';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import RelatedLink from './RelatedLink';
@@ -38,14 +38,14 @@ type SearchTab = {
 };
 interface StateProps {
     globalSearchResults: GlobalSearchResult[];
-    globalSearchOptions: GlobalSearchOption[];
+    globalSearchOptions: SearchEntry[];
     tabs: SearchTab[];
     defaultTab: SearchTab | null;
 }
 
 interface DispatchProps {
     setGlobalSearchCategory: (category: string) => void;
-    passthroughGlobalSearchOptions: (searchOptions: GlobalSearchOption[], category: string) => void;
+    passthroughGlobalSearchOptions: (searchOptions: SearchEntry[], category: string) => void;
 }
 
 interface PassedProps {
@@ -195,7 +195,7 @@ function SearchResults({
         setGlobalSearchCategory(selectedTab.category);
     }
 
-    const amendSearchOptions = (searchCategory: string, name: string) => {
+    const amendSearchOptions = (searchCategory: string, name: string): SearchEntry[] => {
         if (name) {
             const searchModifier = `${mapping[searchCategory].name as string}:`;
             return [
@@ -209,7 +209,7 @@ function SearchResults({
                     value: name,
                     label: name,
                     className: 'Select-create-option-placeholder',
-                } as GlobalSearchOption,
+                } as SearchEntry,
             ];
         }
         return [...globalSearchOptions];

--- a/ui/apps/platform/src/types/search.ts
+++ b/ui/apps/platform/src/types/search.ts
@@ -18,12 +18,6 @@ export type SearchEntry = {
     label: string; // an option ends with a colon
 };
 
-export type GlobalSearchOption = {
-    value: string;
-    label: string;
-    type?: string;
-};
-
 export type ApiSortOption = {
     field: string;
     reversed: boolean;

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -1,11 +1,5 @@
 import qs from 'qs';
-import {
-    SearchEntry,
-    GlobalSearchOption,
-    ApiSortOption,
-    GraphQLSortOption,
-    SearchFilter,
-} from 'types/search';
+import { SearchEntry, ApiSortOption, GraphQLSortOption, SearchFilter } from 'types/search';
 
 /**
  *  Checks if the modifier exists in the searchOptions
@@ -90,7 +84,7 @@ export function convertSortToRestFormat(graphqlSort: GraphQLSortOption[]): Parti
  * Function to convert the legacy SearchEntry array format to the
  * SearchFilter format.
  */
-export function searchOptionsToSearchFilter(searchOptions: GlobalSearchOption[]): SearchFilter {
+export function searchOptionsToSearchFilter(searchOptions: SearchEntry[]): SearchFilter {
     const searchFilter = {};
     let currentOption = '';
     searchOptions.forEach(({ value, type }) => {


### PR DESCRIPTION
## Description

This removes the `GlobalSearchOption` type, which is a redundant and less-specific version of `SearchEntry`.

```typescript
export type GlobalSearchOption = {
    type?: string;
    value: string;
    label: string;
};

export type SearchEntry = {
    type?: 'categoryOption';
    value: string;
    label: string;
};
```

The only place that `GlobalSearchOption` was used was as an argument to the [`passthroughGlobalSearchOptions` function in JavaScript code](https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/sagas/globalSearchSagas.js#L35), which in turn dispatched actions that expect a type of `SearchEntry[]`.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Automated tests only, as this is a type-level change.
