### PR TITLE
ROX-9785: Fix RiskTest flake.

### DIFF
--- a/qa-tests-backend/src/test/groovy/RiskTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RiskTest.groovy
@@ -41,7 +41,6 @@ class RiskTest extends BaseSpecification {
     @Shared
     private List<DeploymentWithProcessInfo> whenOneHasRisk
 
-
     static final private int RETRIES = isRaceBuild() ? 120 : (
             (Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 50 : 24)
     static final private int RETRY_DELAY = 5
@@ -112,7 +111,6 @@ class RiskTest extends BaseSpecification {
                         println "SR found ${element.element.processName} for ${DEPLOYMENTS[i].name}"
                     }
                 }
-
             }
 
             if (!processesFound) {
@@ -122,12 +120,12 @@ class RiskTest extends BaseSpecification {
 
             def risksFound = true
             for (DeploymentWithProcessInfo d :  listDeployments()) {
-                if (!DeploymentService.getDeploymentWithRisk(d.getDeployment().getId()).hasRisk()) {
-                    println "not yet ready to test - risk not found for ${d.getDeployment().getName()}"
-                    risksFound = false
-                } else {
+                if (DeploymentService.getDeploymentWithRisk(d.getDeployment().getId()).hasRisk()) {
                     println "risk found for deployment ${d.getDeployment().getName()}"
+                    continue
                 }
+                println "not yet ready to test - risk not found for ${d.getDeployment().getName()}"
+                risksFound = false
             }
 
             if (!risksFound) {

--- a/qa-tests-backend/src/test/groovy/RiskTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RiskTest.groovy
@@ -118,18 +118,14 @@ class RiskTest extends BaseSpecification {
                 continue
             }
 
-            def risksFound = true
-            for (DeploymentWithProcessInfo d :  listDeployments()) {
-                if (DeploymentService.getDeploymentWithRisk(d.getDeployment().getId()).hasRisk()) {
-                    println "risk found for deployment ${d.getDeployment().getName()}"
-                    continue
-                }
-                println "not yet ready to test - risk not found for ${d.getDeployment().getName()}"
-                risksFound = false
-            }
+            List<String> deploymentNamesWithoutRisk = listDeployments()
+                    .collect {
+                        DeploymentService.getDeploymentWithRisk(it.getDeployment().getId()) }
+                    .findAll { !it.hasRisk() }
+                    .collect { it.deployment.name }
 
-            if (!risksFound) {
-                println "not yet ready to test - risks not found"
+            if (!deploymentNamesWithoutRisk.isEmpty()) {
+                print "not yet ready to tst - risks not found ${deploymentNamesWithoutRisk}"
                 continue
             }
 

--- a/qa-tests-backend/src/test/groovy/RiskTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RiskTest.groovy
@@ -1,12 +1,11 @@
 import static io.stackrox.proto.api.v1.SearchServiceOuterClass.RawQuery.newBuilder
 
-import orchestratormanager.OrchestratorTypes
-
 import io.stackrox.proto.api.v1.DeploymentServiceOuterClass.ListDeploymentsWithProcessInfoResponse.DeploymentWithProcessInfo
 import io.stackrox.proto.storage.DeploymentOuterClass.ListDeployment
 import io.stackrox.proto.storage.ProcessBaselineOuterClass
 
 import objects.Deployment
+import orchestratormanager.OrchestratorTypes
 import services.ClusterService
 import services.DeploymentService
 import services.ProcessBaselineService
@@ -42,7 +41,9 @@ class RiskTest extends BaseSpecification {
     @Shared
     private List<DeploymentWithProcessInfo> whenOneHasRisk
 
-    static final private int RETRIES = 24
+
+    static final private int RETRIES = isRaceBuild() ? 120 : (
+            (Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 50 : 24)
     static final private int RETRY_DELAY = 5
     static final private List<Deployment> DEPLOYMENTS = []
     static final private String TEST_NAMESPACE = "qa-risk-${UUID.randomUUID()}"
@@ -111,10 +112,26 @@ class RiskTest extends BaseSpecification {
                         println "SR found ${element.element.processName} for ${DEPLOYMENTS[i].name}"
                     }
                 }
+
             }
 
             if (!processesFound) {
                 println "not yet ready to test - processes not found"
+                continue
+            }
+
+            def risksFound = true
+            for (DeploymentWithProcessInfo d :  listDeployments()) {
+                if (!DeploymentService.getDeploymentWithRisk(d.getDeployment().getId()).hasRisk()) {
+                    println "not yet ready to test - risk not found for ${d.getDeployment().getName()}"
+                    risksFound = false
+                } else {
+                    println "risk found for deployment ${d.getDeployment().getName()}"
+                }
+            }
+
+            if (!risksFound) {
+                println "not yet ready to test - risks not found"
                 continue
             }
 


### PR DESCRIPTION
## Description

Within RiskTest, sometimes the risk test fails within `race-condition-tests`, see [here](https://app.circleci.com/pipelines/github/stackrox/stackrox/7496/workflows/710a6e1a-3d1c-49eb-882e-a3f48756a3e2/jobs/328006).

Check that deployments have their risk calculated properly + increase timeout conditionally based on the environment + race build.

## Testing Performed
- step `race-condition-tests` shouldn't fail anymore.
