### PR TITLE
Update cypress 9.6.1 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -139,7 +139,7 @@
         "@types/react-dom": "^17.0.11",
         "@types/react-redux": "^7.1.20",
         "autoprefixer": "^10.2.5",
-        "cypress": "^9.6.0",
+        "cypress": "^9.6.1",
         "cypress-file-upload": "^5.0.8",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7532,10 +7532,10 @@ cypress-file-upload@^5.0.8:
   resolved "https://registry.yarnpkg.com/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz#d8824cbeaab798e44be8009769f9a6c9daa1b4a1"
   integrity sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==
 
-cypress@^9.6.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.6.0.tgz#84473b3362255fa8f5e627a596e58575c9e5320f"
-  integrity sha512-nNwt9eBQmSENamwa8LxvggXksfyzpyYaQ7lNBLgks3XZ6dPE/6BCQFBzeAyAPt/bNXfH3tKPkAyhiAZPYkWoEg==
+cypress@^9.6.1:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.6.1.tgz#a7d6b5a53325b3dc4960181f5800a5ade0f085eb"
+  integrity sha512-ECzmV7pJSkk+NuAhEw6C3D+RIRATkSb2VAHXDY6qGZbca/F9mv5pPsj2LO6Ty6oIFVBTrwCyL9agl28MtJMe2g==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## Description

https://github.com/cypress-io/cypress/releases/tag/v9.6.1

* Updates were made to ensure XHR calls are properly displaying the response body in the command log.
* Fixed `cy.contains()` and `.should('contain', ...)` to handle finding text that contains backslash characters.
* Updated `.type('{enter}')` to support sending the Enter keystroke to submit buttons that are not rendered within a form html element, but are associated with a form via the `form` attribute.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed