### PR TITLE
Apply PF search widget overrides to Violations and Policy pages.

### DIFF
--- a/ui/apps/platform/src/Containers/Network/Header/NetworkSearch.css
+++ b/ui/apps/platform/src/Containers/Network/Header/NetworkSearch.css
@@ -1,38 +1,52 @@
 /*
-* This is a transitional stylesheet to make the classic NetworkSearch component (using ReduxSearchInput
-* under the hood) look closer to the PatternFly style. This should be removed when an equivalent
+* This is a transitional stylesheet to make the classic search component 
+* look closer to the PatternFly style. This should be removed when an equivalent
 * PatternFly component can be built.
 */
-.network-search * {
+
+.pf-search-shim.react-select--is-disabled {
+  /* 
+  * Note that this opacity change is a result of Tailwind styles that are applied
+  * throughout the app and *not* something that comes from PatternFly. When we are 
+  * fully migrated to PatternFly this rule should be removed.
+  */
+  opacity: 0.5;
+}
+
+.pf-search-shim.react-select--is-disabled > div {
+  background-color: var(--pf-global--disabled-color--300) !important;
+}
+
+.pf-search-shim * {
   font-family: var(--pf-global--FontFamily--sans-serif) !important;
 }
 
-.network-search > div > span,
-.network-search > div .react-select__value-container * {
+.pf-search-shim > div > span,
+.pf-search-shim > div .react-select__value-container * {
   color: var(--pf-global--Color--100) !important;
   font-weight: var(--pf-global--FontWeight--normal) !important;
 }
 
-.network-search > div .react-select__value-container span {
+.pf-search-shim > div .react-select__value-container span {
   font-size: var(--pf-global--FontSize--md) !important;
 }
 
-.network-search svg {
+.pf-search-shim svg {
   fill: var(--pf-global--Color--100);
 }
 
-.network-search > .react-select__control {
+.pf-search-shim > .react-select__control {
   border-radius: 0 !important;
   border-width: var(--pf-global--BorderWidth--sm) !important;
   border-bottom-color: var(	--pf-global--BorderColor--200) !important;
   min-height: 36px !important;
 }
 
-.network-search .react-select__indicator-separator {
+.pf-search-shim .react-select__indicator-separator {
   display: none;
 }
 
-.network-search .react-select__multi-value__label {
+.pf-search-shim .react-select__multi-value__label {
   color: var(--pf-global--Color--100) !important;
   font-size: var(--pf-global--FontSize--xs) !important;
 }

--- a/ui/apps/platform/src/Containers/Network/Header/NetworkSearch.js
+++ b/ui/apps/platform/src/Containers/Network/Header/NetworkSearch.js
@@ -41,7 +41,7 @@ function NetworkSearch({
 
     return (
         <ReduxSearchInput
-            className="pf-u-w-100 network-search"
+            className="pf-u-w-100 pf-search-shim"
             placeholder="Add one or more deployment filters"
             searchOptions={searchOptions}
             searchModifiers={searchModifiers}

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -270,7 +270,7 @@ function PoliciesTable({
                             className="pf-u-flex-grow-1 pf-u-flex-shrink-1"
                         >
                             <SearchFilterInput
-                                className="w-full theme-light"
+                                className="w-full theme-light pf-search-shim"
                                 handleChangeSearchFilter={handleChangeSearchFilter}
                                 placeholder="Filter policies"
                                 searchCategory="POLICIES"

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -162,7 +162,7 @@ function ViolationsTablePage(): ReactElement {
                 <Title headingLevel="h1">Violations</Title>
                 <Divider className="pf-u-py-md" />
                 <SearchFilterInput
-                    className="theme-light"
+                    className="theme-light pf-search-shim"
                     handleChangeSearchFilter={setSearchFilter}
                     placeholder="Filter violations"
                     searchCategory={searchCategory}


### PR DESCRIPTION
## Description

In working on the Network page I noticed that the search bar `disabled` style was not correctly applied like other input elements on the page. This adds CSS rules to match the other page widgets when in the disabled state.

In addition to the style fixes, this also applies the PatternFly style overrides to the other places the widget is used in the app, Violations and Policies. Eventually we will need to replace the code for this widget, but short term adding the `pf-search-shim` class will help it blend in better on PF styled pages.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Test style and functionality on Violations page:
![image](https://user-images.githubusercontent.com/1292638/166798001-45c69880-ac14-4d40-8ab9-6e6b13e6bf66.png)

Test style and functionality on Policies page:
![image](https://user-images.githubusercontent.com/1292638/166798424-9cdcb794-9024-4947-92e7-3b41419d8784.png)

Test disabled styles on Network page:
![image](https://user-images.githubusercontent.com/1292638/166798911-9396b41e-38a8-4fff-93c5-57bbd53cb3cb.png)

