### PR TITLE
Replace beforeEach in Vulnerability Management Reporting integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/vulnmanagement/reporting.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/reporting.js
@@ -1,0 +1,46 @@
+import * as api from '../../constants/apiEndpoints';
+import { url } from '../../constants/VulnManagementPage';
+
+import { visitFromLeftNavExpandable } from '../nav';
+import { visit } from '../visit';
+
+// visit
+
+export function visitVulnerabilityReportingFromLeftNav() {
+    cy.intercept('POST', api.graphql('searchOptions')).as('searchOptions');
+    cy.intercept('GET', api.report.configurations).as('getReportConfigurations');
+    cy.intercept('GET', api.report.configurationsCount).as('getReportConfigurationsCount');
+
+    visitFromLeftNavExpandable('Vulnerability Management', 'Reporting');
+
+    cy.wait(['@searchOptions', '@getReportConfigurations', '@getReportConfigurationsCount']);
+    cy.get('h1:contains("Vulnerability reporting")');
+}
+
+export function visitVulnerabilityReporting() {
+    cy.intercept('POST', api.graphql('searchOptions')).as('searchOptions');
+    cy.intercept('GET', api.report.configurations).as('getReportConfigurations');
+    cy.intercept('GET', api.report.configurationsCount).as('getReportConfigurationsCount');
+
+    cy.visit(url.reporting.list);
+
+    cy.wait(['@searchOptions', '@getReportConfigurations', '@getReportConfigurationsCount']);
+    cy.get('h1:contains("Vulnerability reporting")');
+}
+
+export function visitVulnerabilityReportingWithFixture(fixturePath) {
+    cy.fixture(fixturePath).then(({ reportConfigs }) => {
+        cy.intercept('POST', api.graphql('searchOptions')).as('searchOptions');
+        cy.intercept('GET', api.report.configurations, {
+            body: { reportConfigs },
+        }).as('getReportConfigurations');
+        cy.intercept('GET', api.report.configurationsCount, {
+            body: { count: reportConfigs.length },
+        }).as('getReportConfigurationsCount');
+
+        visit(url.reporting.list);
+
+        cy.wait(['@searchOptions', '@getReportConfigurations', '@getReportConfigurationsCount']);
+        cy.get('h1:contains("Vulnerability reporting")');
+    });
+}

--- a/ui/apps/platform/cypress/integration/vulnmanagement/reporting/displayReports.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/reporting/displayReports.test.js
@@ -1,33 +1,13 @@
-import * as api from '../../../constants/apiEndpoints';
-import { url, selectors as VulnMgmtPageSelectors } from '../../../constants/VulnManagementPage';
+import { selectors as VulnMgmtPageSelectors } from '../../../constants/VulnManagementPage';
 import withAuth from '../../../helpers/basicAuth';
+import { visitVulnerabilityReportingWithFixture } from '../../../helpers/vulnmanagement/reporting';
 
 describe('Vulnmanagement reports', () => {
     withAuth();
 
     describe('report configurations', () => {
-        beforeEach(() => {
-            cy.intercept('GET', api.report.configurations, {
-                fixture: 'reports/reportConfigurations.json',
-            }).as('getReportConfigurations');
-            cy.intercept('GET', api.report.configurationsCount, { count: 2 }).as(
-                'getReportConfigurationsCount'
-            );
-            cy.intercept('POST', api.graphql('searchOptions')).as('searchOptions');
-        });
-
         it('should show a list of report configurations', () => {
-            cy.visit(`${url.reporting.list}`);
-
-            cy.wait('@getReportConfigurations');
-            cy.wait('@getReportConfigurationsCount');
-            cy.wait('@searchOptions');
-
-            // Hard-coded wait is to ameliorate a tenacious flake in CI that has resisted all more gentle solutions
-            cy.wait(1000);
-
-            // page title
-            cy.get('h1:contains("Vulnerability reporting")');
+            visitVulnerabilityReportingWithFixture('reports/reportConfigurations.json');
 
             // column headings
             cy.get(VulnMgmtPageSelectors.reportSection.table.column.name).should('be.visible');

--- a/ui/apps/platform/cypress/integration/vulnmanagement/reporting/manageReports.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/reporting/manageReports.test.js
@@ -2,27 +2,19 @@ import * as api from '../../../constants/apiEndpoints';
 import { url, selectors } from '../../../constants/VulnManagementPage';
 import withAuth from '../../../helpers/basicAuth';
 import { getHelperElementByLabel, getInputByLabel } from '../../../helpers/formHelpers';
-import { visitFromLeftNavExpandable } from '../../../helpers/nav';
+import {
+    visitVulnerabilityReporting,
+    visitVulnerabilityReportingFromLeftNav,
+} from '../../../helpers/vulnmanagement/reporting';
 import navigationSelectors from '../../../selectors/navigation';
-
-function visitVulnerabilityReporting() {
-    cy.intercept('GET', api.report.configurations).as('getReportConfigurations');
-    cy.intercept('GET', api.report.configurationsCount).as('getReportConfigurationsCount');
-    cy.visit(url.reporting.list);
-    cy.wait(['@getReportConfigurations', '@getReportConfigurationsCount']);
-}
 
 describe('Vulnmanagement reports', () => {
     withAuth();
 
     describe('creating a report', () => {
         it('should go from left navigation', () => {
-            cy.intercept('GET', api.report.configurations).as('getReportConfigurations');
-            cy.intercept('GET', api.report.configurationsCount).as('getReportConfigurationsCount');
-            visitFromLeftNavExpandable('Vulnerability Management', 'Reporting');
-            cy.wait(['@getReportConfigurations', '@getReportConfigurationsCount']);
+            visitVulnerabilityReportingFromLeftNav();
 
-            cy.get('h1:contains("Vulnerability reporting")');
             cy.location('pathname').should('eq', url.reporting.list);
         });
 


### PR DESCRIPTION
## Description

### Goal

* For each test, decide which helper function to call for actual or mock requests instead of letting `beforeEach` decide.
* Group tests by subject instead of by shared setup.

Find `beforeEach` in cypress/integration: from 12 results in 9 files to 11 results in 8 files.

### Changed files

1. Add helpers/vulnmanagement/reporting.js
    * Add `visitVulnerabilityReportingFromLeftNav` function adapted from test file
    * Move `visitVulnerabilityReporting` function from test file
    * Add `visitVulnerabilityReportingWithFixture` function adapted from test file

2. Edit integration/vulnmanagement/reporting/displayReports.test.js
    * Replace `beforeEach` with helper function
    * Delete hard-coded `wait`

3. Edit integration/vulnmanagement/reporting/manageReports.test.js
    * Import helper functions

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Ran tests one at a time in local deployment