### PR TITLE
ROX-10072: Prevent panic when postgres tests are skipped

### DIFF
--- a/central/alert/datastore/internal/store/postgres/store_test.go
+++ b/central/alert/datastore/internal/store/postgres/store_test.go
@@ -55,7 +55,9 @@ func (s *AlertsStoreSuite) SetupTest() {
 }
 
 func (s *AlertsStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/apitoken/datastore/internal/store/postgres/store_test.go
+++ b/central/apitoken/datastore/internal/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *ApitokensStoreSuite) SetupTest() {
 }
 
 func (s *ApitokensStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/cluster/store/cluster/postgres/store_test.go
+++ b/central/cluster/store/cluster/postgres/store_test.go
@@ -55,7 +55,9 @@ func (s *ClustersStoreSuite) SetupTest() {
 }
 
 func (s *ClustersStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/cluster/store/clusterhealth/postgres/store_test.go
+++ b/central/cluster/store/clusterhealth/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *ClusterHealthStatusStoreSuite) SetupTest() {
 }
 
 func (s *ClusterHealthStatusStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/clusterinit/store/postgres/store_test.go
+++ b/central/clusterinit/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *ClusterinitbundlesStoreSuite) SetupTest() {
 }
 
 func (s *ClusterinitbundlesStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/componentcveedge/datastore/internal/postgres/store_test.go
+++ b/central/componentcveedge/datastore/internal/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *ImageComponentCveRelationsStoreSuite) SetupTest() {
 }
 
 func (s *ImageComponentCveRelationsStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/cve/datastore/cluster/internal/store/postgres/store_test.go
+++ b/central/cve/datastore/cluster/internal/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *ClusterCvesStoreSuite) SetupTest() {
 }
 
 func (s *ClusterCvesStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/cve/datastore/node/internal/store/postgres/store_test.go
+++ b/central/cve/datastore/node/internal/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *NodeCvesStoreSuite) SetupTest() {
 }
 
 func (s *NodeCvesStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/cve/image/datastore/internal/store/postgres/store_test.go
+++ b/central/cve/image/datastore/internal/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *ImageCvesStoreSuite) SetupTest() {
 }
 
 func (s *ImageCvesStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/deployment/store/postgres/store_test.go
+++ b/central/deployment/store/postgres/store_test.go
@@ -55,7 +55,9 @@ func (s *DeploymentsStoreSuite) SetupTest() {
 }
 
 func (s *DeploymentsStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/imagecomponent/datastore/internal/store/postgres/store_test.go
+++ b/central/imagecomponent/datastore/internal/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *ImageComponentsStoreSuite) SetupTest() {
 }
 
 func (s *ImageComponentsStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store_test.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *ImageComponentRelationsStoreSuite) SetupTest() {
 }
 
 func (s *ImageComponentRelationsStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/imagecveedge/datastore/internal/postgres/store_test.go
+++ b/central/imagecveedge/datastore/internal/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *ImageCveRelationsStoreSuite) SetupTest() {
 }
 
 func (s *ImageCveRelationsStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/integrationhealth/store/postgres/store_test.go
+++ b/central/integrationhealth/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *IntegrationhealthStoreSuite) SetupTest() {
 }
 
 func (s *IntegrationhealthStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/namespace/store/postgres/store_test.go
+++ b/central/namespace/store/postgres/store_test.go
@@ -55,7 +55,9 @@ func (s *NamespacesStoreSuite) SetupTest() {
 }
 
 func (s *NamespacesStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/networkbaseline/store/postgres/store_test.go
+++ b/central/networkbaseline/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *NetworkbaselineStoreSuite) SetupTest() {
 }
 
 func (s *NetworkbaselineStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *NetworkentityStoreSuite) SetupTest() {
 }
 
 func (s *NetworkentityStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/pod/store/postgres/store_test.go
+++ b/central/pod/store/postgres/store_test.go
@@ -55,7 +55,9 @@ func (s *PodsStoreSuite) SetupTest() {
 }
 
 func (s *PodsStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/policy/store/postgres/store_test.go
+++ b/central/policy/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *PolicyStoreSuite) SetupTest() {
 }
 
 func (s *PolicyStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/processbaseline/store/postgres/store_test.go
+++ b/central/processbaseline/store/postgres/store_test.go
@@ -55,7 +55,9 @@ func (s *ProcessbaselinesStoreSuite) SetupTest() {
 }
 
 func (s *ProcessbaselinesStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *ProcesswhitelistresultsStoreSuite) SetupTest() {
 }
 
 func (s *ProcesswhitelistresultsStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/processindicator/store/postgres/store_test.go
+++ b/central/processindicator/store/postgres/store_test.go
@@ -55,7 +55,9 @@ func (s *ProcessIndicatorsStoreSuite) SetupTest() {
 }
 
 func (s *ProcessIndicatorsStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/rbac/k8srole/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srole/internal/store/postgres/store_test.go
@@ -55,7 +55,9 @@ func (s *K8srolesStoreSuite) SetupTest() {
 }
 
 func (s *K8srolesStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
@@ -55,7 +55,9 @@ func (s *RolebindingsStoreSuite) SetupTest() {
 }
 
 func (s *RolebindingsStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/reportconfigurations/store/postgres/store_test.go
+++ b/central/reportconfigurations/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *ReportconfigsStoreSuite) SetupTest() {
 }
 
 func (s *ReportconfigsStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/risk/datastore/internal/store/postgres/store_test.go
+++ b/central/risk/datastore/internal/store/postgres/store_test.go
@@ -55,7 +55,9 @@ func (s *RiskStoreSuite) SetupTest() {
 }
 
 func (s *RiskStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/role/store/permissionset/postgres/store_test.go
+++ b/central/role/store/permissionset/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *PermissionsetsStoreSuite) SetupTest() {
 }
 
 func (s *PermissionsetsStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/role/store/role/postgres/store_test.go
+++ b/central/role/store/role/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *RolesStoreSuite) SetupTest() {
 }
 
 func (s *RolesStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/role/store/simpleaccessscope/postgres/store_test.go
+++ b/central/role/store/simpleaccessscope/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *SimpleaccessscopesStoreSuite) SetupTest() {
 }
 
 func (s *SimpleaccessscopesStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/secret/internal/store/postgres/store_test.go
+++ b/central/secret/internal/store/postgres/store_test.go
@@ -55,7 +55,9 @@ func (s *SecretsStoreSuite) SetupTest() {
 }
 
 func (s *SecretsStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/serviceaccount/internal/store/postgres/store_test.go
+++ b/central/serviceaccount/internal/store/postgres/store_test.go
@@ -55,7 +55,9 @@ func (s *ServiceaccountsStoreSuite) SetupTest() {
 }
 
 func (s *ServiceaccountsStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/signatureintegration/store/postgres/store_test.go
+++ b/central/signatureintegration/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *SignatureintegrationsStoreSuite) SetupTest() {
 }
 
 func (s *SignatureintegrationsStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *VulnreqStoreSuite) SetupTest() {
 }
 
 func (s *VulnreqStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/watchedimage/datastore/internal/store/postgres/store_test.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *WatchedimagesStoreSuite) SetupTest() {
 }
 
 func (s *WatchedimagesStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *MultikeyStoreSuite) SetupTest() {
 }
 
 func (s *MultikeyStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -61,7 +61,9 @@ func (s *{{$namePrefix}}StoreSuite) SetupTest() {
 }
 
 func (s *{{$namePrefix}}StoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
@@ -53,7 +53,9 @@ func (s *SinglekeyStoreSuite) SetupTest() {
 }
 
 func (s *SinglekeyStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
@@ -53,7 +53,9 @@ func (s *Testchild1StoreSuite) SetupTest() {
 }
 
 func (s *Testchild1StoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store_test.go
@@ -53,7 +53,9 @@ func (s *Testchild2StoreSuite) SetupTest() {
 }
 
 func (s *Testchild2StoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store_test.go
@@ -53,7 +53,9 @@ func (s *Testg2grandchild1StoreSuite) SetupTest() {
 }
 
 func (s *Testg2grandchild1StoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
@@ -53,7 +53,9 @@ func (s *Testg3grandchild1StoreSuite) SetupTest() {
 }
 
 func (s *Testg3grandchild1StoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
@@ -53,7 +53,9 @@ func (s *Testggrandchild1StoreSuite) SetupTest() {
 }
 
 func (s *Testggrandchild1StoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store_test.go
@@ -53,7 +53,9 @@ func (s *Testgrandchild1StoreSuite) SetupTest() {
 }
 
 func (s *Testgrandchild1StoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
@@ -53,7 +53,9 @@ func (s *TestgrandparentStoreSuite) SetupTest() {
 }
 
 func (s *TestgrandparentStoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store_test.go
@@ -53,7 +53,9 @@ func (s *Testparent1StoreSuite) SetupTest() {
 }
 
 func (s *Testparent1StoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store_test.go
@@ -53,7 +53,9 @@ func (s *Testparent2StoreSuite) SetupTest() {
 }
 
 func (s *Testparent2StoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store_test.go
@@ -53,7 +53,9 @@ func (s *Testparent3StoreSuite) SetupTest() {
 }
 
 func (s *Testparent3StoreSuite) TearDownTest() {
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 	s.envIsolator.RestoreAll()
 }
 


### PR DESCRIPTION
## Description

The version 4 of `github.com/jackc/pgx/v4/pgxpool` library consist of a bug, which causes panic on calling `Close` on a null `pool` pointer.

The PR wraps such calls with a condition. See the test template file [store_test.go.tpl](tools/generate-helpers/pg-table-bindings/store_test.go.tpl) which is used to generate the tests.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI job `postgres`.