### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/central/deployment/datastore/datastore_bench_test.go
+++ b/central/deployment/datastore/datastore_bench_test.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -33,8 +32,7 @@ func BenchmarkSearchAllDeployments(b *testing.B) {
 			sac.ResourceScopeKeys(resources.Deployment),
 		))
 
-	tempPath, err := os.MkdirTemp("", "")
-	require.NoError(b, err)
+	tempPath := b.TempDir()
 
 	blevePath := filepath.Join(tempPath, "scorch.bleve")
 

--- a/central/globalindex/bleveindex_test.go
+++ b/central/globalindex/bleveindex_test.go
@@ -2,7 +2,6 @@ package globalindex
 
 import (
 	"encoding/json"
-	"os"
 	"testing"
 
 	bleveMapping "github.com/blevesearch/bleve/mapping"
@@ -15,8 +14,7 @@ import (
 func TestCompareMapping(t *testing.T) {
 	indexMapping := mapping.GetIndexMapping()
 
-	tmpDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	index, err := TempInitializeIndices(tmpDir)
 	require.NoError(t, err)

--- a/central/image/datastore/datastore_bench_test.go
+++ b/central/image/datastore/datastore_bench_test.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -34,8 +33,7 @@ func BenchmarkImages(b *testing.B) {
 	dacky, err := dackbox.NewRocksDBDackBox(db, nil, []byte("graph"), []byte("dirty"), []byte("valid"))
 	require.NoError(b, err)
 
-	tempPath, err := os.MkdirTemp("", "")
-	require.NoError(b, err)
+	tempPath := b.TempDir()
 	blevePath := filepath.Join(tempPath, "scorch.bleve")
 	bleveIndex, err := globalindex.InitializeIndices("main", blevePath, globalindex.EphemeralIndex, "")
 	require.NoError(b, err)

--- a/central/image/datastore/datastore_impl_test.go
+++ b/central/image/datastore/datastore_impl_test.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -67,10 +66,7 @@ func (suite *ImageDataStoreTestSuite) SetupSuite() {
 		suite.FailNow("failed to create dackbox", err.Error())
 	}
 
-	suite.blevePath, err = os.MkdirTemp("", "")
-	if err != nil {
-		suite.FailNow("failed to create dir for bleve", err.Error())
-	}
+	suite.blevePath = suite.T().TempDir()
 	blevePath := filepath.Join(suite.blevePath, "scorch.bleve")
 	bleveIndex, err := globalindex.InitializeIndices("main", blevePath, globalindex.EphemeralIndex, "")
 	if err != nil {
@@ -91,7 +87,6 @@ func (suite *ImageDataStoreTestSuite) SetupSuite() {
 }
 
 func (suite *ImageDataStoreTestSuite) TearDownSuite() {
-	_ = os.RemoveAll(suite.blevePath)
 	rocksdbtest.TearDownRocksDB(suite.db)
 }
 

--- a/central/imagecomponent/search/searcher_impl_test.go
+++ b/central/imagecomponent/search/searcher_impl_test.go
@@ -2,7 +2,6 @@ package search
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -75,10 +74,7 @@ func (suite *ImageComponentSearchTestSuite) SetupSuite() {
 		suite.FailNow("failed to create dackbox", err.Error())
 	}
 
-	suite.blevePath, err = os.MkdirTemp("", "")
-	if err != nil {
-		suite.FailNow("failed to create dir for bleve", err.Error())
-	}
+	suite.blevePath = suite.T().TempDir()
 	blevePath := filepath.Join(suite.blevePath, "scorch.bleve")
 	bleveIndex, err := globalindex.InitializeIndices("main", blevePath, globalindex.EphemeralIndex, "")
 	if err != nil {
@@ -110,7 +106,6 @@ func (suite *ImageComponentSearchTestSuite) SetupSuite() {
 }
 
 func (suite *ImageComponentSearchTestSuite) TearDownSuite() {
-	_ = os.RemoveAll(suite.blevePath)
 	rocksdbtest.TearDownRocksDB(suite.db)
 }
 

--- a/central/node/datastore/dackbox/datastore/datastore_bench_test.go
+++ b/central/node/datastore/dackbox/datastore/datastore_bench_test.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -34,11 +33,7 @@ func BenchmarkNodes(b *testing.B) {
 	dacky, err := dackbox.NewRocksDBDackBox(db, nil, []byte("graph"), []byte("dirty"), []byte("valid"))
 	require.NoError(b, err)
 
-	tempPath, err := os.MkdirTemp("", "")
-	require.NoError(b, err)
-	defer func() {
-		_ = os.RemoveAll(tempPath)
-	}()
+	tempPath := b.TempDir()
 	blevePath := filepath.Join(tempPath, "scorch.bleve")
 	bleveIndex, err := globalindex.InitializeIndices("main", blevePath, globalindex.EphemeralIndex, "")
 	require.NoError(b, err)

--- a/central/node/datastore/dackbox/datastore/datastore_impl_test.go
+++ b/central/node/datastore/dackbox/datastore/datastore_impl_test.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -63,10 +62,7 @@ func (suite *NodeDataStoreTestSuite) SetupSuite() {
 		suite.FailNow("failed to create dackbox", err.Error())
 	}
 
-	suite.blevePath, err = os.MkdirTemp("", "")
-	if err != nil {
-		suite.FailNow("failed to create dir for bleve", err.Error())
-	}
+	suite.blevePath = suite.T().TempDir()
 	blevePath := filepath.Join(suite.blevePath, "scorch.bleve")
 	bleveIndex, err := globalindex.InitializeIndices("main", blevePath, globalindex.EphemeralIndex, "")
 	if err != nil {
@@ -87,7 +83,6 @@ func (suite *NodeDataStoreTestSuite) SetupSuite() {
 }
 
 func (suite *NodeDataStoreTestSuite) TearDownSuite() {
-	_ = os.RemoveAll(suite.blevePath)
 	rocksdbtest.TearDownRocksDB(suite.db)
 }
 

--- a/central/pod/datastore/datastore_bench_test.go
+++ b/central/pod/datastore/datastore_bench_test.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,8 +29,7 @@ func BenchmarkSearchAllPods(b *testing.B) {
 			sac.ResourceScopeKeys(resources.Deployment),
 		))
 
-	tempPath, err := os.MkdirTemp("", "")
-	require.NoError(b, err)
+	tempPath := b.TempDir()
 
 	blevePath := filepath.Join(tempPath, "scorch.bleve")
 

--- a/central/probeupload/manager/manager_impl_test.go
+++ b/central/probeupload/manager/manager_impl_test.go
@@ -30,16 +30,9 @@ func TestManager(t *testing.T) {
 }
 
 func (s *managerTestSuite) SetupTest() {
-	dataDir, err := os.MkdirTemp("", "probeupload-mgr-test-")
-	s.Require().NoError(err)
-
-	s.dataDir = dataDir
+	s.dataDir = s.T().TempDir()
 	s.mgr = newManager(s.dataDir)
 	s.mgr.freeDiskThreshold = 0 // not interested in testing this
-}
-
-func (s *managerTestSuite) TearDownTest() {
-	_ = os.RemoveAll(s.dataDir)
 }
 
 func (s *managerTestSuite) TestInitializeOnEmptyDir() {

--- a/central/tlsconfig/manager_impl_test.go
+++ b/central/tlsconfig/manager_impl_test.go
@@ -34,8 +34,7 @@ func (s *managerTestSuite) SetupSuite() {
 	ca, err := certgen.GenerateCA()
 	s.Require().NoError(err)
 
-	testCertDir, err := os.MkdirTemp("", "tlsconfig-manager-test-")
-	s.Require().NoError(err)
+	testCertDir := s.T().TempDir()
 
 	caFile := filepath.Join(testCertDir, "ca.pem")
 	s.Require().NoError(os.WriteFile(caFile, ca.CertPEM(), 0644))

--- a/compliance/collection/auditlog/auditlog_impl_test.go
+++ b/compliance/collection/auditlog/auditlog_impl_test.go
@@ -44,11 +44,7 @@ func (s *ComplianceAuditLogReaderTestSuite) TestReaderReturnsGracefullyIfFileDoe
 }
 
 func (s *ComplianceAuditLogReaderTestSuite) TestReaderReturnsErrorIfFileExistsButCannotBeRead() {
-	tempDir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-	defer func() {
-		s.NoError(os.RemoveAll(tempDir))
-	}()
+	tempDir := s.T().TempDir()
 	logPath := filepath.Join(tempDir, "testaudit_notopenable.log")
 
 	// Create a file that the reader cannot open due to permissions missing
@@ -87,11 +83,7 @@ func (s *ComplianceAuditLogReaderTestSuite) TestReaderReturnsErrorIfReaderIsAlre
 }
 
 func (s *ComplianceAuditLogReaderTestSuite) TestReaderTailsLog() {
-	tempDir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-	defer func() {
-		s.NoError(os.RemoveAll(tempDir))
-	}()
+	tempDir := s.T().TempDir()
 	logPath := filepath.Join(tempDir, "testaudit_tail.log")
 
 	sender, reader := s.getMocks(logPath)
@@ -138,11 +130,7 @@ func (s *ComplianceAuditLogReaderTestSuite) TestReaderTailsLog() {
 }
 
 func (s *ComplianceAuditLogReaderTestSuite) TestReaderOnlySendsEventsThatMatchResourceTypeFilter() {
-	tempDir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-	defer func() {
-		s.NoError(os.RemoveAll(tempDir))
-	}()
+	tempDir := s.T().TempDir()
 	logPath := filepath.Join(tempDir, "testaudit_filter.log")
 
 	sender, reader := s.getMocks(logPath)
@@ -175,11 +163,7 @@ func (s *ComplianceAuditLogReaderTestSuite) TestReaderOnlySendsEventsThatMatchRe
 }
 
 func (s *ComplianceAuditLogReaderTestSuite) TestReaderOnlySendsEventsForValidStages() {
-	tempDir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-	defer func() {
-		s.NoError(os.RemoveAll(tempDir))
-	}()
+	tempDir := s.T().TempDir()
 	logPath := filepath.Join(tempDir, "testaudit_filter.log")
 
 	sender, reader := s.getMocks(logPath)
@@ -223,11 +207,7 @@ func (s *ComplianceAuditLogReaderTestSuite) TestReaderOnlySendsEventsForValidSta
 }
 
 func (s *ComplianceAuditLogReaderTestSuite) TestReaderOnlySendsEventsForVerbsNotInDenyList() {
-	tempDir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-	defer func() {
-		s.NoError(os.RemoveAll(tempDir))
-	}()
+	tempDir := s.T().TempDir()
 	logPath := filepath.Join(tempDir, "testaudit_filter_verb.log")
 
 	sender, reader := s.getMocks(logPath)
@@ -271,11 +251,7 @@ func (s *ComplianceAuditLogReaderTestSuite) TestReaderOnlySendsEventsForVerbsNot
 }
 
 func (s *ComplianceAuditLogReaderTestSuite) TestReaderSkipsEventsThatCannotBeParsed() {
-	tempDir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-	defer func() {
-		s.NoError(os.RemoveAll(tempDir))
-	}()
+	tempDir := s.T().TempDir()
 	logPath := filepath.Join(tempDir, "testaudit_marshallerr.log")
 
 	sender, reader := s.getMocks(logPath)
@@ -307,11 +283,7 @@ func (s *ComplianceAuditLogReaderTestSuite) TestReaderSkipsEventsThatCannotBePar
 }
 
 func (s *ComplianceAuditLogReaderTestSuite) TestReaderStartsSendingEventsAfterStartState() {
-	tempDir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-	defer func() {
-		s.NoError(os.RemoveAll(tempDir))
-	}()
+	tempDir := s.T().TempDir()
 	logPath := filepath.Join(tempDir, "testaudit_filestate.log")
 
 	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
@@ -352,11 +324,7 @@ func (s *ComplianceAuditLogReaderTestSuite) TestReaderStartsSendingEventsAfterSt
 }
 
 func (s *ComplianceAuditLogReaderTestSuite) TestReaderStartsSendingEventsAtStartStateIfIdsDontMatch() {
-	tempDir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-	defer func() {
-		s.NoError(os.RemoveAll(tempDir))
-	}()
+	tempDir := s.T().TempDir()
 	logPath := filepath.Join(tempDir, "testaudit_filestate.log")
 
 	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)

--- a/pkg/fileutils/dir_empty_test.go
+++ b/pkg/fileutils/dir_empty_test.go
@@ -14,11 +14,7 @@ func assertPathReturns(t *testing.T, path string, retVal bool) {
 }
 
 func TestDirEmpty(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	assertPathReturns(t, tempDir, true)
 	randomFile := filepath.Join(tempDir, "RANDOM_FILE")

--- a/pkg/migrations/migration_version_test.go
+++ b/pkg/migrations/migration_version_test.go
@@ -13,12 +13,6 @@ import (
 )
 
 func TestMigrationVersion_Read(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "migver-read")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.Remove(tempDir)
-	}()
-
 	testCases := []struct {
 		description string
 		prepFunc    func(dbPath string)
@@ -59,8 +53,7 @@ func TestMigrationVersion_Read(t *testing.T) {
 
 	for _, c := range testCases {
 		t.Run(c.description, func(t *testing.T) {
-			dir, err := os.MkdirTemp(tempDir, "")
-			require.NoError(t, err)
+			dir := t.TempDir()
 			if c.prepFunc != nil {
 				c.prepFunc(dir)
 			}
@@ -77,12 +70,6 @@ func TestMigrationVersion_Read(t *testing.T) {
 }
 
 func TestMigrationVersion_Write(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "migver-write")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.Remove(tempDir)
-	}()
-
 	testCases := []struct {
 		description  string
 		prepFunc     func(dbPath string)
@@ -117,8 +104,7 @@ func TestMigrationVersion_Write(t *testing.T) {
 
 	for _, c := range testCases {
 		t.Run(c.description, func(t *testing.T) {
-			dir, err := os.MkdirTemp(tempDir, "")
-			require.NoError(t, err)
+			dir := t.TempDir()
 			if c.prepFunc != nil {
 				c.prepFunc(dir)
 			}

--- a/pkg/rocksdb/crud/generic_impl_test.go
+++ b/pkg/rocksdb/crud/generic_impl_test.go
@@ -2,7 +2,6 @@ package generic
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -48,8 +47,8 @@ type CRUDTestSuite struct {
 }
 
 func (s *CRUDTestSuite) SetupTest() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
+	var err error
+	dir := s.T().TempDir()
 
 	s.dir = dir
 
@@ -60,7 +59,6 @@ func (s *CRUDTestSuite) SetupTest() {
 
 func (s *CRUDTestSuite) TearDownTest() {
 	s.db.Close()
-	_ = os.RemoveAll(s.dir)
 }
 
 func (s *CRUDTestSuite) TestWalkAllWithID() {
@@ -284,8 +282,8 @@ type CRUDTestSuiteWithoutIndexTracking struct {
 }
 
 func (s *CRUDTestSuiteWithoutIndexTracking) SetupTest() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
+	var err error
+	dir := s.T().TempDir()
 
 	s.dir = dir
 
@@ -296,7 +294,6 @@ func (s *CRUDTestSuiteWithoutIndexTracking) SetupTest() {
 
 func (s *CRUDTestSuiteWithoutIndexTracking) TearDownTest() {
 	s.db.Close()
-	_ = os.RemoveAll(s.dir)
 }
 
 func (s *CRUDTestSuiteWithoutIndexTracking) verifyNoKeysMarkedForIndexing() {

--- a/pkg/rocksdb/crud/unique_key_crud_test.go
+++ b/pkg/rocksdb/crud/unique_key_crud_test.go
@@ -1,7 +1,6 @@
 package generic
 
 import (
-	"os"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -36,8 +35,8 @@ type UniqueKeyCRUDTestSuite struct {
 }
 
 func (s *UniqueKeyCRUDTestSuite) SetupTest() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
+	var err error
+	dir := s.T().TempDir()
 
 	s.dir = dir
 
@@ -48,7 +47,6 @@ func (s *UniqueKeyCRUDTestSuite) SetupTest() {
 
 func (s *UniqueKeyCRUDTestSuite) TearDownTest() {
 	s.db.Close()
-	_ = os.RemoveAll(s.dir)
 }
 
 func (s *UniqueKeyCRUDTestSuite) TestUpsert() {

--- a/pkg/search/blevesearch/query_bench_test.go
+++ b/pkg/search/blevesearch/query_bench_test.go
@@ -3,7 +3,6 @@ package blevesearch
 import (
 	"fmt"
 	"math"
-	"os"
 	"testing"
 
 	"github.com/blevesearch/bleve"
@@ -15,12 +14,7 @@ import (
 )
 
 func preload(b *testing.B) bleve.Index {
-	tmpDir, err := os.MkdirTemp("", "")
-	require.NoError(b, err)
-
-	defer func() {
-		_ = os.RemoveAll(tmpDir)
-	}()
+	tmpDir := b.TempDir()
 
 	kvconfig := map[string]interface{}{
 		// Persist the index

--- a/pkg/tar/tar_test.go
+++ b/pkg/tar/tar_test.go
@@ -12,12 +12,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const testBasePathIn = "tarTestIn"
-const testTarHolder = "tar"
-const testTarName = "test_path.tar"
-const testBasePathOut = "tarTestOut"
-
-const testFileContents = "test file"
+const (
+	testTarName      = "test_path.tar"
+	testFileContents = "test file"
+)
 
 var testStructure = []string{
 	"f1",
@@ -45,16 +43,12 @@ func TestFromPathTarUntar(t *testing.T) {
 }
 
 func doTestTarUntar(t *testing.T, tarFunc func(string, *tar.Writer)) {
-	tmpDirIn, err := os.MkdirTemp("", testBasePathIn)
-	assert.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tmpDirIn) }()
+	tmpDirIn := t.TempDir()
 
-	err = createTarDir(t, tmpDirIn)
+	err := createTarDir(t, tmpDirIn)
 	assert.NoError(t, err)
 
-	tmpDir, err := os.MkdirTemp("", testTarHolder)
-	assert.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	f, err := os.OpenFile(filepath.Join(tmpDir, testTarName), os.O_CREATE|os.O_RDWR, os.ModePerm)
 	defer utils.IgnoreError(f.Close)
@@ -68,9 +62,7 @@ func doTestTarUntar(t *testing.T, tarFunc func(string, *tar.Writer)) {
 	err = f.Close()
 	assert.NoError(t, err)
 
-	tmpDirOut, err := os.MkdirTemp("", testBasePathOut)
-	defer func() { _ = os.RemoveAll(tmpDirOut) }()
-	assert.NoError(t, err)
+	tmpDirOut := t.TempDir()
 
 	f, err = os.OpenFile(filepath.Join(tmpDir, testTarName), os.O_RDONLY, os.ModePerm)
 	defer utils.IgnoreError(f.Close)

--- a/roxctl/central/backup/backup_test.go
+++ b/roxctl/central/backup/backup_test.go
@@ -14,11 +14,7 @@ import (
 )
 
 func TestGetFilePath(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.Remove(tempDir)
-	}()
+	tempDir := t.TempDir()
 	const existingFileName = "existing.file"
 	existingFile, err := os.Create(filepath.Join(tempDir, existingFileName))
 	require.NoError(t, err)

--- a/roxctl/central/generate/generate_test.go
+++ b/roxctl/central/generate/generate_test.go
@@ -3,7 +3,6 @@ package generate
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -36,9 +35,7 @@ const (
 )
 
 func TestRestoreKeysAndCerts(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "testGenerate")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	testutils.SetExampleVersion(t)
 	buildTestutils.SetBuildTimestamp(t, time.Now())

--- a/roxctl/helm/output/output_lint_test.go
+++ b/roxctl/helm/output/output_lint_test.go
@@ -88,15 +88,11 @@ func (s *HelmChartTestSuite) TestOutputHelmChart() {
 		tt := tt
 		for chartName := range common.ChartTemplates {
 			s.Run(fmt.Sprintf("%s-rhacs-%t-flavorProvided-%t-image-defaults-%s", chartName, tt.rhacs, tt.flavorProvided, tt.flavor), func() {
-				outputDir, err := os.MkdirTemp("", "roxctl-helm-output-lint-")
-				s.T().Cleanup(func() {
-					_ = os.RemoveAll(outputDir)
-				})
-				require.NoError(s.T(), err)
+				outputDir := s.T().TempDir()
 				if tt.flavor != "" {
 					tt.flavorProvided = true
 				}
-				err = executeHelpOutputCommand(chartName, outputDir, true, tt.flavor, tt.flavorProvided, tt.rhacs, env)
+				err := executeHelpOutputCommand(chartName, outputDir, true, tt.flavor, tt.flavorProvided, tt.rhacs, env)
 				if tt.wantErr {
 					assert.Error(s.T(), err)
 				} else {
@@ -126,16 +122,12 @@ func (s *HelmChartTestSuite) TestHelmLint() {
 }
 
 func testChartLint(t *testing.T, chartName string, rhacs bool, imageFlavor string) {
-	outputDir, err := os.MkdirTemp("", "roxctl-helm-output-lint-")
-	t.Cleanup(func() {
-		_ = os.RemoveAll(outputDir)
-	})
-	require.NoError(t, err)
+	outputDir := t.TempDir()
 
 	testIO, _, _, _ := environment.TestIO()
 	env := environment.NewCLIEnvironment(testIO, printer.DefaultColorPrinter())
 
-	err = executeHelpOutputCommand(chartName, outputDir, true, imageFlavor, imageFlavor != "", rhacs, env)
+	err := executeHelpOutputCommand(chartName, outputDir, true, imageFlavor, imageFlavor != "", rhacs, env)
 	require.NoErrorf(t, err, "failed to output helm chart %s", chartName)
 
 	for _, ns := range lintNamespaces {

--- a/roxctl/helm/output/output_test.go
+++ b/roxctl/helm/output/output_test.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -10,7 +9,6 @@ import (
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/printer"
 	"github.com/stackrox/rox/roxctl/helm/internal/common"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -136,12 +134,7 @@ func (suite *helmOutputTestSuite) TestValidate() {
 			helmOutputCmd.removeOutputDir = c.removeOutputDir
 			helmOutputCmd.outputDir = c.outputDir
 			if c.createOutputDir {
-				outputDir, mkDirErr := os.MkdirTemp("", "roxctl-helm-output-")
-				suite.T().Cleanup(func() {
-					_ = os.RemoveAll(outputDir)
-				})
-				require.NoError(suite.T(), mkDirErr)
-				helmOutputCmd.outputDir = outputDir
+				helmOutputCmd.outputDir = suite.T().TempDir()
 			}
 
 			err := helmOutputCmd.Validate()

--- a/sensor/common/centralclient/client_test.go
+++ b/sensor/common/centralclient/client_test.go
@@ -71,8 +71,7 @@ func (t *ClientTestSuite) SetupSuite() {
 	ca, err := certgen.GenerateCA()
 	t.Require().NoError(err)
 
-	t.clientCertDir, err = os.MkdirTemp("", "client-certs")
-	t.Require().NoError(err)
+	t.clientCertDir = t.T().TempDir()
 
 	leafCert, err := ca.IssueCertForSubject(mtls.SensorSubject)
 	t.Require().NoError(err)
@@ -84,7 +83,6 @@ func (t *ClientTestSuite) SetupSuite() {
 }
 
 func (t *ClientTestSuite) TearDownSuite() {
-	_ = os.RemoveAll(t.clientCertDir)
 	t.envIsolator.RestoreAll()
 }
 

--- a/tests/backup_test.go
+++ b/tests/backup_test.go
@@ -20,8 +20,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const scratchPath = "backuptest"
-
 // Grab the backup DB and open it, ensuring that there are values for deployments
 func TestBackup(t *testing.T) {
 	setupNginxLatestTagDeployment(t)
@@ -37,12 +35,10 @@ func TestBackup(t *testing.T) {
 }
 
 func doTestBackup(t *testing.T, includeCerts bool) {
-	tmpZipDir, err := os.MkdirTemp("", scratchPath)
-	require.NoError(t, err)
+	tmpZipDir := t.TempDir()
 	zipFilePath := filepath.Join(tmpZipDir, "backup.zip")
 	out, err := os.Create(zipFilePath)
 	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tmpZipDir) }()
 
 	client := testutils.HTTPClientForCentral(t)
 	endpoint := "/db/backup"
@@ -104,9 +100,7 @@ func checkZipForRocks(t *testing.T, zipFile *zip.ReadCloser) {
 	require.NoError(t, err)
 
 	// Dump the untar'd rocks file to a scratch directory.
-	tmpBackupDir, err := os.MkdirTemp("", scratchPath)
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tmpBackupDir) }()
+	tmpBackupDir := t.TempDir()
 
 	err = tar.ToPath(tmpBackupDir, rocksFile)
 	require.NoError(t, err)
@@ -118,9 +112,7 @@ func checkZipForRocks(t *testing.T, zipFile *zip.ReadCloser) {
 	require.NoError(t, err)
 
 	// Restore the db to another temp directory
-	tmpDBDir, err := os.MkdirTemp("", scratchPath)
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tmpDBDir) }()
+	tmpDBDir := t.TempDir()
 	err = backupEngine.RestoreDBFromLatestBackup(tmpDBDir, tmpDBDir, gorocksdb.NewRestoreOptions())
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description

A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

This PR is a non-user facing changes, and it does not introduce any new features.

## Testing Performed

Run each of the changed test on GoLand

![image](https://user-images.githubusercontent.com/20135478/167263475-a3f267f5-9bf6-4938-b6fb-267a9f15d937.png)