### PR TITLE
ROX-10922: Set QA test timeout

### DIFF
--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -141,6 +141,7 @@ tasks.withType(Test) {
 }
 
 test {
+    timeout = Duration.ofHours(2)
     testLogging.showStandardStreams = true
 
     // This ensures that repeated invocations of tests actually run the tests.


### PR DESCRIPTION
## Description

Add qa test timeout to prevent it running indefinitely. 
When test get timeouted we will see following message:

> Requesting stop of task ':test' as it has exceeded its configured timeout of ...

See: https://docs.gradle.org/current/dsl/org.gradle.api.Task.html#org.gradle.api.Task:timeout

## Testing Performed

CI