### PR TITLE
OSCI: onboard gke-qa-e2e-tests

### DIFF
--- a/.openshift-ci/README.md
+++ b/.openshift-ci/README.md
@@ -2,7 +2,9 @@ This folder contains hooks to run OpenShift CI jobs.
 
 ## Workflow aliases for test/format/lint
 
+```
 alias osci='cdrox; cd .openshift-ci'
 alias osci-format='osci; ack -f --python | entr black .'
 alias osci-lint='osci; ack -f --python | entr pylint --rcfile .pylintrc *.py tests'
 alias osci-test='osci; ack -f --python --shell | entr python -m unittest discover'
+```

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -76,7 +76,7 @@ class QaE2eDBBackupRestoreTest(BaseTest):
     TEST_OUTPUT_DIR = "/tmp/db-backup-restore-test"
 
     def run(self):
-        print("Executing qa-tests-backend tests (part II)")
+        print("Executing DB backup and restore test")
 
         def set_dirs_after_start():
             # let post test know where logs are

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -69,3 +69,21 @@ class QaE2eTestPart2(BaseTest):
         self.run_with_graceful_kill(
             ["qa-tests-backend/scripts/run-part-2.sh"], QaE2eTestPart2.TEST_TIMEOUT
         )
+
+
+class QaE2eDBBackupRestoreTest(BaseTest):
+    TEST_TIMEOUT = 30 * 60
+    TEST_OUTPUT_DIR = "/tmp/db-backup-restore-test"
+
+    def run(self):
+        print("Executing qa-tests-backend tests (part II)")
+
+        def set_dirs_after_start():
+            # let post test know where logs are
+            self.test_output_dirs = [UpgradeTest.TEST_OUTPUT_DIR]
+
+        self.run_with_graceful_kill(
+            ["tests/e2e/lib.sh", "db_backup_and_restore_test"],
+            QaE2eDBBackupRestoreTest.TEST_TIMEOUT,
+            post_start_hook=set_dirs_after_start,
+        )

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -80,10 +80,14 @@ class QaE2eDBBackupRestoreTest(BaseTest):
 
         def set_dirs_after_start():
             # let post test know where logs are
-            self.test_output_dirs = [UpgradeTest.TEST_OUTPUT_DIR]
+            self.test_output_dirs = [QaE2eDBBackupRestoreTest.TEST_OUTPUT_DIR]
 
         self.run_with_graceful_kill(
-            ["tests/e2e/lib.sh", "db_backup_and_restore_test"],
+            [
+                "tests/e2e/lib.sh",
+                "db_backup_and_restore_test",
+                QaE2eDBBackupRestoreTest.TEST_OUTPUT_DIR,
+            ],
             QaE2eDBBackupRestoreTest.TEST_TIMEOUT,
             post_start_hook=set_dirs_after_start,
         )

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -8,9 +8,6 @@ import subprocess
 
 from common import popen_graceful_kill
 
-# Where the QA tests store failure logs: qa-tests-backend/src/main/groovy/common/Constants.groovy
-QA_TESTS_OUTPUT_DIR = "/tmp/qa-tests-backend-logs"
-
 
 class BaseTest:
     def __init__(self):
@@ -43,7 +40,7 @@ class UpgradeTest(BaseTest):
 
         def set_dirs_after_start():
             # let post test know where logs are
-            self.test_output_dirs = [UpgradeTest.TEST_OUTPUT_DIR, QA_TESTS_OUTPUT_DIR]
+            self.test_output_dirs = [UpgradeTest.TEST_OUTPUT_DIR]
 
         self.run_with_graceful_kill(
             ["tests/upgrade/run.sh", UpgradeTest.TEST_OUTPUT_DIR],

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -36,6 +36,9 @@ case "$ci_job" in
     push-images)
         "$ROOT/scripts/ci/jobs/push-images.sh"
         ;;
+    gke-qa-e2e-tests)
+        "$ROOT/.openshift-ci/gke_qa_e2e_test.py"
+        ;;
     gke-upgrade-tests)
         "$ROOT/.openshift-ci/gke_upgrade_test.py"
         ;;

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -26,7 +26,7 @@ fi
 
 ci_job="$1"
 shift
-ci_export CI_JOB_NAME="$ci_job"
+ci_export CI_JOB_NAME "$ci_job"
 
 gate_job "$ci_job"
 

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -26,6 +26,7 @@ fi
 
 ci_job="$1"
 shift
+ci_export CI_JOB_NAME="$ci_job"
 
 gate_job "$ci_job"
 

--- a/.openshift-ci/gke_qa_e2e_test.py
+++ b/.openshift-ci/gke_qa_e2e_test.py
@@ -44,6 +44,7 @@ ClusterTestSetsRunner(
             "name": "DB backup and restore",
             "test": QaE2eDBBackupRestoreTest(),
             "post_test": StoreArtifacts(),
+            "always_run": False,
         },
     ],
     final_post=FinalPost(),

--- a/.openshift-ci/gke_qa_e2e_test.py
+++ b/.openshift-ci/gke_qa_e2e_test.py
@@ -27,7 +27,7 @@ ClusterTestSetsRunner(
                 check_stackrox_logs=True,
                 store_qa_test_debug_logs=False,
                 store_qa_spock_results=False,
-                artifact_destination="part-1",
+                artifact_destination_prefix="part-1",
             ),
         },
         {
@@ -37,7 +37,7 @@ ClusterTestSetsRunner(
                 check_stackrox_logs=True,
                 store_qa_test_debug_logs=True,
                 store_qa_spock_results=True,
-                artifact_destination="part-2",
+                artifact_destination_prefix="part-2",
             ),
         },
         {

--- a/.openshift-ci/gke_qa_e2e_test.py
+++ b/.openshift-ci/gke_qa_e2e_test.py
@@ -6,7 +6,7 @@ Run qa-tests-backend in a GKE cluster
 import os
 from pre_tests import PreSystemTests
 from ci_tests import QaE2eTestPart1, QaE2eTestPart2, QaE2eDBBackupRestoreTest
-from post_tests import PostClusterTest, StoreArtifacts, FinalPost
+from post_tests import PostClusterTest, CheckStackroxLogs, FinalPost
 from clusters import GKECluster
 from runners import ClusterTestSetsRunner
 
@@ -43,7 +43,10 @@ ClusterTestSetsRunner(
         {
             "name": "DB backup and restore",
             "test": QaE2eDBBackupRestoreTest(),
-            "post_test": StoreArtifacts(),
+            "post_test": CheckStackroxLogs(
+                check_for_errors_in_stackrox_logs=True,
+                artifact_destination_prefix="db-test",
+            ),
             "always_run": False,
         },
     ],

--- a/.openshift-ci/gke_qa_e2e_test.py
+++ b/.openshift-ci/gke_qa_e2e_test.py
@@ -25,8 +25,6 @@ ClusterTestSetsRunner(
             "test": QaE2eTestPart1(),
             "post_test": PostClusterTest(
                 check_stackrox_logs=True,
-                store_qa_test_debug_logs=False,
-                store_qa_spock_results=False,
                 artifact_destination_prefix="part-1",
             ),
         },
@@ -35,8 +33,6 @@ ClusterTestSetsRunner(
             "test": QaE2eTestPart2(),
             "post_test": PostClusterTest(
                 check_stackrox_logs=True,
-                store_qa_test_debug_logs=True,
-                store_qa_spock_results=True,
                 artifact_destination_prefix="part-2",
             ),
         },
@@ -50,5 +46,8 @@ ClusterTestSetsRunner(
             "always_run": False,
         },
     ],
-    final_post=FinalPost(),
+    final_post=FinalPost(
+        store_qa_test_debug_logs=True,
+        store_qa_spock_results=True,
+    ),
 ).run()

--- a/.openshift-ci/gke_qa_e2e_test.py
+++ b/.openshift-ci/gke_qa_e2e_test.py
@@ -5,8 +5,8 @@ Run qa-tests-backend in a GKE cluster
 """
 import os
 from pre_tests import PreSystemTests
-from ci_tests import QaE2eTestPart1, QaE2eTestPart2
-from post_tests import PostClusterTest
+from ci_tests import QaE2eTestPart1, QaE2eTestPart2, QaE2eDBBackupRestoreTest
+from post_tests import PostClusterTest, StoreArtifacts
 from clusters import GKECluster
 from runners import ClusterTestSetsRunner
 
@@ -41,6 +41,10 @@ ClusterTestSetsRunner(
                 store_qa_spock_results=True,
                 artifact_destination="part-2",
             ),
+        },
+        {
+            "test": QaE2eDBBackupRestoreTest(),
+            "post_test": StoreArtifacts(),
         },
     ],
 ).run()

--- a/.openshift-ci/gke_qa_e2e_test.py
+++ b/.openshift-ci/gke_qa_e2e_test.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run qa-tests-backend in a GKE cluster
+"""
+import os
+from ci_tests import QaE2eTestPart1, QaE2eTestPart2
+from clusters import GKECluster
+from runners import ClusterTestSetsRunner
+
+os.environ["ADMISSION_CONTROLLER_UPDATES"] = "true"
+os.environ["ADMISSION_CONTROLLER"] = "true"
+os.environ["COLLECTION_METHOD"] = "ebpf"
+os.environ["GCP_IMAGE_TYPE"] = "COS"
+os.environ["LOAD_BALANCER"] = "lb"
+os.environ["LOCAL_PORT"] = "443"
+os.environ["MONITORING_SUPPORT"] = "false"
+os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["ROX_BASELINE_GENERATION_DURATION"] = "1m"
+os.environ["ROX_NETWORK_BASELINE_OBSERVATION_PERIOD"] = "2m"
+os.environ["ROX_NEW_POLICY_CATEGORIES"] = "true"
+os.environ["SCANNER_SUPPORT"] = "true"
+
+ClusterTestSetsRunner(
+    cluster=GKECluster("qa-e2e-test"),
+    sets=[{"test": QaE2eTestPart1()}, {"test": QaE2eTestPart2()}],
+).run()

--- a/.openshift-ci/gke_qa_e2e_test.py
+++ b/.openshift-ci/gke_qa_e2e_test.py
@@ -10,18 +10,11 @@ from post_tests import PostClusterTest, StoreArtifacts, FinalPost
 from clusters import GKECluster
 from runners import ClusterTestSetsRunner
 
-os.environ["ADMISSION_CONTROLLER_UPDATES"] = "true"
-os.environ["ADMISSION_CONTROLLER"] = "true"
-os.environ["COLLECTION_METHOD"] = "ebpf"
-os.environ["GCP_IMAGE_TYPE"] = "COS"
-os.environ["LOAD_BALANCER"] = "lb"
-os.environ["LOCAL_PORT"] = "443"
-os.environ["MONITORING_SUPPORT"] = "false"
+# set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
-os.environ["ROX_BASELINE_GENERATION_DURATION"] = "1m"
-os.environ["ROX_NETWORK_BASELINE_OBSERVATION_PERIOD"] = "2m"
-os.environ["ROX_NEW_POLICY_CATEGORIES"] = "true"
-os.environ["SCANNER_SUPPORT"] = "true"
+
+# override default test environment
+os.environ["LOAD_BALANCER"] = "lb"
 
 ClusterTestSetsRunner(
     cluster=GKECluster("qa-e2e-test"),

--- a/.openshift-ci/gke_qa_e2e_test.py
+++ b/.openshift-ci/gke_qa_e2e_test.py
@@ -30,7 +30,10 @@ ClusterTestSetsRunner(
             "pre_test": PreSystemTests(),
             "test": QaE2eTestPart1(),
             "post_test": PostClusterTest(
-                check_stackrox_logs=True, artifact_destination="part-1"
+                check_stackrox_logs=True,
+                store_qa_test_debug_logs=False,
+                store_qa_spock_results=False,
+                artifact_destination="part-1",
             ),
         },
         {

--- a/.openshift-ci/gke_qa_e2e_test.py
+++ b/.openshift-ci/gke_qa_e2e_test.py
@@ -6,7 +6,7 @@ Run qa-tests-backend in a GKE cluster
 import os
 from pre_tests import PreSystemTests
 from ci_tests import QaE2eTestPart1, QaE2eTestPart2, QaE2eDBBackupRestoreTest
-from post_tests import PostClusterTest, StoreArtifacts
+from post_tests import PostClusterTest, StoreArtifacts, FinalPost
 from clusters import GKECluster
 from runners import ClusterTestSetsRunner
 
@@ -47,4 +47,5 @@ ClusterTestSetsRunner(
             "post_test": StoreArtifacts(),
         },
     ],
+    final_post=FinalPost(),
 ).run()

--- a/.openshift-ci/gke_qa_e2e_test.py
+++ b/.openshift-ci/gke_qa_e2e_test.py
@@ -27,6 +27,7 @@ ClusterTestSetsRunner(
     cluster=GKECluster("qa-e2e-test"),
     sets=[
         {
+            "name": "QA tests part I",
             "pre_test": PreSystemTests(),
             "test": QaE2eTestPart1(),
             "post_test": PostClusterTest(
@@ -37,6 +38,7 @@ ClusterTestSetsRunner(
             ),
         },
         {
+            "name": "QA tests part II",
             "test": QaE2eTestPart2(),
             "post_test": PostClusterTest(
                 check_stackrox_logs=True,
@@ -46,6 +48,7 @@ ClusterTestSetsRunner(
             ),
         },
         {
+            "name": "DB backup and restore",
             "test": QaE2eDBBackupRestoreTest(),
             "post_test": StoreArtifacts(),
         },

--- a/.openshift-ci/gke_upgrade_test.py
+++ b/.openshift-ci/gke_upgrade_test.py
@@ -8,7 +8,7 @@ from runners import ClusterTestRunner
 from clusters import GKECluster
 from pre_tests import PreSystemTests
 from ci_tests import UpgradeTest
-from post_tests import PostClusterTest
+from post_tests import PostClusterTest, FinalPost
 
 os.environ["LOAD_BALANCER"] = "lb"
 ClusterTestRunner(
@@ -16,4 +16,5 @@ ClusterTestRunner(
     pre_test=PreSystemTests(),
     test=UpgradeTest(),
     post_test=PostClusterTest(),
+    final_post=FinalPost(),
 ).run()

--- a/.openshift-ci/gke_upgrade_test.py
+++ b/.openshift-ci/gke_upgrade_test.py
@@ -18,5 +18,8 @@ ClusterTestRunner(
     pre_test=PreSystemTests(),
     test=UpgradeTest(),
     post_test=PostClusterTest(),
-    final_post=FinalPost(),
+    final_post=FinalPost(
+        store_qa_test_debug_logs=True,
+        store_qa_spock_results=True,
+    ),
 ).run()

--- a/.openshift-ci/gke_upgrade_test.py
+++ b/.openshift-ci/gke_upgrade_test.py
@@ -10,7 +10,9 @@ from pre_tests import PreSystemTests
 from ci_tests import UpgradeTest
 from post_tests import PostClusterTest, FinalPost
 
+# Override test env defaults here:
 os.environ["LOAD_BALANCER"] = "lb"
+
 ClusterTestRunner(
     cluster=GKECluster("upgrade-test"),
     pre_test=PreSystemTests(),

--- a/.openshift-ci/gke_upgrade_test.py
+++ b/.openshift-ci/gke_upgrade_test.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env -S python3 -u
 
 """
-A hook for OpenShift CI to execute an upgrade test in a GKE cluster
+Run the upgrade test in a GKE cluster
 """
 import os
 from runners import ClusterTestRunner
 from clusters import GKECluster
 from pre_tests import PreSystemTests
 from ci_tests import UpgradeTest
-from posts import PostClusterTest
+from post_tests import PostClusterTest
 
 os.environ["LOAD_BALANCER"] = "lb"
 ClusterTestRunner(
     cluster=GKECluster("upgrade-test"),
     pre_test=PreSystemTests(),
     test=UpgradeTest(),
-    post=PostClusterTest(),
+    post_test=PostClusterTest(),
 ).run()

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -8,7 +8,7 @@ import subprocess
 from typing import List
 
 
-class NullPost:
+class NullPostTest:
     def run(self, test_output_dirs=None):
         pass
 

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -79,7 +79,7 @@ class StoreArtifacts(RunWithBestEffortMixin):
         self.store_artifacts(test_output_dirs)
         self.handle_run_failure()
 
-    def store_artifacts(self, test_output_dirs):
+    def store_artifacts(self, test_output_dirs=None):
         if test_output_dirs is not None:
             self.data_to_store = test_output_dirs + self.data_to_store
         for source in self.data_to_store:

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 """
-Common steps when tests complete
+Common steps to run when e2e tests are complete. All post steps are run in spite
+of prior failures. This models existing CI behavior from Circle CI.
 """
 
 import subprocess
@@ -44,6 +45,8 @@ class RunWithBestEffortMixin:
 
 
 class StoreArtifacts(RunWithBestEffortMixin):
+    """For tests that only need to store artifacts"""
+
     STORE_TIMEOUT = 5 * 60
 
     def __init__(
@@ -71,6 +74,8 @@ class StoreArtifacts(RunWithBestEffortMixin):
 
 # pylint: disable=too-many-instance-attributes
 class PostClusterTest(StoreArtifacts):
+    """The standard cluster test suite of debug gathering and analysis"""
+
     API_TIMEOUT = 5 * 60
     COLLECT_TIMEOUT = 5 * 60
     CHECK_TIMEOUT = 5 * 60

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -65,7 +65,7 @@ class StoreArtifacts(RunWithBestEffortMixin):
                 args.append(self.artifact_destination)
             self.run_with_best_effort(
                 args,
-                timeout=PostClusterTest.STORE_TIMEOUT,
+                timeout=StoreArtifacts.STORE_TIMEOUT,
             )
 
 
@@ -74,7 +74,6 @@ class PostClusterTest(StoreArtifacts):
     API_TIMEOUT = 5 * 60
     COLLECT_TIMEOUT = 5 * 60
     CHECK_TIMEOUT = 5 * 60
-    STORE_TIMEOUT = 5 * 60
     # Where the QA tests store failure logs:
     # qa-tests-backend/src/main/groovy/common/Constants.groovy
     QA_TEST_DEBUG_LOGS = "/tmp/qa-tests-backend-logs"
@@ -121,8 +120,6 @@ class PostClusterTest(StoreArtifacts):
         if self._check_stackrox_logs:
             self.check_stackrox_logs()
         self.store_artifacts(test_output_dirs)
-        self.fixup_artifacts_content_type()
-        self.make_artifacts_help()
         self.handle_run_failure()
 
     def wait_for_central_api(self):
@@ -193,14 +190,23 @@ class PostClusterTest(StoreArtifacts):
             timeout=PostClusterTest.CHECK_TIMEOUT,
         )
 
+
+class FinalPost(RunWithBestEffortMixin):
+    FIXUP_TIMEOUT = 5 * 60
+
+    def run(self):
+        self.fixup_artifacts_content_type()
+        self.make_artifacts_help()
+        self.handle_run_failure()
+
     def fixup_artifacts_content_type(self):
         self.run_with_best_effort(
             ["scripts/ci/store-artifacts.sh", "fixup_artifacts_content_type"],
-            timeout=PostClusterTest.STORE_TIMEOUT,
+            timeout=FinalPost.FIXUP_TIMEOUT,
         )
 
     def make_artifacts_help(self):
         self.run_with_best_effort(
             ["scripts/ci/store-artifacts.sh", "make_artifacts_help"],
-            timeout=PostClusterTest.STORE_TIMEOUT,
+            timeout=FinalPost.FIXUP_TIMEOUT,
         )

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -43,7 +43,7 @@ class RunWithBestEffortMixin:
             raise RuntimeError(f"Post failed: exit {self.exitstatus}")
 
 
-class PostStoreArtifacts(RunWithBestEffortMixin):
+class StoreArtifacts(RunWithBestEffortMixin):
     STORE_TIMEOUT = 5 * 60
 
     def __init__(
@@ -70,7 +70,7 @@ class PostStoreArtifacts(RunWithBestEffortMixin):
 
 
 # pylint: disable=too-many-instance-attributes
-class PostClusterTest(PostStoreArtifacts):
+class PostClusterTest(StoreArtifacts):
     API_TIMEOUT = 5 * 60
     COLLECT_TIMEOUT = 5 * 60
     CHECK_TIMEOUT = 5 * 60

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -10,6 +10,25 @@ import subprocess
 from typing import List
 
 
+class PostTestsConstants:
+
+    API_TIMEOUT = 5 * 60
+    COLLECT_TIMEOUT = 5 * 60
+    CHECK_TIMEOUT = 5 * 60
+    STORE_TIMEOUT = 5 * 60
+    FIXUP_TIMEOUT = 5 * 60
+    # Where the QA tests store failure logs:
+    # qa-tests-backend/src/main/groovy/common/Constants.groovy
+    QA_TEST_DEBUG_LOGS = "/tmp/qa-tests-backend-logs"
+    QA_SPOCK_RESULTS = "qa-tests-backend/build/spock-reports"
+    K8S_LOG_DIR = "/tmp/k8s-service-logs"
+    COLLECTOR_METRICS_DIR = "/tmp/collector-metrics"
+    DEBUG_OUTPUT = "debug-dump"
+    DIAGNOSTIC_OUTPUT = "diagnostic-bundle"
+    CENTRAL_DATA_OUTPUT = "central-data"
+    STACKROX_LOG_DIR = "/tmp/stackrox-logs"
+
+
 class NullPostTest:
     def run(self, test_output_dirs=None):
         pass
@@ -48,8 +67,6 @@ class RunWithBestEffortMixin:
 class StoreArtifacts(RunWithBestEffortMixin):
     """For tests that only need to store artifacts"""
 
-    STORE_TIMEOUT = 5 * 60
-
     def __init__(
         self,
         artifact_destination_prefix=None,
@@ -73,26 +90,13 @@ class StoreArtifacts(RunWithBestEffortMixin):
                 )
             self.run_with_best_effort(
                 args,
-                timeout=StoreArtifacts.STORE_TIMEOUT,
+                timeout=PostTestsConstants.STORE_TIMEOUT,
             )
 
 
 # pylint: disable=too-many-instance-attributes
 class PostClusterTest(StoreArtifacts):
     """The standard cluster test suite of debug gathering and analysis"""
-
-    API_TIMEOUT = 5 * 60
-    COLLECT_TIMEOUT = 5 * 60
-    CHECK_TIMEOUT = 5 * 60
-    # Where the QA tests store failure logs:
-    # qa-tests-backend/src/main/groovy/common/Constants.groovy
-    QA_TEST_DEBUG_LOGS = "/tmp/qa-tests-backend-logs"
-    QA_SPOCK_RESULTS = "qa-tests-backend/build/spock-reports"
-    K8S_LOG_DIR = "/tmp/k8s-service-logs"
-    COLLECTOR_METRICS_DIR = "/tmp/collector-metrics"
-    DEBUG_OUTPUT = "debug-dump"
-    DIAGNOSTIC_OUTPUT = "diagnostic-bundle"
-    CENTRAL_DATA_OUTPUT = "central-data"
 
     def __init__(
         self,
@@ -115,9 +119,9 @@ class PostClusterTest(StoreArtifacts):
         ]
         self.central_is_responsive = False
         if self._store_qa_test_debug_logs:
-            self.data_to_store.append(PostClusterTest.QA_TEST_DEBUG_LOGS)
+            self.data_to_store.append(PostTestsConstants.QA_TEST_DEBUG_LOGS)
         if self._store_qa_spock_results:
-            self.data_to_store.append(PostClusterTest.QA_SPOCK_RESULTS)
+            self.data_to_store.append(PostTestsConstants.QA_SPOCK_RESULTS)
 
     def run(self, test_output_dirs=None):
         self.central_is_responsive = self.wait_for_central_api()
@@ -135,7 +139,7 @@ class PostClusterTest(StoreArtifacts):
     def wait_for_central_api(self):
         return self.run_with_best_effort(
             ["tests/e2e/lib.sh", "wait_for_api"],
-            timeout=PostClusterTest.API_TIMEOUT,
+            timeout=PostTestsConstants.API_TIMEOUT,
         )
 
     def collect_service_logs(self):
@@ -144,66 +148,133 @@ class PostClusterTest(StoreArtifacts):
                 [
                     "scripts/ci/collect-service-logs.sh",
                     namespace,
-                    PostClusterTest.K8S_LOG_DIR,
+                    PostTestsConstants.K8S_LOG_DIR,
                 ],
-                timeout=PostClusterTest.COLLECT_TIMEOUT,
+                timeout=PostTestsConstants.COLLECT_TIMEOUT,
             )
         self.run_with_best_effort(
-            ["scripts/ci/collect-infrastructure-logs.sh", PostClusterTest.K8S_LOG_DIR],
-            timeout=PostClusterTest.COLLECT_TIMEOUT,
+            [
+                "scripts/ci/collect-infrastructure-logs.sh",
+                PostTestsConstants.K8S_LOG_DIR,
+            ],
+            timeout=PostTestsConstants.COLLECT_TIMEOUT,
         )
-        self.data_to_store.append(PostClusterTest.K8S_LOG_DIR)
+        self.data_to_store.append(PostTestsConstants.K8S_LOG_DIR)
 
     def collect_collector_metrics(self):
         self.run_with_best_effort(
             [
                 "scripts/ci/collect-collector-metrics.sh",
                 "stackrox",
-                PostClusterTest.COLLECTOR_METRICS_DIR,
+                PostTestsConstants.COLLECTOR_METRICS_DIR,
             ],
-            timeout=PostClusterTest.COLLECT_TIMEOUT,
+            timeout=PostTestsConstants.COLLECT_TIMEOUT,
         )
-        self.data_to_store.append(PostClusterTest.COLLECTOR_METRICS_DIR)
+        self.data_to_store.append(PostTestsConstants.COLLECTOR_METRICS_DIR)
 
     def get_central_debug_dump(self):
         self.run_with_best_effort(
             [
                 "scripts/ci/lib.sh",
                 "get_central_debug_dump",
-                PostClusterTest.DEBUG_OUTPUT,
+                PostTestsConstants.DEBUG_OUTPUT,
             ],
-            timeout=PostClusterTest.COLLECT_TIMEOUT,
+            timeout=PostTestsConstants.COLLECT_TIMEOUT,
         )
-        self.data_to_store.append(PostClusterTest.DEBUG_OUTPUT)
+        self.data_to_store.append(PostTestsConstants.DEBUG_OUTPUT)
 
     def get_central_diagnostics(self):
         self.run_with_best_effort(
             [
                 "scripts/ci/lib.sh",
                 "get_central_diagnostics",
-                PostClusterTest.DIAGNOSTIC_OUTPUT,
+                PostTestsConstants.DIAGNOSTIC_OUTPUT,
             ],
-            timeout=PostClusterTest.COLLECT_TIMEOUT,
+            timeout=PostTestsConstants.COLLECT_TIMEOUT,
         )
-        self.data_to_store.append(PostClusterTest.DIAGNOSTIC_OUTPUT)
+        self.data_to_store.append(PostTestsConstants.DIAGNOSTIC_OUTPUT)
 
     def grab_central_data(self):
         self.run_with_best_effort(
-            ["scripts/grab-data-from-central.sh", PostClusterTest.CENTRAL_DATA_OUTPUT],
-            timeout=PostClusterTest.COLLECT_TIMEOUT,
+            [
+                "scripts/grab-data-from-central.sh",
+                PostTestsConstants.CENTRAL_DATA_OUTPUT,
+            ],
+            timeout=PostTestsConstants.COLLECT_TIMEOUT,
         )
-        self.data_to_store.append(PostClusterTest.CENTRAL_DATA_OUTPUT)
+        self.data_to_store.append(PostTestsConstants.CENTRAL_DATA_OUTPUT)
 
     def check_stackrox_logs(self):
         self.run_with_best_effort(
-            ["tests/e2e/lib.sh", "check_stackrox_logs", PostClusterTest.K8S_LOG_DIR],
-            timeout=PostClusterTest.CHECK_TIMEOUT,
+            ["tests/e2e/lib.sh", "check_stackrox_logs", PostTestsConstants.K8S_LOG_DIR],
+            timeout=PostTestsConstants.CHECK_TIMEOUT,
+        )
+
+
+class CheckStackroxLogs(StoreArtifacts):
+    """When only stackrox logs and checks are required"""
+
+    def __init__(
+        self,
+        check_for_stackrox_restarts=False,
+        check_for_errors_in_stackrox_logs=False,
+        artifact_destination_prefix=None,
+    ):
+        super().__init__(artifact_destination_prefix=artifact_destination_prefix)
+        self._check_for_stackrox_restarts = check_for_stackrox_restarts
+        self._check_for_errors_in_stackrox_logs = check_for_errors_in_stackrox_logs
+        self.central_is_responsive = False
+
+    def run(self, test_output_dirs=None):
+        self.central_is_responsive = self.wait_for_central_api()
+        if self.central_is_responsive:
+            self.collect_stackrox_logs()
+            if self._check_for_stackrox_restarts:
+                self.check_for_stackrox_restarts()
+            if self._check_for_errors_in_stackrox_logs:
+                self.check_for_errors_in_stackrox_logs()
+        self.store_artifacts(test_output_dirs)
+        self.handle_run_failure()
+
+    def wait_for_central_api(self):
+        return self.run_with_best_effort(
+            ["tests/e2e/lib.sh", "wait_for_api"],
+            timeout=PostTestsConstants.API_TIMEOUT,
+        )
+
+    def collect_stackrox_logs(self):
+        self.run_with_best_effort(
+            [
+                "scripts/ci/collect-service-logs.sh",
+                "stackrox",
+                PostTestsConstants.STACKROX_LOG_DIR,
+            ],
+            timeout=PostTestsConstants.COLLECT_TIMEOUT,
+        )
+        self.data_to_store.append(PostTestsConstants.STACKROX_LOG_DIR)
+
+    def check_for_stackrox_restarts(self):
+        self.run_with_best_effort(
+            [
+                "tests/e2e/lib.sh",
+                "check_for_stackrox_restarts",
+                PostTestsConstants.STACKROX_LOG_DIR,
+            ],
+            timeout=PostTestsConstants.CHECK_TIMEOUT,
+        )
+
+    def check_for_errors_in_stackrox_logs(self):
+        self.run_with_best_effort(
+            [
+                "tests/e2e/lib.sh",
+                "check_for_errors_in_stackrox_logs",
+                PostTestsConstants.STACKROX_LOG_DIR,
+            ],
+            timeout=PostTestsConstants.CHECK_TIMEOUT,
         )
 
 
 class FinalPost(RunWithBestEffortMixin):
-    FIXUP_TIMEOUT = 5 * 60
-
     def run(self):
         self.fixup_artifacts_content_type()
         self.make_artifacts_help()
@@ -212,11 +283,11 @@ class FinalPost(RunWithBestEffortMixin):
     def fixup_artifacts_content_type(self):
         self.run_with_best_effort(
             ["scripts/ci/store-artifacts.sh", "fixup_artifacts_content_type"],
-            timeout=FinalPost.FIXUP_TIMEOUT,
+            timeout=PostTestsConstants.FIXUP_TIMEOUT,
         )
 
     def make_artifacts_help(self):
         self.run_with_best_effort(
             ["scripts/ci/store-artifacts.sh", "make_artifacts_help"],
-            timeout=FinalPost.FIXUP_TIMEOUT,
+            timeout=PostTestsConstants.FIXUP_TIMEOUT,
         )

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -80,7 +80,9 @@ class StoreArtifacts(RunWithBestEffortMixin):
         self.handle_run_failure()
 
     def store_artifacts(self, test_output_dirs):
-        for source in test_output_dirs + self.data_to_store:
+        if test_output_dirs is not None:
+            self.data_to_store = test_output_dirs + self.data_to_store
+        for source in self.data_to_store:
             args = ["scripts/ci/store-artifacts.sh", "store_artifacts", source]
             if self.artifact_destination_prefix:
                 args.append(
@@ -283,8 +285,8 @@ class FinalPost(StoreArtifacts):
         if self._store_qa_spock_results:
             self.data_to_store.append(PostTestsConstants.QA_SPOCK_RESULTS)
 
-    def run(self, test_output_dirs=None):
-        self.store_artifacts(test_output_dirs)
+    def run(self):
+        self.store_artifacts()
         self.fixup_artifacts_content_type()
         self.make_artifacts_help()
         self.handle_run_failure()

--- a/.openshift-ci/runners.py
+++ b/.openshift-ci/runners.py
@@ -20,9 +20,11 @@ class ClusterTestSetsRunner:
     def __init__(
         self,
         cluster=NullCluster(),
+        final_post=NullPostTest(),
         sets=None,
     ):
         self.cluster = cluster
+        self.final_post = final_post
         if sets is None:
             sets = []
         self.sets = sets
@@ -65,6 +67,15 @@ class ClusterTestSetsRunner:
             self.log_event("teardown completed")
         except Exception as err:
             self.log_event("ERROR: teardown failed")
+            if hold is None:
+                hold = err
+
+        try:
+            self.log_event("About to run final post")
+            self.final_post.run()
+            self.log_event("final post completed")
+        except Exception as err:
+            self.log_event("ERROR: final post failed")
             if hold is None:
                 hold = err
 
@@ -113,6 +124,7 @@ class ClusterTestSetsRunner:
         print(marker)
 
 
+# pylint: disable=too-many-arguments
 class ClusterTestRunner(ClusterTestSetsRunner):
     """A simple cluster test runner that:
     . provisions a cluster
@@ -127,9 +139,11 @@ class ClusterTestRunner(ClusterTestSetsRunner):
         pre_test=NullPreTest(),
         test=NullTest(),
         post_test=NullPostTest(),
+        final_post=NullPostTest(),
     ):
         super().__init__(
             cluster=cluster,
+            final_post=final_post,
             sets=[
                 {
                     "name": None,

--- a/.openshift-ci/runners.py
+++ b/.openshift-ci/runners.py
@@ -8,72 +8,132 @@ from datetime import datetime
 from clusters import NullCluster
 from pre_tests import NullPreTest
 from ci_tests import NullTest
-from posts import NullPost
+from post_tests import NullPostTest
 
 
-class ClusterTestRunner:
+class ClusterTestSetsRunner:
+    """A cluster test runner that runs multiple sets of pre, test & post steps
+    wrapped by a cluster provision and with similar semantics to
+    ClusterTestRunner. Each test set will attempt to run regardless of the outcome of
+    prior sets."""
+
     def __init__(
         self,
         cluster=NullCluster(),
-        pre_test=NullPreTest(),
-        test=NullTest(),
-        post=NullPost(),
+        sets=None,
     ):
         self.cluster = cluster
-        self.pre_test = pre_test
-        self.test = test
-        self.post = post
+        if sets is None:
+            sets = []
+        self.sets = sets
 
     def run(self):
         hold = None
         try:
-            self.log_significant_event("About to provision")
+            self.log_event("About to provision")
             self.cluster.provision()
-            self.log_significant_event("provisioned")
+            self.log_event("provisioned")
         except Exception as err:
-            self.log_significant_event("ERROR: provision failed")
+            self.log_event("ERROR: provision failed")
             hold = err
+
         if hold is None:
-            try:
-                self.log_significant_event("About to run pre test")
-                self.pre_test.run()
-                self.log_significant_event("pre test completed")
-            except Exception as err:
-                self.log_significant_event("ERROR: pre test failed")
-                hold = err
-        if hold is None:
-            try:
-                self.log_significant_event("About to run test")
-                self.test.run()
-                self.log_significant_event("test completed")
-            except Exception as err:
-                self.log_significant_event("ERROR: test failed")
-                hold = err
-            try:
-                self.log_significant_event("About to post")
-                self.post.run(test_output_dirs=self.test.test_output_dirs)
-                self.log_significant_event("post completed")
-            except Exception as err:
-                self.log_significant_event("ERROR: post failed")
-                if hold is None:
-                    hold = err
+            for idx, test_set in enumerate(self.sets):
+                test_set = {
+                    **{
+                        "name": f"set {idx + 1}",
+                        "pre_test": NullPreTest(),
+                        "test": NullTest(),
+                        "post_test": NullPostTest(),
+                    },
+                    **test_set,
+                }
+                try:
+                    self.log_event("About to run", test_set)
+                    self.run_test_set(test_set)
+                    self.log_event("run completed", test_set)
+                except Exception as err:
+                    self.log_event("ERROR: run failed", test_set)
+                    if hold is None:
+                        hold = err
 
         try:
-            self.log_significant_event("About to teardown")
+            self.log_event("About to teardown")
             self.cluster.teardown()
-            self.log_significant_event("teardown completed")
+            self.log_event("teardown completed")
         except Exception as err:
-            self.log_significant_event("ERROR: teardown failed")
+            self.log_event("ERROR: teardown failed")
             if hold is None:
                 hold = err
 
         if hold is not None:
             raise hold
 
-    def log_significant_event(self, msg):
+    def run_test_set(self, test_set):
+        hold = None
+        try:
+            self.log_event("About to run pre test", test_set)
+            test_set["pre_test"].run()
+            self.log_event("pre test completed", test_set)
+        except Exception as err:
+            self.log_event("ERROR: pre test failed", test_set)
+            hold = err
+        if hold is None:
+            try:
+                self.log_event("About to run test", test_set)
+                test_set["test"].run()
+                self.log_event("test completed", test_set)
+            except Exception as err:
+                self.log_event("ERROR: test failed", test_set)
+                hold = err
+            try:
+                self.log_event("About to run post test", test_set)
+                test_set["post_test"].run(
+                    test_output_dirs=test_set["test"].test_output_dirs
+                )
+                self.log_event("post test completed", test_set)
+            except Exception as err:
+                self.log_event("ERROR: post test failed", test_set)
+                if hold is None:
+                    hold = err
+
+        if hold is not None:
+            raise hold
+
+    def log_event(self, msg, test_set=None):
         now = datetime.now()
         time = now.strftime("%H:%M:%S")
         marker = "****"
+        if test_set is not None and test_set["name"] is not None:
+            msg = f"{msg} [{test_set['name']}]"
         print(marker)
         print(f"{marker} {time}: {msg}")
         print(marker)
+
+
+class ClusterTestRunner(ClusterTestSetsRunner):
+    """A simple cluster test runner that:
+    . provisions a cluster
+    . runs any pre_test (if provision was successful)
+    . runs the test (if provisioned and any pre_test was successful)
+    . runs post_test (if the test ran)
+    . tearsdown the cluster"""
+
+    def __init__(
+        self,
+        cluster=NullCluster(),
+        pre_test=NullPreTest(),
+        test=NullTest(),
+        post_test=NullPostTest(),
+    ):
+        super().__init__(
+            cluster=cluster,
+            sets=[
+                {
+                    "name": None,
+                    "pre_test": pre_test,
+                    "test": test,
+                    "post_test": post_test,
+                }
+            ],
+        )

--- a/.openshift-ci/runners.py
+++ b/.openshift-ci/runners.py
@@ -131,7 +131,7 @@ class ClusterTestRunner(ClusterTestSetsRunner):
     . runs any pre_test (if provision was successful)
     . runs the test (if provisioned and any pre_test was successful)
     . runs post_test (if the test ran)
-    . tearsdown the cluster"""
+    . tears down the cluster"""
 
     def __init__(
         self,

--- a/.openshift-ci/runners.py
+++ b/.openshift-ci/runners.py
@@ -15,7 +15,7 @@ class ClusterTestSetsRunner:
     """A cluster test runner that runs multiple sets of pre, test & post steps
     wrapped by a cluster provision and with similar semantics to
     ClusterTestRunner. Each test set will attempt to run regardless of the outcome of
-    prior sets. This can be overriden on a set by set basis with 'skip_when_failed'"""
+    prior sets. This can be overriden on a set by set basis with 'always_run'"""
 
     def __init__(
         self,
@@ -47,11 +47,11 @@ class ClusterTestSetsRunner:
                         "pre_test": NullPreTest(),
                         "test": NullTest(),
                         "post_test": NullPostTest(),
-                        "skip_when_failed": False,
+                        "always_run": True,
                     },
                     **test_set,
                 }
-                if hold is None or not test_set["skip_when_failed"]:
+                if hold is None or test_set["always_run"]:
                     try:
                         self.log_event("About to run", test_set)
                         self.run_test_set(test_set)

--- a/.openshift-ci/runners.py
+++ b/.openshift-ci/runners.py
@@ -15,7 +15,7 @@ class ClusterTestSetsRunner:
     """A cluster test runner that runs multiple sets of pre, test & post steps
     wrapped by a cluster provision and with similar semantics to
     ClusterTestRunner. Each test set will attempt to run regardless of the outcome of
-    prior sets."""
+    prior sets. This can be overriden on a set by set basis with 'skip_when_failed'"""
 
     def __init__(
         self,
@@ -45,17 +45,19 @@ class ClusterTestSetsRunner:
                         "pre_test": NullPreTest(),
                         "test": NullTest(),
                         "post_test": NullPostTest(),
+                        "skip_when_failed": False,
                     },
                     **test_set,
                 }
-                try:
-                    self.log_event("About to run", test_set)
-                    self.run_test_set(test_set)
-                    self.log_event("run completed", test_set)
-                except Exception as err:
-                    self.log_event("ERROR: run failed", test_set)
-                    if hold is None:
-                        hold = err
+                if hold is None or not test_set["skip_when_failed"]:
+                    try:
+                        self.log_event("About to run", test_set)
+                        self.run_test_set(test_set)
+                        self.log_event("run completed", test_set)
+                    except Exception as err:
+                        self.log_event("ERROR: run failed", test_set)
+                        if hold is None:
+                            hold = err
 
         try:
             self.log_event("About to teardown")

--- a/.openshift-ci/tests/test_runners.py
+++ b/.openshift-ci/tests/test_runners.py
@@ -216,7 +216,7 @@ class TestClusterTestSetsRunner(unittest.TestCase):
         with self.assertRaisesRegex(Exception, "test1 oops"):
             ClusterTestSetsRunner(sets=[{"test": test1}, {"test": test2}]).run()
 
-    def test_can_skip_when_failed(self):
+    def test_can_always_run(self):
         test1 = Mock()
         test1.run.side_effect = Exception("test1 oops")
         test2 = Mock()
@@ -227,7 +227,7 @@ class TestClusterTestSetsRunner(unittest.TestCase):
             ClusterTestSetsRunner(
                 sets=[
                     {"test": test1},
-                    {"test": test2, "post_test": post_test2, "skip_when_failed": True},
+                    {"test": test2, "post_test": post_test2, "always_run": False},
                     {"test": test3, "post_test": post_test3},
                 ]
             ).run()

--- a/.openshift-ci/tests/test_runners.py
+++ b/.openshift-ci/tests/test_runners.py
@@ -189,3 +189,23 @@ class TestClusterTestSetsRunner(unittest.TestCase):
         test2.run.side_effect = Exception("test2 oops")
         with self.assertRaisesRegex(Exception, "test1 oops"):
             ClusterTestSetsRunner(sets=[{"test": test1}, {"test": test2}]).run()
+
+    def test_can_skip_when_failed(self):
+        test1 = Mock()
+        test1.run.side_effect = Exception("test1 oops")
+        test2 = Mock()
+        post_test2 = Mock()
+        test3 = Mock()
+        post_test3 = Mock()
+        with self.assertRaisesRegex(Exception, "test1 oops"):
+            ClusterTestSetsRunner(
+                sets=[
+                    {"test": test1},
+                    {"test": test2, "post_test": post_test2, "skip_when_failed": True},
+                    {"test": test3, "post_test": post_test3},
+                ]
+            ).run()
+        test2.run.assert_not_called()
+        post_test2.run.assert_not_called()
+        test3.run.assert_called_once()
+        post_test3.run.assert_called_once()

--- a/.openshift-ci/tests/test_runners.py
+++ b/.openshift-ci/tests/test_runners.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import Mock
-from runners import ClusterTestRunner
+from runners import ClusterTestRunner, ClusterTestSetsRunner
 
 
 class TestClusterTestRunner(unittest.TestCase):
@@ -19,111 +19,173 @@ class TestClusterTestRunner(unittest.TestCase):
         ClusterTestRunner(test=test).run()
         test.run.assert_called_once()
 
+    def test_runs_post_test(self):
+        post_test = Mock()
+        ClusterTestRunner(post_test=post_test).run()
+        post_test.run.assert_called_once()
+
     def test_tearsdown(self):
         cluster = Mock()
         ClusterTestRunner(cluster=cluster).run()
         cluster.teardown.assert_called_once()
 
-    def test_runs_post(self):
-        post = Mock()
-        ClusterTestRunner(post=post).run()
-        post.run.assert_called_once()
-
     def test_provision_failure(self):
         cluster = Mock()
         test = Mock()
-        post = Mock()
+        post_test = Mock()
         cluster.provision.side_effect = Exception("oops")
         with self.assertRaisesRegex(Exception, "oops"):
-            ClusterTestRunner(cluster=cluster, test=test, post=post).run()
+            ClusterTestRunner(cluster=cluster, test=test, post_test=post_test).run()
         test.run.assert_not_called()  # skips test
-        post.run.assert_not_called()  # skips post
+        post_test.run.assert_not_called()  # skips post test
         cluster.teardown.assert_called_once()  # still tearsdown
 
     def test_pre_test_failure(self):
         cluster = Mock()
         pre_test = Mock()
         test = Mock()
-        post = Mock()
+        post_test = Mock()
         pre_test.run.side_effect = Exception("oops")
         with self.assertRaisesRegex(Exception, "oops"):
             ClusterTestRunner(
-                cluster=cluster, pre_test=pre_test, test=test, post=post
+                cluster=cluster, pre_test=pre_test, test=test, post_test=post_test
             ).run()
         test.run.assert_not_called()  # skips test
-        post.run.assert_not_called()  # skips post
+        post_test.run.assert_not_called()  # skips post test
         cluster.teardown.assert_called_once()  # still tearsdown
 
     def test_run_failure(self):
         cluster = Mock()
         test = Mock()
-        post = Mock()
+        post_test = Mock()
         test.run.side_effect = Exception("oops")
         with self.assertRaisesRegex(Exception, "oops"):
-            ClusterTestRunner(cluster=cluster, test=test, post=post).run()
+            ClusterTestRunner(cluster=cluster, test=test, post_test=post_test).run()
         test.run.assert_called_once()  # skips test
-        post.run.assert_called_once()  # still posts
+        post_test.run.assert_called_once()  # still post tests
         cluster.teardown.assert_called_once()  # still tearsdown
 
     def test_post_failure(self):
         cluster = Mock()
         test = Mock()
-        post = Mock()
-        post.run.side_effect = Exception("oops")
+        post_test = Mock()
+        post_test.run.side_effect = Exception("oops")
         with self.assertRaisesRegex(Exception, "oops"):
-            ClusterTestRunner(cluster=cluster, test=test, post=post).run()
+            ClusterTestRunner(cluster=cluster, test=test, post_test=post_test).run()
         cluster.teardown.assert_called_once()  # still tearsdown
 
-    def test_run_and_post_failure(self):
+    def test_run_and_post_test_failure(self):
         cluster = Mock()
         test = Mock()
-        post = Mock()
+        post_test = Mock()
         test.run.side_effect = Exception("run oops")
-        post.run.side_effect = Exception("post oops")
+        post_test.run.side_effect = Exception("post test oops")
         with self.assertRaisesRegex(Exception, "run oops"):  # the run error is #1
-            ClusterTestRunner(cluster=cluster, test=test, post=post).run()
+            ClusterTestRunner(cluster=cluster, test=test, post_test=post_test).run()
         cluster.teardown.assert_called_once()  # still tearsdown
 
-    def test_run_and_post_and_teardown_failure(self):
+    def test_run_and_post_test_and_teardown_failure(self):
         cluster = Mock()
         test = Mock()
-        post = Mock()
+        post_test = Mock()
         test.run.side_effect = Exception("run oops")
-        post.run.side_effect = Exception("post oops")
+        post_test.run.side_effect = Exception("post test oops")
         cluster.teardown.side_effect = Exception("teardown oops")
         with self.assertRaisesRegex(Exception, "run oops"):  # the run error is #1
-            ClusterTestRunner(cluster=cluster, test=test, post=post).run()
+            ClusterTestRunner(cluster=cluster, test=test, post_test=post_test).run()
 
-    def test_post_and_teardown_failure(self):
+    def test_post_test_and_teardown_failure(self):
         cluster = Mock()
         test = Mock()
-        post = Mock()
-        post.run.side_effect = Exception("post oops")
+        post_test = Mock()
+        post_test.run.side_effect = Exception("post test oops")
         cluster.teardown.side_effect = Exception("teardown oops")
-        with self.assertRaisesRegex(Exception, "post oops"):  # the post error is #1
-            ClusterTestRunner(cluster=cluster, test=test, post=post).run()
+        with self.assertRaisesRegex(
+            Exception, "post test oops"
+        ):  # the post_test error is #1
+            ClusterTestRunner(cluster=cluster, test=test, post_test=post_test).run()
 
     def test_provision_and_teardown_failure(self):
         cluster = Mock()
         test = Mock()
-        post = Mock()
+        post_test = Mock()
         cluster.provision.side_effect = Exception("provision oops")
         cluster.teardown.side_effect = Exception("teardown oops")
         with self.assertRaisesRegex(
             Exception, "provision oops"
         ):  # the provision error is #1
-            ClusterTestRunner(cluster=cluster, test=test, post=post).run()
+            ClusterTestRunner(cluster=cluster, test=test, post_test=post_test).run()
 
     def test_pre_test_and_teardown_failure(self):
         cluster = Mock()
         pre_test = Mock()
         test = Mock()
-        post = Mock()
-        pre_test.run.side_effect = Exception("pre_test oops")
+        post_test = Mock()
+        pre_test.run.side_effect = Exception("pre test oops")
         cluster.teardown.side_effect = Exception("teardown oops")
         with self.assertRaisesRegex(
-            Exception, "pre_test oops"
-        ):  # the pre_test error is #1
+            Exception, "pre test oops"
+        ):  # the pre test error is #1
             ClusterTestRunner(
-                cluster=cluster, pre_test=pre_test, test=test, post=post
+                cluster=cluster, pre_test=pre_test, test=test, post_test=post_test
             ).run()
+
+
+class TestClusterTestSetsRunner(unittest.TestCase):
+    def test_provisions(self):
+        cluster = Mock()
+        ClusterTestSetsRunner(cluster=cluster).run()
+        cluster.provision.assert_called_once()
+
+    def test_tearsdown(self):
+        cluster = Mock()
+        ClusterTestSetsRunner(cluster=cluster).run()
+        cluster.teardown.assert_called_once()
+
+    def test_runs_pre_test(self):
+        pre_test = Mock()
+        ClusterTestSetsRunner(sets=[{"pre_test": pre_test}]).run()
+        pre_test.run.assert_called_once()
+
+    def test_runs_test(self):
+        test = Mock()
+        ClusterTestSetsRunner(sets=[{"test": test}]).run()
+        test.run.assert_called_once()
+
+    def test_runs_post_test(self):
+        post_test = Mock()
+        ClusterTestSetsRunner(sets=[{"post_test": post_test}]).run()
+        post_test.run.assert_called_once()
+
+    def test_runs_nth_pre_test(self):
+        pre_test = Mock()
+        ClusterTestSetsRunner(sets=[{}, {"pre_test": pre_test}]).run()
+        pre_test.run.assert_called_once()
+
+    def test_runs_nth_test(self):
+        test = Mock()
+        ClusterTestSetsRunner(sets=[{"test": test}, {}]).run()
+        test.run.assert_called_once()
+
+    def test_runs_nth_post_test(self):
+        post_test = Mock()
+        ClusterTestSetsRunner(sets=[{}, {"post_test": post_test}, {}]).run()
+        post_test.run.assert_called_once()
+
+    # Failure semantics
+
+    def test_initial_failure_does_not_halt_the_set(self):
+        test1 = Mock()
+        test1.run.side_effect = Exception("test1 oops")
+        test2 = Mock()
+        with self.assertRaisesRegex(Exception, "test1 oops"):
+            ClusterTestSetsRunner(sets=[{"test": test1}, {"test": test2}]).run()
+        test2.run.assert_called_once()
+
+    def test_first_failure_is_reported(self):
+        test1 = Mock()
+        test1.run.side_effect = Exception("test1 oops")
+        test2 = Mock()
+        test2.run.side_effect = Exception("test2 oops")
+        with self.assertRaisesRegex(Exception, "test1 oops"):
+            ClusterTestSetsRunner(sets=[{"test": test1}, {"test": test2}]).run()

--- a/.openshift-ci/tests/test_runners.py
+++ b/.openshift-ci/tests/test_runners.py
@@ -29,6 +29,13 @@ class TestClusterTestRunner(unittest.TestCase):
         ClusterTestRunner(cluster=cluster).run()
         cluster.teardown.assert_called_once()
 
+    def test_post_gets_output_from_test(self):
+        test = Mock()
+        test.test_output_dirs = ["a", "b"]
+        post_test = Mock()
+        ClusterTestRunner(test=test, post_test=post_test).run()
+        post_test.run.assert_called_with(test_output_dirs=["a", "b"])
+
     def test_provision_failure(self):
         cluster = Mock()
         test = Mock()

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+
+# Tests part I of qa-tests-backend. Formerly CircleCI gke-api-e2e-tests.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+source "$ROOT/scripts/ci/lib.sh"
+source "$ROOT/scripts/ci/sensor-wait.sh"
+source "$ROOT/tests/e2e/lib.sh"
+source "$ROOT/tests/scripts/setup-certs.sh"
+
+set -euo pipefail
+
+test_part_1() {
+    info "Starting test (qa-tests-backend part I)"
+
+    require_environment "ORCHESTRATOR_FLAVOR"
+    require_environment "KUBECONFIG"
+
+    if is_OPENSHIFT_CI; then
+        # TODO(RS-494) may provide roxctl
+        make cli-linux
+        install_built_roxctl_in_gopath
+    fi
+
+    setup_deployment_env false false
+    remove_existing_stackrox_resources
+    setup_default_TLS_certs
+
+    deploy_central
+
+    get_central_basic_auth_creds
+    wait_for_api
+    setup_client_TLS_certs
+
+    deploy_sensor
+    sensor_wait
+
+    # Bounce collectors to avoid restarts on initial module pull
+    kubectl -n stackrox delete pod -l app=collector --grace-period=0
+
+    sensor_wait
+
+    deploy_default_psp
+    deploy_webhook_server
+    deploy_authz_plugin
+    get_ECR_docker_pull_password
+
+    run_tests_part_1
+}
+
+deploy_central() {
+    info "Deploying central"
+
+    # If we're running a nightly build or race condition check, then set CGO_CHECKS=true so that central is
+    # deployed with strict checks
+    if is_nightly_tag || pr_has_label ci-race-tests; then
+        ci_export CGO_CHECKS "true"
+    fi
+
+    if pr_has_label ci-race-tests; then
+        ci_export IS_RACE_BUILD "true"
+    fi
+
+    if [[ -z "${OUTPUT_FORMAT:-}" ]]; then
+        if pr_has_label ci-helm-deploy; then
+            ci_export OUTPUT_FORMAT helm
+        fi
+    fi
+
+    DEPLOY_DIR="deploy/${ORCHESTRATOR_FLAVOR}"
+    "$ROOT/${DEPLOY_DIR}/central.sh"
+}
+
+deploy_sensor() {
+    info "Deploying sensor"
+
+    ci_export ROX_AFTERGLOW_PERIOD "15"
+    if [[ "${OUTPUT_FORMAT:-}" == "helm" ]]; then
+        echo "Deploying Sensor using Helm ..."
+        ci_export SENSOR_HELM_DEPLOY "true"
+        ci_export ADMISSION_CONTROLLER "true"
+    else
+        echo "Deploying sensor using kubectl ... "
+        if [[ -n "${IS_RACE_BUILD:-}" ]]; then
+            # builds with -race are slow at generating the sensor bundle
+            # https://stack-rox.atlassian.net/browse/ROX-6987
+            ci_export ROXCTL_TIMEOUT "60s"
+        fi
+    fi
+
+    DEPLOY_DIR="deploy/${ORCHESTRATOR_FLAVOR}"
+    "$ROOT/${DEPLOY_DIR}/sensor.sh"
+
+    if [[ "${ORCHESTRATOR_FLAVOR}" == "openshift" ]]; then
+        # Sensor is CPU starved under OpenShift causing all manner of test failures:
+        # https://stack-rox.atlassian.net/browse/ROX-5334
+        # https://stack-rox.atlassian.net/browse/ROX-6891
+        # et al.
+        kubectl -n stackrox set resources deploy/sensor -c sensor --requests 'cpu=2' --limits 'cpu=4'
+    fi
+}
+
+deploy_default_psp() {
+    info "Deploy Default PSP for stackrox namespace"
+    "${ROOT}/scripts/ci/create-default-psp.sh"
+}
+
+deploy_webhook_server() {
+    info "Deploy Webhook server"
+
+    local certs_dir
+    certs_dir="$(mktemp -d)"
+    "${ROOT}/scripts/ci/create-webhookserver.sh" "${certs_dir}"
+    ci_export GENERIC_WEBHOOK_SERVER_CA_CONTENTS "$(cat "${certs_dir}/ca.crt")"
+}
+
+deploy_authz_plugin() {
+    info "Deploy Default Authorization Plugin"
+
+    "${ROOT}/scripts/ci/create-scopedaccessserver.sh"
+}
+
+get_ECR_docker_pull_password() {
+    info "Get AWS ECR Docker Pull Password"
+
+    aws --version
+    local pass
+    pass="$(aws --region="${AWS_ECR_REGISTRY_REGION}" ecr get-login-password)"
+    ci_export AWS_ECR_DOCKER_PULL_PASSWORD "${pass}"
+}
+
+run_tests_part_1() {
+    info "QA Automation Platform Part 1"
+
+    if [[ "${ORCHESTRATOR_FLAVOR}" == "openshift" ]]; then
+        oc get scc qatest-anyuid || oc create -f "${ROOT}/qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
+    fi
+
+    export CLUSTER="${ORCHESTRATOR_FLAVOR^^}"
+
+    local base_ref
+    base_ref="$(get_base_ref)"
+
+    if [[ "$base_ref" == "master" ]] || is_tagged; then
+        info "On master or tagged, running all QA tests..."
+        make -C qa-tests-backend test || touch FAIL
+    elif pr_has_label ci-all-qa-tests; then
+        info "ci-all-qa-tests label was specified, so running all QA tests..."
+        make -C qa-tests-backend test || touch FAIL
+    else
+        info "On a PR branch without ci-all-qa-tests, running BAT tests only..."
+        make -C qa-tests-backend bat-test || touch FAIL
+    fi
+
+    store_qa_test_results "part-1-tests"
+    [[ ! -f FAIL ]] || die "Part 1 tests failed"
+}
+
+test_part_1

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -110,7 +110,7 @@ deploy_webhook_server() {
 
     local certs_dir
     certs_dir="$(mktemp -d)"
-    NAMESPACE="" "${ROOT}/scripts/ci/create-webhookserver.sh" "${certs_dir}"
+    (unset NAMESPACE; "${ROOT}/scripts/ci/create-webhookserver.sh" "${certs_dir}")
     ci_export GENERIC_WEBHOOK_SERVER_CA_CONTENTS "$(cat "${certs_dir}/ca.crt")"
 }
 

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -160,7 +160,10 @@ run_tests_part_1() {
     local base_ref
     base_ref="$(get_base_ref)"
 
-    if [[ "$base_ref" == "master" ]] || is_tagged; then
+    if is_openshift_CI_rehearse_PR; then
+        info "On an openshift rehearse PR, running BAT tests only..."
+        make -C qa-tests-backend bat-test || touch FAIL
+    elif [[ "$base_ref" == "master" ]] || is_tagged; then
         info "On master or tagged, running all QA tests..."
         make -C qa-tests-backend test || touch FAIL
     elif pr_has_label ci-all-qa-tests; then

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -110,7 +110,7 @@ deploy_webhook_server() {
 
     local certs_dir
     certs_dir="$(mktemp -d)"
-    (unset NAMESPACE; "${ROOT}/scripts/ci/create-webhookserver.sh" "${certs_dir}")
+    "${ROOT}/scripts/ci/create-webhookserver.sh" "${certs_dir}"
     ci_export GENERIC_WEBHOOK_SERVER_CA_CONTENTS "$(cat "${certs_dir}/ca.crt")"
 }
 

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -110,7 +110,7 @@ deploy_webhook_server() {
 
     local certs_dir
     certs_dir="$(mktemp -d)"
-    "${ROOT}/scripts/ci/create-webhookserver.sh" "${certs_dir}"
+    NAMESPACE="" "${ROOT}/scripts/ci/create-webhookserver.sh" "${certs_dir}"
     ci_export GENERIC_WEBHOOK_SERVER_CA_CONTENTS "$(cat "${certs_dir}/ca.crt")"
 }
 

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -16,6 +16,8 @@ test_part_1() {
     require_environment "ORCHESTRATOR_FLAVOR"
     require_environment "KUBECONFIG"
 
+    export_test_environment
+
     if is_OPENSHIFT_CI; then
         # TODO(RS-494) may provide roxctl
         make cli-linux
@@ -46,6 +48,23 @@ test_part_1() {
     get_ECR_docker_pull_password
 
     run_tests_part_1
+}
+
+# export_test_environment() - Persist environment variables for the remainder of
+# this context (context == whatever pod or VM this test is running in)
+# Existing settings are maintained to allow override for different test flavors.
+export_test_environment() {
+    ci_export ADMISSION_CONTROLLER_UPDATES "${ADMISSION_CONTROLLER_UPDATES:-true}"
+    ci_export ADMISSION_CONTROLLER "${ADMISSION_CONTROLLER:-true}"
+    ci_export COLLECTION_METHOD "${COLLECTION_METHOD:-ebpf}"
+    ci_export GCP_IMAGE_TYPE "${GCP_IMAGE_TYPE:-COS}"
+    ci_export LOAD_BALANCER "${LOAD_BALANCER:-none}"
+    ci_export LOCAL_PORT "${LOCAL_PORT:-443}"
+    ci_export MONITORING_SUPPORT "${MONITORING_SUPPORT:-false}"
+    ci_export ROX_BASELINE_GENERATION_DURATION "${ROX_BASELINE_GENERATION_DURATION:-1m}"
+    ci_export ROX_NETWORK_BASELINE_OBSERVATION_PERIOD "${ROX_NETWORK_BASELINE_OBSERVATION_PERIOD:-2m}"
+    ci_export ROX_NEW_POLICY_CATEGORIES "${ROX_NEW_POLICY_CATEGORIES:-true}"
+    ci_export SCANNER_SUPPORT "${SCANNER_SUPPORT:-true}"
 }
 
 deploy_central() {

--- a/qa-tests-backend/scripts/run-part-2.sh
+++ b/qa-tests-backend/scripts/run-part-2.sh
@@ -8,7 +8,7 @@ source "$ROOT/scripts/ci/lib.sh"
 set -euo pipefail
 
 run_tests_part_2() {
-    info "QA Automation Platform Part 1"
+    info "QA Automation Platform Part 2"
 
     export CLUSTER="${ORCHESTRATOR_FLAVOR^^}"
 

--- a/qa-tests-backend/scripts/run-part-2.sh
+++ b/qa-tests-backend/scripts/run-part-2.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Tests part II of qa-tests-backend. Formerly CircleCI gke-api-e2e-tests.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+source "$ROOT/scripts/ci/lib.sh"
+
+set -euo pipefail
+
+run_tests_part_2() {
+    info "QA Automation Platform Part 1"
+
+    export CLUSTER="${ORCHESTRATOR_FLAVOR^^}"
+
+    rm -f FAIL
+    make -C qa-tests-backend sensor-bounce-test || touch FAIL
+
+    store_qa_test_results "part-2-tests"
+    [[ ! -f FAIL ]] || die "Part 2 tests failed"
+}
+
+run_tests_part_2

--- a/scripts/ci/collect-service-logs.sh
+++ b/scripts/ci/collect-service-logs.sh
@@ -51,7 +51,7 @@ main() {
         echo ">>> ${object} <<<"
         out="$(mktemp)"
         if ! kubectl -n "${namespace}" get "${object}" -o wide > "$out" 2>&1; then
-            echo "Cannot get $object in $namespace: $out"
+            echo "Cannot get $object in $namespace: $(cat "$out")"
             continue
         fi
 

--- a/scripts/ci/collect-service-logs.sh
+++ b/scripts/ci/collect-service-logs.sh
@@ -49,7 +49,7 @@ main() {
     for object in deployments services pods secrets serviceaccounts validatingwebhookconfigurations catalogsources subscriptions clusterserviceversions; do
         # A feel good command before pulling logs
         echo ">>> ${object} <<<"
-        kubectl -n "${namespace}" get "${object}" -o wide
+        kubectl -n "${namespace}" get "${object}" -o wide 2>&1 | sed -e 's/^/out: /' # (prefix output to avoid triggering prow log focus)
 
         mkdir -p "${log_dir}/${object}"
 

--- a/scripts/ci/collect-service-logs.sh
+++ b/scripts/ci/collect-service-logs.sh
@@ -54,6 +54,7 @@ main() {
             echo "Cannot get $object in $namespace: $(cat "$out")"
             continue
         fi
+        cat "$out"
 
         mkdir -p "${log_dir}/${object}"
 

--- a/scripts/ci/collect-service-logs.sh
+++ b/scripts/ci/collect-service-logs.sh
@@ -49,7 +49,11 @@ main() {
     for object in deployments services pods secrets serviceaccounts validatingwebhookconfigurations catalogsources subscriptions clusterserviceversions; do
         # A feel good command before pulling logs
         echo ">>> ${object} <<<"
-        kubectl -n "${namespace}" get "${object}" -o wide 2>&1 | sed -e 's/^/out: /' # (prefix output to avoid triggering prow log focus)
+        out="$(mktemp)"
+        if ! kubectl -n "${namespace}" get "${object}" -o wide > "$out" 2>&1; then
+            echo "Cannot get $object in $namespace: $out"
+            continue
+        fi
 
         mkdir -p "${log_dir}/${object}"
 

--- a/scripts/ci/create-webhookserver.sh
+++ b/scripts/ci/create-webhookserver.sh
@@ -26,7 +26,7 @@ gitroot="$(git rev-parse --show-toplevel)"
 cd "${gitroot}/webhookserver"
 mkdir -p chart/certs
 cp "${certs_tmp_dir}/tls.crt" "${certs_tmp_dir}/tls.key" chart/certs
-helm upgrade --install webhookserver chart/
+helm -n stackrox upgrade --install webhookserver chart/
 
 sleep 5
 pod="$(kubectl -n stackrox get pod -l app=webhookserver -o name)"

--- a/scripts/ci/gate-jobs-config.json
+++ b/scripts/ci/gate-jobs-config.json
@@ -1,4 +1,12 @@
 {
+    "gke-qa-e2e-tests": {
+        "run_with_labels": [],
+        "skip_with_label": "ci-no-qa-tests",
+        "run_with_changed_path": "^.*$",
+        "changed_path_to_ignore": "^ui/",
+        "run_on_master": "true",
+        "run_on_tags": "true"
+    },
     "gke-upgrade-tests": {
         "run_with_labels": ["ci-upgrade-tests"],
         "skip_with_label": "ci-no-upgrade-tests",

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -696,6 +696,13 @@ openshift_ci_mods() {
     # For gradle
     export GRADLE_USER_HOME="${HOME}"
 
+    # NAMESPACE is injected by OpenShift CI for the cluster running tests but
+    # can have side effects for stackrox tests e.g. with helm.
+    if [[ -n "$NAMESPACE" ]]; then
+        export OPENSHIFT_CI_NAMESPACE="$NAMESPACE"
+        unset NAMESPACE
+    fi
+
     # Prow tests PRs rebased against master. This is a pain during migration
     # because Circle CI does not and so images built in Circle CI have different
     # tags.

--- a/scripts/ci/store-artifacts.bats
+++ b/scripts/ci/store-artifacts.bats
@@ -79,6 +79,7 @@ make_env() {
         GS_URL="gs://roxci-artifacts/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_WORKFLOW_ID}/${CIRCLE_BUILD_NUM}-${CIRCLE_JOB}"
     fi
     PATH="$BATS_RUN_TMPDIR:$PATH"
+    TEST_OUTPUT=1
 }
 
 mock_gcloud() {

--- a/scripts/ci/store-artifacts.sh
+++ b/scripts/ci/store-artifacts.sh
@@ -43,12 +43,13 @@ store_artifacts() {
     local gs_destination
     gs_destination=$(get_unique_gs_destination "${destination}")
 
-    info "Writing to $gs_destination"
+    info "Writing to $gs_destination..."
     local exitstatus=0
     local tmp_out
     tmp_out="$(mktemp)"
     gsutil -m cp -r "$path" "$gs_destination" > "${tmp_out}" 2>&1 || exitstatus=$?
     [[ $exitstatus -eq 0 ]] || { info "gsutil cp failed:"; cat "${tmp_out}"; exit $exitstatus; }
+    [[ ${TEST_OUTPUT:-0} -eq 0 ]] || cat "${tmp_out}"
 }
 
 _artifacts_preamble() {

--- a/scripts/ci/store-artifacts.sh
+++ b/scripts/ci/store-artifacts.sh
@@ -44,7 +44,11 @@ store_artifacts() {
     gs_destination=$(get_unique_gs_destination "${destination}")
 
     info "Writing to $gs_destination"
-    gsutil -m cp -r "$path" "$gs_destination"
+    local exitstatus=0
+    local tmp_out
+    tmp_out="$(mktemp)"
+    gsutil -m cp -r "$path" "$gs_destination" > "${tmp_out}" 2>&1 || exitstatus=$?
+    [[ $exitstatus -eq 0 ]] || { info "gsutil cp failed:"; cat "${tmp_out}"; exit $exitstatus; }
 }
 
 _artifacts_preamble() {
@@ -129,7 +133,7 @@ make_artifacts_help() {
     local help_file
     if is_OPENSHIFT_CI; then
         require_environment "ARTIFACT_DIR"
-        help_file="$ARTIFACT_DIR/howto-locate-artifacts.html"
+        help_file="$ARTIFACT_DIR/howto-locate-other-artifacts.html"
     elif is_CIRCLECI; then
         help_file="/tmp/howto-locate-artifacts.html"
     else

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -257,6 +257,24 @@ restore_56_1_backup() {
         central db restore --timeout 2m stackrox_56_1_fixed_upgrade.zip
 }
 
+db_backup_and_restore_test() {
+    info "Running a backup and restore test"
+
+    if [[ "$#" -ne 1 ]]; then
+        die "missing args. usage: db_backup_and_restore_test <output dir>"
+    fi
+
+    local output_dir="$1/central-backup"
+    info "Backing up to $1/central-backup"
+    mkdir -p "$output_dir"
+    roxctl -e "${API_ENDPOINT}" -p "${ROX_PASSWORD}" central backup --output "$output_dir"
+
+    info "Restoring from $1/central-backup"
+    roxctl -e "${API_ENDPOINT}" -p "${ROX_PASSWORD}" central db restore "$output_dir"/stackrox_db_*
+
+    collect_and_check_stackrox_logs "$1" "stackrox-logs"
+}
+
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     if [[ "$#" -lt 1 ]]; then
         usage

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -107,7 +107,7 @@ check_stackrox_logs() {
     if [[ -n "$previous_logs" ]]; then
         echo >&2 "Previous logs found"
         # shellcheck disable=SC2086
-        if ! scripts/ci/logcheck/check-restart-logs.sh upgrade-tests $previous_logs; then
+        if ! scripts/ci/logcheck/check-restart-logs.sh "${CI_JOB_NAME}" $previous_logs; then
             exit 1
         fi
     fi
@@ -274,7 +274,7 @@ db_backup_and_restore_test() {
         roxctl -e "${API_ENDPOINT}" -p "${ROX_PASSWORD}" central db restore "$output_dir"/stackrox_db_* || touch DB_TEST_FAIL
     fi
 
-    collect_and_check_stackrox_logs "$1" "stackrox-logs"
+    ./scripts/ci/collect-service-logs.sh stackrox "$1/service-logs"
 
     [[ ! -f DB_TEST_FAIL ]] || die "The DB test failed"
 }

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -122,7 +122,7 @@ check_for_stackrox_restarts() {
     if [[ -n "$previous_logs" ]]; then
         echo >&2 "Previous logs found"
         # shellcheck disable=SC2086
-        if ! scripts/ci/logcheck/check-restart-logs.sh "${CI_JOB_NAME}" $previous_logs; then
+        if ! scripts/ci/logcheck/check-restart-logs.sh "${CI_JOB_NAME:-${CIRCLE_JOB}}" $previous_logs; then
             exit 1
         fi
     fi

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -99,7 +99,22 @@ check_stackrox_logs() {
     local dir="$1"
 
     if [[ ! -d "$dir/stackrox/pods" ]]; then
-        die "StackRox logs were not collected. (See ./scripts/ci/collect-service-logs.sh stackrox)"
+        die "StackRox logs were not collected. (Use ./scripts/ci/collect-service-logs.sh stackrox)"
+    fi
+
+    check_for_stackrox_restarts "$dir"
+    check_for_errors_in_stackrox_logs "$dir"
+}
+
+check_for_stackrox_restarts() {
+        if [[ "$#" -ne 1 ]]; then
+        die "missing args. usage: check_for_stackrox_restarts <dir>"
+    fi
+
+    local dir="$1"
+
+    if [[ ! -d "$dir/stackrox/pods" ]]; then
+        die "StackRox logs were not collected. (Use ./scripts/ci/collect-service-logs.sh stackrox)"
     fi
 
     local previous_logs
@@ -110,6 +125,18 @@ check_stackrox_logs() {
         if ! scripts/ci/logcheck/check-restart-logs.sh "${CI_JOB_NAME}" $previous_logs; then
             exit 1
         fi
+    fi
+}
+
+check_for_errors_in_stackrox_logs() {
+    if [[ "$#" -ne 1 ]]; then
+        die "missing args. usage: check_for_errors_in_stackrox_logs <dir>"
+    fi
+
+    local dir="$1"
+
+    if [[ ! -d "$dir/stackrox/pods" ]]; then
+        die "StackRox logs were not collected. (Use ./scripts/ci/collect-service-logs.sh stackrox)"
     fi
 
     local logs

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -291,17 +291,15 @@ db_backup_and_restore_test() {
         die "missing args. usage: db_backup_and_restore_test <output dir>"
     fi
 
-    local output_dir="$1/central-backup"
-    info "Backing up to $1/central-backup"
+    local output_dir="$1"
+    info "Backing up to $1"
     mkdir -p "$output_dir"
     roxctl -e "${API_ENDPOINT}" -p "${ROX_PASSWORD}" central backup --output "$output_dir" || touch DB_TEST_FAIL
 
     if [[ ! -e DB_TEST_FAIL ]]; then
-        info "Restoring from $1/central-backup"
+        info "Restoring from $1"
         roxctl -e "${API_ENDPOINT}" -p "${ROX_PASSWORD}" central db restore "$output_dir"/stackrox_db_* || touch DB_TEST_FAIL
     fi
-
-    ./scripts/ci/collect-service-logs.sh stackrox "$1/service-logs"
 
     [[ ! -f DB_TEST_FAIL ]] || die "The DB test failed"
 }

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -231,7 +231,7 @@ install_metrics_server_and_deactivate() {
     echo "Waiting for metrics.k8s.io to be in kubectl API resources..."
     local success=0
     for i in $(seq 1 10); do
-        if kubectl api-resources | grep metrics.k8s.io; then
+        if kubectl api-resources 2>&1 | sed -e 's/^/out: /' | grep metrics.k8s.io; then
             success=1
             break
         fi
@@ -253,7 +253,7 @@ install_metrics_server_and_deactivate() {
         fi
         echo "metrics.k8s.io still in API resources. Will try again..."
         cat stdout.out
-        cat stderr.out
+        sed -e 's/^/out: /' < stderr.out # (prefix output to avoid triggering prow log focus)
         sleep 5
     done
     [[ "$success" -eq 1 ]]


### PR DESCRIPTION
## Description

This PR enables `gke-qa-e2e-tests` (formerly `gke-api-e2e-tests`) for OpenShift CI.

## Checklist
- [x] Investigated and inspected CI test results

## Test Plan

May/23/2022: A hard 2 hour timeout applied to openshift/release pj-rehearse tests means that most of the negative test cases will need to happen post merge.

### gke-qa-e2e-tests

- Happy path
  - [ ] There are no spurious errors in the prow buildlog
  - [ ] Artifacts are stored similar to CCI

- Cluster create fails
  - [ ] The prow buildlog indicates it was the create that failed
  - [ ] There are no spurious errors in the prow buildlog
  - [ ] Teardown is attempted but should not block

- Unit test fails in part I (forced)
  - [ ] The test that failed is indicated
  - [ ] There are no spurious errors in the prow buildlog
  - [ ] Backend logs are gathered at point of failure and saved to artifacts
  - [ ] Part II tests still run
  - [ ] DB tests do not run
  - [ ] Artifacts are stored similar to CCI

- Test meltdown (delete cluster mid test)
  - [ ] Some number of failed tests are indicated in the prow buildlog
  - [ ] The process completes without openshift CI timeout
  - [ ] Part II tests still run
  - [ ] DB tests do not run
  - [ ] Artifacts are stored similar to CCI

- Unit test fails in part II (forced)
  - [ ] The test that failed is indicated
  - [ ] There are no spurious errors in the prow buildlog
  - [ ] Backend logs are gathered at point of failure and saved to artifacts
  - [ ] DB tests do not run
  - [ ] Artifacts are stored similar to CCI

- DB test fails at backup
  - [ ] The point of failure is indicated in the prow buildlog
  - [ ] There are no spurious errors in the prow buildlog
  - [ ] DB test artifacts are saved in artifacts

- DB test fails at restore
  - [ ] The point of failure is indicated in the prow buildlog
  - [ ] There are no spurious errors in the prow buildlog
  - [ ] DB test artifacts are saved in artifacts

- Error in central logs after part I (verifies check_stackrox_logs())
  - [ ] The cause of failure is indicated in the prow buildlog
  - [ ] There are no spurious errors in the prow buildlog
  - [ ] Part II tests still run
  - [ ] DB tests do not run
  - [ ] Artifacts are stored similar to CCI

- Error in central logs after part II (verifies check_stackrox_logs())
  - [ ] The cause of failure is indicated in the prow buildlog
  - [ ] There are no spurious errors in the prow buildlog
  - [ ] DB tests do not run
  - [ ] Artifacts are stored similar to CCI

- Error in central logs after DB test (verifies check_stackrox_logs())
  - [ ] The cause of failure is indicated in the prow buildlog
  - [ ] There are no spurious errors in the prow buildlog
  - [ ] Artifacts are stored


### gke-upgrade-tests

- Happy path
  - [ ] There are no spurious errors in the prow buildlog
  - [ ] Artifacts are stored similar to CCI

- Forced failure
  - [ ] The point of failure is indicated in the prow buildlog
  - [ ] There are no spurious errors in the prow buildlog
  - [ ] Artifacts are stored similar to CCI

### After merge tests

Pre merge these runs are rehearsed by openshift CI and the tag + label checks
will not apply to set BAT -v- all level of tests.

- [ ] On a new PR ensure that BAT only runs
- [ ] With the 'all' label ensure that all runs
- [ ] With the 'no' label ensure that QA tests do not run
- [ ] With only UI changes ensure that QA tests do not run

