### PR TITLE
ROX-9669: Press enter as alternative to click Generate on Cluster Init Bundle form

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/FormSaveButton.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/FormSaveButton.tsx
@@ -7,6 +7,7 @@ export type FormSaveButtonProps = {
     isSubmitting: boolean;
     isTesting: boolean;
     isDisabled?: boolean;
+    type?: 'button' | 'submit' | 'reset';
 };
 
 function FormSaveButton({
@@ -15,9 +16,11 @@ function FormSaveButton({
     isSubmitting,
     isTesting,
     isDisabled = false,
+    type = 'button',
 }: FormSaveButtonProps): ReactElement {
     return (
         <Button
+            type={type}
             variant="primary"
             onClick={onSave}
             data-testid="create-btn"

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClusterInitBundleIntegrationForm/ClusterInitBundleIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClusterInitBundleIntegrationForm/ClusterInitBundleIntegrationForm.tsx
@@ -73,6 +73,17 @@ function ClusterInitBundleIntegrationForm({
         return setFieldValue(event.target.id, value);
     }
 
+    function onSubmit(e) {
+        // Press enter to submit as client-rendered form instead of server-rendered form.
+        e.preventDefault();
+
+        if (!dirty || !isValid || isSubmitting || isTesting) {
+            return; // because Generate button is disabled
+        }
+
+        onSave();
+    }
+
     // The edit flow doesn't make sense for Cluster Init Bundles so we'll show an empty state message here
     if (isEditing) {
         return (
@@ -92,7 +103,7 @@ function ClusterInitBundleIntegrationForm({
                 {isViewingDetails && initialValues ? (
                     <ClusterInitBundleDetails meta={initialValues} />
                 ) : (
-                    <Form isWidthLimited>
+                    <Form isWidthLimited onSubmit={onSubmit}>
                         <FormLabelGroup
                             label="Cluster init bundle name"
                             isRequired
@@ -117,6 +128,7 @@ function ClusterInitBundleIntegrationForm({
                 (!isGenerated ? (
                     <IntegrationFormActions>
                         <FormSaveButton
+                            type="submit"
                             onSave={onSave}
                             isSubmitting={isSubmitting}
                             isTesting={isTesting}


### PR DESCRIPTION
## Description

### Problem

By default, press enter submits as server-rendered form instead of client-rendered form.

### Solution

Adapt pattern in the following forms:
* Containers/Login/LoginPage.js
* Containers/SystemConfig/Page.tsx
* Containers/VulnMgmt/List/Images/WatchedImagesDialog.tsx

See also https://reactjs.org/docs/handling-events.html

```jsx
function Form() {
  function handleSubmit(e) {
    e.preventDefault();
    console.log('You clicked submit.');
  }

  return (
    <form onSubmit={handleSubmit}>
      <button type="submit">Submit</button>
    </form>
  );
}
```

### Changed files

1. Edit Components/PatternFly/FormSaveButton.tsx
    * Add optional `type` prop

2. Edit Containers/Integrations/IntegrationForm/Forms/ClusterInitBundleIntegrationForm/ClusterInitBundleIntegrationForm.tsx
    * Add `onSubmit` function
    * Add `onSubmit={onSubmit}` prop for `Form` element
    * Add `type="submit"` prop to `FormSaveButton` element

### Residue

* Discuss with team: refactor `isSubmitting`, `isTesting`, and `isDisabled={!dirty || !isValid}` props which are not consistent with equivalent `if` condition: `!dirty || !isValid || isSubmitting || isTesting`
* Discuss with team: follow-up for other forms.
* Add integration test, but not necessarily for this form (because it uses random string instead of random date).

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added

## Testing Performed

### manual testing

1. Visit Platform Configuration > Integrations
2. Click **Cluster Init Bundle**
3. Click **Generate bundle**
4. Type a name, and then press enter
    * Incorrect behavior before change: The form is cleared and nothing happens.
        GET /main/integrations/authProviders/clusterInitBundle/create?
    * Correct behavior after change if name is valid: See response details.
        POST /v1/cluster-init/init-bundles
        ![ResponseDetails](https://user-images.githubusercontent.com/11862657/166553153-bdc2e025-6a7b-42d4-94e9-f0e9a1c7790e.png)
    * Correct behavior after change if name is invalid: Nothing happens.

### integration testing

* integrations/clusterInitBundles.test.js