### PR TITLE
Disable RBAC risk due to performance instability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-10018: The policy `OpenShift: Kubeadmin Secret Accessed` will no longer trigger if the request was from the default OpenShift `oauth-apiserver-sa` service account, because this is an expected access pattern for the OpenShift apiserver.
 - Violation tags and process tags are deprecated, and will be removed in version 3.72.0.
 - Users who do not want to include the RBAC factor in risk calculation can set
-  the "INCLUDE_RBAC_IN_RISK" environment variable to "false" in the Central deployment spec.
+  the "ROX_INCLUDE_RBAC_IN_RISK" environment variable to "false" in the Central deployment spec.
 
 ## [69.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - For questions about this change, please contact the Red Hat support team at support@redhat.com.
 - ROX-10018: The policy `OpenShift: Kubeadmin Secret Accessed` will no longer trigger if the request was from the default OpenShift `oauth-apiserver-sa` service account, because this is an expected access pattern for the OpenShift apiserver.
 - Violation tags and process tags are deprecated, and will be removed in version 3.72.0.
-- RBAC calculation is no longer included in Risk by default, since it was not performant. Users who want it included can set
-  the "INCLUDE_RBAC_IN_RISK" to "true" in the Central deployment spec.
+- Users who do not want to include the RBAC factor in risk calculation can set
+  the "INCLUDE_RBAC_IN_RISK" environment variable to "false" in the Central deployment spec.
 
 ## [69.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - For questions about this change, please contact the Red Hat support team at support@redhat.com.
 - ROX-10018: The policy `OpenShift: Kubeadmin Secret Accessed` will no longer trigger if the request was from the default OpenShift `oauth-apiserver-sa` service account, because this is an expected access pattern for the OpenShift apiserver.
 - Violation tags and process tags are deprecated, and will be removed in version 3.72.0.
-
+- RBAC calculation is no longer included in Risk by default, since it was not performant. Users who want it included can set
+  the "INCLUDE_RBAC_IN_RISK" to "true" in the Central deployment spec.
 
 ## [69.1]
 

--- a/central/risk/scorer/deployment/scorer.go
+++ b/central/risk/scorer/deployment/scorer.go
@@ -40,7 +40,8 @@ func NewDeploymentScorer(alertGetter getters.AlertGetter, roles roleStore.DataSt
 			deployment.NewImageMultiplier(image.RiskyComponentCountHeading),
 			deployment.NewImageMultiplier(image.ComponentCountHeading),
 			deployment.NewImageMultiplier(image.ImageAgeHeading),
-			deployment.NewSAPermissionsMultiplier(roles, bindings, serviceAccounts),
+			// TODO(ROX-10854)
+			// deployment.NewSAPermissionsMultiplier(roles, bindings, serviceAccounts),
 		},
 	}
 

--- a/central/risk/scorer/deployment/scorer.go
+++ b/central/risk/scorer/deployment/scorer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/central/risk/multipliers/image"
 	saStore "github.com/stackrox/rox/central/serviceaccount/datastore"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 )
 
@@ -40,9 +41,12 @@ func NewDeploymentScorer(alertGetter getters.AlertGetter, roles roleStore.DataSt
 			deployment.NewImageMultiplier(image.RiskyComponentCountHeading),
 			deployment.NewImageMultiplier(image.ComponentCountHeading),
 			deployment.NewImageMultiplier(image.ImageAgeHeading),
-			// TODO(ROX-10854)
-			// deployment.NewSAPermissionsMultiplier(roles, bindings, serviceAccounts),
 		},
+	}
+	if env.IncludeRBACInRisk.BooleanSetting() {
+		scoreImpl.ConfiguredMultipliers = append(scoreImpl.ConfiguredMultipliers,
+			deployment.NewSAPermissionsMultiplier(roles, bindings, serviceAccounts),
+		)
 	}
 
 	return scoreImpl

--- a/central/risk/scorer/deployment/scorer_test.go
+++ b/central/risk/scorer/deployment/scorer_test.go
@@ -100,15 +100,11 @@ func TestScore(t *testing.T) {
 		},
 	}
 
-	mockServiceAccounts.EXPECT().SearchRawServiceAccounts(ctx, gomock.Any()).Return(nil, nil)
-
 	actualRisk := scorer.Score(ctx, deployment, getMockImagesRisk())
 	assert.Equal(t, expectedRiskResults, actualRisk.GetResults())
 	assert.InDelta(t, expectedRiskScore, actualRisk.GetScore(), 0.0001)
 
 	expectedRiskScore = 12.1794405
-
-	mockServiceAccounts.EXPECT().SearchRawServiceAccounts(ctx, gomock.Any()).Return(nil, nil)
 
 	actualRisk = scorer.Score(ctx, deployment, getMockImagesRisk())
 	assert.Equal(t, expectedRiskResults, actualRisk.GetResults())

--- a/central/risk/scorer/deployment/scorer_test.go
+++ b/central/risk/scorer/deployment/scorer_test.go
@@ -100,11 +100,15 @@ func TestScore(t *testing.T) {
 		},
 	}
 
+	mockServiceAccounts.EXPECT().SearchRawServiceAccounts(ctx, gomock.Any()).Return(nil, nil)
+
 	actualRisk := scorer.Score(ctx, deployment, getMockImagesRisk())
 	assert.Equal(t, expectedRiskResults, actualRisk.GetResults())
 	assert.InDelta(t, expectedRiskScore, actualRisk.GetScore(), 0.0001)
 
 	expectedRiskScore = 12.1794405
+
+	mockServiceAccounts.EXPECT().SearchRawServiceAccounts(ctx, gomock.Any()).Return(nil, nil)
 
 	actualRisk = scorer.Score(ctx, deployment, getMockImagesRisk())
 	assert.Equal(t, expectedRiskResults, actualRisk.GetResults())

--- a/pkg/env/rbac_risk.go
+++ b/pkg/env/rbac_risk.go
@@ -1,0 +1,6 @@
+package env
+
+var (
+	// IncludeRBACInRisk toggles whether RBAC is included in the risk calculation.
+	IncludeRBACInRisk = RegisterBooleanSetting("INCLUDE_RBAC_IN_RISK", false)
+)

--- a/pkg/env/rbac_risk.go
+++ b/pkg/env/rbac_risk.go
@@ -2,5 +2,5 @@ package env
 
 var (
 	// IncludeRBACInRisk toggles whether RBAC is included in the risk calculation.
-	IncludeRBACInRisk = RegisterBooleanSetting("INCLUDE_RBAC_IN_RISK", false)
+	IncludeRBACInRisk = RegisterBooleanSetting("INCLUDE_RBAC_IN_RISK", true)
 )

--- a/pkg/env/rbac_risk.go
+++ b/pkg/env/rbac_risk.go
@@ -2,5 +2,5 @@ package env
 
 var (
 	// IncludeRBACInRisk toggles whether RBAC is included in the risk calculation.
-	IncludeRBACInRisk = RegisterBooleanSetting("INCLUDE_RBAC_IN_RISK", true)
+	IncludeRBACInRisk = RegisterBooleanSetting("ROX_INCLUDE_RBAC_IN_RISK", true)
 )

--- a/pkg/env/setting.go
+++ b/pkg/env/setting.go
@@ -66,6 +66,10 @@ func RegisterSetting(envVar string, opts ...SettingOption) Setting {
 	return s
 }
 
+func unregisterSetting(envVar string) {
+	delete(Settings, envVar)
+}
+
 func (s *setting) EnvVar() string {
 	return s.envVar
 }

--- a/pkg/env/setting_test.go
+++ b/pkg/env/setting_test.go
@@ -19,6 +19,7 @@ func TestWithoutDefault(t *testing.T) {
 
 	name := newRandomName()
 	s := RegisterSetting(name)
+	defer unregisterSetting(name)
 
 	a.Equal(name, s.EnvVar())
 	a.Empty(s.Setting())
@@ -32,6 +33,7 @@ func TestWithDefault(t *testing.T) {
 
 	name := newRandomName()
 	s := RegisterSetting(name, WithDefault("baz"))
+	defer unregisterSetting(name)
 
 	a.Equal("baz", s.Setting())
 
@@ -47,6 +49,7 @@ func TestWithDefaultAndAllowEmpty(t *testing.T) {
 
 	name := newRandomName()
 	s := RegisterSetting(name, WithDefault("baz"), AllowEmpty())
+	defer unregisterSetting(name)
 
 	a.Equal("baz", s.Setting())
 
@@ -62,6 +65,7 @@ func TestDurationSetting(t *testing.T) {
 
 	name := newRandomName()
 	s := registerDurationSetting(name, time.Minute)
+	defer unregisterSetting(name)
 
 	a.Equal(time.Minute, s.DurationSetting())
 	a.Equal("1m0s", s.Setting())

--- a/pkg/env/setting_test.go
+++ b/pkg/env/setting_test.go
@@ -3,6 +3,7 @@ package env
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -68,4 +69,14 @@ func TestDurationSetting(t *testing.T) {
 	a.NoError(os.Setenv(name, "1h"))
 	a.Equal(time.Hour, s.DurationSetting())
 	a.Equal("1h0m0s", s.Setting())
+}
+
+func TestSettingEnvVarsStartWithRox(t *testing.T) {
+	for k := range Settings {
+		// This one slipped by, too late to change it, so ignore in the test.
+		if k == NotifyEveryRuntimeEvent.EnvVar() {
+			continue
+		}
+		assert.True(t, strings.HasPrefix(k, "ROX_"), "Env var %s doesn't start with ROX_", k)
+	}
 }


### PR DESCRIPTION
## Description

12k roles, rolebindings, service accounts
11k deployments

Running for 13 minutes
```
goroutine 1 [chan receive, 13 minutes]:
```
```
process_cpu_throttled_time                                                       3448381546095
```
which is 57 minutes of throttling which explains some of the slowness.

<img width="163" alt="Screen Shot 2022-05-06 at 10 38 30 AM" src="https://user-images.githubusercontent.com/2565181/167184981-00ede2b1-e635-4c14-b584-c94a49691ab7.png">
<img width="597" alt="Screen Shot 2022-05-06 at 10 38 07 AM" src="https://user-images.githubusercontent.com/2565181/167184988-de368c3f-4101-41f1-84cf-5245da3e4de1.png">
<img width="217" alt="Screen Shot 2022-05-06 at 10 38 19 AM" src="https://user-images.githubusercontent.com/2565181/167184995-df5e14aa-466c-4dac-b533-6bb9a0bdd8d4.png">


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI should pass