### PR TITLE
Replace beforeEach in System Health integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/SystemHealthPatternFly.js
+++ b/ui/apps/platform/cypress/constants/SystemHealthPatternFly.js
@@ -1,0 +1,45 @@
+import scopeSelectors from '../helpers/scopeSelectors';
+
+export const systemHealthUrl = '/main/system-health-pf';
+
+export const selectors = {
+    bundle: {
+        generateDiagnosticBundleButton: 'button:contains("Generate Diagnostic Bundle")',
+        filterByClusters: '[data-testid="filter-by-clusters"]',
+        filterByStartingTime: '#filter-by-starting-time',
+        startingTimeMessage: '[data-testid="starting-time-message"]',
+        downloadDiagnosticBundleButton: 'button:contains("Download Diagnostic Bundle")',
+    },
+    clusters: {
+        categoryCount: '[data-testid="count"]',
+        categoryLabel: '[data-testid="label"]',
+        healthyText: '[data-testid="healthy-text"]',
+        healthySubtext: '[data-testid="healthy-subtext"]',
+        problemCount: '[data-testid="problem-count"]',
+        viewAllButton: '[data-testid="cluster-health"] a:contains("View All")',
+        widgets: {
+            clusterOverview: '[data-testid="cluster-overview"]',
+            collectorStatus: '[data-testid="collector-status"]',
+            sensorStatus: '[data-testid="sensor-status"]',
+            sensorUpgrade: '[data-testid="sensor-upgrade"]',
+            credentialExpiration: '[data-testid="credential-expiration"]',
+        },
+    },
+    integrations: {
+        errorMessage: '[data-testid="error-message"]',
+        healthyText: '[data-testid="healthy-text"]',
+        integrationName: '[data-testid="integration-name"]',
+        integrationLabel: '[data-testid="integration-label"]',
+        lastContact: '[data-testid="last-contact"]',
+        viewAllButton: 'a:contains("View All")',
+        widgets: {
+            imageIntegrations: '[data-testid="image-integrations"]',
+            notifierIntegrations: '[data-testid="notifier-integrations"]',
+            backupIntegrations: '[data-testid="backup-integrations"]',
+        },
+    },
+    vulnDefinitions: scopeSelectors('[data-testid="vulnerability-definitions"]', {
+        header: '[data-testid="widget-header"]',
+        text: '[data-testid="text"]',
+    }),
+};

--- a/ui/apps/platform/cypress/helpers/systemHealth.js
+++ b/ui/apps/platform/cypress/helpers/systemHealth.js
@@ -1,0 +1,244 @@
+import * as api from '../constants/apiEndpoints';
+import { systemHealthUrl } from '../constants/SystemHealth';
+
+import { visitFromLeftNavExpandable } from './nav';
+import { visit } from './visit';
+
+// clock
+
+// Call before visit function.
+export function setClock(currentDatetime) {
+    cy.clock(currentDatetime.getTime(), ['Date']);
+}
+
+// visit
+
+export function visitSystemHealthFromLeftNav() {
+    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
+    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
+    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
+    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+
+    visitFromLeftNavExpandable('Platform Configuration', 'System Health');
+
+    cy.wait([
+        '@getClusters',
+        '@getBackupIntegrations',
+        '@getImageIntegrations',
+        '@getNotifierIntegrations',
+        '@getBackupIntegrationsHealth',
+        '@getImageIntegrationsHealth',
+        '@getNotifierIntegrationsHealth',
+        '@getVulnDefinitionsHealth',
+    ]);
+    cy.get('h1:contains("System Health")');
+}
+
+export function visitSystemHealth() {
+    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
+    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
+    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
+    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+
+    visit(systemHealthUrl);
+
+    cy.wait([
+        '@getClusters',
+        '@getBackupIntegrations',
+        '@getImageIntegrations',
+        '@getNotifierIntegrations',
+        '@getBackupIntegrationsHealth',
+        '@getImageIntegrationsHealth',
+        '@getNotifierIntegrationsHealth',
+        '@getVulnDefinitionsHealth',
+    ]);
+    cy.get('h1:contains("System Health")');
+}
+
+// visit clusters
+
+export function visitSystemHealthWithClustersFixture(fixturePath) {
+    cy.intercept('GET', api.clusters.list, {
+        fixture: fixturePath,
+    }).as('getClusters');
+    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
+    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
+    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
+    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+
+    visit(systemHealthUrl);
+
+    cy.wait([
+        '@getClusters',
+        '@getBackupIntegrations',
+        '@getImageIntegrations',
+        '@getNotifierIntegrations',
+        '@getBackupIntegrationsHealth',
+        '@getImageIntegrationsHealth',
+        '@getNotifierIntegrationsHealth',
+        '@getVulnDefinitionsHealth',
+    ]);
+    cy.get('h1:contains("System Health")');
+}
+
+export function visitSystemHealthWithClustersFixtureFilteredByNames(fixturePath, clusterNames) {
+    cy.fixture(fixturePath).then(({ clusters }) => {
+        cy.intercept('GET', api.clusters.list, {
+            body: { clusters: clusters.filter(({ name }) => clusterNames.includes(name)) },
+        }).as('getClusters');
+        cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
+        cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
+        cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
+        cy.intercept('GET', api.integrationHealth.externalBackups).as(
+            'getBackupIntegrationsHealth'
+        );
+        cy.intercept('GET', api.integrationHealth.imageIntegrations).as(
+            'getImageIntegrationsHealth'
+        );
+        cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
+        cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+
+        visit(systemHealthUrl);
+
+        cy.wait([
+            '@getClusters',
+            '@getBackupIntegrations',
+            '@getImageIntegrations',
+            '@getNotifierIntegrations',
+            '@getBackupIntegrationsHealth',
+            '@getImageIntegrationsHealth',
+            '@getNotifierIntegrationsHealth',
+            '@getVulnDefinitionsHealth',
+        ]);
+        cy.get('h1:contains("System Health")');
+    });
+}
+
+// visit integrations
+
+export function visitSystemHealthWithBackupIntegrations(externalBackups, integrationHealth) {
+    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', api.integrations.externalBackups, {
+        body: { externalBackups },
+    }).as('getBackupIntegrations');
+    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
+    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
+    cy.intercept('GET', api.integrationHealth.externalBackups, {
+        body: { integrationHealth },
+    }).as('getBackupIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+
+    visit(systemHealthUrl);
+
+    cy.wait([
+        '@getClusters',
+        '@getBackupIntegrations',
+        '@getImageIntegrations',
+        '@getNotifierIntegrations',
+        '@getBackupIntegrationsHealth',
+        '@getImageIntegrationsHealth',
+        '@getNotifierIntegrationsHealth',
+        '@getVulnDefinitionsHealth',
+    ]);
+    cy.get('h1:contains("System Health")');
+}
+
+export function visitSystemHealthWithImageIntegrations(integrations, integrationHealth) {
+    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
+    cy.intercept('GET', api.integrations.imageIntegrations, {
+        body: { integrations },
+    }).as('getImageIntegrations');
+    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
+    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.imageIntegrations, {
+        body: { integrationHealth },
+    }).as('getImageIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+
+    visit(systemHealthUrl);
+
+    cy.wait([
+        '@getClusters',
+        '@getBackupIntegrations',
+        '@getImageIntegrations',
+        '@getNotifierIntegrations',
+        '@getBackupIntegrationsHealth',
+        '@getImageIntegrationsHealth',
+        '@getNotifierIntegrationsHealth',
+        '@getVulnDefinitionsHealth',
+    ]);
+    cy.get('h1:contains("System Health")');
+}
+
+export function visitSystemHealthWithNotifierIntegrations(notifiers, integrationHealth) {
+    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
+    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
+    cy.intercept('GET', api.integrations.notifiers, {
+        body: { notifiers },
+    }).as('getNotifierIntegrations');
+    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.notifiers, {
+        body: { integrationHealth },
+    }).as('getNotifierIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+
+    visit(systemHealthUrl);
+
+    cy.wait([
+        '@getClusters',
+        '@getBackupIntegrations',
+        '@getImageIntegrations',
+        '@getNotifierIntegrations',
+        '@getBackupIntegrationsHealth',
+        '@getImageIntegrationsHealth',
+        '@getNotifierIntegrationsHealth',
+        '@getVulnDefinitionsHealth',
+    ]);
+    cy.get('h1:contains("System Health")');
+}
+
+// visit vulnerability definitions
+
+export function visitSystemHealthWithVulnerabilityDefinitionsTimestamp(lastUpdatedTimestamp) {
+    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
+    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
+    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
+    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.vulnDefinitions, {
+        body: { lastUpdatedTimestamp },
+    }).as('getVulnDefinitionsHealth');
+
+    visit(systemHealthUrl);
+
+    cy.wait([
+        '@getClusters',
+        '@getBackupIntegrations',
+        '@getImageIntegrations',
+        '@getNotifierIntegrations',
+        '@getBackupIntegrationsHealth',
+        '@getImageIntegrationsHealth',
+        '@getNotifierIntegrationsHealth',
+        '@getVulnDefinitionsHealth',
+    ]);
+    cy.get('h1:contains("System Health")');
+}

--- a/ui/apps/platform/cypress/helpers/systemHealthPatternFly.js
+++ b/ui/apps/platform/cypress/helpers/systemHealthPatternFly.js
@@ -1,0 +1,244 @@
+import * as api from '../constants/apiEndpoints';
+import { systemHealthUrl } from '../constants/SystemHealthPatternFly';
+
+import { visitFromLeftNavExpandable } from './nav';
+import { visit } from './visit';
+
+// clock
+
+// Call before visit function.
+export function setClock(currentDatetime) {
+    cy.clock(currentDatetime.getTime(), ['Date']);
+}
+
+// visit
+
+export function visitSystemHealthFromLeftNav() {
+    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
+    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
+    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
+    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+
+    visitFromLeftNavExpandable('Platform Configuration', 'System Health');
+
+    cy.wait([
+        '@getClusters',
+        '@getBackupIntegrations',
+        '@getImageIntegrations',
+        '@getNotifierIntegrations',
+        '@getBackupIntegrationsHealth',
+        '@getImageIntegrationsHealth',
+        '@getNotifierIntegrationsHealth',
+        '@getVulnDefinitionsHealth',
+    ]);
+    cy.get('h1:contains("System Health")');
+}
+
+export function visitSystemHealth() {
+    // cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
+    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
+    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
+    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+
+    visit(systemHealthUrl);
+
+    cy.wait([
+        // '@getClusters',
+        '@getBackupIntegrations',
+        '@getImageIntegrations',
+        '@getNotifierIntegrations',
+        '@getBackupIntegrationsHealth',
+        '@getImageIntegrationsHealth',
+        '@getNotifierIntegrationsHealth',
+        '@getVulnDefinitionsHealth',
+    ]);
+    cy.get('h1:contains("System Health")');
+}
+
+// visit clusters
+
+export function visitSystemHealthWithClustersFixture(fixturePath) {
+    cy.intercept('GET', api.clusters.list, {
+        fixture: fixturePath,
+    }).as('getClusters');
+    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
+    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
+    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
+    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+
+    visit(systemHealthUrl);
+
+    cy.wait([
+        '@getClusters',
+        '@getBackupIntegrations',
+        '@getImageIntegrations',
+        '@getNotifierIntegrations',
+        '@getBackupIntegrationsHealth',
+        '@getImageIntegrationsHealth',
+        '@getNotifierIntegrationsHealth',
+        '@getVulnDefinitionsHealth',
+    ]);
+    cy.get('h1:contains("System Health")');
+}
+
+export function visitSystemHealthWithClustersFixtureFilteredByNames(fixturePath, clusterNames) {
+    cy.fixture(fixturePath).then(({ clusters }) => {
+        cy.intercept('GET', api.clusters.list, {
+            body: { clusters: clusters.filter(({ name }) => clusterNames.includes(name)) },
+        }).as('getClusters');
+        cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
+        cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
+        cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
+        cy.intercept('GET', api.integrationHealth.externalBackups).as(
+            'getBackupIntegrationsHealth'
+        );
+        cy.intercept('GET', api.integrationHealth.imageIntegrations).as(
+            'getImageIntegrationsHealth'
+        );
+        cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
+        cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+
+        visit(systemHealthUrl);
+
+        cy.wait([
+            '@getClusters',
+            '@getBackupIntegrations',
+            '@getImageIntegrations',
+            '@getNotifierIntegrations',
+            '@getBackupIntegrationsHealth',
+            '@getImageIntegrationsHealth',
+            '@getNotifierIntegrationsHealth',
+            '@getVulnDefinitionsHealth',
+        ]);
+        cy.get('h1:contains("System Health")');
+    });
+}
+
+// visit integrations
+
+export function visitSystemHealthWithBackupIntegrations(externalBackups, integrationHealth) {
+    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', api.integrations.externalBackups, {
+        body: { externalBackups },
+    }).as('getBackupIntegrations');
+    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
+    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
+    cy.intercept('GET', api.integrationHealth.externalBackups, {
+        body: { integrationHealth },
+    }).as('getBackupIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+
+    visit(systemHealthUrl);
+
+    cy.wait([
+        '@getClusters',
+        '@getBackupIntegrations',
+        '@getImageIntegrations',
+        '@getNotifierIntegrations',
+        '@getBackupIntegrationsHealth',
+        '@getImageIntegrationsHealth',
+        '@getNotifierIntegrationsHealth',
+        '@getVulnDefinitionsHealth',
+    ]);
+    cy.get('h1:contains("System Health")');
+}
+
+export function visitSystemHealthWithImageIntegrations(integrations, integrationHealth) {
+    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
+    cy.intercept('GET', api.integrations.imageIntegrations, {
+        body: { integrations },
+    }).as('getImageIntegrations');
+    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
+    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.imageIntegrations, {
+        body: { integrationHealth },
+    }).as('getImageIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+
+    visit(systemHealthUrl);
+
+    cy.wait([
+        '@getClusters',
+        '@getBackupIntegrations',
+        '@getImageIntegrations',
+        '@getNotifierIntegrations',
+        '@getBackupIntegrationsHealth',
+        '@getImageIntegrationsHealth',
+        '@getNotifierIntegrationsHealth',
+        '@getVulnDefinitionsHealth',
+    ]);
+    cy.get('h1:contains("System Health")');
+}
+
+export function visitSystemHealthWithNotifierIntegrations(notifiers, integrationHealth) {
+    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
+    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
+    cy.intercept('GET', api.integrations.notifiers, {
+        body: { notifiers },
+    }).as('getNotifierIntegrations');
+    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.notifiers, {
+        body: { integrationHealth },
+    }).as('getNotifierIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+
+    visit(systemHealthUrl);
+
+    cy.wait([
+        '@getClusters',
+        '@getBackupIntegrations',
+        '@getImageIntegrations',
+        '@getNotifierIntegrations',
+        '@getBackupIntegrationsHealth',
+        '@getImageIntegrationsHealth',
+        '@getNotifierIntegrationsHealth',
+        '@getVulnDefinitionsHealth',
+    ]);
+    cy.get('h1:contains("System Health")');
+}
+
+// visit vulnerability definitions
+
+export function visitSystemHealthWithVulnerabilityDefinitionsTimestamp(lastUpdatedTimestamp) {
+    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
+    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
+    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
+    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
+    cy.intercept('GET', api.integrationHealth.vulnDefinitions, {
+        body: { lastUpdatedTimestamp },
+    }).as('getVulnDefinitionsHealth');
+
+    visit(systemHealthUrl);
+
+    cy.wait([
+        '@getClusters',
+        '@getBackupIntegrations',
+        '@getImageIntegrations',
+        '@getNotifierIntegrations',
+        '@getBackupIntegrationsHealth',
+        '@getImageIntegrationsHealth',
+        '@getNotifierIntegrationsHealth',
+        '@getVulnDefinitionsHealth',
+    ]);
+    cy.get('h1:contains("System Health")');
+}

--- a/ui/apps/platform/cypress/integration/systemHealth/integrations.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/integrations.test.js
@@ -49,7 +49,7 @@ describe('System Health Integrations local deployment', () => {
 
 describe('System Health Integrations fixtures', () => {
     withAuth();
-    it('should not have count in healthy text for notifier integrations', () => {
+    it('should not have count in healthy text for backup integrations', () => {
         visitSystemHealthWithNotifierIntegrations([], []);
 
         const { healthyText, widgets } = selectors.integrations;

--- a/ui/apps/platform/cypress/integration/systemHealth/integrations.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/integrations.test.js
@@ -3,6 +3,7 @@ import { selectors } from '../../constants/SystemHealth';
 import withAuth from '../../helpers/basicAuth';
 import {
     visitSystemHealth,
+    visitSystemHealthWithBackupIntegrations,
     visitSystemHealthWithImageIntegrations,
     visitSystemHealthWithNotifierIntegrations,
 } from '../../helpers/systemHealth';
@@ -50,7 +51,7 @@ describe('System Health Integrations local deployment', () => {
 describe('System Health Integrations fixtures', () => {
     withAuth();
     it('should not have count in healthy text for backup integrations', () => {
-        visitSystemHealthWithNotifierIntegrations([], []);
+        visitSystemHealthWithBackupIntegrations([], []);
 
         const { healthyText, widgets } = selectors.integrations;
         cy.get(`${widgets.backupIntegrations} ${healthyText}`).should(

--- a/ui/apps/platform/cypress/integration/systemHealth/integrations.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/integrations.test.js
@@ -1,232 +1,167 @@
-import { selectors, systemHealthUrl } from '../../constants/SystemHealth';
-import {
-    integrationHealth as integrationHealthApi,
-    integrations as integrationsApi,
-} from '../../constants/apiEndpoints';
+import { url as integrationsUrl } from '../../constants/IntegrationsPage';
+import { selectors } from '../../constants/SystemHealth';
 import withAuth from '../../helpers/basicAuth';
-import navigationSelectors from '../../selectors/navigation';
+import {
+    visitSystemHealth,
+    visitSystemHealthWithImageIntegrations,
+    visitSystemHealthWithNotifierIntegrations,
+} from '../../helpers/systemHealth';
 
 describe('System Health Integrations local deployment', () => {
     withAuth();
 
-    beforeEach(() => {
-        cy.intercept('GET', integrationHealthApi.imageIntegrations).as(
-            'GetImageIntegrationsHealth'
-        );
-        cy.intercept('GET', integrationHealthApi.notifiers).as('GetNotifiersHealth');
-        cy.intercept('GET', integrationHealthApi.externalBackups).as('GetExternalBackupsHealth');
-        cy.intercept('GET', integrationsApi.imageIntegrations).as('GetImageIntegrations');
-        cy.intercept('GET', integrationsApi.notifiers).as('GetNotifiers');
-        cy.intercept('GET', integrationsApi.externalBackups).as('GetExternalBackups');
-    });
-
-    const allApis = [
-        '@GetImageIntegrationsHealth',
-        '@GetNotifiersHealth',
-        '@GetExternalBackupsHealth',
-        '@GetImageIntegrations',
-        '@GetNotifiers',
-        '@GetExternalBackups',
-    ];
-
-    it('should go from left navigation to Dashboard and have widgets', () => {
-        cy.visit('/');
-        cy.get(`${navigationSelectors.navExpandable}:contains("Platform Configuration")`).click();
-        cy.get(`${navigationSelectors.nestedNavLinks}:contains("System Health")`).click();
-        cy.wait(allApis);
-
-        cy.get('[data-testid="header-text"]').should('have.text', 'System Health');
-
-        Object.entries({
-            imageIntegrations: 'Image Integrations',
-            notifierIntegrations: 'Notifier Integrations',
-            backupIntegrations: 'Backup Integrations',
-        }).forEach(([key, text]) => {
-            cy.get(`${selectors.integrations.widgets[key]} [data-testid="widget-header"]`).should(
-                'have.text',
-                text
-            );
-        });
-    });
-
     it('should go to Image Integrations anchor on Integrations page via click View All', () => {
-        cy.visit(systemHealthUrl);
-        cy.wait('@GetImageIntegrations');
+        visitSystemHealth();
 
         cy.get(
             `${selectors.integrations.widgets.imageIntegrations} ${selectors.integrations.viewAllButton}`
         ).click();
-        cy.wait('@GetImageIntegrations');
 
-        cy.url().should('include', '/integrations');
-        cy.get('#image-integrations h2:contains("Image Integrations")').should('be.visible');
+        cy.location('pathname').should('eq', integrationsUrl);
+        cy.get('h1:contains("Integrations")');
+        cy.get('h2:contains("Image Integrations")').should('be.visible'); // should scroll to anchor
     });
 
     it('should go to Notifier Integrations anchor on Integrations page via click View All', () => {
-        cy.visit(systemHealthUrl);
-        cy.wait('@GetNotifiers');
+        visitSystemHealth();
 
         cy.get(
             `${selectors.integrations.widgets.notifierIntegrations} ${selectors.integrations.viewAllButton}`
         ).click();
-        cy.wait('@GetNotifiers');
 
-        cy.url().should('include', '/integrations');
-        cy.get('#notifier-integrations h2:contains("Notifier Integrations")').should('be.visible');
+        cy.location('pathname').should('eq', integrationsUrl);
+        cy.get('h1:contains("Integrations")');
+        cy.get('h2:contains("Notifier Integrations")').should('be.visible'); // should scroll to anchor
     });
 
     it('should go to Backup Integrations anchor on Integrations page via click View All', () => {
-        cy.visit(systemHealthUrl);
-        cy.wait('@GetExternalBackups');
+        visitSystemHealth();
 
         cy.get(
             `${selectors.integrations.widgets.backupIntegrations} ${selectors.integrations.viewAllButton}`
         ).click();
-        cy.wait('@GetExternalBackups');
 
-        cy.url().should('include', '/integrations');
-        cy.get('#backup-integrations h2:contains("Backup Integrations")').should('be.visible');
+        cy.location('pathname').should('eq', integrationsUrl);
+        cy.get('h1:contains("Integrations")');
+        cy.get('h2:contains("Backup Integrations")').should('be.visible'); // should scroll to anchor
     });
 });
 
 describe('System Health Integrations fixtures', () => {
     withAuth();
-
-    const { integrations } = selectors;
-
-    // re-enable when we update this test to work with ROX-7120 System Health in PatternFly
-    it.skip('should have counts in healthy text', () => {
-        // 2 / 3 healthy integrations
-        cy.intercept('GET', integrationHealthApi.imageIntegrations, {
-            body: {
-                integrationHealth: [
-                    {
-                        id: '05fea766-e2f8-44b3-9959-eaa61a4f7466',
-                        name: 'Public GCR',
-                        type: 'IMAGE_INTEGRATION',
-                        status: 'UNINITIALIZED',
-                        errorMessage: '',
-                        lastTimestamp: '2020-12-09T15:11:16.942655900Z',
-                    },
-                    {
-                        id: '10d3b4dc-8295-41bc-bb50-6da5484cdb1a',
-                        name: 'Public DockerHub',
-                        type: 'IMAGE_INTEGRATION',
-                        status: 'HEALTHY',
-                        errorMessage: '',
-                        lastTimestamp: '2020-12-09T15:15:19.318789700Z',
-                    },
-                    {
-                        id: '169b0d3f-8277-4900-bbce-1127077defae',
-                        name: 'Stackrox Scanner',
-                        type: 'IMAGE_INTEGRATION',
-                        status: 'HEALTHY',
-                        errorMessage: '',
-                        lastTimestamp: '2020-12-09T15:15:38.327627700Z',
-                    },
-                ],
-            },
-        }).as('GetImageIntegrationsHealth');
-        cy.intercept('GET', integrationsApi.imageIntegrations, {
-            body: {
-                integrations: [
-                    {
-                        id: '05fea766-e2f8-44b3-9959-eaa61a4f7466',
-                        type: 'docker',
-                        // omit irrelevant properties
-                    },
-                    {
-                        id: '10d3b4dc-8295-41bc-bb50-6da5484cdb1a',
-                        type: 'docker',
-                        // omit irrelevant properties
-                    },
-                    {
-                        id: '169b0d3f-8277-4900-bbce-1127077defae',
-                        type: 'clairify',
-                        // omit irrelevant properties
-                    },
-                ],
-            },
-        }).as('GetImageIntegrations');
-
-        // 1 healthy integration
-        cy.intercept('GET', integrationHealthApi.notifiers, {
-            body: {
-                integrationHealth: [
-                    {
-                        id: '4af2a32d-adeb-40ad-b509-0b191faecf7b',
-                        name: 'Slack',
-                        type: 'NOTIFIER',
-                        status: 'HEALTHY',
-                        errorMessage: '',
-                        lastTimestamp: '2020-12-09T17:52:18.743384877Z',
-                    },
-                ],
-            },
-        }).as('GetNotifiersHealth');
-        cy.intercept('GET', integrationsApi.notifiers, {
-            body: {
-                notifiers: [
-                    {
-                        id: '4af2a32d-adeb-40ad-b509-0b191faecf7b',
-                        type: 'slack',
-                        // omit irrelevant properties
-                    },
-                ],
-            },
-        }).as('GetNotifiers');
-
-        cy.visit(systemHealthUrl);
-        cy.wait([
-            '@GetImageIntegrationsHealth',
-            '@GetNotifiersHealth',
-            '@GetImageIntegrations',
-            '@GetNotifiers',
-        ]);
+    it('should not have count in healthy text for notifier integrations', () => {
+        visitSystemHealthWithNotifierIntegrations([], []);
 
         const { healthyText, widgets } = selectors.integrations;
+        cy.get(`${widgets.backupIntegrations} ${healthyText}`).should(
+            'have.text',
+            'No configured integrations'
+        );
+    });
 
-        Object.entries({
-            imageIntegrations: '2 / 3 healthy integrations',
-            notifierIntegrations: '1 healthy integration',
-            backupIntegrations: 'No configured integrations',
-        }).forEach(([key, text]) => {
-            cy.get(`${widgets[key]} ${healthyText}`).should('have.text', text);
-        });
+    it('should have counts in healthy text for image integrations', () => {
+        const integrations = [
+            {
+                id: '05fea766-e2f8-44b3-9959-eaa61a4f7466',
+                type: 'docker',
+                // omit irrelevant properties
+            },
+            {
+                id: '10d3b4dc-8295-41bc-bb50-6da5484cdb1a',
+                type: 'docker',
+                // omit irrelevant properties
+            },
+            {
+                id: '169b0d3f-8277-4900-bbce-1127077defae',
+                type: 'clairify',
+                // omit irrelevant properties
+            },
+        ];
+        const integrationHealth = [
+            {
+                id: '05fea766-e2f8-44b3-9959-eaa61a4f7466',
+                name: 'Public GCR',
+                type: 'IMAGE_INTEGRATION',
+                status: 'UNINITIALIZED',
+                errorMessage: '',
+                lastTimestamp: '2020-12-09T15:11:16.942655900Z',
+            },
+            {
+                id: '10d3b4dc-8295-41bc-bb50-6da5484cdb1a',
+                name: 'Public DockerHub',
+                type: 'IMAGE_INTEGRATION',
+                status: 'HEALTHY',
+                errorMessage: '',
+                lastTimestamp: '2020-12-09T15:15:19.318789700Z',
+            },
+            {
+                id: '169b0d3f-8277-4900-bbce-1127077defae',
+                name: 'Stackrox Scanner',
+                type: 'IMAGE_INTEGRATION',
+                status: 'HEALTHY',
+                errorMessage: '',
+                lastTimestamp: '2020-12-09T15:15:38.327627700Z',
+            },
+        ];
+        visitSystemHealthWithImageIntegrations(integrations, integrationHealth);
+
+        const { healthyText, widgets } = selectors.integrations;
+        cy.get(`${widgets.imageIntegrations} ${healthyText}`).should(
+            'have.text',
+            '2 / 3 healthy integrations'
+        );
+    });
+
+    it('should have count in healthy text for notifier integrations', () => {
+        const notifiers = [
+            {
+                id: '4af2a32d-adeb-40ad-b509-0b191faecf7b',
+                type: 'slack',
+                // omit irrelevant properties
+            },
+        ];
+        const integrationHealth = [
+            {
+                id: '4af2a32d-adeb-40ad-b509-0b191faecf7b',
+                name: 'Slack',
+                type: 'NOTIFIER',
+                status: 'HEALTHY',
+                errorMessage: '',
+                lastTimestamp: '2020-12-09T17:52:18.743384877Z',
+            },
+        ];
+        visitSystemHealthWithNotifierIntegrations(notifiers, integrationHealth);
+
+        const { healthyText, widgets } = selectors.integrations;
+        cy.get(`${widgets.notifierIntegrations} ${healthyText}`).should(
+            'have.text',
+            '1 healthy integration'
+        );
     });
 
     it('should have a list with 1 Unhealthy image integration', () => {
-        cy.intercept('GET', integrationHealthApi.imageIntegrations, {
-            body: {
-                integrationHealth: [
-                    {
-                        id: '169b0d3f-8277-4900-bbce-1127077defae',
-                        name: 'StackRox Scanner',
-                        type: 'IMAGE_INTEGRATION',
-                        status: 'UNHEALTHY',
-                        errorMessage:
-                            'Error scanning "docker.io/library/nginx:latest" with scanner "Stackrox Scanner": dial tcp 10.0.1.229:5432: connect: connection refused',
-                        lastTimestamp: '2020-12-04T00:38:17.906318735Z',
-                    },
-                ],
+        const integrations = [
+            {
+                id: '169b0d3f-8277-4900-bbce-1127077defae',
+                name: 'StackRox Scanner',
+                type: 'clairify',
             },
-        }).as('GetImageIntegrationsHealth');
-        cy.intercept('GET', integrationsApi.imageIntegrations, {
-            body: {
-                integrations: [
-                    {
-                        id: '169b0d3f-8277-4900-bbce-1127077defae',
-                        name: 'StackRox Scanner',
-                        type: 'clairify',
-                    },
-                ],
+        ];
+        const integrationHealth = [
+            {
+                id: '169b0d3f-8277-4900-bbce-1127077defae',
+                name: 'StackRox Scanner',
+                type: 'IMAGE_INTEGRATION',
+                status: 'UNHEALTHY',
+                errorMessage:
+                    'Error scanning "docker.io/library/nginx:latest" with scanner "Stackrox Scanner": dial tcp 10.0.1.229:5432: connect: connection refused',
+                lastTimestamp: '2020-12-04T00:38:17.906318735Z',
             },
-        }).as('GetImageIntegrations');
+        ];
+        visitSystemHealthWithImageIntegrations(integrations, integrationHealth);
 
-        cy.visit(systemHealthUrl);
-        cy.wait(['@GetImageIntegrationsHealth', '@GetImageIntegrations']);
+        const { integrationLabel, integrationName, widgets } = selectors.integrations;
 
-        const widgetSelector = integrations.widgets.imageIntegrations;
         [
             {
                 name: 'StackRox Scanner',
@@ -235,9 +170,9 @@ describe('System Health Integrations fixtures', () => {
                     'Error scanning "docker.io/library/nginx:latest" with scanner "Stackrox Scanner": dial tcp 10.0.1.229:5432: connect: connection refused',
             },
         ].forEach(({ name }, i) => {
-            const itemSelector = `${widgetSelector} li:nth-child(${i + 1})`;
-            cy.get(`${itemSelector} ${integrations.integrationName}`).should('have.text', name);
-            cy.get(`${itemSelector} ${integrations.integrationLabel}`).should('not.exist'); // because redundant
+            const itemSelector = `${widgets.imageIntegrations} li:nth-child(${i + 1})`;
+            cy.get(`${itemSelector} ${integrationName}`).should('have.text', name);
+            cy.get(`${itemSelector} ${integrationLabel}`).should('not.exist'); // because redundant
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/systemHealth/systemHealthGeneral.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/systemHealthGeneral.test.js
@@ -1,0 +1,21 @@
+import withAuth from '../../helpers/basicAuth';
+import { visitSystemHealth, visitSystemHealthFromLeftNav } from '../../helpers/systemHealth';
+import navSelectors from '../../selectors/navigation';
+
+describe('System Health general', () => {
+    withAuth();
+
+    it('should visit from left nav', () => {
+        visitSystemHealthFromLeftNav();
+    });
+
+    it('should have selected item in left nav', () => {
+        visitSystemHealth();
+
+        cy.get(`${navSelectors.navExpandable}:contains("Platform Configuration")`);
+        cy.get(`${navSelectors.nestedNavLinks}:contains("System Health")`).should(
+            'have.class',
+            'pf-m-current'
+        );
+    });
+});

--- a/ui/apps/platform/cypress/integration/systemHealthPatternFly/systemHealthGeneral.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealthPatternFly/systemHealthGeneral.test.js
@@ -1,0 +1,31 @@
+import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
+import {
+    visitSystemHealth,
+    visitSystemHealthFromLeftNav,
+} from '../../helpers/systemHealthPatternFly';
+import navSelectors from '../../selectors/navigation';
+
+describe('System Health general', () => {
+    withAuth();
+
+    before(function beforeHook() {
+        if (!hasFeatureFlag('ROX_SYSTEM_HEALTH_PF')) {
+            this.skip();
+        }
+    });
+
+    it.skip('should visit from left nav', () => {
+        visitSystemHealthFromLeftNav();
+    });
+
+    it('should have selected item in left nav', () => {
+        visitSystemHealth();
+
+        cy.get(`${navSelectors.navExpandable}:contains("Platform Configuration")`);
+        cy.get(`${navSelectors.nestedNavLinks}:contains("System Health")`).should(
+            'have.class',
+            'pf-m-current'
+        );
+    });
+});


### PR DESCRIPTION
## Description


### Goal

* For each test, decide which helper function to call for actual or mock requests instead of letting `beforeEach` decide.
* Group tests by subject instead of by shared setup.

Find `beforeEach` in cypress/integration: from 11 results in 8 files to 6 results in 5 files.

### Changed files

1. Add constants/SystemHealthPatternFly.js
    * Only difference so far is `systemHealthUrl` path

2. Add helpers/systemHealth.js
    * Add `visitSystemHealthFromLeftNav` function adapted from test file
    * Move `visitSystemHealth` function from test file
    * Add functions adapted from test files and tolerate "damp" repetition to simplify adding new functions with fixture

3. Add helpers/systemHealthPatternFly.js
    * Only difference so far is `systemHealthUrl` path
    * Comment out clusters request because page does not yet make it

4. Edit integration/systemHealth/bundle.test.js
    * Replace `beforeEach` with helper function calls in relevant tests
    * Replace `url` with `pathname` property without query parameters

5. Edit integration/systemHealth/clusters.test.js
    * Replace local functions with imports from helpers file
    * Move 2 tests to general test file
    * Replace `beforeEach` with helper function calls in relevant tests
    * Separate `setClock` function for certificate expiration from `visit` functions
    * Move PatternFly test to separate file

6. Edit integration/systemHealth/integrations.test.js
    * Move `intercept` from `beforeEach` into tests
    * Replace `cy.url(…)` with `cy.location('pathname')`
    * Replace intercepts with fixtures with helper functions
    * Split test for healthy backup and image and notifier integrations

7. Add integration/systemHealth/systemHealthGeneral.test.js 

8. Edit integration/systemHealth/vulnDefinitions.test.js
    * Replace `beforeEach` with helper function calls in relevant tests

9. Add integration/systemHealthPatternFly/systemHealthGeneral.test.js

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Ran tests one at a time in local deployment with and without
* `export ROX_SYSTEM_HEALTH_PF=true` in ui folder
* `export CYPRESS_ROX_SYSTEM_HEALTH_PF=true` in ui/apps/platform folder