### PR TITLE
ROX-10846: Add sentence to DebugLogs resource description about additional information

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
@@ -28,7 +28,7 @@ const resourceDescriptions: Record<ResourceName, string> = {
         'Read: View recent compliance runs and their completion status. Write: Trigger compliance runs.',
     Config: 'Read: View options for data retention, security notices, and other related configurations. Write: Modify options for data retention, security notices, and other related configurations.',
     DebugLogs:
-        "Read: View the current logging verbosity level of all components, including Central, Scanner, Sensor, Collector, and Admission controller. Download the diagnostic bundle. Important: The diagnostic bundle contains sensitive information, not dependent on the user's role and access scope. The diagnostic bundle includes information about all clusters and namespaces, access control, notifier integrations, and system configuration. Do not give this permission to users with limited access scope.",
+        "Read: View the current logging verbosity level of all components, including Central, Scanner, Sensor, Collector, and Admission controller. Download the diagnostic bundle. Important: The diagnostic bundle contains sensitive information, not dependent on the user's role and access scope. The diagnostic bundle includes information about all clusters and namespaces, access control, notifier integrations, and system configuration. Do not give this permission to users with limited access scope. Write: Modify the logging verbosity level.",
     Deployment: 'Read: View deployments (workloads) in secured clusters. Write: N/A',
     DeploymentExtension:
         'Read: View network and process baseline extensions, risk score of deployments. Write: Modify the process and network baseline extensions of deployments.',

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
@@ -28,7 +28,7 @@ const resourceDescriptions: Record<ResourceName, string> = {
         'Read: View recent compliance runs and their completion status. Write: Trigger compliance runs.',
     Config: 'Read: View options for data retention, security notices, and other related configurations. Write: Modify options for data retention, security notices, and other related configurations.',
     DebugLogs:
-        "Read: View the current logging verbosity level of all components, including Central, Scanner, Sensor, Collector, and Admission controller. Download diagnostic bundle. Note: The diagnostic bundle contains information about all clusters and namespaces regardless of the user's role and access scope. Don't give this permission to users with limited access scope. Write: Modify the logging verbosity level.",
+        "Read: View the current logging verbosity level of all components, including Central, Scanner, Sensor, Collector, and Admission controller. Download diagnostic bundle. Note: The diagnostic bundle contains information about all clusters and namespaces regardless of the user's role and access scope. It also contains information about access control, notifier integrations, and system configuration, regardless of the user's role. Don't give this permission to users with limited access scope. Write: Modify the logging verbosity level.",
     Deployment: 'Read: View deployments (workloads) in secured clusters. Write: N/A',
     DeploymentExtension:
         'Read: View network and process baseline extensions, risk score of deployments. Write: Modify the process and network baseline extensions of deployments.',

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
@@ -28,7 +28,7 @@ const resourceDescriptions: Record<ResourceName, string> = {
         'Read: View recent compliance runs and their completion status. Write: Trigger compliance runs.',
     Config: 'Read: View options for data retention, security notices, and other related configurations. Write: Modify options for data retention, security notices, and other related configurations.',
     DebugLogs:
-        "Read: View the current logging verbosity level of all components, including Central, Scanner, Sensor, Collector, and Admission controller. Download diagnostic bundle. Note: The diagnostic bundle contains information about all clusters and namespaces regardless of the user's role and access scope. It also contains information about access control, notifier integrations, and system configuration, regardless of the user's role. Don't give this permission to users with limited access scope. Write: Modify the logging verbosity level.",
+        "Read: View the current logging verbosity level of all components, including Central, Scanner, Sensor, Collector, and Admission controller. Download the diagnostic bundle. Important: The diagnostic bundle contains sensitive information, not dependent on the user's role and access scope. The diagnostic bundle includes information about all clusters and namespaces, access control, notifier integrations, and system configuration. Do not give this permission to users with limited access scope.",
     Deployment: 'Read: View deployments (workloads) in secured clusters. Write: N/A',
     DeploymentExtension:
         'Read: View network and process baseline extensions, risk score of deployments. Write: Modify the process and network baseline extensions of deployments.',


### PR DESCRIPTION
## Description

> It also contains information about access control, notifier integrations, and system configuration, regardless of the user's role.

Subtask of ROX-9358 in progress to add information for release 71

/cc @gaurav-nelson for corresponding information in Help Center

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn start` in ui
3. Visit Platform Configuration > Access Control
4. Click **Permission sets**
5. Click **Analyst**
![DebugLogs](https://user-images.githubusercontent.com/11862657/167157288-98e8a888-2869-4355-95a6-f1af8e7e3770.png)
