### PR TITLE
[ROX-10811] : Add PlottedNodeVulnerabilities resolver and tie it to sub-resolvers in cluster and node

### DIFF
--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -1101,6 +1101,7 @@ func (resolver *clusterResolver) PlottedNodeVulnerabilities(ctx context.Context,
 
 	if !features.PostgresDatastore.Enabled() {
 		query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
+		query = withNodeTypeFiltering(query)
 		return newPlottedNodeVulnerabilitiesResolver(ctx, resolver.root, RawQuery{Query: &query})
 	}
 	// TODO : Add postgres support

--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -1096,12 +1096,12 @@ func (resolver *clusterResolver) PlottedVulns(ctx context.Context, args RawQuery
 	return newPlottedVulnerabilitiesResolver(ctx, resolver.root, RawQuery{Query: &query})
 }
 
+// PlottedNodeVulnerabilities returns the data required by top risky entity scatter-plot on vuln mgmt dashboard
 func (resolver *clusterResolver) PlottedNodeVulnerabilities(ctx context.Context, args RawQuery) (*PlottedNodeVulnerabilitiesResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "PlottedNodeVulnerabilities")
 
 	if !features.PostgresDatastore.Enabled() {
 		query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
-		query = withNodeTypeFiltering(query)
 		return newPlottedNodeVulnerabilitiesResolver(ctx, resolver.root, RawQuery{Query: &query})
 	}
 	// TODO : Add postgres support

--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -66,7 +66,7 @@ func init() {
 			"nodeVulnerabilityCount(query: String): Int!",
 			"nodeVulnerabilityCounter(query: String): VulnerabilityCounter!",
 			"passingControls(query: String): [ComplianceControl!]!",
-			"plottedVulns(query: String): PlottedVulnerabilities!",
+			"plottedNodeVulnerabilities(query: String): PlottedNodeVulnerabilities!",
 			"policies(query: String, pagination: Pagination): [Policy!]!",
 			"policyCount(query: String): Int!",
 			"policyStatus(query: String): PolicyStatus!",
@@ -106,6 +106,8 @@ func init() {
 				"@deprecated(reason: \"use 'clusterVulnerabilities'\")",
 			"openShiftVulnCount(query: String): Int! " +
 				"@deprecated(reason: \"use 'clusterVulnerabilityCount'\")",
+			"plottedVulns(query: String): PlottedVulnerabilities!" +
+				"@deprecated(reason: \"use 'plottedNodeVulnerabilities' or 'plottedImageVulnerabilities'\")",
 		}),
 		schema.AddQuery("clusters(query: String, pagination: Pagination): [Cluster!]!"),
 		schema.AddQuery("clusterCount(query: String): Int!"),
@@ -1092,6 +1094,17 @@ func (resolver *clusterResolver) LatestViolation(ctx context.Context, args RawQu
 func (resolver *clusterResolver) PlottedVulns(ctx context.Context, args RawQuery) (*PlottedVulnerabilitiesResolver, error) {
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
 	return newPlottedVulnerabilitiesResolver(ctx, resolver.root, RawQuery{Query: &query})
+}
+
+func (resolver *clusterResolver) PlottedNodeVulnerabilities(ctx context.Context, args RawQuery) (*PlottedNodeVulnerabilitiesResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "PlottedNodeVulnerabilities")
+
+	if !features.PostgresDatastore.Enabled() {
+		query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
+		return newPlottedNodeVulnerabilitiesResolver(ctx, resolver.root, RawQuery{Query: &query})
+	}
+	// TODO : Add postgres support
+	return nil, errors.New("Sub-resolver PlottedNodeVulnerabilities in Cluster does not support postgres yet")
 }
 
 func (resolver *clusterResolver) UnusedVarSink(ctx context.Context, args RawQuery) *int32 {

--- a/central/graphql/resolvers/components_v2.go
+++ b/central/graphql/resolvers/components_v2.go
@@ -591,10 +591,10 @@ func (eicr *imageComponentResolver) PlottedVulns(ctx context.Context, args RawQu
 }
 
 // PlottedNodeVulnerabilities returns the data required by top risky component scatter-plot on vuln mgmt dashboard
-func (eicr *imageComponentResolver) PlottedNodeVulnerabilities(ctx context.Context, args RawQuery) (*PlottedVulnerabilitiesResolver, error) {
+func (eicr *imageComponentResolver) PlottedNodeVulnerabilities(ctx context.Context, args RawQuery) (*PlottedNodeVulnerabilitiesResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageComponents, "PlottedNodeVulnerabilities")
 	if !features.PostgresDatastore.Enabled() {
-		return eicr.PlottedVulns(ctx, args)
+		return newPlottedNodeVulnerabilitiesResolver(eicr.imageComponentScopeContext(), eicr.root, args)
 	}
 	// TODO : Add postgres support
 	return nil, errors.New("Sub-resolver PlottedNodeVulnerabilities in NodeComponent does not support postgres yet")

--- a/central/graphql/resolvers/node_components.go
+++ b/central/graphql/resolvers/node_components.go
@@ -59,7 +59,7 @@ type NodeComponentResolver interface {
 	NodeVulnerabilities(ctx context.Context, args PaginatedQuery) ([]NodeVulnerabilityResolver, error)
 	NodeVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error)
 	NodeVulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error)
-	PlottedNodeVulnerabilities(ctx context.Context, args RawQuery) (*PlottedVulnerabilitiesResolver, error)
+	PlottedNodeVulnerabilities(ctx context.Context, args RawQuery) (*PlottedNodeVulnerabilitiesResolver, error)
 	Priority(ctx context.Context) int32
 	RiskScore(ctx context.Context) float64
 	Source(ctx context.Context) string

--- a/central/graphql/resolvers/node_components.go
+++ b/central/graphql/resolvers/node_components.go
@@ -18,7 +18,7 @@ func init() {
 	utils.Must(
 		// NOTE: This list is and should remain alphabetically ordered
 		schema.AddType("NodeComponent", []string{
-			"fixedIn: String!", // is this needed?
+			"fixedIn: String!",
 			"id: ID!",
 			"nodeComponentLastScanned: Time",
 			"license: License",
@@ -32,7 +32,7 @@ func init() {
 			"plottedNodeVulnerabilities(query: String): PlottedNodeVulnerabilities!",
 			"priority: Int!",
 			"riskScore: Float!",
-			"source: String!", // is this infrastructure ?
+			"source: String!",
 			"topNodeVulnerability: NodeVulnerability",
 			"unusedVarSink(query: String): Int",
 			"version: String!",
@@ -45,7 +45,6 @@ func init() {
 }
 
 // NodeComponentResolver represents a generic resolver of node component fields.
-// Values may come from either an embedded component context, or a top level component context.
 // NOTE: This list is and should remain alphabetically ordered
 type NodeComponentResolver interface {
 	FixedIn(ctx context.Context) string

--- a/central/graphql/resolvers/node_components.go
+++ b/central/graphql/resolvers/node_components.go
@@ -29,7 +29,7 @@ func init() {
 			"nodeVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [NodeVulnerability]!",
 			"nodeVulnerabilityCount(query: String, scopeQuery: String): Int!",
 			"nodeVulnerabilityCounter(query: String): VulnerabilityCounter!",
-			"plottedNodeVulnerabilities(query: String): PlottedVulnerabilities!",
+			"plottedNodeVulnerabilities(query: String): PlottedNodeVulnerabilities!",
 			"priority: Int!",
 			"riskScore: Float!",
 			"source: String!", // is this infrastructure ?

--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -55,7 +55,7 @@ func (resolver *Resolver) NodeVulnerability(ctx context.Context, args IDQuery) (
 func (resolver *Resolver) NodeVulnerabilities(ctx context.Context, q PaginatedQuery) ([]NodeVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "NodeVulnerabilities")
 	if !features.PostgresDatastore.Enabled() {
-		query := withNodeTypeFiltering(q.String())
+		query := withNodeCveTypeFiltering(q.String())
 		return resolver.nodeVulnerabilitiesV2(ctx, PaginatedQuery{Query: &query, Pagination: q.Pagination})
 	}
 	// TODO : Add postgres support
@@ -66,7 +66,7 @@ func (resolver *Resolver) NodeVulnerabilities(ctx context.Context, q PaginatedQu
 func (resolver *Resolver) NodeVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "NodeVulnerabilityCount")
 	if !features.PostgresDatastore.Enabled() {
-		query := withNodeTypeFiltering(args.String())
+		query := withNodeCveTypeFiltering(args.String())
 		return resolver.vulnerabilityCountV2(ctx, RawQuery{Query: &query})
 	}
 	// TODO : Add postgres support
@@ -77,15 +77,15 @@ func (resolver *Resolver) NodeVulnerabilityCount(ctx context.Context, args RawQu
 func (resolver *Resolver) NodeVulnCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "NodeVulnerabilityCounter")
 	if !features.PostgresDatastore.Enabled() {
-		query := withNodeTypeFiltering(args.String())
+		query := withNodeCveTypeFiltering(args.String())
 		return resolver.vulnCounterV2(ctx, RawQuery{Query: &query})
 	}
 	// TODO : Add postgres support
 	return nil, errors.New("Resolver NodeVulnCounter does not support postgres yet")
 }
 
-// withNodeTypeFiltering adds a conjunction as a raw query to filter vulns by CVEType Node
-func withNodeTypeFiltering(q string) string {
+// withNodeCveTypeFiltering adds a conjunction as a raw query to filter vulns by CVEType Node
+func withNodeCveTypeFiltering(q string) string {
 	return search.AddRawQueriesAsConjunction(q,
 		search.NewQueryBuilder().AddExactMatches(search.CVEType, storage.CVE_NODE_CVE.String()).Query())
 }

--- a/central/graphql/resolvers/nodes.go
+++ b/central/graphql/resolvers/nodes.go
@@ -43,7 +43,6 @@ func init() {
 			"nodeVulnerabilityCounter(query: String): VulnerabilityCounter!",
 			"passingControls(query: String): [ComplianceControl!]!",
 			"plottedNodeVulnerabilities(query: String): PlottedNodeVulnerabilities!",
-			"plottedVulns(query: String): PlottedVulnerabilities!",
 			"topNodeVulnerability(query: String): NodeVulnerability",
 			"unusedVarSink(query: String): Int",
 		}),
@@ -61,6 +60,8 @@ func init() {
 				"@deprecated(reason: \"use 'nodeVulnerabilityCount'\")",
 			"vulnCounter(query: String): VulnerabilityCounter!" +
 				"@deprecated(reason: \"use 'nodeVulnerabilityCounter'\")",
+			"plottedVulns(query: String): PlottedVulnerabilities!" +
+				"@deprecated(reason: \"use 'plottedNodeVulnerabilities'\")",
 		}),
 	)
 }
@@ -523,16 +524,11 @@ func (resolver *nodeResolver) PlottedVulns(ctx context.Context, args RawQuery) (
 	return newPlottedVulnerabilitiesResolver(ctx, resolver.root, RawQuery{Query: &query})
 }
 
+// PlottedNodeVulnerabilities returns the data required by top risky entity scatter-plot on vuln mgmt dashboard
 func (resolver *nodeResolver) PlottedNodeVulnerabilities(ctx context.Context, args RawQuery) (*PlottedNodeVulnerabilitiesResolver, error) {
-	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Nodes, "PlottedVulnerabilities")
-	if err := readNodes(ctx); err != nil {
-		return nil, err
-	}
-
-	ctx = resolver.nodeScopeContext(ctx)
-
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Nodes, "PlottedNodeVulnerabilities")
 	if !features.PostgresDatastore.Enabled() {
-		return newPlottedNodeVulnerabilitiesResolver(ctx, resolver.root, args)
+		return newPlottedNodeVulnerabilitiesResolver(resolver.nodeScopeContext(ctx), resolver.root, args)
 	}
 	// TODO : Add postgres support
 	return nil, errors.New("Sub-resolver PlottedNodeVulnerabilities in Node does not support postgres yet")

--- a/central/graphql/resolvers/nodes.go
+++ b/central/graphql/resolvers/nodes.go
@@ -42,7 +42,7 @@ func init() {
 			"nodeVulnerabilityCount(query: String): Int!",
 			"nodeVulnerabilityCounter(query: String): VulnerabilityCounter!",
 			"passingControls(query: String): [ComplianceControl!]!",
-			"plottedVulnerabilities(query: String): PlottedNodeVulnerabilities!",
+			"plottedNodeVulnerabilities(query: String): PlottedNodeVulnerabilities!",
 			"plottedVulns(query: String): PlottedVulnerabilities!",
 			"topNodeVulnerability(query: String): NodeVulnerability",
 			"unusedVarSink(query: String): Int",
@@ -523,7 +523,7 @@ func (resolver *nodeResolver) PlottedVulns(ctx context.Context, args RawQuery) (
 	return newPlottedVulnerabilitiesResolver(ctx, resolver.root, RawQuery{Query: &query})
 }
 
-func (resolver *nodeResolver) PlottedVulnerabilities(ctx context.Context, args RawQuery) (*PlottedNodeVulnerabilitiesResolver, error) {
+func (resolver *nodeResolver) PlottedNodeVulnerabilities(ctx context.Context, args RawQuery) (*PlottedNodeVulnerabilitiesResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Nodes, "PlottedVulnerabilities")
 	if err := readNodes(ctx); err != nil {
 		return nil, err
@@ -535,7 +535,7 @@ func (resolver *nodeResolver) PlottedVulnerabilities(ctx context.Context, args R
 		return newPlottedNodeVulnerabilitiesResolver(ctx, resolver.root, args)
 	}
 	// TODO : Add postgres support
-	return nil, errors.New("Sub-resolver PlottedVulnerabilities in nodeResolver does not support postgres yet")
+	return nil, errors.New("Sub-resolver PlottedNodeVulnerabilities in Node does not support postgres yet")
 }
 
 func (resolver *nodeResolver) UnusedVarSink(ctx context.Context, args RawQuery) *int32 {

--- a/central/graphql/resolvers/plotted_node_vulnerabilities.go
+++ b/central/graphql/resolvers/plotted_node_vulnerabilities.go
@@ -10,8 +10,8 @@ func init() {
 	schema := getBuilder()
 	utils.Must(
 		schema.AddType("PlottedNodeVulnerabilities", []string{
-			"basicVulnerabilityCounter: VulnerabilityCounter!",
-			"vulnerabilities(pagination: Pagination): [NodeVulnerability]!",
+			"basicNodeVulnerabilityCounter: VulnerabilityCounter!",
+			"nodeVulnerabilities(pagination: Pagination): [NodeVulnerability]!",
 		}),
 	)
 }
@@ -36,8 +36,8 @@ func newPlottedNodeVulnerabilitiesResolver(ctx context.Context, root *Resolver, 
 	}, nil
 }
 
-// BasicVulnerabilityCounter returns the vulnCounter for scatter-plot with only total and fixable
-func (pvr *PlottedNodeVulnerabilitiesResolver) BasicVulnerabilityCounter(ctx context.Context) (*VulnerabilityCounterResolver, error) {
+// BasicNodeVulnerabilityCounter returns the NodeVulnerabilityCounter for scatter-plot with only total and fixable
+func (pvr *PlottedNodeVulnerabilitiesResolver) BasicNodeVulnerabilityCounter(ctx context.Context) (*VulnerabilityCounterResolver, error) {
 	return &VulnerabilityCounterResolver{
 		all: &VulnerabilityFixableCounterResolver{
 			total:   int32(len(pvr.all)),
@@ -46,8 +46,8 @@ func (pvr *PlottedNodeVulnerabilitiesResolver) BasicVulnerabilityCounter(ctx con
 	}, nil
 }
 
-// Vulnerabilities returns the node vulnerabilities for top risky nodes scatter-plot
-func (pvr *PlottedNodeVulnerabilitiesResolver) Vulnerabilities(ctx context.Context, args PaginatedQuery) ([]NodeVulnerabilityResolver, error) {
+// NodesVulnerabilities returns the node vulnerabilities for top risky nodes scatter-plot
+func (pvr *PlottedNodeVulnerabilitiesResolver) NodesVulnerabilities(ctx context.Context, args PaginatedQuery) ([]NodeVulnerabilityResolver, error) {
 	vulnResolvers, err := unwrappedPlottedVulnerabilities(ctx, pvr.root, pvr.all, args)
 	if err != nil {
 		return nil, err

--- a/central/graphql/resolvers/plotted_node_vulnerabilities.go
+++ b/central/graphql/resolvers/plotted_node_vulnerabilities.go
@@ -1,0 +1,61 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+func init() {
+	schema := getBuilder()
+	utils.Must(
+		schema.AddType("PlottedNodeVulnerabilities", []string{
+			"basicVulnerabilityCounter: VulnerabilityCounter!",
+			"vulnerabilities(pagination: Pagination): [NodeVulnerability]!",
+		}),
+	)
+}
+
+// PlottedNodeVulnerabilitiesResolver returns the data required by top risky nodes scatter-plot on vuln mgmt dashboard
+type PlottedNodeVulnerabilitiesResolver struct {
+	root    *Resolver
+	all     []string
+	fixable int
+}
+
+func newPlottedNodeVulnerabilitiesResolver(ctx context.Context, root *Resolver, args RawQuery) (*PlottedNodeVulnerabilitiesResolver, error) {
+	allCveIds, fixableCount, err := getPlottedVulnsIdsAndFixableCount(ctx, root, args)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PlottedNodeVulnerabilitiesResolver{
+		root:    root,
+		all:     allCveIds,
+		fixable: fixableCount,
+	}, nil
+}
+
+// BasicVulnerabilityCounter returns the vulnCounter for scatter-plot with only total and fixable
+func (pvr *PlottedNodeVulnerabilitiesResolver) BasicVulnerabilityCounter(ctx context.Context) (*VulnerabilityCounterResolver, error) {
+	return &VulnerabilityCounterResolver{
+		all: &VulnerabilityFixableCounterResolver{
+			total:   int32(len(pvr.all)),
+			fixable: int32(pvr.fixable),
+		},
+	}, nil
+}
+
+// Vulnerabilities returns the node vulnerabilities for top risky nodes scatter-plot
+func (pvr *PlottedNodeVulnerabilitiesResolver) Vulnerabilities(ctx context.Context, args PaginatedQuery) ([]NodeVulnerabilityResolver, error) {
+	vulnResolvers, err := unwrappedPlottedVulnerabilities(ctx, pvr.root, pvr.all, args)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]NodeVulnerabilityResolver, 0, len(vulnResolvers))
+	for _, resolver := range vulnResolvers {
+		ret = append(ret, resolver)
+	}
+	return ret, nil
+}

--- a/central/graphql/resolvers/plotted_node_vulnerabilities.go
+++ b/central/graphql/resolvers/plotted_node_vulnerabilities.go
@@ -24,7 +24,8 @@ type PlottedNodeVulnerabilitiesResolver struct {
 }
 
 func newPlottedNodeVulnerabilitiesResolver(ctx context.Context, root *Resolver, args RawQuery) (*PlottedNodeVulnerabilitiesResolver, error) {
-	allCveIds, fixableCount, err := getPlottedVulnsIdsAndFixableCount(ctx, root, args)
+	query := withNodeCveTypeFiltering(args.String())
+	allCveIds, fixableCount, err := getPlottedVulnsIdsAndFixableCount(ctx, root, RawQuery{Query: &query})
 	if err != nil {
 		return nil, err
 	}
@@ -46,8 +47,8 @@ func (pvr *PlottedNodeVulnerabilitiesResolver) BasicNodeVulnerabilityCounter(ctx
 	}, nil
 }
 
-// NodesVulnerabilities returns the node vulnerabilities for top risky nodes scatter-plot
-func (pvr *PlottedNodeVulnerabilitiesResolver) NodesVulnerabilities(ctx context.Context, args PaginatedQuery) ([]NodeVulnerabilityResolver, error) {
+// NodeVulnerabilities returns the node vulnerabilities for top risky nodes scatter-plot
+func (pvr *PlottedNodeVulnerabilitiesResolver) NodeVulnerabilities(ctx context.Context, args PaginatedQuery) ([]NodeVulnerabilityResolver, error) {
 	vulnResolvers, err := unwrappedPlottedVulnerabilities(ctx, pvr.root, pvr.all, args)
 	if err != nil {
 		return nil, err

--- a/central/graphql/resolvers/plotted_vulnerabilities_common.go
+++ b/central/graphql/resolvers/plotted_vulnerabilities_common.go
@@ -1,0 +1,63 @@
+package resolvers
+
+import (
+	"context"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/search"
+)
+
+func getPlottedVulnsIdsAndFixableCount(ctx context.Context, root *Resolver, args RawQuery) ([]string, int, error) {
+	q, err := args.AsV1QueryOrEmpty()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	q = tryUnsuppressedQuery(q)
+	q.Pagination = &v1.QueryPagination{
+		SortOptions: []*v1.QuerySortOption{
+			{
+				Field:    search.CVSS.String(),
+				Reversed: true,
+			},
+		},
+	}
+	all, err := root.CVEDataStore.Search(ctx, q)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	fixable, err := root.CVEDataStore.Count(ctx,
+		search.ConjunctionQuery(q, search.NewQueryBuilder().AddBools(search.Fixable, true).ProtoQuery()))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return search.ResultsToIDs(all), fixable, nil
+}
+
+func unwrappedPlottedVulnerabilities(ctx context.Context, resolver *Resolver, cveIds []string, args PaginatedQuery) ([]*cVEResolver, error) {
+	q, err := args.AsV1QueryOrEmpty()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(cveIds) == 0 {
+		return nil, nil
+	}
+
+	cvesInterface, err := paginationWrapper{
+		pv: q.GetPagination(),
+	}.paginate(cveIds, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	vulns, err := resolver.CVEDataStore.GetBatch(ctx, cvesInterface.([]string))
+	if err != nil {
+		return nil, err
+	}
+
+	vulnResolvers, err := resolver.wrapCVEs(vulns, err)
+	return vulnResolvers, err
+}


### PR DESCRIPTION
## Description

- Added new schema type `PlotterNodeVulnerabilities` and resolver interface `PlottedNodeVulnerabilitiesResolver` for that type.
- Added `plottedVulnerabilities` sub-resolver to node queries and wired it to use `PlottedNodeVulnerabilitiesResolver`.
- Added `plottedNodeVulnerabilities` sub-resolver to cluster queries and wired it to use `PlottedNodeVulnerabilitiesResolver`.
- Removed `activeState` query from `NodeVulnerabilitiy` type because active state info is only returned under deployment context and is `nil` otherwise.
- New plotted node vulns resolvers error out on Postgres enabled. Resolution logic for Postgres will be added after Postgres datastores are implemented.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- Manually tested by querying `plottedVulnerabilities`  sub-resolver on node and `plottedNodeVulnerabilities` on cluster to see if they return correct node vulnerabilities (and no other vuln types) and that they contain expected fields, when Postgres is disabled.
