### PR TITLE
ROX-10080: Ensure circle ci sets image flavor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -927,9 +927,6 @@ commands:
       branding:
         type: string
         default: stackrox
-      image_flavor:
-        type: string
-        default: ""
     steps:
       - checkout-with-submodules
       - check-docs-step:
@@ -962,7 +959,12 @@ commands:
 
       - run:
           name: Build main image
-          command: make docker-build-main-image ROX_PRODUCT_BRANDING="<< parameters.branding >>" ROX_IMAGE_FLAVOR="<< parameters.image_flavor >>"
+          command: |
+            if [[ "<< parameters.branding >>" == "STACKROX_BRANDING" ]]; then
+              make docker-build-main-image ROX_PRODUCT_BRANDING="<< parameters.branding >>" ROX_IMAGE_FLAVOR="opensource>"
+            else
+              make docker-build-main-image ROX_PRODUCT_BRANDING="<< parameters.branding >>"
+            fi
 
       - run:
           name: Check debugger presence in the main image
@@ -2768,7 +2770,6 @@ jobs:
     steps:
       - build:
           branding: STACKROX_BRANDING
-          image_flavor: opensource
 
   build-rhacs:
     executor: custom

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -961,7 +961,7 @@ commands:
           name: Build main image
           command: |
             if [[ "<< parameters.branding >>" == "STACKROX_BRANDING" ]]; then
-              make docker-build-main-image ROX_PRODUCT_BRANDING="<< parameters.branding >>" ROX_IMAGE_FLAVOR="opensource>"
+              make docker-build-main-image ROX_PRODUCT_BRANDING="<< parameters.branding >>" ROX_IMAGE_FLAVOR="opensource"
             else
               make docker-build-main-image ROX_PRODUCT_BRANDING="<< parameters.branding >>"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -960,11 +960,11 @@ commands:
       - run:
           name: Build main image
           command: |
+            PARAMS=(ROX_PRODUCT_BRANDING="<< parameters.branding >>")
             if [[ "<< parameters.branding >>" == "STACKROX_BRANDING" ]]; then
-              make docker-build-main-image ROX_PRODUCT_BRANDING="<< parameters.branding >>" ROX_IMAGE_FLAVOR="opensource"
-            else
-              make docker-build-main-image ROX_PRODUCT_BRANDING="<< parameters.branding >>"
+              PARAMS+=(ROX_IMAGE_FLAVOR="opensource")
             fi
+            make docker-build-main-image "${PARAMS[@]}"
 
       - run:
           name: Check debugger presence in the main image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -929,6 +929,7 @@ commands:
         default: stackrox
       image_flavor:
         type: string
+        default: ""
     steps:
       - checkout-with-submodules
       - check-docs-step:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -927,6 +927,8 @@ commands:
       branding:
         type: string
         default: stackrox
+      image_flavor:
+        type: string
     steps:
       - checkout-with-submodules
       - check-docs-step:
@@ -959,7 +961,7 @@ commands:
 
       - run:
           name: Build main image
-          command: make docker-build-main-image ROX_PRODUCT_BRANDING="<< parameters.branding >>"
+          command: make docker-build-main-image ROX_PRODUCT_BRANDING="<< parameters.branding >>" ROX_IMAGE_FLAVOR="<< parameters.image_flavor >>"
 
       - run:
           name: Check debugger presence in the main image
@@ -2765,6 +2767,7 @@ jobs:
     steps:
       - build:
           branding: STACKROX_BRANDING
+          image_flavor: opensource
 
   build-rhacs:
     executor: custom

--- a/pkg/images/defaults/env.go
+++ b/pkg/images/defaults/env.go
@@ -11,8 +11,8 @@ const (
 	ImageFlavorNameStackRoxIORelease = "stackrox.io"
 	// ImageFlavorNameRHACSRelease is a name for image flavor (image defaults) for images released to registry.redhat.io.
 	ImageFlavorNameRHACSRelease = "rhacs"
-	// ImageFlavorNameOpenSourceRelease is a name for image flavor (image defaults) for images released to quay.io/stackrox-io.
-	ImageFlavorNameOpenSourceRelease = "opensource"
+	// ImageFlavorNameOpenSource is a name for image flavor (image defaults) for images released to quay.io/stackrox-io.
+	ImageFlavorNameOpenSource = "opensource"
 )
 
 var (

--- a/pkg/images/defaults/flavor.go
+++ b/pkg/images/defaults/flavor.go
@@ -43,9 +43,9 @@ var (
 			constructorFunc:         RHACSReleaseImageFlavor,
 		},
 		{
-			imageFlavorName:         ImageFlavorNameOpenSourceRelease,
+			imageFlavorName:         ImageFlavorNameOpenSource,
 			isAllowedInReleaseBuild: true,
-			constructorFunc:         OpenSourceReleaseImageFlavor,
+			constructorFunc:         OpenSourceImageFlavor,
 		},
 	}
 
@@ -195,8 +195,8 @@ func RHACSReleaseImageFlavor() ImageFlavor {
 	}
 }
 
-// OpenSourceReleaseImageFlavor returns image values for `opensource` flavor.
-func OpenSourceReleaseImageFlavor() ImageFlavor {
+// OpenSourceImageFlavor returns image values for `opensource` flavor.
+func OpenSourceImageFlavor() ImageFlavor {
 	v := version.GetAllVersionsUnified()
 	return ImageFlavor{
 		MainRegistry:       "quay.io/stackrox-io",

--- a/pkg/images/defaults/flavor_test.go
+++ b/pkg/images/defaults/flavor_test.go
@@ -54,7 +54,7 @@ func (s *imageFlavorTestSuite) TestGetImageFlavorFromEnv() {
 			expectedFlavor: RHACSReleaseImageFlavor(),
 		},
 		"opensource": {
-			expectedFlavor: OpenSourceReleaseImageFlavor(),
+			expectedFlavor: OpenSourceImageFlavor(),
 		},
 		"wrong_value": {
 			shouldPanicAlways: true,
@@ -101,7 +101,7 @@ func (s *imageFlavorTestSuite) TestGetImageFlavorByName() {
 			expectedFlavor: RHACSReleaseImageFlavor(),
 		},
 		"opensource": {
-			expectedFlavor: OpenSourceReleaseImageFlavor(),
+			expectedFlavor: OpenSourceImageFlavor(),
 		},
 		"wrong_value": {
 			expectedErrorRelease:    "unexpected value 'wrong_value'",


### PR DESCRIPTION
## Description

Goal: CircleCI builds OSS release images (ROX_IMAGE_FLAVOR=opensource) and pushes them to quay.io/stackrox-io

We have a separate build process for OSS images.

This process needs to be updated to build the image flavor OSS and push these images to quay.io/stackrox-io.
Currently, it seems we're only pushing development images to quay.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Ran CI
