### PR TITLE
OSCI: Use OpenShiftCI images

### DIFF
--- a/.openshift-ci/build/build-main-and-bundles.sh
+++ b/.openshift-ci/build/build-main-and-bundles.sh
@@ -122,11 +122,10 @@ build_main_and_bundles() {
     # be in the 'src' delivered by OSCI in the final env so this can then be removed.
     git submodule update --init
 
+    info "Current Status:"
     "$ROOT/status.sh" || true
 
     openshift_ci_mods
-
-    "$ROOT/status.sh" || true
 
     background_build_ui
     build_cli

--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -8,6 +8,11 @@ set -euo pipefail
 push_images() {
     info "Will push images built in CI"
 
+    if [[ "$#" -ne 1 ]]; then
+        die "missing args. usage: push_images <brand>"
+    fi
+
+    info "Images from OpenShift CI builds:"
     env | grep IMAGE
 
     [[ "${OPENSHIFT_CI:-false}" == "true" ]] || { die "Only supported in OpenShift CI"; }
@@ -24,4 +29,4 @@ push_images() {
     push_main_image_set "$branch" "$brand"
 }
 
-push_images "STACKROX_BRANDING"
+push_images "$*"


### PR DESCRIPTION
## Description

Use the images build in the OpenShift CI pipe in e2e tests.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.