### PR TITLE
ROX-10783: Add integration tests for K8S role bindings datastore.

### DIFF
--- a/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
@@ -1,0 +1,365 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blevesearch/bleve"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/central/globalindex"
+	"github.com/stackrox/rox/central/rbac/k8srolebinding/internal/index"
+	"github.com/stackrox/rox/central/rbac/k8srolebinding/internal/store"
+	pgStore "github.com/stackrox/rox/central/rbac/k8srolebinding/internal/store/postgres"
+	rdbStore "github.com/stackrox/rox/central/rbac/k8srolebinding/internal/store/rocksdb"
+	"github.com/stackrox/rox/central/rbac/k8srolebinding/mappings"
+	"github.com/stackrox/rox/central/rbac/k8srolebinding/search"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/sac/testutils"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestK8sRoleBindingSAC(t *testing.T) {
+	suite.Run(t, new(k8sRoleBindingSACSuite))
+}
+
+type k8sRoleBindingSACSuite struct {
+	suite.Suite
+
+	datastore DataStore
+
+	pool *pgxpool.Pool
+
+	engine *rocksdb.RocksDB
+	index  bleve.Index
+
+	storage store.Store
+	indexer index.Indexer
+	search  search.Searcher
+
+	testContexts          map[string]context.Context
+	testK8sRoleBindingIDs []string
+}
+
+func (s *k8sRoleBindingSACSuite) SetupSuite() {
+	var err error
+
+	if features.PostgresDatastore.Enabled() {
+		ctx := context.Background()
+		src := pgtest.GetConnectionString(s.T())
+		cfg, err := pgxpool.ParseConfig(src)
+		s.Require().NoError(err)
+		s.pool, err = pgxpool.ConnectConfig(ctx, cfg)
+		s.Require().NoError(err)
+		pgStore.Destroy(ctx, s.pool)
+		s.storage = pgStore.New(ctx, s.pool)
+		s.indexer = pgStore.NewIndexer(s.pool)
+	} else {
+		s.engine, err = rocksdb.NewTemp("k8sRoleBindingSACTest")
+		s.Require().NoError(err)
+		bleveIndex, err := globalindex.MemOnlyIndex()
+		s.Require().NoError(err)
+		s.index = bleveIndex
+
+		s.storage = rdbStore.New(s.engine)
+		s.indexer = index.New(s.index)
+	}
+
+	s.search = search.New(s.storage, s.indexer)
+	s.datastore, err = New(s.storage, s.indexer, s.search)
+	s.Require().NoError(err)
+
+	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(),
+		resources.K8sRoleBinding.GetResource())
+}
+
+func (s *k8sRoleBindingSACSuite) TearDownSuite() {
+	if features.PostgresDatastore.Enabled() {
+		s.pool.Close()
+	} else {
+		s.Require().NoError(rocksdb.CloseAndRemove(s.engine))
+		s.Require().NoError(s.index.Close())
+	}
+}
+
+func (s *k8sRoleBindingSACSuite) SetupTest() {
+	s.testK8sRoleBindingIDs = make([]string, 0)
+
+	k8sRoleBindings := fixtures.GetSACTestK8SRoleBindingSet()
+
+	for i := range k8sRoleBindings {
+		err := s.datastore.UpsertRoleBinding(s.testContexts[testutils.UnrestrictedReadWriteCtx], k8sRoleBindings[i])
+		s.Require().NoError(err)
+	}
+
+	for _, rb := range k8sRoleBindings {
+		s.testK8sRoleBindingIDs = append(s.testK8sRoleBindingIDs, rb.GetId())
+	}
+}
+
+func (s *k8sRoleBindingSACSuite) TearDownTest() {
+	for _, id := range s.testK8sRoleBindingIDs {
+		s.deleteK8sRoleBinding(id)
+	}
+}
+
+func (s *k8sRoleBindingSACSuite) deleteK8sRoleBinding(id string) {
+	s.Require().NoError(s.datastore.RemoveRoleBinding(s.testContexts[testutils.UnrestrictedReadWriteCtx], id))
+}
+
+func (s *k8sRoleBindingSACSuite) TestUpsertRoleBinding() {
+	cases := map[string]struct {
+		scopeKey    string
+		expectFail  bool
+		expectedErr error
+	}{
+		"global read-only should not be able to add": {
+			scopeKey:    testutils.UnrestrictedReadCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"global read-write should be able to add": {
+			scopeKey: testutils.UnrestrictedReadWriteCtx,
+		},
+		"read-write on wrong cluster should not be able to add": {
+			scopeKey:    testutils.Cluster1ReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and namespace should not be able to add": {
+			scopeKey:    testutils.Cluster1NamespaceAReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and matching namespace should not be able to add": {
+			scopeKey:    testutils.Cluster1NamespaceBReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and wrong namespace should not be able to add": {
+			scopeKey:    testutils.Cluster2NamespaceAReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and matching namespace should be able to add": {
+			scopeKey:    testutils.Cluster2NamespaceBReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and at least one matching namespace should be able to add": {
+			scopeKey:    testutils.Cluster2NamespacesABReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			roleBinding := fixtures.GetScopedK8SRoleBinding(uuid.NewV4().String(), testconsts.Cluster2,
+				testconsts.NamespaceB)
+			s.testK8sRoleBindingIDs = append(s.testK8sRoleBindingIDs, roleBinding.GetId())
+			ctx := s.testContexts[c.scopeKey]
+			err := s.datastore.UpsertRoleBinding(ctx, roleBinding)
+			defer s.deleteK8sRoleBinding(roleBinding.GetId())
+			if c.expectFail {
+				s.Require().Error(err)
+				s.ErrorIs(err, c.expectedErr)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}
+
+func (s *k8sRoleBindingSACSuite) TestGetRoleBinding() {
+	roleBinding := fixtures.GetScopedK8SRoleBinding(uuid.NewV4().String(), testconsts.Cluster2,
+		testconsts.NamespaceB)
+	err := s.datastore.UpsertRoleBinding(s.testContexts[testutils.UnrestrictedReadWriteCtx], roleBinding)
+	s.Require().NoError(err)
+	s.testK8sRoleBindingIDs = append(s.testK8sRoleBindingIDs, roleBinding.GetId())
+
+	cases := map[string]struct {
+		scopeKey string
+		found    bool
+	}{
+		"global read-only can get": {
+			scopeKey: testutils.UnrestrictedReadCtx,
+			found:    true,
+		},
+		"global read-write can get": {
+			scopeKey: testutils.UnrestrictedReadWriteCtx,
+			found:    true,
+		},
+		"read-write on wrong cluster cannot get": {
+			scopeKey: testutils.Cluster1ReadWriteCtx,
+		},
+		"read-write on wrong cluster and wrong namespace cannot get": {
+			scopeKey: testutils.Cluster1NamespaceAReadWriteCtx,
+		},
+		"read-write on wrong cluster and matching namespace cannot get": {
+			scopeKey: testutils.Cluster1NamespaceBReadWriteCtx,
+		},
+		"read-write on matching cluster but wrong namespaces cannot get": {
+			scopeKey: testutils.Cluster2NamespacesACReadWriteCtx,
+		},
+		"read-write on matching cluster can read": {
+			scopeKey: testutils.Cluster2ReadWriteCtx,
+			found:    true,
+		},
+		"read-write on the matching cluster and namespace can get": {
+			scopeKey: testutils.Cluster2NamespaceBReadWriteCtx,
+			found:    true,
+		},
+		"read-write on the matching cluster and at least one matching namespace can get": {
+			scopeKey: testutils.Cluster2NamespacesABReadWriteCtx,
+			found:    true,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[c.scopeKey]
+			res, found, err := s.datastore.GetRoleBinding(ctx, roleBinding.GetId())
+			s.Require().NoError(err)
+			if c.found {
+				s.True(found)
+				s.Equal(*roleBinding, *res)
+			} else {
+				s.False(found)
+				s.Nil(res)
+			}
+		})
+	}
+}
+
+func (s *k8sRoleBindingSACSuite) TestRemoveRoleBinding() {
+	cases := map[string]struct {
+		scopeKey    string
+		expectFail  bool
+		expectedErr error
+	}{
+		"global read-only cannot remove": {
+			scopeKey:    testutils.UnrestrictedReadCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"global read-write can remove": {
+			scopeKey:    testutils.UnrestrictedReadWriteCtx,
+			expectedErr: nil,
+		},
+		"read-write on wrong cluster cannot remove": {
+			scopeKey:    testutils.Cluster1ReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and wrong namespace cannot remove": {
+			scopeKey:    testutils.Cluster1NamespaceAReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and matching namespace cannot remove": {
+			scopeKey:    testutils.Cluster1NamespaceBReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster but wrong namespaces cannot remove": {
+			scopeKey:    testutils.Cluster2NamespacesACReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"full read-write on matching cluster cannot remove": {
+			scopeKey:    testutils.Cluster2ReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on the matching cluster and namespace cannot remove": {
+			scopeKey:    testutils.Cluster2NamespaceBReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on the matching cluster and at least the right namespace cannot remove": {
+			scopeKey:    testutils.Cluster2NamespacesABReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			roleBinding := fixtures.GetScopedK8SRoleBinding(uuid.NewV4().String(), testconsts.Cluster2,
+				testconsts.NamespaceB)
+			s.testK8sRoleBindingIDs = append(s.testK8sRoleBindingIDs, roleBinding.GetId())
+
+			ctx := s.testContexts[c.scopeKey]
+			err := s.datastore.UpsertRoleBinding(s.testContexts[testutils.UnrestrictedReadWriteCtx], roleBinding)
+			s.Require().NoError(err)
+			defer s.deleteK8sRoleBinding(roleBinding.GetId())
+
+			err = s.datastore.RemoveRoleBinding(ctx, roleBinding.GetId())
+			if c.expectFail {
+				s.Require().Error(err)
+				s.ErrorIs(err, c.expectedErr)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}
+
+func (s *k8sRoleBindingSACSuite) runSearchRawTest(c testutils.SACSearchTestCase) {
+	ctx := s.testContexts[c.ScopeKey]
+	results, err := s.datastore.SearchRawRoleBindings(ctx, nil)
+	s.Require().NoError(err)
+	resultObjs := make([]sac.NamespaceScopedObject, 0, len(results))
+	for i := range results {
+		resultObjs = append(resultObjs, results[i])
+	}
+	resultCounts := testutils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), resultObjs)
+	testutils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
+}
+
+func (s *k8sRoleBindingSACSuite) runSearchTest(c testutils.SACSearchTestCase) {
+	ctx := s.testContexts[c.ScopeKey]
+	results, err := s.datastore.Search(ctx, nil)
+	s.Require().NoError(err)
+	resultCounts := testutils.CountResultsPerClusterAndNamespace(s.T(), results, mappings.OptionsMap)
+	testutils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
+}
+
+func (s *k8sRoleBindingSACSuite) TestScopedSearch() {
+	for name, c := range testutils.GenericScopedSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runSearchTest(c)
+		})
+	}
+}
+
+func (s *k8sRoleBindingSACSuite) TestUnrestrictedSearch() {
+	for name, c := range testutils.GenericUnrestrictedSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runSearchTest(c)
+		})
+	}
+}
+
+func (s *k8sRoleBindingSACSuite) TestScopeSearchRaw() {
+	for name, c := range testutils.GenericScopedSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runSearchRawTest(c)
+		})
+	}
+}
+
+func (s *k8sRoleBindingSACSuite) TestUnrestrictedSearchRaw() {
+	for name, c := range testutils.GenericUnrestrictedRawSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runSearchRawTest(c)
+		})
+	}
+}

--- a/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
@@ -152,6 +152,11 @@ func (s *k8sRoleBindingSACSuite) TestUpsertRoleBinding() {
 			expectFail:  true,
 			expectedErr: sac.ErrResourceAccessDenied,
 		},
+		"read-write on matching cluster and no namespace should not be able to add": {
+			scopeKey:    testutils.Cluster2ReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
 		"read-write on matching cluster and at least one matching namespace should be able to add": {
 			scopeKey:    testutils.Cluster2NamespacesABReadWriteCtx,
 			expectFail:  true,

--- a/pkg/fixtures/role_bindings.go
+++ b/pkg/fixtures/role_bindings.go
@@ -1,0 +1,65 @@
+package fixtures
+
+import (
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/uuid"
+)
+
+// GetScopedK8SRoleBinding returns a mock K8SRoleBinding belonging to the input scope.
+func GetScopedK8SRoleBinding(id string, clusterID string, namespace string) *storage.K8SRoleBinding {
+	return &storage.K8SRoleBinding{
+		Id:          id,
+		Namespace:   namespace,
+		ClusterId:   clusterID,
+		ClusterRole: false,
+		Subjects: []*storage.Subject{{
+			Id:        id,
+			Namespace: namespace,
+			ClusterId: clusterID,
+		}},
+		RoleId: id,
+	}
+}
+
+// GetSACTestK8SRoleBindingSet returns a set of mock K8SRoleBindings that can be used
+// for scoped access control sets.
+// It will include:
+// 9 Process indicators scoped to Cluster1, 3 to each Namespace A / B / C.
+// 9 Process indicators scoped to Cluster2, 3 to each Namespace A / B / C.
+// 9 Process indicators scoped to Cluster3, 3 to each Namespace A / B / C.
+func GetSACTestK8SRoleBindingSet() []*storage.K8SRoleBinding {
+	return []*storage.K8SRoleBinding{
+		scopedK8SRoleBinding(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedK8SRoleBinding(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedK8SRoleBinding(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedK8SRoleBinding(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedK8SRoleBinding(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedK8SRoleBinding(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedK8SRoleBinding(testconsts.Cluster1, testconsts.NamespaceC),
+		scopedK8SRoleBinding(testconsts.Cluster1, testconsts.NamespaceC),
+		scopedK8SRoleBinding(testconsts.Cluster1, testconsts.NamespaceC),
+		scopedK8SRoleBinding(testconsts.Cluster2, testconsts.NamespaceA),
+		scopedK8SRoleBinding(testconsts.Cluster2, testconsts.NamespaceA),
+		scopedK8SRoleBinding(testconsts.Cluster2, testconsts.NamespaceA),
+		scopedK8SRoleBinding(testconsts.Cluster2, testconsts.NamespaceB),
+		scopedK8SRoleBinding(testconsts.Cluster2, testconsts.NamespaceB),
+		scopedK8SRoleBinding(testconsts.Cluster2, testconsts.NamespaceB),
+		scopedK8SRoleBinding(testconsts.Cluster2, testconsts.NamespaceC),
+		scopedK8SRoleBinding(testconsts.Cluster2, testconsts.NamespaceC),
+		scopedK8SRoleBinding(testconsts.Cluster2, testconsts.NamespaceC),
+		scopedK8SRoleBinding(testconsts.Cluster3, testconsts.NamespaceA),
+		scopedK8SRoleBinding(testconsts.Cluster3, testconsts.NamespaceA),
+		scopedK8SRoleBinding(testconsts.Cluster3, testconsts.NamespaceA),
+		scopedK8SRoleBinding(testconsts.Cluster3, testconsts.NamespaceB),
+		scopedK8SRoleBinding(testconsts.Cluster3, testconsts.NamespaceB),
+		scopedK8SRoleBinding(testconsts.Cluster3, testconsts.NamespaceB),
+		scopedK8SRoleBinding(testconsts.Cluster3, testconsts.NamespaceC),
+		scopedK8SRoleBinding(testconsts.Cluster3, testconsts.NamespaceC),
+		scopedK8SRoleBinding(testconsts.Cluster3, testconsts.NamespaceC),
+	}
+}
+
+func scopedK8SRoleBinding(clusterID, namespace string) *storage.K8SRoleBinding {
+	return GetScopedK8SRoleBinding(uuid.NewV4().String(), clusterID, namespace)
+}


### PR DESCRIPTION
## Description

Add integration tests for `K8sRoleBindings` datastore.

Additionally create mock objects for usage within SAC tests.

## Testing Performed
- see CI
