### PR TITLE
ROX-10820: Abstracting table modal component in policy criteria section

### DIFF
--- a/ui/apps/platform/cypress/constants/PoliciesPagePatternFly.js
+++ b/ui/apps/platform/cypress/constants/PoliciesPagePatternFly.js
@@ -68,9 +68,9 @@ export const selectors = {
                 tableModal: {
                     textInput: '[data-testid="table-modal-text-input"]',
                     openButton: '[data-testid="table-modal-open-button"]',
-                    firstRow: '[data-testid="table-modal-table"] tbody tr:nth(0)',
+                    firstRowName: '[data-testid="table-modal-table"] tbody tr:nth(0) a',
                     firstRowCheckbox:
-                        '[data-testid="table-modal-table"] .pf-c-table__check input[type="checkbox"]',
+                        '[data-testid="table-modal-table"] tbody .pf-c-table__check input[type="checkbox"]',
                     saveBtn: '[data-testid="table-modal-save-btn"]',
                     cancelBtn: '[data-testid="table-modal-cancel-btn"]',
                     emptyState: '[data-testid="table-modal-empty-state"]',

--- a/ui/apps/platform/cypress/constants/PoliciesPagePatternFly.js
+++ b/ui/apps/platform/cypress/constants/PoliciesPagePatternFly.js
@@ -65,6 +65,16 @@ export const selectors = {
                 negateCheckbox: '[data-testid="policy-criteria-value-negate-checkbox"]',
                 multiselect: '[data-testid="policy-criteria-value-multiselect"]',
                 multiselectOption: '[data-testid="policy-criteria-value-multiselect-option"]',
+                tableModal: {
+                    textInput: '[data-testid="table-modal-text-input"]',
+                    openButton: '[data-testid="table-modal-open-button"]',
+                    firstRow: '[data-testid="table-modal-table"] tbody tr:nth(0)',
+                    firstRowCheckbox:
+                        '[data-testid="table-modal-table"] .pf-c-table__check input[type="checkbox"]',
+                    saveBtn: '[data-testid="table-modal-save-btn"]',
+                    cancelBtn: '[data-testid="table-modal-cancel-btn"]',
+                    emptyState: '[data-testid="table-modal-empty-state"]',
+                },
                 addBtn: '[data-testid="add-policy-criteria-value-btn"]',
                 deleteBtn: '[data-testid="delete-policy-criteria-value-btn"]',
             },

--- a/ui/apps/platform/cypress/fixtures/integrations/signatureIntegrations.json
+++ b/ui/apps/platform/cypress/fixtures/integrations/signatureIntegrations.json
@@ -1,0 +1,16 @@
+{
+    "integrations": [
+        {
+            "id":"io.stackrox.signatureintegration.ac53725f-d5b3-43d6-a473-af4998d2bfc0",
+            "name":"Distroless",
+            "cosign":{
+                "publicKeys":[
+                    {
+                        "name":"Distroless",
+                        "publicKeyPemEnc":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWZzVzkb8A+DbgDpaJId/bOmV8n7Q\nOqxYbK0Iro6GzSmOzxkn+N2AKawLyXi84WSwJQBK//psATakCgAQKkNTAA==\n-----END PUBLIC KEY-----"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
@@ -1,4 +1,5 @@
 import { selectors } from '../../constants/PoliciesPagePatternFly';
+import * as api from '../../constants/apiEndpoints';
 import withAuth from '../../helpers/basicAuth';
 import DndSimulatorDataTransfer from '../../helpers/dndSimulatorDataTransfer';
 import {
@@ -387,11 +388,16 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
 
         describe('table modal', () => {
             beforeEach(() => {
+                cy.intercept('GET', api.integrations.signatureIntegrations, {
+                    fixture: 'integrations/signatureIntegrations.json',
+                }).as('getSignatureIntegrations');
+
                 goToPoliciesAndCloneToStep3();
                 clearPolicyCriteriaCards();
                 dragFieldIntoSection(
                     `${selectors.step3.policyCriteria.key}:contains('trusted image signers')`
                 );
+                cy.wait('@getSignatureIntegrations');
             });
 
             it('should populate table modal select and respect changed values on save', () => {
@@ -400,14 +406,11 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                     'Add trusted image signers'
                 );
                 cy.get(selectors.step3.policyCriteria.value.tableModal.openButton).click();
-                cy.get(selectors.step3.policyCriteria.value.tableModal.saveBtn).should(
-                    'be.disabled'
-                );
                 cy.get(selectors.step3.policyCriteria.value.tableModal.firstRowCheckbox).click();
                 cy.get(selectors.step3.policyCriteria.value.tableModal.saveBtn).click();
                 cy.get(selectors.step3.policyCriteria.value.tableModal.textInput).should(
                     'have.value',
-                    'Selected 1 trusted image signers'
+                    'Selected 1 trusted image signer'
                 );
             });
 
@@ -423,7 +426,7 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
 
             it('should go to link when table row is clicked', () => {
                 cy.get(selectors.step3.policyCriteria.value.tableModal.openButton).click();
-                cy.get(selectors.step3.policyCriteria.value.tableModal.firstRow).click();
+                cy.get(selectors.step3.policyCriteria.value.tableModal.firstRowName).click();
                 cy.location('pathname').should('contain', 'signatureIntegrations');
             });
         });

--- a/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
@@ -384,6 +384,49 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                 cy.get(selectors.step3.policyCriteria.value.numberInput).should('have.value', '10');
             });
         });
+
+        describe('table modal', () => {
+            beforeEach(() => {
+                goToPoliciesAndCloneToStep3();
+                clearPolicyCriteriaCards();
+                dragFieldIntoSection(
+                    `${selectors.step3.policyCriteria.key}:contains('trusted image signers')`
+                );
+            });
+
+            it('should populate table modal select and respect changed values on save', () => {
+                cy.get(selectors.step3.policyCriteria.value.tableModal.textInput).should(
+                    'have.value',
+                    'Add trusted image signers'
+                );
+                cy.get(selectors.step3.policyCriteria.value.tableModal.openButton).click();
+                cy.get(selectors.step3.policyCriteria.value.tableModal.saveBtn).should(
+                    'be.disabled'
+                );
+                cy.get(selectors.step3.policyCriteria.value.tableModal.firstRowCheckbox).click();
+                cy.get(selectors.step3.policyCriteria.value.tableModal.saveBtn).click();
+                cy.get(selectors.step3.policyCriteria.value.tableModal.textInput).should(
+                    'have.value',
+                    'Selected 1 trusted image signers'
+                );
+            });
+
+            it('should populate table modal select and not change values on cancel', () => {
+                cy.get(selectors.step3.policyCriteria.value.tableModal.openButton).click();
+                cy.get(selectors.step3.policyCriteria.value.tableModal.firstRowCheckbox).click();
+                cy.get(selectors.step3.policyCriteria.value.tableModal.cancelBtn).click();
+                cy.get(selectors.step3.policyCriteria.value.tableModal.textInput).should(
+                    'have.value',
+                    'Add trusted image signers'
+                );
+            });
+
+            it('should go to link when table row is clicked', () => {
+                cy.get(selectors.step3.policyCriteria.value.tableModal.openButton).click();
+                cy.get(selectors.step3.policyCriteria.value.tableModal.firstRow).click();
+                cy.location('pathname').should('contain', 'signatureIntegrations');
+            });
+        });
     });
 
     describe('Existing values', () => {

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/ImageSigningTableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/ImageSigningTableModal.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+
+import { integrationsPath } from 'routePaths';
+import { fetchSignatureIntegrations } from 'services/SignatureIntegrationsService';
+import { SignatureIntegration } from 'types/signatureIntegration.proto';
+import tableColumnDescriptor from 'Containers/Integrations/utils/tableColumnDescriptor';
+import TableModal from './TableModal';
+
+function ImageSigningTableModal({ setValue, value, readOnly }) {
+    const [integrations, setIntegrations] = useState<SignatureIntegration[]>([]);
+    const rows = integrations.map((integration) => {
+        return {
+            ...integration,
+            link: `${integrationsPath}/signatureIntegrations/signature/view/${integration.id}`,
+        };
+    });
+    const columns = [...tableColumnDescriptor.signatureIntegrations.signature];
+
+    useEffect(() => {
+        fetchSignatureIntegrations()
+            .then((data) => {
+                setIntegrations(data);
+            })
+            .catch(() => {
+                setIntegrations([]);
+            });
+    }, []);
+
+    return (
+        <TableModal
+            typeText="trusted image signers"
+            setValue={setValue}
+            value={value}
+            readOnly={readOnly}
+            rows={rows}
+            columns={columns}
+        />
+    );
+}
+
+export default ImageSigningTableModal;

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/ImageSigningTableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/ImageSigningTableModal.tsx
@@ -28,7 +28,7 @@ function ImageSigningTableModal({ setValue, value, readOnly }) {
 
     return (
         <TableModal
-            typeText="trusted image signers"
+            typeText="trusted image signer"
             setValue={setValue}
             value={value}
             readOnly={readOnly}

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldInput.tsx
@@ -12,7 +12,7 @@ import {
 
 import { Descriptor } from './policyCriteriaDescriptors';
 import PolicyCriteriaFieldSubInput from './PolicyCriteriaFieldSubInput';
-import ImageSignersCriteriaFieldInput from './ImageSignersCriteriaFieldInput';
+import TableModalFieldInput from './TableModalFieldInput';
 
 type PolicyCriteriaFieldInputProps = {
     descriptor: Descriptor;
@@ -189,12 +189,13 @@ function PolicyCriteriaFieldInput({
             );
             /* eslint-enable react/no-array-index-key */
         }
-        case 'signaturePolicyCriteria': {
+        case 'tableModal': {
             return (
-                <ImageSignersCriteriaFieldInput
+                <TableModalFieldInput
                     setValue={setValue}
                     value={value}
                     readOnly={readOnly}
+                    tableType={descriptor.tableType}
                 />
             );
         }

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyGroupCard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyGroupCard.tsx
@@ -145,7 +145,7 @@ function PolicyGroupCard({
                     })}
                     {/* this is because there can't be multiple boolean values */}
                     {!readOnly &&
-                        descriptor.type !== 'signaturePolicyCriteria' &&
+                        descriptor.type !== 'tableModal' &&
                         descriptor.type !== 'radioGroup' &&
                         descriptor.type !== 'radioGroupString' && (
                             <Flex

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
@@ -54,7 +54,7 @@ function TableModal({
     return (
         <>
             <TextInput
-                id="table-modal-text-input"
+                data-testid="table-modal-text-input"
                 isDisabled
                 value={
                     value.arrayValue?.length > 0
@@ -67,6 +67,7 @@ function TableModal({
             />
             <Button
                 key="open-select-modal"
+                data-testid="table-modal-open-button"
                 variant={ButtonVariant.primary}
                 onClick={() => {
                     setIsModalOpen(true);
@@ -79,7 +80,6 @@ function TableModal({
                 isOpen={isModalOpen}
                 variant={ModalVariant.large}
                 onClose={onCloseModalHandler}
-                data-testid="select-table-modal"
                 aria-label={`Select ${typeText}s modal`}
                 hasNoBodyWrapper
             >
@@ -88,7 +88,11 @@ function TableModal({
                         {!!rows.length && (
                             <>
                                 Select {typeText}s from the table below.
-                                <TableComposable variant="compact" isStickyHeader>
+                                <TableComposable
+                                    variant="compact"
+                                    isStickyHeader
+                                    data-testid="table-modal-table"
+                                >
                                     <Thead>
                                         <Tr>
                                             <Th
@@ -157,7 +161,9 @@ function TableModal({
                             </>
                         )}
                         {!rows.length && (
-                            <div>Please configure {typeText}s to add them as policy criteria.</div>
+                            <div data-testid="table-modal-empty-state">
+                                Please configure {typeText}s to add them as policy criteria.
+                            </div>
                         )}
                     </PageSection>
                 </ModalBoxBody>
@@ -165,6 +171,7 @@ function TableModal({
                     <Button
                         key="save"
                         variant="primary"
+                        data-testid="table-modal-save-btn"
                         onClick={onSaveHandler}
                         isDisabled={
                             readOnly || isEqual(value.arrayValue, getSelectedIds()) || !rows.length
@@ -172,7 +179,12 @@ function TableModal({
                     >
                         Save
                     </Button>
-                    <Button key="cancel" variant="secondary" onClick={onCloseModalHandler}>
+                    <Button
+                        key="cancel"
+                        variant="secondary"
+                        data-testid="table-modal-cancel-btn"
+                        onClick={onCloseModalHandler}
+                    >
                         Cancel
                     </Button>
                 </ModalBoxFooter>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
@@ -18,10 +18,10 @@ import useTableSelection from 'hooks/useTableSelection';
 import TableCellValue from 'Components/TableCellValue/TableCellValue';
 
 type TableModalProps = {
-    setValue: (value: any) => void;
+    setValue: (value: unknown) => void;
     value: any;
     readOnly?: boolean;
-    rows: any;
+    rows: { id: string; link: string }[];
     columns: any;
     typeText: string;
 };

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
@@ -85,70 +85,80 @@ function TableModal({
             >
                 <ModalBoxBody>
                     <PageSection variant="light">
-                        Select {typeText}s from the table below.
-                        <TableComposable variant="compact" isStickyHeader>
-                            <Thead>
-                                <Tr>
-                                    <Th
-                                        select={{
-                                            onSelect: onSelectAll,
-                                            isSelected: allRowsSelected,
-                                            isHeaderSelectDisabled: readOnly,
-                                        }}
-                                    />
-                                    {columns.map((column) => {
-                                        return (
-                                            <Th key={column.Header} modifier="wrap">
-                                                {column.Header}
-                                            </Th>
-                                        );
-                                    })}
-                                    <Th aria-label="Row actions" />
-                                </Tr>
-                            </Thead>
-                            <Tbody>
-                                {rows.map((row, rowIndex) => {
-                                    const { id, link } = row;
-                                    return (
-                                        <Tr key={id}>
-                                            <Td
-                                                key={id}
+                        {!!rows.length && (
+                            <>
+                                Select {typeText}s from the table below.
+                                <TableComposable variant="compact" isStickyHeader>
+                                    <Thead>
+                                        <Tr>
+                                            <Th
                                                 select={{
-                                                    rowIndex,
-                                                    onSelect,
-                                                    isSelected: selected[rowIndex],
-                                                    disable: readOnly,
+                                                    onSelect: onSelectAll,
+                                                    isSelected: allRowsSelected,
+                                                    isHeaderSelectDisabled: readOnly,
                                                 }}
                                             />
                                             {columns.map((column) => {
-                                                if (column.Header === 'Name') {
-                                                    return (
-                                                        <Td key="name">
-                                                            <Button
-                                                                variant={ButtonVariant.link}
-                                                                isInline
-                                                                component={LinkShim}
-                                                                href={link}
-                                                            >
+                                                return (
+                                                    <Th key={column.Header} modifier="wrap">
+                                                        {column.Header}
+                                                    </Th>
+                                                );
+                                            })}
+                                            <Th aria-label="Row actions" />
+                                        </Tr>
+                                    </Thead>
+                                    <Tbody>
+                                        {rows.map((row, rowIndex) => {
+                                            const { id, link } = row;
+                                            return (
+                                                <Tr key={id}>
+                                                    <Td
+                                                        key={id}
+                                                        select={{
+                                                            rowIndex,
+                                                            onSelect,
+                                                            isSelected: selected[rowIndex],
+                                                            disable: readOnly,
+                                                        }}
+                                                    />
+                                                    {columns.map((column) => {
+                                                        if (column.Header === 'Name') {
+                                                            return (
+                                                                <Td key="name">
+                                                                    <Button
+                                                                        variant={ButtonVariant.link}
+                                                                        isInline
+                                                                        component={LinkShim}
+                                                                        href={link}
+                                                                    >
+                                                                        <TableCellValue
+                                                                            row={row}
+                                                                            column={column}
+                                                                        />
+                                                                    </Button>
+                                                                </Td>
+                                                            );
+                                                        }
+                                                        return (
+                                                            <Td key={column.Header}>
                                                                 <TableCellValue
                                                                     row={row}
                                                                     column={column}
                                                                 />
-                                                            </Button>
-                                                        </Td>
-                                                    );
-                                                }
-                                                return (
-                                                    <Td key={column.Header}>
-                                                        <TableCellValue row={row} column={column} />
-                                                    </Td>
-                                                );
-                                            })}
-                                        </Tr>
-                                    );
-                                })}
-                            </Tbody>
-                        </TableComposable>
+                                                            </Td>
+                                                        );
+                                                    })}
+                                                </Tr>
+                                            );
+                                        })}
+                                    </Tbody>
+                                </TableComposable>
+                            </>
+                        )}
+                        {!rows.length && (
+                            <div>Please configure {typeText}s to add them as policy criteria.</div>
+                        )}
                     </PageSection>
                 </ModalBoxBody>
                 <ModalBoxFooter>
@@ -156,7 +166,9 @@ function TableModal({
                         key="save"
                         variant="primary"
                         onClick={onSaveHandler}
-                        isDisabled={readOnly || isEqual(value.arrayValue, getSelectedIds())}
+                        isDisabled={
+                            readOnly || isEqual(value.arrayValue, getSelectedIds()) || !rows.length
+                        }
                     >
                         Save
                     </Button>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModalFieldInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModalFieldInput.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import ImageSigningTableModal from './ImageSigningTableModal';
+
+function TableModalFieldInput({
+    setValue,
+    value,
+    readOnly = false,
+    tableType,
+}): React.ReactElement {
+    if (tableType === 'imageSigning') {
+        return <ImageSigningTableModal setValue={setValue} value={value} readOnly={readOnly} />;
+    }
+    return <div>no such {tableType}</div>;
+}
+
+export default TableModalFieldInput;

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -189,7 +189,7 @@ export type DescriptorType =
     | 'radioGroupString'
     | 'select'
     | 'text'
-    | 'signaturePolicyCriteria';
+    | 'tableModal';
 
 export type Descriptor =
     | GroupDescriptor
@@ -197,10 +197,11 @@ export type Descriptor =
     | RadioGroupDescriptor
     | SelectDescriptor
     | TextDescriptor
-    | SignatureDescriptor;
+    | TableModalDescriptor;
 
-export type SignatureDescriptor = {
-    type: 'signaturePolicyCriteria';
+export type TableModalDescriptor = {
+    type: 'tableModal';
+    tableType: string;
 } & BaseDescriptor;
 
 export type GroupDescriptor = {
@@ -272,7 +273,8 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         shortName: 'Not verified by trusted image signers',
         longName: 'Not verified by trusted image signers',
         category: policyCriteriaCategories.IMAGE_REGISTRY,
-        type: 'signaturePolicyCriteria',
+        type: 'tableModal',
+        tableType: 'imageSigning',
         canBooleanLogic: true,
     },
     {

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -10,6 +10,7 @@ import {
     severityRatings,
 } from 'messages/common';
 import { FeatureFlagEnvVar } from 'types/featureFlag';
+import ImageSigningTableModal from 'Containers/Policies/Wizard/Step3/ImageSigningTableModal';
 
 const equalityOptions: DescriptorOption[] = [
     { label: 'Is greater than', value: '>' },
@@ -201,6 +202,7 @@ export type Descriptor =
 
 export type TableModalDescriptor = {
     type: 'tableModal';
+    component: React.ReactNode;
     tableType: string;
 } & BaseDescriptor;
 
@@ -275,6 +277,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         category: policyCriteriaCategories.IMAGE_REGISTRY,
         type: 'tableModal',
         tableType: 'imageSigning',
+        component: ImageSigningTableModal,
         canBooleanLogic: true,
     },
     {


### PR DESCRIPTION
## Description

As it states above. The `Not verified by trusted image signers:` policy criteria should still work (edit/save/view) as before. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
