### PR TITLE
OSCI: remove Circle CI style checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4776,8 +4776,6 @@ workflows:
       - slack-notify:
           <<: *runOnTagsOnly
           context: custom-executor-pull
-      - style-checks:
-          <<: *runOnAllTagsWithQuayIOPullCtx
       - check-generated-files-up-to-date:
           <<: *runOnAllTagsWithQuayIOPullCtx
       - check-policy-files-up-to-date:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2319,27 +2319,6 @@ jobs:
 
       - *storeUITestReports
 
-  style-checks:
-    executor: custom
-    resource_class: xlarge
-    steps:
-      - checkout
-
-      - setup-go-build-env
-      - *restoreGoLintCache
-      - *restoreGradle
-      - restore-npm-deps-cache
-
-      - run:
-          name: Run style checks
-          command: make style
-
-      - ci-artifacts/store:
-          path: qa-tests-backend/build/reports/codenarc
-          destination: reports/codenarc
-
-      - *saveGoLintCache
-
   # This job checks that the docs/content submodule is pointing to the correct branch in the openshift-docs repo,
   # and that it is up-to-date. It only runs on RC builds, and is primarily intended as a reminder for the release
   # manager to inquire about docs and, if available, update the submodule pointer.


### PR DESCRIPTION
## Description

Removes `style-checks` from the `build_all` workflow now that PRs rely on prow. Leaves the job present in case we want to scurry back.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient
