### PR TITLE
ROX-10644: add account_id and is_org_admin attributes to OIDC auth provider

### DIFF
--- a/pkg/auth/authproviders/oidc/backend_impl.go
+++ b/pkg/auth/authproviders/oidc/backend_impl.go
@@ -571,10 +571,9 @@ type userInfoType struct {
 	EMail  string   `json:"email"`
 	UID    string   `json:"sub"`
 	Groups []string `json:"groups"`
-	// Claim "account_id" is the claim that represents organisation id within sso.redhat.com.
-	// Red Hat users are united in organisations.
-	// See more on the claims here:
-	// https://source.redhat.com/groups/public/it-user/it_user_team_wiki/topic_external_sso_enablements#attributes-needed
+	// Every Red Hat SSO user belongs to exactly one organization, claim
+	// "account_id" represents that organisation. See more on the claims here:
+	// 	https://source.redhat.com/groups/public/it-user/it_user_team_wiki/topic_external_sso_enablements#attributes-needed
 	OrgID string `json:"account_id"`
 	// Claim "is_org_admin" is the claim that identifies organisation admins within sso.redhat.com.
 	IsOrgAdmin bool `json:"is_org_admin"`

--- a/pkg/auth/authproviders/oidc/backend_impl.go
+++ b/pkg/auth/authproviders/oidc/backend_impl.go
@@ -36,6 +36,9 @@ const (
 	modeConfigKey                = "mode"
 
 	userInfoExpiration = 5 * time.Minute
+
+	RolesAttribute = "roles"
+	OrgidAttribute = "orgid"
 )
 
 type nonceVerificationSetting int
@@ -562,7 +565,7 @@ func (p *backendImpl) Validate(context.Context, *tokens.Claims) error {
 // Helpers
 ///////////
 
-// realmAccess is an internal helper struct to represent Keycloak-specific realm_access claim.
+// realmAccess is an internal helper struct to unmarshal the keycloak-specific realm_access claim into.
 type realmAccess struct {
 	Roles []string `json:"roles"`
 }
@@ -576,6 +579,8 @@ type userInfoType struct {
 	RealmAccess *realmAccess `json:"realm_access"`
 	// Claim "account_id" is the claim that represents organisation id within sso.redhat.com.
 	// Red Hat users are united in organisations.
+	// See more on the claims here:
+	// https://source.redhat.com/groups/public/it-user/it_user_team_wiki/topic_external_sso_enablements#attributes-needed
 	OrgID string `json:"account_id"`
 }
 
@@ -595,10 +600,10 @@ func userInfoToExternalClaims(userInfo *userInfoType) *tokens.ExternalUserClaim 
 	claim.Attributes = make(map[string][]string)
 	realmAccess := userInfo.RealmAccess
 	if realmAccess != nil && len(realmAccess.Roles) > 0 {
-		claim.Attributes[authproviders.RolesAttribute] = realmAccess.Roles
+		claim.Attributes[RolesAttribute] = realmAccess.Roles
 	}
 	if userInfo.OrgID != "" {
-		claim.Attributes[authproviders.OrgIDAttribute] = []string{userInfo.OrgID}
+		claim.Attributes[OrgidAttribute] = []string{userInfo.OrgID}
 	}
 
 	// Add all fields as attributes.

--- a/pkg/auth/authproviders/oidc/backend_impl.go
+++ b/pkg/auth/authproviders/oidc/backend_impl.go
@@ -37,8 +37,8 @@ const (
 
 	userInfoExpiration = 5 * time.Minute
 
-	RolesAttribute = "roles"
-	OrgidAttribute = "orgid"
+	rolesAttribute = "roles"
+	orgidAttribute = "orgid"
 )
 
 type nonceVerificationSetting int
@@ -600,10 +600,10 @@ func userInfoToExternalClaims(userInfo *userInfoType) *tokens.ExternalUserClaim 
 	claim.Attributes = make(map[string][]string)
 	realmAccess := userInfo.RealmAccess
 	if realmAccess != nil && len(realmAccess.Roles) > 0 {
-		claim.Attributes[RolesAttribute] = realmAccess.Roles
+		claim.Attributes[rolesAttribute] = realmAccess.Roles
 	}
 	if userInfo.OrgID != "" {
-		claim.Attributes[OrgidAttribute] = []string{userInfo.OrgID}
+		claim.Attributes[orgidAttribute] = []string{userInfo.OrgID}
 	}
 
 	// Add all fields as attributes.

--- a/pkg/auth/authproviders/oidc/backend_impl.go
+++ b/pkg/auth/authproviders/oidc/backend_impl.go
@@ -562,18 +562,21 @@ func (p *backendImpl) Validate(context.Context, *tokens.Claims) error {
 // Helpers
 ///////////
 
-type RealmAccess struct {
+// realmAccess is an internal helper struct to represent Keycloak-specific realm_access claim.
+type realmAccess struct {
 	Roles []string `json:"roles"`
 }
 
-// UserInfo is an internal helper struct to unmarshal OIDC token info into.
+// userInfoType is an internal helper struct to unmarshal OIDC token info into.
 type userInfoType struct {
 	Name        string       `json:"name"`
 	EMail       string       `json:"email"`
 	UID         string       `json:"sub"`
 	Groups      []string     `json:"groups"`
-	RealmAccess *RealmAccess `json:"realm_access"`
-	OrgId       string       `json:"account_id"`
+	RealmAccess *realmAccess `json:"realm_access"`
+	// Claim "account_id" is the claim that represents organisation id within sso.redhat.com.
+	// Red Hat users are united in organisations.
+	OrgID string `json:"account_id"`
 }
 
 func userInfoToExternalClaims(userInfo *userInfoType) *tokens.ExternalUserClaim {
@@ -594,8 +597,8 @@ func userInfoToExternalClaims(userInfo *userInfoType) *tokens.ExternalUserClaim 
 	if realmAccess != nil && len(realmAccess.Roles) > 0 {
 		claim.Attributes[authproviders.RolesAttribute] = realmAccess.Roles
 	}
-	if userInfo.OrgId != "" {
-		claim.Attributes[authproviders.OrgIdAttribute] = []string{userInfo.OrgId}
+	if userInfo.OrgID != "" {
+		claim.Attributes[authproviders.OrgIDAttribute] = []string{userInfo.OrgID}
 	}
 
 	// Add all fields as attributes.

--- a/pkg/auth/authproviders/oidc/backend_impl.go
+++ b/pkg/auth/authproviders/oidc/backend_impl.go
@@ -37,7 +37,7 @@ const (
 
 	userInfoExpiration = 5 * time.Minute
 
-	orgidAttribute = "orgid"
+	orgIDAttribute = "orgid"
 	orgAdminGroup  = "org_admin"
 )
 
@@ -611,7 +611,7 @@ func userInfoToExternalClaims(userInfo *userInfoType) *tokens.ExternalUserClaim 
 
 	// Add sso.redhat.com attributes.
 	if userInfo.OrgID != "" {
-		claim.Attributes[orgidAttribute] = []string{userInfo.OrgID}
+		claim.Attributes[orgIDAttribute] = []string{userInfo.OrgID}
 	}
 	if userInfo.IsOrgAdmin {
 		claim.Attributes[authproviders.GroupsAttribute] = append(claim.Attributes[authproviders.GroupsAttribute], orgAdminGroup)

--- a/pkg/auth/authproviders/util.go
+++ b/pkg/auth/authproviders/util.go
@@ -15,7 +15,7 @@ const (
 	UseridAttribute = "userid"
 	NameAttribute   = "name"
 	RolesAttribute  = "roles"
-	OrgIdAttribute  = "org_id"
+	OrgIDAttribute  = "org_id"
 )
 
 // AllUIEndpoints returns all UI endpoints for a given auth provider, with the default UI endpoint first.

--- a/pkg/auth/authproviders/util.go
+++ b/pkg/auth/authproviders/util.go
@@ -14,6 +14,8 @@ const (
 	EmailAttribute  = "email"
 	UseridAttribute = "userid"
 	NameAttribute   = "name"
+	RolesAttribute  = "roles"
+	OrgIdAttribute  = "org_id"
 )
 
 // AllUIEndpoints returns all UI endpoints for a given auth provider, with the default UI endpoint first.

--- a/pkg/auth/authproviders/util.go
+++ b/pkg/auth/authproviders/util.go
@@ -14,8 +14,6 @@ const (
 	EmailAttribute  = "email"
 	UseridAttribute = "userid"
 	NameAttribute   = "name"
-	RolesAttribute  = "roles"
-	OrgIDAttribute  = "org_id"
 )
 
 // AllUIEndpoints returns all UI endpoints for a given auth provider, with the default UI endpoint first.

--- a/ui/apps/platform/src/Containers/Login/TestLoginResultsPage.js
+++ b/ui/apps/platform/src/Containers/Login/TestLoginResultsPage.js
@@ -31,7 +31,9 @@ function getMessage(response) {
         return (
             <li key={curr.key}>
                 <span id={curr.key}>{curr.key}</span>:{' '}
-                <span aria-labelledby={curr.key}>{curr.values}</span>
+                <span aria-labelledby={curr.key}>
+                    {Array.isArray(curr.values) ? curr.values.join(', ') : curr.values}
+                </span>
             </li>
         );
     });


### PR DESCRIPTION
## Description

Our OIDC client for `sso.redhat.com` allows us to receive both "account_id"(corresponds to organisation id within Red Hat) and "is_org_admin"(identifies organisation administrator account) claims in `sso.redhat.com` token. 
This PR  adds these claims to the RHACS-issued tokens. `is_org_admin` is added to the `groups` as `org_admin` group.

Also, on the test login page multi-value attributes are separated by a comma now.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Manual test which verified account_id is returned and "org_admin" group is added

<img width="1535" alt="Screenshot 2022-05-18 at 19 04 39" src="https://user-images.githubusercontent.com/78353299/169101067-1e00a207-92cd-48e7-991c-35cde0dc4056.png">


