### PR TITLE
ROX-10078: Add context to blevesearch index Search and Count functions

### DIFF
--- a/central/activecomponent/datastore/index/indexer_impl_test.go
+++ b/central/activecomponent/datastore/index/indexer_impl_test.go
@@ -57,6 +57,7 @@ func (suite *ActiveComponentIndexTestSuite) TestIndexing() {
 		},
 	}
 
+	ctx := context.Background()
 	q := search.NewQueryBuilder().AddExactMatches(search.ImageSHA, imageID).ProtoQuery()
 
 	results, err := suite.indexer.Search(suite.ctx, q)

--- a/central/alert/datastore/internal/index/bench_test.go
+++ b/central/alert/datastore/internal/index/bench_test.go
@@ -74,6 +74,7 @@ func BenchmarkAddAlertsThen1(b *testing.B) {
 }
 
 func BenchmarkSearchAlert(b *testing.B) {
+	ctx := context.Background()
 	indexer := getAlertIndex()
 	qb := search.NewQueryBuilder().AddStrings(search.Cluster, "prod cluster")
 	for i := 0; i < b.N; i++ {

--- a/central/cluster/index/indexer_impl_test.go
+++ b/central/cluster/index/indexer_impl_test.go
@@ -49,6 +49,7 @@ func (suite *ClusterIndexTestSuite) TestIndexing() {
 
 	suite.NoError(suite.indexer.AddCluster(cluster))
 
+	ctx := context.Background()
 	q := search.NewQueryBuilder().AddStrings(search.Cluster, "cluster1").ProtoQuery()
 	results, err := suite.indexer.Search(ctx, q)
 	suite.NoError(err)

--- a/central/deployment/index/bench_test.go
+++ b/central/deployment/index/bench_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -62,6 +63,7 @@ func BenchmarkAddDeploymentsThen1(b *testing.B) {
 }
 
 func BenchmarkSearchDeployment(b *testing.B) {
+	ctx := context.Background()
 	indexer := getDeploymentIndex(b)
 	qb := search.NewQueryBuilder().AddStrings(search.Cluster, "prod cluster")
 	for i := 0; i < b.N; i++ {

--- a/central/deployment/index/indexer_impl_test.go
+++ b/central/deployment/index/indexer_impl_test.go
@@ -329,6 +329,7 @@ func (suite *DeploymentIndexTestSuite) TestDeploymentsQuery() {
 	}
 
 	for _, c := range cases {
+		ctx := context.Background()
 		qb := search.NewQueryBuilder()
 		for field, value := range c.fieldValues {
 			qb.AddStrings(field, value)
@@ -367,6 +368,7 @@ func (suite *DeploymentIndexTestSuite) TestDeploymentsQuery() {
 }
 
 func (suite *DeploymentIndexTestSuite) TestBatches() {
+	ctx := context.Background()
 	deployments := []*storage.Deployment{
 		fixtures.GetDeployment(),
 		fixtures.GetDeployment(),
@@ -386,6 +388,7 @@ func (suite *DeploymentIndexTestSuite) TestBatches() {
 }
 
 func (suite *DeploymentIndexTestSuite) TestCaseInsensitivityOfFieldNames() {
+	ctx := context.Background()
 	dep := fixtures.GetDeployment()
 	suite.NoError(suite.indexer.AddDeployment(dep))
 	ns := dep.GetNamespace()
@@ -402,6 +405,7 @@ func (suite *DeploymentIndexTestSuite) TestCaseInsensitivityOfFieldNames() {
 }
 
 func (suite *DeploymentIndexTestSuite) TestDeploymentDelete() {
+	ctx := context.Background()
 	dep := fixtures.GetDeployment()
 	suite.NoError(suite.indexer.AddDeployment(dep))
 
@@ -580,6 +584,7 @@ func TestEnumComparisonSearch(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%s%s-%s", c.prefix, c.queryLevel, c.deploymentLevel), func(t *testing.T) {
+			ctx := context.Background()
 			d := fixtures.GetDeployment()
 			d.ServiceAccountPermissionLevel = c.deploymentLevel
 			require.NoError(t, indexer.AddDeployment(d))
@@ -651,6 +656,7 @@ func TestMapQueries(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		ctx := context.Background()
 		q := search.NewQueryBuilder().AddMapQuery(search.Label, c.key, c.value).ProtoQuery()
 		results, err := deploymentIndexer.Search(ctx, q)
 		assert.NoError(t, err)

--- a/central/deployment/index/search_comparison_test.go
+++ b/central/deployment/index/search_comparison_test.go
@@ -65,6 +65,7 @@ func TestImageSearchResults(t *testing.T) {
 	factory := predicate.NewFactory("image", (*storage.Image)(nil))
 	for _, c := range cases {
 		t.Run("test", func(t *testing.T) {
+			ctx := context.Background()
 			predicate, err := factory.GeneratePredicate(c.query)
 			require.NoError(t, err)
 
@@ -107,6 +108,7 @@ func TestDeploymentSearchResults(t *testing.T) {
 	factory := predicate.NewFactory("deployment", (*storage.Deployment)(nil))
 	for _, c := range cases {
 		t.Run("test", func(t *testing.T) {
+			ctx := context.Background()
 			predicate, err := factory.GeneratePredicate(c.query)
 			require.NoError(t, err)
 

--- a/central/image/index/indexer_impl_test.go
+++ b/central/image/index/indexer_impl_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"context"
 	"testing"
 
 	"github.com/blevesearch/bleve"
@@ -73,6 +74,7 @@ func (suite *ImageIndexTestSuite) TearDownSuite() {
 }
 
 func (suite *ImageIndexTestSuite) TestSearchImages() {
+	ctx := context.Background()
 	// No filter on either => should return everything.
 	results, err := suite.indexer.Search(ctx, search.EmptyQuery())
 	suite.NoError(err)

--- a/central/namespace/index/indexer_impl_test.go
+++ b/central/namespace/index/indexer_impl_test.go
@@ -47,6 +47,7 @@ func (suite *NamespaceIndexTestSuite) TestIndexing() {
 
 	suite.NoError(suite.indexer.AddNamespaceMetadata(ns))
 
+	ctx := context.Background()
 	q := search.NewQueryBuilder().AddStrings(search.Namespace, "namespace1").ProtoQuery()
 	results, err := suite.indexer.Search(ctx, q)
 	suite.NoError(err)

--- a/central/node/index/indexer_impl_test.go
+++ b/central/node/index/indexer_impl_test.go
@@ -47,6 +47,7 @@ func (suite *NodeIndexTestSuite) TestIndexing() {
 
 	suite.NoError(suite.indexer.AddNode(node))
 
+	ctx := context.Background()
 	q := search.NewQueryBuilder().AddStrings(search.Node, "node").ProtoQuery()
 	results, err := suite.indexer.Search(ctx, q)
 	suite.NoError(err)

--- a/central/processbaseline/index/indexer_impl_test.go
+++ b/central/processbaseline/index/indexer_impl_test.go
@@ -83,6 +83,7 @@ func (suite *ProcessBaselineIndexTestSuite) TestEmptySearch() {
 }
 
 func (suite *ProcessBaselineIndexTestSuite) TestAddSearchDeleteBaseline() {
+	ctx := context.Background()
 	baseline := suite.getAndStoreBaseline()
 	suite.getAndStoreBaseline() // Don't find this one
 

--- a/tools/generate-helpers/pg-table-bindings/index.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/index.go.tpl
@@ -2,6 +2,7 @@
 package postgres
 
 import (
+    "context"
     "reflect"
 	"time"
 


### PR DESCRIPTION
## Description

Before the migration to relational database, scoped access control checks in search use cases were performed on the fields of all objects returned by the search call. This post-filtering also allowed scope checks being performed in black-box mode by external SAC plugins.
With the data storage migrating to a relational database engine and the external SAC plugin being deprecated, it would be possible to delegate SAC filtering to the database engine.
Should code generation be considered for SAC filtered search, the generated code would need access to the context in order to extract the scope checker in the indexer `Count` and `Search` functions.

The change here is preparing the way for indexer filtered SAC search code generation.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

The change at hand is a refactor to propagate data that is not used for the time being.
The existing CI tests should be enough to ensure the change did not break anything.