### PR TITLE
ROX-10080: Derive `opensource` image flavor from branding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -923,12 +923,6 @@ commands:
       - cleanup-clusters-on-fail
 
   build:
-    parameters:
-      branding:
-        type: string
-        default: stackrox
-    environment:
-      ROX_PRODUCT_BRANDING: "<< parameters.branding >>"
     steps:
       - checkout-with-submodules
       - check-docs-step:
@@ -945,9 +939,17 @@ commands:
           at: /go/src/github.com/stackrox/rox
 
       - run:
+          name: Ensure product branding is set
+          command: |
+            [[ -n "${ROX_PRODUCT_BRANDING}" ]] || {
+              echo >&2 "Will not proceed until product branding env variable is defined"
+              exit 2
+            }
+
+      - run:
           name: Restore the branded UI
           command: |
-            cp -au ui-<< parameters.branding >>/* ui
+            cp -au "ui-${ROX_PRODUCT_BRANDING}/*" ui
 
       - *refreshAlpineBaseImage
 
@@ -976,18 +978,18 @@ commands:
           name: Push new Docker image
           command: |
             source ./scripts/ci/lib.sh
-            push_main_image_set "${CIRCLE_BRANCH}" "<< parameters.branding >>"
+            push_main_image_set "${CIRCLE_BRANCH}" "${ROX_PRODUCT_BRANDING}"
 
       - run:
           name: Push collector & scanner images tagged with main-version to registries
           command: |
             source ./scripts/ci/lib.sh
-            push_matching_collector_scanner_images "<< parameters.branding >>"
+            push_matching_collector_scanner_images "${ROX_PRODUCT_BRANDING}"
 
       - run:
           name: Publish new versions of NPM packages if any
           command: |
-            if [[ "${CIRCLE_BRANCH}" == "master" && "<< parameters.branding >>" == "STACKROX_BRANDING" ]]; then
+            if [[ "${CIRCLE_BRANCH}" == "master" && "${ROX_PRODUCT_BRANDING}" == "STACKROX_BRANDING" ]]; then
               echo "//npm.pkg.github.com/:_authToken=\"$GITHUB_PACKAGES_PUBLISH_TOKEN\"" > ~/.npmrc
               make ui-publish-packages
             else
@@ -1007,7 +1009,7 @@ commands:
       - run:
           name: Comment on PR
           command: |
-            if [[ "<< parameters.branding >>" == "STACKROX_BRANDING" ]]; then
+            if [[ "${ROX_PRODUCT_BRANDING}" == "STACKROX_BRANDING" ]]; then
               wget --quiet https://github.com/joshdk/hub-comment/releases/download/0.1.0-rc6/hub-comment_linux_amd64
               echo "2a2640f44737873dfe30da0d5b8453419d48a494f277a70fd9108e4204fc4a53 hub-comment_linux_amd64" | sha256sum -c -
               sudo install hub-comment_linux_amd64 /usr/bin/hub-comment
@@ -2765,18 +2767,18 @@ jobs:
     resource_class: medium
     environment:
       EKS_AUTOMATION_VERSION: 0.2.17
+      ROX_PRODUCT_BRANDING: "STACKROX_BRANDING"
     steps:
       - build:
-          branding: STACKROX_BRANDING
 
   build-rhacs:
     executor: custom
     resource_class: medium
     environment:
       EKS_AUTOMATION_VERSION: 0.2.17
+      ROX_PRODUCT_BRANDING: "RHACS_BRANDING"
     steps:
       - build:
-          branding: RHACS_BRANDING
 
   build-race-condition-debug-image:
     executor: custom

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -960,11 +960,7 @@ commands:
       - run:
           name: Build main image
           command: |
-            PARAMS=(ROX_PRODUCT_BRANDING="<< parameters.branding >>")
-            if [[ "<< parameters.branding >>" == "STACKROX_BRANDING" ]]; then
-              PARAMS+=(ROX_IMAGE_FLAVOR="opensource")
-            fi
-            make docker-build-main-image "${PARAMS[@]}"
+            make docker-build-main-image ROX_PRODUCT_BRANDING="<< parameters.branding >>"
 
       - run:
           name: Check debugger presence in the main image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -949,7 +949,7 @@ commands:
       - run:
           name: Restore the branded UI
           command: |
-            cp -au "ui-${ROX_PRODUCT_BRANDING}/*" ui
+            cp -au ui-${ROX_PRODUCT_BRANDING}/* ui
 
       - *refreshAlpineBaseImage
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -942,7 +942,7 @@ commands:
           name: Ensure product branding is set
           command: |
             if [[ -z "${ROX_PRODUCT_BRANDING}" ]]; then
-              echo >&2 "Will not proceed until product branding env variable is defined"
+              echo >&2 "Will not proceed until ROX_PRODUCT_BRANDING env variable is defined"
               exit 2
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -941,10 +941,10 @@ commands:
       - run:
           name: Ensure product branding is set
           command: |
-            [[ -n "${ROX_PRODUCT_BRANDING}" ]] || {
+            if [[ -z "${ROX_PRODUCT_BRANDING}" ]]; then
               echo >&2 "Will not proceed until product branding env variable is defined"
               exit 2
-            }
+            fi
 
       - run:
           name: Restore the branded UI
@@ -2769,7 +2769,7 @@ jobs:
       EKS_AUTOMATION_VERSION: 0.2.17
       ROX_PRODUCT_BRANDING: "STACKROX_BRANDING"
     steps:
-      - build:
+      - build
 
   build-rhacs:
     executor: custom
@@ -2778,7 +2778,7 @@ jobs:
       EKS_AUTOMATION_VERSION: 0.2.17
       ROX_PRODUCT_BRANDING: "RHACS_BRANDING"
     steps:
-      - build:
+      - build
 
   build-race-condition-debug-image:
     executor: custom

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -927,6 +927,8 @@ commands:
       branding:
         type: string
         default: stackrox
+    environment:
+      ROX_PRODUCT_BRANDING: "<< parameters.branding >>"
     steps:
       - checkout-with-submodules
       - check-docs-step:
@@ -960,7 +962,7 @@ commands:
       - run:
           name: Build main image
           command: |
-            make docker-build-main-image ROX_PRODUCT_BRANDING="<< parameters.branding >>"
+            make docker-build-main-image
 
       - run:
           name: Check debugger presence in the main image

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,7 @@ ROX_IMAGE_FLAVOR ?= $(shell \
 	fi)
 
 DEFAULT_IMAGE_REGISTRY := quay.io/stackrox-io
-BUILD_IMAGE_VERSION=$(shell sed 's/\s*\#.*//' BUILD_IMAGE_VERSION)
-BUILD_IMAGE := $(DEFAULT_IMAGE_REGISTRY)/apollo-ci:$(BUILD_IMAGE_VERSION)
+BUILD_IMAGE := quay.io/stackrox-io/apollo-ci:$(shell sed 's/\s*\#.*//' BUILD_IMAGE_VERSION)
 DOCS_IMAGE_BASE := $(DEFAULT_IMAGE_REGISTRY)/docs
 
 ifdef CI

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ ROX_IMAGE_FLAVOR ?= $(shell \
 BUILD_IMAGE := quay.io/stackrox-io/apollo-ci:$(shell sed 's/\s*\#.*//' BUILD_IMAGE_VERSION)
 
 DEFAULT_IMAGE_REGISTRY := quay.io/stackrox-io
-ifneq ($(ROX_PRODUCT_BRANDING),STACKROX_BRANDING)
+ifeq ($(ROX_PRODUCT_BRANDING),RHACS_BRANDING)
 	DEFAULT_IMAGE_REGISTRY := quay.io/rhacs-eng
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,13 @@ ROX_IMAGE_FLAVOR ?= $(shell \
 
 DEFAULT_IMAGE_REGISTRY := quay.io/stackrox-io
 BUILD_IMAGE := quay.io/stackrox-io/apollo-ci:$(shell sed 's/\s*\#.*//' BUILD_IMAGE_VERSION)
-DOCS_IMAGE_BASE := $(DEFAULT_IMAGE_REGISTRY)/docs
 
+DOCS_IMAGE_BASE := $(DEFAULT_IMAGE_REGISTRY)
 ifdef CI
-    DOCS_IMAGE_BASE := quay.io/rhacs-eng/docs
+    DOCS_IMAGE_BASE := quay.io/rhacs-eng
 endif
 
-DOCS_IMAGE = $(DOCS_IMAGE_BASE):$(shell make --quiet --no-print-directory docs-tag)
+DOCS_IMAGE = $(DOCS_IMAGE_BASE)/docs:$(shell make --quiet --no-print-directory docs-tag)
 
 GOBUILD := $(CURDIR)/scripts/go-build.sh
 

--- a/Makefile
+++ b/Makefile
@@ -32,15 +32,14 @@ ROX_IMAGE_FLAVOR ?= $(shell \
 	  echo "development_build"; \
 	fi)
 
-DEFAULT_IMAGE_REGISTRY := quay.io/stackrox-io
 BUILD_IMAGE := quay.io/stackrox-io/apollo-ci:$(shell sed 's/\s*\#.*//' BUILD_IMAGE_VERSION)
 
-DOCS_IMAGE_BASE := $(DEFAULT_IMAGE_REGISTRY)
-ifdef CI
-    DOCS_IMAGE_BASE := quay.io/rhacs-eng
+DEFAULT_IMAGE_REGISTRY := quay.io/stackrox-io
+ifneq ($(ROX_PRODUCT_BRANDING),STACKROX_BRANDING)
+	DEFAULT_IMAGE_REGISTRY := quay.io/rhacs-eng
 endif
 
-DOCS_IMAGE = $(DOCS_IMAGE_BASE)/docs:$(shell make --quiet --no-print-directory docs-tag)
+DOCS_IMAGE = $(DEFAULT_IMAGE_REGISTRY)/docs:$(shell make --quiet --no-print-directory docs-tag)
 
 GOBUILD := $(CURDIR)/scripts/go-build.sh
 

--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,19 @@ else
 QUAY_TAG_EXPIRATION=never
 endif
 
-# ROX_IMAGE_FLAVOR is an ARG used in Dockerfiles that defines the default registries for main, scaner, and collector images.
-# ROX_IMAGE_FLAVOR valid values are: development_build, stackrox.io, rhacs.
-# The value is assigned as following:
-# 1. Use environment variable if provided.
-# 2. If makefile variable GOTAGS is contains "release", use "stackrox.io".
-# 3. Otherwise set it to "development_build" by default, e.g. for developers running the Makefile locally.
-ROX_IMAGE_FLAVOR ?= $(shell if [[ "$(GOTAGS)" == *"$(RELEASE_GOTAGS)"* ]]; then echo "stackrox.io"; else echo "development_build"; fi)
-
 ROX_PRODUCT_BRANDING ?= STACKROX_BRANDING
+
+# ROX_IMAGE_FLAVOR is an ARG used in Dockerfiles that defines the default registries for main, scaner, and collector images.
+# ROX_IMAGE_FLAVOR valid values are: development_build, stackrox.io, rhacs, opensource.
+ROX_IMAGE_FLAVOR ?= $(shell \
+	if [[ "$(ROX_PRODUCT_BRANDING)" == "STACKROX_BRANDING" ]]; then \
+	  echo "opensource"; \
+	elif [[ "$(GOTAGS)" == *"$(RELEASE_GOTAGS)"* ]]; then \
+	  echo "stackrox.io"; \
+	else \
+	  echo "development_build"; \
+	fi)
+
 DEFAULT_IMAGE_REGISTRY := quay.io/stackrox-io
 BUILD_IMAGE_VERSION=$(shell sed 's/\s*\#.*//' BUILD_IMAGE_VERSION)
 BUILD_IMAGE := $(DEFAULT_IMAGE_REGISTRY)/apollo-ci:$(BUILD_IMAGE_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,7 @@ BUILD_IMAGE := quay.io/stackrox-io/apollo-ci:$(shell sed 's/\s*\#.*//' BUILD_IMA
 DOCS_IMAGE_BASE := $(DEFAULT_IMAGE_REGISTRY)/docs
 
 ifdef CI
-    CI_QUAY_REPO := rhacs-eng
-    DOCS_IMAGE_BASE := quay.io/$(CI_QUAY_REPO)/docs
+    DOCS_IMAGE_BASE := quay.io/rhacs-eng/docs
 endif
 
 DOCS_IMAGE = $(DOCS_IMAGE_BASE):$(shell make --quiet --no-print-directory docs-tag)
@@ -595,21 +594,27 @@ scale-image: scale-build clean-image
 	cp bin/linux/profiler scale/image/bin/profiler
 	cp bin/linux/chaos scale/image/bin/chaos
 	chmod +w scale/image/bin/*
-	docker build -t stackrox/scale:$(TAG) -f scale/image/Dockerfile scale
-	docker tag stackrox/scale:$(TAG) quay.io/$(CI_QUAY_REPO)/scale:$(TAG)
+	docker build \
+		-t stackrox/scale:$(TAG) \
+		-t quay.io/rhacs-eng/scale:$(TAG) \
+		-f scale/image/Dockerfile scale
 
 webhookserver-image: webhookserver-build
 	-mkdir webhookserver/bin
 	cp bin/linux/webhookserver webhookserver/bin/webhookserver
 	chmod +w webhookserver/bin/webhookserver
-	docker build -t stackrox/webhookserver:1.2 -f webhookserver/Dockerfile webhookserver
-	docker tag stackrox/webhookserver:1.2 quay.io/$(CI_QUAY_REPO)/webhookserver:1.2
+	docker build \
+		-t stackrox/webhookserver:1.2 \
+		-t quay.io/rhacs-eng/webhookserver:1.2 \
+		-f webhookserver/Dockerfile webhookserver
 
 .PHONY: mock-grpc-server-image
 mock-grpc-server-image: mock-grpc-server-build clean-image
 	cp bin/linux/mock-grpc-server integration-tests/mock-grpc-server/image/bin/mock-grpc-server
-	docker build -t stackrox/grpc-server:$(TAG) integration-tests/mock-grpc-server/image
-	docker tag stackrox/grpc-server:$(TAG) quay.io/$(CI_QUAY_REPO)/grpc-server:$(TAG)
+	docker build \
+		-t stackrox/grpc-server:$(TAG) \
+		-t quay.io/rhacs-eng/grpc-server:$(TAG) \
+		integration-tests/mock-grpc-server/image
 
 $(CURDIR)/image/postgres/bundle.tar.gz:
 	/usr/bin/env DEBUG_BUILD="$(DEBUG_BUILD)" $(CURDIR)/image/postgres/create-bundle.sh $(CURDIR)/image/postgres $(CURDIR)/image/postgres


### PR DESCRIPTION
## Description

While looking at https://github.com/stackrox/stackrox/pull/1707 I realized that:
1. `Makefile` would assume non-open source flavor when ran standalone (e.g. with `make image`). We don't want that, we want open source users who clone the repo to be able to see open source image flavor by default, without overriding anything.
2. `Makefile` would tag images for `quay.io/stackrox-io` in all cases, even when non-open source flavor is selected. While not many developers on the team have write permissions to `quay.io/stackrox-io`, this still feels wrong and confusing.

I moved derivation of image flavor to the `Makefile` and made a couple other cleanups there.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~ can't think of such tests.
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ not worth a changelog record.
- ~~[ ] Determined and documented upgrade steps~~ not needed.
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~ not needed.

## Testing Performed

* For now only CI.