### PR TITLE
ROX-10784: Add PgSearchHelper for K8S Rolebindings.

### DIFF
--- a/central/rbac/k8srolebinding/search/searcher_impl.go
+++ b/central/rbac/k8srolebinding/search/searcher_impl.go
@@ -9,15 +9,19 @@ import (
 	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 )
 
 var (
-	k8sRoleBindingsSACSearchHelper = sac.ForResource(resources.K8sRoleBinding).MustCreateSearchHelper(mappings.OptionsMap)
+	k8sRoleBindingsSACSearchHelper = sac.ForResource(resources.K8sRoleBinding).
+					MustCreateSearchHelper(mappings.OptionsMap)
+	k8sRoleBindingsSACPgSearchHelper = sac.ForResource(resources.K8sRoleBinding).
+						MustCreatePgSearchHelper(mappings.OptionsMap)
 )
 
-// searcherImpl provides an search implementation for k8s role bindings
+// searcherImpl provides a search implementation for k8s role bindings.
 type searcherImpl struct {
 	storage store.Store
 	index   index.Indexer
@@ -32,17 +36,23 @@ func (ds *searcherImpl) SearchRoleBindings(ctx context.Context, q *v1.Query) ([]
 	return convertMany(bindings, results), nil
 }
 
-// Search returns the raw search results from the query
+// Search returns the raw search results from the query.
 func (ds *searcherImpl) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
+	if features.PostgresDatastore.Enabled() {
+		return k8sRoleBindingsSACPgSearchHelper.Apply(ds.index.Search)(ctx, q)
+	}
 	return k8sRoleBindingsSACSearchHelper.Apply(ds.index.Search)(ctx, q)
 }
 
-// Count returns the number of search results from the query
+// Count returns the number of search results from the query.
 func (ds *searcherImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
+	if features.PostgresDatastore.Enabled() {
+		return k8sRoleBindingsSACPgSearchHelper.ApplyCount(ds.index.Count)(ctx, q)
+	}
 	return k8sRoleBindingsSACSearchHelper.ApplyCount(ds.index.Count)(ctx, q)
 }
 
-// SearchRawRoleBindings returns the rolebindings  that match the query.
+// SearchRawRoleBindings returns the rolebindings that match the query.
 func (ds *searcherImpl) SearchRawRoleBindings(ctx context.Context, q *v1.Query) ([]*storage.K8SRoleBinding, error) {
 	bindings, _, err := ds.searchRoleBindings(ctx, q)
 	if err != nil {


### PR DESCRIPTION
## Description

Add `PgSearchHelper` within the K8S rolebinding searcher, conditionally if the postgres feature flag is enabled.

## Testing Performed
- Integration tests for the datastore will be added in a follow-up PR in the scope of [ROX-10783](https://issues.redhat.com/browse/ROX-10783)
