### PR TITLE
Use logger to print warn and errors in qa test

### DIFF
--- a/qa-tests-backend/codenarc-rules.groovy
+++ b/qa-tests-backend/codenarc-rules.groovy
@@ -300,7 +300,7 @@ ruleset {
     // LoggerForDifferentClass
     // LoggerWithWrongModifiers
     LoggingSwallowsStacktrace 
-    MultipleLoggers 
+    // MultipleLoggers
     // PrintStackTrace
     // Println
     // SystemErrPrint

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerNoImageScanTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerNoImageScanTest.groovy
@@ -128,7 +128,7 @@ class AdmissionControllerNoImageScanTest extends BaseSpecification {
                 }
             }
             if (!deleted) {
-                println "Warning: failed to delete deployment. Subsequent tests may be affected ..."
+                log.warn "Failed to delete deployment. Subsequent tests may be affected ..."
             }
             orchestrator.waitForDeploymentDeletion(deployment)
         }

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -435,7 +435,7 @@ class AdmissionControllerTest extends BaseSpecification {
             }
         }
         if (!deleted) {
-            println "Warning: failed to delete deployment. Subsequent tests may be affected ..."
+            log.warn "Failed to delete deployment. Subsequent tests may be affected ..."
         }
     }
 

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -198,7 +198,7 @@ class BaseSpecification extends Specification {
             orchestrator.setup()
         } catch (Exception e) {
             e.printStackTrace()
-            println "Error setting up orchestrator: ${e.message}"
+            log.error("Error setting up orchestrator", e)
             throw e
         }
         BaseService.useBasicAuth()
@@ -208,7 +208,7 @@ class BaseSpecification extends Specification {
             pluginConfigID = response.getId()
             println response.toString()
         } catch (StatusRuntimeException e) {
-            println("Unable to enable the authz plugin, defaulting to basic auth: ${e.message}")
+            log.error("Unable to enable the authz plugin, defaulting to basic auth", e)
         }
 
         coreImageIntegrationId = ImageIntegrationService.getImageIntegrationByName(
@@ -282,7 +282,7 @@ class BaseSpecification extends Specification {
         try {
             orchestrator.cleanup()
         } catch (Exception e) {
-            println "Error to clean up orchestrator: ${e.message}"
+            log.error "Error to clean up orchestrator: ${e.message}"
             throw e
         }
         disableAuthzPlugin()

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -37,6 +37,8 @@ import util.OnFailure
 @OnFailure(handler = { Helpers.collectDebugForFailure(delegate as Throwable) })
 class BaseSpecification extends Specification {
 
+    static final Logger LOG = LoggerFactory.getLogger("test." + BaseSpecification.getSimpleName())
+
     static final String TEST_IMAGE = "quay.io/rhacs-eng/qa:nginx-1-7-9"
 
     static final String RUN_ID
@@ -62,7 +64,7 @@ class BaseSpecification extends Specification {
 
     Map<String, List<String>> resourceRecord = [:]
 
-    private globalSetup() {
+    private static globalSetup() {
         if (globalSetupDone) {
             return
         }
@@ -282,7 +284,7 @@ class BaseSpecification extends Specification {
         try {
             orchestrator.cleanup()
         } catch (Exception e) {
-            log.error "Error to clean up orchestrator: ${e.message}"
+            log.error("Error to clean up orchestrator", e)
             throw e
         }
         disableAuthzPlugin()
@@ -324,7 +326,7 @@ class BaseSpecification extends Specification {
         Helpers.resetRetryAttempts()
     }
 
-    def addStackroxImagePullSecret(ns = Constants.ORCHESTRATOR_NAMESPACE) {
+    static addStackroxImagePullSecret(ns = Constants.ORCHESTRATOR_NAMESPACE) {
         // Add an image pull secret to the qa namespace and also the default service account so the qa namespace can
         // pull stackrox images from dockerhub
 
@@ -332,7 +334,7 @@ class BaseSpecification extends Specification {
                            Env.get("REGISTRY_PASSWORD", null) == null)) {
             // Arguably this should be fatal but for tests that don't pull from docker.io/stackrox it is not strictly
             // necessary.
-            log.warn "The REGISTRY_USERNAME and/or REGISTRY_PASSWORD env var is missing. " +
+            LOG.warn "The REGISTRY_USERNAME and/or REGISTRY_PASSWORD env var is missing. " +
                     "(this is ok if your test does not use images from docker.io/stackrox)"
             return
         }
@@ -366,7 +368,7 @@ class BaseSpecification extends Specification {
     static addGCRImagePullSecret(ns = Constants.ORCHESTRATOR_NAMESPACE) {
         if (!Env.IN_CI && Env.get("GOOGLE_CREDENTIALS_GCR_SCANNER", null) == null) {
             // Arguably this should be fatal but for tests that don't pull from us.gcr.io it is not strictly necessary
-            log.warn "The GOOGLE_CREDENTIALS_GCR_SCANNER env var is missing. "+
+            LOG.warn "The GOOGLE_CREDENTIALS_GCR_SCANNER env var is missing. "+
                     "(this is ok if your test does not use images on us.gcr.io)"
             return
         }

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -284,7 +284,7 @@ class BaseSpecification extends Specification {
         try {
             orchestrator.cleanup()
         } catch (Exception e) {
-            log.error("Error to clean up orchestrator", e)
+            log.error("Failed to clean up orchestrator", e)
             throw e
         }
         disableAuthzPlugin()

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -62,7 +62,7 @@ class BaseSpecification extends Specification {
 
     Map<String, List<String>> resourceRecord = [:]
 
-    private static globalSetup() {
+    private globalSetup() {
         if (globalSetupDone) {
             return
         }
@@ -230,7 +230,7 @@ class BaseSpecification extends Specification {
             )
         }
         if (!coreImageIntegrationId) {
-            println "WARNING: Could not create the core image integration."
+            log.warn "Could not create the core image integration."
             println "Check that REGISTRY_USERNAME and REGISTRY_PASSWORD are valid for quay.io."
         }
 
@@ -324,7 +324,7 @@ class BaseSpecification extends Specification {
         Helpers.resetRetryAttempts()
     }
 
-    static addStackroxImagePullSecret(ns = Constants.ORCHESTRATOR_NAMESPACE) {
+    def addStackroxImagePullSecret(ns = Constants.ORCHESTRATOR_NAMESPACE) {
         // Add an image pull secret to the qa namespace and also the default service account so the qa namespace can
         // pull stackrox images from dockerhub
 
@@ -332,7 +332,7 @@ class BaseSpecification extends Specification {
                            Env.get("REGISTRY_PASSWORD", null) == null)) {
             // Arguably this should be fatal but for tests that don't pull from docker.io/stackrox it is not strictly
             // necessary.
-            println "WARNING: The REGISTRY_USERNAME and/or REGISTRY_PASSWORD env var is missing. " +
+            log.warn "The REGISTRY_USERNAME and/or REGISTRY_PASSWORD env var is missing. " +
                     "(this is ok if your test does not use images from docker.io/stackrox)"
             return
         }
@@ -366,7 +366,7 @@ class BaseSpecification extends Specification {
     static addGCRImagePullSecret(ns = Constants.ORCHESTRATOR_NAMESPACE) {
         if (!Env.IN_CI && Env.get("GOOGLE_CREDENTIALS_GCR_SCANNER", null) == null) {
             // Arguably this should be fatal but for tests that don't pull from us.gcr.io it is not strictly necessary
-            println "WARNING: The GOOGLE_CREDENTIALS_GCR_SCANNER env var is missing. "+
+            log.warn "The GOOGLE_CREDENTIALS_GCR_SCANNER env var is missing. "+
                     "(this is ok if your test does not use images on us.gcr.io)"
             return
         }

--- a/qa-tests-backend/src/test/groovy/ClientCertAuthTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ClientCertAuthTest.groovy
@@ -54,20 +54,20 @@ class ClientCertAuthTest extends BaseSpecification {
         }
     }
 
-    private static getAuthProviderType() {
+    private getAuthProviderType() {
         try {
             return AuthService.getAuthStatus().authProvider.type
         } catch (StatusRuntimeException ex) {
-            println "Error getting auth status: ${ex}"
+            log.error("Error getting auth status", ex)
             return "error"
         }
     }
 
-    private static getAuthProviderID() {
+    private getAuthProviderID() {
         try {
             return AuthService.getAuthStatus().authProvider.id
         } catch (StatusRuntimeException ex) {
-            println "Error getting auth status: ${ex}"
+            log.error("Error getting auth status", ex)
             return ""
         }
     }

--- a/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
@@ -149,7 +149,7 @@ class ReconciliationTest extends BaseSpecification {
             try {
                 createOrchestratorDeployment(sensor)
             } catch (Exception e) {
-                println "Error re-creating the sensor: " + e
+                log.error("Error re-creating the sensor: ", e)
                 throw e
             }
         }

--- a/qa-tests-backend/src/test/groovy/SACv2Test.groovy
+++ b/qa-tests-backend/src/test/groovy/SACv2Test.groovy
@@ -91,7 +91,7 @@ class SACv2Test extends SACTest {
                 RoleService.deleteRole(role.name)
                 RoleService.deleteAccessScope(role.accessScopeId)
             } catch (Exception e) {
-                println "Error deleting role ${name}: ${e}"
+                log.error("Error deleting role ${name}", e)
             }
         }
     }

--- a/qa-tests-backend/src/test/resources/logback-test.xml
+++ b/qa-tests-backend/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
     <withJansi>true</withJansi>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%gray(%d{HH:mm:ss}) | %highlight(%-5level) | %logger{1} | %m%n%rEx{full,
+            <pattern>%gray(%d{HH:mm:ss}) | %highlight(%-5level) | %-25logger{0} | %m%n%rEx{full,
                 com.sun,
                 com.jayway.restassured.internal,
                 groovy.lang,


### PR DESCRIPTION
## Description

Use logger to print warning and errors in qa test.

This is part of #1705 

## Testing Performed

CI