### PR TITLE
Add FF gated PatternFly Dashboard page shell.

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Divider, PageSection, Text, Title } from '@patternfly/react-core';
+
+function DashboardPage() {
+    return (
+        <>
+            <PageSection variant="light">
+                <Title headingLevel="h1">Dashboard</Title>
+                <Text>Review security metrics across all or select resources</Text>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection />
+        </>
+    );
+}
+
+export default DashboardPage;

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -5,6 +5,7 @@ import { PageSection } from '@patternfly/react-core';
 import {
     mainPath,
     dashboardPath,
+    dashboardPathPF,
     networkPath,
     violationsPath,
     compliancePath,
@@ -44,6 +45,11 @@ function NotFoundPage(): ReactElement {
 
 const AsyncApiDocsPage = asyncComponent(() => import('Containers/Docs/ApiPage'));
 const AsyncDashboardPage = asyncComponent(() => import('Containers/Dashboard/DashboardPage'));
+// TODO Rename this and replace AsyncDashboardPage once Sec Metrics Phase One is complete
+// Jira: https://issues.redhat.com/browse/ROX-10650
+const AsyncDashboardPagePF = asyncComponent(
+    () => import('Containers/Dashboard/PatternFly/DashboardPage')
+);
 const AsyncNetworkPage = asyncComponent(() => import('Containers/Network/Page'));
 const AsyncClustersPage = asyncComponent(() => import('Containers/Clusters/ClustersPage'));
 const AsyncPFClustersPage = asyncComponent(() => import('Containers/Clusters/PF/ClustersPage'));
@@ -86,6 +92,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
     const { isDarkMode } = useTheme();
 
     const isSystemHealthPatternFlyEnabled = isFeatureFlagEnabled('ROX_SYSTEM_HEALTH_PF');
+    const isDashboardPatternFlyEnabled = isFeatureFlagEnabled('ROX_SECURITY_METRICS_PHASE_ONE');
 
     const hasVulnerabilityReportsPermission = hasReadAccess('VulnerabilityReports');
 
@@ -100,6 +107,9 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     <Route path="/" exact render={() => <Redirect to={dashboardPath} />} />
                     <Route path={mainPath} exact render={() => <Redirect to={dashboardPath} />} />
                     <Route path={dashboardPath} component={AsyncDashboardPage} />
+                    {isDashboardPatternFlyEnabled && (
+                        <Route path={dashboardPathPF} component={AsyncDashboardPagePF} />
+                    )}
                     <Route path={networkPath} component={AsyncNetworkPage} />
                     <Route path={violationsPath} component={AsyncViolationsPage} />
                     <Route path={compliancePath} component={AsyncCompliancePage} />

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -10,6 +10,7 @@ export const testLoginResultsPath = '/test-login-results';
 export const authResponsePrefix = '/auth/response/';
 
 export const dashboardPath = `${mainPath}/dashboard`;
+export const dashboardPathPF = `${mainPath}/dashboard-pf`;
 export const networkBasePath = `${mainPath}/network`;
 export const networkPath = `${networkBasePath}/:deploymentId?/:externalType?`;
 export const violationsBasePath = `${mainPath}/violations`;


### PR DESCRIPTION
## Description

Adds a PatternFly page shell for upcoming security metrics dashboard work.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Test that the placeholder page loads when visiting the `main/dashboard-pf` URL directly, when the feature flag is enabled:
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/168130087-61853d24-6534-425e-9bcf-d55c70f12a0b.png">

Test that a 404 page is displayed instead when visiting the URL with the feature flag disabled:
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1292638/168131137-6d02e1ee-63f5-416b-8222-d9f5a33c29d5.png">

