### PR TITLE
ROX-10781: Added SAC tests for rbac K8sRole

### DIFF
--- a/central/rbac/k8srole/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srole/datastore/datastore_sac_test.go
@@ -1,0 +1,389 @@
+package datastore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/blevesearch/bleve"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/central/globalindex"
+	"github.com/stackrox/rox/central/rbac/k8srole/internal/index"
+	"github.com/stackrox/rox/central/rbac/k8srole/internal/store"
+	pgStore "github.com/stackrox/rox/central/rbac/k8srole/internal/store/postgres"
+	rdbStore "github.com/stackrox/rox/central/rbac/k8srole/internal/store/rocksdb"
+	"github.com/stackrox/rox/central/rbac/k8srole/mappings"
+	"github.com/stackrox/rox/central/rbac/k8srole/search"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/sac/testutils"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestK8sRoleSAC(t *testing.T) {
+	suite.Run(t, new(k8sRoleSACSuite))
+}
+
+type k8sRoleSACSuite struct {
+	suite.Suite
+
+	datastore DataStore
+
+	pool *pgxpool.Pool
+
+	engine *rocksdb.RocksDB
+	index  bleve.Index
+
+	storage store.Store
+	indexer index.Indexer
+	search  search.Searcher
+
+	testContexts   map[string]context.Context
+	testK8sRoleIDs []string
+}
+
+func (s *k8sRoleSACSuite) SetupSuite() {
+	var err error
+
+	if features.PostgresDatastore.Enabled() {
+		ctx := context.Background()
+		src := pgtest.GetConnectionString(s.T())
+		cfg, err := pgxpool.ParseConfig(src)
+		s.Require().NoError(err)
+		s.pool, err = pgxpool.ConnectConfig(ctx, cfg)
+		s.Require().NoError(err)
+		pgStore.Destroy(ctx, s.pool)
+		s.storage = pgStore.New(ctx, s.pool)
+		s.indexer = pgStore.NewIndexer(s.pool)
+	} else {
+		s.engine, err = rocksdb.NewTemp("k8sRoleSACTest")
+		s.Require().NoError(err)
+		bleveIndex, err := globalindex.MemOnlyIndex()
+		s.Require().NoError(err)
+		s.index = bleveIndex
+
+		s.storage = rdbStore.New(s.engine)
+		s.indexer = index.New(s.index)
+	}
+
+	s.search = search.New(s.storage, s.indexer)
+	s.datastore, err = New(s.storage, s.indexer, s.search)
+	s.Require().NoError(err)
+
+	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(),
+		resources.K8sRole.GetResource())
+}
+
+func (s *k8sRoleSACSuite) TearDownSuite() {
+	if features.PostgresDatastore.Enabled() {
+		s.pool.Close()
+	} else {
+		s.Require().NoError(rocksdb.CloseAndRemove(s.engine))
+		s.Require().NoError(s.index.Close())
+	}
+}
+
+func (s *k8sRoleSACSuite) SetupTest() {
+	s.testK8sRoleIDs = make([]string, 0)
+
+	k8sRoles := fixtures.GetSACTestK8SRoleSet()
+
+	for i := range k8sRoles {
+		err := s.datastore.UpsertRole(s.testContexts[testutils.UnrestrictedReadWriteCtx], k8sRoles[i])
+		s.Require().NoError(err)
+	}
+
+	for _, rb := range k8sRoles {
+		s.testK8sRoleIDs = append(s.testK8sRoleIDs, rb.GetId())
+	}
+
+	fmt.Println(s.testK8sRoleIDs)
+}
+
+func (s *k8sRoleSACSuite) TearDownTest() {
+	for _, id := range s.testK8sRoleIDs {
+		s.deleteK8sRole(id)
+	}
+}
+
+func (s *k8sRoleSACSuite) deleteK8sRole(id string) {
+	s.Require().NoError(s.datastore.RemoveRole(s.testContexts[testutils.UnrestrictedReadWriteCtx], id))
+}
+
+func (s *k8sRoleSACSuite) TestUpsertRole() {
+	cases := map[string]struct {
+		scopeKey    string
+		expectFail  bool
+		expectedErr error
+	}{
+		"global read-only should not be able to add": {
+			scopeKey:    testutils.UnrestrictedReadCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"global read-write should be able to add": {
+			scopeKey: testutils.UnrestrictedReadWriteCtx,
+		},
+		"read-write on wrong cluster should not be able to add": {
+			scopeKey:    testutils.Cluster1ReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and namespace should not be able to add": {
+			scopeKey:    testutils.Cluster1NamespaceAReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and matching namespace should not be able to add": {
+			scopeKey:    testutils.Cluster1NamespaceBReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and wrong namespace should not be able to add": {
+			scopeKey:    testutils.Cluster2NamespaceAReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and matching namespace should be able to add": {
+			scopeKey:    testutils.Cluster2NamespaceBReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and no namespace should not be able to add": {
+			scopeKey:    testutils.Cluster2ReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and at least one matching namespace should be able to add": {
+			scopeKey:    testutils.Cluster2NamespacesABReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			role := fixtures.GetScopedK8SRole(uuid.NewV4().String(), testconsts.Cluster2,
+				testconsts.NamespaceB)
+			s.testK8sRoleIDs = append(s.testK8sRoleIDs, role.GetId())
+			ctx := s.testContexts[c.scopeKey]
+			err := s.datastore.UpsertRole(ctx, role)
+			defer s.deleteK8sRole(role.GetId())
+			if c.expectFail {
+				s.Require().Error(err)
+				s.ErrorIs(err, c.expectedErr)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}
+
+func (s *k8sRoleSACSuite) TestGetRole() {
+	role := fixtures.GetScopedK8SRole(uuid.NewV4().String(), testconsts.Cluster2,
+		testconsts.NamespaceB)
+	err := s.datastore.UpsertRole(s.testContexts[testutils.UnrestrictedReadWriteCtx], role)
+	s.Require().NoError(err)
+	s.testK8sRoleIDs = append(s.testK8sRoleIDs, role.GetId())
+
+	cases := map[string]struct {
+		scopeKey string
+		found    bool
+	}{
+		"global read-only can get": {
+			scopeKey: testutils.UnrestrictedReadCtx,
+			found:    true,
+		},
+		"global read-write can get": {
+			scopeKey: testutils.UnrestrictedReadWriteCtx,
+			found:    true,
+		},
+		"read-write on wrong cluster cannot get": {
+			scopeKey: testutils.Cluster1ReadWriteCtx,
+		},
+		"read-write on wrong cluster and wrong namespace cannot get": {
+			scopeKey: testutils.Cluster1NamespaceAReadWriteCtx,
+		},
+		"read-write on wrong cluster and matching namespace cannot get": {
+			scopeKey: testutils.Cluster1NamespaceBReadWriteCtx,
+		},
+		"read-write on matching cluster but wrong namespaces cannot get": {
+			scopeKey: testutils.Cluster2NamespacesACReadWriteCtx,
+		},
+		"read-write on matching cluster can read": {
+			scopeKey: testutils.Cluster2ReadWriteCtx,
+			found:    true,
+		},
+		"read-write on the matching cluster and namespace can get": {
+			scopeKey: testutils.Cluster2NamespaceBReadWriteCtx,
+			found:    true,
+		},
+		"read-write on the matching cluster and at least one matching namespace can get": {
+			scopeKey: testutils.Cluster2NamespacesABReadWriteCtx,
+			found:    true,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[c.scopeKey]
+			res, found, err := s.datastore.GetRole(ctx, role.GetId())
+			s.Require().NoError(err)
+			if c.found {
+				s.True(found)
+				s.Equal(*role, *res)
+			} else {
+				s.False(found)
+				s.Nil(res)
+			}
+		})
+	}
+}
+
+func (s *k8sRoleSACSuite) TestRemoveRole() {
+	cases := map[string]struct {
+		scopeKey    string
+		expectFail  bool
+		expectedErr error
+	}{
+		"global read-only cannot remove": {
+			scopeKey:    testutils.UnrestrictedReadCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"global read-write can remove": {
+			scopeKey:    testutils.UnrestrictedReadWriteCtx,
+			expectedErr: nil,
+		},
+		"read-write on wrong cluster cannot remove": {
+			scopeKey:    testutils.Cluster1ReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and wrong namespace cannot remove": {
+			scopeKey:    testutils.Cluster1NamespaceAReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and matching namespace cannot remove": {
+			scopeKey:    testutils.Cluster1NamespaceBReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster but wrong namespaces cannot remove": {
+			scopeKey:    testutils.Cluster2NamespacesACReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"full read-write on matching cluster cannot remove": {
+			scopeKey:    testutils.Cluster2ReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on the matching cluster and namespace cannot remove": {
+			scopeKey:    testutils.Cluster2NamespaceBReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+		"read-write on the matching cluster and at least the right namespace cannot remove": {
+			scopeKey:    testutils.Cluster2NamespacesABReadWriteCtx,
+			expectFail:  true,
+			expectedErr: sac.ErrResourceAccessDenied,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			role := fixtures.GetScopedK8SRole(uuid.NewV4().String(), testconsts.Cluster2,
+				testconsts.NamespaceB)
+			s.testK8sRoleIDs = append(s.testK8sRoleIDs, role.GetId())
+
+			ctx := s.testContexts[c.scopeKey]
+			err := s.datastore.UpsertRole(s.testContexts[testutils.UnrestrictedReadWriteCtx], role)
+			s.Require().NoError(err)
+			defer s.deleteK8sRole(role.GetId())
+
+			err = s.datastore.RemoveRole(ctx, role.GetId())
+			if c.expectFail {
+				s.Require().Error(err)
+				s.ErrorIs(err, c.expectedErr)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}
+
+func (s *k8sRoleSACSuite) runSearchRawTest(c testutils.SACSearchTestCase) {
+	ctx := s.testContexts[c.ScopeKey]
+	results, err := s.datastore.SearchRawRoles(ctx, nil)
+	s.Require().NoError(err)
+	resultObjs := make([]sac.NamespaceScopedObject, 0, len(results))
+	for i := range results {
+		resultObjs = append(resultObjs, results[i])
+	}
+	resultCounts := testutils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), resultObjs)
+	testutils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
+}
+
+func (s *k8sRoleSACSuite) runSearchTest(c testutils.SACSearchTestCase) {
+	ctx := s.testContexts[c.ScopeKey]
+	results, err := s.datastore.Search(ctx, nil)
+	s.Require().NoError(err)
+	resultCounts := testutils.CountResultsPerClusterAndNamespace(s.T(), results, mappings.OptionsMap)
+	testutils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
+}
+
+func (s *k8sRoleSACSuite) TestScopedSearch() {
+	if features.PostgresDatastore.Enabled() {
+		s.T().Skip("Not implemented!")
+	}
+
+	for name, c := range testutils.GenericScopedSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runSearchTest(c)
+		})
+	}
+}
+
+func (s *k8sRoleSACSuite) TestUnrestrictedSearch() {
+	if features.PostgresDatastore.Enabled() {
+		s.T().Skip("Not implemented!")
+	}
+
+	for name, c := range testutils.GenericUnrestrictedSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runSearchTest(c)
+		})
+	}
+}
+
+func (s *k8sRoleSACSuite) TestScopeSearchRaw() {
+	if features.PostgresDatastore.Enabled() {
+		s.T().Skip("Not implemented!")
+	}
+
+	for name, c := range testutils.GenericScopedSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runSearchRawTest(c)
+		})
+	}
+}
+
+func (s *k8sRoleSACSuite) TestUnrestrictedSearchRaw() {
+	if features.PostgresDatastore.Enabled() {
+		s.T().Skip("Not implemented!")
+	}
+
+	for name, c := range testutils.GenericUnrestrictedRawSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runSearchRawTest(c)
+		})
+	}
+}

--- a/pkg/fixtures/roles.go
+++ b/pkg/fixtures/roles.go
@@ -1,0 +1,58 @@
+package fixtures
+
+import (
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/uuid"
+)
+
+// GetScopedK8SRole returns a mock K8SRole belonging to the input scope.
+func GetScopedK8SRole(id string, clusterID string, namespace string) *storage.K8SRole {
+	return &storage.K8SRole{
+		Id:        id,
+		Namespace: namespace,
+		ClusterId: clusterID,
+	}
+}
+
+// GetSACTestK8SRoleSet returns a set of mock K8SRoleBindings that can be used
+// for scoped access control sets.
+// It will include:
+// 9 Process indicators scoped to Cluster1, 3 to each Namespace A / B / C.
+// 9 Process indicators scoped to Cluster2, 3 to each Namespace A / B / C.
+// 9 Process indicators scoped to Cluster3, 3 to each Namespace A / B / C.
+func GetSACTestK8SRoleSet() []*storage.K8SRole {
+	return []*storage.K8SRole{
+		scopedK8SRole(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedK8SRole(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedK8SRole(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedK8SRole(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedK8SRole(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedK8SRole(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedK8SRole(testconsts.Cluster1, testconsts.NamespaceC),
+		scopedK8SRole(testconsts.Cluster1, testconsts.NamespaceC),
+		scopedK8SRole(testconsts.Cluster1, testconsts.NamespaceC),
+		scopedK8SRole(testconsts.Cluster2, testconsts.NamespaceA),
+		scopedK8SRole(testconsts.Cluster2, testconsts.NamespaceA),
+		scopedK8SRole(testconsts.Cluster2, testconsts.NamespaceA),
+		scopedK8SRole(testconsts.Cluster2, testconsts.NamespaceB),
+		scopedK8SRole(testconsts.Cluster2, testconsts.NamespaceB),
+		scopedK8SRole(testconsts.Cluster2, testconsts.NamespaceB),
+		scopedK8SRole(testconsts.Cluster2, testconsts.NamespaceC),
+		scopedK8SRole(testconsts.Cluster2, testconsts.NamespaceC),
+		scopedK8SRole(testconsts.Cluster2, testconsts.NamespaceC),
+		scopedK8SRole(testconsts.Cluster3, testconsts.NamespaceA),
+		scopedK8SRole(testconsts.Cluster3, testconsts.NamespaceA),
+		scopedK8SRole(testconsts.Cluster3, testconsts.NamespaceA),
+		scopedK8SRole(testconsts.Cluster3, testconsts.NamespaceB),
+		scopedK8SRole(testconsts.Cluster3, testconsts.NamespaceB),
+		scopedK8SRole(testconsts.Cluster3, testconsts.NamespaceB),
+		scopedK8SRole(testconsts.Cluster3, testconsts.NamespaceC),
+		scopedK8SRole(testconsts.Cluster3, testconsts.NamespaceC),
+		scopedK8SRole(testconsts.Cluster3, testconsts.NamespaceC),
+	}
+}
+
+func scopedK8SRole(clusterID, namespace string) *storage.K8SRole {
+	return GetScopedK8SRole(uuid.NewV4().String(), clusterID, namespace)
+}


### PR DESCRIPTION
## Description

We are adding only tests with this PR.

Tests related to search with Postgres DB are skipped because integration will be done in another PR.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~ - not relevant
- ~[ ] Determined and documented upgrade steps~ - not relevant
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~ - not relevant

## Testing Performed

1. spin up local Postgres DB: `docker run --name test-sr -p 5432:5432 -e POSTGRES_USER=sr -e POSTGRES_PASSWORD=sr -e POSTGRES_DB=sr -d postgres`
2. export env variables for test
```
export ROX_POSTGRES_DATASTORE=true

export USER=sr
export POSTGRES_PASSWORD=sr
export POSTGRES_DB=sr
export POSTGRES_HOST=localhost
```
3. go to `central/rbac/k8srole/datastore` and run: `go test -v .`
4. to test old backend DB export following env variables
```
export ROX_POSTGRES_DATASTORE=false
```
5. and run again `go test -v .`
