### PR TITLE
Add ability to push history state when updating URL parameters via hook.

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
@@ -1,6 +1,5 @@
-import React, { useEffect, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { generatePath } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import { HashLink } from 'react-router-hash-link';
 
@@ -9,7 +8,7 @@ import SearchFilterInput from 'Components/SearchFilterInput';
 import entityTypes, { searchCategories } from 'constants/entityTypes';
 import workflowStateContext from 'Containers/workflowStateContext';
 import { SEARCH_OPTIONS_QUERY } from 'queries/search';
-import { clustersBasePath, clustersPathWithParam, integrationsPath } from 'routePaths';
+import { integrationsPath } from 'routePaths';
 import useURLSearch from 'hooks/useURLSearch';
 import parseURL from 'utils/URLParser';
 

--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
@@ -49,16 +49,6 @@ const ClustersPage = ({
     const { data: searchData } = useQuery(SEARCH_OPTIONS_QUERY, searchQueryOptions);
     const searchOptions = (searchData && searchData.searchOptions) || [];
 
-    // When the selected cluster changes, update the URL.
-    useEffect(() => {
-        const newPath = selectedClusterId
-            ? generatePath(clustersPathWithParam, { clusterId: selectedClusterId })
-            : clustersBasePath;
-        history.push({
-            pathname: newPath,
-            search,
-        });
-    }, [history, search, selectedClusterId]);
     const headerText = 'Clusters';
     const subHeaderText = 'Resource list';
 

--- a/ui/apps/platform/src/hooks/useURLParameter.ts
+++ b/ui/apps/platform/src/hooks/useURLParameter.ts
@@ -5,7 +5,10 @@ import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
 
 export type QueryValue = undefined | string | string[] | qs.ParsedQs | qs.ParsedQs[];
 
-type UseURLParameterResult = [QueryValue, (newValue: QueryValue) => void];
+// Note that when we upgrade React Router and 'history' we can probably import a more accurate version of this type
+type Action = 'push' | 'replace';
+
+type UseURLParameterResult = [QueryValue, (newValue: QueryValue, historyAction?: Action) => void];
 
 /**
  * Hook to handle reading and writing of a piece of state in the page's URL query parameters.
@@ -32,7 +35,7 @@ function useURLParameter(keyPrefix: string, defaultValue: QueryValue): UseURLPar
     // memoize the setter function to retain referential equality as long
     // as the URL parameters do not change
     const setValue = useCallback(
-        (newValue: QueryValue) => {
+        (newValue: QueryValue, historyAction: Action = 'push') => {
             const previousQuery = getQueryObject(location.search) || {};
             const newQueryString = getQueryString({
                 ...previousQuery,
@@ -44,9 +47,7 @@ function useURLParameter(keyPrefix: string, defaultValue: QueryValue): UseURLPar
                 delete newQueryString[keyPrefix];
             }
 
-            history.replace({
-                search: newQueryString,
-            });
+            history[historyAction]({ search: newQueryString });
         },
         [keyPrefix, history, location.search]
     );

--- a/ui/apps/platform/src/hooks/useURLParameter.ts
+++ b/ui/apps/platform/src/hooks/useURLParameter.ts
@@ -49,7 +49,6 @@ function useURLParameter(keyPrefix: string, defaultValue: QueryValue): UseURLPar
 
             // Do not change history states if setter is called with current value
             if (!isEqual(previousQuery[keyPrefix], newValue)) {
-                console.log('history', historyAction, previousQuery[keyPrefix], newValue);
                 history[historyAction]({ search: newQueryString });
             }
         },

--- a/ui/apps/platform/src/hooks/useURLParameter.ts
+++ b/ui/apps/platform/src/hooks/useURLParameter.ts
@@ -47,7 +47,11 @@ function useURLParameter(keyPrefix: string, defaultValue: QueryValue): UseURLPar
                 delete newQueryString[keyPrefix];
             }
 
-            history[historyAction]({ search: newQueryString });
+            // Do not change history states if setter is called with current value
+            if (!isEqual(previousQuery[keyPrefix], newValue)) {
+                console.log('history', historyAction, previousQuery[keyPrefix], newValue);
+                history[historyAction]({ search: newQueryString });
+            }
         },
         [keyPrefix, history, location.search]
     );


### PR DESCRIPTION
## Description

Adds the ability to change URL parameters via `history.push` or `history.replace`, with the former being the default.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

Added unit test to check new behavior and that `history.replace` remains the default when no action is specified.

Test that search filters, pagination, and sorts can be stepped back in Violations history:
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/167492618-c58bf6be-c998-437e-8397-c92b916d336d.png">
<- back (sort removed)
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/167492713-a30cdb45-59a2-44da-b2f1-c479392a4fe0.png">
<- back (per page removed)
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/167492776-d53c02f2-9658-4a21-b69f-c9fd839f515c.png">
<- back (search entry removed)
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/167492855-ceabbc19-3b91-4032-91b4-b286e420bb05.png">
<- back (search category removed)
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/167492900-67ce2dc5-dfc4-47b5-9577-8e7ffe86aaba.png">

Tested same behavior on Polices page (searching only, sort and pagination are not part of URL)

Tested same behavior on Clusters page (searching only)

Tested same behavior on Risk Acceptance page (searching only)
