### PR TITLE
ROX-10732: SAC NetworkBaseline tests

### DIFF
--- a/central/networkbaseline/datastore/datastore_impl_test.go
+++ b/central/networkbaseline/datastore/datastore_impl_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"testing"
 
-	"github.com/golang/mock/gomock"
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/central/networkbaseline/store"
-	"github.com/stackrox/rox/central/networkbaseline/store/rocksdb"
+	pgStore "github.com/stackrox/rox/central/networkbaseline/store/postgres"
+	rdbStore "github.com/stackrox/rox/central/networkbaseline/store/rocksdb"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
-	pkgRocksDB "github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stretchr/testify/suite"
 )
@@ -27,23 +30,43 @@ func TestNetworkBaselineDatastoreSuite(t *testing.T) {
 type NetworkBaselineDataStoreTestSuite struct {
 	suite.Suite
 
-	datastore *dataStoreImpl
+	datastore DataStore
 	storage   store.Store
-
-	mockCtrl *gomock.Controller
+	pool      *pgxpool.Pool
+	engine    *rocksdb.RocksDB
 }
 
-func (suite *NetworkBaselineDataStoreTestSuite) SetupTest() {
-	mockCtrl := gomock.NewController(suite.T())
-	suite.mockCtrl = mockCtrl
-	db, err := pkgRocksDB.NewTemp(suite.T().Name())
-	suite.Require().NoError(err)
-	suite.storage = rocksdb.New(db)
-	suite.datastore = newNetworkBaselineDataStore(suite.storage).(*dataStoreImpl)
+var _ interface {
+	suite.SetupAllSuite
+	suite.TearDownAllSuite
+} = (*NetworkBaselineDataStoreTestSuite)(nil)
+
+func (suite *NetworkBaselineDataStoreTestSuite) SetupSuite() {
+	if features.PostgresDatastore.Enabled() {
+		ctx := context.Background()
+		source := pgtest.GetConnectionString(suite.T())
+		config, err := pgxpool.ParseConfig(source)
+		suite.NoError(err)
+		suite.pool, err = pgxpool.ConnectConfig(ctx, config)
+		suite.NoError(err)
+		pgStore.Destroy(ctx, suite.pool)
+		suite.storage = pgStore.New(ctx, suite.pool)
+	} else {
+		var err error
+		suite.engine, err = rocksdb.NewTemp(suite.T().Name())
+		suite.Require().NoError(err)
+		suite.storage = rdbStore.New(suite.engine)
+	}
+	suite.datastore = newNetworkBaselineDataStore(suite.storage)
 }
 
-func (suite *NetworkBaselineDataStoreTestSuite) TearDownTest() {
-	suite.mockCtrl.Finish()
+func (suite *NetworkBaselineDataStoreTestSuite) TearDownSuite() {
+	if features.PostgresDatastore.Enabled() {
+		suite.pool.Close()
+	} else {
+		err := rocksdb.CloseAndRemove(suite.engine)
+		suite.NoError(err)
+	}
 }
 
 func (suite *NetworkBaselineDataStoreTestSuite) mustGetBaseline(ctx context.Context, deploymentID string) (*storage.NetworkBaseline, bool) {
@@ -133,6 +156,12 @@ func (suite *NetworkBaselineDataStoreTestSuite) TestSAC() {
 				sac.ClusterScopeKeys(expectedBaseline.GetClusterId()),
 				sac.NamespaceScopeKeys(expectedBaseline.GetNamespace())))
 
+	ctxWithUnrestrictedWriteAccess :=
+		sac.WithGlobalAccessScopeChecker(context.Background(),
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resources.NetworkBaseline)))
+
 	// Test Update
 	{
 		expectedBaseline.Locked = !expectedBaseline.Locked
@@ -164,5 +193,26 @@ func (suite *NetworkBaselineDataStoreTestSuite) TestSAC() {
 		suite.Error(suite.datastore.DeleteNetworkBaseline(ctxWithReadAccess, expectedBaseline.GetDeploymentId()), "permission denied")
 		suite.Error(suite.datastore.DeleteNetworkBaseline(ctxWithWrongClusterWriteAccess, expectedBaseline.GetDeploymentId()), "permission denied")
 		suite.Nil(suite.datastore.DeleteNetworkBaseline(ctxWithWriteAccess, expectedBaseline.GetDeploymentId()))
+		_, ok := suite.mustGetBaseline(ctxWithReadAccess, expectedBaseline.GetDeploymentId())
+		suite.False(ok)
+	}
+
+	// Test Delete Multiple
+	{
+		nbs := fixtures.GetSACTestNetworkBaseline()
+		var ids []string
+		for _, nb := range nbs {
+			ids = append(ids, nb.GetDeploymentId())
+		}
+
+		suite.Nil(suite.datastore.UpsertNetworkBaselines(ctxWithUnrestrictedWriteAccess, nbs))
+		suite.Error(suite.datastore.DeleteNetworkBaselines(ctxWithWrongClusterReadAccess, ids), "permission denied")
+		suite.Error(suite.datastore.DeleteNetworkBaselines(ctxWithReadAccess, ids), "permission denied")
+		suite.Error(suite.datastore.DeleteNetworkBaselines(ctxWithWrongClusterWriteAccess, ids), "permission denied")
+		suite.Nil(suite.datastore.DeleteNetworkBaselines(ctxWithUnrestrictedWriteAccess, ids))
+		for _, id := range ids {
+			_, ok := suite.mustGetBaseline(ctxWithReadAccess, id)
+			suite.False(ok)
+		}
 	}
 }

--- a/central/networkbaseline/datastore/datastore_sac_test.go
+++ b/central/networkbaseline/datastore/datastore_sac_test.go
@@ -1,0 +1,363 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/central/networkbaseline/store"
+	pgStore "github.com/stackrox/rox/central/networkbaseline/store/postgres"
+	rdbStore "github.com/stackrox/rox/central/networkbaseline/store/rocksdb"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/sac/testutils"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	cleanupCtxKey = testutils.UnrestrictedReadWriteCtx
+)
+
+func TestNetworkBaselineDatastoreSAC(t *testing.T) {
+	suite.Run(t, new(networkBaselineDatastoreSACTestSuite))
+}
+
+type networkBaselineDatastoreSACTestSuite struct {
+	suite.Suite
+	engine       *rocksdb.RocksDB
+	pool         *pgxpool.Pool
+	storage      store.Store
+	datastore    DataStore
+	testContexts map[string]context.Context
+	testNBIDs    []string
+}
+
+var _ interface {
+	suite.SetupAllSuite
+	suite.TearDownAllSuite
+	suite.SetupTestSuite
+	suite.TearDownTestSuite
+} = (*networkBaselineDatastoreSACTestSuite)(nil)
+
+func (s *networkBaselineDatastoreSACTestSuite) SetupSuite() {
+	var err error
+	networkBaselineObj := "networkBaselineSACTest"
+
+	if features.PostgresDatastore.Enabled() {
+		ctx := context.Background()
+		source := pgtest.GetConnectionString(s.T())
+		config, err := pgxpool.ParseConfig(source)
+		s.NoError(err)
+		s.pool, err = pgxpool.ConnectConfig(ctx, config)
+		s.NoError(err)
+		pgStore.Destroy(ctx, s.pool)
+		s.storage = pgStore.New(ctx, s.pool)
+	} else {
+		s.engine, err = rocksdb.NewTemp(networkBaselineObj)
+		s.NoError(err)
+
+		s.storage = rdbStore.New(s.engine)
+	}
+	s.datastore = newNetworkBaselineDataStore(s.storage)
+
+	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.NetworkBaseline.GetResource())
+}
+
+func (s *networkBaselineDatastoreSACTestSuite) TearDownSuite() {
+	if features.PostgresDatastore.Enabled() {
+		s.pool.Close()
+	} else {
+		err := rocksdb.CloseAndRemove(s.engine)
+		s.NoError(err)
+	}
+}
+
+func (s *networkBaselineDatastoreSACTestSuite) SetupTest() {
+	s.testNBIDs = make([]string, 0)
+}
+
+func (s *networkBaselineDatastoreSACTestSuite) TearDownTest() {
+	for _, id := range s.testNBIDs {
+		s.cleanupNetworkBaseline(id)
+	}
+}
+
+type crudTest struct {
+	scopeKey      string
+	expectedError error
+	expectFound   bool
+}
+
+func (s *networkBaselineDatastoreSACTestSuite) cleanupNetworkBaseline(ID string) {
+	err := s.datastore.DeleteNetworkBaseline(s.testContexts[cleanupCtxKey], ID)
+	s.NoError(err)
+}
+
+func (s *networkBaselineDatastoreSACTestSuite) TestGetNetworkBaseline() {
+	var err error
+	testNB := fixtures.GetScopedNetworkBaseline(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
+	err = s.datastore.UpsertNetworkBaselines(s.testContexts[testutils.UnrestrictedReadWriteCtx], []*storage.NetworkBaseline{testNB})
+	s.testNBIDs = append(s.testNBIDs, testNB.GetDeploymentId())
+	s.NoError(err)
+
+	cases := map[string]crudTest{
+		"(full) read-only can read": {
+			scopeKey:    testutils.UnrestrictedReadCtx,
+			expectFound: true,
+		},
+		"full read-write can read": {
+			scopeKey:    testutils.UnrestrictedReadCtx,
+			expectFound: true,
+		},
+		"full read-write on wrong cluster cannot read": {
+			scopeKey:    testutils.Cluster1ReadWriteCtx,
+			expectFound: false,
+		},
+		"read-write on wrong cluster and wrong namespace cannot read": {
+			scopeKey:    testutils.Cluster1NamespaceAReadWriteCtx,
+			expectFound: false,
+		},
+		"read-write on wrong cluster and matching namespace cannot read": {
+			scopeKey:    testutils.Cluster1NamespaceBReadWriteCtx,
+			expectFound: false,
+		},
+		"read-write on right cluster but wrong namespaces cannot read": {
+			scopeKey:    testutils.Cluster2NamespacesACReadWriteCtx,
+			expectFound: false,
+		},
+		"full read-write on right cluster can read": {
+			scopeKey:    testutils.Cluster2ReadWriteCtx,
+			expectFound: true,
+		},
+		"read-write on the right cluster and namespace can read": {
+			scopeKey:    testutils.Cluster2NamespaceBReadWriteCtx,
+			expectFound: true,
+		},
+		"read-write on the right cluster and at least the right namespace can read": {
+			scopeKey:    testutils.Cluster2NamespacesABReadWriteCtx,
+			expectFound: true,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[c.scopeKey]
+			readNetworkBaseline, found, getErr := s.datastore.GetNetworkBaseline(ctx, testNB.GetDeploymentId())
+			s.NoError(getErr)
+			s.Equal(c.expectFound, found)
+			if c.expectFound {
+				s.Equal(testNB, readNetworkBaseline)
+			} else {
+				s.Nil(readNetworkBaseline)
+			}
+		})
+	}
+}
+
+func (s *networkBaselineDatastoreSACTestSuite) TestUpsertNetworkBaselines() {
+	cases := map[string]crudTest{
+		"(full) read-only cannot upsert": {
+			scopeKey:      testutils.UnrestrictedReadCtx,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write can upsert": {
+			scopeKey:      testutils.UnrestrictedReadWriteCtx,
+			expectedError: nil,
+		},
+		"full read-write on wrong cluster cannot upsert": {
+			scopeKey:      testutils.Cluster1ReadWriteCtx,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and wrong namespace cannot upsert": {
+			scopeKey:      testutils.Cluster1NamespaceAReadWriteCtx,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and matching namespace cannot upsert": {
+			scopeKey:      testutils.Cluster1NamespaceBReadWriteCtx,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on right cluster but wrong namespaces cannot upsert": {
+			scopeKey:      testutils.Cluster2NamespacesACReadWriteCtx,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write on right cluster can upsert": {
+			scopeKey:      testutils.Cluster2ReadWriteCtx,
+			expectedError: nil,
+		},
+		"read-write on the right cluster and namespace can upsert": {
+			scopeKey:      testutils.Cluster2NamespaceBReadWriteCtx,
+			expectedError: nil,
+		},
+		"read-write on the right cluster and at least the right namespace can upsert": {
+			scopeKey:      testutils.Cluster2NamespacesABReadWriteCtx,
+			expectedError: nil,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			testNB := fixtures.GetScopedNetworkBaseline(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
+			s.testNBIDs = append(s.testNBIDs, testNB.GetDeploymentId())
+			ctx := s.testContexts[c.scopeKey]
+			err := s.datastore.UpsertNetworkBaselines(ctx, []*storage.NetworkBaseline{testNB})
+			s.Equal(c.expectedError, err)
+
+			_, ok, err := s.datastore.GetNetworkBaseline(ctx, testNB.GetDeploymentId())
+			s.NoError(err)
+			s.Equal(c.expectedError == nil, ok, "The resource must exist if Upsert succeeded, or not otherwise")
+		})
+	}
+}
+
+func (s *networkBaselineDatastoreSACTestSuite) TestDeleteNetworkBaseline() {
+	cases := map[string]crudTest{
+		"(full) read-only cannot remove": {
+			scopeKey:      testutils.UnrestrictedReadCtx,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write can remove": {
+			scopeKey:      testutils.UnrestrictedReadWriteCtx,
+			expectedError: nil,
+		},
+		"full read-write on wrong cluster cannot remove": {
+			scopeKey:      testutils.Cluster1ReadWriteCtx,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and wrong namespace cannot remove": {
+			scopeKey:      testutils.Cluster1NamespaceAReadWriteCtx,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and matching namespace cannot remove": {
+			scopeKey:      testutils.Cluster1NamespaceBReadWriteCtx,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on right cluster but wrong namespaces cannot remove": {
+			scopeKey:      testutils.Cluster2NamespacesACReadWriteCtx,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write on right cluster can remove": {
+			scopeKey:      testutils.Cluster2ReadWriteCtx,
+			expectedError: nil,
+		},
+		"read-write on the right cluster and namespace can remove": {
+			scopeKey:      testutils.Cluster2NamespaceBReadWriteCtx,
+			expectedError: nil,
+		},
+		"read-write on the right cluster and at least the right namespace can remove": {
+			scopeKey:      testutils.Cluster2NamespacesABReadWriteCtx,
+			expectedError: nil,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			testNB := fixtures.GetScopedNetworkBaseline(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
+			s.testNBIDs = append(s.testNBIDs, testNB.GetDeploymentId())
+			s.NoError(s.datastore.UpsertNetworkBaselines(s.testContexts[testutils.UnrestrictedReadWriteCtx], []*storage.NetworkBaseline{testNB}))
+			ctx := s.testContexts[c.scopeKey]
+			err := s.datastore.DeleteNetworkBaseline(ctx, testNB.GetDeploymentId())
+			s.Equal(c.expectedError, err)
+			_, ok, err := s.datastore.GetNetworkBaseline(s.testContexts[testutils.UnrestrictedReadWriteCtx], testNB.GetDeploymentId())
+			s.NoError(err)
+			s.Equal(c.expectedError != nil, ok, "The resource must still exist if Delete failed, or not otherwise")
+		})
+	}
+}
+
+func (s *networkBaselineDatastoreSACTestSuite) TestDeleteNetworkBaselines() {
+	cases := map[string]crudTest{
+		"(full) read-only cannot remove": {
+			scopeKey:      testutils.UnrestrictedReadCtx,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write can remove": {
+			scopeKey: testutils.UnrestrictedReadWriteCtx,
+		},
+		"full read-write on wrong cluster cannot remove": {
+			scopeKey:      testutils.Cluster1ReadWriteCtx,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and wrong namespace cannot remove": {
+			scopeKey:      testutils.Cluster1NamespaceAReadWriteCtx,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and matching namespace cannot remove": {
+			scopeKey:      testutils.Cluster1NamespaceBReadWriteCtx,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on right cluster but wrong namespaces cannot remove": {
+			scopeKey:      testutils.Cluster2NamespacesACReadWriteCtx,
+			expectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write on right cluster can remove": {
+			scopeKey: testutils.Cluster2ReadWriteCtx,
+		},
+		"read-write on the right cluster and namespace can remove": {
+			scopeKey: testutils.Cluster2NamespaceBReadWriteCtx,
+		},
+		"read-write on the right cluster and at least the right namespace can remove": {
+			scopeKey: testutils.Cluster2NamespacesABReadWriteCtx,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			testNB := fixtures.GetScopedNetworkBaseline(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
+			s.testNBIDs = append(s.testNBIDs, testNB.GetDeploymentId())
+			ctx := s.testContexts[c.scopeKey]
+			var err error
+			err = s.datastore.UpsertNetworkBaselines(s.testContexts[testutils.UnrestrictedReadWriteCtx], []*storage.NetworkBaseline{testNB})
+			defer s.cleanupNetworkBaseline(testNB.GetDeploymentId())
+			s.NoError(err)
+			err = s.datastore.DeleteNetworkBaselines(ctx, []string{testNB.GetDeploymentId()})
+			s.Equal(c.expectedError, err)
+		})
+	}
+
+	s.Run("Delete multiple NetworkBaselines", func() {
+		var nbs = fixtures.GetSACTestNetworkBaseline()
+		// Upsert resources with various scopes.
+		s.NoError(s.datastore.UpsertNetworkBaselines(s.testContexts[testutils.UnrestrictedReadWriteCtx], nbs))
+		var (
+			ids         []string
+			cluster1ids []string
+		)
+		for _, nb := range nbs {
+			ids = append(ids, nb.GetDeploymentId())
+			if nb.GetClusterId() == testconsts.Cluster1 {
+				cluster1ids = append(cluster1ids, nb.GetDeploymentId())
+			}
+		}
+		s.testNBIDs = append(s.testNBIDs, ids...)
+		// Try to delete everything.
+		err := s.datastore.DeleteNetworkBaselines(s.testContexts[testutils.Cluster1ReadWriteCtx], ids)
+		s.ErrorIs(err, sac.ErrResourceAccessDenied)
+		// Check that nothing has been deleted.
+		for _, id := range ids {
+			_, ok, err := s.datastore.GetNetworkBaseline(s.testContexts[testutils.UnrestrictedReadWriteCtx], id)
+			s.NoError(err)
+			s.True(ok)
+		}
+
+		// Try to delete only cluster1 resources.
+		err = s.datastore.DeleteNetworkBaselines(s.testContexts[testutils.Cluster1ReadWriteCtx], cluster1ids)
+		s.NoErrorf(err, "Must be able to delete all the %v resources", testconsts.Cluster1)
+		// Check that all cluster1 resources have been deleted.
+		for _, nb := range nbs {
+			result, ok, err := s.datastore.GetNetworkBaseline(s.testContexts[testutils.UnrestrictedReadWriteCtx], nb.GetDeploymentId())
+			s.NoError(err)
+			if ok {
+				s.NotEqual(testconsts.Cluster1, result.GetClusterId(), "The resource of %v must have been deleted", result.GetClusterId())
+			} else {
+				s.Equalf(testconsts.Cluster1, nb.GetClusterId(), "The resource of %v must have not been deleted", nb.GetClusterId())
+			}
+		}
+	})
+}

--- a/pkg/fixtures/network_baseline.go
+++ b/pkg/fixtures/network_baseline.go
@@ -2,18 +2,54 @@ package fixtures
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/uuid"
 )
 
-// GetNetworkBaseline returns a mock network baseline
+// GetNetworkBaseline returns a mock network baseline.
 func GetNetworkBaseline() *storage.NetworkBaseline {
+	return GetScopedNetworkBaseline(GetDeployment().GetId(), "prod cluster", "stackrox")
+}
+
+// GetScopedNetworkBaseline returns a mock network baseline belonging to the input scope.
+func GetScopedNetworkBaseline(id, clusterID, namespace string) *storage.NetworkBaseline {
 	return &storage.NetworkBaseline{
-		DeploymentId:         GetDeployment().GetId(),
-		ClusterId:            "prod cluster",
-		Namespace:            "stackrox",
+		DeploymentId:         id,
+		ClusterId:            clusterID,
+		Namespace:            namespace,
 		Peers:                nil,
 		ForbiddenPeers:       nil,
 		ObservationPeriodEnd: nil,
 		Locked:               false,
 		DeploymentName:       GetDeployment().GetName(),
 	}
+}
+
+// GetSACTestNetworkBaseline returns a set of mock network baselines that can be
+// used for scoped access control tests.
+func GetSACTestNetworkBaseline() []*storage.NetworkBaseline {
+	return []*storage.NetworkBaseline{
+		scopedNetworkBaseline(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedNetworkBaseline(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedNetworkBaseline(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedNetworkBaseline(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedNetworkBaseline(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedNetworkBaseline(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedNetworkBaseline(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedNetworkBaseline(testconsts.Cluster1, testconsts.NamespaceA),
+		scopedNetworkBaseline(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedNetworkBaseline(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedNetworkBaseline(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedNetworkBaseline(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedNetworkBaseline(testconsts.Cluster1, testconsts.NamespaceB),
+		scopedNetworkBaseline(testconsts.Cluster2, testconsts.NamespaceB),
+		scopedNetworkBaseline(testconsts.Cluster2, testconsts.NamespaceB),
+		scopedNetworkBaseline(testconsts.Cluster2, testconsts.NamespaceB),
+		scopedNetworkBaseline(testconsts.Cluster2, testconsts.NamespaceC),
+		scopedNetworkBaseline(testconsts.Cluster2, testconsts.NamespaceC),
+	}
+}
+
+func scopedNetworkBaseline(clusterID, namespace string) *storage.NetworkBaseline {
+	return GetScopedNetworkBaseline(uuid.NewV4().String(), clusterID, namespace)
 }


### PR DESCRIPTION
## Description

A set of unit tests on SAC operations on the `NetworkBaseline` resource, supporting migration to PostgreSQL.

Added also the `PostgresDatastore` feature flag test to the existing test suite in `datastore_impl_test.go` as well as some tests on multiple delete. The tests are slightly duplicated in `datastore_impl_test.go` and the new `datastore_sac_test.go`, as the latest follow the pattern of the other `*_sac_test.go` cases.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Unit tests.