### PR TITLE
Fix missing logs in tests

### DIFF
--- a/qa-tests-backend/codenarc-rules.groovy
+++ b/qa-tests-backend/codenarc-rules.groovy
@@ -297,8 +297,8 @@ ruleset {
     UseAssertTrueInsteadOfNegation 
     
     // rulesets/logging.xml
-    LoggerForDifferentClass 
-    LoggerWithWrongModifiers 
+    // LoggerForDifferentClass
+    // LoggerWithWrongModifiers
     LoggingSwallowsStacktrace 
     MultipleLoggers 
     // PrintStackTrace

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -1,5 +1,4 @@
 import common.Constants
-import groovy.util.logging.Slf4j
 import groups.BAT
 import groups.SensorBounceNext
 import io.stackrox.proto.api.v1.Common
@@ -22,12 +21,11 @@ import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Timeout
 import spock.lang.Unroll
+import util.ChaosMonkey
 import util.Env
 import util.Helpers
 import util.Timer
-import util.ChaosMonkey
 
-@Slf4j
 @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
 class AdmissionControllerTest extends BaseSpecification {
     @Shared

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -1,10 +1,11 @@
 import com.jayway.restassured.RestAssured
 import common.Constants
-import groovy.util.logging.Slf4j
 import io.grpc.StatusRuntimeException
 import io.stackrox.proto.api.v1.ApiTokenService
 import io.stackrox.proto.storage.ImageIntegrationOuterClass
 import io.stackrox.proto.storage.RoleOuterClass
+import java.security.SecureRandom
+import java.util.concurrent.TimeUnit
 import objects.K8sServiceAccount
 import objects.Secret
 import orchestratormanager.OrchestratorMain
@@ -17,6 +18,8 @@ import org.javers.core.diff.ListCompareAlgorithm
 import org.junit.Rule
 import org.junit.rules.TestName
 import org.junit.rules.Timeout
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import services.BaseService
 import services.ClusterService
 import services.ImageIntegrationService
@@ -30,10 +33,6 @@ import util.Env
 import util.Helpers
 import util.OnFailure
 
-import java.security.SecureRandom
-import java.util.concurrent.TimeUnit
-
-@Slf4j
 @Retry(condition = { Helpers.determineRetry(failure) })
 @OnFailure(handler = { Helpers.collectDebugForFailure(delegate as Throwable) })
 class BaseSpecification extends Specification {
@@ -158,6 +157,9 @@ class BaseSpecification extends Specification {
     )
     @Rule
     TestName name = new TestName()
+
+    @Shared
+    Logger log = LoggerFactory.getLogger("test." + this.getClass().getSimpleName())
 
     @Shared
     OrchestratorMain orchestrator = OrchestratorType.create(

--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -1,22 +1,20 @@
 import static io.stackrox.proto.storage.ClusterOuterClass.ClusterHealthStatus.HealthStatusLabel
-import groovy.util.logging.Slf4j
-import io.fabric8.kubernetes.api.model.EnvVar
-import orchestratormanager.OrchestratorManagerException
-import spock.lang.Shared
 import groups.SensorBounceNext
+import io.fabric8.kubernetes.api.model.EnvVar
 import io.stackrox.proto.storage.ClusterOuterClass
+import java.nio.file.Files
+import java.nio.file.Paths
 import objects.ConfigMap
 import objects.Deployment
 import objects.Secret
-import services.ClusterService
+import orchestratormanager.OrchestratorManagerException
 import org.junit.experimental.categories.Category
+import services.ClusterService
 import spock.lang.Retry
+import spock.lang.Shared
 import util.ApplicationHealth
 import util.Timer
-import java.nio.file.Files
-import java.nio.file.Paths
 
-@Slf4j
 @Retry(count = 1)
 class TLSChallengeTest extends BaseSpecification {
     @Shared

--- a/qa-tests-backend/src/test/resources/logback-test.xml
+++ b/qa-tests-backend/src/test/resources/logback-test.xml
@@ -28,6 +28,7 @@
     <logger name="util" level="DEBUG"/>
     <logger name="objects" level="DEBUG"/>
     <logger name="common" level="DEBUG"/>
+    <logger name="test" level="DEBUG"/>
 
     <!-- control the level of output here -->
     <root level="ERROR">


### PR DESCRIPTION
## Description

After switching from `println` to `slf4j.log` in #1387 we lost info logs from tests methods. This was because our global configuration prints only error messages except couple of specific packages. Unfortunately our tests are not in any package causing them to print only error messages.
Since logback does not provide a way to filter loggers base on pattern, we cannot use something like 
```xml
<logger name="*Test" level="DEBUG"/>
``` 
we need to prefix logger name with a "virtual" package.
This PR creates logger in `BaseSpecification` with name `test.<class name>` and set debug log level for `test` package.  

## Testing Performed

CI