### PR TITLE
Add GetAll to Postgres generation

### DIFF
--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Alert, bool, error)
+	GetAll(ctx context.Context) ([]*storage.Alert, error)
 	Upsert(ctx context.Context, obj *storage.Alert) error
 	UpsertMany(ctx context.Context, objs []*storage.Alert) error
 	Delete(ctx context.Context, id string) error
@@ -474,6 +475,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Alert, bool, e
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.Alert, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "Alert")
+
+	var objs []*storage.Alert
+	err := s.Walk(ctx, func(obj *storage.Alert) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/alert/datastore/internal/store/postgres/store_test.go
+++ b/central/alert/datastore/internal/store/postgres/store_test.go
@@ -82,6 +82,10 @@ func (s *AlertsStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(alert, foundAlert)
 
+	allAlert, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(alert, allAlert[0])
+
 	alertCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, alertCount)
@@ -111,6 +115,10 @@ func (s *AlertsStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, alerts))
+
+	allAlert, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(alerts, allAlert)
 
 	alertCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TokenMetadata, bool, error)
+	GetAll(ctx context.Context) ([]*storage.TokenMetadata, error)
 	Upsert(ctx context.Context, obj *storage.TokenMetadata) error
 	UpsertMany(ctx context.Context, objs []*storage.TokenMetadata) error
 	Delete(ctx context.Context, id string) error
@@ -304,6 +305,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TokenMetadata,
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.TokenMetadata, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "TokenMetadata")
+
+	var objs []*storage.TokenMetadata
+	err := s.Walk(ctx, func(obj *storage.TokenMetadata) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/apitoken/datastore/internal/store/postgres/store_test.go
+++ b/central/apitoken/datastore/internal/store/postgres/store_test.go
@@ -80,6 +80,10 @@ func (s *ApitokensStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(tokenMetadata, foundTokenMetadata)
 
+	allTokenMetadata, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(tokenMetadata, allTokenMetadata[0])
+
 	tokenMetadataCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, tokenMetadataCount)
@@ -113,6 +117,10 @@ func (s *ApitokensStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, tokenMetadatas))
+
+	allTokenMetadata, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(tokenMetadatas, allTokenMetadata)
 
 	tokenMetadataCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Cluster, bool, error)
+	GetAll(ctx context.Context) ([]*storage.Cluster, error)
 	Upsert(ctx context.Context, obj *storage.Cluster) error
 	UpsertMany(ctx context.Context, objs []*storage.Cluster) error
 	Delete(ctx context.Context, id string) error
@@ -329,6 +330,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Cluster, bool,
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.Cluster, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "Cluster")
+
+	var objs []*storage.Cluster
+	err := s.Walk(ctx, func(obj *storage.Cluster) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/cluster/store/cluster/postgres/store_test.go
+++ b/central/cluster/store/cluster/postgres/store_test.go
@@ -82,6 +82,10 @@ func (s *ClustersStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(cluster, foundCluster)
 
+	allCluster, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(cluster, allCluster[0])
+
 	clusterCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, clusterCount)
@@ -111,6 +115,10 @@ func (s *ClustersStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, clusters))
+
+	allCluster, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(clusters, allCluster)
 
 	clusterCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ClusterHealthStatus, bool, error)
+	GetAll(ctx context.Context) ([]*storage.ClusterHealthStatus, error)
 	Upsert(ctx context.Context, obj *storage.ClusterHealthStatus) error
 	UpsertMany(ctx context.Context, objs []*storage.ClusterHealthStatus) error
 	Delete(ctx context.Context, id string) error
@@ -288,6 +289,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ClusterHealthS
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.ClusterHealthStatus, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "ClusterHealthStatus")
+
+	var objs []*storage.ClusterHealthStatus
+	err := s.Walk(ctx, func(obj *storage.ClusterHealthStatus) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/cluster/store/clusterhealth/postgres/store_test.go
+++ b/central/cluster/store/clusterhealth/postgres/store_test.go
@@ -78,6 +78,10 @@ func (s *ClusterHealthStatusStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(clusterHealthStatus, foundClusterHealthStatus)
 
+	allClusterHealthStatus, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(clusterHealthStatus, allClusterHealthStatus[0])
+
 	clusterHealthStatusCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, clusterHealthStatusCount)
@@ -106,6 +110,10 @@ func (s *ClusterHealthStatusStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, clusterHealthStatuss))
+
+	allClusterHealthStatus, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(clusterHealthStatuss, allClusterHealthStatus)
 
 	clusterHealthStatusCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.InitBundleMeta, bool, error)
+	GetAll(ctx context.Context) ([]*storage.InitBundleMeta, error)
 	Upsert(ctx context.Context, obj *storage.InitBundleMeta) error
 	UpsertMany(ctx context.Context, objs []*storage.InitBundleMeta) error
 	Delete(ctx context.Context, id string) error
@@ -293,6 +294,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.InitBundleMeta
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.InitBundleMeta, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "InitBundleMeta")
+
+	var objs []*storage.InitBundleMeta
+	err := s.Walk(ctx, func(obj *storage.InitBundleMeta) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/clusterinit/store/postgres/store_test.go
+++ b/central/clusterinit/store/postgres/store_test.go
@@ -80,6 +80,10 @@ func (s *ClusterinitbundlesStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(initBundleMeta, foundInitBundleMeta)
 
+	allInitBundleMeta, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(initBundleMeta, allInitBundleMeta[0])
+
 	initBundleMetaCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, initBundleMetaCount)
@@ -113,6 +117,10 @@ func (s *ClusterinitbundlesStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, initBundleMetas))
+
+	allInitBundleMeta, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(initBundleMetas, allInitBundleMeta)
 
 	initBundleMetaCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/componentcveedge/datastore/internal/postgres/store.go
+++ b/central/componentcveedge/datastore/internal/postgres/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string, imageComponentId string, imageComponentName string, imageComponentVersion string, imageComponentOperatingSystem string, imageCveId string, imageCve string, imageCveOperatingSystem string) (bool, error)
 	Get(ctx context.Context, id string, imageComponentId string, imageComponentName string, imageComponentVersion string, imageComponentOperatingSystem string, imageCveId string, imageCve string, imageCveOperatingSystem string) (*storage.ComponentCVEEdge, bool, error)
+	GetAll(ctx context.Context) ([]*storage.ComponentCVEEdge, error)
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComponentCVEEdge, []int, error)
 
@@ -116,6 +117,17 @@ func (s *storeImpl) Get(ctx context.Context, id string, imageComponentId string,
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.ComponentCVEEdge, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "ComponentCVEEdge")
+
+	var objs []*storage.ComponentCVEEdge
+	err := s.Walk(ctx, func(obj *storage.ComponentCVEEdge) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/cve/datastore/cluster/internal/store/postgres/store.go
+++ b/central/cve/datastore/cluster/internal/store/postgres/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string, cve string, operatingSystem string) (bool, error)
 	Get(ctx context.Context, id string, cve string, operatingSystem string) (*storage.CVE, bool, error)
+	GetAll(ctx context.Context) ([]*storage.CVE, error)
 	Upsert(ctx context.Context, obj *storage.CVE) error
 	UpsertMany(ctx context.Context, objs []*storage.CVE) error
 	Delete(ctx context.Context, id string, cve string, operatingSystem string) error
@@ -303,6 +304,17 @@ func (s *storeImpl) Get(ctx context.Context, id string, cve string, operatingSys
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.CVE, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "CVE")
+
+	var objs []*storage.CVE
+	err := s.Walk(ctx, func(obj *storage.CVE) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/cve/datastore/cluster/internal/store/postgres/store_test.go
+++ b/central/cve/datastore/cluster/internal/store/postgres/store_test.go
@@ -78,6 +78,10 @@ func (s *ClusterCvesStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(cVE, foundCVE)
 
+	allCVE, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(cVE, allCVE[0])
+
 	cVECount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, cVECount)
@@ -106,6 +110,10 @@ func (s *ClusterCvesStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, cVEs))
+
+	allCVE, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(cVEs, allCVE)
 
 	cVECount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/cve/datastore/node/internal/store/postgres/store.go
+++ b/central/cve/datastore/node/internal/store/postgres/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string, cve string, operatingSystem string) (bool, error)
 	Get(ctx context.Context, id string, cve string, operatingSystem string) (*storage.CVE, bool, error)
+	GetAll(ctx context.Context) ([]*storage.CVE, error)
 	Upsert(ctx context.Context, obj *storage.CVE) error
 	UpsertMany(ctx context.Context, objs []*storage.CVE) error
 	Delete(ctx context.Context, id string, cve string, operatingSystem string) error
@@ -303,6 +304,17 @@ func (s *storeImpl) Get(ctx context.Context, id string, cve string, operatingSys
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.CVE, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "CVE")
+
+	var objs []*storage.CVE
+	err := s.Walk(ctx, func(obj *storage.CVE) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/cve/datastore/node/internal/store/postgres/store_test.go
+++ b/central/cve/datastore/node/internal/store/postgres/store_test.go
@@ -78,6 +78,10 @@ func (s *NodeCvesStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(cVE, foundCVE)
 
+	allCVE, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(cVE, allCVE[0])
+
 	cVECount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, cVECount)
@@ -106,6 +110,10 @@ func (s *NodeCvesStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, cVEs))
+
+	allCVE, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(cVEs, allCVE)
 
 	cVECount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/cve/image/datastore/internal/store/postgres/store.go
+++ b/central/cve/image/datastore/internal/store/postgres/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string, cve string, operatingSystem string) (bool, error)
 	Get(ctx context.Context, id string, cve string, operatingSystem string) (*storage.CVE, bool, error)
+	GetAll(ctx context.Context) ([]*storage.CVE, error)
 	Upsert(ctx context.Context, obj *storage.CVE) error
 	UpsertMany(ctx context.Context, objs []*storage.CVE) error
 	Delete(ctx context.Context, id string, cve string, operatingSystem string) error
@@ -303,6 +304,17 @@ func (s *storeImpl) Get(ctx context.Context, id string, cve string, operatingSys
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.CVE, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "CVE")
+
+	var objs []*storage.CVE
+	err := s.Walk(ctx, func(obj *storage.CVE) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/cve/image/datastore/internal/store/postgres/store_test.go
+++ b/central/cve/image/datastore/internal/store/postgres/store_test.go
@@ -78,6 +78,10 @@ func (s *ImageCvesStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(cVE, foundCVE)
 
+	allCVE, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(cVE, allCVE[0])
+
 	cVECount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, cVECount)
@@ -106,6 +110,10 @@ func (s *ImageCvesStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, cVEs))
+
+	allCVE, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(cVEs, allCVE)
 
 	cVECount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Deployment, bool, error)
+	GetAll(ctx context.Context) ([]*storage.Deployment, error)
 	Upsert(ctx context.Context, obj *storage.Deployment) error
 	UpsertMany(ctx context.Context, objs []*storage.Deployment) error
 	Delete(ctx context.Context, id string) error
@@ -1030,6 +1031,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Deployment, bo
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.Deployment, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "Deployment")
+
+	var objs []*storage.Deployment
+	err := s.Walk(ctx, func(obj *storage.Deployment) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/deployment/store/postgres/store_test.go
+++ b/central/deployment/store/postgres/store_test.go
@@ -82,6 +82,10 @@ func (s *DeploymentsStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(deployment, foundDeployment)
 
+	allDeployment, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(deployment, allDeployment[0])
+
 	deploymentCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, deploymentCount)
@@ -111,6 +115,10 @@ func (s *DeploymentsStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, deployments))
+
+	allDeployment, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(deployments, allDeployment)
 
 	deploymentCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/imagecomponent/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponent/datastore/internal/store/postgres/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string, name string, version string, operatingSystem string) (bool, error)
 	Get(ctx context.Context, id string, name string, version string, operatingSystem string) (*storage.ImageComponent, bool, error)
+	GetAll(ctx context.Context) ([]*storage.ImageComponent, error)
 	Upsert(ctx context.Context, obj *storage.ImageComponent) error
 	UpsertMany(ctx context.Context, objs []*storage.ImageComponent) error
 	Delete(ctx context.Context, id string, name string, version string, operatingSystem string) error
@@ -288,6 +289,17 @@ func (s *storeImpl) Get(ctx context.Context, id string, name string, version str
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.ImageComponent, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "ImageComponent")
+
+	var objs []*storage.ImageComponent
+	err := s.Walk(ctx, func(obj *storage.ImageComponent) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/imagecomponent/datastore/internal/store/postgres/store_test.go
+++ b/central/imagecomponent/datastore/internal/store/postgres/store_test.go
@@ -78,6 +78,10 @@ func (s *ImageComponentsStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(imageComponent, foundImageComponent)
 
+	allImageComponent, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(imageComponent, allImageComponent[0])
+
 	imageComponentCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, imageComponentCount)
@@ -106,6 +110,10 @@ func (s *ImageComponentsStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, imageComponents))
+
+	allImageComponent, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(imageComponents, allImageComponent)
 
 	imageComponentCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string, imageId string, imageComponentId string, imageComponentName string, imageComponentVersion string, imageComponentOperatingSystem string) (bool, error)
 	Get(ctx context.Context, id string, imageId string, imageComponentId string, imageComponentName string, imageComponentVersion string, imageComponentOperatingSystem string) (*storage.ImageComponentEdge, bool, error)
+	GetAll(ctx context.Context) ([]*storage.ImageComponentEdge, error)
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ImageComponentEdge, []int, error)
 
@@ -116,6 +117,17 @@ func (s *storeImpl) Get(ctx context.Context, id string, imageId string, imageCom
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.ImageComponentEdge, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "ImageComponentEdge")
+
+	var objs []*storage.ImageComponentEdge
+	err := s.Walk(ctx, func(obj *storage.ImageComponentEdge) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/imagecveedge/datastore/internal/postgres/store.go
+++ b/central/imagecveedge/datastore/internal/postgres/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string, imageId string, imageCveId string, imageCve string, imageCveOperatingSystem string) (bool, error)
 	Get(ctx context.Context, id string, imageId string, imageCveId string, imageCve string, imageCveOperatingSystem string) (*storage.ImageCVEEdge, bool, error)
+	GetAll(ctx context.Context) ([]*storage.ImageCVEEdge, error)
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ImageCVEEdge, []int, error)
 
@@ -116,6 +117,17 @@ func (s *storeImpl) Get(ctx context.Context, id string, imageId string, imageCve
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.ImageCVEEdge, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "ImageCVEEdge")
+
+	var objs []*storage.ImageCVEEdge
+	err := s.Walk(ctx, func(obj *storage.ImageCVEEdge) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.IntegrationHealth, bool, error)
+	GetAll(ctx context.Context) ([]*storage.IntegrationHealth, error)
 	Upsert(ctx context.Context, obj *storage.IntegrationHealth) error
 	UpsertMany(ctx context.Context, objs []*storage.IntegrationHealth) error
 	Delete(ctx context.Context, id string) error
@@ -293,6 +294,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.IntegrationHea
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.IntegrationHealth, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "IntegrationHealth")
+
+	var objs []*storage.IntegrationHealth
+	err := s.Walk(ctx, func(obj *storage.IntegrationHealth) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/integrationhealth/store/postgres/store_test.go
+++ b/central/integrationhealth/store/postgres/store_test.go
@@ -80,6 +80,10 @@ func (s *IntegrationhealthStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(integrationHealth, foundIntegrationHealth)
 
+	allIntegrationHealth, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(integrationHealth, allIntegrationHealth[0])
+
 	integrationHealthCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, integrationHealthCount)
@@ -113,6 +117,10 @@ func (s *IntegrationhealthStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, integrationHealths))
+
+	allIntegrationHealth, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(integrationHealths, allIntegrationHealth)
 
 	integrationHealthCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.NamespaceMetadata, bool, error)
+	GetAll(ctx context.Context) ([]*storage.NamespaceMetadata, error)
 	Upsert(ctx context.Context, obj *storage.NamespaceMetadata) error
 	UpsertMany(ctx context.Context, objs []*storage.NamespaceMetadata) error
 	Delete(ctx context.Context, id string) error
@@ -325,6 +326,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NamespaceMetad
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.NamespaceMetadata, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "NamespaceMetadata")
+
+	var objs []*storage.NamespaceMetadata
+	err := s.Walk(ctx, func(obj *storage.NamespaceMetadata) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/namespace/store/postgres/store_test.go
+++ b/central/namespace/store/postgres/store_test.go
@@ -82,6 +82,10 @@ func (s *NamespacesStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(namespaceMetadata, foundNamespaceMetadata)
 
+	allNamespaceMetadata, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(namespaceMetadata, allNamespaceMetadata[0])
+
 	namespaceMetadataCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, namespaceMetadataCount)
@@ -111,6 +115,10 @@ func (s *NamespacesStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, namespaceMetadatas))
+
+	allNamespaceMetadata, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(namespaceMetadatas, allNamespaceMetadata)
 
 	namespaceMetadataCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, deploymentId string) (bool, error)
 	Get(ctx context.Context, deploymentId string) (*storage.NetworkBaseline, bool, error)
+	GetAll(ctx context.Context) ([]*storage.NetworkBaseline, error)
 	Upsert(ctx context.Context, obj *storage.NetworkBaseline) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkBaseline) error
 	Delete(ctx context.Context, deploymentId string) error
@@ -268,6 +269,17 @@ func (s *storeImpl) Get(ctx context.Context, deploymentId string) (*storage.Netw
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.NetworkBaseline, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "NetworkBaseline")
+
+	var objs []*storage.NetworkBaseline
+	err := s.Walk(ctx, func(obj *storage.NetworkBaseline) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/networkbaseline/store/postgres/store_test.go
+++ b/central/networkbaseline/store/postgres/store_test.go
@@ -78,6 +78,10 @@ func (s *NetworkbaselineStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(networkBaseline, foundNetworkBaseline)
 
+	allNetworkBaseline, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(networkBaseline, allNetworkBaseline[0])
+
 	networkBaselineCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, networkBaselineCount)
@@ -106,6 +110,10 @@ func (s *NetworkbaselineStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, networkBaselines))
+
+	allNetworkBaseline, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(networkBaselines, allNetworkBaseline)
 
 	networkBaselineCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, infoId string) (bool, error)
 	Get(ctx context.Context, infoId string) (*storage.NetworkEntity, bool, error)
+	GetAll(ctx context.Context) ([]*storage.NetworkEntity, error)
 	Upsert(ctx context.Context, obj *storage.NetworkEntity) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkEntity) error
 	Delete(ctx context.Context, infoId string) error
@@ -273,6 +274,17 @@ func (s *storeImpl) Get(ctx context.Context, infoId string) (*storage.NetworkEnt
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.NetworkEntity, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "NetworkEntity")
+
+	var objs []*storage.NetworkEntity
+	err := s.Walk(ctx, func(obj *storage.NetworkEntity) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
@@ -78,6 +78,10 @@ func (s *NetworkentityStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(networkEntity, foundNetworkEntity)
 
+	allNetworkEntity, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(networkEntity, allNetworkEntity[0])
+
 	networkEntityCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, networkEntityCount)
@@ -106,6 +110,10 @@ func (s *NetworkentityStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, networkEntitys))
+
+	allNetworkEntity, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(networkEntitys, allNetworkEntity)
 
 	networkEntityCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Pod, bool, error)
+	GetAll(ctx context.Context) ([]*storage.Pod, error)
 	Upsert(ctx context.Context, obj *storage.Pod) error
 	UpsertMany(ctx context.Context, objs []*storage.Pod) error
 	Delete(ctx context.Context, id string) error
@@ -406,6 +407,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Pod, bool, err
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.Pod, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "Pod")
+
+	var objs []*storage.Pod
+	err := s.Walk(ctx, func(obj *storage.Pod) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/pod/store/postgres/store_test.go
+++ b/central/pod/store/postgres/store_test.go
@@ -82,6 +82,10 @@ func (s *PodsStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(pod, foundPod)
 
+	allPod, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(pod, allPod[0])
+
 	podCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, podCount)
@@ -111,6 +115,10 @@ func (s *PodsStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, pods))
+
+	allPod, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(pods, allPod)
 
 	podCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Policy, bool, error)
+	GetAll(ctx context.Context) ([]*storage.Policy, error)
 	Upsert(ctx context.Context, obj *storage.Policy) error
 	UpsertMany(ctx context.Context, objs []*storage.Policy) error
 	Delete(ctx context.Context, id string) error
@@ -359,6 +360,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Policy, bool, 
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.Policy, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "Policy")
+
+	var objs []*storage.Policy
+	err := s.Walk(ctx, func(obj *storage.Policy) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/policy/store/postgres/store_test.go
+++ b/central/policy/store/postgres/store_test.go
@@ -80,6 +80,10 @@ func (s *PolicyStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(policy, foundPolicy)
 
+	allPolicy, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(policy, allPolicy[0])
+
 	policyCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, policyCount)
@@ -113,6 +117,10 @@ func (s *PolicyStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, policys))
+
+	allPolicy, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(policys, allPolicy)
 
 	policyCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ProcessBaseline, bool, error)
+	GetAll(ctx context.Context) ([]*storage.ProcessBaseline, error)
 	Upsert(ctx context.Context, obj *storage.ProcessBaseline) error
 	UpsertMany(ctx context.Context, objs []*storage.ProcessBaseline) error
 	Delete(ctx context.Context, id string) error
@@ -314,6 +315,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ProcessBaselin
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.ProcessBaseline, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "ProcessBaseline")
+
+	var objs []*storage.ProcessBaseline
+	err := s.Walk(ctx, func(obj *storage.ProcessBaseline) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/processbaseline/store/postgres/store_test.go
+++ b/central/processbaseline/store/postgres/store_test.go
@@ -82,6 +82,10 @@ func (s *ProcessbaselinesStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(processBaseline, foundProcessBaseline)
 
+	allProcessBaseline, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(processBaseline, allProcessBaseline[0])
+
 	processBaselineCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, processBaselineCount)
@@ -111,6 +115,10 @@ func (s *ProcessbaselinesStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, processBaselines))
+
+	allProcessBaseline, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(processBaselines, allProcessBaseline)
 
 	processBaselineCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, deploymentId string) (bool, error)
 	Get(ctx context.Context, deploymentId string) (*storage.ProcessBaselineResults, bool, error)
+	GetAll(ctx context.Context) ([]*storage.ProcessBaselineResults, error)
 	Upsert(ctx context.Context, obj *storage.ProcessBaselineResults) error
 	UpsertMany(ctx context.Context, objs []*storage.ProcessBaselineResults) error
 	Delete(ctx context.Context, deploymentId string) error
@@ -268,6 +269,17 @@ func (s *storeImpl) Get(ctx context.Context, deploymentId string) (*storage.Proc
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.ProcessBaselineResults, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "ProcessBaselineResults")
+
+	var objs []*storage.ProcessBaselineResults
+	err := s.Walk(ctx, func(obj *storage.ProcessBaselineResults) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
@@ -78,6 +78,10 @@ func (s *ProcesswhitelistresultsStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(processBaselineResults, foundProcessBaselineResults)
 
+	allProcessBaselineResults, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(processBaselineResults, allProcessBaselineResults[0])
+
 	processBaselineResultsCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, processBaselineResultsCount)
@@ -106,6 +110,10 @@ func (s *ProcesswhitelistresultsStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, processBaselineResultss))
+
+	allProcessBaselineResults, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(processBaselineResultss, allProcessBaselineResults)
 
 	processBaselineResultsCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ProcessIndicator, bool, error)
+	GetAll(ctx context.Context) ([]*storage.ProcessIndicator, error)
 	Upsert(ctx context.Context, obj *storage.ProcessIndicator) error
 	UpsertMany(ctx context.Context, objs []*storage.ProcessIndicator) error
 	Delete(ctx context.Context, id string) error
@@ -354,6 +355,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ProcessIndicat
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.ProcessIndicator, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "ProcessIndicator")
+
+	var objs []*storage.ProcessIndicator
+	err := s.Walk(ctx, func(obj *storage.ProcessIndicator) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/processindicator/store/postgres/store_test.go
+++ b/central/processindicator/store/postgres/store_test.go
@@ -82,6 +82,10 @@ func (s *ProcessIndicatorsStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(processIndicator, foundProcessIndicator)
 
+	allProcessIndicator, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(processIndicator, allProcessIndicator[0])
+
 	processIndicatorCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, processIndicatorCount)
@@ -111,6 +115,10 @@ func (s *ProcessIndicatorsStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, processIndicators))
+
+	allProcessIndicator, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(processIndicators, allProcessIndicator)
 
 	processIndicatorCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.K8SRole, bool, error)
+	GetAll(ctx context.Context) ([]*storage.K8SRole, error)
 	Upsert(ctx context.Context, obj *storage.K8SRole) error
 	UpsertMany(ctx context.Context, objs []*storage.K8SRole) error
 	Delete(ctx context.Context, id string) error
@@ -334,6 +335,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.K8SRole, bool,
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.K8SRole, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "K8SRole")
+
+	var objs []*storage.K8SRole
+	err := s.Walk(ctx, func(obj *storage.K8SRole) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/rbac/k8srole/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srole/internal/store/postgres/store_test.go
@@ -82,6 +82,10 @@ func (s *K8srolesStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(k8SRole, foundK8SRole)
 
+	allK8SRole, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(k8SRole, allK8SRole[0])
+
 	k8SRoleCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, k8SRoleCount)
@@ -111,6 +115,10 @@ func (s *K8srolesStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, k8SRoles))
+
+	allK8SRole, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(k8SRoles, allK8SRole)
 
 	k8SRoleCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.K8SRoleBinding, bool, error)
+	GetAll(ctx context.Context) ([]*storage.K8SRoleBinding, error)
 	Upsert(ctx context.Context, obj *storage.K8SRoleBinding) error
 	UpsertMany(ctx context.Context, objs []*storage.K8SRoleBinding) error
 	Delete(ctx context.Context, id string) error
@@ -430,6 +431,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.K8SRoleBinding
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.K8SRoleBinding, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "K8SRoleBinding")
+
+	var objs []*storage.K8SRoleBinding
+	err := s.Walk(ctx, func(obj *storage.K8SRoleBinding) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
@@ -82,6 +82,10 @@ func (s *RolebindingsStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(k8SRoleBinding, foundK8SRoleBinding)
 
+	allK8SRoleBinding, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(k8SRoleBinding, allK8SRoleBinding[0])
+
 	k8SRoleBindingCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, k8SRoleBindingCount)
@@ -111,6 +115,10 @@ func (s *RolebindingsStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, k8SRoleBindings))
+
+	allK8SRoleBinding, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(k8SRoleBindings, allK8SRoleBinding)
 
 	k8SRoleBindingCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ReportConfiguration, bool, error)
+	GetAll(ctx context.Context) ([]*storage.ReportConfiguration, error)
 	Upsert(ctx context.Context, obj *storage.ReportConfiguration) error
 	UpsertMany(ctx context.Context, objs []*storage.ReportConfiguration) error
 	Delete(ctx context.Context, id string) error
@@ -314,6 +315,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ReportConfigur
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.ReportConfiguration, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "ReportConfiguration")
+
+	var objs []*storage.ReportConfiguration
+	err := s.Walk(ctx, func(obj *storage.ReportConfiguration) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/reportconfigurations/store/postgres/store_test.go
+++ b/central/reportconfigurations/store/postgres/store_test.go
@@ -80,6 +80,10 @@ func (s *ReportconfigsStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(reportConfiguration, foundReportConfiguration)
 
+	allReportConfiguration, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(reportConfiguration, allReportConfiguration[0])
+
 	reportConfigurationCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, reportConfigurationCount)
@@ -113,6 +117,10 @@ func (s *ReportconfigsStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, reportConfigurations))
+
+	allReportConfiguration, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(reportConfigurations, allReportConfiguration)
 
 	reportConfigurationCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Risk, bool, error)
+	GetAll(ctx context.Context) ([]*storage.Risk, error)
 	Upsert(ctx context.Context, obj *storage.Risk) error
 	UpsertMany(ctx context.Context, objs []*storage.Risk) error
 	Delete(ctx context.Context, id string) error
@@ -319,6 +320,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Risk, bool, er
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.Risk, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "Risk")
+
+	var objs []*storage.Risk
+	err := s.Walk(ctx, func(obj *storage.Risk) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/risk/datastore/internal/store/postgres/store_test.go
+++ b/central/risk/datastore/internal/store/postgres/store_test.go
@@ -82,6 +82,10 @@ func (s *RiskStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(risk, foundRisk)
 
+	allRisk, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(risk, allRisk[0])
+
 	riskCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, riskCount)
@@ -111,6 +115,10 @@ func (s *RiskStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, risks))
+
+	allRisk, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(risks, allRisk)
 
 	riskCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.PermissionSet, bool, error)
+	GetAll(ctx context.Context) ([]*storage.PermissionSet, error)
 	Upsert(ctx context.Context, obj *storage.PermissionSet) error
 	UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error
 	Delete(ctx context.Context, id string) error
@@ -304,6 +305,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.PermissionSet,
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.PermissionSet, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "PermissionSet")
+
+	var objs []*storage.PermissionSet
+	err := s.Walk(ctx, func(obj *storage.PermissionSet) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/role/store/permissionset/postgres/store_test.go
+++ b/central/role/store/permissionset/postgres/store_test.go
@@ -80,6 +80,10 @@ func (s *PermissionsetsStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(permissionSet, foundPermissionSet)
 
+	allPermissionSet, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(permissionSet, allPermissionSet[0])
+
 	permissionSetCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, permissionSetCount)
@@ -113,6 +117,10 @@ func (s *PermissionsetsStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, permissionSets))
+
+	allPermissionSet, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(permissionSets, allPermissionSet)
 
 	permissionSetCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, name string) (bool, error)
 	Get(ctx context.Context, name string) (*storage.Role, bool, error)
+	GetAll(ctx context.Context) ([]*storage.Role, error)
 	Upsert(ctx context.Context, obj *storage.Role) error
 	UpsertMany(ctx context.Context, objs []*storage.Role) error
 	Delete(ctx context.Context, name string) error
@@ -304,6 +305,17 @@ func (s *storeImpl) Get(ctx context.Context, name string) (*storage.Role, bool, 
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.Role, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "Role")
+
+	var objs []*storage.Role
+	err := s.Walk(ctx, func(obj *storage.Role) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/role/store/role/postgres/store_test.go
+++ b/central/role/store/role/postgres/store_test.go
@@ -80,6 +80,10 @@ func (s *RolesStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(role, foundRole)
 
+	allRole, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(role, allRole[0])
+
 	roleCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, roleCount)
@@ -113,6 +117,10 @@ func (s *RolesStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, roles))
+
+	allRole, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(roles, allRole)
 
 	roleCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.SimpleAccessScope, bool, error)
+	GetAll(ctx context.Context) ([]*storage.SimpleAccessScope, error)
 	Upsert(ctx context.Context, obj *storage.SimpleAccessScope) error
 	UpsertMany(ctx context.Context, objs []*storage.SimpleAccessScope) error
 	Delete(ctx context.Context, id string) error
@@ -304,6 +305,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.SimpleAccessSc
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.SimpleAccessScope, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "SimpleAccessScope")
+
+	var objs []*storage.SimpleAccessScope
+	err := s.Walk(ctx, func(obj *storage.SimpleAccessScope) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/role/store/simpleaccessscope/postgres/store_test.go
+++ b/central/role/store/simpleaccessscope/postgres/store_test.go
@@ -80,6 +80,10 @@ func (s *SimpleaccessscopesStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(simpleAccessScope, foundSimpleAccessScope)
 
+	allSimpleAccessScope, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(simpleAccessScope, allSimpleAccessScope[0])
+
 	simpleAccessScopeCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, simpleAccessScopeCount)
@@ -113,6 +117,10 @@ func (s *SimpleaccessscopesStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, simpleAccessScopes))
+
+	allSimpleAccessScope, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(simpleAccessScopes, allSimpleAccessScope)
 
 	simpleAccessScopeCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/secret/internal/store/postgres/store_test.go
+++ b/central/secret/internal/store/postgres/store_test.go
@@ -82,6 +82,10 @@ func (s *SecretsStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(secret, foundSecret)
 
+	allSecret, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(secret, allSecret[0])
+
 	secretCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, secretCount)
@@ -111,6 +115,10 @@ func (s *SecretsStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, secrets))
+
+	allSecret, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(secrets, allSecret)
 
 	secretCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ServiceAccount, bool, error)
+	GetAll(ctx context.Context) ([]*storage.ServiceAccount, error)
 	Upsert(ctx context.Context, obj *storage.ServiceAccount) error
 	UpsertMany(ctx context.Context, objs []*storage.ServiceAccount) error
 	Delete(ctx context.Context, id string) error
@@ -329,6 +330,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ServiceAccount
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.ServiceAccount, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "ServiceAccount")
+
+	var objs []*storage.ServiceAccount
+	err := s.Walk(ctx, func(obj *storage.ServiceAccount) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/serviceaccount/internal/store/postgres/store_test.go
+++ b/central/serviceaccount/internal/store/postgres/store_test.go
@@ -82,6 +82,10 @@ func (s *ServiceaccountsStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(serviceAccount, foundServiceAccount)
 
+	allServiceAccount, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(serviceAccount, allServiceAccount[0])
+
 	serviceAccountCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, serviceAccountCount)
@@ -111,6 +115,10 @@ func (s *ServiceaccountsStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, serviceAccounts))
+
+	allServiceAccount, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(serviceAccounts, allServiceAccount)
 
 	serviceAccountCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.SignatureIntegration, bool, error)
+	GetAll(ctx context.Context) ([]*storage.SignatureIntegration, error)
 	Upsert(ctx context.Context, obj *storage.SignatureIntegration) error
 	UpsertMany(ctx context.Context, objs []*storage.SignatureIntegration) error
 	Delete(ctx context.Context, id string) error
@@ -304,6 +305,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.SignatureInteg
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.SignatureIntegration, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "SignatureIntegration")
+
+	var objs []*storage.SignatureIntegration
+	err := s.Walk(ctx, func(obj *storage.SignatureIntegration) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/signatureintegration/store/postgres/store_test.go
+++ b/central/signatureintegration/store/postgres/store_test.go
@@ -80,6 +80,10 @@ func (s *SignatureintegrationsStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(signatureIntegration, foundSignatureIntegration)
 
+	allSignatureIntegration, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(signatureIntegration, allSignatureIntegration[0])
+
 	signatureIntegrationCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, signatureIntegrationCount)
@@ -113,6 +117,10 @@ func (s *SignatureintegrationsStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, signatureIntegrations))
+
+	allSignatureIntegration, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(signatureIntegrations, allSignatureIntegration)
 
 	signatureIntegrationCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.VulnerabilityRequest, bool, error)
+	GetAll(ctx context.Context) ([]*storage.VulnerabilityRequest, error)
 	Upsert(ctx context.Context, obj *storage.VulnerabilityRequest) error
 	UpsertMany(ctx context.Context, objs []*storage.VulnerabilityRequest) error
 	Delete(ctx context.Context, id string) error
@@ -503,6 +504,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.VulnerabilityR
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.VulnerabilityRequest, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "VulnerabilityRequest")
+
+	var objs []*storage.VulnerabilityRequest
+	err := s.Walk(ctx, func(obj *storage.VulnerabilityRequest) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
@@ -80,6 +80,10 @@ func (s *VulnreqStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(vulnerabilityRequest, foundVulnerabilityRequest)
 
+	allVulnerabilityRequest, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(vulnerabilityRequest, allVulnerabilityRequest[0])
+
 	vulnerabilityRequestCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, vulnerabilityRequestCount)
@@ -113,6 +117,10 @@ func (s *VulnreqStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, vulnerabilityRequests))
+
+	allVulnerabilityRequest, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(vulnerabilityRequests, allVulnerabilityRequest)
 
 	vulnerabilityRequestCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, name string) (bool, error)
 	Get(ctx context.Context, name string) (*storage.WatchedImage, bool, error)
+	GetAll(ctx context.Context) ([]*storage.WatchedImage, error)
 	Upsert(ctx context.Context, obj *storage.WatchedImage) error
 	UpsertMany(ctx context.Context, objs []*storage.WatchedImage) error
 	Delete(ctx context.Context, name string) error
@@ -304,6 +305,17 @@ func (s *storeImpl) Get(ctx context.Context, name string) (*storage.WatchedImage
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.WatchedImage, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "WatchedImage")
+
+	var objs []*storage.WatchedImage
+	err := s.Walk(ctx, func(obj *storage.WatchedImage) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/central/watchedimage/datastore/internal/store/postgres/store_test.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store_test.go
@@ -80,6 +80,10 @@ func (s *WatchedimagesStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(watchedImage, foundWatchedImage)
 
+	allWatchedImage, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(watchedImage, allWatchedImage[0])
+
 	watchedImageCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, watchedImageCount)
@@ -113,6 +117,10 @@ func (s *WatchedimagesStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, watchedImages))
+
+	allWatchedImage, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(watchedImages, allWatchedImage)
 
 	watchedImageCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, key1 string, key2 string) (bool, error)
 	Get(ctx context.Context, key1 string, key2 string) (*storage.TestMultiKeyStruct, bool, error)
+	GetAll(ctx context.Context) ([]*storage.TestMultiKeyStruct, error)
 	Upsert(ctx context.Context, obj *storage.TestMultiKeyStruct) error
 	UpsertMany(ctx context.Context, objs []*storage.TestMultiKeyStruct) error
 	Delete(ctx context.Context, key1 string, key2 string) error
@@ -439,6 +440,17 @@ func (s *storeImpl) Get(ctx context.Context, key1 string, key2 string) (*storage
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.TestMultiKeyStruct, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "TestMultiKeyStruct")
+
+	var objs []*storage.TestMultiKeyStruct
+	err := s.Walk(ctx, func(obj *storage.TestMultiKeyStruct) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
@@ -78,6 +78,10 @@ func (s *MultikeyStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(testMultiKeyStruct, foundTestMultiKeyStruct)
 
+	allTestMultiKeyStruct, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(testMultiKeyStruct, allTestMultiKeyStruct[0])
+
 	testMultiKeyStructCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, testMultiKeyStructCount)
@@ -106,6 +110,10 @@ func (s *MultikeyStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, testMultiKeyStructs))
+
+	allTestMultiKeyStruct, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(testMultiKeyStructs, allTestMultiKeyStruct)
 
 	testMultiKeyStructCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -92,6 +92,10 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal({{$name}}, found{{.TrimmedType|upperCamelCase}})
 
+	all{{.TrimmedType|upperCamelCase}}, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal({{$name}}, all{{.TrimmedType|upperCamelCase}}[0])
+
 	{{$name}}Count, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, {{$name}}Count)
@@ -133,6 +137,10 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
     }
 
 	s.NoError(store.UpsertMany(ctx, {{.TrimmedType|lowerCamelCase}}s))
+
+	all{{.TrimmedType|upperCamelCase}}, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal({{$name}}s, all{{.TrimmedType|upperCamelCase}})
 
     {{.TrimmedType|lowerCamelCase}}Count, err = store.Count(ctx)
     s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, key string) (bool, error)
 	Get(ctx context.Context, key string) (*storage.TestSingleKeyStruct, bool, error)
+	GetAll(ctx context.Context) ([]*storage.TestSingleKeyStruct, error)
 	Upsert(ctx context.Context, obj *storage.TestSingleKeyStruct) error
 	UpsertMany(ctx context.Context, objs []*storage.TestSingleKeyStruct) error
 	Delete(ctx context.Context, key string) error
@@ -318,6 +319,17 @@ func (s *storeImpl) Get(ctx context.Context, key string) (*storage.TestSingleKey
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.TestSingleKeyStruct, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "TestSingleKeyStruct")
+
+	var objs []*storage.TestSingleKeyStruct
+	err := s.Walk(ctx, func(obj *storage.TestSingleKeyStruct) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
@@ -78,6 +78,10 @@ func (s *SinglekeyStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(testSingleKeyStruct, foundTestSingleKeyStruct)
 
+	allTestSingleKeyStruct, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(testSingleKeyStruct, allTestSingleKeyStruct[0])
+
 	testSingleKeyStructCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, testSingleKeyStructCount)
@@ -106,6 +110,10 @@ func (s *SinglekeyStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, testSingleKeyStructs))
+
+	allTestSingleKeyStruct, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(testSingleKeyStructs, allTestSingleKeyStruct)
 
 	testSingleKeyStructCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestChild1, bool, error)
+	GetAll(ctx context.Context) ([]*storage.TestChild1, error)
 	Upsert(ctx context.Context, obj *storage.TestChild1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestChild1) error
 	Delete(ctx context.Context, id string) error
@@ -273,6 +274,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestChild1, bo
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.TestChild1, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "TestChild1")
+
+	var objs []*storage.TestChild1
+	err := s.Walk(ctx, func(obj *storage.TestChild1) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
@@ -78,6 +78,10 @@ func (s *Testchild1StoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(testChild1, foundTestChild1)
 
+	allTestChild1, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(testChild1, allTestChild1[0])
+
 	testChild1Count, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, testChild1Count)
@@ -106,6 +110,10 @@ func (s *Testchild1StoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, testChild1s))
+
+	allTestChild1, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(testChild1s, allTestChild1)
 
 	testChild1Count, err = store.Count(ctx)
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestChild2, bool, error)
+	GetAll(ctx context.Context) ([]*storage.TestChild2, error)
 	Upsert(ctx context.Context, obj *storage.TestChild2) error
 	UpsertMany(ctx context.Context, objs []*storage.TestChild2) error
 	Delete(ctx context.Context, id string) error
@@ -285,6 +286,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestChild2, bo
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.TestChild2, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "TestChild2")
+
+	var objs []*storage.TestChild2
+	err := s.Walk(ctx, func(obj *storage.TestChild2) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestG2GrandChild1, bool, error)
+	GetAll(ctx context.Context) ([]*storage.TestG2GrandChild1, error)
 	Upsert(ctx context.Context, obj *storage.TestG2GrandChild1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestG2GrandChild1) error
 	Delete(ctx context.Context, id string) error
@@ -285,6 +286,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestG2GrandChi
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.TestG2GrandChild1, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "TestG2GrandChild1")
+
+	var objs []*storage.TestG2GrandChild1
+	err := s.Walk(ctx, func(obj *storage.TestG2GrandChild1) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestG3GrandChild1, bool, error)
+	GetAll(ctx context.Context) ([]*storage.TestG3GrandChild1, error)
 	Upsert(ctx context.Context, obj *storage.TestG3GrandChild1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestG3GrandChild1) error
 	Delete(ctx context.Context, id string) error
@@ -273,6 +274,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestG3GrandChi
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.TestG3GrandChild1, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "TestG3GrandChild1")
+
+	var objs []*storage.TestG3GrandChild1
+	err := s.Walk(ctx, func(obj *storage.TestG3GrandChild1) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
@@ -78,6 +78,10 @@ func (s *Testg3grandchild1StoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(testG3GrandChild1, foundTestG3GrandChild1)
 
+	allTestG3GrandChild1, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(testG3GrandChild1, allTestG3GrandChild1[0])
+
 	testG3GrandChild1Count, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, testG3GrandChild1Count)
@@ -106,6 +110,10 @@ func (s *Testg3grandchild1StoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, testG3GrandChild1s))
+
+	allTestG3GrandChild1, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(testG3GrandChild1s, allTestG3GrandChild1)
 
 	testG3GrandChild1Count, err = store.Count(ctx)
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestGGrandChild1, bool, error)
+	GetAll(ctx context.Context) ([]*storage.TestGGrandChild1, error)
 	Upsert(ctx context.Context, obj *storage.TestGGrandChild1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestGGrandChild1) error
 	Delete(ctx context.Context, id string) error
@@ -273,6 +274,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestGGrandChil
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.TestGGrandChild1, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "TestGGrandChild1")
+
+	var objs []*storage.TestGGrandChild1
+	err := s.Walk(ctx, func(obj *storage.TestGGrandChild1) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
@@ -78,6 +78,10 @@ func (s *Testggrandchild1StoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(testGGrandChild1, foundTestGGrandChild1)
 
+	allTestGGrandChild1, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(testGGrandChild1, allTestGGrandChild1[0])
+
 	testGGrandChild1Count, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, testGGrandChild1Count)
@@ -106,6 +110,10 @@ func (s *Testggrandchild1StoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, testGGrandChild1s))
+
+	allTestGGrandChild1, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(testGGrandChild1s, allTestGGrandChild1)
 
 	testGGrandChild1Count, err = store.Count(ctx)
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestGrandChild1, bool, error)
+	GetAll(ctx context.Context) ([]*storage.TestGrandChild1, error)
 	Upsert(ctx context.Context, obj *storage.TestGrandChild1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestGrandChild1) error
 	Delete(ctx context.Context, id string) error
@@ -285,6 +286,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestGrandChild
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.TestGrandChild1, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "TestGrandChild1")
+
+	var objs []*storage.TestGrandChild1
+	err := s.Walk(ctx, func(obj *storage.TestGrandChild1) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestGrandparent, bool, error)
+	GetAll(ctx context.Context) ([]*storage.TestGrandparent, error)
 	Upsert(ctx context.Context, obj *storage.TestGrandparent) error
 	UpsertMany(ctx context.Context, objs []*storage.TestGrandparent) error
 	Delete(ctx context.Context, id string) error
@@ -450,6 +451,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestGrandparen
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.TestGrandparent, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "TestGrandparent")
+
+	var objs []*storage.TestGrandparent
+	err := s.Walk(ctx, func(obj *storage.TestGrandparent) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
@@ -78,6 +78,10 @@ func (s *TestgrandparentStoreSuite) TestStore() {
 	s.True(exists)
 	s.Equal(testGrandparent, foundTestGrandparent)
 
+	allTestGrandparent, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(testGrandparent, allTestGrandparent[0])
+
 	testGrandparentCount, err := store.Count(ctx)
 	s.NoError(err)
 	s.Equal(1, testGrandparentCount)
@@ -106,6 +110,10 @@ func (s *TestgrandparentStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, testGrandparents))
+
+	allTestGrandparent, err = store.GetAll(ctx)
+	s.NoError(err)
+	s.Equal(testGrandparents, allTestGrandparent)
 
 	testGrandparentCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestParent1, bool, error)
+	GetAll(ctx context.Context) ([]*storage.TestParent1, error)
 	Upsert(ctx context.Context, obj *storage.TestParent1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestParent1) error
 	Delete(ctx context.Context, id string) error
@@ -365,6 +366,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestParent1, b
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.TestParent1, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "TestParent1")
+
+	var objs []*storage.TestParent1
+	err := s.Walk(ctx, func(obj *storage.TestParent1) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestParent2, bool, error)
+	GetAll(ctx context.Context) ([]*storage.TestParent2, error)
 	Upsert(ctx context.Context, obj *storage.TestParent2) error
 	UpsertMany(ctx context.Context, objs []*storage.TestParent2) error
 	Delete(ctx context.Context, id string) error
@@ -279,6 +280,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestParent2, b
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.TestParent2, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "TestParent2")
+
+	var objs []*storage.TestParent2
+	err := s.Walk(ctx, func(obj *storage.TestParent2) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestParent3, bool, error)
+	GetAll(ctx context.Context) ([]*storage.TestParent3, error)
 	Upsert(ctx context.Context, obj *storage.TestParent3) error
 	UpsertMany(ctx context.Context, objs []*storage.TestParent3) error
 	Delete(ctx context.Context, id string) error
@@ -279,6 +280,17 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestParent3, b
 		return nil, false, err
 	}
 	return &msg, true, nil
+}
+
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.TestParent3, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "TestParent3")
+
+	var objs []*storage.TestParent3
+	err := s.Walk(ctx, func(obj *storage.TestParent3) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {


### PR DESCRIPTION
## Description

Although I had purposefully avoided adding this function because it's truly an anti-pattern (pagination-based is the correct way), many bolt stores do things like GetAll. So to facilitate migration, this is desired

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

unit test