### PR TITLE
ROX-10733: Add SAC integration tests for Pod Datastore.

### DIFF
--- a/central/pod/datastore/datastore_sac_test.go
+++ b/central/pod/datastore/datastore_sac_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/testconsts"
-	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/pkg/sac/testutils"
+	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/central/pod/datastore/datastore_sac_test.go
+++ b/central/pod/datastore/datastore_sac_test.go
@@ -1,0 +1,376 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blevesearch/bleve"
+	"github.com/golang/mock/gomock"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/central/globalindex"
+	"github.com/stackrox/rox/central/pod/datastore/internal/search"
+	"github.com/stackrox/rox/central/pod/index"
+	"github.com/stackrox/rox/central/pod/mappings"
+	"github.com/stackrox/rox/central/pod/store"
+	pgStore "github.com/stackrox/rox/central/pod/store/postgres"
+	rdbStore "github.com/stackrox/rox/central/pod/store/rocksdb"
+	mockProcessStore "github.com/stackrox/rox/central/processindicator/datastore/mocks"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/process/filter"
+	"github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stackrox/rox/pkg/sac/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestPodDatastoreSAC(t *testing.T) {
+	suite.Run(t, new(podDatastoreSACSuite))
+}
+
+type podDatastoreSACSuite struct {
+	suite.Suite
+
+	datastore DataStore
+
+	pool *pgxpool.Pool
+
+	engine *rocksdb.RocksDB
+	index  bleve.Index
+
+	storage store.Store
+	indexer index.Indexer
+	search  search.Searcher
+	filter  filter.Filter
+
+	processStore *mockProcessStore.MockDataStore
+
+	testContexts map[string]context.Context
+	testPodIDs   []string
+}
+
+func (s *podDatastoreSACSuite) SetupSuite() {
+	var err error
+
+	s.processStore = mockProcessStore.NewMockDataStore(gomock.NewController(s.T()))
+	s.processStore.EXPECT().RemoveProcessIndicatorsByPod(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	s.filter = filter.NewFilter(5, []int{5, 4, 3, 2, 1})
+
+	if features.PostgresDatastore.Enabled() {
+		ctx := context.Background()
+		src := pgtest.GetConnectionString(s.T())
+		cfg, err := pgxpool.ParseConfig(src)
+		s.Require().NoError(err)
+		s.pool, err = pgxpool.ConnectConfig(ctx, cfg)
+		s.Require().NoError(err)
+		pgStore.Destroy(ctx, s.pool)
+		s.storage = pgStore.New(ctx, s.pool)
+		s.indexer = pgStore.NewIndexer(s.pool)
+
+		s.datastore, err = NewPostgresDB(s.pool, s.processStore, s.filter)
+		s.Require().NoError(err)
+	} else {
+		s.engine, err = rocksdb.NewTemp("podSACTest")
+		s.Require().NoError(err)
+		bleveIndex, err := globalindex.MemOnlyIndex()
+		s.Require().NoError(err)
+		s.index = bleveIndex
+
+		s.storage = rdbStore.New(s.engine)
+		s.indexer = index.New(s.index)
+
+		s.datastore, err = NewRocksDB(s.engine, s.index, s.processStore, s.filter)
+		s.Require().NoError(err)
+	}
+
+	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(),
+		resources.Deployment.GetResource())
+}
+
+func (s *podDatastoreSACSuite) TearDownSuite() {
+	if features.PostgresDatastore.Enabled() {
+		s.pool.Close()
+	} else {
+		s.Require().NoError(rocksdb.CloseAndRemove(s.engine))
+	}
+
+	s.Require().NoError(s.index.Close())
+}
+
+func (s *podDatastoreSACSuite) SetupTest() {
+	s.testPodIDs = make([]string, 0)
+
+	pods := fixtures.GetSACTestPodSet()
+	for i := range pods {
+		s.Require().NoError(s.datastore.UpsertPod(s.testContexts[testutils.UnrestrictedReadWriteCtx], pods[i]))
+	}
+
+	for _, p := range pods {
+		s.testPodIDs = append(s.testPodIDs, p.GetId())
+	}
+}
+
+func (s *podDatastoreSACSuite) TearDownTest() {
+	for _, id := range s.testPodIDs {
+		s.deletePod(id)
+	}
+}
+
+func (s *podDatastoreSACSuite) deletePod(id string) {
+	s.Require().NoError(s.datastore.RemovePod(s.testContexts[testutils.UnrestrictedReadWriteCtx], id))
+}
+
+func (s *podDatastoreSACSuite) TestUpsertPod() {
+	cases := map[string]struct {
+		scopeKey    string
+		expectFail  bool
+		expectedErr error
+	}{
+		"global read-only should not be able to add": {
+			scopeKey:    testutils.UnrestrictedReadCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"global read-write should be able to add": {
+			scopeKey: testutils.UnrestrictedReadWriteCtx,
+		},
+		"read-write on wrong cluster should not be able to add": {
+			scopeKey:    testutils.Cluster1ReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and namespace should not be able to add": {
+			scopeKey:    testutils.Cluster1NamespaceAReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and matching namespace should not be able to add": {
+			scopeKey:    testutils.Cluster1NamespaceBReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and wrong namespace should not be able to add": {
+			scopeKey:    testutils.Cluster2NamespaceAReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and matching namespace should be able to add": {
+			scopeKey:    testutils.Cluster2NamespaceBReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and at least one matching namespace should be able to add": {
+			scopeKey:    testutils.Cluster2NamespacesABReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			pod := fixtures.GetScopedPod(uuid.NewV4().String(), uuid.NewV4().String(), testconsts.Cluster2,
+				testconsts.NamespaceB)
+			s.testPodIDs = append(s.testPodIDs, pod.GetId())
+			ctx := s.testContexts[c.scopeKey]
+			err := s.datastore.UpsertPod(ctx, pod)
+			defer s.deletePod(pod.GetId())
+			if c.expectFail {
+				s.Require().Error(err)
+				s.ErrorIs(err, c.expectedErr)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}
+
+func (s *podDatastoreSACSuite) TestGetPod() {
+	pod := fixtures.GetScopedPod(uuid.NewV4().String(), uuid.NewV4().String(), testconsts.Cluster2,
+		testconsts.NamespaceB)
+	err := s.datastore.UpsertPod(s.testContexts[testutils.UnrestrictedReadWriteCtx], pod)
+	s.Require().NoError(err)
+	s.testPodIDs = append(s.testPodIDs, pod.GetId())
+
+	cases := map[string]struct {
+		scopeKey string
+		found    bool
+	}{
+		"global read-only can get": {
+			scopeKey: testutils.UnrestrictedReadCtx,
+			found:    true,
+		},
+		"global read-write can get": {
+			scopeKey: testutils.UnrestrictedReadWriteCtx,
+			found:    true,
+		},
+		"read-write on wrong cluster cannot get": {
+			scopeKey: testutils.Cluster1ReadWriteCtx,
+		},
+		"read-write on wrong cluster and wrong namespace cannot get": {
+			scopeKey: testutils.Cluster1NamespaceAReadWriteCtx,
+		},
+		"read-write on wrong cluster and matching namespace cannot get": {
+			scopeKey: testutils.Cluster1NamespaceBReadWriteCtx,
+		},
+		"read-write on matching cluster but wrong namespaces cannot get": {
+			scopeKey: testutils.Cluster2NamespacesACReadWriteCtx,
+		},
+		"read-write on matching cluster can read": {
+			scopeKey: testutils.Cluster2ReadWriteCtx,
+			found:    true,
+		},
+		"read-write on the matching cluster and namespace can get": {
+			scopeKey: testutils.Cluster2NamespaceBReadWriteCtx,
+			found:    true,
+		},
+		"read-write on the matching cluster and at least one matching namespace can get": {
+			scopeKey: testutils.Cluster2NamespacesABReadWriteCtx,
+			found:    true,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[c.scopeKey]
+			res, found, err := s.datastore.GetPod(ctx, pod.GetId())
+			s.Require().NoError(err)
+			if c.found {
+				s.True(found)
+				s.Equal(*pod, *res)
+			} else {
+				s.False(found)
+				s.Nil(res)
+			}
+		})
+	}
+}
+
+func (s *podDatastoreSACSuite) TestRemovePod() {
+	cases := map[string]struct {
+		scopeKey    string
+		expectFail  bool
+		expectedErr error
+	}{
+		"global read-only cannot remove": {
+			scopeKey:    testutils.UnrestrictedReadCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"global read-write can remove": {
+			scopeKey:    testutils.UnrestrictedReadWriteCtx,
+			expectedErr: nil,
+		},
+		"read-write on wrong cluster cannot remove": {
+			scopeKey:    testutils.Cluster1ReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and wrong namespace cannot remove": {
+			scopeKey:    testutils.Cluster1NamespaceAReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and matching namespace cannot remove": {
+			scopeKey:    testutils.Cluster1NamespaceBReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster but wrong namespaces cannot remove": {
+			scopeKey:    testutils.Cluster2NamespacesACReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"full read-write on matching cluster cannot remove": {
+			scopeKey:    testutils.Cluster2ReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on the matching cluster and namespace cannot remove": {
+			scopeKey:    testutils.Cluster2NamespaceBReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on the matching cluster and at least the right namespace cannot remove": {
+			scopeKey:    testutils.Cluster2NamespacesABReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			pod := fixtures.GetScopedPod(uuid.NewV4().String(), uuid.NewV4().String(), testconsts.Cluster2,
+				testconsts.NamespaceB)
+			s.testPodIDs = append(s.testPodIDs, pod.GetId())
+
+			ctx := s.testContexts[c.scopeKey]
+			err := s.datastore.UpsertPod(s.testContexts[testutils.UnrestrictedReadWriteCtx], pod)
+			s.Require().NoError(err)
+			defer s.deletePod(pod.GetId())
+
+			err = s.datastore.RemovePod(ctx, pod.GetId())
+			if c.expectFail {
+				s.Require().Error(err)
+				s.ErrorIs(err, c.expectedErr)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}
+
+func (s *podDatastoreSACSuite) runSearchRawTest(c testutils.SACSearchTestCase) {
+	ctx := s.testContexts[c.ScopeKey]
+	results, err := s.datastore.SearchRawPods(ctx, nil)
+	s.Require().NoError(err)
+	resultObjs := make([]sac.NamespaceScopedObject, 0, len(results))
+	for i := range results {
+		resultObjs = append(resultObjs, results[i])
+	}
+	resultCounts := testutils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), resultObjs)
+	testutils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
+}
+
+func (s *podDatastoreSACSuite) runSearchTest(c testutils.SACSearchTestCase) {
+	ctx := s.testContexts[c.ScopeKey]
+	results, err := s.datastore.Search(ctx, nil)
+	s.Require().NoError(err)
+	resultCounts := testutils.CountResultsPerClusterAndNamespace(s.T(), results, mappings.OptionsMap)
+	testutils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
+}
+
+func (s *podDatastoreSACSuite) TestScopedSearch() {
+	for name, c := range testutils.GenericScopedSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runSearchTest(c)
+		})
+	}
+}
+
+func (s *podDatastoreSACSuite) TestUnrestrictedSearch() {
+	for name, c := range testutils.GenericUnrestrictedSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runSearchTest(c)
+		})
+	}
+}
+
+func (s *podDatastoreSACSuite) TestScopedSearchRaw() {
+	for name, c := range testutils.GenericScopedSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runSearchRawTest(c)
+		})
+	}
+}
+
+func (s *podDatastoreSACSuite) TestUnrestrictedSearchRaw() {
+	for name, c := range testutils.GenericUnrestrictedRawSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runSearchRawTest(c)
+		})
+	}
+}

--- a/central/processindicator/datastore/datastore_sac_test.go
+++ b/central/processindicator/datastore/datastore_sac_test.go
@@ -314,202 +314,8 @@ func (s *processIndicatorDatastoreSACSuite) TestRemoveProcessIndicators() {
 	}
 }
 
-type searchTestCase struct {
-	scopeKey string
-	results  map[string]map[string]int
-}
-
-var scopeSearchCases = map[string]searchTestCase{
-	"Cluster1 read-write access should only see Cluster1 process indicators": {
-		scopeKey: sacTestUtils.Cluster1ReadWriteCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster1: {
-				testconsts.NamespaceA: 3,
-				testconsts.NamespaceB: 3,
-				testconsts.NamespaceC: 3,
-			},
-		},
-	},
-	"Cluster1 and NamespaceA read-write access should only see Cluster1 and NamespaceA process indicators": {
-		scopeKey: sacTestUtils.Cluster1NamespaceAReadWriteCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster1: {
-				testconsts.NamespaceA: 3,
-			},
-		},
-	},
-	"Cluster1 and NamespaceB read-write access should only see Cluster1 and NamespaceB process indicators": {
-		scopeKey: sacTestUtils.Cluster1NamespaceBReadWriteCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster1: {
-				testconsts.NamespaceB: 3,
-			},
-		},
-	},
-	"Cluster1 and NamespaceC read-write access should only see Cluster1 and NamespaceB process indicators": {
-		scopeKey: sacTestUtils.Cluster1NamespaceCReadWriteCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster1: {
-				testconsts.NamespaceC: 3,
-			},
-		},
-	},
-	"Cluster1 and Namespaces A and B read-write access should only see appropriate cluster/namespace " +
-		"process indicators": {
-		scopeKey: sacTestUtils.Cluster1NamespacesABReadWriteCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster1: {
-				testconsts.NamespaceA: 3,
-				testconsts.NamespaceB: 3,
-			},
-		},
-	},
-	"Cluster1 and Namespaces A and C read-write access should only see appropriate cluster/namespace " +
-		"process indicators": {
-		scopeKey: sacTestUtils.Cluster1NamespacesACReadWriteCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster1: {
-				testconsts.NamespaceA: 3,
-				testconsts.NamespaceC: 3,
-			},
-		},
-	},
-	"Cluster1 and Namespaces B and C read-write access should only see appropriate cluster/namespace " +
-		"process indicators": {
-		scopeKey: sacTestUtils.Cluster1NamespacesBCReadWriteCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster1: {
-				testconsts.NamespaceB: 3,
-				testconsts.NamespaceC: 3,
-			},
-		},
-	},
-	"Cluster2 read-write access should only see Cluster2 process indicators": {
-		scopeKey: sacTestUtils.Cluster2ReadWriteCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster2: {
-				testconsts.NamespaceA: 3,
-				testconsts.NamespaceB: 3,
-				testconsts.NamespaceC: 3,
-			},
-		},
-	},
-	"Cluster2 and NamespaceA read-write access should see Cluster2 and NamespaceA process indicators": {
-		scopeKey: sacTestUtils.Cluster2NamespaceAReadWriteCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster2: {
-				testconsts.NamespaceA: 3,
-			},
-		},
-	},
-	"Cluster2 and NamespaceB read-write access should only see Cluster2 and NamespaceB process indicators": {
-		scopeKey: sacTestUtils.Cluster2NamespaceBReadWriteCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster2: {
-				testconsts.NamespaceB: 3,
-			},
-		},
-	},
-	"Cluster2 and NamespaceC read-write access should only see Cluster2 and NamespaceC process indicators": {
-		scopeKey: sacTestUtils.Cluster2NamespaceCReadWriteCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster2: {
-				testconsts.NamespaceC: 3,
-			},
-		},
-	},
-	"Cluster2 and Namespaces A and B read-write access should only see appropriate cluster/namespace " +
-		"process indicators": {
-		scopeKey: sacTestUtils.Cluster2NamespacesABReadWriteCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster2: {
-				testconsts.NamespaceA: 3,
-				testconsts.NamespaceB: 3,
-			},
-		},
-	},
-	"Cluster2 and Namespaces A and C read-write access should only see appropriate cluster/namespace " +
-		"process indicators": {
-		scopeKey: sacTestUtils.Cluster2NamespacesACReadWriteCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster2: {
-				testconsts.NamespaceA: 3,
-				testconsts.NamespaceC: 3,
-			},
-		},
-	},
-	"Cluster2 and Namespaces B and C read-write access should only see appropriate cluster/namespace " +
-		"process indicators": {
-		scopeKey: sacTestUtils.Cluster2NamespacesBCReadWriteCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster2: {
-				testconsts.NamespaceB: 3,
-				testconsts.NamespaceC: 3,
-			},
-		},
-	},
-}
-
-var unrestrictedSearchCases = map[string]searchTestCase{
-	"global read access should see all process indicators": {
-		scopeKey: sacTestUtils.UnrestrictedReadCtx,
-		results: map[string]map[string]int{
-			"": {"": 27},
-		},
-	},
-	"global read-write access should see all process indicators": {
-		scopeKey: sacTestUtils.UnrestrictedReadCtx,
-		results: map[string]map[string]int{
-			"": {"": 27},
-		},
-	},
-}
-
-var unrestrictedRawSearchCases = map[string]searchTestCase{
-	"global read access should see all process indicators": {
-		scopeKey: sacTestUtils.UnrestrictedReadCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster1: {
-				testconsts.NamespaceA: 3,
-				testconsts.NamespaceB: 3,
-				testconsts.NamespaceC: 3,
-			},
-			testconsts.Cluster2: {
-				testconsts.NamespaceA: 3,
-				testconsts.NamespaceB: 3,
-				testconsts.NamespaceC: 3,
-			},
-			testconsts.Cluster3: {
-				testconsts.NamespaceA: 3,
-				testconsts.NamespaceB: 3,
-				testconsts.NamespaceC: 3,
-			},
-		},
-	},
-	"global read-write access should see all process indicators": {
-		scopeKey: sacTestUtils.UnrestrictedReadCtx,
-		results: map[string]map[string]int{
-			testconsts.Cluster1: {
-				testconsts.NamespaceA: 3,
-				testconsts.NamespaceB: 3,
-				testconsts.NamespaceC: 3,
-			},
-			testconsts.Cluster2: {
-				testconsts.NamespaceA: 3,
-				testconsts.NamespaceB: 3,
-				testconsts.NamespaceC: 3,
-			},
-			testconsts.Cluster3: {
-				testconsts.NamespaceA: 3,
-				testconsts.NamespaceB: 3,
-				testconsts.NamespaceC: 3,
-			},
-		},
-	},
-}
-
 func (s *processIndicatorDatastoreSACSuite) TestScopedSearch() {
-	for name, c := range scopeSearchCases {
+	for name, c := range sacTestUtils.GenericScopedSACSearchTestCases(s.T()) {
 		s.Run(name, func() {
 			s.runSearchTest(c)
 		})
@@ -517,7 +323,7 @@ func (s *processIndicatorDatastoreSACSuite) TestScopedSearch() {
 }
 
 func (s *processIndicatorDatastoreSACSuite) TestUnrestrictedSearch() {
-	for name, c := range unrestrictedSearchCases {
+	for name, c := range sacTestUtils.GenericUnrestrictedSACSearchTestCases(s.T()) {
 		s.Run(name, func() {
 			s.runSearchTest(c)
 		})
@@ -525,7 +331,7 @@ func (s *processIndicatorDatastoreSACSuite) TestUnrestrictedSearch() {
 }
 
 func (s *processIndicatorDatastoreSACSuite) TestScopeSearchRaw() {
-	for name, c := range scopeSearchCases {
+	for name, c := range sacTestUtils.GenericScopedSACSearchTestCases(s.T()) {
 		s.Run(name, func() {
 			s.runSearchRawTest(c)
 		})
@@ -533,15 +339,15 @@ func (s *processIndicatorDatastoreSACSuite) TestScopeSearchRaw() {
 }
 
 func (s *processIndicatorDatastoreSACSuite) TestUnrestrictedSearchRaw() {
-	for name, c := range unrestrictedRawSearchCases {
+	for name, c := range sacTestUtils.GenericUnrestrictedRawSACSearchTestCases(s.T()) {
 		s.Run(name, func() {
 			s.runSearchRawTest(c)
 		})
 	}
 }
 
-func (s *processIndicatorDatastoreSACSuite) runSearchRawTest(c searchTestCase) {
-	ctx := s.testContexts[c.scopeKey]
+func (s *processIndicatorDatastoreSACSuite) runSearchRawTest(c sacTestUtils.SACSearchTestCase) {
+	ctx := s.testContexts[c.ScopeKey]
 	results, err := s.datastore.SearchRawProcessIndicators(ctx, nil)
 	s.Require().NoError(err)
 	resultObjs := make([]sac.NamespaceScopedObject, 0, len(results))
@@ -549,13 +355,13 @@ func (s *processIndicatorDatastoreSACSuite) runSearchRawTest(c searchTestCase) {
 		resultObjs = append(resultObjs, results[i])
 	}
 	resultCounts := sacTestUtils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), resultObjs)
-	sacTestUtils.ValidateSACSearchResultDistribution(&s.Suite, c.results, resultCounts)
+	sacTestUtils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
 }
 
-func (s *processIndicatorDatastoreSACSuite) runSearchTest(c searchTestCase) {
-	ctx := s.testContexts[c.scopeKey]
+func (s *processIndicatorDatastoreSACSuite) runSearchTest(c sacTestUtils.SACSearchTestCase) {
+	ctx := s.testContexts[c.ScopeKey]
 	results, err := s.datastore.Search(ctx, nil)
 	s.Require().NoError(err)
 	resultCounts := sacTestUtils.CountResultsPerClusterAndNamespace(s.T(), results, mappings.OptionsMap)
-	sacTestUtils.ValidateSACSearchResultDistribution(&s.Suite, c.results, resultCounts)
+	sacTestUtils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
 }

--- a/pkg/fixtures/pod.go
+++ b/pkg/fixtures/pod.go
@@ -3,15 +3,23 @@ package fixtures
 import (
 	"github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/uuid"
 )
 
 // GetPod returns a mock Pod
 func GetPod() *storage.Pod {
+	return GetScopedPod("nginx-7db9fccd9b-92hfs", GetDeployment().GetId(),
+		"prod cluster", "stackrox")
+}
+
+// GetScopedPod returns a mock Pod belonging to the input scope.
+func GetScopedPod(ID string, deploymentID string, clusterID string, namespace string) *storage.Pod {
 	return &storage.Pod{
-		Id:           "nginx-7db9fccd9b-92hfs",
-		DeploymentId: GetDeployment().GetId(),
-		ClusterId:    "prod cluster",
-		Namespace:    "stackrox",
+		Id:           ID,
+		DeploymentId: deploymentID,
+		ClusterId:    clusterID,
+		Namespace:    namespace,
 		Started: &types.Timestamp{
 			Seconds: 0,
 		},
@@ -110,4 +118,46 @@ func GetPod() *storage.Pod {
 			},
 		},
 	}
+}
+
+// GetSACTestPodSet returns a set of mock Pods that can be used
+// for scoped access control sets.
+// It will include:
+// 9 Process indicators scoped to Cluster1, 3 to each Namespace A / B / C.
+// 9 Process indicators scoped to Cluster2, 3 to each Namespace A / B / C.
+// 9 Process indicators scoped to Cluster3, 3 to each Namespace A / B / C.
+func GetSACTestPodSet() []*storage.Pod {
+	return []*storage.Pod{
+		scopedPod(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedPod(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedPod(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedPod(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedPod(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedPod(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedPod(testconsts.Cluster1, testconsts.NamespaceC),
+		scopedPod(testconsts.Cluster1, testconsts.NamespaceC),
+		scopedPod(testconsts.Cluster1, testconsts.NamespaceC),
+		scopedPod(testconsts.Cluster2, testconsts.NamespaceA),
+		scopedPod(testconsts.Cluster2, testconsts.NamespaceA),
+		scopedPod(testconsts.Cluster2, testconsts.NamespaceA),
+		scopedPod(testconsts.Cluster2, testconsts.NamespaceB),
+		scopedPod(testconsts.Cluster2, testconsts.NamespaceB),
+		scopedPod(testconsts.Cluster2, testconsts.NamespaceB),
+		scopedPod(testconsts.Cluster2, testconsts.NamespaceC),
+		scopedPod(testconsts.Cluster2, testconsts.NamespaceC),
+		scopedPod(testconsts.Cluster2, testconsts.NamespaceC),
+		scopedPod(testconsts.Cluster3, testconsts.NamespaceA),
+		scopedPod(testconsts.Cluster3, testconsts.NamespaceA),
+		scopedPod(testconsts.Cluster3, testconsts.NamespaceA),
+		scopedPod(testconsts.Cluster3, testconsts.NamespaceB),
+		scopedPod(testconsts.Cluster3, testconsts.NamespaceB),
+		scopedPod(testconsts.Cluster3, testconsts.NamespaceB),
+		scopedPod(testconsts.Cluster3, testconsts.NamespaceC),
+		scopedPod(testconsts.Cluster3, testconsts.NamespaceC),
+		scopedPod(testconsts.Cluster3, testconsts.NamespaceC),
+	}
+}
+
+func scopedPod(clusterID, namespace string) *storage.Pod {
+	return GetScopedPod(uuid.NewV4().String(), uuid.NewV4().String(), clusterID, namespace)
 }

--- a/pkg/sac/testutils/search_test_cases.go
+++ b/pkg/sac/testutils/search_test_cases.go
@@ -1,0 +1,221 @@
+package testutils
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+)
+
+// SACSearchTestCase is used within SAC tests. It will yield the number of found
+// items per cluster & namespace.
+type SACSearchTestCase struct {
+	ScopeKey string
+	Results  map[string]map[string]int
+}
+
+// GenericScopedSACSearchTestCases returns a generic set of SACSearchTestCase.
+// It is appropriate to use when the store contains:
+// 9 objects scoped to Cluster1, 3 to each Namespace A / B / C.
+// 9 objects scoped to Cluster2, 3 to each Namespace A / B / C.
+// 9 objects scoped to Cluster3, 3 to each Namespace A / B / C.
+func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase {
+	return map[string]SACSearchTestCase{
+		"Cluster1 read-write access should only see Cluster1 process indicators": {
+			ScopeKey: Cluster1ReadWriteCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster1: {
+					testconsts.NamespaceA: 3,
+					testconsts.NamespaceB: 3,
+					testconsts.NamespaceC: 3,
+				},
+			},
+		},
+		"Cluster1 and NamespaceA read-write access should only see Cluster1 and NamespaceA process indicators": {
+			ScopeKey: Cluster1NamespaceAReadWriteCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster1: {
+					testconsts.NamespaceA: 3,
+				},
+			},
+		},
+		"Cluster1 and NamespaceB read-write access should only see Cluster1 and NamespaceB process indicators": {
+			ScopeKey: Cluster1NamespaceBReadWriteCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster1: {
+					testconsts.NamespaceB: 3,
+				},
+			},
+		},
+		"Cluster1 and NamespaceC read-write access should only see Cluster1 and NamespaceB process indicators": {
+			ScopeKey: Cluster1NamespaceCReadWriteCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster1: {
+					testconsts.NamespaceC: 3,
+				},
+			},
+		},
+		"Cluster1 and Namespaces A and B read-write access should only see appropriate cluster/namespace " +
+			"process indicators": {
+			ScopeKey: Cluster1NamespacesABReadWriteCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster1: {
+					testconsts.NamespaceA: 3,
+					testconsts.NamespaceB: 3,
+				},
+			},
+		},
+		"Cluster1 and Namespaces A and C read-write access should only see appropriate cluster/namespace " +
+			"process indicators": {
+			ScopeKey: Cluster1NamespacesACReadWriteCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster1: {
+					testconsts.NamespaceA: 3,
+					testconsts.NamespaceC: 3,
+				},
+			},
+		},
+		"Cluster1 and Namespaces B and C read-write access should only see appropriate cluster/namespace " +
+			"process indicators": {
+			ScopeKey: Cluster1NamespacesBCReadWriteCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster1: {
+					testconsts.NamespaceB: 3,
+					testconsts.NamespaceC: 3,
+				},
+			},
+		},
+		"Cluster2 read-write access should only see Cluster2 process indicators": {
+			ScopeKey: Cluster2ReadWriteCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster2: {
+					testconsts.NamespaceA: 3,
+					testconsts.NamespaceB: 3,
+					testconsts.NamespaceC: 3,
+				},
+			},
+		},
+		"Cluster2 and NamespaceA read-write access should see Cluster2 and NamespaceA process indicators": {
+			ScopeKey: Cluster2NamespaceAReadWriteCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster2: {
+					testconsts.NamespaceA: 3,
+				},
+			},
+		},
+		"Cluster2 and NamespaceB read-write access should only see Cluster2 and NamespaceB process indicators": {
+			ScopeKey: Cluster2NamespaceBReadWriteCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster2: {
+					testconsts.NamespaceB: 3,
+				},
+			},
+		},
+		"Cluster2 and NamespaceC read-write access should only see Cluster2 and NamespaceC process indicators": {
+			ScopeKey: Cluster2NamespaceCReadWriteCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster2: {
+					testconsts.NamespaceC: 3,
+				},
+			},
+		},
+		"Cluster2 and Namespaces A and B read-write access should only see appropriate cluster/namespace " +
+			"process indicators": {
+			ScopeKey: Cluster2NamespacesABReadWriteCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster2: {
+					testconsts.NamespaceA: 3,
+					testconsts.NamespaceB: 3,
+				},
+			},
+		},
+		"Cluster2 and Namespaces A and C read-write access should only see appropriate cluster/namespace " +
+			"process indicators": {
+			ScopeKey: Cluster2NamespacesACReadWriteCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster2: {
+					testconsts.NamespaceA: 3,
+					testconsts.NamespaceC: 3,
+				},
+			},
+		},
+		"Cluster2 and Namespaces B and C read-write access should only see appropriate cluster/namespace " +
+			"process indicators": {
+			ScopeKey: Cluster2NamespacesBCReadWriteCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster2: {
+					testconsts.NamespaceB: 3,
+					testconsts.NamespaceC: 3,
+				},
+			},
+		},
+	}
+}
+
+// GenericUnrestrictedSACSearchTestCases returns a generic set of SACSearchTestCase.
+// It is appropriate to use when the store contains 27 objects.
+func GenericUnrestrictedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase {
+	return map[string]SACSearchTestCase{
+		"global read access should see all process indicators": {
+			ScopeKey: UnrestrictedReadCtx,
+			Results: map[string]map[string]int{
+				"": {"": 27},
+			},
+		},
+		"global read-write access should see all process indicators": {
+			ScopeKey: UnrestrictedReadCtx,
+			Results: map[string]map[string]int{
+				"": {"": 27},
+			},
+		},
+	}
+}
+
+// GenericUnrestrictedRawSACSearchTestCases returns a generic set of SACSearchTestCase.
+// It is appropriate to use when the store contains:
+// 9 objects scoped to Cluster1, 3 to each Namespace A / B / C.
+// 9 objects scoped to Cluster2, 3 to each Namespace A / B / C.
+// 9 objects scoped to Cluster3, 3 to each Namespace A / B / C.
+func GenericUnrestrictedRawSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase {
+	return map[string]SACSearchTestCase{
+		"global read access should see all process indicators": {
+			ScopeKey: UnrestrictedReadCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster1: {
+					testconsts.NamespaceA: 3,
+					testconsts.NamespaceB: 3,
+					testconsts.NamespaceC: 3,
+				},
+				testconsts.Cluster2: {
+					testconsts.NamespaceA: 3,
+					testconsts.NamespaceB: 3,
+					testconsts.NamespaceC: 3,
+				},
+				testconsts.Cluster3: {
+					testconsts.NamespaceA: 3,
+					testconsts.NamespaceB: 3,
+					testconsts.NamespaceC: 3,
+				},
+			},
+		},
+		"global read-write access should see all process indicators": {
+			ScopeKey: UnrestrictedReadCtx,
+			Results: map[string]map[string]int{
+				testconsts.Cluster1: {
+					testconsts.NamespaceA: 3,
+					testconsts.NamespaceB: 3,
+					testconsts.NamespaceC: 3,
+				},
+				testconsts.Cluster2: {
+					testconsts.NamespaceA: 3,
+					testconsts.NamespaceB: 3,
+					testconsts.NamespaceC: 3,
+				},
+				testconsts.Cluster3: {
+					testconsts.NamespaceA: 3,
+					testconsts.NamespaceB: 3,
+					testconsts.NamespaceC: 3,
+				},
+			},
+		},
+	}
+}

--- a/pkg/sac/testutils/search_test_cases.go
+++ b/pkg/sac/testutils/search_test_cases.go
@@ -20,7 +20,7 @@ type SACSearchTestCase struct {
 // 9 objects scoped to Cluster3, 3 to each Namespace A / B / C.
 func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase {
 	return map[string]SACSearchTestCase{
-		"Cluster1 read-write access should only see Cluster1 process indicators": {
+		"Cluster1 read-write access should only see Cluster1 objects": {
 			ScopeKey: Cluster1ReadWriteCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster1: {
@@ -30,7 +30,7 @@ func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase 
 				},
 			},
 		},
-		"Cluster1 and NamespaceA read-write access should only see Cluster1 and NamespaceA process indicators": {
+		"Cluster1 and NamespaceA read-write access should only see Cluster1 and NamespaceA objects": {
 			ScopeKey: Cluster1NamespaceAReadWriteCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster1: {
@@ -38,7 +38,7 @@ func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase 
 				},
 			},
 		},
-		"Cluster1 and NamespaceB read-write access should only see Cluster1 and NamespaceB process indicators": {
+		"Cluster1 and NamespaceB read-write access should only see Cluster1 and NamespaceB objects": {
 			ScopeKey: Cluster1NamespaceBReadWriteCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster1: {
@@ -46,7 +46,7 @@ func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase 
 				},
 			},
 		},
-		"Cluster1 and NamespaceC read-write access should only see Cluster1 and NamespaceB process indicators": {
+		"Cluster1 and NamespaceC read-write access should only see Cluster1 and NamespaceB objects": {
 			ScopeKey: Cluster1NamespaceCReadWriteCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster1: {
@@ -55,7 +55,7 @@ func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase 
 			},
 		},
 		"Cluster1 and Namespaces A and B read-write access should only see appropriate cluster/namespace " +
-			"process indicators": {
+			"objects": {
 			ScopeKey: Cluster1NamespacesABReadWriteCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster1: {
@@ -65,7 +65,7 @@ func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase 
 			},
 		},
 		"Cluster1 and Namespaces A and C read-write access should only see appropriate cluster/namespace " +
-			"process indicators": {
+			"objects": {
 			ScopeKey: Cluster1NamespacesACReadWriteCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster1: {
@@ -75,7 +75,7 @@ func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase 
 			},
 		},
 		"Cluster1 and Namespaces B and C read-write access should only see appropriate cluster/namespace " +
-			"process indicators": {
+			"objects": {
 			ScopeKey: Cluster1NamespacesBCReadWriteCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster1: {
@@ -84,7 +84,7 @@ func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase 
 				},
 			},
 		},
-		"Cluster2 read-write access should only see Cluster2 process indicators": {
+		"Cluster2 read-write access should only see Cluster2 objects": {
 			ScopeKey: Cluster2ReadWriteCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster2: {
@@ -94,7 +94,7 @@ func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase 
 				},
 			},
 		},
-		"Cluster2 and NamespaceA read-write access should see Cluster2 and NamespaceA process indicators": {
+		"Cluster2 and NamespaceA read-write access should see Cluster2 and NamespaceA objects": {
 			ScopeKey: Cluster2NamespaceAReadWriteCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster2: {
@@ -102,7 +102,7 @@ func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase 
 				},
 			},
 		},
-		"Cluster2 and NamespaceB read-write access should only see Cluster2 and NamespaceB process indicators": {
+		"Cluster2 and NamespaceB read-write access should only see Cluster2 and NamespaceB objects": {
 			ScopeKey: Cluster2NamespaceBReadWriteCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster2: {
@@ -110,7 +110,7 @@ func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase 
 				},
 			},
 		},
-		"Cluster2 and NamespaceC read-write access should only see Cluster2 and NamespaceC process indicators": {
+		"Cluster2 and NamespaceC read-write access should only see Cluster2 and NamespaceC objects": {
 			ScopeKey: Cluster2NamespaceCReadWriteCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster2: {
@@ -119,7 +119,7 @@ func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase 
 			},
 		},
 		"Cluster2 and Namespaces A and B read-write access should only see appropriate cluster/namespace " +
-			"process indicators": {
+			"objects": {
 			ScopeKey: Cluster2NamespacesABReadWriteCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster2: {
@@ -129,7 +129,7 @@ func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase 
 			},
 		},
 		"Cluster2 and Namespaces A and C read-write access should only see appropriate cluster/namespace " +
-			"process indicators": {
+			"objects": {
 			ScopeKey: Cluster2NamespacesACReadWriteCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster2: {
@@ -139,7 +139,7 @@ func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase 
 			},
 		},
 		"Cluster2 and Namespaces B and C read-write access should only see appropriate cluster/namespace " +
-			"process indicators": {
+			"objects": {
 			ScopeKey: Cluster2NamespacesBCReadWriteCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster2: {
@@ -155,14 +155,14 @@ func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase 
 // It is appropriate to use when the store contains 27 objects.
 func GenericUnrestrictedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase {
 	return map[string]SACSearchTestCase{
-		"global read access should see all process indicators": {
+		"global read access should see all objects": {
 			ScopeKey: UnrestrictedReadCtx,
 			Results: map[string]map[string]int{
 				"": {"": 27},
 			},
 		},
-		"global read-write access should see all process indicators": {
-			ScopeKey: UnrestrictedReadCtx,
+		"global read-write access should see all objects": {
+			ScopeKey: UnrestrictedReadWriteCtx,
 			Results: map[string]map[string]int{
 				"": {"": 27},
 			},
@@ -177,7 +177,7 @@ func GenericUnrestrictedSACSearchTestCases(_ *testing.T) map[string]SACSearchTes
 // 9 objects scoped to Cluster3, 3 to each Namespace A / B / C.
 func GenericUnrestrictedRawSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase {
 	return map[string]SACSearchTestCase{
-		"global read access should see all process indicators": {
+		"global read access should see all objects": {
 			ScopeKey: UnrestrictedReadCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster1: {
@@ -197,8 +197,8 @@ func GenericUnrestrictedRawSACSearchTestCases(_ *testing.T) map[string]SACSearch
 				},
 			},
 		},
-		"global read-write access should see all process indicators": {
-			ScopeKey: UnrestrictedReadCtx,
+		"global read-write access should see all objects": {
+			ScopeKey: UnrestrictedReadWriteCtx,
 			Results: map[string]map[string]int{
 				testconsts.Cluster1: {
 					testconsts.NamespaceA: 3,


### PR DESCRIPTION
## Description

Add SAC integration tests for pod datastore.

Additionally, reduce code duplication and create generic `SACSearchTestCase` that can be applied when 27 scoped resources are used within the test, 9 per cluster, 3 per namespace in each cluster. This way we have the same generic test cases over multiple datastores, and potentially can still add custom ones, if desired. 

## Testing Performed
- see CI
