### PR TITLE
Add PatternFly summary counts to security metrics dashboard.

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import { Divider, PageSection, Text, Title } from '@patternfly/react-core';
+import SummaryCounts from './SummaryCounts';
 
 function DashboardPage() {
     return (
         <>
+            <PageSection variant="light" padding={{ default: 'noPadding' }}>
+                <SummaryCounts />
+            </PageSection>
+            <Divider component="div" />
             <PageSection variant="light">
                 <Title headingLevel="h1">Dashboard</Title>
                 <Text>Review security metrics across all or select resources</Text>
             </PageSection>
             <Divider component="div" />
-            <PageSection />
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/SummaryCounts.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/SummaryCounts.tsx
@@ -70,7 +70,7 @@ function SummaryCounts() {
         );
     }
 
-    const tileData = {
+    const tileData: Record<TileEntity, number> = {
         Cluster: data.clusterCount,
         Node: data.nodeCount,
         Violation: data.violationCount,

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/SummaryCounts.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/SummaryCounts.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { gql, useQuery } from '@apollo/client';
+import Raven from 'raven-js';
+import pluralize from 'pluralize';
+import { Alert, Button, ButtonVariant, Skeleton, Split, Stack } from '@patternfly/react-core';
+
+import {
+    clustersBasePath,
+    configManagementPath,
+    urlEntityListTypes,
+    violationsBasePath,
+    vulnManagementImagesPath,
+} from 'routePaths';
+import { resourceTypes } from 'constants/entityTypes';
+import LinkShim from 'Components/PatternFly/LinkShim';
+
+export type SummaryCountsResponse = {
+    clusterCount: number;
+    nodeCount: number;
+    violationCount: number;
+    deploymentCount: number;
+    imageCount: number;
+    secretCount: number;
+};
+
+export const SUMMARY_COUNTS = gql`
+    query summary_counts {
+        clusterCount
+        nodeCount
+        violationCount
+        deploymentCount
+        imageCount
+        secretCount
+    }
+`;
+
+const tileEntityTypes = ['Cluster', 'Node', 'Violation', 'Deployment', 'Image', 'Secret'] as const;
+type TileEntity = typeof tileEntityTypes[number];
+
+const tileLinks: Record<TileEntity, string> = {
+    Cluster: clustersBasePath,
+    Node: `${configManagementPath}/${urlEntityListTypes[resourceTypes.NODE]}`,
+    Violation: violationsBasePath,
+    Deployment: `${configManagementPath}/${urlEntityListTypes[resourceTypes.DEPLOYMENT]}`,
+    Image: vulnManagementImagesPath,
+    Secret: `${configManagementPath}/${urlEntityListTypes[resourceTypes.SECRET]}`,
+};
+
+function SummaryCounts() {
+    const { loading, error, data } = useQuery<SummaryCountsResponse>(SUMMARY_COUNTS);
+
+    if (loading) {
+        return (
+            <Skeleton
+                height="32px"
+                className="pf-u-m-md"
+                screenreaderText="Loading system summary counts"
+            />
+        );
+    }
+
+    if (error || !data) {
+        Raven.captureException(error);
+        return (
+            <Alert
+                isInline
+                variant="warning"
+                title="There was an error loading system summary counts"
+            />
+        );
+    }
+
+    const tileData = {
+        Cluster: data.clusterCount,
+        Node: data.nodeCount,
+        Violation: data.violationCount,
+        Deployment: data.deploymentCount,
+        Image: data.imageCount,
+        Secret: data.secretCount,
+    };
+
+    return (
+        <Split className="pf-u-flex-wrap">
+            {tileEntityTypes.map((tileEntity) => (
+                <Button
+                    variant={ButtonVariant.link}
+                    component={LinkShim}
+                    href={tileLinks[tileEntity]}
+                >
+                    <Stack className="pf-u-px-xs pf-u-px-sm-on-xl pf-u-align-items-center">
+                        <span className="pf-u-font-size-lg-on-md pf-u-font-size-sm pf-u-font-weight-bold">
+                            {tileData[tileEntity]}
+                        </span>
+                        <span className="pf-u-font-size-md-on-md pf-u-font-size-xs">
+                            {pluralize(tileEntity, tileData[tileEntity])}
+                        </span>
+                    </Stack>
+                </Button>
+            ))}
+        </Split>
+    );
+}
+
+export default SummaryCounts;


### PR DESCRIPTION
## Description

Adds a PF counterpart to the main dashboard summary counts, based on [MVP mocks](https://www.sketch.com/s/9d082d82-3515-40f2-875a-1b322a02bace/a/MyRkjGb).

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Test that summary counts are displayed at the top of the new dashboard:
![image](https://user-images.githubusercontent.com/1292638/171725841-b69447ed-f98d-4888-bbc4-038906cf6168.png)

Test that a loading [skeleton](https://www.patternfly.org/v4/components/skeleton) is displayed in place of counts until the request completes (may require an artificial network tools slowdown):
![image](https://user-images.githubusercontent.com/1292638/171725971-718ec6ca-ad4e-4e04-9762-371028fba1b1.png)

Test that on error, an inline alert is shown instead of invalid data (may also require an artificial network tools failure):
![image](https://user-images.githubusercontent.com/1292638/171726186-c5fe41f8-eed7-4c01-ad58-250a829b3a1b.png)

Test that the new widget tolerates small screen sizes:
<img src="https://user-images.githubusercontent.com/1292638/171726292-1e76f8a4-b258-49bf-afa5-623560be9d3b.png" height=600>



