### PR TITLE
Use official nginx image for docs

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -10,13 +10,9 @@ COPY Makefile ./
 RUN npm install -g npm@8.1.4 && npm install -g yarn@1.22.17
 RUN make
 
-FROM registry.access.redhat.com/ubi8/nginx-120:latest
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/nginx.conf
 
-# Delete unnecessary things from the content directory.
-RUN find . -mindepth 1 -delete
-
-COPY --from=builder /workspace/build/ ./
+COPY --from=builder /workspace/build/ /usr/share/nginx/html
 
 EXPOSE 8080
-
-CMD nginx -g "daemon off;"

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -19,4 +19,6 @@ WORKDIR /docs/public
 
 COPY --from=builder /workspace/build/ .
 
+RUN apk --purge del curl apk-tools
+
 EXPOSE 8080

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -13,6 +13,10 @@ RUN make
 FROM nginx:alpine
 COPY nginx.conf /etc/nginx/nginx.conf
 
-COPY --from=builder /workspace/build/ /usr/share/nginx/html
+# This is well known localtion that other Dockerfiles relies on.
+# Do not change until you ensure that all places were updated.
+WORKDIR /docs/public
+
+COPY --from=builder /workspace/build/ .
 
 EXPOSE 8080

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -39,7 +39,7 @@ http {
         listen       8080 default_server;
         listen       [::]:8080 default_server;
         server_name  _;
-        root         /usr/share/nginx/html;
+        root         /docs/public;
 
         # Load configuration files for the default server block.
         include /opt/app-root/etc/nginx.default.d/*.conf;

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -1,0 +1,71 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 4096;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /opt/app-root/etc/nginx.d/*.conf;
+
+    server {
+        listen       8080 default_server;
+        listen       [::]:8080 default_server;
+        server_name  _;
+        root         /usr/share/nginx/html;
+
+        # Load configuration files for the default server block.
+        include /opt/app-root/etc/nginx.default.d/*.conf;
+
+
+    }
+
+# Settings for a TLS enabled server.
+#
+#    server {
+#        listen       443 ssl http2;
+#        listen       [::]:443 ssl http2;
+#        server_name  _;
+#        root         /opt/app-root/src;
+#
+#        ssl_certificate "/etc/pki/nginx/server.crt";
+#        ssl_certificate_key "/etc/pki/nginx/private/server.key";
+#        ssl_session_cache shared:SSL:1m;
+#        ssl_session_timeout  10m;
+#        ssl_ciphers PROFILE=SYSTEM;
+#        ssl_prefer_server_ciphers on;
+#
+#        # Load configuration files for the default server block.
+#        include /opt/app-root/etc/nginx.default.d/*.conf;
+#
+#
+#    }
+
+}

--- a/image/stackrox-data.Dockerfile
+++ b/image/stackrox-data.Dockerfile
@@ -2,15 +2,6 @@ ARG DOCS_IMAGE
 
 FROM $DOCS_IMAGE AS docs
 
-# Make sure docs data is in the right place.
-# Note: we copy this to a well-known location in order to not depend on the
-# WORKDIR of the docs image. The WORKDIR cannot be referenced as via
-# `COPY --from=docs ./`, as in this context, ./ will refer to the container
-# root.
-USER 0
-RUN mkdir -p /docs/public
-RUN cp -a . /docs/public
-
 FROM alpine:3.14
 
 RUN mkdir /stackrox-data


### PR DESCRIPTION
## Description

Current docs image contains much more packages then we need. This creates big areas for vulnerabilities. 
By using smaller official image we reduce number of potentially vulnerable packages.

Config was obtained with `docker run -p 8081:8080 registry.access.redhat.com/ubi8/nginx-120:latest cat /etc/nginx/nginx.conf` but it will be better if we could use defaults and expose port `80` and changed to reflect new static files path.

## Testing Performed

N/A