### PR TITLE
Add Changelog entry stating that alert and process tags are deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 `v1/policycategories` endpoint have been deprecated, and will be removed in future releases. 
   - For questions about this change, please contact the Red Hat support team at support@redhat.com.
 - ROX-10018: The policy `OpenShift: Kubeadmin Secret Accessed` will no longer trigger if the request was from the default OpenShift `oauth-apiserver-sa` service account, because this is an expected access pattern for the OpenShift apiserver.
+- Violation tags and process tags are deprecated, and will be removed in version 3.72.0.
+
 
 ## [69.1]
 


### PR DESCRIPTION
## Description

Add this in now so we can delete them in 72. Will need to be cherry-picked.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

N/A, no functional change.