### PR TITLE
Image signature tests should be ignored for cri-o.

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -1,5 +1,3 @@
-
-
 import static Services.waitForViolation
 
 import groups.Integration

--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -17,7 +17,7 @@ import spock.lang.Unroll
 import util.Env
 
 // Do not run tests on crio due to an issue with crio trying to pull images referenced by digest from gcr.io.
-@IgnoreIf({ !Env.CI_JOBNAME.contains("crio") })
+@IgnoreIf({ Env.CI_JOBNAME.contains("crio") })
 class ImageSignatureVerificationTest extends BaseSpecification {
     // https://issues.redhat.com/browse/ROX-6891
     static final private Integer WAIT_FOR_VIOLATION_TIMEOUT =

--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -1,6 +1,9 @@
+
+
 import static Services.waitForViolation
 
 import groups.Integration
+import groups.BAT
 import io.stackrox.proto.storage.PolicyOuterClass
 import io.stackrox.proto.storage.PolicyOuterClass.Policy
 import io.stackrox.proto.storage.ScopeOuterClass
@@ -202,7 +205,7 @@ w9e2Azq1OYIh/pbeBMHARDrBaqqmuMR9+BfAaPAYdkNTU6f58M2zBbuL0A==
 
     @Unroll
     @SuppressWarnings('LineLength')
-    @Category(Integration)
+    @Category([BAT, Integration])
     def "Check violations of policy '#policyName' for deployment '#deployment.name'"() {
         expect:
         "Verify deployment has expected violations"


### PR DESCRIPTION
## Description

Typo in `IgnoreIf`, tests should not be run on cri-o since they currently fail all the time.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
- see CI `gke-api-e2e-test` report, `ImageSignatureVerificationTest` report should be visible, `cri-o` should not have it.
