### PR TITLE
Bump `ubi8-minimal` base image version to 8.6

### DIFF
--- a/image/rhel/Dockerfile.envsubst
+++ b/image/rhel/Dockerfile.envsubst
@@ -43,6 +43,7 @@ RUN ln -s entrypoint-wrapper.sh /stackrox/admission-control && \
     ln -s entrypoint-wrapper.sh /stackrox/sensor-upgrader && \
     ln -s /assets/downloads/cli/roxctl-linux /stackrox/roxctl && \
     rpm --import RPM-GPG-KEY-CentOS-Official && \
+    microdnf upgrade && \
     rpm -i /tmp/snappy.rpm && \
     microdnf install lz4 bzip2 util-linux && \
     microdnf clean all && \

--- a/image/rhel/Dockerfile.envsubst
+++ b/image/rhel/Dockerfile.envsubst
@@ -43,7 +43,6 @@ RUN ln -s entrypoint-wrapper.sh /stackrox/admission-control && \
     ln -s entrypoint-wrapper.sh /stackrox/sensor-upgrader && \
     ln -s /assets/downloads/cli/roxctl-linux /stackrox/roxctl && \
     rpm --import RPM-GPG-KEY-CentOS-Official && \
-    microdnf upgrade && \
     rpm -i /tmp/snappy.rpm && \
     microdnf install lz4 bzip2 util-linux && \
     microdnf clean all && \

--- a/image/rhel/Dockerfile.envsubst
+++ b/image/rhel/Dockerfile.envsubst
@@ -1,6 +1,6 @@
 ARG BASE_REGISTRY=registry.access.redhat.com
 ARG BASE_IMAGE=ubi8-minimal
-ARG BASE_TAG=8.5
+ARG BASE_TAG=8.6
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
 


### PR DESCRIPTION
## Description

Bump `ubi8-micro` base image version to 8.6. `microdnf upgrade` won't install `pip` any longer.

Note on previous 8.5 version:

`microdnf upgrade` even on a fresh `ubi-minimal:8.5` image installs new packages, including pip:
```
...
Transaction Summary:
 Installing:       15 packages
 Reinstalling:      0 packages
 Upgrading:        32 packages
 Obsoleting:        0 packages
 Removing:          0 packages
 Downgrading:       0 packages
Downloading packages...
Running transaction test...
Updating: libgcc;8.5.0-10.el8;x86_64;ubi-8-baseos
Installing: python3-pip-wheel;9.0.3-22.el8;noarch;ubi-8-baseos
...
```
This brings some python related vulnerabilities which are then reported by Quay image scanner.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

To do: CI, Quay