### PR TITLE
Fix docs/Makefile git submodule command is not plural

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,8 +4,8 @@ all: site
 .PHONY: prepare
 prepare:
 	# Verify that submodules have been initialized, otherwise we cannot build much.
-	[ -f content/.git ] || { echo >&2 "Submodule docs/content is not initialized, please run 'git submodules update --init'" ; exit 1 ; }
-	[ -f tools/.git ] || { echo >&2 "Submodule docs/tools is not initialized, please run 'git submodules update --init'" ; exit 1 ; }
+	[ -f content/.git ] || { echo >&2 "Submodule docs/content is not initialized, please run 'git submodule update --init'" ; exit 1 ; }
+	[ -f tools/.git ] || { echo >&2 "Submodule docs/tools is not initialized, please run 'git submodule update --init'" ; exit 1 ; }
 	$(MAKE) -C tools prepare
 
 .PHONY:


### PR DESCRIPTION
## Description

As far as I can tell, the git submodule command should not be pluralized.

## Testing Performed

No testing done, this change is purely informational.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
