### PR TITLE
Use 's' instead of 'search' as the default key for URL search parameters

### DIFF
--- a/ui/apps/platform/cypress/integration/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/dashboard.test.js
@@ -98,7 +98,7 @@ describe('Dashboard page', () => {
             cy.wrap(lowSeverityTile).click();
 
             cy.location('pathname').should('eq', violationsUrl);
-            cy.location('search').should('eq', '?search[Severity]=LOW_SEVERITY');
+            cy.location('search').should('eq', '?s[Severity]=LOW_SEVERITY');
             cy.get(violationsSelectors.resultsFoundHeader(lowSeverityCount));
         });
     });

--- a/ui/apps/platform/src/hooks/useURLSearch.ts
+++ b/ui/apps/platform/src/hooks/useURLSearch.ts
@@ -33,7 +33,7 @@ function parseFilter(rawFilter: QueryValue): SearchFilter {
     return parsedFilter;
 }
 
-function useURLSearch(keyPrefix = 'search'): UseUrlSearchReturn {
+function useURLSearch(keyPrefix = 's'): UseUrlSearchReturn {
     const [rawFilter, setSearchFilter] = useURLParameter(keyPrefix, {});
     const searchFilterRef = useRef<SearchFilter>({});
     const sanitizedFilter = parseFilter(rawFilter);

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -129,7 +129,7 @@ export function getRequestQueryStringForSearchFilter(searchFilter: SearchFilter)
 
 export function getUrlQueryStringForSearchFilter(
     searchFilter: SearchFilter,
-    searchPrefix = 'search'
+    searchPrefix = 's'
 ): string {
     return qs.stringify(
         { [searchPrefix]: searchFilter },


### PR DESCRIPTION
## Description

As the title says. As a follow up I need to adjust the comments in [this PR](https://github.com/stackrox/stackrox/pull/1462/files#diff-e2f879d0e2c133fd1f394bfa5edc203b9fe025c71cfaf5b94e1ac3f2ebb75eadR21).

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Tested that links from the dashboard widgets to the Violation page correctly apply search filters:
![image](https://user-images.githubusercontent.com/1292638/166261831-7b524b1d-0dbe-4ca0-a96b-a677848d4d5b.png)

Tested that searching directly on Violations page works correctly:
![image](https://user-images.githubusercontent.com/1292638/166262226-ecaf8670-6a9b-4550-ac74-da3f6a9ef6d3.png)

Test that Risk Acceptance Search UI works as expected.
![image](https://user-images.githubusercontent.com/1292638/166262620-3ec2c40c-f867-441b-b40b-57f8c85bf4b5.png)


