### PR TITLE
ROX-10673: Increase timeout for OpenShift environments for SAC tests.

### DIFF
--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -8,6 +8,7 @@ import io.stackrox.proto.storage.DeploymentOuterClass
 
 import groups.BAT
 import objects.Deployment
+import orchestratormanager.OrchestratorTypes
 import services.AlertService
 import services.ApiTokenService
 import services.BaseService
@@ -60,11 +61,13 @@ class SACTest extends BaseSpecification {
             "stackrox/monitoring -> INTERNET",
     ] as Set
 
-    static final private Integer WAIT_FOR_VIOLATION_TIMEOUT = isRaceBuild() ? 600 : 60
+    // Increase the timeout conditionally based on whether we are running race-detection builds or within OpenShift
+    // environments. Both take longer than the default values.
+    static final private Integer WAIT_FOR_VIOLATION_TIMEOUT =
+            isRaceBuild() ? 600 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 100 : 60)
 
-    // Increase the timeout for race-condition tests. By default, we will wait 60 seconds, on race-condition tests
-    // we will wait 600 seconds.
-    static final private Integer WAIT_FOR_RISK_RETRIES = isRaceBuild() ? 300 : 30
+    static final private Integer WAIT_FOR_RISK_RETRIES =
+            isRaceBuild() ? 300 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 50 : 30)
 
     def setupSpec() {
         // Make sure we scan the image initially to make reprocessing faster.


### PR DESCRIPTION
## Description

Increased timeout waiting for deployments when running on OpenShift environments.

Previously that lead to flakes during the test setup, [where the deployment was not yet reprocessed](https://app.circleci.com/pipelines/github/stackrox/stackrox/10722/workflows/19857095-c423-45a0-a058-f5560b64c853/jobs/493037).

Note:
I saw this pattern now for ImageSignatureVerificationTest as well as SACTests. I think it makes sense to generalize this to avoid potential flakes like this in the future. I'll post a separate PR for this with the required refactoring.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
- see `openshift-rosa-api-e2e-tests`
