### PR TITLE
Try fix docs build issues in `build-race-condition-debug-image`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,6 +455,10 @@ parameters:
     type: string
     # https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
     default: "ubuntu-2004:202111-02"
+  docker_version:
+    type: string
+    # https://circleci.com/docs/2.0/building-docker-images/#docker-version
+    default: "20.10.14"
   release_rc_tag_bash_regex:
     type: string
     # Caution when editing: make sure groups would correspond to BASH_REMATCH use.
@@ -931,7 +935,7 @@ commands:
           fail-on-rc: false
 
       - setup_remote_docker:
-          version: 20.10.7
+          version: << pipeline.parameters.docker_version >>
       - setup-dep-env:
           docker-login: true
 
@@ -2794,7 +2798,8 @@ jobs:
             echo "${TAG}-rcd" > CI_TAG
             make --quiet tag
 
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: << pipeline.parameters.docker_version >>
 
       - restore-go-mod-cache
       - setup-go-build-env
@@ -2857,7 +2862,7 @@ jobs:
 
       - setup_remote_docker:
           # Default docker server version isn't new enough therefore we're asking for more recent one to enjoy Buildkit.
-          version: 20.10.2
+          version: << pipeline.parameters.docker_version >>
       - run:
           name: Login to Docker Hub and Quay.io
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2829,9 +2829,8 @@ jobs:
             ./scripts/ci/push-as-manifest-list.sh "docker.io/stackrox/main:${TAG}" | cat
 
             docker login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin \<<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
-            QUAY_REPO="rhacs-eng"
-            docker tag "stackrox/main:${TAG}" "quay.io/$QUAY_REPO/main:${TAG}"
-            ./scripts/ci/push-as-manifest-list.sh "quay.io/$QUAY_REPO/main:${TAG}" | cat
+            docker tag "stackrox/main:${TAG}" "quay.io/rhacs-eng/main:${TAG}"
+            ./scripts/ci/push-as-manifest-list.sh "quay.io/rhacs-eng/main:${TAG}" | cat
 
       - run:
           # Apparently builds for race-condition-tests get GOTAGS=release due to explicitly set CIRCLE_TAG value.

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,3 @@
 	path = docs/tools
 	url = https://github.com/stackrox/docs-tools.git
 	branch = main
-	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,5 @@
 [submodule "docs/tools"]
 	path = docs/tools
 	url = https://github.com/stackrox/docs-tools.git
-	branch = misha/try-bump-deps
+	branch = main
+	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 [submodule "docs/tools"]
 	path = docs/tools
 	url = https://github.com/stackrox/docs-tools.git
-	branch = main
+	branch = misha/try-bump-deps

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -8,8 +8,7 @@ COPY tools tools
 COPY Makefile ./
 
 RUN npm install -g npm@8.10.0 && npm install -g yarn@1.22.18
-RUN make
-RUN find . -name yarn-error.log -print -exec cat {} \;
+RUN make || find . -name yarn-error.log -print -exec cat {} \;
 RUN exit 1
 
 FROM registry.access.redhat.com/ubi8/nginx-120:latest

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -8,8 +8,6 @@ COPY tools tools
 COPY Makefile ./
 
 RUN npm install -g npm@8.10.0 && npm install -g yarn@1.22.18
-RUN npm cache clean --force
-RUN yarn cache clean
 RUN make
 
 FROM registry.access.redhat.com/ubi8/nginx-120:latest

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -7,8 +7,10 @@ COPY content content
 COPY tools tools
 COPY Makefile ./
 
-RUN npm install -g npm@8.9.0 && npm install -g yarn@1.22.18
+RUN npm install -g npm@8.10.0 && npm install -g yarn@1.22.18
 RUN make
+RUN find . -name yarn-error.log -print -exec cat {} \;
+RUN exit 1
 
 FROM registry.access.redhat.com/ubi8/nginx-120:latest
 

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -8,8 +8,8 @@ COPY tools tools
 COPY Makefile ./
 
 RUN npm install -g npm@8.10.0 && npm install -g yarn@1.22.18
-RUN make || find . -name yarn-error.log -print -exec cat {} \;
-RUN exit 1
+RUN npm cache clean --force
+RUN make
 
 FROM registry.access.redhat.com/ubi8/nginx-120:latest
 

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -9,6 +9,7 @@ COPY Makefile ./
 
 RUN npm install -g npm@8.10.0 && npm install -g yarn@1.22.18
 RUN npm cache clean --force
+RUN yarn cache clean
 RUN make
 
 FROM registry.access.redhat.com/ubi8/nginx-120:latest

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,8 +4,8 @@ all: site
 .PHONY: prepare
 prepare:
 	# Verify that submodules have been initialized, otherwise we cannot build much.
-	[ -f content/.git ] || { echo >&2 "Submodule docs/content is not initialized, please run 'git submodules update --init'" ; exit 1 ; }
-	[ -f tools/.git ] || { echo >&2 "Submodule docs/tools is not initialized, please run 'git submodules update --init'" ; exit 1 ; }
+	[ -f content/.git ] || { echo >&2 "Submodule docs/content is not initialized, please run 'git submodule update --init'" ; exit 1 ; }
+	[ -f tools/.git ] || { echo >&2 "Submodule docs/tools is not initialized, please run 'git submodule update --init'" ; exit 1 ; }
 	$(MAKE) -C tools prepare
 
 .PHONY:


### PR DESCRIPTION
## Description

This follows up on CI failures induced in https://github.com/stackrox/stackrox/pull/1718

See failure in https://app.circleci.com/pipelines/github/stackrox/stackrox/12069/workflows/97a92998-f0e8-4f39-833f-c78059e4e4fa/jobs/562078

More context in https://srox.slack.com/archives/CELUQKESC/p1652775364492389

The fix is described here https://support.circleci.com/hc/en-us/articles/360050934711-Docker-build-fails-with-EPERM-operation-not-permitted-copyfile-when-using-node-14-9-0-or-later-

## Checklist
- [ ] Investigated and inspected CI test results

All below are not needed:
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

* `build-race-condition-debug-image` in CI should be green.