### PR TITLE
Update Network Graph to use URL parameters for core state management

### DIFF
--- a/ui/apps/platform/src/Components/NetworkGraph/NetworkGraph.js
+++ b/ui/apps/platform/src/Components/NetworkGraph/NetworkGraph.js
@@ -86,6 +86,7 @@ const NetworkGraph = ({
     selectedClusterName,
     showNamespaceFlows,
     history,
+    location,
     match,
     featureFlags,
     lastUpdatedTimestamp,
@@ -273,7 +274,7 @@ const NetworkGraph = ({
                 setSelectedNode();
                 setSelectedNodeInGraph();
                 onClickOutside();
-                history.push('/main/network');
+                history.push(`/main/network${location.search}`);
                 return;
             }
 
@@ -314,7 +315,7 @@ const NetworkGraph = ({
                 if (type === nodeTypes.EXTERNAL_ENTITIES || type === nodeTypes.CIDR_BLOCK) {
                     onExternalEntitiesClick();
                 } else {
-                    history.push(`/main/network/${id}`);
+                    history.push(`/main/network/${id}${location.search}`);
                     onNodeClick(evData);
                 }
             }
@@ -734,6 +735,7 @@ NetworkGraph.propTypes = {
     setNetworkGraphRef: PropTypes.func.isRequired,
     setSelectedNamespace: PropTypes.func.isRequired,
     history: ReactRouterPropTypes.history.isRequired,
+    location: ReactRouterPropTypes.location.isRequired,
     match: ReactRouterPropTypes.match.isRequired,
     setSelectedNodeInGraph: PropTypes.func,
     isReadOnly: PropTypes.bool,

--- a/ui/apps/platform/src/Containers/Network/Header/ClusterSelect.tsx
+++ b/ui/apps/platform/src/Containers/Network/Header/ClusterSelect.tsx
@@ -20,6 +20,8 @@ type ClusterSelectProps = {
     isDisabled?: boolean;
 };
 
+// TODO We should probably always keep the cluster in the URL for clarity
+//
 // TODO Are there use cases where we want the possibility of multiple selected clusters,
 // and should that be rolled into this hook?
 // TODO extract

--- a/ui/apps/platform/src/Containers/Network/Header/ClusterSelect.tsx
+++ b/ui/apps/platform/src/Containers/Network/Header/ClusterSelect.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useEffect } from 'react';
+import React, { ReactElement, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { Select, SelectOption } from '@patternfly/react-core';
@@ -8,8 +8,8 @@ import { actions as graphActions, networkGraphClusters } from 'reducers/network/
 import { actions as pageActions } from 'reducers/network/page';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import useURLCluster from 'hooks/useURLCluster';
 import { Cluster } from 'types/cluster.proto';
-import useURLParameter from 'hooks/useURLParameter';
 
 type ClusterSelectProps = {
     id?: string;
@@ -19,26 +19,6 @@ type ClusterSelectProps = {
     selectedClusterId?: string;
     isDisabled?: boolean;
 };
-
-// TODO We should probably always keep the cluster in the URL for clarity
-//
-// TODO Are there use cases where we want the possibility of multiple selected clusters,
-// and should that be rolled into this hook?
-// TODO extract
-function useURLCluster(defaultClusterId: string) {
-    const [cluster, setClusterInternal] = useURLParameter('cluster', defaultClusterId || undefined);
-    const setCluster = useCallback(
-        (clusterId?: string) => {
-            setClusterInternal(clusterId);
-        },
-        [setClusterInternal]
-    );
-
-    return {
-        cluster: typeof cluster === 'string' ? cluster : undefined,
-        setCluster,
-    };
-}
 
 const ClusterSelect = ({
     id,

--- a/ui/apps/platform/src/Containers/Network/Header/ClusterSelect.tsx
+++ b/ui/apps/platform/src/Containers/Network/Header/ClusterSelect.tsx
@@ -55,6 +55,14 @@ const ClusterSelect = ({
         selectClusterId(cluster || '');
     }, [cluster, selectClusterId]);
 
+    // Set the clusterId in the URL to the default selected cluster, if it doesn't
+    // yet exist in the URL
+    useEffect(() => {
+        if (!cluster) {
+            setCluster(selectedClusterId);
+        }
+    }, [cluster, setCluster, selectedClusterId]);
+
     function changeCluster(_e, clusterId) {
         selectClusterId(clusterId);
         closeSelect();

--- a/ui/apps/platform/src/Containers/Network/Header/NamespaceSelect.tsx
+++ b/ui/apps/platform/src/Containers/Network/Header/NamespaceSelect.tsx
@@ -6,8 +6,6 @@ import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import { actions as graphActions } from 'reducers/network/graph';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import useURLParameter from 'hooks/useURLParameter';
-import { isElement } from 'lodash';
-import { availableSearchOptions } from 'constants/searchOptions';
 import useNamespaceFilters from './useNamespaceFilters';
 
 function filterElementsWithValueProp(

--- a/ui/apps/platform/src/Containers/Network/Header/NamespaceSelect.tsx
+++ b/ui/apps/platform/src/Containers/Network/Header/NamespaceSelect.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useRef, ChangeEvent, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import isEqual from 'lodash/isEqual';
-import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import { Select, SelectOption, SelectOptionObject, SelectVariant } from '@patternfly/react-core';
 
 import { actions as graphActions } from 'reducers/network/graph';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
@@ -73,7 +73,7 @@ function NamespaceSelect({ id, className = '', isDisabled = false }: NamespaceSe
         useNamespaceFilters();
     const { namespaces, setNamespaces } = useURLNamespaces(
         selectedNamespaceFilters,
-        availableNamespaceFilters
+        availableNamespaceFilters.map((ns) => ns.id)
     );
     const dispatch = useDispatch();
 
@@ -81,14 +81,17 @@ function NamespaceSelect({ id, className = '', isDisabled = false }: NamespaceSe
         dispatch(graphActions.setSelectedNamespaceFilters(namespaces));
     }, [dispatch, namespaces]);
 
-    function onSelect(e, selected) {
-        const newSelection = selectedNamespaceFilters.find((nsFilter) => nsFilter === selected)
-            ? selectedNamespaceFilters.filter((nsFilter) => nsFilter !== selected)
-            : selectedNamespaceFilters.concat(selected);
+    function onSelect(e, selected: string | SelectOptionObject) {
+        const selectedString = typeof selected === 'string' ? selected : selected.toString();
+        const newSelection = selectedNamespaceFilters.find(
+            (nsFilter) => nsFilter === selectedString
+        )
+            ? selectedNamespaceFilters.filter((nsFilter) => nsFilter !== selectedString)
+            : selectedNamespaceFilters.concat(selectedString);
 
-        const cleanedSelection = newSelection.filter((ns) =>
-            availableNamespaceFilters.includes(ns)
-        );
+        const cleanedSelection = newSelection
+            .filter((ns) => availableNamespaceFilters.find((nsFilter) => nsFilter.id === ns))
+            .map((ns) => ns);
 
         setNamespaces(cleanedSelection);
         dispatch(graphActions.setSelectedNamespaceFilters(cleanedSelection));
@@ -99,7 +102,9 @@ function NamespaceSelect({ id, className = '', isDisabled = false }: NamespaceSe
             filterElementsWithValueProp(
                 filterValue,
                 availableNamespaceFilters.map((nsFilter) => (
-                    <SelectOption key={nsFilter} value={nsFilter} />
+                    <SelectOption key={nsFilter.id} value={nsFilter.id}>
+                        {nsFilter.name}
+                    </SelectOption>
                 ))
             ),
         [availableNamespaceFilters]
@@ -122,7 +127,9 @@ function NamespaceSelect({ id, className = '', isDisabled = false }: NamespaceSe
             hasInlineFilter
         >
             {availableNamespaceFilters.map((nsFilter) => (
-                <SelectOption key={nsFilter} value={nsFilter} />
+                <SelectOption key={nsFilter.id} value={nsFilter.id}>
+                    {nsFilter.name}
+                </SelectOption>
             ))}
         </Select>
     );

--- a/ui/apps/platform/src/Containers/Network/Header/NamespaceSelect.tsx
+++ b/ui/apps/platform/src/Containers/Network/Header/NamespaceSelect.tsx
@@ -1,9 +1,13 @@
-import React, { useCallback, ChangeEvent } from 'react';
+import React, { useCallback, useRef, ChangeEvent, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import isEqual from 'lodash/isEqual';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 
 import { actions as graphActions } from 'reducers/network/graph';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import useURLParameter from 'hooks/useURLParameter';
+import { isElement } from 'lodash';
+import { availableSearchOptions } from 'constants/searchOptions';
 import useNamespaceFilters from './useNamespaceFilters';
 
 function filterElementsWithValueProp(
@@ -24,17 +28,72 @@ interface NamespaceSelectProps {
     className?: string;
 }
 
+// TODO extract
+// TODO Should we tie cluster in here as well? e.g. Multiple selected Clusters?
+function useURLNamespaces(defaultNamespaces: string[], allowedNamespaces: string[]) {
+    const [namespacesInternal, setNamespacesInternal] = useURLParameter(
+        'ns',
+        defaultNamespaces.filter((ns) => allowedNamespaces.includes(ns)) || []
+    );
+    const namespaceRef = useRef<string[]>([]);
+    const setNamespaces = useCallback(
+        (newNamespaces: string[]) => {
+            setNamespacesInternal(newNamespaces.filter((ns) => allowedNamespaces.includes(ns)));
+        },
+        [setNamespacesInternal, allowedNamespaces]
+    );
+
+    const filteredNamespaces: string[] = [];
+    if (!namespacesInternal) {
+        // Do nothing
+    } else if (
+        typeof namespacesInternal === 'string' &&
+        allowedNamespaces.includes(namespacesInternal)
+    ) {
+        filteredNamespaces.push(namespacesInternal);
+    } else if (namespacesInternal && Array.isArray(namespacesInternal)) {
+        namespacesInternal.forEach((ns) => {
+            if (typeof ns === 'string' && allowedNamespaces.includes(ns)) {
+                filteredNamespaces.push(ns);
+            }
+        });
+    }
+
+    if (!isEqual(namespaceRef.current, filteredNamespaces)) {
+        namespaceRef.current = filteredNamespaces;
+    }
+
+    return {
+        namespaces: namespaceRef.current,
+        setNamespaces,
+    };
+}
+
 function NamespaceSelect({ id, className = '', isDisabled = false }: NamespaceSelectProps) {
     const { isOpen, onToggle } = useSelectToggle();
     const { loading, error, availableNamespaceFilters, selectedNamespaceFilters } =
         useNamespaceFilters();
+    const { namespaces, setNamespaces } = useURLNamespaces(
+        selectedNamespaceFilters,
+        availableNamespaceFilters
+    );
     const dispatch = useDispatch();
+
+    useEffect(() => {
+        dispatch(graphActions.setSelectedNamespaceFilters(namespaces));
+    }, [dispatch, namespaces]);
 
     function onSelect(e, selected) {
         const newSelection = selectedNamespaceFilters.find((nsFilter) => nsFilter === selected)
             ? selectedNamespaceFilters.filter((nsFilter) => nsFilter !== selected)
             : selectedNamespaceFilters.concat(selected);
-        dispatch(graphActions.setSelectedNamespaceFilters(newSelection));
+
+        const cleanedSelection = newSelection.filter((ns) =>
+            availableNamespaceFilters.includes(ns)
+        );
+
+        setNamespaces(cleanedSelection);
+        dispatch(graphActions.setSelectedNamespaceFilters(cleanedSelection));
     }
 
     const onFilter = useCallback(
@@ -59,7 +118,7 @@ function NamespaceSelect({ id, className = '', isDisabled = false }: NamespaceSe
             className={`namespace-select ${className}`}
             placeholderText="Namespaces"
             isDisabled={isDisabled || loading || Boolean(error)}
-            selections={selectedNamespaceFilters}
+            selections={namespaces}
             variant={SelectVariant.checkbox}
             maxHeight="275px"
             hasInlineFilter

--- a/ui/apps/platform/src/Containers/Network/Header/NetworkSearch.js
+++ b/ui/apps/platform/src/Containers/Network/Header/NetworkSearch.js
@@ -1,29 +1,69 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 
 import { selectors } from 'reducers';
 import { actions as pageActions } from 'reducers/network/page';
 import { actions as searchActions } from 'reducers/network/search';
+import useURLSearch from 'hooks/useURLSearch';
+import searchOptionsToQuery from 'services/searchOptionsToQuery';
+import { getSearchOptionsForCategory } from 'services/SearchService';
+import { isCompleteSearchFilter } from 'utils/searchUtils';
+import SearchFilterInput from 'Components/SearchFilterInput';
 import {
     ORCHESTRATOR_COMPONENT_KEY,
     orchestratorComponentOption,
 } from 'Containers/Navigation/OrchestratorComponentsToggle';
-import ReduxSearchInput from 'Containers/Search/ReduxSearchInput';
 
 import './NetworkSearch.css';
 
+function searchFilterToSearchEntries(searchFilter) {
+    const entries = [];
+    Object.entries(searchFilter).forEach(([key, value]) => {
+        entries.push({ label: `${key}:`, value: `${key}:`, type: 'categoryOption' });
+        if (value !== '') {
+            const values = Array.isArray(value) ? value : [value];
+            const valueOptions = values.map((v) => ({ label: v, value: v }));
+            entries.push(...valueOptions);
+        }
+    });
+    return entries;
+}
+
+const searchCategory = 'DEPLOYMENTS';
+const searchOptionExclusions = ['Cluster', 'Namespace', 'Namespace ID', 'Orchestrator Component'];
+
 function NetworkSearch({
-    searchOptions,
-    searchModifiers,
     selectedNamespaceFilters,
-    setSearchOptions,
-    setSearchSuggestions,
+    dispatchSearchFilter,
     closeSidePanel,
     isDisabled,
 }) {
+    const [searchOptions, setSearchOptions] = useState([]);
+    const { searchFilter, setSearchFilter } = useURLSearch();
+
+    useEffect(() => {
+        const { request, cancel } = getSearchOptionsForCategory(searchCategory);
+        request
+            .then((options) => {
+                const filteredOptions = options.filter((o) => !searchOptionExclusions.includes(o));
+                setSearchOptions(filteredOptions);
+            })
+            .catch(() => {
+                // A request error will disable the search filter.
+            });
+
+        return cancel;
+    }, [setSearchOptions]);
+
+    // Keep the Redux store in sync with the URL Search Filter
+    useEffect(() => {
+        dispatchSearchFilter(searchFilterToSearchEntries(searchFilter));
+    }, [searchFilter, dispatchSearchFilter]);
+
     function onSearch(options) {
-        if (options.length && !options[options.length - 1].type) {
+        setSearchFilter(options);
+        if (isCompleteSearchFilter(options)) {
             closeSidePanel();
         }
     }
@@ -40,30 +80,25 @@ function NetworkSearch({
     }
 
     return (
-        <ReduxSearchInput
+        <SearchFilterInput
             className="pf-u-w-100 pf-search-shim"
             placeholder="Add one or more deployment filters"
+            searchFilter={searchFilter}
+            searchCategory="DEPLOYMENTS"
             searchOptions={searchOptions}
-            searchModifiers={searchModifiers}
-            setSearchOptions={setSearchOptions}
-            setSearchSuggestions={setSearchSuggestions}
-            onSearch={onSearch}
+            handleChangeSearchFilter={onSearch}
+            autocompleteQueryPrefix={searchOptionsToQuery(prependAutocompleteQuery)}
             isDisabled={isDisabled}
-            prependAutocompleteQuery={prependAutocompleteQuery}
-            autoCompleteCategories={['DEPLOYMENTS']}
         />
     );
 }
 
 const mapStateToProps = createStructuredSelector({
-    searchOptions: selectors.getNetworkSearchOptions,
-    searchModifiers: selectors.getNetworkSearchModifiers,
     selectedNamespaceFilters: selectors.getSelectedNamespaceFilters,
 });
 
 const mapDispatchToProps = {
-    setSearchOptions: searchActions.setNetworkSearchOptions,
-    setSearchSuggestions: searchActions.setNetworkSearchSuggestions,
+    dispatchSearchFilter: searchActions.setNetworkSearchOptions,
     closeSidePanel: pageActions.closeSidePanel,
 };
 

--- a/ui/apps/platform/src/Containers/Network/Header/useNamespaceFilters.ts
+++ b/ui/apps/platform/src/Containers/Network/Header/useNamespaceFilters.ts
@@ -13,13 +13,17 @@ const selector = createStructuredSelector<SelectorState, SelectorResult>({
     selectedNamespaceFilters: selectors.getSelectedNamespaceFilters,
 });
 
+// TODO Better reuse of this type elsewhere?
+export type Namespace = {
+    id: string;
+    name: string;
+};
+
 type NamespaceMetadataResp = {
     id: string;
     results: {
         namespaces: {
-            metadata: {
-                name: string;
-            };
+            metadata: Namespace;
         }[];
     };
 };
@@ -30,6 +34,7 @@ export const NAMESPACES_FOR_CLUSTER_QUERY = gql`
             id
             namespaces {
                 metadata {
+                    id
                     name
                 }
             }
@@ -38,7 +43,7 @@ export const NAMESPACES_FOR_CLUSTER_QUERY = gql`
 `;
 
 function useNamespaceFilters() {
-    const [availableNamespaceFilters, setAvailableNamespaceFilters] = useState<string[]>([]);
+    const [availableNamespaceFilters, setAvailableNamespaceFilters] = useState<Namespace[]>([]);
     const { selectedClusterId, selectedNamespaceFilters } = useSelector<
         SelectorState,
         SelectorResult
@@ -58,7 +63,7 @@ function useNamespaceFilters() {
             return;
         }
 
-        const namespaces = data.results.namespaces.map(({ metadata }) => metadata.name);
+        const namespaces = data.results.namespaces.map(({ metadata }) => metadata);
 
         setAvailableNamespaceFilters(namespaces);
     }, [data]);

--- a/ui/apps/platform/src/Containers/Network/Header/useNamespaceFilters.ts
+++ b/ui/apps/platform/src/Containers/Network/Header/useNamespaceFilters.ts
@@ -4,6 +4,7 @@ import { createStructuredSelector } from 'reselect';
 import { gql, useQuery } from '@apollo/client';
 
 import { selectors } from 'reducers';
+import { NamespaceMetadata } from 'types/namespaceMetadata.proto';
 
 type SelectorState = { selectedClusterId: string | null; selectedNamespaceFilters: string[] };
 type SelectorResult = SelectorState;
@@ -13,23 +14,19 @@ const selector = createStructuredSelector<SelectorState, SelectorResult>({
     selectedNamespaceFilters: selectors.getSelectedNamespaceFilters,
 });
 
-// TODO Better reuse of this type elsewhere?
-export type Namespace = {
-    id: string;
-    name: string;
-};
+type NamespaceMetadataSlim = Pick<NamespaceMetadata, 'id' | 'name'>;
 
 type NamespaceMetadataResp = {
     id: string;
     results: {
         namespaces: {
-            metadata: Namespace;
+            metadata: NamespaceMetadataSlim;
         }[];
     };
 };
 
 export const NAMESPACES_FOR_CLUSTER_QUERY = gql`
-    query getClusterNamespaceNames($id: ID!) {
+    query getClusterNamespaces($id: ID!) {
         results: cluster(id: $id) {
             id
             namespaces {
@@ -43,7 +40,9 @@ export const NAMESPACES_FOR_CLUSTER_QUERY = gql`
 `;
 
 function useNamespaceFilters() {
-    const [availableNamespaceFilters, setAvailableNamespaceFilters] = useState<Namespace[]>([]);
+    const [availableNamespaceFilters, setAvailableNamespaceFilters] = useState<
+        NamespaceMetadataSlim[]
+    >([]);
     const { selectedClusterId, selectedNamespaceFilters } = useSelector<
         SelectorState,
         SelectorResult

--- a/ui/apps/platform/src/Containers/Network/Page.js
+++ b/ui/apps/platform/src/Containers/Network/Page.js
@@ -106,12 +106,12 @@ function NetworkPage({
         }
         // If the page is visited with a deployment id, we need to enable that deployment's
         // namespace filter and switch to the correct cluster
-        fetchDeployment(deploymentId).then(({ clusterId, namespace }) => {
+        fetchDeployment(deploymentId).then(({ clusterId, namespaceId }) => {
             if (clusterId !== selectedClusterId) {
                 dispatch(graphActions.selectNetworkClusterId(clusterId));
-                dispatch(graphActions.setSelectedNamespaceFilters([namespace]));
-            } else if (!selectedNamespaceFilters.includes(namespace)) {
-                const newFilters = [...selectedNamespaceFilters, namespace];
+                dispatch(graphActions.setSelectedNamespaceFilters([namespaceId]));
+            } else if (!selectedNamespaceFilters.includes(namespaceId)) {
+                const newFilters = [...selectedNamespaceFilters, namespaceId];
                 dispatch(graphActions.setSelectedNamespaceFilters(newFilters));
             }
         });

--- a/ui/apps/platform/src/Containers/Network/Page.js
+++ b/ui/apps/platform/src/Containers/Network/Page.js
@@ -1,12 +1,10 @@
-import React, { useEffect, useState } from 'react';
-import { connect, useDispatch, useSelector } from 'react-redux';
-import { useRouteMatch } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { connect, useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 
 import { selectors } from 'reducers';
 import useLocalStorage from 'hooks/useLocalStorage';
 import { actions as dialogueActions } from 'reducers/network/dialogue';
-import { actions as graphActions } from 'reducers/network/graph';
 import { actions as sidepanelActions } from 'reducers/network/sidepanel';
 import { actions as pageActions } from 'reducers/network/page';
 import dialogueStages from 'Containers/Network/Dialogue/dialogueStages';
@@ -17,7 +15,6 @@ import Dialogue from 'Containers/Network/Dialogue';
 import Graph from 'Containers/Network/Graph/Graph';
 import SidePanel from 'Containers/Network/SidePanel/SidePanel';
 import SimulationFrame from 'Components/SimulationFrame';
-import { fetchDeployment } from 'services/DeploymentsService';
 import { getErrorMessageFromServerResponse } from 'utils/networkGraphUtils';
 import Header from './Header/Header';
 import NoSelectedNamespace from './NoSelectedNamespace';
@@ -86,36 +83,10 @@ function NetworkPage({
     const { isNetworkSimulationOn } = useNetworkPolicySimulation();
     const { isBaselineSimulationOn } = useNetworkBaselineSimulation();
     const isSimulationOn = isNetworkSimulationOn || isBaselineSimulationOn;
-    const [isInitialRender, setIsInitialRender] = useState(true);
 
-    const {
-        params: { deploymentId },
-    } = useRouteMatch();
     const { clusters, selectedClusterId, selectedNamespaceFilters } = useSelector(
         networkPageContentSelector
     );
-    const dispatch = useDispatch();
-
-    useEffect(() => {
-        if (!isInitialRender) {
-            return;
-        }
-        setIsInitialRender(false);
-        if (!deploymentId) {
-            return;
-        }
-        // If the page is visited with a deployment id, we need to enable that deployment's
-        // namespace filter and switch to the correct cluster
-        fetchDeployment(deploymentId).then(({ clusterId, namespaceId }) => {
-            if (clusterId !== selectedClusterId) {
-                dispatch(graphActions.selectNetworkClusterId(clusterId));
-                dispatch(graphActions.setSelectedNamespaceFilters([namespaceId]));
-            } else if (!selectedNamespaceFilters.includes(namespaceId)) {
-                const newFilters = [...selectedNamespaceFilters, namespaceId];
-                dispatch(graphActions.setSelectedNamespaceFilters(newFilters));
-            }
-        });
-    }, [dispatch, deploymentId, selectedClusterId, selectedNamespaceFilters, isInitialRender]);
 
     const clusterName = clusters.find((c) => c.id === selectedClusterId)?.name;
 

--- a/ui/apps/platform/src/Containers/Risk/RiskSidePanelContent.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskSidePanelContent.js
@@ -39,13 +39,16 @@ function RiskSidePanelContent({ isFetching, selectedDeployment, deploymentRisk, 
         { text: 'Deployment Details' },
         { text: 'Process Discovery' },
     ];
+
+    const { id, clusterId, namespaceId } = selectedDeployment;
+    const networkGraphLink = `/main/network/${id}?cluster=${clusterId}&ns=${namespaceId}`;
     return (
         <Tabs headers={riskPanelTabs}>
             <Tab>
                 <div className="flex flex-col pb-5">
                     <Link
                         className="btn btn-base h-10 no-underline mt-4 ml-3 mr-3"
-                        to={`/main/network/${selectedDeployment.id}`}
+                        to={networkGraphLink}
                         data-testid="view-deployments-in-network-graph-button"
                     >
                         View Deployment in Network Graph
@@ -88,6 +91,8 @@ RiskSidePanelContent.propTypes = {
     isFetching: PropTypes.bool.isRequired,
     selectedDeployment: PropTypes.shape({
         id: PropTypes.string.isRequired,
+        clusterId: PropTypes.string.isRequired,
+        namespaceId: PropTypes.string.isRequired,
     }),
     deploymentRisk: PropTypes.shape({}),
     processGroup: PropTypes.shape({

--- a/ui/apps/platform/src/Containers/Search/SearchResults.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchResults.tsx
@@ -227,15 +227,7 @@ function SearchResults({
             const searchOptions = amendSearchOptions(searchCategory, name);
             passthroughGlobalSearchOptions(searchOptions, category);
             const searchFilter = searchOptionsToSearchFilter(searchOptions);
-            let queryString = '';
-            // TODO Once Violations, Risk, and Network Graph are all using URL Search Params this can be simplified
-            if (category === 'ALERTS' || category === 'DEPLOYMENTS') {
-                queryString = getUrlQueryStringForSearchFilter(searchFilter);
-            } else if (category === 'NETWORK') {
-                // Do nothing, until Network Graph moves from Redux to URL Params
-            } else {
-                // This should never happen, the only three "filter on" pages are the ones listed above
-            }
+            const queryString = getUrlQueryStringForSearchFilter(searchFilter);
             onClose(`${toURL}?${queryString}`);
         };
 

--- a/ui/apps/platform/src/hooks/useURLCluster.ts
+++ b/ui/apps/platform/src/hooks/useURLCluster.ts
@@ -1,0 +1,18 @@
+import { useCallback } from 'react';
+import useURLParameter from 'hooks/useURLParameter';
+
+// TODO We will likely want to make this support multiple cluster ids in the future.
+export default function useURLCluster(defaultClusterId: string) {
+    const [cluster, setClusterInternal] = useURLParameter('cluster', defaultClusterId || undefined);
+    const setCluster = useCallback(
+        (clusterId?: string) => {
+            setClusterInternal(clusterId);
+        },
+        [setClusterInternal]
+    );
+
+    return {
+        cluster: typeof cluster === 'string' ? cluster : undefined,
+        setCluster,
+    };
+}

--- a/ui/apps/platform/src/hooks/useURLNamespaceIds.ts
+++ b/ui/apps/platform/src/hooks/useURLNamespaceIds.ts
@@ -1,0 +1,39 @@
+import { useCallback, useRef } from 'react';
+import isEqual from 'lodash/isEqual';
+import useURLParameter from 'hooks/useURLParameter';
+
+function useURLNamespaceIds(defaultNamespaces: string[], allowedNamespaces: string[]) {
+    const [namespacesInternal, setNamespacesInternal] = useURLParameter(
+        'ns',
+        defaultNamespaces.filter((ns) => allowedNamespaces.includes(ns)) || []
+    );
+    const namespaceRef = useRef<string[]>([]);
+    const setNamespaceIds = useCallback(
+        (newNamespaces: string[]) => {
+            setNamespacesInternal(newNamespaces.filter((ns) => allowedNamespaces.includes(ns)));
+        },
+        [setNamespacesInternal, allowedNamespaces]
+    );
+
+    const filteredNamespaces: string[] = [];
+    if (typeof namespacesInternal === 'string' && allowedNamespaces.includes(namespacesInternal)) {
+        filteredNamespaces.push(namespacesInternal);
+    } else if (namespacesInternal && Array.isArray(namespacesInternal)) {
+        namespacesInternal.forEach((ns) => {
+            if (typeof ns === 'string' && allowedNamespaces.includes(ns)) {
+                filteredNamespaces.push(ns);
+            }
+        });
+    }
+
+    if (!isEqual(namespaceRef.current, filteredNamespaces)) {
+        namespaceRef.current = filteredNamespaces;
+    }
+
+    return {
+        namespaceIds: namespaceRef.current,
+        setNamespaceIds,
+    };
+}
+
+export default useURLNamespaceIds;

--- a/ui/apps/platform/src/hooks/useURLParameter.ts
+++ b/ui/apps/platform/src/hooks/useURLParameter.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import isEqual from 'lodash/isEqual';
 import { getQueryObject, getQueryString } from 'utils/queryStringUtils';

--- a/ui/apps/platform/src/hooks/useURLParameter.ts
+++ b/ui/apps/platform/src/hooks/useURLParameter.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import isEqual from 'lodash/isEqual';
 import { getQueryObject, getQueryString } from 'utils/queryStringUtils';

--- a/ui/apps/platform/src/reducers/network/search.js
+++ b/ui/apps/platform/src/reducers/network/search.js
@@ -17,20 +17,6 @@ const getNetworkSearchActions = getSearchActions('network');
 
 const networkSearchActions = { ...getNetworkSearchActions };
 
-// Network search should not show the following categories
-const searchOptionExclusions = [
-    'Cluster:',
-    'Namespace:',
-    'Namespace ID:',
-    'Orchestrator Component:',
-];
-const filterSearchOptions = (options) =>
-    options.filter((obj) => !searchOptionExclusions.includes(obj.value));
-networkSearchActions.setNetworkSearchModifiers = (options) =>
-    getNetworkSearchActions.setNetworkSearchModifiers(filterSearchOptions(options));
-networkSearchActions.setNetworkSearchSuggestions = (options) =>
-    getNetworkSearchActions.setNetworkSearchSuggestions(filterSearchOptions(options));
-
 // Actions
 //---------
 

--- a/ui/apps/platform/src/sagas/globalSearchSagas.js
+++ b/ui/apps/platform/src/sagas/globalSearchSagas.js
@@ -1,7 +1,6 @@
 import { takeLatest, all, call, fork, put, select } from 'redux-saga/effects';
 import { fetchGlobalSearchResults } from 'services/SearchService';
 import { actions, types } from 'reducers/globalSearch';
-import { actions as networkActions } from 'reducers/network/search';
 import { actions as secretsActions } from 'reducers/secrets';
 import { actions as policiesActions } from 'reducers/policies/search';
 import { selectors } from 'reducers';
@@ -36,9 +35,6 @@ export function* passthroughGlobalSearchOptions({ searchOptions, category }) {
     switch (category) {
         case 'SECRETS':
             yield put(secretsActions.setSecretsSearchOptions(searchOptions));
-            break;
-        case 'NETWORK':
-            yield put(networkActions.setNetworkSearchOptions(searchOptions));
             break;
         case 'POLICIES':
             yield put(policiesActions.setPoliciesSearchOptions(searchOptions));

--- a/ui/apps/platform/src/sagas/searchSagas.js
+++ b/ui/apps/platform/src/sagas/searchSagas.js
@@ -1,10 +1,9 @@
 import { all, put, call } from 'redux-saga/effects';
 
-import { mainPath, policiesPath, secretsPath, networkPath } from 'routePaths';
+import { mainPath, policiesPath, secretsPath } from 'routePaths';
 import { takeEveryNewlyMatchedLocation } from 'utils/sagaEffects';
 import { actions as policiesActions } from 'reducers/policies/search';
 import { actions as secretsActions } from 'reducers/secrets';
-import { actions as networkActions } from 'reducers/network/search';
 import { actions as globalSearchActions } from 'reducers/globalSearch';
 import { fetchOptions } from 'services/SearchService';
 import capitalize from 'lodash/capitalize';
@@ -90,14 +89,6 @@ export default function* searches() {
             secretsActions.setSecretsSearchSuggestions,
             secretsActions.setSecretsSearchOptions,
             'categories=SECRETS'
-        ),
-        takeEveryNewlyMatchedLocation(
-            networkPath,
-            getSearchOptions,
-            networkActions.setNetworkSearchModifiers,
-            networkActions.setNetworkSearchSuggestions,
-            networkActions.setNetworkSearchOptions,
-            'categories=DEPLOYMENTS'
         ),
     ]);
 }

--- a/ui/apps/platform/src/services/NetworkService.js
+++ b/ui/apps/platform/src/services/NetworkService.js
@@ -154,7 +154,7 @@ export function getUndoModificationForDeployment(deploymentId) {
  */
 export function fetchNetworkPolicyGraph(clusterId, namespaces, query, modification, includePorts) {
     const urlParams = query ? { query } : {};
-    const namespaceQuery = namespaces.length > 0 ? `Namespace:${namespaces.join(',')}` : '';
+    const namespaceQuery = namespaces.length > 0 ? `Namespace ID:${namespaces.join(',')}` : '';
     urlParams.query = query ? `${query}+${namespaceQuery}` : namespaceQuery;
 
     if (includePorts) {
@@ -201,7 +201,7 @@ export function fetchNetworkPolicyGraph(clusterId, namespaces, query, modificati
  */
 export function fetchNetworkFlowGraph(clusterId, namespaces, query, date, includePorts) {
     const urlParams = query ? { query } : {};
-    const namespaceQuery = namespaces.length > 0 ? `Namespace:${namespaces.join(',')}` : '';
+    const namespaceQuery = namespaces.length > 0 ? `Namespace ID:${namespaces.join(',')}` : '';
     urlParams.query = query ? `${query}+${namespaceQuery}` : namespaceQuery;
     if (date) {
         urlParams.since = date.toISOString();

--- a/ui/apps/platform/src/types/namespaceMetadata.proto.ts
+++ b/ui/apps/platform/src/types/namespaceMetadata.proto.ts
@@ -1,0 +1,10 @@
+export type NamespaceMetadata = {
+    id: string;
+    name: string;
+    clusterId: string;
+    clusterName: string;
+    labels: Record<string, string>;
+    creationTime: string; // ISO 8601 date string
+    priority: number;
+    annotations: Record<string, string>;
+};

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -107,6 +107,16 @@ export function searchOptionsToSearchFilter(searchOptions: SearchEntry[]): Searc
     return searchFilter;
 }
 
+/**
+ * Determines whether or not a SearchFilter contains a valid value for
+ * all keys. A valid value is either a non-empty string or non-empty array.
+ */
+export function isCompleteSearchFilter(searchFilter: SearchFilter) {
+    return Object.values(searchFilter).every(
+        (o) => Boolean(o) && (!Array.isArray(o) || o.length > 0)
+    );
+}
+
 /*
  * Return request query string for search filter. Omit filter criterion:
  * If option does not have value.


### PR DESCRIPTION
## Description

Note: Using the URL for search filters only has been moved to PR https://github.com/stackrox/stackrox/pull/1804

This change builds on #1804 to track additional items in the Network Graph URL state for better usability and easier linking from other areas in the app. The goal is to be able to use the URL as the source of truth for the selected cluster and selected namespaces in addition to search filters.

### Still TODO

- [ ] Better comments and tests
- [ ] See if there is a cleaner way to integrate URL state with Redux/Redux-sagas (using the URL as the source of truth)
- [ ] Come up with cleaner solution to setting cluster + namespaces from global search results
- [ ] Make the sidebar panel state sync with URL state when navigating via the back/forward buttons


### Code Oddities:
- Due to the Network Graph page being so intwined with Redux/sagas, the "source of truth" for search parameters is a little murky. Any time the URL is updated the new search filters are dispatched to Redux and stored there as well. **Is this reasonable for now, or should this page wait until the true next phase of Network Graph to work with URL search parameters?**

## Other Considerations:

1. For a better UX it might make sense for the cluster and namespace parameters to be available in the URL as well, for consistency and the ability to "preset" the network graph state via links. There are a couple of design concerns in doing this:

If we remove the integration with Redux entirely, network graph state will only persist through the browser's history. Users will have to click the back button until they return to the configuration they wanted. Currently the cluster and namespace values persist through all navigation actions, as that state is stored globally, but search filters disappear when you leave the page.

- Would this change be acceptable? i.e. We no longer persist global state for the Network Graph?
- Do we abandon URL parameters entirely for this page, and keep everything in Redux?
- Is there a hybrid URL parameter + Redux state approach that won't be a horrible mess, in code and for UX?

2. If we move the namespace state into the URL, should it be part of the search `s` parameter, or separate? Currently the namespace filter gets mixed in with the rest of the search filters to be used in the `query` part of a REST or GraphQL call. However, until that point in the code, namespaces are part of a separate widget and sent as a separate parameter from the search filters in function calls. Should we consider the fact that namespace is sent to the backend as part of the same query an implementation detail?

e.g. 
```
https://localhost:3000/main/network?ns=stackrox&s[Deployment]=scanner
https://localhost:3000/main/network?ns[0]=stackrox&ns[1]=kube-system&s[Deployment]=scanner
```
vs
```
https://localhost:3000/main/network?s[Namespace]=stackrox&s[Deployment]=scanner
https://localhost:3000/main/network?s[Namespace][0]=stackrox&s[Namespace][1]=kube-system&s[Deployment]=scanner
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
