### PR TITLE
ROX-9208: Update Nginx and create stronger certificates

### DIFF
--- a/scripts/ci/proxy/nginx-proxy-plain-http.yaml
+++ b/scripts/ci/proxy/nginx-proxy-plain-http.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.17.1
+          image: nginx:1.20.2
           volumeMounts:
             - name: config-volume
               mountPath: /etc/nginx/conf.d/

--- a/scripts/ci/proxy/nginx-proxy-tls.yaml.template
+++ b/scripts/ci/proxy/nginx-proxy-tls.yaml.template
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.17.1
+          image: nginx:1.20.2
           volumeMounts:
             - name: config-volume
               mountPath: /etc/nginx/conf.d/

--- a/tests/scripts/setup-certs.sh
+++ b/tests/scripts/setup-certs.sh
@@ -40,16 +40,16 @@ keyUsage = critical, digitalSignature, cRLSign, keyCertSign
     openssl req -nodes -config <(echo "$root_ca_exts") -new -x509 -keyout ca.key -out ca.crt -subj "/CN=Root ${ca_name}"
 
     # Intermediate CA
-    openssl genrsa -out intermediate.key 2048
+    openssl genrsa -out intermediate.key 4096
     openssl req -new -key intermediate.key -subj "/CN=Intermediate ${ca_name}" |
-        openssl x509 -extfile <(echo "$intermediate_ca_exts") -req -CA ca.crt -CAkey ca.key -CAcreateserial -out intermediate.crt
+        openssl x509 -sha256 -extfile <(echo "$intermediate_ca_exts") -req -CA ca.crt -CAkey ca.key -CAcreateserial -out intermediate.crt
 
     leaf_ca_exts="subjectAltName=DNS:${cn}"
 
     # Leaf cert
-    openssl genrsa -out leaf.key 2048
+    openssl genrsa -out leaf.key 4096
     openssl req -new -key leaf.key -subj "/CN=${cn}" |
-        openssl x509 -extfile <(echo "$leaf_ca_exts") -req -CA intermediate.crt -CAkey intermediate.key -CAcreateserial -out leaf.crt
+        openssl x509 -sha256 -extfile <(echo "$leaf_ca_exts") -req -CA intermediate.crt -CAkey intermediate.key -CAcreateserial -out leaf.crt
 
     cat leaf.crt intermediate.crt ca.crt >tls.crt
     cp leaf.key tls.key


### PR DESCRIPTION
## Description

It seems that the problem with this flaky test is some incorrect implementation of gRPC in Nginx. More info here: https://trac.nginx.org/nginx/ticket/1792

So the required change was to update Nginx, but with an update of Nginx OpenSSL is also updated and an additional necessary change is to update certificate generation.

**Testing results**
For testing workflow please check *Testing Performed*. Initially, I had ~1/5 fails. After the update to Nginx 1.20.2 result was 0/30 fails.

**Open questions**
1. Should we still support Nginx 1.17 or not?
2. Should we still support weak certificates?

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~ - tests are not added, but modified
- ~[ ] Evaluated and added CHANGELOG entry if required~ - not needed
- ~[ ] Determined and documented upgrade steps~ - not needed
- ~[ ] Documented user facing changes (create PR based on [stackrox/openshift-docs](https://github.com/stackrox/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~ - not needed

## Testing Performed

1. start GKE default cluster
```
export INFRA_NAME=mt-1705-t1
infractl create gke-default "${INFRA_NAME}" --description "CI Flake"
```
2. get artifacts
```
infractl artifacts "${INFRA_NAME}" --download-dir ./artifacts
export KUBECONFIG=$(pwd)/artifacts/kubeconfig
```
3. deployed some recent master branch builds
```
export MAIN_IMAGE_TAG=3.70.x-88-gf19b0089dd
./deploy/k8s/deploy.sh
export ROX_PASSWORD=$(cat deploy/k8s/central-deploy/password)
```
4. edit central deployment and add environment `env` to deployment. Name: `ROX_PLAINTEXT_ENDPOINTS` - value: `"8080,grpc@8081"`
5. prepare tests
```
source tests/e2e/run.sh
setup_proxy_tests
```
6. run tests in loop
```
run_test_with_clean() {
  run_proxy_tests
  rm -rf /tmp/proxy-test-1*
}

for i in {1..20}
do
   echo "=========== LOOP ${i} ==========="
   run_test_with_clean
   echo "============= DONE =============="
done
```
