### PR TITLE
Use message type name for option map prefix

### DIFF
--- a/central/postgres/schema/alerts.go
+++ b/central/postgres/schema/alerts.go
@@ -73,7 +73,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Alert)(nil)), "alerts")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_ALERTS, "alerts", (*storage.ListAlert)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_ALERTS, "alert", (*storage.ListAlert)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/cluster_cves.go
+++ b/central/postgres/schema/cluster_cves.go
@@ -42,7 +42,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.CVE)(nil)), "cluster_cves")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_CLUSTER_VULNERABILITIES, "cluster_cves", (*storage.CVE)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_CLUSTER_VULNERABILITIES, "cve", (*storage.CVE)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/clusters.go
+++ b/central/postgres/schema/clusters.go
@@ -41,7 +41,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Cluster)(nil)), "clusters")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_CLUSTERS, "clusters", (*storage.Cluster)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_CLUSTERS, "cluster", (*storage.Cluster)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/deployments.go
+++ b/central/postgres/schema/deployments.go
@@ -183,7 +183,7 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_DEPLOYMENTS, "deployments", (*storage.Deployment)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_DEPLOYMENTS, "deployment", (*storage.Deployment)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/image_component_cve_relations.go
+++ b/central/postgres/schema/image_component_cve_relations.go
@@ -48,7 +48,7 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_COMPONENT_VULN_EDGE, "image_component_cve_relations", (*storage.ComponentCVEEdge)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_COMPONENT_VULN_EDGE, "componentcveedge", (*storage.ComponentCVEEdge)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/image_component_relations.go
+++ b/central/postgres/schema/image_component_relations.go
@@ -47,7 +47,7 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_IMAGE_COMPONENT_EDGE, "image_component_relations", (*storage.ImageComponentEdge)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_IMAGE_COMPONENT_EDGE, "imagecomponentedge", (*storage.ImageComponentEdge)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/image_components.go
+++ b/central/postgres/schema/image_components.go
@@ -39,7 +39,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ImageComponent)(nil)), "image_components")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_IMAGE_COMPONENTS, "image_components", (*storage.ImageComponent)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_IMAGE_COMPONENTS, "imagecomponent", (*storage.ImageComponent)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/image_cve_relations.go
+++ b/central/postgres/schema/image_cve_relations.go
@@ -48,7 +48,7 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_IMAGE_VULN_EDGE, "image_cve_relations", (*storage.ImageCVEEdge)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_IMAGE_VULN_EDGE, "imagecveedge", (*storage.ImageCVEEdge)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/image_cves.go
+++ b/central/postgres/schema/image_cves.go
@@ -42,7 +42,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.CVE)(nil)), "image_cves")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_VULNERABILITIES, "image_cves", (*storage.CVE)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_VULNERABILITIES, "cve", (*storage.CVE)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/images.go
+++ b/central/postgres/schema/images.go
@@ -70,7 +70,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Image)(nil)), "images")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_IMAGES, "images", (*storage.Image)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_IMAGES, "image", (*storage.Image)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/k8sroles.go
+++ b/central/postgres/schema/k8sroles.go
@@ -41,7 +41,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.K8SRole)(nil)), "k8sroles")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_ROLES, "k8sroles", (*storage.K8SRole)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_ROLES, "k8srole", (*storage.K8SRole)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/multikey.go
+++ b/central/postgres/schema/multikey.go
@@ -69,7 +69,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestMultiKeyStruct)(nil)), "multikey")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SEARCH_UNSET, "multikey", (*storage.TestMultiKeyStruct)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SEARCH_UNSET, "testmultikeystruct", (*storage.TestMultiKeyStruct)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/namespaces.go
+++ b/central/postgres/schema/namespaces.go
@@ -47,7 +47,7 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_NAMESPACES, "namespaces", (*storage.NamespaceMetadata)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_NAMESPACES, "namespacemetadata", (*storage.NamespaceMetadata)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/node_components.go
+++ b/central/postgres/schema/node_components.go
@@ -39,7 +39,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ImageComponent)(nil)), "node_components")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_IMAGE_COMPONENTS, "node_components", (*storage.ImageComponent)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_IMAGE_COMPONENTS, "imagecomponent", (*storage.ImageComponent)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/node_components_to_cves.go
+++ b/central/postgres/schema/node_components_to_cves.go
@@ -48,7 +48,7 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_NODE_COMPONENT_CVE_EDGE, "node_components_to_cves", (*storage.NodeComponentCVEEdge)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_NODE_COMPONENT_CVE_EDGE, "nodecomponentcveedge", (*storage.NodeComponentCVEEdge)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/node_cves.go
+++ b/central/postgres/schema/node_cves.go
@@ -42,7 +42,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.CVE)(nil)), "node_cves")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_NODE_VULNERABILITIES, "node_cves", (*storage.CVE)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_NODE_VULNERABILITIES, "cve", (*storage.CVE)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/nodes.go
+++ b/central/postgres/schema/nodes.go
@@ -113,7 +113,7 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_NODES, "nodes", (*storage.Node)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_NODES, "node", (*storage.Node)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/nodes_to_components.go
+++ b/central/postgres/schema/nodes_to_components.go
@@ -46,7 +46,7 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_NODE_COMPONENT_EDGE, "nodes_to_components", (*storage.NodeComponentEdge)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_NODE_COMPONENT_EDGE, "nodecomponentedge", (*storage.NodeComponentEdge)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/pods.go
+++ b/central/postgres/schema/pods.go
@@ -62,7 +62,7 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PODS, "pods", (*storage.Pod)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PODS, "pod", (*storage.Pod)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/process_indicators.go
+++ b/central/postgres/schema/process_indicators.go
@@ -48,7 +48,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ProcessIndicator)(nil)), "process_indicators")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PROCESS_INDICATORS, "process_indicators", (*storage.ProcessIndicator)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PROCESS_INDICATORS, "processindicator", (*storage.ProcessIndicator)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/processbaselines.go
+++ b/central/postgres/schema/processbaselines.go
@@ -37,7 +37,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ProcessBaseline)(nil)), "processbaselines")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PROCESS_BASELINES, "processbaselines", (*storage.ProcessBaseline)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PROCESS_BASELINES, "processbaseline", (*storage.ProcessBaseline)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/reportconfigs.go
+++ b/central/postgres/schema/reportconfigs.go
@@ -36,7 +36,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ReportConfiguration)(nil)), "reportconfigs")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_REPORT_CONFIGURATIONS, "reportconfigs", (*storage.ReportConfiguration)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_REPORT_CONFIGURATIONS, "reportconfiguration", (*storage.ReportConfiguration)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/rolebindings.go
+++ b/central/postgres/schema/rolebindings.go
@@ -59,7 +59,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.K8SRoleBinding)(nil)), "rolebindings")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_ROLEBINDINGS, "rolebindings", (*storage.K8SRoleBinding)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_ROLEBINDINGS, "k8srolebinding", (*storage.K8SRoleBinding)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/secrets.go
+++ b/central/postgres/schema/secrets.go
@@ -73,7 +73,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Secret)(nil)), "secrets")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SECRETS, "secrets", (*storage.Secret)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SECRETS, "secret", (*storage.Secret)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/serviceaccounts.go
+++ b/central/postgres/schema/serviceaccounts.go
@@ -40,7 +40,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ServiceAccount)(nil)), "serviceaccounts")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SERVICE_ACCOUNTS, "serviceaccounts", (*storage.ServiceAccount)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SERVICE_ACCOUNTS, "serviceaccount", (*storage.ServiceAccount)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/singlekey.go
+++ b/central/postgres/schema/singlekey.go
@@ -46,7 +46,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestSingleKeyStruct)(nil)), "singlekey")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SEARCH_UNSET, "singlekey", (*storage.TestSingleKeyStruct)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SEARCH_UNSET, "testsinglekeystruct", (*storage.TestSingleKeyStruct)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/central/postgres/schema/vulnreq.go
+++ b/central/postgres/schema/vulnreq.go
@@ -74,7 +74,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.VulnerabilityRequest)(nil)), "vulnreq")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_VULN_REQUEST, "vulnreq", (*storage.VulnerabilityRequest)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_VULN_REQUEST, "vulnerabilityrequest", (*storage.VulnerabilityRequest)(nil)))
 		globaldb.RegisterTable(schema)
 		return schema
 	}()

--- a/pkg/search/postgres/index_test.go
+++ b/pkg/search/postgres/index_test.go
@@ -712,7 +712,7 @@ func (s *IndexSuite) TestStringHighlights() {
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestString, "ze").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
 				testStruct0: {
-					"multikey.string": {"zero"},
+					"testmultikeystruct.string": {"zero"},
 				},
 			},
 		},
@@ -721,10 +721,10 @@ func (s *IndexSuite) TestStringHighlights() {
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestString, "r/.*o.*").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
 				testStruct0: {
-					"multikey.string": {"zero"},
+					"testmultikeystruct.string": {"zero"},
 				},
 				testStruct1: {
-					"multikey.string": {"one"},
+					"testmultikeystruct.string": {"one"},
 				},
 			},
 		},
@@ -744,7 +744,7 @@ func (s *IndexSuite) TestBoolHighlights() {
 			q:    search.NewQueryBuilder().AddBoolsHighlighted(search.TestBool, true).ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
 				testStruct1: {
-					"multikey.bool": {"true"},
+					"testmultikeystruct.bool": {"true"},
 				},
 			},
 		},
@@ -753,7 +753,7 @@ func (s *IndexSuite) TestBoolHighlights() {
 			q:    search.NewQueryBuilder().AddBoolsHighlighted(search.TestBool, false).ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
 				testStruct0: {
-					"multikey.bool": {"false"},
+					"testmultikeystruct.bool": {"false"},
 				},
 			},
 		},
@@ -762,10 +762,10 @@ func (s *IndexSuite) TestBoolHighlights() {
 			q:    search.NewQueryBuilder().AddBoolsHighlighted(search.TestBool, true, false).ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
 				testStruct0: {
-					"multikey.bool": {"false"},
+					"testmultikeystruct.bool": {"false"},
 				},
 				testStruct1: {
-					"multikey.bool": {"true"},
+					"testmultikeystruct.bool": {"true"},
 				},
 			},
 		},
@@ -786,7 +786,7 @@ func (s *IndexSuite) TestStringSliceHighlights() {
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestStringSlice, `"yeah"`).ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
 				testStruct0: {
-					"multikey.string_slice": {"yeah"},
+					"testmultikeystruct.string_slice": {"yeah"},
 				},
 			},
 		},
@@ -795,10 +795,10 @@ func (s *IndexSuite) TestStringSliceHighlights() {
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestStringSlice, "r/.*e.*").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
 				testStruct0: {
-					"multikey.string_slice": {"yeah"},
+					"testmultikeystruct.string_slice": {"yeah"},
 				},
 				testStruct1: {
-					"multikey.string_slice": {"whatever", "yeahyeah"},
+					"testmultikeystruct.string_slice": {"whatever", "yeahyeah"},
 				},
 			},
 		},
@@ -828,7 +828,7 @@ func (s *IndexSuite) TestTimeHighlights() {
 			desc: "exact match (should evaluate if it's within the day) - matches",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestTimestamp, "03/09/2022 UTC").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct2022Mar09Noon: {"multikey.timestamp.seconds": {"2022-03-09 12:00:00"}},
+				testStruct2022Mar09Noon: {"testmultikeystruct.timestamp.seconds": {"2022-03-09 12:00:00"}},
 			},
 		},
 		{
@@ -840,29 +840,29 @@ func (s *IndexSuite) TestTimeHighlights() {
 			desc: "< date",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestTimestamp, "< 03/09/2022").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct2021Mar09Noon: {"multikey.timestamp.seconds": {"2021-03-09 12:00:00"}},
-				testStruct2020Mar09Noon: {"multikey.timestamp.seconds": {"2020-03-09 12:00:00"}},
-				testStruct2022Feb09Noon: {"multikey.timestamp.seconds": {"2022-02-09 12:00:00"}},
+				testStruct2021Mar09Noon: {"testmultikeystruct.timestamp.seconds": {"2021-03-09 12:00:00"}},
+				testStruct2020Mar09Noon: {"testmultikeystruct.timestamp.seconds": {"2020-03-09 12:00:00"}},
+				testStruct2022Feb09Noon: {"testmultikeystruct.timestamp.seconds": {"2022-02-09 12:00:00"}},
 			},
 		},
 		{
 			desc: "< date time (this time, includes Mar 10th at noon)",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestTimestamp, "< 03/09/2022 1:00 PM").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct2021Mar09Noon: {"multikey.timestamp.seconds": {"2021-03-09 12:00:00"}},
-				testStruct2020Mar09Noon: {"multikey.timestamp.seconds": {"2020-03-09 12:00:00"}},
-				testStruct2022Feb09Noon: {"multikey.timestamp.seconds": {"2022-02-09 12:00:00"}},
-				testStruct2022Mar09Noon: {"multikey.timestamp.seconds": {"2022-03-09 12:00:00"}},
+				testStruct2021Mar09Noon: {"testmultikeystruct.timestamp.seconds": {"2021-03-09 12:00:00"}},
+				testStruct2020Mar09Noon: {"testmultikeystruct.timestamp.seconds": {"2020-03-09 12:00:00"}},
+				testStruct2022Feb09Noon: {"testmultikeystruct.timestamp.seconds": {"2022-02-09 12:00:00"}},
+				testStruct2022Mar09Noon: {"testmultikeystruct.timestamp.seconds": {"2022-03-09 12:00:00"}},
 			},
 		},
 		{
 			desc: "> duration (this test will fail in 2029, but hopefully it's not still being run then)",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestTimestamp, "> 1d").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct2021Mar09Noon: {"multikey.timestamp.seconds": {"2021-03-09 12:00:00"}},
-				testStruct2020Mar09Noon: {"multikey.timestamp.seconds": {"2020-03-09 12:00:00"}},
-				testStruct2022Feb09Noon: {"multikey.timestamp.seconds": {"2022-02-09 12:00:00"}},
-				testStruct2022Mar09Noon: {"multikey.timestamp.seconds": {"2022-03-09 12:00:00"}},
+				testStruct2021Mar09Noon: {"testmultikeystruct.timestamp.seconds": {"2021-03-09 12:00:00"}},
+				testStruct2020Mar09Noon: {"testmultikeystruct.timestamp.seconds": {"2020-03-09 12:00:00"}},
+				testStruct2022Feb09Noon: {"testmultikeystruct.timestamp.seconds": {"2022-02-09 12:00:00"}},
+				testStruct2022Mar09Noon: {"testmultikeystruct.timestamp.seconds": {"2022-03-09 12:00:00"}},
 			},
 		},
 	})
@@ -884,45 +884,45 @@ func (s *IndexSuite) TestEnumHighlights() {
 			desc: "exact match",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestEnum, `"ENUM1"`).ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct1: {"multikey.enum": {"ENUM1"}},
+				testStruct1: {"testmultikeystruct.enum": {"ENUM1"}},
 			},
 		},
 		{
 			desc: "negation",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestEnum, "!ENUM1").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.enum": {"ENUM0"}},
-				testStruct2: {"multikey.enum": {"ENUM2"}},
+				testStruct0: {"testmultikeystruct.enum": {"ENUM0"}},
+				testStruct2: {"testmultikeystruct.enum": {"ENUM2"}},
 			},
 		},
 		{
 			desc: "regex",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestEnum, "r/E.*1").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct1: {"multikey.enum": {"ENUM1"}},
+				testStruct1: {"testmultikeystruct.enum": {"ENUM1"}},
 			},
 		},
 		{
 			desc: "negated regex",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestEnum, "!r/E.*1").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.enum": {"ENUM0"}},
-				testStruct2: {"multikey.enum": {"ENUM2"}},
+				testStruct0: {"testmultikeystruct.enum": {"ENUM0"}},
+				testStruct2: {"testmultikeystruct.enum": {"ENUM2"}},
 			},
 		},
 		{
 			desc: ">",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestEnum, ">ENUM1").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct2: {"multikey.enum": {"ENUM2"}},
+				testStruct2: {"testmultikeystruct.enum": {"ENUM2"}},
 			},
 		},
 		{
 			desc: "<=",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestEnum, "<=ENUM1").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.enum": {"ENUM0"}},
-				testStruct1: {"multikey.enum": {"ENUM1"}},
+				testStruct0: {"testmultikeystruct.enum": {"ENUM0"}},
+				testStruct1: {"testmultikeystruct.enum": {"ENUM1"}},
 			},
 		},
 	})
@@ -941,22 +941,22 @@ func (s *IndexSuite) TestUint64Highlights() {
 			desc: "exact match",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestUint64, "2").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.uint64": {"2"}},
+				testStruct0: {"testmultikeystruct.uint64": {"2"}},
 			},
 		},
 		{
 			desc: ">",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestUint64, ">5").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct1: {"multikey.uint64": {"7"}},
+				testStruct1: {"testmultikeystruct.uint64": {"7"}},
 			},
 		},
 		{
 			desc: ">=",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestUint64, ">=2").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.uint64": {"2"}},
-				testStruct1: {"multikey.uint64": {"7"}},
+				testStruct0: {"testmultikeystruct.uint64": {"2"}},
+				testStruct1: {"testmultikeystruct.uint64": {"7"}},
 			},
 		},
 	})
@@ -985,29 +985,29 @@ func (s *IndexSuite) TestInt64Highlights() {
 			desc: "exact match",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestInt64, "-2").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.int64": {"-2"}},
+				testStruct0: {"testmultikeystruct.int64": {"-2"}},
 			},
 		},
 		{
 			desc: ">",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestInt64, ">5").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct1: {"multikey.int64": {"7"}},
+				testStruct1: {"testmultikeystruct.int64": {"7"}},
 			},
 		},
 		{
 			desc: ">=",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestInt64, ">=-2").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.int64": {"-2"}},
-				testStruct1: {"multikey.int64": {"7"}},
+				testStruct0: {"testmultikeystruct.int64": {"-2"}},
+				testStruct1: {"testmultikeystruct.int64": {"7"}},
 			},
 		},
 		{
 			desc: "nested",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestNestedInt64, "<-50").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.nested.int64": {"-100"}},
+				testStruct0: {"testmultikeystruct.nested.int64": {"-100"}},
 			},
 		},
 		{
@@ -1015,7 +1015,7 @@ func (s *IndexSuite) TestInt64Highlights() {
 			q: search.NewQueryBuilder().AddStringsHighlighted(search.TestNestedInt64, ">=0").
 				AddStringsHighlighted(search.TestNested2Int64, ">=-200").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct1: {"multikey.nested.nested2.int64": {"-200"}, "multikey.nested.int64": {"100"}},
+				testStruct1: {"testmultikeystruct.nested.nested2.int64": {"-200"}, "testmultikeystruct.nested.int64": {"100"}},
 			},
 		},
 	})
@@ -1034,22 +1034,22 @@ func (s *IndexSuite) TestFloatHighlights() {
 			desc: "exact match",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestFloat, "-2").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.float": {"-2"}},
+				testStruct0: {"testmultikeystruct.float": {"-2"}},
 			},
 		},
 		{
 			desc: ">",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestFloat, ">7.3").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct1: {"multikey.float": {"7.5"}},
+				testStruct1: {"testmultikeystruct.float": {"7.5"}},
 			},
 		},
 		{
 			desc: ">=",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestFloat, ">=-2").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.float": {"-2"}},
-				testStruct1: {"multikey.float": {"7.5"}},
+				testStruct0: {"testmultikeystruct.float": {"-2"}},
+				testStruct1: {"testmultikeystruct.float": {"7.5"}},
 			},
 		},
 	})
@@ -1068,22 +1068,22 @@ func (s *IndexSuite) TestIntArrayHighlights() {
 			desc: "exact match",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestInt64Slice, "-2").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.int_slice": {"-2"}},
+				testStruct0: {"testmultikeystruct.int_slice": {"-2"}},
 			},
 		},
 		{
 			desc: ">",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestInt64Slice, ">5").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct1: {"multikey.int_slice": {"7"}},
+				testStruct1: {"testmultikeystruct.int_slice": {"7"}},
 			},
 		},
 		{
 			desc: ">=",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestInt64Slice, ">=-2").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.int_slice": {"-2"}},
-				testStruct1: {"multikey.int_slice": {"7", "3"}},
+				testStruct0: {"testmultikeystruct.int_slice": {"-2"}},
+				testStruct1: {"testmultikeystruct.int_slice": {"7", "3"}},
 			},
 		},
 	})
@@ -1111,59 +1111,59 @@ func (s *IndexSuite) TestEnumArrayHighlights() {
 			desc: "exact match",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestEnumSlice, `"ENUM1"`).ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct1:   {"multikey.enums": {"ENUM1"}},
-				testStruct01:  {"multikey.enums": {"ENUM1"}},
-				testStruct012: {"multikey.enums": {"ENUM1"}},
-				testStruct12:  {"multikey.enums": {"ENUM1"}},
+				testStruct1:   {"testmultikeystruct.enums": {"ENUM1"}},
+				testStruct01:  {"testmultikeystruct.enums": {"ENUM1"}},
+				testStruct012: {"testmultikeystruct.enums": {"ENUM1"}},
+				testStruct12:  {"testmultikeystruct.enums": {"ENUM1"}},
 			},
 		},
 		{
 			desc: "negation",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestEnumSlice, "!ENUM1").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0:   {"multikey.enums": {"ENUM0"}},
-				testStruct01:  {"multikey.enums": {"ENUM0"}},
-				testStruct012: {"multikey.enums": {"ENUM0", "ENUM2"}},
-				testStruct12:  {"multikey.enums": {"ENUM2"}},
+				testStruct0:   {"testmultikeystruct.enums": {"ENUM0"}},
+				testStruct01:  {"testmultikeystruct.enums": {"ENUM0"}},
+				testStruct012: {"testmultikeystruct.enums": {"ENUM0", "ENUM2"}},
+				testStruct12:  {"testmultikeystruct.enums": {"ENUM2"}},
 			},
 		},
 		{
 			desc: "regex",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestEnumSlice, "r/E.*1").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct1:   {"multikey.enums": {"ENUM1"}},
-				testStruct01:  {"multikey.enums": {"ENUM1"}},
-				testStruct012: {"multikey.enums": {"ENUM1"}},
-				testStruct12:  {"multikey.enums": {"ENUM1"}},
+				testStruct1:   {"testmultikeystruct.enums": {"ENUM1"}},
+				testStruct01:  {"testmultikeystruct.enums": {"ENUM1"}},
+				testStruct012: {"testmultikeystruct.enums": {"ENUM1"}},
+				testStruct12:  {"testmultikeystruct.enums": {"ENUM1"}},
 			},
 		},
 		{
 			desc: "negated regex",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestEnumSlice, "!r/E.*1").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0:   {"multikey.enums": {"ENUM0"}},
-				testStruct01:  {"multikey.enums": {"ENUM0"}},
-				testStruct012: {"multikey.enums": {"ENUM0", "ENUM2"}},
-				testStruct12:  {"multikey.enums": {"ENUM2"}},
+				testStruct0:   {"testmultikeystruct.enums": {"ENUM0"}},
+				testStruct01:  {"testmultikeystruct.enums": {"ENUM0"}},
+				testStruct012: {"testmultikeystruct.enums": {"ENUM0", "ENUM2"}},
+				testStruct12:  {"testmultikeystruct.enums": {"ENUM2"}},
 			},
 		},
 		{
 			desc: ">",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestEnumSlice, ">ENUM1").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct012: {"multikey.enums": {"ENUM2"}},
-				testStruct12:  {"multikey.enums": {"ENUM2"}},
+				testStruct012: {"testmultikeystruct.enums": {"ENUM2"}},
+				testStruct12:  {"testmultikeystruct.enums": {"ENUM2"}},
 			},
 		},
 		{
 			desc: "<=",
 			q:    search.NewQueryBuilder().AddStringsHighlighted(search.TestEnumSlice, "<=ENUM1").ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0:   {"multikey.enums": {"ENUM0"}},
-				testStruct1:   {"multikey.enums": {"ENUM1"}},
-				testStruct12:  {"multikey.enums": {"ENUM1"}},
-				testStruct012: {"multikey.enums": {"ENUM0", "ENUM1"}},
-				testStruct01:  {"multikey.enums": {"ENUM0", "ENUM1"}},
+				testStruct0:   {"testmultikeystruct.enums": {"ENUM0"}},
+				testStruct1:   {"testmultikeystruct.enums": {"ENUM1"}},
+				testStruct12:  {"testmultikeystruct.enums": {"ENUM1"}},
+				testStruct012: {"testmultikeystruct.enums": {"ENUM0", "ENUM1"}},
+				testStruct01:  {"testmultikeystruct.enums": {"ENUM0", "ENUM1"}},
 			},
 		},
 	})
@@ -1192,7 +1192,7 @@ func (s *IndexSuite) TestMapHighlights() {
 			desc: "key exists",
 			q:    search.NewQueryBuilder().AddMapQuery(search.TestLabels, "new", "").MarkHighlighted(search.TestLabels).ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.labels": {"new=old"}},
+				testStruct0: {"testmultikeystruct.labels": {"new=old"}},
 			},
 		},
 		{
@@ -1212,15 +1212,15 @@ func (s *IndexSuite) TestMapHighlights() {
 			desc: "non-empty map",
 			q:    search.NewQueryBuilder().AddMapQuery(search.TestLabels, "", "").MarkHighlighted(search.TestLabels).ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.labels": {"foo=bar", "new=old"}},
-				testStruct1: {"multikey.labels": {"foo=car", "one=two", "three=four"}},
+				testStruct0: {"testmultikeystruct.labels": {"foo=bar", "new=old"}},
+				testStruct1: {"testmultikeystruct.labels": {"foo=car", "one=two", "three=four"}},
 			},
 		},
 		{
 			desc: "value only",
 			q:    search.NewQueryBuilder().AddMapQuery(search.TestLabels, "", "bar").MarkHighlighted(search.TestLabels).ProtoQuery(),
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.labels": {"foo=bar"}},
+				testStruct0: {"testmultikeystruct.labels": {"foo=bar"}},
 			},
 		},
 		{
@@ -1229,8 +1229,8 @@ func (s *IndexSuite) TestMapHighlights() {
 			// Negated value does not mean non-existence of value, it just means there should be at least one element
 			// not matching the value. Unclear what the use-case of this is, but it is supported...
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.labels": {"new=old"}},
-				testStruct1: {"multikey.labels": {"foo=car", "one=two", "three=four"}},
+				testStruct0: {"testmultikeystruct.labels": {"new=old"}},
+				testStruct1: {"testmultikeystruct.labels": {"foo=car", "one=two", "three=four"}},
 			},
 		},
 		{
@@ -1246,7 +1246,7 @@ func (s *IndexSuite) TestMapHighlights() {
 			// Negated value does not mean non-existence of value, it just means there should be at least one element
 			// not matching the value. Unclear what the use-case of this is, but it is supported...
 			expectedResults: map[*storage.TestMultiKeyStruct]map[string][]string{
-				testStruct0: {"multikey.labels": {"foo=bar"}},
+				testStruct0: {"testmultikeystruct.labels": {"foo=bar"}},
 			},
 		},
 	})

--- a/tools/generate-helpers/pg-table-bindings/schema.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/schema.go.tpl
@@ -77,7 +77,7 @@ var (
             {{- if eq $ty "*storage.Alert"}}
                 {{- $ty = "*storage.ListAlert"}}
             {{- end}}
-            schema.SetOptionsMap(search.Walk(v1.{{.SearchCategory}}, "{{.Schema.Table}}", ({{$ty}})(nil)))
+            schema.SetOptionsMap(search.Walk(v1.{{.SearchCategory}}, "{{.Schema.TypeName|lower}}", ({{$ty}})(nil)))
         {{- end }}
         globaldb.RegisterTable(schema)
         return schema


### PR DESCRIPTION
## Description

In non-postgres world, option map prefix are message type names (in most but not all cases). Therefore, follow that pattern into postgres. Seeing following logs due to mismatched prefixes:
```
reprocessor: 2022/05/12 21:53:17.496259 reprocessor.go:242: Error: no cluster id found in fields
reprocessor: 2022/05/12 21:53:17.496279 reprocessor.go:242: Error: no cluster id found in fields
```

There are a bunch of ad-hoc options maps (outside the datastore layer) and we need to streamline all of those to point to `OptionsMap` in `walker.Schema`. I created a JIRA for tracking https://issues.redhat.com/browse/ROX-10951. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
CI