### PR TITLE
ROX-10823: Add tests for replaced resources.

### DIFF
--- a/central/analystnotes/access_control_test.go
+++ b/central/analystnotes/access_control_test.go
@@ -1,0 +1,58 @@
+package analystnotes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/grpc/authn"
+	"github.com/stackrox/rox/pkg/grpc/authn/mocks"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommentIsDeletable(t *testing.T) {
+	comment := &storage.Comment{
+		User: &storage.Comment_User{Id: "1"},
+	}
+	identity := mocks.NewMockIdentity(gomock.NewController(t))
+
+	// 1. Comment is not deletable with no access to any resource.
+	noAccessCtx := sac.WithNoAccess(context.Background())
+	assert.False(t, CommentIsDeletable(noAccessCtx, comment))
+
+	// 2. Comment is deletable when it's the user's own comment.
+	identity.EXPECT().User().Return(nil)
+	identity.EXPECT().UID().Return("1")
+	identity.EXPECT().FullName().Return("name")
+	identity.EXPECT().FriendlyName().Return("name")
+
+	commentOwnerCtx := authn.ContextWithIdentity(context.Background(), identity, t)
+	assert.True(t, CommentIsDeletable(commentOwnerCtx, comment))
+
+	// 3. Comment is deletable when user has access to the AllComments resource.
+	identity.EXPECT().User().Return(nil)
+	identity.EXPECT().UID().Return("2")
+	identity.EXPECT().FullName().Return("name")
+	identity.EXPECT().FriendlyName().Return("name")
+	identity.EXPECT().Permissions().Return(map[string]storage.Access{
+		resources.AllComments.String(): storage.Access_READ_WRITE_ACCESS,
+	})
+
+	allCommentsAccessCtx := authn.ContextWithIdentity(context.Background(), identity, t)
+	assert.True(t, CommentIsDeletable(allCommentsAccessCtx, comment))
+
+	// 4. Comment is deletable when user has access to the Administration resource.
+	identity.EXPECT().User().Return(nil)
+	identity.EXPECT().UID().Return("2")
+	identity.EXPECT().FullName().Return("name")
+	identity.EXPECT().FriendlyName().Return("name")
+	identity.EXPECT().Permissions().Return(map[string]storage.Access{
+		resources.Administration.String(): storage.Access_READ_WRITE_ACCESS,
+	})
+
+	administrationAccessCtx := authn.ContextWithIdentity(context.Background(), identity, t)
+	assert.True(t, CommentIsDeletable(administrationAccessCtx, comment))
+}

--- a/central/authprovider/datastore/datastore_impl_test.go
+++ b/central/authprovider/datastore/datastore_impl_test.go
@@ -96,6 +96,8 @@ type authProviderDataStoreTestSuite struct {
 	hasReadCtx  context.Context
 	hasWriteCtx context.Context
 
+	hasWriteAccessCtx context.Context
+
 	storage   *storeMocks.MockStore
 	dataStore authproviders.Store
 
@@ -112,6 +114,10 @@ func (s *authProviderDataStoreTestSuite) SetupTest() {
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.AuthProvider)))
+	s.hasWriteAccessCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Access)))
 
 	s.mockCtrl = gomock.NewController(s.T())
 	s.storage = storeMocks.NewMockStore(s.mockCtrl)
@@ -124,11 +130,14 @@ func (s *authProviderDataStoreTestSuite) TearDownTest() {
 }
 
 func (s *authProviderDataStoreTestSuite) TestAllowsAdd() {
-	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil)
-	s.storage.EXPECT().Exists(gomock.Any(), gomock.Any()).Return(false, nil)
+	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	s.storage.EXPECT().Exists(gomock.Any(), gomock.Any()).Return(false, nil).Times(2)
 
 	err := s.dataStore.AddAuthProvider(s.hasWriteCtx, &storage.AuthProvider{})
 	s.NoError(err, "expected no error trying to write with permissions")
+
+	err = s.dataStore.AddAuthProvider(s.hasWriteAccessCtx, &storage.AuthProvider{})
+	s.NoError(err, "expected no error trying to write with Access permission")
 }
 
 func (s *authProviderDataStoreTestSuite) TestErrorOnAdd() {
@@ -139,11 +148,14 @@ func (s *authProviderDataStoreTestSuite) TestErrorOnAdd() {
 }
 
 func (s *authProviderDataStoreTestSuite) TestAllowsUpdate() {
-	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil)
-	s.storage.EXPECT().Exists(gomock.Any(), gomock.Any()).Return(true, nil)
+	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	s.storage.EXPECT().Exists(gomock.Any(), gomock.Any()).Return(true, nil).Times(2)
 
 	err := s.dataStore.UpdateAuthProvider(s.hasWriteCtx, &storage.AuthProvider{})
 	s.NoError(err, "expected no error trying to write with permissions")
+
+	err = s.dataStore.UpdateAuthProvider(s.hasWriteAccessCtx, &storage.AuthProvider{})
+	s.NoError(err, "expected no error trying to write with Access permission")
 }
 
 func (s *authProviderDataStoreTestSuite) TestErrorOnUpdate() {
@@ -154,8 +166,11 @@ func (s *authProviderDataStoreTestSuite) TestErrorOnUpdate() {
 }
 
 func (s *authProviderDataStoreTestSuite) TestAllowsRemove() {
-	s.storage.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil)
+	s.storage.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
 	err := s.dataStore.RemoveAuthProvider(s.hasWriteCtx, "id")
 	s.NoError(err, "expected no error trying to write with permissions")
+
+	err = s.dataStore.RemoveAuthProvider(s.hasWriteAccessCtx, "id")
+	s.NoError(err, "expect no error trying to write with Access permissions")
 }

--- a/central/config/datastore/datastore_test.go
+++ b/central/config/datastore/datastore_test.go
@@ -24,6 +24,8 @@ type configDataStoreTestSuite struct {
 	hasReadCtx  context.Context
 	hasWriteCtx context.Context
 
+	hasWriteAdministrationCtx context.Context
+
 	dataStore DataStore
 	storage   *storeMocks.MockStore
 
@@ -40,6 +42,10 @@ func (s *configDataStoreTestSuite) SetupTest() {
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.Config)))
+	s.hasWriteAdministrationCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Administration)))
 
 	s.mockCtrl = gomock.NewController(s.T())
 	s.storage = storeMocks.NewMockStore(s.mockCtrl)
@@ -64,10 +70,13 @@ func (s *configDataStoreTestSuite) TestAllowsGet() {
 	_, err := s.dataStore.GetConfig(s.hasReadCtx)
 	s.NoError(err, "expected no error trying to read with permissions")
 
-	s.storage.EXPECT().GetConfig().Return(nil, nil)
+	s.storage.EXPECT().GetConfig().Return(nil, nil).Times(2)
 
 	_, err = s.dataStore.GetConfig(s.hasWriteCtx)
 	s.NoError(err, "expected no error trying to read with permissions")
+
+	_, err = s.dataStore.GetConfig(s.hasWriteAdministrationCtx)
+	s.NoError(err, "expected no error trying to read with Administration permissions")
 }
 
 func (s *configDataStoreTestSuite) TestEnforcesUpdate() {
@@ -81,8 +90,11 @@ func (s *configDataStoreTestSuite) TestEnforcesUpdate() {
 }
 
 func (s *configDataStoreTestSuite) TestAllowsUpdate() {
-	s.storage.EXPECT().UpsertConfig(gomock.Any()).Return(nil)
+	s.storage.EXPECT().UpsertConfig(gomock.Any()).Return(nil).Times(2)
 
 	err := s.dataStore.UpsertConfig(s.hasWriteCtx, &storage.Config{})
 	s.NoError(err, "expected no error trying to write with permissions")
+
+	err = s.dataStore.UpsertConfig(s.hasWriteAdministrationCtx, &storage.Config{})
+	s.NoError(err, "expected no error trying to write with Administration permissions")
 }

--- a/central/group/datastore/datastore_test.go
+++ b/central/group/datastore/datastore_test.go
@@ -20,9 +20,10 @@ func TestGroupDataStore(t *testing.T) {
 type groupDataStoreTestSuite struct {
 	suite.Suite
 
-	hasNoneCtx  context.Context
-	hasReadCtx  context.Context
-	hasWriteCtx context.Context
+	hasNoneCtx        context.Context
+	hasReadCtx        context.Context
+	hasWriteCtx       context.Context
+	hasWriteAccessCtx context.Context
 
 	dataStore DataStore
 	storage   *storeMocks.MockStore
@@ -40,6 +41,10 @@ func (s *groupDataStoreTestSuite) SetupTest() {
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.Group)))
+	s.hasWriteAccessCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Access)))
 
 	s.mockCtrl = gomock.NewController(s.T())
 	s.storage = storeMocks.NewMockStore(s.mockCtrl)
@@ -64,10 +69,13 @@ func (s *groupDataStoreTestSuite) TestAllowsGet() {
 	_, err := s.dataStore.Get(s.hasReadCtx, &storage.GroupProperties{})
 	s.NoError(err, "expected no error trying to read with permissions")
 
-	s.storage.EXPECT().Get(gomock.Any()).Return(nil, nil)
+	s.storage.EXPECT().Get(gomock.Any()).Return(nil, nil).Times(2)
 
 	_, err = s.dataStore.Get(s.hasWriteCtx, &storage.GroupProperties{})
 	s.NoError(err, "expected no error trying to read with permissions")
+
+	_, err = s.dataStore.Get(s.hasWriteAccessCtx, &storage.GroupProperties{})
+	s.NoError(err, "expected no error trying to read with Access permissions")
 }
 
 func (s *groupDataStoreTestSuite) TestEnforcesGetAll() {
@@ -84,10 +92,13 @@ func (s *groupDataStoreTestSuite) TestAllowsGetAll() {
 	_, err := s.dataStore.GetAll(s.hasReadCtx)
 	s.NoError(err, "expected no error trying to read with permissions")
 
-	s.storage.EXPECT().GetAll().Return(nil, nil)
+	s.storage.EXPECT().GetAll().Return(nil, nil).Times(2)
 
 	_, err = s.dataStore.GetAll(s.hasWriteCtx)
 	s.NoError(err, "expected no error trying to read with permissions")
+
+	_, err = s.dataStore.GetAll(s.hasWriteAccessCtx)
+	s.NoError(err, "expected no error trying to read with Access permissions")
 }
 
 func (s *groupDataStoreTestSuite) TestEnforcesWalk() {
@@ -104,10 +115,13 @@ func (s *groupDataStoreTestSuite) TestAllowsWalk() {
 	_, err := s.dataStore.Walk(s.hasReadCtx, "provider", nil)
 	s.NoError(err, "expected no error trying to read with permissions")
 
-	s.storage.EXPECT().Walk(gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.storage.EXPECT().Walk(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 
 	_, err = s.dataStore.Walk(s.hasWriteCtx, "provider", nil)
 	s.NoError(err, "expected no error trying to read with permissions")
+
+	_, err = s.dataStore.Walk(s.hasWriteAccessCtx, "provider", nil)
+	s.NoError(err, "expected no error trying to read with Access permissions")
 }
 
 func (s *groupDataStoreTestSuite) TestEnforcesAdd() {
@@ -121,10 +135,13 @@ func (s *groupDataStoreTestSuite) TestEnforcesAdd() {
 }
 
 func (s *groupDataStoreTestSuite) TestAllowsAdd() {
-	s.storage.EXPECT().Add(gomock.Any()).Return(nil)
+	s.storage.EXPECT().Add(gomock.Any()).Return(nil).Times(2)
 
 	err := s.dataStore.Add(s.hasWriteCtx, &storage.Group{})
 	s.NoError(err, "expected no error trying to write with permissions")
+
+	err = s.dataStore.Add(s.hasWriteCtx, &storage.Group{})
+	s.NoError(err, "expected no error trying to write with Access permissions")
 }
 
 func (s *groupDataStoreTestSuite) TestEnforcesUpdate() {
@@ -138,10 +155,13 @@ func (s *groupDataStoreTestSuite) TestEnforcesUpdate() {
 }
 
 func (s *groupDataStoreTestSuite) TestAllowsUpdate() {
-	s.storage.EXPECT().Update(gomock.Any()).Return(nil)
+	s.storage.EXPECT().Update(gomock.Any()).Return(nil).Times(2)
 
 	err := s.dataStore.Update(s.hasWriteCtx, &storage.Group{})
 	s.NoError(err, "expected no error trying to write with permissions")
+
+	err = s.dataStore.Update(s.hasWriteCtx, &storage.Group{})
+	s.NoError(err, "expected no error trying to write with Access permissions")
 }
 
 func (s *groupDataStoreTestSuite) TestEnforcesUpsert() {
@@ -155,10 +175,13 @@ func (s *groupDataStoreTestSuite) TestEnforcesUpsert() {
 }
 
 func (s *groupDataStoreTestSuite) TestAllowsUpsert() {
-	s.storage.EXPECT().Upsert(gomock.Any()).Return(nil)
+	s.storage.EXPECT().Upsert(gomock.Any()).Return(nil).Times(2)
 
 	err := s.dataStore.Upsert(s.hasWriteCtx, &storage.Group{})
 	s.NoError(err, "expected no error trying to write with permissions")
+
+	err = s.dataStore.Upsert(s.hasWriteCtx, &storage.Group{})
+	s.NoError(err, "expected no error trying to write with Access permissions")
 }
 
 func (s *groupDataStoreTestSuite) TestEnforcesMutate() {
@@ -172,10 +195,13 @@ func (s *groupDataStoreTestSuite) TestEnforcesMutate() {
 }
 
 func (s *groupDataStoreTestSuite) TestAllowsMutate() {
-	s.storage.EXPECT().Mutate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	s.storage.EXPECT().Mutate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
 	err := s.dataStore.Mutate(s.hasWriteCtx, []*storage.Group{}, []*storage.Group{}, []*storage.Group{})
 	s.NoError(err, "expected no error trying to write with permissions")
+
+	err = s.dataStore.Mutate(s.hasWriteCtx, []*storage.Group{}, []*storage.Group{}, []*storage.Group{})
+	s.NoError(err, "expected no error trying to write with Access permissions")
 }
 
 func (s *groupDataStoreTestSuite) TestEnforcesRemove() {
@@ -189,8 +215,11 @@ func (s *groupDataStoreTestSuite) TestEnforcesRemove() {
 }
 
 func (s *groupDataStoreTestSuite) TestAllowsRemove() {
-	s.storage.EXPECT().Remove(gomock.Any()).Return(nil)
+	s.storage.EXPECT().Remove(gomock.Any()).Return(nil).Times(2)
 
 	err := s.dataStore.Remove(s.hasWriteCtx, &storage.GroupProperties{})
 	s.NoError(err, "expected no error trying to write with permissions")
+
+	err = s.dataStore.Remove(s.hasWriteCtx, &storage.GroupProperties{})
+	s.NoError(err, "expected no error trying to write with Access permissions")
 }

--- a/central/group/datastore/datastore_test.go
+++ b/central/group/datastore/datastore_test.go
@@ -140,7 +140,7 @@ func (s *groupDataStoreTestSuite) TestAllowsAdd() {
 	err := s.dataStore.Add(s.hasWriteCtx, &storage.Group{})
 	s.NoError(err, "expected no error trying to write with permissions")
 
-	err = s.dataStore.Add(s.hasWriteCtx, &storage.Group{})
+	err = s.dataStore.Add(s.hasWriteAccessCtx, &storage.Group{})
 	s.NoError(err, "expected no error trying to write with Access permissions")
 }
 
@@ -160,7 +160,7 @@ func (s *groupDataStoreTestSuite) TestAllowsUpdate() {
 	err := s.dataStore.Update(s.hasWriteCtx, &storage.Group{})
 	s.NoError(err, "expected no error trying to write with permissions")
 
-	err = s.dataStore.Update(s.hasWriteCtx, &storage.Group{})
+	err = s.dataStore.Update(s.hasWriteAccessCtx, &storage.Group{})
 	s.NoError(err, "expected no error trying to write with Access permissions")
 }
 
@@ -180,7 +180,7 @@ func (s *groupDataStoreTestSuite) TestAllowsUpsert() {
 	err := s.dataStore.Upsert(s.hasWriteCtx, &storage.Group{})
 	s.NoError(err, "expected no error trying to write with permissions")
 
-	err = s.dataStore.Upsert(s.hasWriteCtx, &storage.Group{})
+	err = s.dataStore.Upsert(s.hasWriteAccessCtx, &storage.Group{})
 	s.NoError(err, "expected no error trying to write with Access permissions")
 }
 
@@ -200,7 +200,7 @@ func (s *groupDataStoreTestSuite) TestAllowsMutate() {
 	err := s.dataStore.Mutate(s.hasWriteCtx, []*storage.Group{}, []*storage.Group{}, []*storage.Group{})
 	s.NoError(err, "expected no error trying to write with permissions")
 
-	err = s.dataStore.Mutate(s.hasWriteCtx, []*storage.Group{}, []*storage.Group{}, []*storage.Group{})
+	err = s.dataStore.Mutate(s.hasWriteAccessCtx, []*storage.Group{}, []*storage.Group{}, []*storage.Group{})
 	s.NoError(err, "expected no error trying to write with Access permissions")
 }
 
@@ -220,6 +220,6 @@ func (s *groupDataStoreTestSuite) TestAllowsRemove() {
 	err := s.dataStore.Remove(s.hasWriteCtx, &storage.GroupProperties{})
 	s.NoError(err, "expected no error trying to write with permissions")
 
-	err = s.dataStore.Remove(s.hasWriteCtx, &storage.GroupProperties{})
+	err = s.dataStore.Remove(s.hasWriteAccessCtx, &storage.GroupProperties{})
 	s.NoError(err, "expected no error trying to write with Access permissions")
 }

--- a/central/imageintegration/datastore/datastore_impl_test.go
+++ b/central/imageintegration/datastore/datastore_impl_test.go
@@ -23,9 +23,11 @@ func TestImageIntegrationDataStore(t *testing.T) {
 type ImageIntegrationDataStoreTestSuite struct {
 	suite.Suite
 
-	hasNoneCtx              context.Context
-	hasReadCtx              context.Context
-	hasWriteCtx             context.Context
+	hasNoneCtx  context.Context
+	hasReadCtx  context.Context
+	hasWriteCtx context.Context
+
+	hasReadIntegrationsCtx  context.Context
 	hasWriteIntegrationsCtx context.Context
 
 	db *bolt.DB
@@ -40,6 +42,10 @@ func (suite *ImageIntegrationDataStoreTestSuite) SetupTest() {
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
 			sac.ResourceScopeKeys(resources.ImageIntegration)))
+	suite.hasReadIntegrationsCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Integrations)))
 	suite.hasWriteCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
@@ -206,6 +212,11 @@ func (suite *ImageIntegrationDataStoreTestSuite) TestAllowsGet() {
 	suite.Equal(integration, gotInt)
 	suite.True(exists)
 
+	gotInt, exists, err = suite.datastore.GetImageIntegration(suite.hasReadIntegrationsCtx, integration.GetId())
+	suite.NoError(err, "expected no error trying to read with permissions")
+	suite.Equal(integration, gotInt)
+	suite.True(exists)
+
 	gotInt, exists, err = suite.datastore.GetImageIntegration(suite.hasWriteCtx, integration.GetId())
 	suite.NoError(err, "expected no error trying to read with permissions")
 	suite.Equal(integration, gotInt)
@@ -233,6 +244,10 @@ func (suite *ImageIntegrationDataStoreTestSuite) TestAllowsGetBatch() {
 	suite.NoError(err, "expected no error trying to read with permissions")
 	suite.ElementsMatch(integrationList, gotImages)
 
+	gotImages, err = suite.datastore.GetImageIntegrations(suite.hasReadIntegrationsCtx, getRequest)
+	suite.NoError(err, "expected no error trying to read with permissions")
+	suite.ElementsMatch(integrationList, gotImages)
+
 	gotImages, err = suite.datastore.GetImageIntegrations(suite.hasWriteCtx, getRequest)
 	suite.NoError(err, "expected no error trying to read with permissions")
 	suite.ElementsMatch(integrationList, gotImages)
@@ -252,10 +267,18 @@ func (suite *ImageIntegrationDataStoreTestSuite) TestEnforcesAdd() {
 	id, err = suite.datastore.AddImageIntegration(suite.hasReadCtx, integrationTwo)
 	suite.Error(err, "expected an error trying to write without permissions")
 	suite.Empty(id)
+
+	id, err = suite.datastore.AddImageIntegration(suite.hasReadIntegrationsCtx, integrationTwo)
+	suite.Error(err, "expected an error trying to write without permissions")
+	suite.Empty(id)
 }
 
 func (suite *ImageIntegrationDataStoreTestSuite) TestAllowsAdd() {
 	id, err := suite.datastore.AddImageIntegration(suite.hasWriteCtx, getIntegration("namenamenamename"))
+	suite.NoError(err, "expected no error trying to write with permissions")
+	suite.NotEmpty(id)
+
+	id, err = suite.datastore.AddImageIntegration(suite.hasWriteIntegrationsCtx, getIntegration("namenamenamename2"))
 	suite.NoError(err, "expected no error trying to write with permissions")
 	suite.NotEmpty(id)
 }
@@ -268,12 +291,20 @@ func (suite *ImageIntegrationDataStoreTestSuite) TestEnforcesUpdate() {
 
 	err = suite.datastore.UpdateImageIntegration(suite.hasReadCtx, integration)
 	suite.Error(err, "expected an error trying to write without permissions")
+
+	err = suite.datastore.UpdateImageIntegration(suite.hasReadIntegrationsCtx, integration)
+	suite.Error(err, "expected an error trying to write without permissions")
 }
 
 func (suite *ImageIntegrationDataStoreTestSuite) TestAllowsUpdate() {
 	integration := suite.storeIntegration("joseph is the best")
 
 	err := suite.datastore.UpdateImageIntegration(suite.hasWriteCtx, integration)
+	suite.NoError(err, "expected no error trying to write with permissions")
+
+	integration = suite.storeIntegration("joseph is the best again")
+
+	err = suite.datastore.UpdateImageIntegration(suite.hasWriteIntegrationsCtx, integration)
 	suite.NoError(err, "expected no error trying to write with permissions")
 }
 
@@ -283,11 +314,19 @@ func (suite *ImageIntegrationDataStoreTestSuite) TestEnforcesRemove() {
 
 	err = suite.datastore.RemoveImageIntegration(suite.hasReadCtx, "hkddsfk")
 	suite.Error(err, "expected an error trying to write without permissions")
+
+	err = suite.datastore.RemoveImageIntegration(suite.hasReadIntegrationsCtx, "hkddsfk2")
+	suite.Error(err, "expected an error trying to write without permissions")
 }
 
 func (suite *ImageIntegrationDataStoreTestSuite) TestAllowsRemove() {
 	integration := suite.storeIntegration("jdgbfdkjh")
 
 	err := suite.datastore.RemoveImageIntegration(suite.hasWriteCtx, integration.GetId())
+	suite.NoError(err, "expected no error trying to write with permissions")
+
+	integration = suite.storeIntegration("jdgbfdkjh2")
+
+	err = suite.datastore.RemoveImageIntegration(suite.hasWriteIntegrationsCtx, integration.GetId())
 	suite.NoError(err, "expected no error trying to write with permissions")
 }

--- a/central/sensorupgradeconfig/datastore/datastore_test.go
+++ b/central/sensorupgradeconfig/datastore/datastore_test.go
@@ -20,9 +20,10 @@ func TestSensorUpgradeConfigDataStore(t *testing.T) {
 type sensorUpgradeConfigDataStoreTestSuite struct {
 	suite.Suite
 
-	hasNoneCtx  context.Context
-	hasReadCtx  context.Context
-	hasWriteCtx context.Context
+	hasNoneCtx                context.Context
+	hasReadCtx                context.Context
+	hasWriteCtx               context.Context
+	hasWriteAdministrationCtx context.Context
 
 	dataStore DataStore
 	storage   *storeMocks.MockStore
@@ -40,6 +41,10 @@ func (s *sensorUpgradeConfigDataStoreTestSuite) SetupTest() {
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.SensorUpgradeConfig)))
+	s.hasWriteAdministrationCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Administration)))
 
 	s.mockCtrl = gomock.NewController(s.T())
 	s.storage = storeMocks.NewMockStore(s.mockCtrl)
@@ -67,10 +72,13 @@ func (s *sensorUpgradeConfigDataStoreTestSuite) TestAllowsGet() {
 	_, err := s.dataStore.GetSensorUpgradeConfig(s.hasReadCtx)
 	s.NoError(err, "expected no error trying to read with permissions")
 
-	s.storage.EXPECT().GetSensorUpgradeConfig().Return(nil, nil)
+	s.storage.EXPECT().GetSensorUpgradeConfig().Return(nil, nil).Times(2)
 
 	_, err = s.dataStore.GetSensorUpgradeConfig(s.hasWriteCtx)
 	s.NoError(err, "expected no error trying to read with permissions")
+
+	_, err = s.dataStore.GetSensorUpgradeConfig(s.hasWriteAdministrationCtx)
+	s.NoError(err, "expected no error trying to read with Administration permissions")
 }
 
 func (s *sensorUpgradeConfigDataStoreTestSuite) TestEnforcesUpdate() {
@@ -84,10 +92,13 @@ func (s *sensorUpgradeConfigDataStoreTestSuite) TestEnforcesUpdate() {
 }
 
 func (s *sensorUpgradeConfigDataStoreTestSuite) TestAllowsUpdate() {
-	s.storage.EXPECT().UpsertSensorUpgradeConfig(gomock.Any()).Return(nil)
+	s.storage.EXPECT().UpsertSensorUpgradeConfig(gomock.Any()).Return(nil).Times(2)
 
 	err := s.dataStore.UpsertSensorUpgradeConfig(s.hasWriteCtx, &storage.SensorUpgradeConfig{})
 	s.NoError(err, "expected no error trying to write with permissions")
+
+	err = s.dataStore.UpsertSensorUpgradeConfig(s.hasWriteAdministrationCtx, &storage.SensorUpgradeConfig{})
+	s.NoError(err, "expected no error trying to write with Administration permissions")
 }
 
 func (s *sensorUpgradeConfigDataStoreTestSuite) TestDefault() {


### PR DESCRIPTION
## Description

Add additional tests to cover datastores where deprecated resources are used, ensuring that access to both old resources as well as new, grouped resource allows access.

## Testing Performed
- CI
