### PR TITLE
Consolidate duplicate uses of test util `getEntityState`.

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Components/ListComponents.utils.test.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Components/ListComponents.utils.test.js
@@ -13,7 +13,7 @@ describe('ListComponents.utils', () => {
                 new WorkflowEntity(entityTypes.IMAGE, 'abcd-ef09'),
                 new WorkflowEntity(entityTypes.COMPONENT),
             ];
-            const workflowState = getEntityState(useCases.VULN_MANAGEMENT, stateStack);
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
             const tableColumns = getComponentTableColumns(workflowState);
 
             const filteredColumns = getFilteredComponentColumns(tableColumns, workflowState);
@@ -23,7 +23,7 @@ describe('ListComponents.utils', () => {
 
         it('should remove the source and location columns when in Components main list context', () => {
             const stateStack = [new WorkflowEntity(entityTypes.COMPONENT)];
-            const workflowState = getEntityState(useCases.VULN_MANAGEMENT, stateStack);
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
             const tableColumns = getComponentTableColumns(workflowState);
 
             const filteredColumns = getFilteredComponentColumns(tableColumns, workflowState);
@@ -41,7 +41,7 @@ describe('ListComponents.utils', () => {
                 new WorkflowEntity(entityTypes.CVE, 'abcd-ef09'),
                 new WorkflowEntity(entityTypes.COMPONENT),
             ];
-            const workflowState = getEntityState(useCases.VULN_MANAGEMENT, stateStack);
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
             const tableColumns = getComponentTableColumns(workflowState);
 
             const filteredColumns = getFilteredComponentColumns(tableColumns, workflowState);
@@ -59,7 +59,7 @@ describe('ListComponents.utils', () => {
                 new WorkflowEntity(entityTypes.DEPLOYMENT, 'abcd-ef09'),
                 new WorkflowEntity(entityTypes.COMPONENT),
             ];
-            const workflowState = getEntityState(useCases.VULN_MANAGEMENT, stateStack);
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
             const tableColumns = getComponentTableColumns(workflowState);
 
             const filteredColumns = getFilteredComponentColumns(tableColumns, workflowState);
@@ -73,10 +73,6 @@ describe('ListComponents.utils', () => {
         });
     });
 });
-
-function getEntityState(useCase, stateStack) {
-    return new WorkflowState(useCase, stateStack);
-}
 
 function getComponentTableColumns(workflowState) {
     const tableColumns = [

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.test.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.test.js
@@ -13,7 +13,7 @@ describe('ListCVEs.utils', () => {
                 new WorkflowEntity(entityTypes.COMPONENT),
                 new WorkflowEntity(entityTypes.CVE),
             ];
-            const workflowState = getEntityState(useCases.VULN_MANAGEMENT, stateStack);
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
             const tableColumns = getCveTableColumns(workflowState);
 
             const filteredColumns = getFilteredCVEColumns(tableColumns, workflowState);
@@ -23,7 +23,7 @@ describe('ListCVEs.utils', () => {
 
         it('should remove the fixed in columns when in CVE main list context', () => {
             const stateStack = [new WorkflowEntity(entityTypes.CVE)];
-            const workflowState = getEntityState(useCases.VULN_MANAGEMENT, stateStack);
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
             const tableColumns = getCveTableColumns(workflowState);
 
             const filteredColumns = getFilteredCVEColumns(tableColumns, workflowState);
@@ -39,7 +39,7 @@ describe('ListCVEs.utils', () => {
                 new WorkflowEntity(entityTypes.DEPLOYMENT, 'abcd-ef09'),
                 new WorkflowEntity(entityTypes.CVE),
             ];
-            const workflowState = getEntityState(useCases.VULN_MANAGEMENT, stateStack);
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
             const tableColumns = getCveTableColumns(workflowState);
 
             const filteredColumns = getFilteredCVEColumns(tableColumns, workflowState);
@@ -55,7 +55,7 @@ describe('ListCVEs.utils', () => {
                 new WorkflowEntity(entityTypes.COMPONENT, 'abcd-ef09'),
                 new WorkflowEntity(entityTypes.CVE),
             ];
-            const workflowState = getEntityState(useCases.VULN_MANAGEMENT, stateStack);
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
             const tableColumns = getCveTableColumns(workflowState);
 
             const filteredColumns = getFilteredCVEColumns(tableColumns, workflowState);
@@ -64,8 +64,3 @@ describe('ListCVEs.utils', () => {
         });
     });
 });
-
-// TODO: ROX-4546
-function getEntityState(useCase, stateStack) {
-    return new WorkflowState(useCase, stateStack);
-}

--- a/ui/apps/platform/src/test-utils/workflowUtils.js
+++ b/ui/apps/platform/src/test-utils/workflowUtils.js
@@ -1,0 +1,61 @@
+import entityTypes from 'constants/entityTypes';
+import { searchParams, sortParams, pagingParams } from 'constants/searchParams';
+import useCases from 'constants/useCaseTypes';
+import WorkflowEntity from 'utils/WorkflowEntity';
+import { WorkflowState } from 'utils/WorkflowState';
+
+export const entityId1 = '1234';
+export const entityId2 = '5678';
+export const entityId3 = '1111';
+
+export const searchParamValues = {
+    [searchParams.page]: {
+        sk1: 'v1',
+        sk2: 'v2',
+    },
+    [searchParams.sidePanel]: {
+        sk3: 'v3',
+        sk4: 'v4',
+    },
+};
+
+export const sortParamValues = {
+    [sortParams.page]: entityTypes.CLUSTER,
+    [sortParams.sidePanel]: entityTypes.DEPLOYMENT,
+};
+
+export const pagingParamValues = {
+    [pagingParams.page]: 1,
+    [pagingParams.sidePanel]: 2,
+};
+
+export function getEntityState(isSidePanelOpen) {
+    const stateStack = [new WorkflowEntity(entityTypes.CLUSTER, entityId1)];
+    if (isSidePanelOpen) {
+        stateStack.push(new WorkflowEntity(entityTypes.DEPLOYMENT));
+        stateStack.push(new WorkflowEntity(entityTypes.DEPLOYMENT, entityId2));
+    }
+
+    return new WorkflowState(
+        useCases.CONFIG_MANAGEMENT,
+        stateStack,
+        searchParamValues,
+        sortParamValues,
+        pagingParamValues
+    );
+}
+
+export function getListState(isSidePanelOpen) {
+    const stateStack = [new WorkflowEntity(entityTypes.CLUSTER)];
+    if (isSidePanelOpen) {
+        stateStack.push(new WorkflowEntity(entityTypes.CLUSTER, entityId1));
+    }
+
+    return new WorkflowState(
+        useCases.CONFIG_MANAGEMENT,
+        stateStack,
+        searchParamValues,
+        sortParamValues,
+        pagingParamValues
+    );
+}

--- a/ui/apps/platform/src/utils/WorkflowState.test.js
+++ b/ui/apps/platform/src/utils/WorkflowState.test.js
@@ -2,65 +2,19 @@ import entityTypes from 'constants/entityTypes';
 import relationshipTypes from 'constants/relationshipTypes';
 import useCases from 'constants/useCaseTypes';
 import { searchParams, sortParams, pagingParams } from 'constants/searchParams';
+import {
+    entityId1,
+    entityId2,
+    entityId3,
+    getEntityState,
+    getListState,
+    searchParamValues,
+    sortParamValues,
+    pagingParamValues,
+} from 'test-utils/workflowUtils';
 import { getEntityTypesByRelationship, useCaseEntityMap } from './entityRelationships';
 import WorkflowEntity from './WorkflowEntity';
 import { WorkflowState } from './WorkflowState';
-
-const entityId1 = '1234';
-const entityId2 = '5678';
-const entityId3 = '1111';
-
-const searchParamValues = {
-    [searchParams.page]: {
-        sk1: 'v1',
-        sk2: 'v2',
-    },
-    [searchParams.sidePanel]: {
-        sk3: 'v3',
-        sk4: 'v4',
-    },
-};
-
-const sortParamValues = {
-    [sortParams.page]: entityTypes.CLUSTER,
-    [sortParams.sidePanel]: entityTypes.DEPLOYMENT,
-};
-
-const pagingParamValues = {
-    [pagingParams.page]: 1,
-    [pagingParams.sidePanel]: 2,
-};
-
-function getEntityState(isSidePanelOpen) {
-    const stateStack = [new WorkflowEntity(entityTypes.CLUSTER, entityId1)];
-    if (isSidePanelOpen) {
-        stateStack.push(new WorkflowEntity(entityTypes.DEPLOYMENT));
-        stateStack.push(new WorkflowEntity(entityTypes.DEPLOYMENT, entityId2));
-    }
-
-    return new WorkflowState(
-        useCases.CONFIG_MANAGEMENT,
-        stateStack,
-        searchParamValues,
-        sortParamValues,
-        pagingParamValues
-    );
-}
-
-function getListState(isSidePanelOpen) {
-    const stateStack = [new WorkflowEntity(entityTypes.CLUSTER)];
-    if (isSidePanelOpen) {
-        stateStack.push(new WorkflowEntity(entityTypes.CLUSTER, entityId1));
-    }
-
-    return new WorkflowState(
-        useCases.CONFIG_MANAGEMENT,
-        stateStack,
-        searchParamValues,
-        sortParamValues,
-        pagingParamValues
-    );
-}
 
 describe('WorkflowState', () => {
     it('clears current state on current use case', () => {

--- a/ui/apps/platform/src/utils/workflowUtils.test.ts
+++ b/ui/apps/platform/src/utils/workflowUtils.test.ts
@@ -1,6 +1,6 @@
 import entityTypes from 'constants/entityTypes';
 
-import { getEntityState } from '../test-utils/workflowUtils';
+import { getEntityState } from 'test-utils/workflowUtils';
 
 // system under test (SUT)
 import { createOptions, getOption, shouldUseOriginalCase } from './workflowUtils';

--- a/ui/apps/platform/src/utils/workflowUtils.test.ts
+++ b/ui/apps/platform/src/utils/workflowUtils.test.ts
@@ -1,8 +1,6 @@
 import entityTypes from 'constants/entityTypes';
-import { searchParams, sortParams, pagingParams } from 'constants/searchParams';
-import useCases from 'constants/useCaseTypes';
-import WorkflowEntity from 'utils/WorkflowEntity';
-import { WorkflowState } from 'utils/WorkflowState';
+
+import { getEntityState } from '../test-utils/workflowUtils';
 
 // system under test (SUT)
 import { createOptions, getOption, shouldUseOriginalCase } from './workflowUtils';
@@ -75,43 +73,3 @@ describe('workflowUtils', () => {
         });
     });
 });
-
-const entityId1 = '1234';
-const entityId2 = '5678';
-
-const searchParamValues = {
-    [searchParams.page]: {
-        sk1: 'v1',
-        sk2: 'v2',
-    },
-    [searchParams.sidePanel]: {
-        sk3: 'v3',
-        sk4: 'v4',
-    },
-};
-
-const sortParamValues = {
-    [sortParams.page]: entityTypes.CLUSTER,
-    [sortParams.sidePanel]: entityTypes.DEPLOYMENT,
-};
-
-const pagingParamValues = {
-    [pagingParams.page]: 1,
-    [pagingParams.sidePanel]: 2,
-};
-
-function getEntityState(isSidePanelOpen) {
-    const stateStack = [new WorkflowEntity(entityTypes.CLUSTER, entityId1)];
-    if (isSidePanelOpen) {
-        stateStack.push(new WorkflowEntity(entityTypes.DEPLOYMENT));
-        stateStack.push(new WorkflowEntity(entityTypes.DEPLOYMENT, entityId2));
-    }
-
-    return new WorkflowState(
-        useCases.CONFIG_MANAGEMENT,
-        stateStack,
-        searchParamValues,
-        sortParamValues,
-        pagingParamValues
-    );
-}


### PR DESCRIPTION
## Description

Fixes https://issues.redhat.com/browse/ROX-4546.

I found two test functions with the `getEntityState` name, and two usages of each. One of them directly called the `WorkflowState` constructor with the same arguments passed to the function Since it didn't seem too useful to abstract that one, I inlined the class instantiation in those tests.

The other function was less of a utility and more of a fixture instantiating function, but it was duplicated across two test files (as well as a handful of constants). The most fitting place I could think of to put the functions was in a file under `test-utils/`. I had considered putting the file directly next to the other test files (workflowUtils.test.utils.js?) but didn't see another example of that in the code base.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

This is a unit test only level change, so `yarn test`.
