### PR TITLE
OpenShift CI: remove gke-api-upgrade-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2982,16 +2982,6 @@ jobs:
       - provision-gke-cluster:
           cluster-id: kernel-api-e2e-tests
 
-  provision-gke-api-upgrade-tests:
-    executor: custom
-    resource_class: small
-    steps:
-      - checkout
-      - gate-job:
-          job: gke-upgrade-tests
-      - provision-gke-cluster:
-          cluster-id: upgrade-test
-
   build-scale-monitoring-and-mock-server:
     executor: custom
     resource_class: medium
@@ -3665,41 +3655,6 @@ jobs:
                 label: ci-kernel-module-tests
                 run-on-master: true
                 run-on-tags: true
-
-  gke-api-upgrade-tests:
-    executor: custom
-    environment:
-      LOAD_BALANCER: "lb"
-    steps:
-      - checkout
-      - gate-job:
-          job: gke-upgrade-tests
-      - attach_workspace:
-          at: /go/src/github.com/stackrox/rox
-      - restore-go-mod-cache
-
-      - setup-gcp
-      - attach-gke-cluster:
-          cluster-id: upgrade-test
-
-      - run:
-          name: Upgrade tests
-          command: |
-            ./tests/upgrade/run.sh /tmp/upgrade-test-logs
-
-      - ci-artifacts/store:
-          path: /tmp/upgrade-test-logs
-          destination: upgrade-test-logs
-
-      - *alwaysWaitForAPI
-
-      - collect-k8s-logs
-      - get-and-store-debug-dump
-      - get-and-store-diagnostic-bundle
-      - get-central-data
-      - store-k8s-logs
-      - *storeQALogs
-      - teardown-gke
 
   gke-api-scale-tests:
     executor: custom
@@ -4873,14 +4828,6 @@ workflows:
             - build-rhacs
             - build-scale-monitoring-and-mock-server
             - provision-gke-kernel-api-e2e-tests
-      - provision-gke-api-upgrade-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-      - gke-api-upgrade-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-          requires:
-            - build-stackrox
-            - build-rhacs
-            - provision-gke-api-upgrade-tests
       - provision-gke-api-scale-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
       - gke-api-scale-tests:


### PR DESCRIPTION
## Description

Removes the test from Circle CI in favor of OpenShift CI.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient