### PR TITLE
ROX-10695: CI: Fix for unbound rvm var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,6 +415,12 @@ checkToRunSeparateRaceConditionTestPipe: &checkToRunSeparateRaceConditionTestPip
     run-on-tags: true
     label: ci-race-tests
 
+workaroundRvmUnboundVar: &workaroundRvmUnboundVar
+  run:
+    name: Add a workaround for RVM unbound var (ROX-10695)
+    command: |
+      echo export rvm_bash_nounset=1 >> ~/.bashrc
+
 version: 2.1
 
 parameters:
@@ -2742,6 +2748,7 @@ jobs:
     resource_class: large
     steps:
       - checkout
+      - *workaroundRvmUnboundVar
       - attach_workspace:
           at: ~/go/src/github.com/stackrox/rox
       - run:
@@ -3101,6 +3108,7 @@ jobs:
     machine:
       image: << pipeline.parameters.ci_machine_image >>
     steps:
+      - *workaroundRvmUnboundVar
       - check-label-exists-or-skip:
           label: ci-openshift-tests
           run-on-master: false
@@ -3113,6 +3121,7 @@ jobs:
     machine:
       image: << pipeline.parameters.ci_machine_image >>
     steps:
+      - *workaroundRvmUnboundVar
       - check-label-exists-or-skip:
           label: ci-openshift-crio-tests
           run-on-master: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,12 +415,6 @@ checkToRunSeparateRaceConditionTestPipe: &checkToRunSeparateRaceConditionTestPip
     run-on-tags: true
     label: ci-race-tests
 
-workaroundRvmUnboundVar: &workaroundRvmUnboundVar
-  run:
-    name: Add a workaround for RVM unbound var (ROX-10695)
-    command: |
-      echo export rvm_bash_nounset=1 >> ~/.bashrc
-
 version: 2.1
 
 parameters:
@@ -2748,7 +2742,6 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - *workaroundRvmUnboundVar
       - attach_workspace:
           at: ~/go/src/github.com/stackrox/rox
       - run:
@@ -3108,7 +3101,6 @@ jobs:
     machine:
       image: << pipeline.parameters.ci_machine_image >>
     steps:
-      - *workaroundRvmUnboundVar
       - check-label-exists-or-skip:
           label: ci-openshift-tests
           run-on-master: false
@@ -3121,7 +3113,6 @@ jobs:
     machine:
       image: << pipeline.parameters.ci_machine_image >>
     steps:
-      - *workaroundRvmUnboundVar
       - check-label-exists-or-skip:
           label: ci-openshift-crio-tests
           run-on-master: false

--- a/scripts/ci/gcp.sh
+++ b/scripts/ci/gcp.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 # A collection of GCP related reusable bash functions for CI
 
-set +u
 SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
-set -u
-
 source "$SCRIPTS_ROOT/scripts/ci/lib.sh"
+
+set -euo pipefail
 
 setup_gcp() {
     info "Setting up GCP auth and config"

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 # A collection of GKE related reusable bash functions for CI
 
-set +u
 SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
-set -u
-
 source "$SCRIPTS_ROOT/scripts/ci/lib.sh"
 source "$SCRIPTS_ROOT/scripts/ci/gcp.sh"
+
+set -euo pipefail
 
 provision_gke_cluster() {
     info "Provisioning a GKE cluster"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 
+# A library of CI related reusable bash functions
+
 SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 source "$SCRIPTS_ROOT/scripts/lib.sh"
 
 set -euo pipefail
-
-# A library of CI related reusable bash functions
-
 
 # Caution when editing: make sure groups would correspond to BASH_REMATCH use.
 RELEASE_RC_TAG_BASH_REGEX='^([[:digit:]]+(\.[[:digit:]]+)*)(-rc\.[[:digit:]]+)?$'

--- a/scripts/ci/store-artifacts.sh
+++ b/scripts/ci/store-artifacts.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 # A secure store for CI artifacts
 
-set +u; SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"; set -u
-
+SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 source "$SCRIPTS_ROOT/scripts/ci/gcp.sh"
+
+set -euo pipefail
 
 store_artifacts() {
     info "Storing artifacts"


### PR DESCRIPTION
## Description

In Circle CI we see this error when running in machine environments:
`/opt/********/.rvm/scripts/functions/rvmrc_env: line 66: rvm_saved_env: unbound variable`
It seems to be a long standing bug in rvm (https://github.com/rvm/rvm/issues/4342). 
It is hard to know why this is occurring consistently now. The change to `set -u` scripts https://github.com/stackrox/stackrox/pull/520 was Feb 1. Perhaps the Circle CI machines were updated to an rvm with this bug.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient
