### PR TITLE
ROX-10034: Deactivate PodSecurityPolicies by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2501,7 +2501,7 @@ jobs:
       - LOCAL_PORT: 8000
       - COLLECTION_METHOD: ebpf
       - GCP_IMAGE_TYPE: "COS"
-      - POD_SECURITY_POLICIES: "true"
+      - POD_SECURITY_POLICIES: "false"
       - MONITORING_SUPPORT: false
       - SCANNER_SUPPORT: true
       - ROX_BASELINE_GENERATION_DURATION: 1m
@@ -2918,7 +2918,7 @@ jobs:
     resource_class: small
     environment:
       - GCP_IMAGE_TYPE: "COS"
-      - POD_SECURITY_POLICIES: "true"
+      - POD_SECURITY_POLICIES: "false"
     steps:
       - checkout
       - check-backend-changes
@@ -3287,7 +3287,7 @@ jobs:
     resource_class: small
     environment:
       GCP_IMAGE_TYPE: "COS"
-      POD_SECURITY_POLICIES: "true"
+      POD_SECURITY_POLICIES: "false"
     steps:
       - checkout
       - check-backend-changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - /v1/compliance/results was never implemented and will be removed in this release
 - In release 73.0, the /v1/compliance/runresults endpoint will contain a slimmed down version of the ComplianceDomain object. This allows for greater scalability and reduced memory usage.
 - When the underlying database changes to Postgres the api `/db/restore` will no longer be a supported means for database restores.  At that time using `roxctl` will be the supported mechanism for database restores.
+- PodSecurityPolicies can be disabled when generating deployment bundles and when configuring the Helm charts. The Helm charts also support auto-sensing
+  availability of the PodSecurityPolicies API. PodSecurityPolicies must be disabled when deploying to Kubernetes >= v1.25.
 
 ## [70.0]
 

--- a/central/clusters/deployer.go
+++ b/central/clusters/deployer.go
@@ -179,6 +179,6 @@ func getBaseMetaValues(c *storage.Cluster, versions version.Versions, opts *Rend
 		AdmissionControlEnforceOnUpdates: c.GetDynamicConfig().GetAdmissionControllerConfig().GetEnforceOnUpdates(),
 		ReleaseBuild:                     buildinfo.ReleaseBuild,
 
-		EnablePodSecurityPolicies: true,
+		EnablePodSecurityPolicies: false,
 	}
 }

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -190,8 +190,8 @@ function launch_central {
     	add_args "--with-config-file=${ROXDEPLOY_CONFIG_FILE_MAP}"
     fi
 
-    if [[ "$POD_SECURITY_POLICIES" == "false" ]]; then
-      add_args "--enable-pod-security-policies=false"
+    if [[ "$POD_SECURITY_POLICIES" == "true" ]]; then
+      add_args "--enable-pod-security-policies"
     fi
 
     local unzip_dir="${k8s_dir}/central-deploy/"
@@ -292,9 +292,9 @@ function launch_central {
         )
       fi
 
-      if [[ "$POD_SECURITY_POLICIES" == "false" ]]; then
+      if [[ "$POD_SECURITY_POLICIES" == "true" ]]; then
         helm_args+=(
-          --set system.enablePodSecurityPolicies=false
+          --set system.enablePodSecurityPolicies=true
         )
       fi
 

--- a/image/templates/helm/shared/templates/_psp.tpl
+++ b/image/templates/helm/shared/templates/_psp.tpl
@@ -1,0 +1,19 @@
+{{/*
+    srox.autoSensePodSecurityPolicies $
+  */}}
+
+{{ define "srox.autoSensePodSecurityPolicies" }}
+
+{{ $ := index . 0 }}
+{{ $system := $._rox.system }}
+
+{{ if kindIs "invalid" $system.enablePodSecurityPolicies }}
+  {{ $_ := set $system "enablePodSecurityPolicies" (has "policy/v1beta1" $._rox._apiServer.apiResources) }}
+  {{ if $system.enablePodSecurityPolicies }}
+    {{ include "srox.note" (list $ (printf "PodSecurityPolicies are enabled, since your environment supports them according to API server properties.")) }}
+  {{ else }}
+    {{ include "srox.note" (list $ (printf "PodSecurityPolicies are disabled, since your environment does not support them according to API server properties.")) }}
+  {{ end }}
+{{ end }}
+
+{{ end }}

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -82,7 +82,10 @@ defaults:
 
   system:
     createSCCs: [< not .Operator >]
+
+    [<- if not .AutoSensePodSecurityPolicies >]
     enablePodSecurityPolicies: [< .EnablePodSecurityPolicies >]
+    [<- end >]
 
   enableOpenShiftMonitoring: false
 

--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -116,6 +116,11 @@
   {{ $_ := set $env "platform" $platform }}
 {{ end }}
 
+[<- if .AutoSensePodSecurityPolicies >]
+{{/* Detect enablePodSecurityPolicies */}}
+{{ include "srox.autoSensePodSecurityPolicies" (list $) }}
+[<- end >]
+
 {{/* Apply defaults */}}
 {{ $defaultsCfg := dict }}
 {{ $platformCfgFile := dict }}

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/00-bootstrap.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/00-bootstrap.yaml.htpl
@@ -15,5 +15,3 @@ _namespace: {{ default .Release.Namespace ._rox.meta.namespaceOverride }}
 meta:
   useLookup: true
   fileOverrides: {}
-system:
-  enablePodSecurityPolicies: [< .EnablePodSecurityPolicies >]

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/10-env.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/10-env.yaml.htpl
@@ -8,3 +8,7 @@ env:
   istio: false
   {{- end }}
 {{- end }}
+system:
+  [<- if not .AutoSensePodSecurityPolicies >]
+  enablePodSecurityPolicies: [< .EnablePodSecurityPolicies >]
+  [<- end >]

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -118,6 +118,11 @@
   {{ include "srox.note" (list $ (printf "To have openshift-monitoring include metrics from the %s namespace a label metadata is required. Run: oc label namespace/%s openshift.io/cluster-monitoring=true." .Release.Namespace .Release.Namespace)) }}
 {{ end }}
 
+[<- if .AutoSensePodSecurityPolicies >]
+{{/* Detect enablePodSecurityPolicies */}}
+{{ include "srox.autoSensePodSecurityPolicies" (list $) }}
+[<- end >]
+
 {{ include "srox.applyDefaults" $ }}
 
 {{/* Expand applicable config values */}}

--- a/pkg/helm/charts/meta.go
+++ b/pkg/helm/charts/meta.go
@@ -54,7 +54,8 @@ type MetaValues struct {
 	AdmissionControlEnforceOnUpdates bool
 	ReleaseBuild                     bool
 
-	EnablePodSecurityPolicies bool
+	AutoSensePodSecurityPolicies bool
+	EnablePodSecurityPolicies    bool // Only used in the Helm chart if AutoSensePodSecurityPolicies is false.
 }
 
 // GetMetaValuesForFlavor are the default meta values for rendering the StackRox charts in production.
@@ -83,7 +84,7 @@ func GetMetaValuesForFlavor(imageFlavor defaults.ImageFlavor) *MetaValues {
 		ReleaseBuild:             buildinfo.ReleaseBuild,
 		FeatureFlags:             getFeatureFlags(),
 
-		EnablePodSecurityPolicies: false,
+		AutoSensePodSecurityPolicies: true,
 	}
 
 	return &metaValues

--- a/pkg/helm/charts/meta.go
+++ b/pkg/helm/charts/meta.go
@@ -83,7 +83,7 @@ func GetMetaValuesForFlavor(imageFlavor defaults.ImageFlavor) *MetaValues {
 		ReleaseBuild:             buildinfo.ReleaseBuild,
 		FeatureFlags:             getFeatureFlags(),
 
-		EnablePodSecurityPolicies: true,
+		EnablePodSecurityPolicies: false,
 	}
 
 	return &metaValues

--- a/pkg/helm/charts/tests/centralservices/base_suite_test.go
+++ b/pkg/helm/charts/tests/centralservices/base_suite_test.go
@@ -76,7 +76,7 @@ scanner:
     key: "scanner-db tls key pem"
 enableOpenShiftMonitoring: true
 system:
-    enableDeprecatedPodSecurityPolicies: true
+    enablePodSecurityPolicies: true
 `
 	autogenerateAll = `
 licenseKey: "my license key"
@@ -101,7 +101,7 @@ central:
   enableCentralDB: true
 enableOpenShiftMonitoring: true
 system:
-    enableDeprecatedPodSecurityPolicies: true
+    enablePodSecurityPolicies: true
 `
 )
 

--- a/pkg/helm/charts/tests/centralservices/base_suite_test.go
+++ b/pkg/helm/charts/tests/centralservices/base_suite_test.go
@@ -75,6 +75,8 @@ scanner:
     cert: "scanner-db tls cert pem"
     key: "scanner-db tls key pem"
 enableOpenShiftMonitoring: true
+system:
+    enableDeprecatedPodSecurityPolicies: true
 `
 	autogenerateAll = `
 licenseKey: "my license key"
@@ -98,6 +100,8 @@ central:
       enabled: true
   enableCentralDB: true
 enableOpenShiftMonitoring: true
+system:
+    enableDeprecatedPodSecurityPolicies: true
 `
 )
 

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
@@ -20,7 +20,7 @@ tests:
     .deployments["central"] | assertThat(. != null)
     .services["central"] | assertThat(. != null)
 
-- name: "central with deprecated PodSecurityPolicies disabled"
+- name: "central with deprecated PodSecurityPolicies enabled"
   values:
     system:
       enablePodSecurityPolicies: true

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
@@ -12,9 +12,6 @@ values:
 tests:
 - name: "central with default settings"
   expect: |
-    .podsecuritypolicys["stackrox-central"] | assertThat(. != null)
-    .rolebindings["stackrox-central-psp"] | assertThat(. != null)
-    .clusterroles["stackrox-central-psp"] | assertThat(. != null)
     .serviceaccounts["central"] | assertThat(. != null)
     .secrets["central-htpasswd"].stringData.htpasswd | assertThat(length != 0)
     .configmaps["central-config"].data.["central-config.yaml"] | assertThat(length != 0)
@@ -26,11 +23,11 @@ tests:
 - name: "central with deprecated PodSecurityPolicies disabled"
   values:
     system:
-      enablePodSecurityPolicies: false
+      enablePodSecurityPolicies: true
   expect: |
-    .podsecuritypolicys["stackrox-central"] | assertThat(. == null)
-    .rolebindings["stackrox-central-psp"] | assertThat(. == null)
-    .clusterroles["stackrox-central-psp"] | assertThat(. == null)
+    .podsecuritypolicys["stackrox-central"] | assertThat(. != null)
+    .rolebindings["stackrox-central-psp"] | assertThat(. != null)
+    .clusterroles["stackrox-central-psp"] | assertThat(. != null)
 
 - name: "central with OpenShift 3 and enabled SCCs"
   server:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/psp-autosense.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/psp-autosense.test.yaml
@@ -1,0 +1,19 @@
+tests:
+  - name: "Detect support for PodSecurityPolicies"
+    values:
+      meta:
+        apiServer:
+          overrideAPIResources: ["policy/v1beta"]
+      system:
+        enablePodSecurityPolicies: null
+    expect: |
+      .podsecuritypolicys["stackrox-central"] | assertThat(. != null)
+  - name: "Detect absent support for PodSecurityPolicies"
+    values:
+      meta:
+        apiServer:
+          overrideAPIResources: []
+      system:
+        enablePodSecurityPolicies: null
+    expect: |
+      .podsecuritypolicys["stackrox-central"] | assertThat(. == null)

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/psp-autosense.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/psp-autosense.test.yaml
@@ -3,7 +3,8 @@ tests:
     values:
       meta:
         apiServer:
-          overrideAPIResources: ["policy/v1beta"]
+          overrideAPIResources:
+            - "policy/v1beta1"
       system:
         enablePodSecurityPolicies: null
     expect: |

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
@@ -12,9 +12,6 @@ values:
 tests:
 - name: "scanner with default settings"
   expect: |
-    .podsecuritypolicys["stackrox-scanner"] | assertThat(. != null)
-    .rolebindings["stackrox-scanner-psp"] | assertThat(. != null)
-    .clusterroles["stackrox-scanner-psp"] | assertThat(. != null)
     .serviceaccounts["scanner"] | assertThat(. != null)
     .secrets["scanner-db-password"].stringData.password | assertThat(length != 0)
     .configmaps["scanner-config"].data.["config.yaml"] | assertThat(length != 0)
@@ -42,11 +39,11 @@ tests:
 - name: "scanner with deprecated PodSecurityPolicies disabled"
   values:
     system:
-      enablePodSecurityPolicies: false
+      enablePodSecurityPolicies: true
   expect: |
-    .podsecuritypolicys["stackrox-scanner"] | assertThat(. == null)
-    .rolebindings["stackrox-scanner-psp"] | assertThat(. == null)
-    .clusterroles["stackrox-scanner-psp"] | assertThat(. == null)
+    .podsecuritypolicys["stackrox-scanner"] | assertThat(. != null)
+    .rolebindings["stackrox-scanner-psp"] | assertThat(. != null)
+    .clusterroles["stackrox-scanner-psp"] | assertThat(. != null)
 
 #TODO: Add istio tests
 - name: "configured scanner"

--- a/pkg/helm/charts/tests/securedclusterservices/base_suite_test.go
+++ b/pkg/helm/charts/tests/securedclusterservices/base_suite_test.go
@@ -96,7 +96,7 @@ scanner:
   disable: false
 
 system:
-    enableDeprecatedPodSecurityPolicies: true
+    enablePodSecurityPolicies: true
 `
 )
 

--- a/pkg/helm/charts/tests/securedclusterservices/base_suite_test.go
+++ b/pkg/helm/charts/tests/securedclusterservices/base_suite_test.go
@@ -94,6 +94,9 @@ config:
 enableOpenShiftMonitoring: true
 scanner:
   disable: false
+
+system:
+    enableDeprecatedPodSecurityPolicies: true
 `
 )
 

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/psp-autosense.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/psp-autosense.test.yaml
@@ -1,0 +1,19 @@
+tests:
+  - name: "Detect support for PodSecurityPolicies"
+    values:
+      meta:
+        apiServer:
+          overrideAPIResources: ["policy/v1beta"]
+      system:
+        enablePodSecurityPolicies: null
+    expect: |
+      .podsecuritypolicys["stackrox-sensor"] | assertThat(. != null)
+  - name: "Detect absent support for PodSecurityPolicies"
+    values:
+      meta:
+        apiServer:
+          overrideAPIResources: []
+      system:
+        enablePodSecurityPolicies: null
+    expect: |
+      .podsecuritypolicys["stackrox-sensor"] | assertThat(. == null)

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/psp-autosense.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/psp-autosense.test.yaml
@@ -3,7 +3,8 @@ tests:
     values:
       meta:
         apiServer:
-          overrideAPIResources: ["policy/v1beta"]
+          overrideAPIResources:
+            - "policy/v1beta1"
       system:
         enablePodSecurityPolicies: null
     expect: |

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -203,6 +203,15 @@ func createBundle(logger logger.Logger, config renderer.Config) (*zip.Wrapper, e
 func OutputZip(logger logger.Logger, config renderer.Config) error {
 	logger.InfofLn("Generating deployment bundle...")
 
+	if config.EnablePodSecurityPolicies {
+		logger.InfofLn("Central deployment bundle includes PodSecurityPolicies (PSPs). This is incompatible with Kubernetes >= v1.25.")
+		logger.InfofLn("Use --enable-pod-security-policies=false for disabling PodSecurityPolicies.")
+		logger.InfofLn("For the time being PodSecurityPolicies remain enabled by default in deployment bundles and need to be disabled explicitly for Kubernetes >= v1.25.")
+	} else {
+		logger.InfofLn("Central deployment bundle does not include PodSecurityPolicies (PSPs).")
+		logger.InfofLn("This is incompatible with pre-v1.25 Kubernetes installations having the PodSecurityPolicy Admission Controller plugin enabled.")
+		logger.InfofLn("Use --enable-pod-security-policies if PodSecurityPolicies are required for your Kubernetes environment.")
+	}
 	wrapper, err := createBundle(logger, config)
 	if err != nil {
 		return err
@@ -310,7 +319,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	if !buildinfo.ReleaseBuild {
 		flags.AddHelmChartDebugSetting(c)
 	}
-	c.PersistentFlags().BoolVar(&centralGenerateCmd.rendererConfig.EnablePodSecurityPolicies, "enable-pod-security-policies", false, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
+	c.PersistentFlags().BoolVar(&centralGenerateCmd.rendererConfig.EnablePodSecurityPolicies, "enable-pod-security-policies", true, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
 
 	c.AddCommand(centralGenerateCmd.interactive())
 	c.AddCommand(k8s(cliEnvironment))

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -204,13 +204,9 @@ func OutputZip(logger logger.Logger, config renderer.Config) error {
 	logger.InfofLn("Generating deployment bundle...")
 
 	if config.EnablePodSecurityPolicies {
-		logger.InfofLn("Central deployment bundle includes PodSecurityPolicies (PSPs). This is incompatible with Kubernetes >= v1.25.")
-		logger.InfofLn("Use --enable-pod-security-policies=false for disabling PodSecurityPolicies.")
-		logger.InfofLn("For the time being PodSecurityPolicies remain enabled by default in deployment bundles and need to be disabled explicitly for Kubernetes >= v1.25.")
+		common.LogInfoPspEnabled(logger)
 	} else {
-		logger.InfofLn("Central deployment bundle does not include PodSecurityPolicies (PSPs).")
-		logger.InfofLn("This is incompatible with pre-v1.25 Kubernetes installations having the PodSecurityPolicy Admission Controller plugin enabled.")
-		logger.InfofLn("Use --enable-pod-security-policies if PodSecurityPolicies are required for your Kubernetes environment.")
+		common.LogInfoPspDisabled(logger)
 	}
 	wrapper, err := createBundle(logger, config)
 	if err != nil {

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -310,7 +310,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	if !buildinfo.ReleaseBuild {
 		flags.AddHelmChartDebugSetting(c)
 	}
-	c.PersistentFlags().BoolVar(&centralGenerateCmd.rendererConfig.EnablePodSecurityPolicies, "enable-pod-security-policies", true, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
+	c.PersistentFlags().BoolVar(&centralGenerateCmd.rendererConfig.EnablePodSecurityPolicies, "enable-pod-security-policies", false, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
 
 	c.AddCommand(centralGenerateCmd.interactive())
 	c.AddCommand(k8s(cliEnvironment))

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -203,11 +203,8 @@ func createBundle(logger logger.Logger, config renderer.Config) (*zip.Wrapper, e
 func OutputZip(logger logger.Logger, config renderer.Config) error {
 	logger.InfofLn("Generating deployment bundle...")
 
-	if config.EnablePodSecurityPolicies {
-		common.LogInfoPspEnabled(logger)
-	} else {
-		common.LogInfoPspDisabled(logger)
-	}
+	common.LogInfoPsp(logger, config.EnablePodSecurityPolicies)
+
 	wrapper, err := createBundle(logger, config)
 	if err != nil {
 		return err

--- a/roxctl/common/psp.go
+++ b/roxctl/common/psp.go
@@ -4,16 +4,25 @@ import (
 	"github.com/stackrox/rox/roxctl/common/logger"
 )
 
-// LogInfoPspEnabled writes informational message about PodSecurityPolicies being enabled to the provided logger.
-func LogInfoPspEnabled(logger logger.Logger) {
+// logInfoPspEnabled writes informational message about PodSecurityPolicies being enabled to the provided logger.
+func logInfoPspEnabled(logger logger.Logger) {
 	logger.InfofLn("Deployment bundle includes PodSecurityPolicies (PSPs). This is incompatible with Kubernetes >= v1.25.")
 	logger.InfofLn("Use --enable-pod-security-policies=false to disable PodSecurityPolicies.")
 	logger.InfofLn("For the time being PodSecurityPolicies remain enabled by default in deployment bundles and need to be disabled explicitly for Kubernetes >= v1.25.")
 }
 
-// LogInfoPspDisabled writes informational message about PodSecurityPolicies being disabled to the provided logger.
-func LogInfoPspDisabled(logger logger.Logger) {
+// logInfoPspDisabled writes informational message about PodSecurityPolicies being disabled to the provided logger.
+func logInfoPspDisabled(logger logger.Logger) {
 	logger.InfofLn("Deployment bundle does not include PodSecurityPolicies (PSPs).")
 	logger.InfofLn("This is incompatible with pre-v1.25 Kubernetes installations having the PodSecurityPolicy Admission Controller plugin enabled.")
 	logger.InfofLn("Use --enable-pod-security-policies if PodSecurityPolicies are required for your Kubernetes environment.")
+}
+
+// LogInfoPsp writes informational message about PodSecurityPolicies to the provided logger, depending on whether they are enabled or not.
+func LogInfoPsp(logger logger.Logger, pspEnabled bool) {
+	if pspEnabled {
+		logInfoPspEnabled(logger)
+	} else {
+		logInfoPspDisabled(logger)
+	}
 }

--- a/roxctl/common/psp.go
+++ b/roxctl/common/psp.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"github.com/stackrox/rox/roxctl/common/logger"
+)
+
+// LogInfoPspEnabled writes informational message about PodSecurityPolicies being enabled to the provided logger.
+func LogInfoPspEnabled(logger logger.Logger) {
+	logger.InfofLn("Deployment bundle includes PodSecurityPolicies (PSPs). This is incompatible with Kubernetes >= v1.25.")
+	logger.InfofLn("Use --enable-pod-security-policies=false to disable PodSecurityPolicies.")
+	logger.InfofLn("For the time being PodSecurityPolicies remain enabled by default in deployment bundles and need to be disabled explicitly for Kubernetes >= v1.25.")
+}
+
+// LogInfoPspDisabled writes informational message about PodSecurityPolicies being disabled to the provided logger.
+func LogInfoPspDisabled(logger logger.Logger) {
+	logger.InfofLn("Deployment bundle does not include PodSecurityPolicies (PSPs).")
+	logger.InfofLn("This is incompatible with pre-v1.25 Kubernetes installations having the PodSecurityPolicy Admission Controller plugin enabled.")
+	logger.InfofLn("Use --enable-pod-security-policies if PodSecurityPolicies are required for your Kubernetes environment.")
+}

--- a/roxctl/scanner/generate/generate.go
+++ b/roxctl/scanner/generate/generate.go
@@ -62,11 +62,7 @@ func (cmd *scannerGenerateCommand) validate() error {
 }
 
 func (cmd *scannerGenerateCommand) generate(logger logger.Logger) error {
-	if cmd.enablePodSecurityPolicies {
-		common.LogInfoPspEnabled(logger)
-	} else {
-		common.LogInfoPspDisabled(logger)
-	}
+	common.LogInfoPsp(logger, cmd.enablePodSecurityPolicies)
 
 	cmd.apiParams.ClusterType = clustertype.Get().String()
 	cmd.apiParams.DisablePodSecurityPolicies = !cmd.enablePodSecurityPolicies

--- a/roxctl/scanner/generate/generate.go
+++ b/roxctl/scanner/generate/generate.go
@@ -109,7 +109,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		fmt.Sprintf(
 			"Generate deployment files supporting the given Istio version. Valid versions: %s",
 			strings.Join(istioutils.ListKnownIstioVersions(), ", ")))
-	c.PersistentFlags().BoolVar(&scannerGenerateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", true, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
+	c.PersistentFlags().BoolVar(&scannerGenerateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", false, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
 
 	return c
 }

--- a/roxctl/scanner/generate/generate.go
+++ b/roxctl/scanner/generate/generate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/apiparams"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/istioutils"
+	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/common/logger"
@@ -62,13 +63,9 @@ func (cmd *scannerGenerateCommand) validate() error {
 
 func (cmd *scannerGenerateCommand) generate(logger logger.Logger) error {
 	if cmd.enablePodSecurityPolicies {
-		logger.InfofLn("Scanner deployment bundle includes PodSecurityPolicies (PSPs). This is incompatible with Kubernetes >= v1.25.")
-		logger.InfofLn("Use --enable-pod-security-policies=false for disabling PodSecurityPolicies.")
-		logger.InfofLn("For the time being PodSecurityPolicies remain enabled by default in deployment bundles and need to be disabled explicitly for Kubernetes >= v1.25.")
+		common.LogInfoPspEnabled(logger)
 	} else {
-		logger.InfofLn("Scanner deployment bundle does not include PodSecurityPolicies (PSPs).")
-		logger.InfofLn("This is incompatible with pre-v1.25 Kubernetes installations having the PodSecurityPolicy Admission Controller plugin enabled.")
-		logger.InfofLn("Use --enable-pod-security-policies if PodSecurityPolicies are required for your Kubernetes environment.")
+		common.LogInfoPspDisabled(logger)
 	}
 
 	cmd.apiParams.ClusterType = clustertype.Get().String()

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -130,6 +130,16 @@ func (s *sensorGenerateCommand) fullClusterCreation() error {
 	}
 	s.setClusterDefaults(env)
 
+	if s.enablePodSecurityPolicies {
+		s.env.Logger().InfofLn("Sensor deployment bundle includes PodSecurityPolicies (PSPs). This is incompatible with Kubernetes >= v1.25.")
+		s.env.Logger().InfofLn("Use --enable-pod-security-policies=false for disabling PodSecurityPolicies.")
+		s.env.Logger().InfofLn("For the time being PodSecurityPolicies remain enabled by default in deployment bundles and need to be disabled explicitly for Kubernetes >= v1.25.")
+	} else {
+		s.env.Logger().InfofLn("Sensor deployment bundle does not include PodSecurityPolicies (PSPs).")
+		s.env.Logger().InfofLn("This is incompatible with pre-v1.25 Kubernetes installations having the PodSecurityPolicy Admission Controller plugin enabled.")
+		s.env.Logger().InfofLn("Use --enable-pod-security-policies if PodSecurityPolicies are required for your Kubernetes environment.")
+	}
+
 	id, err := s.createCluster(ctx, service)
 
 	// If the error is not explicitly AlreadyExists or it is AlreadyExists AND continueIfExists isn't set
@@ -228,7 +238,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	c.PersistentFlags().BoolVar(&generateCmd.cluster.AdmissionController, "admission-controller-listen-on-creates", false, "whether or not to configure the admission controller webhook to listen on deployment creates")
 	c.PersistentFlags().BoolVar(&generateCmd.cluster.AdmissionControllerUpdates, "admission-controller-listen-on-updates", false, "whether or not to configure the admission controller webhook to listen on deployment updates")
-	c.PersistentFlags().BoolVar(&generateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", false, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
+	c.PersistentFlags().BoolVar(&generateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", true, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
 
 	// Admission controller config
 	ac := generateCmd.cluster.DynamicConfig.AdmissionControllerConfig

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -131,13 +131,9 @@ func (s *sensorGenerateCommand) fullClusterCreation() error {
 	s.setClusterDefaults(env)
 
 	if s.enablePodSecurityPolicies {
-		s.env.Logger().InfofLn("Sensor deployment bundle includes PodSecurityPolicies (PSPs). This is incompatible with Kubernetes >= v1.25.")
-		s.env.Logger().InfofLn("Use --enable-pod-security-policies=false for disabling PodSecurityPolicies.")
-		s.env.Logger().InfofLn("For the time being PodSecurityPolicies remain enabled by default in deployment bundles and need to be disabled explicitly for Kubernetes >= v1.25.")
+		common.LogInfoPspEnabled(s.env.Logger())
 	} else {
-		s.env.Logger().InfofLn("Sensor deployment bundle does not include PodSecurityPolicies (PSPs).")
-		s.env.Logger().InfofLn("This is incompatible with pre-v1.25 Kubernetes installations having the PodSecurityPolicy Admission Controller plugin enabled.")
-		s.env.Logger().InfofLn("Use --enable-pod-security-policies if PodSecurityPolicies are required for your Kubernetes environment.")
+		common.LogInfoPspDisabled(s.env.Logger())
 	}
 
 	id, err := s.createCluster(ctx, service)

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -130,11 +130,7 @@ func (s *sensorGenerateCommand) fullClusterCreation() error {
 	}
 	s.setClusterDefaults(env)
 
-	if s.enablePodSecurityPolicies {
-		common.LogInfoPspEnabled(s.env.Logger())
-	} else {
-		common.LogInfoPspDisabled(s.env.Logger())
-	}
+	common.LogInfoPsp(s.env.Logger(), s.enablePodSecurityPolicies)
 
 	id, err := s.createCluster(ctx, service)
 

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -228,7 +228,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	c.PersistentFlags().BoolVar(&generateCmd.cluster.AdmissionController, "admission-controller-listen-on-creates", false, "whether or not to configure the admission controller webhook to listen on deployment creates")
 	c.PersistentFlags().BoolVar(&generateCmd.cluster.AdmissionControllerUpdates, "admission-controller-listen-on-updates", false, "whether or not to configure the admission controller webhook to listen on deployment updates")
-	c.PersistentFlags().BoolVar(&generateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", true, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
+	c.PersistentFlags().BoolVar(&generateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", false, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
 
 	// Admission controller config
 	ac := generateCmd.cluster.DynamicConfig.AdmissionControllerConfig

--- a/tests/roxctl/bats-tests/cluster/scanner-generate.bats
+++ b/tests/roxctl/bats-tests/cluster/scanner-generate.bats
@@ -30,16 +30,17 @@ scanner_generate() {
 }
 
 run_scanner_generate_and_check() {
-  local -r cluster_type="$1";shift
+  local -r cluster_type="$1"
+  shift
 
   scanner_generate --cluster-type "${cluster_type}" "$@"
   assert_success
 }
 
 assert_number_of_k8s_resources() {
-    local -r k8s_resources_count=$(cat "${output_dir}/scanner/"*.yaml | grep -c "^apiVersion") || true
+  local -r k8s_resources_count=$(cat "${output_dir}/scanner/"*.yaml | grep -c "^apiVersion") || true
 
-    [[ "${k8s_resources_count}" = "${1}" ]] || fail "Unexpected number of k8s resources"
+  [[ "${k8s_resources_count}" = "${1}" ]] || fail "Unexpected number of k8s resources"
 }
 
 @test "[openshift4] roxctl scanner generate" {
@@ -51,7 +52,7 @@ assert_number_of_k8s_resources() {
   # additional mounted volume. It's called "trusted-ca-volume" and we use it to identify OpenShift 4 configuration.
   run -0 grep -q 'trusted-ca-volume' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   run -0 grep -q 'ROX_OPENSHIFT_API' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  assert_number_of_k8s_resources 16
+  assert_number_of_k8s_resources 13
 }
 
 @test "[openshift] roxctl scanner generate" {
@@ -60,7 +61,7 @@ assert_number_of_k8s_resources() {
   assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   run -0 grep -q 'ROX_OPENSHIFT_API' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   run -1 grep -q 'trusted-ca-volume' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  assert_number_of_k8s_resources 16
+  assert_number_of_k8s_resources 13
 }
 
 @test "[k8s] roxctl scanner generate" {
@@ -72,7 +73,7 @@ assert_number_of_k8s_resources() {
   assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   run -1 grep -q 'ROX_OPENSHIFT_API' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
 
-  assert_number_of_k8s_resources 15
+  assert_number_of_k8s_resources 12
 }
 
 @test "[k8s istio-support] roxctl scanner generate" {
@@ -80,7 +81,7 @@ assert_number_of_k8s_resources() {
 
   assert_file_exist "${output_dir}/scanner/02-scanner-07-service.yaml"
   run -0 grep -q "^apiVersion: networking.istio.io/v1alpha3" "${output_dir}/scanner/02-scanner-07-service.yaml"
-  assert_number_of_k8s_resources 17
+  assert_number_of_k8s_resources 14
 }
 
 @test "[k8s scanner-image] roxctl scanner generate" {

--- a/tests/roxctl/bats-tests/cluster/scanner-generate.bats
+++ b/tests/roxctl/bats-tests/cluster/scanner-generate.bats
@@ -30,17 +30,16 @@ scanner_generate() {
 }
 
 run_scanner_generate_and_check() {
-  local -r cluster_type="$1"
-  shift
+  local -r cluster_type="$1";shift
 
   scanner_generate --cluster-type "${cluster_type}" "$@"
   assert_success
 }
 
 assert_number_of_k8s_resources() {
-  local -r k8s_resources_count=$(cat "${output_dir}/scanner/"*.yaml | grep -c "^apiVersion") || true
+    local -r k8s_resources_count=$(cat "${output_dir}/scanner/"*.yaml | grep -c "^apiVersion") || true
 
-  [[ "${k8s_resources_count}" = "${1}" ]] || fail "Unexpected number of k8s resources"
+    [[ "${k8s_resources_count}" = "${1}" ]] || fail "Unexpected number of k8s resources"
 }
 
 @test "[openshift4] roxctl scanner generate" {
@@ -52,7 +51,7 @@ assert_number_of_k8s_resources() {
   # additional mounted volume. It's called "trusted-ca-volume" and we use it to identify OpenShift 4 configuration.
   run -0 grep -q 'trusted-ca-volume' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   run -0 grep -q 'ROX_OPENSHIFT_API' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  assert_number_of_k8s_resources 13
+  assert_number_of_k8s_resources 16
 }
 
 @test "[openshift] roxctl scanner generate" {
@@ -61,7 +60,7 @@ assert_number_of_k8s_resources() {
   assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   run -0 grep -q 'ROX_OPENSHIFT_API' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   run -1 grep -q 'trusted-ca-volume' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  assert_number_of_k8s_resources 13
+  assert_number_of_k8s_resources 16
 }
 
 @test "[k8s] roxctl scanner generate" {
@@ -73,7 +72,7 @@ assert_number_of_k8s_resources() {
   assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   run -1 grep -q 'ROX_OPENSHIFT_API' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
 
-  assert_number_of_k8s_resources 12
+  assert_number_of_k8s_resources 15
 }
 
 @test "[k8s istio-support] roxctl scanner generate" {
@@ -81,7 +80,7 @@ assert_number_of_k8s_resources() {
 
   assert_file_exist "${output_dir}/scanner/02-scanner-07-service.yaml"
   run -0 grep -q "^apiVersion: networking.istio.io/v1alpha3" "${output_dir}/scanner/02-scanner-07-service.yaml"
-  assert_number_of_k8s_resources 14
+  assert_number_of_k8s_resources 17
 }
 
 @test "[k8s scanner-image] roxctl scanner generate" {


### PR DESCRIPTION
## Description

This PR is built on top of https://github.com/stackrox/stackrox/pull/1249 and toggles the defaults for generating deprecated PodSecurityPolicies effectively disabling them by default while still supporting explicit generation of them.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
