### PR TITLE
ROX-10920: Fix ComplianceTests

### DIFF
--- a/central/role/resources/list.go
+++ b/central/role/resources/list.go
@@ -32,7 +32,7 @@ var (
 	// SAC check is not performed directly on CVE resource. It exists here for postgres sac generation to pass.
 	CVE        = newResourceMetadata("CVE", permissions.NamespaceScope)
 	Cluster    = newResourceMetadata("Cluster", permissions.ClusterScope)
-	Compliance = newResourceMetadata("Compliance", permissions.GlobalScope)
+	Compliance = newResourceMetadata("Compliance", permissions.ClusterScope)
 	Deployment = newResourceMetadata("Deployment", permissions.NamespaceScope)
 	// DeploymentExtension is the new resource grouping all deployment extending resources.
 	DeploymentExtension = newResourceMetadata("DeploymentExtension", permissions.NamespaceScope)


### PR DESCRIPTION
## Description

When grouping resources, the permission of `Compliance` was by mistake changed to `GlobalScope` instead of being kept at `ClusterScope`. This lead to `ComplianceTest` failing.

## Testing Performed
- within `openshift-4-api-e2e-tests` `ComplianceTest` shouldn't fail anymore.