### PR TITLE
ROX-10836 add NetworkpoliciesStore to namespaceDispatcher listeners

### DIFF
--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -79,7 +79,7 @@ func NewDispatcherRegistry(
 			rbacUpdater, podLister, processFilter, configHandler, detector, namespaces, credentialsManager),
 
 		rbacDispatcher:            rbac.NewDispatcher(rbacUpdater),
-		namespaceDispatcher:       newNamespaceDispatcher(nsStore, serviceStore, deploymentStore, podStore),
+		namespaceDispatcher:       newNamespaceDispatcher(nsStore, serviceStore, deploymentStore, podStore, netPolicyStore),
 		serviceDispatcher:         newServiceDispatcher(serviceStore, deploymentStore, endpointManager, portExposureReconciler),
 		osRouteDispatcher:         newRouteDispatcher(serviceStore, portExposureReconciler),
 		secretDispatcher:          newSecretDispatcher(registryStore),

--- a/sensor/kubernetes/listener/resources/networkpolicy.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy.go
@@ -32,7 +32,6 @@ func (h *networkPolicyDispatcher) ProcessEvent(obj, old interface{}, action cent
 	roxNetpol := networkPolicyConversion.KubernetesNetworkPolicyWrap{NetworkPolicy: np}.ToRoxNetworkPolicy()
 
 	if features.NetworkPolicySystemPolicy.Enabled() {
-		log.Info("Processing NetworkPolicy: ", np)
 		var roxOldNetpol *storage.NetworkPolicy
 		if oldNp, ok := old.(*networkingV1.NetworkPolicy); ok && oldNp != nil {
 			roxOldNetpol = networkPolicyConversion.KubernetesNetworkPolicyWrap{NetworkPolicy: oldNp}.ToRoxNetworkPolicy()

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -201,8 +201,8 @@ func (n *networkPolicyStoreImpl) OnNamespaceDeleted(namespace string) {
 	defer n.lock.Unlock()
 	defer n.updateStateMetric()
 
-	netpols := n.data[namespace]
-	if netpols == nil {
+	netpols, found := n.data[namespace]
+	if !found {
 		return
 	}
 

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -199,6 +199,7 @@ func (n *networkPolicyStoreImpl) Find(namespace string, podLabels map[string]str
 func (n *networkPolicyStoreImpl) OnNamespaceDeleted(namespace string) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
+	defer n.updateStateMetric()
 
 	netpols := n.data[namespace]
 	if netpols == nil {

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -194,3 +194,19 @@ func (n *networkPolicyStoreImpl) Find(namespace string, podLabels map[string]str
 	}
 	return results
 }
+
+// OnNamespaceDeleted reacts to a namespace deletion, deleting all network policies in this namespace from the store.
+func (n *networkPolicyStoreImpl) OnNamespaceDeleted(namespace string) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
+	netpols := n.data[namespace]
+	if netpols == nil {
+		return
+	}
+
+	for id := range netpols {
+		delete(n.data[namespace], id)
+	}
+	delete(n.data, namespace)
+}


### PR DESCRIPTION
## Description

The `NetworkPoliciesStore` needs to be added to the list of listener in the `namespaceDispatcher`.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* [x] Unit tests passing
* [x] Added metrics to test manually.
    * Create multiple namespaces
    * Create multiple network policies in each namespace
    * Delete one of the namespaces and check the network policies in that namespace get deleted