### PR TITLE
ROX-10810: Add back trigger backup for S3 and GCS

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
@@ -53,10 +53,6 @@ function IntegrationsListPage({
         setDeletingIntegrationIds(ids);
     }
 
-    function onTriggerBackup(id) {
-        triggerBackup(id);
-    }
-
     function onConfirmDeletingIntegrationIds() {
         if (isAPIToken) {
             revokeAPITokens(deletingIntegrationIds);
@@ -101,7 +97,7 @@ function IntegrationsListPage({
                     integrations={integrations}
                     hasMultipleDelete={!isClusterInitBundle}
                     onDeleteIntegrations={onDeleteIntegrations}
-                    onTriggerBackup={onTriggerBackup}
+                    onTriggerBackup={triggerBackup}
                 />
             </PageSection>
             {isAPIToken && (

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
@@ -36,6 +36,7 @@ import DeleteClusterInitBundleConfirmationModal from './DeleteClusterInitBundleC
 
 function IntegrationsListPage({
     deleteIntegrations,
+    triggerBackup,
     fetchClusterInitBundles,
     revokeAPITokens,
 }): ReactElement {
@@ -50,6 +51,10 @@ function IntegrationsListPage({
 
     function onDeleteIntegrations(ids) {
         setDeletingIntegrationIds(ids);
+    }
+
+    function onTriggerBackup(id) {
+        triggerBackup(id);
     }
 
     function onConfirmDeletingIntegrationIds() {
@@ -96,6 +101,7 @@ function IntegrationsListPage({
                     integrations={integrations}
                     hasMultipleDelete={!isClusterInitBundle}
                     onDeleteIntegrations={onDeleteIntegrations}
+                    onTriggerBackup={onTriggerBackup}
                 />
             </PageSection>
             {isAPIToken && (
@@ -143,6 +149,7 @@ function IntegrationsListPage({
 
 const mapDispatchToProps = {
     deleteIntegrations: integrationsActions.deleteIntegrations,
+    triggerBackup: integrationsActions.triggerBackup,
     fetchClusterInitBundles: clusterInitBundlesActions.fetchClusterInitBundles.request,
     revokeAPITokens: apitokensActions.revokeAPITokens,
 };

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -153,7 +153,8 @@ function IntegrationsTable({
                                     {
                                         title: 'Trigger backup',
                                         onClick: () => onTriggerBackup(integration.id),
-                                        isHidden: integration.type !== 's3',
+                                        isHidden:
+                                            integration.type !== 's3' && integration.type !== 'gcs',
                                     },
                                     {
                                         title: (

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -149,12 +149,13 @@ function IntegrationsTable({
                         <Tbody>
                             {integrations.map((integration, rowIndex) => {
                                 const { id } = integration;
+                                const canTriggerBackup =
+                                    integration.type === 's3' || integration.type === 'gcs';
                                 const actionItems = [
                                     {
                                         title: 'Trigger backup',
                                         onClick: () => onTriggerBackup(integration.id),
-                                        isHidden:
-                                            integration.type !== 's3' && integration.type !== 'gcs',
+                                        isHidden: !canTriggerBackup,
                                     },
                                     {
                                         title: (

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -38,12 +38,14 @@ type IntegrationsTableProps = {
     integrations: Integration[];
     hasMultipleDelete: boolean;
     onDeleteIntegrations: (integration) => void;
+    onTriggerBackup: (integrationId) => void;
 };
 
 function IntegrationsTable({
     integrations,
     hasMultipleDelete,
     onDeleteIntegrations,
+    onTriggerBackup,
 }: IntegrationsTableProps): React.ReactElement {
     const permissions = useIntegrationPermissions();
     const { source, type } = useParams();
@@ -149,6 +151,11 @@ function IntegrationsTable({
                                 const { id } = integration;
                                 const actionItems = [
                                     {
+                                        title: 'Trigger backup',
+                                        onClick: () => onTriggerBackup(integration.id),
+                                        isHidden: integration.type !== 's3',
+                                    },
+                                    {
                                         title: (
                                             <Link to={getPathToEdit(source, type, id)}>
                                                 Edit integration
@@ -156,6 +163,7 @@ function IntegrationsTable({
                                         ),
                                         isHidden: isAPIToken || isClusterInitBundle,
                                     },
+
                                     {
                                         title: (
                                             <div className="pf-u-danger-color-100">

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -165,7 +165,6 @@ function IntegrationsTable({
                                         ),
                                         isHidden: isAPIToken || isClusterInitBundle,
                                     },
-
                                     {
                                         title: (
                                             <div className="pf-u-danger-color-100">


### PR DESCRIPTION
## Description

With the migration of the Integrations page to PF, we had removed the option to "Trigger backups" for S3 integrations. This adds that back

Edit: Also for GCS

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

<img width="1552" alt="Screen Shot 2022-05-04 at 2 15 21 PM" src="https://user-images.githubusercontent.com/4805485/166828675-6c72d376-e0b5-4912-be6b-ae967277ee83.png">
<img width="1552" alt="Screen Shot 2022-05-04 at 2 27 28 PM" src="https://user-images.githubusercontent.com/4805485/166828681-11529ce0-53cc-4f5b-803a-0a00b660dc1a.png">