### PR TITLE
ROX-10974: Clarify vuln reporting by adding Image to page title

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/reporting/manageReports.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/reporting/manageReports.test.js
@@ -40,12 +40,12 @@ describe('Vulnmanagement reports', () => {
             cy.location('pathname').should('eq', url.reporting.list);
             cy.location('search').should('eq', '?action=create');
 
-            cy.get('h1:contains("Create a vulnerability report")');
+            cy.get('h1:contains("Create an image vulnerability report")');
 
             // check the breadcrumbs
             cy.get(selectors.reportSection.breadcrumbItems)
                 .last()
-                .contains('Create a vulnerability report');
+                .contains('Create an image vulnerability report');
 
             // first breadcrumb should be link back to reports table
             cy.get(selectors.reportSection.breadcrumbItems).first().click();

--- a/ui/apps/platform/cypress/integration/vulnmanagement/reporting/manageReports.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/reporting/manageReports.test.js
@@ -63,7 +63,7 @@ describe('Vulnmanagement reports', () => {
             visit(`${url.reporting.list}?action=create`);
             cy.wait(['@getSimpleAccessScopes', '@getNotifiers']);
 
-            cy.get('h1:contains("Create a vulnerability report")');
+            cy.get('h1:contains("Create an image vulnerability report")');
 
             // Step 0, should start out with disabled Save button
             cy.get(selectors.reportSection.buttons.create).should('be.disabled');

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtCreateReportPage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtCreateReportPage.tsx
@@ -25,10 +25,10 @@ function VulnMgmtCreateReportPage(): ReactElement {
                     <BreadcrumbItemLink to={vulnManagementReportsPath}>
                         Vulnerability reporting
                     </BreadcrumbItemLink>
-                    <BreadcrumbItem isActive>Create a vulnerability report</BreadcrumbItem>
+                    <BreadcrumbItem isActive>Create an image vulnerability report</BreadcrumbItem>
                 </Breadcrumb>
                 <TextContent>
-                    <Title headingLevel="h1">Create a vulnerability report</Title>
+                    <Title headingLevel="h1">Create an image vulnerability report</Title>
                     <Text component="p">
                         Configure reports, define reporting scopes, and assign distribution lists to
                         report on vulnerabilities across the organization.


### PR DESCRIPTION
## Description

A quick fix to clarify what type of vulns a customer is creating a report for

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added


## Testing Performed

Before
![Screen Shot 2022-05-16 at 3 55 21 PM](https://user-images.githubusercontent.com/715729/168673033-951f0b13-7df3-400f-955d-7829e65e45b7.png)

After
![Screen Shot 2022-05-16 at 3 56 23 PM](https://user-images.githubusercontent.com/715729/168673055-2386d256-c1e8-495f-8481-1c523293ce52.png)
