### PR TITLE
Investigate silent death of OSCI jobs

### DIFF
--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -27,8 +27,6 @@ fi
 ci_job="$1"
 shift
 
-touch /tmp/hold || true
-
 gate_job "$ci_job"
 
 case "$ci_job" in

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -27,6 +27,8 @@ fi
 ci_job="$1"
 shift
 
+touch /tmp/hold || true
+
 gate_job "$ci_job"
 
 case "$ci_job" in

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -511,8 +511,10 @@ gate_job() {
 
     info "Will determine whether to run: $job"
 
+    set -x
     if [[ "$job_config" == "null" ]]; then
         info "$job will run because there is no gating criteria for $job"
+        set +x
         return
     fi
 
@@ -531,6 +533,7 @@ gate_job() {
     else
         die "Could not determine if this is a PR versus a merge"
     fi
+    set +x
 }
 
 get_var_from_job_config() {

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -590,14 +590,17 @@ gate_pr_job() {
         fi
         echo "Diffbase diff:"
         { git diff --name-only "${diff_base}" | cat ; } || true
+        set -x
         ignored_regex="${changed_path_to_ignore}"
         [[ -n "$ignored_regex" ]] || ignored_regex='$^' # regex that matches nothing
         match_regex="${run_with_changed_path}"
         [[ -n "$match_regex" ]] || match_regex='^.*$' # grep -E -q '' returns 0 even on empty input, so we have to specify some pattern
         if grep -E -q "$match_regex" < <({ git diff --name-only "${diff_base}" || echo "???" ; } | grep -E -v "$ignored_regex"); then
             info "$job will run because paths matching $match_regex (and not matching ${ignored_regex}) had changed."
+            set +x
             return
         fi
+        set +x
     fi
 
     info "$job will be skipped"


### PR DESCRIPTION
## Description

OSCI upgrade-test jobs are failing with very little output [e.g.](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-upgrade-tests/1524188456438206464/artifacts/merge-gke-upgrade-tests/job/build-log.txt) on merges. This PR enables some `set -x` and will need to be merged to glean the debug goodness.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient