### PR TITLE
Re-use ScopeChecker within SearchHelper

### DIFF
--- a/pkg/sac/for_resource_helpers.go
+++ b/pkg/sac/for_resource_helpers.go
@@ -56,7 +56,7 @@ func (h ForResourceHelper) WriteAllowed(ctx context.Context, keys ...ScopeKey) (
 // MustCreateSearchHelper creates and returns a search helper with the given options, or panics if the
 // search helper could not be created.
 func (h ForResourceHelper) MustCreateSearchHelper(options search.OptionsMap) SearchHelper {
-	searchHelper, err := NewSearchHelper(h.resourceMD, options)
+	searchHelper, err := NewSearchHelper(h.resourceMD, options, h.ScopeChecker)
 	utils.CrashOnError(err)
 	return searchHelper
 }
@@ -64,7 +64,7 @@ func (h ForResourceHelper) MustCreateSearchHelper(options search.OptionsMap) Sea
 // MustCreatePgSearchHelper creates and returns a search helper with the given options, or panics if the
 // search helper could not be created.
 func (h ForResourceHelper) MustCreatePgSearchHelper(options search.OptionsMap) SearchHelper {
-	searchHelper, err := NewPgSearchHelper(h.resourceMD, options)
+	searchHelper, err := NewPgSearchHelper(h.resourceMD, options, h.ScopeChecker)
 	utils.CrashOnError(err)
 	return searchHelper
 }

--- a/pkg/sac/tests/search_helper_test.go
+++ b/pkg/sac/tests/search_helper_test.go
@@ -60,7 +60,7 @@ func TestSearchHelper_TestApply_WithFilter(t *testing.T) {
 		}, nil
 	}
 
-	h, err := sac.NewSearchHelper(testNSResource, options)
+	h, err := sac.NewSearchHelper(testNSResource, options, sac.ForResource(testNSResource).ScopeChecker)
 	require.NoError(t, err)
 
 	scc := sac.TestScopeCheckerCoreFromFullScopeMap(t,
@@ -109,7 +109,7 @@ func TestSearchHelper_TestApply_WithAllAccess(t *testing.T) {
 		}, nil
 	}
 
-	h, err := sac.NewSearchHelper(testNSResource, options)
+	h, err := sac.NewSearchHelper(testNSResource, options, sac.ForResource(testNSResource).ScopeChecker)
 	require.NoError(t, err)
 
 	scc := sac.AllowAllAccessScopeChecker()
@@ -131,7 +131,7 @@ func TestSearchHelper_TestNew_WithMissingClusterIDField(t *testing.T) {
 		},
 	})
 
-	_, err := sac.NewSearchHelper(testClusterResource, options)
+	_, err := sac.NewSearchHelper(testClusterResource, options, sac.ForResource(testClusterResource).ScopeChecker)
 	assert.Error(t, err)
 }
 
@@ -144,7 +144,7 @@ func TestSearchHelper_TestNew_WithFieldNotStored(t *testing.T) {
 		},
 	})
 
-	_, err := sac.NewSearchHelper(testClusterResource, options)
+	_, err := sac.NewSearchHelper(testClusterResource, options, sac.ForResource(testClusterResource).ScopeChecker)
 	assert.Error(t, err)
 }
 
@@ -157,7 +157,7 @@ func TestSearchHelper_TestNew_WithMissingNSField_NotScoped(t *testing.T) {
 		},
 	})
 
-	_, err := sac.NewSearchHelper(testClusterResource, options)
+	_, err := sac.NewSearchHelper(testClusterResource, options, sac.ForResource(testClusterResource).ScopeChecker)
 	assert.NoError(t, err)
 }
 
@@ -170,6 +170,6 @@ func TestSearchHelper_TestNew_WithMissingNSField_Scoped(t *testing.T) {
 		},
 	})
 
-	_, err := sac.NewSearchHelper(testNSResource, options)
+	_, err := sac.NewSearchHelper(testNSResource, options, sac.ForResource(testNSResource).ScopeChecker)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
## Description

After changes within #1384 , the `ScopeChecker` of a resource _may_ deal with resource replacements.
The scope checker created within the `SearchHelper` should respect this. Instead of re–creating the `ScopeChecker`, use the one provided by the `ResourceHelper`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
- see CI
