### PR TITLE
ROX-10799: Quickfix: enable correct feature flag

### DIFF
--- a/pkg/defaults/policies/policies_test.go
+++ b/pkg/defaults/policies/policies_test.go
@@ -28,6 +28,7 @@ func Test_DefaultPolicies_FilterByFeatureFlag(t *testing.T) {
 	isolator := envisolator.NewEnvIsolator(t)
 	defer isolator.RestoreAll()
 	for filename, ff := range featureFlagFileGuard {
+		isolator.Setenv(ff.EnvVar(), "false")
 		require.False(t, checkPoliciesContain(t, fileToPolicyName[filename]))
 		isolator.Setenv(ff.EnvVar(), "true")
 		require.True(t, checkPoliciesContain(t, fileToPolicyName[filename]))

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -41,8 +41,8 @@ var (
 
 	// NetworkPolicySystemPolicy enables two system policy fields (Missing (Ingress|Egress) Network Policy) to check deployments
 	// against network policies applied in the secured cluster.
-	NetworkPolicySystemPolicy = registerFeature("Enable NetworkPolicy-related system policy fields", "ROX_NETPOL_FIELDS", false)
+	NetworkPolicySystemPolicy = registerFeature("Enable NetworkPolicy-related system policy fields", "ROX_NETPOL_FIELDS", true)
 
 	// NewPolicyCategories enables new policy categories as first-class entities.
-	NewPolicyCategories = registerFeature("Enable new policy categories as first-class entities", "ROX_NEW_POLICY_CATEGORIES", true)
+	NewPolicyCategories = registerFeature("Enable new policy categories as first-class entities", "ROX_NEW_POLICY_CATEGORIES", false)
 )


### PR DESCRIPTION
## Description

I accidentally toggled the incorrect feature flag on  #1448. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- CI upgrade test
