### PR TITLE
ROX-6284: Replace beforeEach in risk integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/RiskPage.js
+++ b/ui/apps/platform/cypress/constants/RiskPage.js
@@ -8,13 +8,17 @@ import scopeSelectors from '../helpers/scopeSelectors';
 
 export const url = '/main/risk';
 
+/*
+// TODO after PatternFly conversion: update if relevant or delete if not relevant.
 export const errorMessages = {
     deploymentNotFound: 'Deployment not found',
     riskNotFound: 'Risk not found',
     processNotFound: 'No processes discovered',
 };
+*/
 
-const sidePanelSelectors = scopeSelectors('[data-testid="panel"]:eq(1)', {
+const sidePanel = scopeSelectors('[data-testid="panel"]:eq(1)', {
+    panelHeader: '[data-testid="panel-header"]',
     firstProcessCard: scopeSelectors('[data-testid="process-discovery-card"]:first', {
         header: '[data-testid="process"]',
         tags: {
@@ -81,6 +85,7 @@ const eventTimelineSelectors = scopeSelectors('[data-testid="event-timeline"]', 
 export const selectors = {
     risk: `${navigationSelectors.navLinks}:contains("Risk")`,
     errMgBox: 'div.error-message',
+    panel: '[data-testid="panel"]',
     panelTabs: {
         riskIndicators: 'button[data-testid="tab"]:contains("Risk Indicators")',
         deploymentDetails: 'button[data-testid="tab"]:contains("Deployment Details")',
@@ -88,6 +93,7 @@ export const selectors = {
     },
     cancelButton: 'button[data-testid="cancel"]',
     search: {
+        valueContainer: '.react-select__value-container',
         searchLabels: '.react-select__multi-value__label',
         // selectors for legacy tests
         searchModifier: '.react-select__multi-value__label:first',
@@ -108,7 +114,7 @@ export const selectors = {
     },
     suspiciousProcesses: "[data-testid='suspicious-process']",
     viewDeploymentsInNetworkGraphButton: '[data-testid="view-deployments-in-network-graph-button"]',
-    sidePanel: sidePanelSelectors,
+    sidePanel,
     commentsDialog: commentsDialogSelectors,
     eventTimeline: eventTimelineSelectors,
     eventTimelineOverview: eventTimelineOverviewSelectors,

--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -1,9 +1,8 @@
-import { selectors as RiskPageSelectors, url, errorMessages } from '../../constants/RiskPage';
-import { selectors as searchSelectors } from '../../constants/SearchPage';
-import * as api from '../../constants/apiEndpoints';
+import { selectors as RiskPageSelectors } from '../../constants/RiskPage';
 import withAuth from '../../helpers/basicAuth';
 import {
     visitRiskDeployments,
+    visitRiskDeploymentsWithSearchQuery,
     viewRiskDeploymentByName,
     viewRiskDeploymentInNetworkGraph,
 } from '../../helpers/risk';
@@ -11,102 +10,94 @@ import {
 describe('Risk page', () => {
     withAuth();
 
-    describe('with mock API', () => {
-        beforeEach(() => {
-            cy.intercept('GET', api.risks.riskyDeployments, {
-                fixture: 'risks/riskyDeployments.json',
-            }).as('deployments');
-            cy.intercept('GET', api.risks.deploymentsCount).as('deploymentsCount');
-
-            cy.visit(url);
-            cy.wait('@deployments');
-            cy.wait('@deploymentsCount');
-        });
-
-        const mockGetDeployment = () => {
-            cy.intercept('GET', api.risks.fetchDeploymentWithRisk, {
-                fixture: 'risks/firstDeployment.json',
-            }).as('firstDeployment');
-        };
-
+    describe('without mock API', () => {
         it('should have selected item in nav bar', () => {
+            visitRiskDeployments();
+
             cy.get(RiskPageSelectors.risk).should('have.class', 'pf-m-current');
         });
 
         it('should sort priority in the table', () => {
-            cy.get(RiskPageSelectors.table.column.priority).click({ force: true }); // ascending
-            cy.get(RiskPageSelectors.table.column.priority).click({ force: true }); // descending
-            cy.get(RiskPageSelectors.table.row.firstRow).should('contain', '3');
+            visitRiskDeployments();
+
+            const priorityColumnHeadingSelector = `${RiskPageSelectors.table.columnHeaders}:contains("Priority")`;
+
+            // Default is not sorted by priority.
+            cy.get(priorityColumnHeadingSelector)
+                .should('not.have.class', '-sort-asc')
+                .should('not.have.class', '-sort-desc');
+
+            // Sort ascending by priority.
+            cy.get(priorityColumnHeadingSelector).click();
+            cy.location('search').should(
+                'eq',
+                '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=false'
+            );
+            // Why no request here?
+            cy.get(priorityColumnHeadingSelector).should('have.class', '-sort-asc');
+            cy.get(`${RiskPageSelectors.table.dataRows} .rt-td:nth-child(5)`).then(
+                ($priorityCells) => {
+                    const firstCellPriority = Number($priorityCells.eq(0).text());
+                    const lastCellPriority = Number(
+                        $priorityCells.eq($priorityCells.length - 1).text()
+                    );
+                    expect(lastCellPriority).to.be.at.least(firstCellPriority);
+                }
+            );
+
+            // Sort descending by priority.
+            cy.get(priorityColumnHeadingSelector).click();
+            cy.location('search').should(
+                'eq',
+                '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=true'
+            );
+            cy.wait('@getDeploymentsWithProcessInfo'); // assume intercept in visitRiskDeployments
+            cy.get(priorityColumnHeadingSelector).should('have.class', '-sort-desc');
+            cy.get(`${RiskPageSelectors.table.dataRows} .rt-td:nth-child(5)`).then(
+                ($priorityCells) => {
+                    const firstCellPriority = Number($priorityCells.eq(0).text());
+                    const lastCellPriority = Number(
+                        $priorityCells.eq($priorityCells.length - 1).text()
+                    );
+                    expect(firstCellPriority).to.be.at.least(lastCellPriority);
+                }
+            );
         });
 
-        it('should highlight selected deployment row', () => {
-            cy.get(RiskPageSelectors.table.row.firstRow)
-                .click({ force: true })
-                .should('have.class', 'row-active');
+        it('should open side panel for deployment', () => {
+            visitRiskDeployments();
+            viewRiskDeploymentByName('collector');
         });
 
-        it('should display deployment error message in panel', () => {
-            cy.get(RiskPageSelectors.table.row.firstRow).click({ force: true });
-            cy.get(RiskPageSelectors.errMgBox).contains(errorMessages.deploymentNotFound);
-        });
-
-        it('should display error message in process discovery tab', () => {
-            mockGetDeployment();
-            cy.get(RiskPageSelectors.table.row.firstRow).click({ force: true });
-            cy.wait('@firstDeployment');
-
-            cy.get(RiskPageSelectors.panelTabs.processDiscovery).click();
-            cy.get(RiskPageSelectors.errMgBox).contains(errorMessages.processNotFound);
-            cy.get(RiskPageSelectors.cancelButton).click();
-        });
+        // TODO add relevant tests for error messages in PatternFly
 
         it('should open the panel to view risk indicators', () => {
-            mockGetDeployment();
-            cy.get(RiskPageSelectors.table.row.firstRow).click({ force: true });
-            cy.wait('@firstDeployment');
+            visitRiskDeployments();
+            viewRiskDeploymentByName('collector');
 
+            cy.get(RiskPageSelectors.panel).should('have.length', 2); // main panel and side panel
             cy.get(RiskPageSelectors.panelTabs.riskIndicators);
             cy.get(RiskPageSelectors.cancelButton).click();
+            cy.get(RiskPageSelectors.panel).should('have.length', 1); // main panel
         });
 
         it('should open the panel to view deployment details', () => {
-            mockGetDeployment();
-            cy.get(RiskPageSelectors.table.row.firstRow).click({ force: true });
-            cy.wait('@firstDeployment');
+            visitRiskDeployments();
+            viewRiskDeploymentByName('collector');
 
+            cy.get(RiskPageSelectors.panel).should('have.length', 2); // main panel and side panel
             cy.get(RiskPageSelectors.panelTabs.deploymentDetails);
             cy.get(RiskPageSelectors.cancelButton).click();
+            cy.get(RiskPageSelectors.panel).should('have.length', 1); // main panel
         });
 
         it('should navigate from Risk Page to Vulnerability Management Image Page', () => {
-            mockGetDeployment();
-            cy.get(RiskPageSelectors.table.row.firstRow).click({ force: true });
-            cy.wait('@firstDeployment');
+            visitRiskDeployments();
+            viewRiskDeploymentByName('collector');
 
-            cy.get(RiskPageSelectors.panelTabs.deploymentDetails).click({ force: true });
-            cy.get(RiskPageSelectors.imageLink).first().click({ force: true });
-            cy.url().should('contain', '/main/vulnerability-management/image');
-        });
-
-        it.skip('should close the side panel on search filter', () => {
-            mockGetDeployment();
-            cy.get(RiskPageSelectors.table.row.firstRow).click({ force: true });
-            cy.wait('@firstDeployment');
-
-            // The side panel opens to display the first deployment.
-            // Use tabs as the criterion, because both the main and side panels have
-            // [data-testid="panel"] nor [data-testid="panel-header"]
-            cy.get(RiskPageSelectors.sidePanel.tabs);
-
-            // TODO skip this test because Platform UI does not close the side panel,
-            // even if the deployment does not match the search filter.
-            // Assuming that the behavior changes, to make this test work,
-            // it is necessary to mock the requests with search filter.
-            // See the corresponding test in violations/violations.test.js
-            cy.get(searchSelectors.pageSearch.input).type('Cluster:{enter}', { force: true });
-            cy.get(searchSelectors.pageSearch.input).type('remote{enter}', { force: true });
-            cy.get(searchSelectors.pageSearch.input).type('{esc}'); // close the drop-down menu
-            cy.get(RiskPageSelectors.sidePanel.tabs).should('not.exist');
+            cy.get(RiskPageSelectors.panelTabs.deploymentDetails).click();
+            cy.get(RiskPageSelectors.imageLink).first().click();
+            cy.location('pathname').should('contain', '/main/vulnerability-management/image');
         });
     });
 
@@ -118,97 +109,113 @@ describe('Risk page', () => {
 
             cy.location('pathname').should('match', /^\/main\/network\/[-0-9a-z]+$/);
         });
-    });
 
-    describe('search with URL parameters, actual API', () => {
-        beforeEach(() => {
-            cy.intercept('GET', api.risks.riskyDeployments).as('deployments');
-            cy.intercept('GET', api.risks.deploymentsCount).as('deploymentsCount');
-
-            cy.visit(url);
-            cy.wait('@deployments');
-            cy.wait('@deploymentsCount');
-        });
+        const searchPlaceholderText = 'Add one or more resource filters';
 
         it('should not have anything in search bar when URL has no search params', () => {
+            visitRiskDeployments();
+
+            // Positive assertion:
+            cy.get(RiskPageSelectors.search.valueContainer).should(
+                'have.text',
+                searchPlaceholderText
+            );
+            // Negative assertion:
             cy.get(RiskPageSelectors.search.searchLabels).should('not.exist');
         });
 
         it('should have a single URL search param key/value pair in its search bar', () => {
+            visitRiskDeployments();
+
             const nsOption = 'Namespace';
             const nsValue = 'stackrox';
-            cy.get(RiskPageSelectors.table.dataRows)
-                .filter(`:contains("${nsValue}")`)
-                .then((stackroxDeps) => {
-                    const stackroxCount = stackroxDeps.length;
+            cy.get(
+                `${RiskPageSelectors.table.dataRows} .rt-td:nth-child(4):contains("${nsValue}")`
+            ).then((stackroxDeps) => {
+                const stackroxCount = stackroxDeps.length;
 
-                    const urlWithSearch = `${url}?s[${nsOption}]=${nsValue}`;
-                    cy.visit(urlWithSearch);
-                    cy.get(RiskPageSelectors.search.searchLabels)
-                        .should('have.length', 2)
-                        .each(($el, index) => {
-                            if (index === 0) {
-                                expect($el.text()).to.equal(`${nsOption}:`);
-                            } else {
-                                expect($el.text()).to.equal(nsValue);
-                            }
-                        });
+                visitRiskDeploymentsWithSearchQuery(`?s[${nsOption}]=${nsValue}`);
 
-                    cy.get(RiskPageSelectors.table.dataRows).should('have.length', stackroxCount);
-                });
+                // Negative assertion:
+                cy.get(RiskPageSelectors.search.valueContainer).should(
+                    'not.have.text',
+                    searchPlaceholderText
+                );
+                // Positive assertions:
+                cy.get(RiskPageSelectors.search.searchLabels).should('have.length', 2);
+                cy.get(`${RiskPageSelectors.search.searchLabels}:nth(0)`).should(
+                    'have.text',
+                    `${nsOption}:`
+                );
+                cy.get(`${RiskPageSelectors.search.searchLabels}:nth(1)`).should(
+                    'have.text',
+                    nsValue
+                );
+
+                cy.get(RiskPageSelectors.table.dataRows).should('have.length', stackroxCount);
+            });
         });
 
         it('should have multiple URL search param key/value pairs in its search bar', () => {
+            visitRiskDeployments();
+
             const nsOption = 'Namespace';
             const nsValue = 'stackrox';
             const deployOption = 'Deployment';
             const deployValue = 'scanner';
-            cy.get(RiskPageSelectors.table.dataRows)
-                .filter(`:contains("${deployValue}")`)
-                .then((staticDeps) => {
-                    const staticCount = staticDeps.length;
+            cy.get(
+                `${RiskPageSelectors.table.dataRows} .rt-td:nth-child(1):contains("${deployValue}")`
+            ).then((staticDeps) => {
+                const staticCount = staticDeps.length;
 
-                    const urlWithSearch = `${url}?s[${nsOption}]=${nsValue}&s[${deployOption}]=${deployValue}`;
-                    cy.visit(urlWithSearch);
+                visitRiskDeploymentsWithSearchQuery(
+                    `?s[${nsOption}]=${nsValue}&s[${deployOption}]=${deployValue}`
+                );
 
-                    cy.get(RiskPageSelectors.search.searchLabels)
-                        .should('have.length', 4)
-                        .each(($el, index) => {
-                            // $el is a wrapped jQuery element
-                            switch (index) {
-                                case 0: {
-                                    expect($el.text()).to.equal(`${nsOption}:`);
-                                    break;
-                                }
-                                case 1: {
-                                    expect($el.text()).to.equal(`${nsValue}`);
-                                    break;
-                                }
-                                case 2: {
-                                    expect($el.text()).to.equal(`${deployOption}:`);
-                                    break;
-                                }
-                                case 3:
-                                default: {
-                                    expect($el.text()).to.equal(`${deployValue}`);
-                                    break;
-                                }
-                            }
-                        });
+                // Negative assertion:
+                cy.get(RiskPageSelectors.search.valueContainer).should(
+                    'not.have.text',
+                    searchPlaceholderText
+                );
+                // Positive assertions:
+                cy.get(RiskPageSelectors.search.searchLabels).should('have.length', 4);
+                cy.get(`${RiskPageSelectors.search.searchLabels}:nth(0)`).should(
+                    'have.text',
+                    `${nsOption}:`
+                );
+                cy.get(`${RiskPageSelectors.search.searchLabels}:nth(1)`).should(
+                    'have.text',
+                    nsValue
+                );
+                cy.get(`${RiskPageSelectors.search.searchLabels}:nth(2)`).should(
+                    'have.text',
+                    `${deployOption}:`
+                );
+                cy.get(`${RiskPageSelectors.search.searchLabels}:nth(3)`).should(
+                    'have.text',
+                    deployValue
+                );
 
-                    cy.get(RiskPageSelectors.table.dataRows).should('have.length', staticCount);
-                });
+                cy.get(RiskPageSelectors.table.dataRows).should('have.length', staticCount);
+            });
         });
 
         it('should not use invalid URL search param key/value pair in its search bar', () => {
+            visitRiskDeployments();
+
             const sillyOption = 'Wingardium';
             const sillyValue = 'leviosa';
-            cy.get(RiskPageSelectors.table.dataRows).then((stackroxDeps) => {
-                const allCount = stackroxDeps.length;
+            cy.get(RiskPageSelectors.table.dataRows).then((allDeps) => {
+                const allCount = allDeps.length;
 
-                const urlWithSearch = `${url}?s[${sillyOption}]=${sillyValue}`;
-                cy.visit(urlWithSearch);
+                visitRiskDeploymentsWithSearchQuery(`?s[${sillyOption}]=${sillyValue}`);
 
+                // Positive assertion:
+                cy.get(RiskPageSelectors.search.valueContainer).should(
+                    'have.text',
+                    searchPlaceholderText
+                );
+                // Negative assertion:
                 cy.get(RiskPageSelectors.search.searchLabels).should('not.exist');
 
                 cy.get(RiskPageSelectors.table.dataRows).should('have.length', allCount);


### PR DESCRIPTION
## Description

### Goal

* For each test, decide which helper function to call for actual or mock requests instead of letting `beforeEach` decide.
* Group tests by subject instead of by shared setup.

Find `beforeEach` in cypress/integration: from 14 results in 10 files to 12 results in 9 files.

### Problem

Risk page search with URL parameters, actual API should have a single URL search param key/value pair in its search bar

AssertionError: Timed out retrying: Expected to find element: {{[data-testid="panel"]:first .rt-tbody .rt-tr-group .rt-tr}}, but never found it.

### Analysis

Last occurrence of failure was in 2021-01-08 so artifacts are unavailable to investigate.

This test made many requests with few wait calls:
* Visit **without** search query made a pair of requests before 2021-09-08 https://github.com/stackrox/rox/pull/9309
* Tests that visit page with search query do not wait for requests before assertion about number of table rows.
* Visit **with** search query makes a pair of requests before and after response for search options.
* If requests have a delay or an error, it is possible for assertions about search filter to pass, but assertion about table rows to fail.

### Changed files

1. constants/RiskPage.js
    * Comment out error messages pending PatternFly rewrite
    * Add `panelHeader`, `panel`, and `valueContainer` selectors

2. helpers/risk.js
    * Replace `cy.visit` with `visit` in `visitRiskDeployments` function
    * Add intercept and wait for searchOptions in `visitRiskDeployments` function
    * Add wait for heading in `visitRiskDeployments` function
    * Add `visitRiskDeploymentsWithSearchQuery` function to encapsulate requests in case future improvements to RiskTablePanel replace double pair with single pair of requests
    * Add assertions for side panel header to `viewRiskDeploymentByName` function

3. integration/risk/risk.test.js
    * Did not remove `as RiskPageSelectors` because it ruined alignment of common lines in changed files
    * Rewrite several tests to not need mock api
    * Delete `{ force: true }` option from `click` method
    * Omit assertion for active row because it will not be relevant for PatternFly
    * Replace tests for error messages with TODO comment for PatternFly
    * Balance negative assertions and positive assertions about search filter
    * Replace method chains with selectors and call helper function for second visit
    * Replace `cy.url` with more precise `cy.location` assertions
    * Delete skipped test because will not be relevant for PatternFly

### Residue

* Investigate duplicate /v1/processes/deployment/:deploymentId/grouped/container request to view deployment

## Checklist
- [x] Investigated and inspected CI test results
- [x] Rewrote integration tests

## Testing Performed

Ran tests one at a time in local deployment