### PR TITLE
sensor/central communication: remove license check

### DIFF
--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -318,10 +318,8 @@ func (s *Sensor) pollMetadata() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	// Metadata result doesn't matter, as long as central is reachable
-	if _, err := s.centralRestClient.GetMetadata(ctx); err != nil {
-		return errors.Wrap(err, "polling metadata")
-	}
-	return nil
+	_, err := s.centralRestClient.GetMetadata(ctx)
+	return err
 }
 
 func (s *Sensor) communicationWithCentral(centralReachable *concurrency.Flag) {

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cenkalti/backoff/v3"
 	"github.com/pkg/errors"
-	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
@@ -318,13 +317,9 @@ func (s *Sensor) waitUntilCentralIsReady() {
 func (s *Sensor) pollMetadata() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	md, err := s.centralRestClient.GetMetadata(ctx)
-
-	if err != nil {
-		return err
-	}
-	if md.GetLicenseStatus() != v1.Metadata_VALID {
-		return errors.Errorf("central license status is not VALID but %v", md.GetLicenseStatus())
+	// Metadata result doesn't matter, as long as central is reachable
+	if _, err := s.centralRestClient.GetMetadata(ctx); err != nil {
+		return errors.Wrap(err, "polling metadata")
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

As per internal slack thread: https://srox.slack.com/archives/CELUQKESC/p1652713038114379

We are no longer checking for license status on initial sensor sync. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~


## Testing Performed
- CI might be enough
