### PR TITLE
Restore arbitrary wait for cytoscape in Network Graph integration tests

### DIFF
--- a/ui/apps/platform/cypress/support/commands.js
+++ b/ui/apps/platform/cypress/support/commands.js
@@ -2,6 +2,7 @@
 import 'cypress-file-upload';
 
 Cypress.Commands.add('getCytoscape', (containerId) => {
+    cy.wait(100);
     cy.get(containerId).then(() => {
         cy.window().then((win) => {
             return win.cytoscape;


### PR DESCRIPTION
## Description

Because these tests do wait on relevant requests, restore what I deleted in #1656 after which these failures began

### Problem

1. Network Baseline Flows Active Network Flows should show anomalous flows section above the baseline flows

    Error: Could not find node "central" of type "DEPLOYMENT"

    * 1644 master https://app.circleci.com/pipelines/github/stackrox/stackrox/11678/workflows/b7c8f09b-6fa2-4049-8379-efc375fabf4f/jobs/542152
        ![1644](https://user-images.githubusercontent.com/11862657/168345702-fbfb874b-1d3b-4eb1-b2d2-d95e15b6db35.png)

2. Network Baseline Flows Toggling Status of Active Baseline Network Flows should be able to toggle status of a single flow

    Error: Could not find node "central" of type "DEPLOYMENT"

    * 1580 master https://app.circleci.com/pipelines/github/stackrox/stackrox/11827/workflows/3bee1b22-36ab-4037-9cd6-cb03986dfb99/jobs/549966
    * 1690 branch https://app.circleci.com/pipelines/github/stackrox/stackrox/11804/workflows/1df83e06-4fab-4b97-884f-85d1b3021df6/jobs/548962
        ![1690](https://user-images.githubusercontent.com/11862657/168345751-09c857b3-ec8e-4c01-ae81-aea8767b8a75.png)

### Analysis

There are at least 2 computation stages upon which cypress cannot wait:

1. sagas/networkSagas.js and reducers/network/graph.js
    * Plus: call `setNetworkEdgeMap` and `setNetworkNodeMap` actions before call `updateNetworkGraphTimestamp` action (verified by console.log)
    * Minus: actions indirectly call `setEdgeMapState` and `setNodeMapState` for both active and allowed after change to `lastUpdatedTimestamp`
    * Idea: It might be possible to call the computations directly in networkSagas and store computed result before update to `lastUpdatedTimestamp` so cypress can get with retry to detect rendering of graph after initial selection of namespace

2. Containers/Network/SidePanel/SidePanel.js
    * Plus: render `NodesUpdateSection` only after `lastUpdatedTimestamp`

3. Components/NetworkGraph/NetworkGraph.js
    * Minus: call `getElements` before cytoscape can render the graph
    * Question: At the same time as an update to cytoscape data, is it possible to render something in the DOM so cypress can get with retry to detect rendering of graph after initial selection of namespace?

## Checklist
- [x] Investigated and inspected CI test results
- [x] Integration tests edited

## Testing Performed

1. `yarn start` in ui
2. `yarn cypress-open` in ui/apps/platform
    * clusters.test.js
    * network.test.js
    * networkGraph/connections.test.js
    * networkGraph/externalEntities.test.js
    * networkGraph/networkFlows.test.js
    * networkGraph/networkGraph.test.js