### PR TITLE
OpenShift CI: Some common handling for job gating

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -641,8 +641,9 @@ commands:
             source scripts/ci/lib.sh
             # gate_job() exits with 0 when a job should *not* be run in keeping
             # with OpenShift CI semantics.
-            (gate_job '<< parameters.job >>'; exit 1)
-            if [[ "$?" == "0" ]]; then
+            exitstatus=0
+            (gate_job '<< parameters.job >>'; exit 1) || exitstatus="$?"
+            if [[ "$exitstatus" == "0" ]]; then
               echo "Not running tests"
               circleci step halt
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -629,6 +629,24 @@ commands:
           echo "Not running tests"
           circleci step halt
 
+  gate-job:
+    description: Decide whether to run a job
+    parameters:
+      job:
+        type: string
+    steps:
+      - run:
+          name: Decide whether to run << parameters.job >>
+          command: |
+            source scripts/ci/lib.sh
+            # gate_job() exits with 0 when a job should *not* be run in keeping
+            # with OpenShift CI semantics.
+            (gate_job '<< parameters.job >>'; exit 1)
+            if [[ "$?" == "0" ]]; then
+              echo "Not running tests"
+              circleci step halt
+            fi
+
   get-and-store-debug-dump:
     description: Runs roxctl debug dump and stores it for the job.
     steps:
@@ -3016,15 +3034,8 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - check-backend-changes
-      - check-to-run:
-          label: ci-upgrade-tests
-          run-on-master: true
-          run-on-tags: true
-          changed-path: '^migrator/.*$|^image/'
-      - check-label-to-skip-tests:
-          label: ci-no-upgrade-tests
-
+      - gate-job:
+          job: gke-upgrade-tests
       - provision-gke-cluster:
           cluster-id: upgrade-test
 
@@ -3706,14 +3717,8 @@ jobs:
       LOAD_BALANCER: "lb"
     steps:
       - checkout
-      - check-backend-changes
-      - check-to-run:
-          label: ci-upgrade-tests
-          run-on-master: true
-          run-on-tags: true
-          changed-path: '^migrator/.*$|^image/'
-      - check-label-to-skip-tests:
-          label: ci-no-upgrade-tests
+      - gate-job:
+          job: gke-upgrade-tests
       - attach_workspace:
           at: /go/src/github.com/stackrox/rox
       - restore-go-mod-cache

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -27,6 +27,8 @@ fi
 ci_job="$1"
 shift
 
+gate_job "$ci_job"
+
 case "$ci_job" in
     style-checks)
         make style

--- a/scripts/ci/gate-jobs-config.json
+++ b/scripts/ci/gate-jobs-config.json
@@ -1,0 +1,10 @@
+{
+    "gke-upgrade-tests": {
+        "run_with_labels": ["ci-upgrade-tests"],
+        "skip_with_label": "ci-no-upgrade-tests",
+        "run_with_changed_path": "^migrator/.*$|^image/",
+        "changed_path_to_ignore": "",
+        "run_on_master": "true",
+        "run_on_tags": "true"
+    }
+}

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -488,7 +488,7 @@ get_pr_details() {
 
     url="https://api.github.com/repos/${org}/${repo}/pulls/${pull_request}"
     pr_details=$(curl -sS "${headers[@]}" "${url}")
-    if [[ "$(jq .id <<<"$pr_details")" != "null" ]]; then
+    if [[ "$(jq .id <<<"$pr_details")" == "null" ]]; then
         # A valid PR response is expected at this point
         echo "Invalid response from GitHub: $pr_details"
         exit 2

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -544,6 +544,8 @@ gate_pr_job() {
         elif is_OPENSHIFT_CI; then
             diff_base="$(jq -r '.refs[0].base_sha' <<<"$CLONEREFS_OPTIONS")"
             echo "Determined diff-base as ${diff_base}"
+        else
+            die "unsupported"
         fi
         echo "Diffbase diff:"
         { git diff --name-only "${diff_base}" | cat ; } || true
@@ -576,7 +578,13 @@ gate_merge_job() {
     esac
 
     local base_ref
-    base_ref="$(jq -r '.refs[0].base_ref' <<<"$CLONEREFS_OPTIONS")"
+    if is_CIRCLECI; then
+        base_ref="${CIRCLE_BRANCH}"
+    elif is_OPENSHIFT_CI; then
+        base_ref="$(jq -r '.refs[0].base_ref' <<<"$CLONEREFS_OPTIONS")"
+    else
+        die "unsupported"
+    fi
 
     if [[ "${base_ref}" == "master" && "${run_on_master}" == "true" ]]; then
         info "$job will run because this is master and run_on_master==true"


### PR DESCRIPTION
## Description

This PR provides similar job run gating for OpenShift CI that is used throughout Circle CI. And applies it to the `gke-api-upgrade-tests` for coverage.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] in a run that does not add labels, tags, or change related files, `gke-api-upgrade-tests` will not run.
- [x] it will run if a tag is pushed to the branch.
- [x] add the label and it will run.
- [x] remove the label and make a change to one of the regex paths and it will run.
- [x] it won't run if labeled not to (and a path is changed).