### PR TITLE
Specify timeouts for tests within BaseSpecification.

### DIFF
--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -403,20 +403,20 @@ class BaseSpecification extends Specification {
 
     // getViolationTimeout will return the timeout value based on the specific environment / build that is
     // used during test execution. The following values will be returned:
-    // Default: 30s
+    // Default: 60s
     // OpenShift: 100s
-    // Race build: 300s
+    // Race build: 600s
     static Integer getViolationTimeout() {
-        return  isRaceBuild() ? 300 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 100 : 30)
+        return  isRaceBuild() ? 600 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 100 : 60)
     }
 
     // getReprocessingRetries will return the number of retries based on the specific environment / build that is
     // used during test execution. The following values will be returned:
     // Default: 30
-    // OpenShift: 100
+    // OpenShift: 50
     // Race build: 300
     static Integer getReprocessingRetries() {
-        return isRaceBuild() ? 300 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 100 : 30)
+        return isRaceBuild() ? 300 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 50 : 30)
     }
 }
 

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -401,6 +401,23 @@ class BaseSpecification extends Specification {
         return Env.get("IS_RACE_BUILD", null) == "true" || Env.CI_JOBNAME == "race-condition-tests"
     }
 
+    // getViolationTimeout will return the timeout value based on the specific environment / build that is
+    // used during test execution. The following values will be returned:
+    // Default: 30s
+    // OpenShift: 100s
+    // Race build: 300s
+    static Integer getViolationTimeout() {
+        return  isRaceBuild() ? 300 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 100 : 30)
+    }
+
+    // getReprocessingRetries will return the number of retries based on the specific environment / build that is
+    // used during test execution. The following values will be returned:
+    // Default: 30
+    // OpenShift: 100
+    // Race build: 300
+    static Integer getReprocessingRetries() {
+        return isRaceBuild() ? 300 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 100 : 30)
+    }
 }
 
 class TestSpecRuntimeException extends RuntimeException {

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -199,7 +199,7 @@ class ImageManagementTest extends BaseSpecification {
 
         then:
         "Assert that riskScore is non-zero"
-        withRetry(10, 3) {
+        withRetry(getReprocessingRetries(), 2) {
             def image = ImageService.getImage(
                     "sha256:de2913a0ec53d98ced6f6bd607f487b7ad8fe8d2a86e2128308ebf4be2f92667")
             assert image != null && image.riskScore != 0
@@ -222,7 +222,7 @@ class ImageManagementTest extends BaseSpecification {
 
         then:
         "Assert that riskScore is non-zero"
-        withRetry(10, 3) {
+        withRetry(getReprocessingRetries(), 2) {
             def image = ImageService.getImage(
                     "sha256:f7985e36c668bb862a0e506f4ef9acdd1254cdf690469816f99633898895f7fa")
             assert image != null && image.riskScore != 0

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -51,7 +51,7 @@ class ImageScanningTest extends BaseSpecification {
             "Secure Shell (ssh) Port Exposed in Image",
     ]
 
-    static final private Integer WAIT_FOR_VIOLATION_TIMEOUT = isRaceBuild() ? 450 : 30
+    static final private Integer WAIT_FOR_VIOLATION_TIMEOUT = getViolationTimeout()
 
     static final private Map<String, Deployment> DEPLOYMENTS = [
             "quay": new Deployment()
@@ -211,7 +211,7 @@ class ImageScanningTest extends BaseSpecification {
         "validate registry based image metadata"
         def imageDigest
         try {
-            withRetry(30, 2) {
+            withRetry(getReprocessingRetries(), 2) {
                 imageDigest = ImageService.getImages().find { it.name == deployment.image }
                 assert imageDigest?.id
             }
@@ -721,7 +721,7 @@ class ImageScanningTest extends BaseSpecification {
 
     private static ImageOuterClass.Image expectDigestedImage(String imageName, String source) {
         def imageDigest
-        withRetry(30, 2) {
+        withRetry(getReprocessingRetries(), 2) {
             imageDigest = ImageService.getImages().find { it.name == imageName }
             assert imageDigest?.id
         }

--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -20,8 +20,7 @@ import util.Env
 @IgnoreIf({ !Env.CI_JOBNAME.contains("crio") })
 class ImageSignatureVerificationTest extends BaseSpecification {
     // https://issues.redhat.com/browse/ROX-6891
-    static final private Integer WAIT_FOR_VIOLATION_TIMEOUT =
-            isRaceBuild() ? 450 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 100 : 30)
+    static final private Integer WAIT_FOR_VIOLATION_TIMEOUT = getViolationTimeout()
 
     static final private String SIGNATURE_TESTING_NAMESPACE = "qa-signature-tests"
 

--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -7,7 +7,6 @@ import io.stackrox.proto.storage.ScopeOuterClass
 import io.stackrox.proto.storage.SignatureIntegrationOuterClass.CosignPublicKeyVerification
 import io.stackrox.proto.storage.SignatureIntegrationOuterClass.SignatureIntegration
 import objects.Deployment
-import orchestratormanager.OrchestratorTypes
 import org.junit.experimental.categories.Category
 import services.PolicyService
 import services.SignatureIntegrationService

--- a/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
@@ -244,8 +244,7 @@ class PolicyFieldsTest extends BaseSpecification {
     ]
 
     // https://stack-rox.atlassian.net/browse/ROX-6891
-    static final private Integer WAIT_FOR_VIOLATION_TIMEOUT =
-                isRaceBuild() ? 450 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 100 : 30)
+    static final private Integer WAIT_FOR_VIOLATION_TIMEOUT = getViolationTimeout()
 
     static final private BASE_POLICY = Policy.newBuilder()
             .addLifecycleStages(LifecycleStage.DEPLOY)

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -60,11 +60,11 @@ class SACTest extends BaseSpecification {
             "stackrox/monitoring -> INTERNET",
     ] as Set
 
-    static final private Integer WAIT_FOR_VIOLATION_TIMEOUT = isRaceBuild() ? 600 : 60
+    static final private Integer WAIT_FOR_VIOLATION_TIMEOUT = getViolationTimeout()
 
     // Increase the timeout for race-condition tests. By default, we will wait 60 seconds, on race-condition tests
     // we will wait 600 seconds.
-    static final private Integer WAIT_FOR_RISK_RETRIES = isRaceBuild() ? 300 : 30
+    static final private Integer WAIT_FOR_RISK_RETRIES = getReprocessingRetries()
 
     def setupSpec() {
         // Make sure we scan the image initially to make reprocessing faster.


### PR DESCRIPTION
## Description

Throughout the tests we have patterns as such:
`WAIT_FOR_VIOLATION_TIMEOUT = isRaceBuild() ? : <some-value>`

Sometimes different values are used, sometimes the OpenShift environment is not taken into account at all.
This led to flakes in the past.

Now, we specify the timeout in the BaseSpecification and reference the value within all test cases, ensuring there's no discrepancy for them.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
- see `CI` (`QA` tests should pass without unknown failures)
