### PR TITLE
ROX-10693 Update Risk page URL search

### DIFF
--- a/ui/apps/platform/src/Components/SearchFilterInput/SearchFilterInput.tsx
+++ b/ui/apps/platform/src/Components/SearchFilterInput/SearchFilterInput.tsx
@@ -12,6 +12,8 @@ type SearchFilterInputProps = {
     searchCategory?: SearchCategory;
     searchFilter: SearchFilter;
     searchOptions: string[]; // differs from searchOptions prop of SearchInput
+    autocompleteQueryPrefix?: string;
+    isDisabled?: boolean;
 };
 
 /*
@@ -31,22 +33,28 @@ function SearchFilterInput({
     searchCategory,
     searchFilter,
     searchOptions,
+    autocompleteQueryPrefix,
+    isDisabled = false,
 }: SearchFilterInputProps) {
     const [autoCompleteValues, setAutoCompleteValues] = useState<string[]>([]);
     const [valuelessOption, setValuelessOption] = useState('');
 
     useEffect(() => {
         if (valuelessOption.length !== 0) {
+            const query = autocompleteQueryPrefix
+                ? `${autocompleteQueryPrefix}+${getEntryValueForOption(valuelessOption)}`
+                : getEntryValueForOption(valuelessOption);
+
             fetchAutoCompleteResults({
                 categories: [searchCategory],
-                query: getEntryValueForOption(valuelessOption),
+                query,
             })
                 .then((values) => {
                     setAutoCompleteValues(values);
                 })
                 .catch(() => {});
         }
-    }, [searchCategory, valuelessOption]);
+    }, [searchCategory, autocompleteQueryPrefix, valuelessOption]);
 
     function handleChangeSearchEntries(searchEntries: SearchEntry[]) {
         setValuelessOption(getValuelessOption(searchEntries));
@@ -68,7 +76,7 @@ function SearchFilterInput({
         <SearchInput
             autoCompleteResults={autoCompleteValues}
             className={className}
-            isDisabled={searchOptions.length === 0}
+            isDisabled={searchOptions.length === 0 || isDisabled}
             isGlobal
             placeholder={placeholder}
             searchModifiers={createSearchModifiers(searchOptions)}

--- a/ui/apps/platform/src/Containers/Risk/RiskPage.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskPage.js
@@ -48,15 +48,9 @@ const RiskPage = ({
     const filteredSearchOptions = searchOptions.filter(
         (option) => option !== 'Orchestrator Component'
     );
-    const autoFocusSearchInput = !deploymentId;
-
     return (
         <workflowStateContext.Provider value={workflowState}>
-            <RiskPageHeader
-                isViewFiltered={isViewFiltered}
-                searchOptions={filteredSearchOptions}
-                autoFocusSearchInput={autoFocusSearchInput}
-            />
+            <RiskPageHeader isViewFiltered={isViewFiltered} searchOptions={filteredSearchOptions} />
             <PageBody>
                 <div className="flex-shrink-1 overflow-hidden w-full">
                     <RiskTablePanel

--- a/ui/apps/platform/src/Containers/Risk/RiskPageHeader.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskPageHeader.js
@@ -3,31 +3,33 @@ import PropTypes from 'prop-types';
 
 import entityTypes, { searchCategories } from 'constants/entityTypes';
 import PageHeader from 'Components/PageHeader';
-import URLSearchInput from 'Components/URLSearchInput';
 import {
     ORCHESTRATOR_COMPONENT_KEY,
     orchestratorComponentOption,
 } from 'Containers/Navigation/OrchestratorComponentsToggle';
+import SearchFilterInput from 'Components/SearchFilterInput';
+import useURLSearch from 'hooks/useURLSearch';
+import searchOptionsToQuery from 'services/searchOptionsToQuery';
 import CreatePolicyFromSearch from './CreatePolicyFromSearch';
 
-function RiskPageHeader({ autoFocusSearchInput, isViewFiltered, searchOptions }) {
+function RiskPageHeader({ isViewFiltered, searchOptions }) {
+    const { searchFilter, setSearchFilter } = useURLSearch();
     const subHeader = isViewFiltered ? 'Filtered view' : 'Default view';
-    const autoCompleteCategories = [searchCategories[entityTypes.DEPLOYMENT]];
+    const autoCompleteCategory = searchCategories[entityTypes.DEPLOYMENT];
 
-    let prependAutocompleteQuery;
     const orchestratorComponentShowState = localStorage.getItem(ORCHESTRATOR_COMPONENT_KEY);
-    if (orchestratorComponentShowState !== 'true') {
-        prependAutocompleteQuery = orchestratorComponentOption;
-    }
+    const prependAutocompleteQuery =
+        orchestratorComponentShowState !== 'true' ? orchestratorComponentOption : [];
     return (
         <PageHeader header="Risk" subHeader={subHeader}>
-            <URLSearchInput
+            <SearchFilterInput
                 className="w-full"
-                categoryOptions={searchOptions}
-                categories={autoCompleteCategories}
+                searchFilter={searchFilter}
+                searchOptions={searchOptions}
+                searchCategory={autoCompleteCategory}
                 placeholder="Add one or more resource filters"
-                autoFocus={autoFocusSearchInput}
-                prependAutocompleteQuery={prependAutocompleteQuery}
+                handleChangeSearchFilter={(filter) => setSearchFilter(filter, 'push')}
+                autocompleteQueryPrefix={searchOptionsToQuery(prependAutocompleteQuery)}
             />
             <CreatePolicyFromSearch />
         </PageHeader>
@@ -35,7 +37,6 @@ function RiskPageHeader({ autoFocusSearchInput, isViewFiltered, searchOptions })
 }
 
 RiskPageHeader.propTypes = {
-    autoFocusSearchInput: PropTypes.bool.isRequired,
     isViewFiltered: PropTypes.bool.isRequired,
     searchOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
 };


### PR DESCRIPTION
## Description

This updates the Risk page to use the `useURLParameter` hook used in other pages for search.

Note that this also duplicates prop updates to SearchFilterInput that are present in draft PR #1532

## Follow ups

The sorting functionality and tracking the sort in the URL works correctly, but the icon display in the column header is incorrect. Clicking the back button will revert the sort but the icon does not change.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Test that the search bar correctly updates the page URL and search results:
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/167859985-93dbf69d-6c11-46ab-90f3-acd9f5acc858.png">

Test the use of the back button steps through previous page states (search and sorting applied):
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/167860126-6e463198-5f4b-480c-addd-45b9b6e62bda.png">
<- back, remove descending sort
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/167860184-f62519fb-025c-4aa1-9aa2-23a1cc4bfe1a.png">
<- back, remove sort altogether
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/167864309-aeeee352-95bb-41a6-81e8-a1ffae4638a6.png">
<- back, <- back, remove Deployment search value and then Deployment search category
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/167860545-6925a759-b2ba-4f5c-ad50-9267f4331af9.png">

Test that enabling "Show Orchestrator Components" correctly passes autocomplete options to the search dropdown:
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/167860696-302f0f2c-c426-4fbb-a72e-def1fbd94470.png">
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/167860746-cc67150a-379c-49ea-a95d-3d9c3dc1015e.png">

Test that search values are propagated to the policy wizard via the "Create Policy" button.
- Enter search criteria
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/167899927-88df4a5f-b4d7-4c42-8b95-5edee7d598f5.png">
- Click "Create Policy", fill out the forms with any value and advance to step 3
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/167900119-8399b8e8-2f64-452b-be99-1b26af1a0606.png">

Test that the search input auto-focuses on navigation to the page when no deployment is selected (note the barely visible input cursor) (also note that if search option data has not been cached yet, the input will be disabled and will not autofocus on first render):
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/167900303-1419a2cd-ced9-4b3c-b2c8-150002fce61c.png">



