### PR TITLE
OSCI: hold jobs based on file presence

### DIFF
--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -12,13 +12,13 @@ done
 
 openshift_ci_mods
 
-if pr_has_label "delay-tests"; then
-    function hold() {
-        info "Holding on for debug"
-        sleep 3600
-    }
-    trap hold EXIT
-fi
+function hold() {
+    while [[ -e /tmp/hold ]]; do
+        info "Holding this job for debug"
+        sleep 60
+    done
+}
+trap hold EXIT
 
 if [[ "$#" -lt 1 ]]; then
     die "usage: dispatch <ci-job> [<...other parameters...>]"


### PR DESCRIPTION
## Description

Holding jobs based on a label is too broad for production use.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Manually tested that outcome is propagated despite the exit `trap` with and without the `/tmp/hold` file.