### PR TITLE
OSCI: fix merge checks

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -516,6 +516,7 @@ gate_job() {
 
     info "Will determine whether to run: $job"
 
+    # TODO(RS-509) remove once this behaves better
     set -x
     if [[ "$job_config" == "null" ]]; then
         info "$job will run because there is no gating criteria for $job"
@@ -598,6 +599,7 @@ gate_pr_job() {
         fi
         echo "Diffbase diff:"
         { git diff --name-only "${diff_base}" | cat ; } || true
+        # TODO(RS-509) remove once this behaves better
         set -x
         ignored_regex="${changed_path_to_ignore}"
         [[ -n "$ignored_regex" ]] || ignored_regex='$^' # regex that matches nothing

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -525,7 +525,7 @@ gate_job() {
     fi
 
     local pr_details
-    local exitstatus
+    local exitstatus=0
     pr_details="$(get_pr_details)" || exitstatus="$?"
 
     if [[ "$exitstatus" == "0" ]]; then


### PR DESCRIPTION
## Description

Fixes the unexpected exit mentioned in #1660. I'm leaving the `set -x` in place for now to catch initial teething problems.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient