### PR TITLE
E2E: Fail tests fast on nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1508,9 +1508,12 @@ commands:
             else
               export CLUSTER=K8S
             fi
-            if [[ "${CIRCLE_BRANCH}" == "master" || -n "${CIRCLE_TAG}" ]]; then
-              echo "On master, running all QA tests..."
+            if [[ "$CIRCLE_TAG" =~ .*-nightly-.* ]]; then
+              echo "On nightly tag, running all QA tests but failing fast..."
               make -C qa-tests-backend test FAIL_FAST=true || touch FAIL
+            elif [[ "${CIRCLE_BRANCH}" == "master" || -n "${CIRCLE_TAG}" ]]; then
+              echo "On master, running all QA tests..."
+              make -C qa-tests-backend test || touch FAIL
             elif .circleci/pr_has_label.sh ci-all-qa-tests; then
               echo "ci-all-qa-tests label was specified, so running all QA tests..."
               make -C qa-tests-backend test || touch FAIL
@@ -1848,9 +1851,12 @@ commands:
             export CLUSTER=OPENSHIFT
             export API_HOSTNAME=localhost
             export API_PORT=${LOCAL_PORT}
-            if [[ "${CIRCLE_BRANCH}" == "master" || -n "${CIRCLE_TAG}" ]]; then
-              echo "On master, running all QA tests..."
+            if [[ "$CIRCLE_TAG" =~ .*-nightly-.* ]]; then
+              echo "On nightly tag, running all QA tests but failing fast..."
               make -C qa-tests-backend test FAIL_FAST=true || touch FAIL
+            elif [[ "${CIRCLE_BRANCH}" == "master" || -n "${CIRCLE_TAG}" ]]; the
+              echo "On master, running all QA tests..."
+              make -C qa-tests-backend test || touch FAIL
             elif .circleci/pr_has_label.sh ci-all-qa-tests; then
               echo "ci-all-qa-tests label was specified, so running all QA tests..."
               make -C qa-tests-backend test || touch FAIL

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1510,7 +1510,7 @@ commands:
             fi
             if [[ "${CIRCLE_BRANCH}" == "master" || -n "${CIRCLE_TAG}" ]]; then
               echo "On master, running all QA tests..."
-              make -C qa-tests-backend test || touch FAIL
+              make -C qa-tests-backend test FAIL_FAST=true || touch FAIL
             elif .circleci/pr_has_label.sh ci-all-qa-tests; then
               echo "ci-all-qa-tests label was specified, so running all QA tests..."
               make -C qa-tests-backend test || touch FAIL
@@ -1850,7 +1850,7 @@ commands:
             export API_PORT=${LOCAL_PORT}
             if [[ "${CIRCLE_BRANCH}" == "master" || -n "${CIRCLE_TAG}" ]]; then
               echo "On master, running all QA tests..."
-              make -C qa-tests-backend test || touch FAIL
+              make -C qa-tests-backend test FAIL_FAST=true || touch FAIL
             elif .circleci/pr_has_label.sh ci-all-qa-tests; then
               echo "ci-all-qa-tests label was specified, so running all QA tests..."
               make -C qa-tests-backend test || touch FAIL

--- a/qa-tests-backend/Makefile
+++ b/qa-tests-backend/Makefile
@@ -2,6 +2,12 @@
 all: style test
 
 GRADLE := ./gradlew
+fail_fast = ""
+ifdef FAIL_FAST
+GRADLE_TEST := ./gradlew test --fail-fast
+else
+GRADLE_TEST := ./gradlew test
+endif
 
 ###########
 ## Style ##
@@ -46,55 +52,55 @@ clean-generated-srcs:
 .PHONY: test
 test: compile
 	@echo "+ $@"
-	$(GRADLE) test -Dgroups=-Upgrade,-SensorBounce,-SensorBounceNext
+	$(GRADLE_TEST) -Dgroups=-Upgrade,-SensorBounce,-SensorBounceNext
 
 .PHONY: bat-test
 bat-test: compile
 	@echo "+ $@"
-	$(GRADLE) test -Dgroups=BAT
+	$(GRADLE_TEST) -Dgroups=BAT
 
 .PHONY: smoke-test
 smoke-test: compile
 	@echo "+ $@"
-	$(GRADLE) test -Dgroups=SMOKE
+	$(GRADLE_TEST) -Dgroups=SMOKE
 
 .PHONY: runtime-test
 runtime-test: compile
 	@echo "+ $@"
-	$(GRADLE) test -Dgroups=RUNTIME
+	$(GRADLE_TEST) -Dgroups=RUNTIME
 
 .PHONY: enforcement-test
 enforcement-test: compile
 	@echo "+ $@"
-	$(GRADLE) test -Dgroups=PolicyEnforcement
+	$(GRADLE_TEST) -Dgroups=PolicyEnforcement
 
 .PHONY: integration-test
 integration-test: compile
 	@echo "+ $@"
-	$(GRADLE) test -Dgroups=Integration
+	$(GRADLE_TEST) -Dgroups=Integration
 
 .PHONY: networkpolicy-simulator-test
 networkpolicy-simulator-test: compile
 	@echo "+ $@"
-	$(GRADLE) test -Dgroups=NetworkPolicySimulation
+	$(GRADLE_TEST) -Dgroups=NetworkPolicySimulation
 
 .PHONY: non-bat-test
 non-bat-test: compile
 	@echo "+ $@"
-	$(GRADLE) test -Dgroups=-BAT,-Upgrade,-SensorBounce,-SensorBounceNext
+	$(GRADLE_TEST) -Dgroups=-BAT,-Upgrade,-SensorBounce,-SensorBounceNext
 
 .PHONY: upgrade-test
 upgrade-test: compile
 	@echo "+ $@"
-	$(GRADLE) test -Dgroups=Upgrade
+	$(GRADLE_TEST) -Dgroups=Upgrade
 
 .PHONY: graphql-test
 graphql-test: compile
 	@echo "+ $@"
-	$(GRADLE) test -Dgroups=GraphQL
+	$(GRADLE_TEST) -Dgroups=GraphQL
 
 .PHONY: sensor-bounce-test
 sensor-bounce-test: compile
 	@echo "+ $@"
-	$(GRADLE) test -Dgroups=SensorBounce
-	$(GRADLE) test -Dgroups=SensorBounceNext
+	$(GRADLE_TEST) -Dgroups=SensorBounce
+	$(GRADLE_TEST) -Dgroups=SensorBounceNext

--- a/qa-tests-backend/Makefile
+++ b/qa-tests-backend/Makefile
@@ -2,11 +2,9 @@
 all: style test
 
 GRADLE := ./gradlew
-fail_fast = ""
+GRADLE_TEST_ARGS =
 ifdef FAIL_FAST
-GRADLE_TEST := ./gradlew test --fail-fast
-else
-GRADLE_TEST := ./gradlew test
+GRADLE_TEST_ARGS = --fail-fast
 endif
 
 ###########
@@ -52,55 +50,55 @@ clean-generated-srcs:
 .PHONY: test
 test: compile
 	@echo "+ $@"
-	$(GRADLE_TEST) -Dgroups=-Upgrade,-SensorBounce,-SensorBounceNext
+	$(GRADLE) test $(GRADLE_TEST_ARGS) -Dgroups=-Upgrade,-SensorBounce,-SensorBounceNext
 
 .PHONY: bat-test
 bat-test: compile
 	@echo "+ $@"
-	$(GRADLE_TEST) -Dgroups=BAT
+	$(GRADLE) test $(GRADLE_TEST_ARGS) -Dgroups=BAT
 
 .PHONY: smoke-test
 smoke-test: compile
 	@echo "+ $@"
-	$(GRADLE_TEST) -Dgroups=SMOKE
+	$(GRADLE) test $(GRADLE_TEST_ARGS) -Dgroups=SMOKE
 
 .PHONY: runtime-test
 runtime-test: compile
 	@echo "+ $@"
-	$(GRADLE_TEST) -Dgroups=RUNTIME
+	$(GRADLE) test $(GRADLE_TEST_ARGS) -Dgroups=RUNTIME
 
 .PHONY: enforcement-test
 enforcement-test: compile
 	@echo "+ $@"
-	$(GRADLE_TEST) -Dgroups=PolicyEnforcement
+	$(GRADLE) test $(GRADLE_TEST_ARGS) -Dgroups=PolicyEnforcement
 
 .PHONY: integration-test
 integration-test: compile
 	@echo "+ $@"
-	$(GRADLE_TEST) -Dgroups=Integration
+	$(GRADLE) test $(GRADLE_TEST_ARGS) -Dgroups=Integration
 
 .PHONY: networkpolicy-simulator-test
 networkpolicy-simulator-test: compile
 	@echo "+ $@"
-	$(GRADLE_TEST) -Dgroups=NetworkPolicySimulation
+	$(GRADLE) test $(GRADLE_TEST_ARGS) -Dgroups=NetworkPolicySimulation
 
 .PHONY: non-bat-test
 non-bat-test: compile
 	@echo "+ $@"
-	$(GRADLE_TEST) -Dgroups=-BAT,-Upgrade,-SensorBounce,-SensorBounceNext
+	$(GRADLE) test $(GRADLE_TEST_ARGS) -Dgroups=-BAT,-Upgrade,-SensorBounce,-SensorBounceNext
 
 .PHONY: upgrade-test
 upgrade-test: compile
 	@echo "+ $@"
-	$(GRADLE_TEST) -Dgroups=Upgrade
+	$(GRADLE) test $(GRADLE_TEST_ARGS) -Dgroups=Upgrade
 
 .PHONY: graphql-test
 graphql-test: compile
 	@echo "+ $@"
-	$(GRADLE_TEST) -Dgroups=GraphQL
+	$(GRADLE) test $(GRADLE_TEST_ARGS) -Dgroups=GraphQL
 
 .PHONY: sensor-bounce-test
 sensor-bounce-test: compile
 	@echo "+ $@"
-	$(GRADLE_TEST) -Dgroups=SensorBounce
-	$(GRADLE_TEST) -Dgroups=SensorBounceNext
+	$(GRADLE) test $(GRADLE_TEST_ARGS) -Dgroups=SensorBounce
+	$(GRADLE) test $(GRADLE_TEST_ARGS) -Dgroups=SensorBounceNext


### PR DESCRIPTION
## Description

During nightly tests we often seen a pattern of multiple test failures. Sometimes there is no point in running other tests after failure as cluster might be in dirty state. This change stops tests after the first failure on nightly tag to allow us to focus on the most problematic tests and prioritize fixing them.

See: https://docs.gradle.org/7.4.2/userguide/java_testing.html#sec:test_execution

## Testing Performed

N/A