### PR TITLE
ROX-10097: Do `dnf upgrade` in docs container to aid with rpm vulns

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -25,7 +25,7 @@ RUN dnf upgrade -y && \
 # Switch back to the normal user of nginx container and check that we really switch to the original one.
 USER 1001:0
 RUN echo "If the following command fails, update USER statement to match UID:GID of the user of nginx base container." && \
-    [ "$(id -u):$(id -g)" = "$(cat /tmp/container-uid)" ] && \
+    [[ "$(id -u):$(id -g)" == "$(cat /tmp/container-uid)" ]] && \
     rm -f /tmp/container-uid
 
 # Delete unnecessary things from the content directory.

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/nodejs-16 AS builder
+FROM registry.access.redhat.com/ubi8/nodejs-16:latest AS builder
 
 USER 0:0
 
@@ -7,20 +7,29 @@ COPY content content
 COPY tools tools
 COPY Makefile ./
 
-RUN npm install -g npm@8.1.4 && npm install -g yarn@1.22.17
+RUN npm install -g npm@8.9.0 && npm install -g yarn@1.22.18
 RUN make
 
 FROM registry.access.redhat.com/ubi8/nginx-120:latest
 
-# Delete unnecessary things from the content directory.
-RUN find . -mindepth 1 -delete
+RUN echo "$(id -u):$(id -g)" > /tmp/container-uid
 
 # Update RPMs to hopefully aid with vulns that aren't yet patched in the base image. Also remove package management
-# utils because our own policies don't recommend having them in the image.
+# utils because our own policies don't recommend having them in the image. For that we need to be root.
+USER 0:0
 RUN dnf upgrade -y && \
     dnf clean all && \
     rpm --verbose -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum
+
+# Switch back to the normal user of nginx container and check that we really switch to the original one.
+USER 1001:0
+RUN echo "If the following command fails, update USER statement to match UID:GID of the user of nginx base container." && \
+    [ "$(id -u):$(id -g)" = "$(cat /tmp/container-uid)" ] && \
+    rm -f /tmp/container-uid
+
+# Delete unnecessary things from the content directory.
+RUN find . -mindepth 1 -delete
 
 COPY --from=builder /workspace/build/ ./
 

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -15,6 +15,13 @@ FROM registry.access.redhat.com/ubi8/nginx-120:latest
 # Delete unnecessary things from the content directory.
 RUN find . -mindepth 1 -delete
 
+# Update RPMs to hopefully aid with vulns that aren't yet patched in the base image. Also remove package management
+# utils because our own policies don't recommend having them in the image.
+RUN dnf upgrade -y && \
+    dnf clean all && \
+    rpm --verbose -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
+    rm -rf /var/cache/dnf /var/cache/yum
+
 COPY --from=builder /workspace/build/ ./
 
 EXPOSE 8080


### PR DESCRIPTION
## Description

This follows up on https://github.com/stackrox/stackrox/pull/1576

Note that I don't know if this fully addresses ROX-10097 because one needs to see nightly run results. This change should make things better but then I'd leave it to nightly tests to tell us vuln results.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~ - not for this change.
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ - not needed.
- ~~[ ] Determined and documented upgrade steps~~ - not needed.
- ~~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~ - none.

## Testing Performed

* Relying on CI to tell if docs image build would be ok.
* Will try to see docs image vulns in Quay if it will be available.
  * https://quay.io/repository/rhacs-eng/docs/manifest/sha256:a3ac779aab060c9327beb49f00c7dba3bcdfdafaef82c78cf8e55d7da789f0b7?tab=vulnerabilities (no fixable here)
* Checked that docs are served with `docker run --rm -it -p 8080:8080 quay.io/rhacs-eng/docs:b53e0b9e-42186efb-b6d8cf96`