### PR TITLE
ROX-10786: Add PgSearchHelper for ProcessIndicator.

### DIFF
--- a/central/processindicator/search/searcher_impl.go
+++ b/central/processindicator/search/searcher_impl.go
@@ -8,13 +8,16 @@ import (
 	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/options/processindicators"
 )
 
 var (
-	indicatorSACSearchHelper = sac.ForResource(resources.Indicator).MustCreateSearchHelper(processindicators.OptionsMap)
+	indicatorSACSearchHelper   = sac.ForResource(resources.Indicator).MustCreateSearchHelper(processindicators.OptionsMap)
+	indicatorSACPgSearchHelper = sac.ForResource(resources.Indicator).
+					MustCreatePgSearchHelper(processindicators.OptionsMap)
 )
 
 // searcherImpl provides an intermediary implementation layer for ProcessStorage.
@@ -23,7 +26,7 @@ type searcherImpl struct {
 	indexer index.Indexer
 }
 
-// SearchRawIndicators retrieves Policies from the indexer and storage
+// SearchRawProcessIndicators retrieves Policies from the indexer and storage
 func (s *searcherImpl) SearchRawProcessIndicators(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error) {
 	results, err := s.Search(ctx, q)
 	if err != nil {
@@ -34,10 +37,16 @@ func (s *searcherImpl) SearchRawProcessIndicators(ctx context.Context, q *v1.Que
 }
 
 func (s *searcherImpl) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
+	if features.PostgresDatastore.Enabled() {
+		return indicatorSACPgSearchHelper.Apply(s.indexer.Search)(ctx, q)
+	}
 	return indicatorSACSearchHelper.Apply(s.indexer.Search)(ctx, q)
 }
 
 // Count returns the number of search results from the query
 func (s *searcherImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
+	if features.PostgresDatastore.Enabled() {
+		return indicatorSACPgSearchHelper.ApplyCount(s.indexer.Count)(ctx, q)
+	}
 	return indicatorSACSearchHelper.ApplyCount(s.indexer.Count)(ctx, q)
 }


### PR DESCRIPTION
## Description

Conditionally use the `PgSearchHelper` for the `ProcessIndicator` resource.

## Testing Performed
- Integration tests will be done in a follow-up PR for [ROX-10785](https://issues.redhat.com/browse/ROX-10785)
