### PR TITLE
ROX-10651: use image vuln graphQL resolver in sub resolvers

### DIFF
--- a/central/graphql/generator/schema2.go
+++ b/central/graphql/generator/schema2.go
@@ -119,6 +119,7 @@ type SchemaBuilder interface {
 	AddInterfaceType(name string, fields []string) error
 	AddUnionType(name string, types []string) error
 	AddExtraResolver(name string, resolver string) error
+	AddExtraResolvers(name string, resolver []string) error
 	AddQuery(resolver string) error
 	// Deprecated: Use REST APIs instead
 	AddMutation(resolver string) error
@@ -187,6 +188,18 @@ func (s *schemaBuilderImpl) AddUnionType(name string, types []string) error {
 		name:        name,
 		unionValues: types,
 	}
+	return nil
+}
+
+func (s *schemaBuilderImpl) AddExtraResolvers(name string, resolvers []string) error {
+	entry, ok := s.entries[name]
+	if !ok {
+		return fmt.Errorf("no type data for %q (known: %v)", name, s.entries)
+	}
+	if entry.definedResolvers == nil {
+		return fmt.Errorf("%q is an invalid type for adding resolvers", name)
+	}
+	entry.extraResolvers = append(entry.extraResolvers, resolvers...)
 	return nil
 }
 

--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -27,63 +27,68 @@ func init() {
 	schema := getBuilder()
 	utils.Must(
 		schema.AddType("PolicyStatus", []string{"status: String!", "failingPolicies: [Policy!]!"}),
+		schema.AddExtraResolvers("Cluster", []string{
+			"alerts(query: String, pagination: Pagination): [Alert!]!",
+			"alertCount(query: String): Int!",
+			"latestViolation(query: String): Time",
+			"failingPolicyCounter(query: String): PolicyCounter",
+			"deployments(query: String, pagination: Pagination): [Deployment!]!",
+			"deploymentCount(query: String): Int!",
+			"nodes(query: String, pagination: Pagination): [Node!]!",
+			"nodeCount(query: String): Int!",
+			"node(node: ID!): Node",
+			"namespaces(query: String, pagination: Pagination): [Namespace!]!",
+			"namespace(name: String!): Namespace",
+			"namespaceCount(query: String): Int!",
+			"complianceResults(query: String): [ControlResult!]!",
+			"k8sRoles(query: String, pagination: Pagination): [K8SRole!]!",
+			"k8sRole(role: ID!): K8SRole",
+			"k8sRoleCount(query: String): Int!",
+			"serviceAccounts(query: String, pagination: Pagination): [ServiceAccount!]!",
+			"serviceAccount(sa: ID!): ServiceAccount",
+			"serviceAccountCount(query: String): Int!",
+			"subjects(query: String, pagination: Pagination): [Subject!]!",
+			"subject(name: String!): Subject",
+			"subjectCount(query: String): Int!",
+			"images(query: String, pagination: Pagination): [Image!]!",
+			"imageCount(query: String): Int!",
+			"components(query: String, pagination: Pagination): [EmbeddedImageScanComponent!]!",
+			"componentCount(query: String): Int!",
+			"vulns(query: String, scopeQuery: String, pagination: Pagination): [EmbeddedVulnerability!]!",
+			"vulnCount(query: String): Int!",
+			"vulnCounter(query: String): VulnerabilityCounter!",
+			`nodeVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [NodeVulnerability!]!`,
+			`nodeVulnerabilityCount(query: String): Int!`,
+			`nodeVulnerabilityCounter(query: String): VulnerabilityCounter!`,
+			"imageVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [ImageVulnerability!]!",
+			"imageVulnerabilityCount(query: String): Int!",
+			"imageVulnerabilityCounter(query: String): VulnerabilityCounter!",
+			"k8sVulns(query: String, pagination: Pagination): [EmbeddedVulnerability!]!",
+			"k8sVulnCount(query: String): Int!",
+			"istioVulns(query: String, pagination: Pagination): [EmbeddedVulnerability!]!",
+			"istioVulnCount(query: String): Int!",
+			"openShiftVulns(query: String, pagination: Pagination): [EmbeddedVulnerability!]!",
+			"openShiftVulnCount(query: String): Int!",
+			"policies(query: String, pagination: Pagination): [Policy!]!",
+			"policyCount(query: String): Int!",
+			"policyStatus(query: String): PolicyStatus!",
+			"secrets(query: String, pagination: Pagination): [Secret!]!",
+			"secretCount(query: String): Int!",
+			"controlStatus(query: String): String!",
+			"controls(query: String): [ComplianceControl!]!",
+			"failingControls(query: String): [ComplianceControl!]!",
+			"passingControls(query: String): [ComplianceControl!]!",
+			"complianceControlCount(query: String): ComplianceControlCount!",
+			"risk: Risk",
+			"isGKECluster: Boolean!",
+			"isOpenShiftCluster: Boolean!",
+			"unusedVarSink(query: String): Int",
+			"istioEnabled: Boolean!",
+			"plottedVulns(query: String): PlottedVulnerabilities!",
+		}),
 		schema.AddQuery("clusters(query: String, pagination: Pagination): [Cluster!]!"),
 		schema.AddQuery("clusterCount(query: String): Int!"),
 		schema.AddQuery("cluster(id: ID!): Cluster"),
-		schema.AddExtraResolver("Cluster", `alerts(query: String, pagination: Pagination): [Alert!]!`),
-		schema.AddExtraResolver("Cluster", `alertCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", `latestViolation(query: String): Time`),
-		schema.AddExtraResolver("Cluster", `failingPolicyCounter(query: String): PolicyCounter`),
-		schema.AddExtraResolver("Cluster", `deployments(query: String, pagination: Pagination): [Deployment!]!`),
-		schema.AddExtraResolver("Cluster", `deploymentCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", `nodes(query: String, pagination: Pagination): [Node!]!`),
-		schema.AddExtraResolver("Cluster", `nodeCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", `node(node: ID!): Node`),
-		schema.AddExtraResolver("Cluster", `namespaces(query: String, pagination: Pagination): [Namespace!]!`),
-		schema.AddExtraResolver("Cluster", `namespace(name: String!): Namespace`),
-		schema.AddExtraResolver("Cluster", `namespaceCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", "complianceResults(query: String): [ControlResult!]!"),
-		schema.AddExtraResolver("Cluster", `k8sRoles(query: String, pagination: Pagination): [K8SRole!]!`),
-		schema.AddExtraResolver("Cluster", `k8sRole(role: ID!): K8SRole`),
-		schema.AddExtraResolver("Cluster", `k8sRoleCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", `serviceAccounts(query: String, pagination: Pagination): [ServiceAccount!]!`),
-		schema.AddExtraResolver("Cluster", `serviceAccount(sa: ID!): ServiceAccount`),
-		schema.AddExtraResolver("Cluster", `serviceAccountCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", `subjects(query: String, pagination: Pagination): [Subject!]!`),
-		schema.AddExtraResolver("Cluster", `subject(name: String!): Subject`),
-		schema.AddExtraResolver("Cluster", `subjectCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", `images(query: String, pagination: Pagination): [Image!]!`),
-		schema.AddExtraResolver("Cluster", `imageCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", `components(query: String, pagination: Pagination): [EmbeddedImageScanComponent!]!`),
-		schema.AddExtraResolver("Cluster", `componentCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", `vulns(query: String, scopeQuery: String, pagination: Pagination): [EmbeddedVulnerability!]!`),
-		schema.AddExtraResolver("Cluster", `vulnCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", `vulnCounter(query: String): VulnerabilityCounter!`),
-		schema.AddExtraResolver("Cluster", `nodeVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [NodeVulnerability!]!`),
-		schema.AddExtraResolver("Cluster", `nodeVulnerabilityCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", `nodeVulnerabilityCounter(query: String): VulnerabilityCounter!`),
-		schema.AddExtraResolver("Cluster", `k8sVulns(query: String, pagination: Pagination): [EmbeddedVulnerability!]!`),
-		schema.AddExtraResolver("Cluster", `k8sVulnCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", `istioVulns(query: String, pagination: Pagination): [EmbeddedVulnerability!]!`),
-		schema.AddExtraResolver("Cluster", `istioVulnCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", `openShiftVulns(query: String, pagination: Pagination): [EmbeddedVulnerability!]!`),
-		schema.AddExtraResolver("Cluster", `openShiftVulnCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", `policies(query: String, pagination: Pagination): [Policy!]!`),
-		schema.AddExtraResolver("Cluster", `policyCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", `policyStatus(query: String): PolicyStatus!`),
-		schema.AddExtraResolver("Cluster", `secrets(query: String, pagination: Pagination): [Secret!]!`),
-		schema.AddExtraResolver("Cluster", `secretCount(query: String): Int!`),
-		schema.AddExtraResolver("Cluster", `controlStatus(query: String): String!`),
-		schema.AddExtraResolver("Cluster", `controls(query: String): [ComplianceControl!]!`),
-		schema.AddExtraResolver("Cluster", `failingControls(query: String): [ComplianceControl!]!`),
-		schema.AddExtraResolver("Cluster", `passingControls(query: String): [ComplianceControl!]!`),
-		schema.AddExtraResolver("Cluster", `complianceControlCount(query: String): ComplianceControlCount!`),
-		schema.AddExtraResolver("Cluster", `risk: Risk`),
-		schema.AddExtraResolver("Cluster", `isGKECluster: Boolean!`),
-		schema.AddExtraResolver("Cluster", `isOpenShiftCluster: Boolean!`),
-		schema.AddExtraResolver("Cluster", `unusedVarSink(query: String): Int`),
-		schema.AddExtraResolver("Cluster", `istioEnabled: Boolean!`),
-		schema.AddExtraResolver("Cluster", "plottedVulns(query: String): PlottedVulnerabilities!"),
 		schema.AddExtraResolver("OrchestratorMetadata", `openshiftVersion: String!`),
 	)
 }
@@ -588,6 +593,39 @@ func (resolver *clusterResolver) NodeVulnerabilityCounter(ctx context.Context, a
 	}
 	// TODO : Add postgres support
 	return nil, errors.New("Sub-resolver NodeVulnerabilityCounter in clusterResolver does not support postgres yet")
+}
+
+func (resolver *clusterResolver) vulnQueryScoping(ctx context.Context, query string) (context.Context, string) {
+	ctx = scoped.Context(ctx, scoped.Scope{
+		Level: v1.SearchCategory_CLUSTERS,
+		ID:    resolver.data.GetId(),
+	})
+
+	return ctx, query
+}
+
+func (resolver *clusterResolver) ImageVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ImageVulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ImageVulnerabilities")
+
+	ctx, query := resolver.vulnQueryScoping(ctx, args.String())
+
+	return resolver.root.ImageVulnerabilities(ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
+}
+
+func (resolver *clusterResolver) ImageVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ImageVulnerabilityCount")
+
+	ctx, query := resolver.vulnQueryScoping(ctx, args.String())
+
+	return resolver.root.ImageVulnerabilityCount(ctx, RawQuery{Query: &query})
+}
+
+func (resolver *clusterResolver) ImageVulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ImageVulnerabilityCounter")
+
+	ctx, query := resolver.vulnQueryScoping(ctx, args.String())
+
+	return resolver.root.ImageVulnerabilityCounter(ctx, RawQuery{Query: &query})
 }
 
 func (resolver *clusterResolver) K8sVulns(ctx context.Context, args PaginatedQuery) ([]VulnerabilityResolver, error) {

--- a/central/graphql/resolvers/deployments.go
+++ b/central/graphql/resolvers/deployments.go
@@ -571,8 +571,6 @@ func (resolver *deploymentResolver) vulnQueryScoping(ctx context.Context) contex
 		ID:    resolver.data.GetId(),
 	})
 
-	ctx = deploymentctx.Context(ctx, resolver.data.GetId())
-
 	return ctx
 }
 

--- a/central/graphql/resolvers/image_vulnerabilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities.go
@@ -99,7 +99,7 @@ func (resolver *Resolver) ImageVulnerability(ctx context.Context, args IDQuery) 
 	return nil, errors.New("Resolver ImageVulnerability does not support postgres yet")
 }
 
-// ImageVulnerabilities resolves a set of image vulnerabilities based on a query.
+// ImageVulnerabilities resolves a set of image vulnerabilities for the input query
 func (resolver *Resolver) ImageVulnerabilities(ctx context.Context, q PaginatedQuery) ([]ImageVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "ImageVulnerabilities")
 	if !features.PostgresDatastore.Enabled() {
@@ -110,7 +110,7 @@ func (resolver *Resolver) ImageVulnerabilities(ctx context.Context, q PaginatedQ
 	return nil, errors.New("Resolver ImageVulnerabilities does not support postgres yet")
 }
 
-// ImageVulnerabilityCount returns count of all image vulnerabilities across infrastructure
+// ImageVulnerabilityCount returns count of image vulnerabilities for the input query
 func (resolver *Resolver) ImageVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "ImageVulnerabilityCount")
 	if !features.PostgresDatastore.Enabled() {
@@ -121,9 +121,9 @@ func (resolver *Resolver) ImageVulnerabilityCount(ctx context.Context, args RawQ
 	return 0, errors.New("Resolver ImageVulnerabilityCount does not support postgres yet")
 }
 
-// ImageVulnCounter returns a VulnerabilityCounterResolver for the input query.s
-func (resolver *Resolver) ImageVulnCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
-	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "VulnCounter")
+// ImageVulnerabilityCounter returns a VulnerabilityCounterResolver for the input query
+func (resolver *Resolver) ImageVulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "ImageVulnCounter")
 	if !features.PostgresDatastore.Enabled() {
 		query := withImageTypeFiltering(args.String())
 		return resolver.vulnCounterV2(ctx, RawQuery{Query: &query})
@@ -132,7 +132,8 @@ func (resolver *Resolver) ImageVulnCounter(ctx context.Context, args RawQuery) (
 	return nil, errors.New("Resolver ImageVulnCounter does not support postgres yet")
 }
 
-// withImageTypeFiltering adds a conjunction as a raw query to filter vuln type by image
+// withImageTypeFiltering adds a conjunction as a raw query to filter vulnerability type by image
+// this is needed to support pre postgres requests
 func withImageTypeFiltering(q string) string {
 	return search.AddRawQueriesAsConjunction(q,
 		search.NewQueryBuilder().AddExactMatches(search.CVEType, storage.CVE_IMAGE_CVE.String()).Query())

--- a/central/graphql/resolvers/images.go
+++ b/central/graphql/resolvers/images.go
@@ -223,7 +223,7 @@ func (resolver *imageResolver) VulnerabilityCount(ctx context.Context, args RawQ
 }
 
 func (resolver *imageResolver) VulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
-	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Images, "VulnerabilityCount")
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Images, "VulnerabilityCounter")
 
 	ctx = resolver.vulnQueryScoping(ctx)
 


### PR DESCRIPTION
## Description

Swap the usage of `Vulnerabilities` and similar functions invoked in other resolver's sub resolvers to `ImageVulnerabilities` and similar. In the case of cluster, define new sub resolvers.