### PR TITLE
OSCI: Run tests against the PR branch

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -690,7 +690,7 @@ openshift_ci_mods() {
     local pr_details
     local exitstatus=0
     pr_details="${2:-$(get_pr_details)}" || exitstatus="$?"
-    if [[ "$exitstatus" == "0"  && "$(jq -r .base.repo.full_name <<<"$pr_details")" == "stackrox/stackrox" ]]; then
+    if [[ "$exitstatus" == "0" && "$(jq -r .base.repo.full_name <<<"$pr_details")" == "stackrox/stackrox" ]]; then
         info "Will switch to the PR branch"
 
         # Clone the target repo

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -701,7 +701,7 @@ openshift_ci_mods() {
 
         # Checkout the PR branch
         head_ref="$(jq -r '.head.ref' <<<"$pr_details")"
-        info "Will try to checkout a matching PR branch using: $head_ref"
+        info "Checking out a matching PR branch using: $head_ref"
         git checkout "$head_ref"
     fi
 }

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -691,7 +691,7 @@ openshift_ci_mods() {
     local exitstatus=0
     pr_details="${2:-$(get_pr_details)}" || exitstatus="$?"
     if [[ "$exitstatus" == "0" && "$(jq -r .base.repo.full_name <<<"$pr_details")" == "stackrox/stackrox" ]]; then
-        info "Will switch to the PR branch"
+        info "Switching to the PR branch"
 
         # Clone the target repo
         cd ..


### PR DESCRIPTION
## Description

Prow tests PRs with the branch rebased against master. This is a pain during migration because builds still come from Circle CI and thus have a different tag from what prow tests expect causing [failures](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/1692/pull-ci-stackrox-stackrox-master-gke-upgrade-tests/1524847886951518208). This PR has prow tests run in the context of their PR branch.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient