### PR TITLE
ROX-10993: Respect replaced resources within built-in scope checker.

### DIFF
--- a/central/sac/authorizer/builtin_scoped_authorizer.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer.go
@@ -194,7 +194,7 @@ func (a *resourceLevelScopeCheckerCore) EffectiveAccessScope(resource permission
 	}
 	// Ensure replaced resources are also taken into account.
 	if a.resource != resource.Resource && (a.resource.ReplacingResource == nil ||
-		a.resource.ReplacingResource != nil && *a.resource.ReplacingResource != resource.Resource) {
+		(a.resource.ReplacingResource != nil && *a.resource.ReplacingResource != resource.Resource)) {
 		return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
 	}
 

--- a/central/sac/authorizer/builtin_scoped_authorizer_test.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer_test.go
@@ -53,6 +53,7 @@ var (
 func TestBuiltInScopeAuthorizerWithTracing(t *testing.T) {
 	t.Parallel()
 	clusterEdit := map[string]storage.Access{string(resources.Cluster.Resource): storage.Access_READ_WRITE_ACCESS}
+	complianceEdit := map[string]storage.Access{string(resources.Compliance.Resource): storage.Access_READ_WRITE_ACCESS}
 
 	tests := []struct {
 		name      string
@@ -63,7 +64,7 @@ func TestBuiltInScopeAuthorizerWithTracing(t *testing.T) {
 		{
 			name:      "allow read from cluster with permissions",
 			roles:     []permissions.ResolvedRole{role(allResourcesView, withAccessTo1Cluster())},
-			scopeKeys: readCluster(firstCluster.ID),
+			scopeKeys: readCluster(firstCluster.ID, resources.Cluster.Resource),
 			results:   []sac.TryAllowedResult{sac.Deny, sac.Deny, sac.Allow},
 		},
 		{
@@ -75,7 +76,7 @@ func TestBuiltInScopeAuthorizerWithTracing(t *testing.T) {
 		{
 			name:      "deny cluster view with permissions but no access scope if id does not exist",
 			roles:     []permissions.ResolvedRole{role(clusterEdit, withAccessTo1Cluster())},
-			scopeKeys: readCluster("unknown ID"),
+			scopeKeys: readCluster("unknown ID", resources.Cluster.Resource),
 			results:   []sac.TryAllowedResult{sac.Deny, sac.Deny, sac.Deny},
 		},
 		{
@@ -87,8 +88,20 @@ func TestBuiltInScopeAuthorizerWithTracing(t *testing.T) {
 		{
 			name:      "deny read from cluster with no scope access",
 			roles:     []permissions.ResolvedRole{role(allResourcesView, withAccessTo1Cluster())},
-			scopeKeys: readCluster(secondCluster.ID),
+			scopeKeys: readCluster(secondCluster.ID, resources.Cluster.Resource),
 			results:   []sac.TryAllowedResult{sac.Deny, sac.Deny, sac.Deny},
+		},
+		{
+			name:      "allow read from compliance with permissions",
+			roles:     []permissions.ResolvedRole{role(complianceEdit, withAccessTo1Cluster())},
+			scopeKeys: readCluster(firstCluster.ID, resources.Compliance.Resource),
+			results:   []sac.TryAllowedResult{sac.Deny, sac.Deny, sac.Allow},
+		},
+		{
+			name:      "allow read from compliance with replacing resource permissions",
+			roles:     []permissions.ResolvedRole{role(complianceEdit, withAccessTo1Cluster())},
+			scopeKeys: readCluster(firstCluster.ID, resources.ComplianceRuns.Resource),
+			results:   []sac.TryAllowedResult{sac.Deny, sac.Deny, sac.Allow},
 		},
 		{
 			name: "allow read from namespace with multiple roles",
@@ -101,25 +114,25 @@ func TestBuiltInScopeAuthorizerWithTracing(t *testing.T) {
 		{
 			name:      "allow read from anything when scope unrestricted",
 			roles:     []permissions.ResolvedRole{role(allResourcesView, rolePkg.AccessScopeIncludeAll)},
-			scopeKeys: readCluster("unknown ID"),
+			scopeKeys: readCluster("unknown ID", resources.Cluster.Resource),
 			results:   []sac.TryAllowedResult{sac.Deny, sac.Allow, sac.Allow},
 		},
 		{
 			name:      "deny read from anything when scope is nil",
 			roles:     []permissions.ResolvedRole{role(allResourcesView, nil)},
-			scopeKeys: readCluster("unknown ID"),
+			scopeKeys: readCluster("unknown ID", resources.Cluster.Resource),
 			results:   []sac.TryAllowedResult{sac.Deny, sac.Deny, sac.Deny},
 		},
 		{
 			name:      "deny read from anything when scope is empty",
 			roles:     []permissions.ResolvedRole{role(allResourcesView, &storage.SimpleAccessScope{Id: "empty"})},
-			scopeKeys: readCluster(firstCluster.ID),
+			scopeKeys: readCluster(firstCluster.ID, resources.Cluster.Resource),
 			results:   []sac.TryAllowedResult{sac.Deny, sac.Deny, sac.Deny},
 		},
 		{
 			name:      "deny read from anything when scope deny all",
 			roles:     []permissions.ResolvedRole{role(allResourcesView, rolePkg.AccessScopeExcludeAll)},
-			scopeKeys: readCluster(firstCluster.ID),
+			scopeKeys: readCluster(firstCluster.ID, resources.Cluster.Resource),
 			results:   []sac.TryAllowedResult{sac.Deny, sac.Deny, sac.Deny},
 		},
 	}
@@ -158,7 +171,7 @@ func TestScopeCheckerWithParallelAccessAndSharedGlobalScopeChecker(t *testing.T)
 	}{
 		{
 			name:      "allow read from cluster with partial access",
-			scopeKeys: readCluster(firstCluster.ID),
+			scopeKeys: readCluster(firstCluster.ID, resources.Cluster.Resource),
 			results:   []sac.TryAllowedResult{sac.Deny, sac.Deny, sac.Allow},
 		},
 		{
@@ -254,6 +267,8 @@ func TestEffectiveAccessScope(t *testing.T) {
 	t.Parallel()
 
 	clusterEdit := map[string]storage.Access{string(resources.Cluster.Resource): storage.Access_READ_WRITE_ACCESS}
+
+	complianceEdit := map[string]storage.Access{string(resources.Compliance.Resource): storage.Access_READ_WRITE_ACCESS}
 
 	// Note: The scope tree Compactify function relies on cluster names rather than cluster IDs to identify
 	// the cluster part. In order to have the scope validation (which relies on Compactify) working,
@@ -419,6 +434,30 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
+			name:      "Access to replaced resource (read-write) for unrestricted scope gives unrestricted scope tree for the resource and any access (case read cluster)",
+			roles:     []permissions.ResolvedRole{role(complianceEdit, rolePkg.AccessScopeIncludeAll)},
+			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.ComplianceRuns),
+			resultEAS: effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
+		},
+		{
+			name:      "Access to replaced resource (read-write) for unrestricted scope gives unrestricted scope tree for the resource and any access (case write cluster)",
+			roles:     []permissions.ResolvedRole{role(complianceEdit, rolePkg.AccessScopeIncludeAll)},
+			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.ComplianceRuns),
+			resultEAS: effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
+		},
+		{
+			name:      "Access to replaced resource (read-write) for unrestricted scope gives deny-all scope tree for any other resource and any access (case read namespace)",
+			roles:     []permissions.ResolvedRole{role(complianceEdit, rolePkg.AccessScopeIncludeAll)},
+			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),
+			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
+		},
+		{
+			name:      "Access to replaced resource (read-write) for unrestricted scope gives deny-all scope tree for any other resource and any access (case write namespace)",
+			roles:     []permissions.ResolvedRole{role(complianceEdit, rolePkg.AccessScopeIncludeAll)},
+			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Cluster),
+			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
+		},
+		{
 			name:      "Access to any resource (read-write) for cluster scope gives cluster scope tree for any resource and access (case read cluster)",
 			roles:     []permissions.ResolvedRole{role(allResourcesEdit, withAccessTo1Cluster())},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),
@@ -535,6 +574,51 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Namespace),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
+		{
+			name:      "Access to specific replaced resource (read-write) for namespace scope gives namespace scope tree for the resource and any access (case read cluster)",
+			roles:     []permissions.ResolvedRole{role(complianceEdit, withAccessTo1Namespace())},
+			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.ComplianceRuns),
+			resultEAS: oneNamespaceEffectiveScope,
+		},
+		{
+			name:      "Access to specific replaced resource (read-write) for namespace scope gives namespace scope tree for the resource and any access (case write cluster)",
+			roles:     []permissions.ResolvedRole{role(complianceEdit, withAccessTo1Namespace())},
+			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.ComplianceRuns),
+			resultEAS: oneNamespaceEffectiveScope,
+		},
+		{
+			name:      "Access to specific replaced resource (read-write) for namespace scope gives deny-all scope tree for any other resource and access (case read namespace)",
+			roles:     []permissions.ResolvedRole{role(complianceEdit, withAccessTo1Namespace())},
+			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),
+			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
+		},
+		{
+			name:      "Access to specific replaced resource (read-write) for namespace scope gives deny-all scope tree for any other resource and access (case write namespace)",
+			roles:     []permissions.ResolvedRole{role(complianceEdit, withAccessTo1Namespace())},
+			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Cluster),
+			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
+		},
+		{
+			name: "Access to specific replaced resource (read-write) for mixed scope gives union scope tree for the resource and any access (case read cluster)",
+			roles: []permissions.ResolvedRole{
+				role(complianceEdit, withAccessTo1Namespace()), role(complianceEdit, withAccessTo2Cluster())},
+			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.ComplianceRuns),
+			resultEAS: mixedEffectiveScope,
+		},
+		{
+			name: "Access to specific replaced resource (read-write) for mixed scope gives union scope tree for the resource and any access (case write cluster)",
+			roles: []permissions.ResolvedRole{
+				role(complianceEdit, withAccessTo1Namespace()), role(complianceEdit, withAccessTo2Cluster())},
+			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.ComplianceRuns),
+			resultEAS: mixedEffectiveScope,
+		},
+		{
+			name: "Access to specific replaced resource (read-write) for mixed scope gives deny-all scope tree for any other resource and access (case read namespace)",
+			roles: []permissions.ResolvedRole{
+				role(complianceEdit, withAccessTo1Namespace()), role(complianceEdit, withAccessTo2Cluster())},
+			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),
+			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
+		},
 	}
 	for _, tc := range tests {
 		tc := tc
@@ -589,7 +673,7 @@ func TestBuiltInScopeAuthorizerPanicsWhenErrorOnComputeAccessScope(t *testing.T)
 						Requirements: []*storage.SetBasedLabelSelector_Requirement{
 							{Key: "invalid key"},
 						}}}}})},
-			scopeKeys: readCluster(firstCluster.ID),
+			scopeKeys: readCluster(firstCluster.ID, resources.Cluster.Resource),
 			results:   []sac.TryAllowedResult{sac.Deny, sac.Unknown, sac.Unknown, sac.Unknown},
 		},
 	}
@@ -613,8 +697,8 @@ func TestBuiltInScopeAuthorizerPanicsWhenErrorOnComputeAccessScope(t *testing.T)
 	}
 }
 
-func readCluster(clusterID string) []sac.ScopeKey {
-	return scopeKeys(storage.Access_READ_ACCESS, resources.Cluster.Resource, clusterID, "")[:3]
+func readCluster(clusterID string, resource permissions.Resource) []sac.ScopeKey {
+	return scopeKeys(storage.Access_READ_ACCESS, resource, clusterID, "")[:3]
 }
 
 func readNamespace(clusterID, namespaceName string) []sac.ScopeKey {

--- a/central/sac/authorizer/builtin_scoped_authorizer_test.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer_test.go
@@ -320,7 +320,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to all resources (read-only) for unrestricted scope gives deny-all scope tree for any resource write (case write cluster)",
+			name:      "Access to all resources (read-write) for unrestricted scope gives deny-all scope tree for any resource write (case write cluster)",
 			roles:     []permissions.ResolvedRole{role(allResourcesView, rolePkg.AccessScopeIncludeAll)},
 			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Cluster),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
@@ -332,13 +332,13 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to all resources (read-only) for unrestricted scope gives deny-all scope tree for any resource write (case write namespace)",
+			name:      "Access to all resources (read-write) for unrestricted scope gives deny-all scope tree for any resource write (case write namespace)",
 			roles:     []permissions.ResolvedRole{role(allResourcesView, rolePkg.AccessScopeIncludeAll)},
 			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Namespace),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to all resources (read-write) for deny-all scope gives deny-all scope tree for any resource and access (case read cluster)",
+			name:      "Access to all resources (read-only) for deny-all scope gives deny-all scope tree for any resource and access (case read cluster)",
 			roles:     []permissions.ResolvedRole{role(allResourcesEdit, rolePkg.AccessScopeExcludeAll)},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
@@ -350,7 +350,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to all resources (read-write) for deny-all scope gives deny-all scope tree for any resource and access (case read namespace)",
+			name:      "Access to all resources (read-only) for deny-all scope gives deny-all scope tree for any resource and access (case read namespace)",
 			roles:     []permissions.ResolvedRole{role(allResourcesEdit, rolePkg.AccessScopeExcludeAll)},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Namespace),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
@@ -362,7 +362,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to all resources (read-write) for nil scope gives deny-all scope tree for any resource and access (case read cluster)",
+			name:      "Access to all resources (read-only) for nil scope gives deny-all scope tree for any resource and access (case read cluster)",
 			roles:     []permissions.ResolvedRole{role(allResourcesEdit, nil)},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
@@ -374,7 +374,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to all resources (read-write) for nil scope gives deny-all scope tree for any resource and access (case read namespace)",
+			name:      "Access to all resources (read-only) for nil scope gives deny-all scope tree for any resource and access (case read namespace)",
 			roles:     []permissions.ResolvedRole{role(allResourcesEdit, nil)},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Namespace),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
@@ -386,7 +386,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to all resources (read-write) for empty scope gives deny-all scope tree for any resource and access (case read cluster)",
+			name:      "Access to all resources (read-only) for empty scope gives deny-all scope tree for any resource and access (case read cluster)",
 			roles:     []permissions.ResolvedRole{role(allResourcesEdit, &storage.SimpleAccessScope{Id: "empty"})},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
@@ -398,7 +398,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to all resources (read-write) for empty scope gives deny-all scope tree for any resource and access (case read namespace)",
+			name:      "Access to all resources (read-only) for empty scope gives deny-all scope tree for any resource and access (case read namespace)",
 			roles:     []permissions.ResolvedRole{role(allResourcesEdit, &storage.SimpleAccessScope{Id: "empty"})},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Namespace),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
@@ -410,7 +410,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to one resource (read-write) for unrestricted scope gives unrestricted scope tree for the resource and any access (case read cluster)",
+			name:      "Access to one resource (read-only) for unrestricted scope gives unrestricted scope tree for the resource and any access (case read cluster)",
 			roles:     []permissions.ResolvedRole{role(clusterEdit, rolePkg.AccessScopeIncludeAll)},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),
 			resultEAS: effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
@@ -422,7 +422,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to one resource (read-write) for unrestricted scope gives deny-all scope tree for any other resource and any access (case read namespace)",
+			name:      "Access to one resource (read-only) for unrestricted scope gives deny-all scope tree for any other resource and any access (case read namespace)",
 			roles:     []permissions.ResolvedRole{role(clusterEdit, rolePkg.AccessScopeIncludeAll)},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Namespace),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
@@ -434,7 +434,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to replaced resource (read-write) for unrestricted scope gives unrestricted scope tree for the resource and any access (case read cluster)",
+			name:      "Access to replaced resource (read-only) for unrestricted scope gives unrestricted scope tree for the resource and any access (case read cluster)",
 			roles:     []permissions.ResolvedRole{role(complianceEdit, rolePkg.AccessScopeIncludeAll)},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.ComplianceRuns),
 			resultEAS: effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
@@ -446,7 +446,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to replaced resource (read-write) for unrestricted scope gives deny-all scope tree for any other resource and any access (case read namespace)",
+			name:      "Access to replaced resource (read-only) for unrestricted scope gives deny-all scope tree for any other resource and any access (case read namespace)",
 			roles:     []permissions.ResolvedRole{role(complianceEdit, rolePkg.AccessScopeIncludeAll)},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
@@ -458,7 +458,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to any resource (read-write) for cluster scope gives cluster scope tree for any resource and access (case read cluster)",
+			name:      "Access to any resource (read-only) for cluster scope gives cluster scope tree for any resource and access (case read cluster)",
 			roles:     []permissions.ResolvedRole{role(allResourcesEdit, withAccessTo1Cluster())},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),
 			resultEAS: oneClusterEffectiveScope,
@@ -470,7 +470,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: oneClusterEffectiveScope,
 		},
 		{
-			name:      "Access to any resource (read-write) for cluster scope gives cluster scope tree for any resource and access (case read namespace)",
+			name:      "Access to any resource (read-only) for cluster scope gives cluster scope tree for any resource and access (case read namespace)",
 			roles:     []permissions.ResolvedRole{role(allResourcesEdit, withAccessTo1Cluster())},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Namespace),
 			resultEAS: oneClusterEffectiveScope,
@@ -482,7 +482,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: oneClusterEffectiveScope,
 		},
 		{
-			name:      "Access to any resource (read-write) for namespace scope gives namespace scope tree for any resource and access (case read cluster)",
+			name:      "Access to any resource (read-only) for namespace scope gives namespace scope tree for any resource and access (case read cluster)",
 			roles:     []permissions.ResolvedRole{role(allResourcesEdit, withAccessTo1Namespace())},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),
 			resultEAS: oneNamespaceEffectiveScope,
@@ -494,7 +494,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: oneNamespaceEffectiveScope,
 		},
 		{
-			name:      "Access to any resource (read-write) for namespace scope gives namespace scope tree for any resource and access (case read namespace)",
+			name:      "Access to any resource (read-only) for namespace scope gives namespace scope tree for any resource and access (case read namespace)",
 			roles:     []permissions.ResolvedRole{role(allResourcesEdit, withAccessTo1Namespace())},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Namespace),
 			resultEAS: oneNamespaceEffectiveScope,
@@ -512,7 +512,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: oneNamespaceEffectiveScope,
 		},
 		{
-			name:      "Access to any resource (read-only) for namespace scope gives deny-all scope tree for any resource and write access (case write cluster)",
+			name:      "Access to any resource (read-write) for namespace scope gives deny-all scope tree for any resource and write access (case write cluster)",
 			roles:     []permissions.ResolvedRole{role(allResourcesView, withAccessTo1Namespace())},
 			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Cluster),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
@@ -524,13 +524,13 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: oneNamespaceEffectiveScope,
 		},
 		{
-			name:      "Access to any resource (read-only) for namespace scope gives deny-all scope tree for any resource and write access (case write namespace)",
+			name:      "Access to any resource (read-write) for namespace scope gives deny-all scope tree for any resource and write access (case write namespace)",
 			roles:     []permissions.ResolvedRole{role(allResourcesView, withAccessTo1Namespace())},
 			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Namespace),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to specific resource (read-write) for namespace scope gives namespace scope tree for the resource and any access (case read cluster)",
+			name:      "Access to specific resource (read-only) for namespace scope gives namespace scope tree for the resource and any access (case read cluster)",
 			roles:     []permissions.ResolvedRole{role(clusterEdit, withAccessTo1Namespace())},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),
 			resultEAS: oneNamespaceEffectiveScope,
@@ -542,7 +542,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: oneNamespaceEffectiveScope,
 		},
 		{
-			name:      "Access to specific resource (read-write) for namespace scope gives deny-all scope tree for any other resource and access (case read namespace)",
+			name:      "Access to specific resource (read-only) for namespace scope gives deny-all scope tree for any other resource and access (case read namespace)",
 			roles:     []permissions.ResolvedRole{role(clusterEdit, withAccessTo1Namespace())},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Namespace),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
@@ -554,7 +554,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name: "Access to specific resource (read-write) for mixed scope gives union scope tree for the resource and any access (case read cluster)",
+			name: "Access to specific resource (read-only) for mixed scope gives union scope tree for the resource and any access (case read cluster)",
 			roles: []permissions.ResolvedRole{
 				role(clusterEdit, withAccessTo1Namespace()), role(clusterEdit, withAccessTo2Cluster())},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),
@@ -568,14 +568,14 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: mixedEffectiveScope,
 		},
 		{
-			name: "Access to specific resource (read-write) for mixed scope gives deny-all scope tree for any other resource and access (case read namespace)",
+			name: "Access to specific resource (read-only) for mixed scope gives deny-all scope tree for any other resource and access (case read namespace)",
 			roles: []permissions.ResolvedRole{
 				role(clusterEdit, withAccessTo1Namespace()), role(clusterEdit, withAccessTo2Cluster())},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Namespace),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to specific replaced resource (read-write) for namespace scope gives namespace scope tree for the resource and any access (case read cluster)",
+			name:      "Access to specific replaced resource (read-only) for namespace scope gives namespace scope tree for the resource and any access (case read cluster)",
 			roles:     []permissions.ResolvedRole{role(complianceEdit, withAccessTo1Namespace())},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.ComplianceRuns),
 			resultEAS: oneNamespaceEffectiveScope,
@@ -587,7 +587,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: oneNamespaceEffectiveScope,
 		},
 		{
-			name:      "Access to specific replaced resource (read-write) for namespace scope gives deny-all scope tree for any other resource and access (case read namespace)",
+			name:      "Access to specific replaced resource (read-only) for namespace scope gives deny-all scope tree for any other resource and access (case read namespace)",
 			roles:     []permissions.ResolvedRole{role(complianceEdit, withAccessTo1Namespace())},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
@@ -599,7 +599,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name: "Access to specific replaced resource (read-write) for mixed scope gives union scope tree for the resource and any access (case read cluster)",
+			name: "Access to specific replaced resource (read-only) for mixed scope gives union scope tree for the resource and any access (case read cluster)",
 			roles: []permissions.ResolvedRole{
 				role(complianceEdit, withAccessTo1Namespace()), role(complianceEdit, withAccessTo2Cluster())},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.ComplianceRuns),
@@ -613,7 +613,7 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: mixedEffectiveScope,
 		},
 		{
-			name: "Access to specific replaced resource (read-write) for mixed scope gives deny-all scope tree for any other resource and access (case read namespace)",
+			name: "Access to specific replaced resource (read-only) for mixed scope gives deny-all scope tree for any other resource and access (case read namespace)",
 			roles: []permissions.ResolvedRole{
 				role(complianceEdit, withAccessTo1Namespace()), role(complianceEdit, withAccessTo2Cluster())},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),

--- a/pkg/auth/permissions/resource_test.go
+++ b/pkg/auth/permissions/resource_test.go
@@ -8,6 +8,27 @@ import (
 )
 
 func TestCheckResourceForAccess(t *testing.T) {
+	testResource := Resource("Test")
+	replacingResource := Resource("Test")
+
+	testResourceMetadata := ResourceMetadata{
+		Resource: testResource,
+	}
+	testResourceWithReplacingResourceMetadata := ResourceMetadata{
+		Resource: testResource,
+		ReplacingResource: &ResourceMetadata{
+			Resource: replacingResource,
+		},
+	}
+
+	testResourceRead := map[string]storage.Access{string(testResource): storage.Access_READ_ACCESS}
+	testResourceReadWrite := map[string]storage.Access{string(testResource): storage.Access_READ_WRITE_ACCESS}
+
+	replacingResourceRead := map[string]storage.Access{string(replacingResource): storage.Access_READ_ACCESS}
+	replacingResourceReadWrite := map[string]storage.Access{string(replacingResource): storage.Access_READ_WRITE_ACCESS}
+
+	otherResourceRead := map[string]storage.Access{"Other": storage.Access_READ_ACCESS}
+
 	cases := map[string]struct {
 		resource    ResourceMetadata
 		permissions map[string]storage.Access
@@ -15,76 +36,48 @@ func TestCheckResourceForAccess(t *testing.T) {
 		expectedRes bool
 	}{
 		"non-replaced resource with READ access asking for READ access should return true": {
-			resource: ResourceMetadata{
-				Resource: "Test",
-			},
-			permissions: map[string]storage.Access{"Test": storage.Access_READ_ACCESS},
+			resource:    testResourceMetadata,
+			permissions: testResourceRead,
 			access:      storage.Access_READ_ACCESS,
 			expectedRes: true,
 		},
 		"non-replaced resource with WRITE access asking for READ access should return true": {
-			resource: ResourceMetadata{
-				Resource: "Test",
-			},
-			permissions: map[string]storage.Access{"Test": storage.Access_READ_WRITE_ACCESS},
+			resource:    testResourceMetadata,
+			permissions: testResourceReadWrite,
 			access:      storage.Access_READ_ACCESS,
 			expectedRes: true,
 		},
 		"non-replaced resource with READ access asking for WRITE access should return false": {
-			resource: ResourceMetadata{
-				Resource: "Test",
-			},
-			permissions: map[string]storage.Access{"Test": storage.Access_READ_ACCESS},
+			resource:    testResourceMetadata,
+			permissions: testResourceRead,
 			access:      storage.Access_READ_WRITE_ACCESS,
 		},
 		"non-replaced resource with no access asking for READ access should return false": {
-			resource: ResourceMetadata{
-				Resource: "Test",
-			},
-			permissions: map[string]storage.Access{"Other resource": storage.Access_READ_ACCESS},
-			access:      storage.Access_READ_WRITE_ACCESS,
+			resource:    testResourceMetadata,
+			permissions: otherResourceRead,
+			access:      storage.Access_READ_ACCESS,
 		},
 		"replaced resource with READ access asking for READ access should return true": {
-			resource: ResourceMetadata{
-				Resource: "Test",
-				ReplacingResource: &ResourceMetadata{
-					Resource: "ReplaceTest",
-				},
-			},
-			permissions: map[string]storage.Access{"ReplaceTest": storage.Access_READ_ACCESS},
+			resource:    testResourceWithReplacingResourceMetadata,
+			permissions: replacingResourceRead,
 			access:      storage.Access_READ_ACCESS,
 			expectedRes: true,
 		},
 		"replaced resource with WRITE access asking for READ access should return true": {
-			resource: ResourceMetadata{
-				Resource: "Test",
-				ReplacingResource: &ResourceMetadata{
-					Resource: "ReplaceTest",
-				},
-			},
-			permissions: map[string]storage.Access{"ReplaceTest": storage.Access_READ_WRITE_ACCESS},
+			resource:    testResourceWithReplacingResourceMetadata,
+			permissions: replacingResourceReadWrite,
 			access:      storage.Access_READ_ACCESS,
 			expectedRes: true,
 		},
 		"replaced resource with READ access asking for WRITE access should return false": {
-			resource: ResourceMetadata{
-				Resource: "Test",
-				ReplacingResource: &ResourceMetadata{
-					Resource: "ReplaceTest",
-				},
-			},
-			permissions: map[string]storage.Access{"ReplaceTest": storage.Access_READ_ACCESS},
+			resource:    testResourceWithReplacingResourceMetadata,
+			permissions: replacingResourceRead,
 			access:      storage.Access_READ_WRITE_ACCESS,
 		},
 		"replaced resource with no access asking for READ access should return false": {
-			resource: ResourceMetadata{
-				Resource: "Test",
-				ReplacingResource: &ResourceMetadata{
-					Resource: "ReplaceTest",
-				},
-			},
-			permissions: map[string]storage.Access{"Other Resource": storage.Access_READ_ACCESS},
-			access:      storage.Access_READ_WRITE_ACCESS,
+			resource:    testResourceWithReplacingResourceMetadata,
+			permissions: otherResourceRead,
+			access:      storage.Access_READ_ACCESS,
 		},
 	}
 

--- a/pkg/auth/permissions/resource_test.go
+++ b/pkg/auth/permissions/resource_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestCheckResourceForAccess(t *testing.T) {
 	testResource := Resource("Test")
-	replacingResource := Resource("Test")
+	replacingResource := Resource("TestReplace")
 
 	testResourceMetadata := ResourceMetadata{
 		Resource: testResource,

--- a/pkg/auth/permissions/resource_test.go
+++ b/pkg/auth/permissions/resource_test.go
@@ -1,0 +1,96 @@
+package permissions
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckResourceForAccess(t *testing.T) {
+	cases := map[string]struct {
+		resource    ResourceMetadata
+		permissions map[string]storage.Access
+		access      storage.Access
+		expectedRes bool
+	}{
+		"non-replaced resource with READ access asking for READ access should return true": {
+			resource: ResourceMetadata{
+				Resource: "Test",
+			},
+			permissions: map[string]storage.Access{"Test": storage.Access_READ_ACCESS},
+			access:      storage.Access_READ_ACCESS,
+			expectedRes: true,
+		},
+		"non-replaced resource with WRITE access asking for READ access should return true": {
+			resource: ResourceMetadata{
+				Resource: "Test",
+			},
+			permissions: map[string]storage.Access{"Test": storage.Access_READ_WRITE_ACCESS},
+			access:      storage.Access_READ_ACCESS,
+			expectedRes: true,
+		},
+		"non-replaced resource with READ access asking for WRITE access should return false": {
+			resource: ResourceMetadata{
+				Resource: "Test",
+			},
+			permissions: map[string]storage.Access{"Test": storage.Access_READ_ACCESS},
+			access:      storage.Access_READ_WRITE_ACCESS,
+		},
+		"non-replaced resource with no access asking for READ access should return false": {
+			resource: ResourceMetadata{
+				Resource: "Test",
+			},
+			permissions: map[string]storage.Access{"Other resource": storage.Access_READ_ACCESS},
+			access:      storage.Access_READ_WRITE_ACCESS,
+		},
+		"replaced resource with READ access asking for READ access should return true": {
+			resource: ResourceMetadata{
+				Resource: "Test",
+				ReplacingResource: &ResourceMetadata{
+					Resource: "ReplaceTest",
+				},
+			},
+			permissions: map[string]storage.Access{"ReplaceTest": storage.Access_READ_ACCESS},
+			access:      storage.Access_READ_ACCESS,
+			expectedRes: true,
+		},
+		"replaced resource with WRITE access asking for READ access should return true": {
+			resource: ResourceMetadata{
+				Resource: "Test",
+				ReplacingResource: &ResourceMetadata{
+					Resource: "ReplaceTest",
+				},
+			},
+			permissions: map[string]storage.Access{"ReplaceTest": storage.Access_READ_WRITE_ACCESS},
+			access:      storage.Access_READ_ACCESS,
+			expectedRes: true,
+		},
+		"replaced resource with READ access asking for WRITE access should return false": {
+			resource: ResourceMetadata{
+				Resource: "Test",
+				ReplacingResource: &ResourceMetadata{
+					Resource: "ReplaceTest",
+				},
+			},
+			permissions: map[string]storage.Access{"ReplaceTest": storage.Access_READ_ACCESS},
+			access:      storage.Access_READ_WRITE_ACCESS,
+		},
+		"replaced resource with no access asking for READ access should return false": {
+			resource: ResourceMetadata{
+				Resource: "Test",
+				ReplacingResource: &ResourceMetadata{
+					Resource: "ReplaceTest",
+				},
+			},
+			permissions: map[string]storage.Access{"Other Resource": storage.Access_READ_ACCESS},
+			access:      storage.Access_READ_WRITE_ACCESS,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, c.expectedRes, CheckResourceForAccess(c.resource, c.permissions, c.access))
+		})
+	}
+}

--- a/pkg/grpc/authz/user/user.go
+++ b/pkg/grpc/authz/user/user.go
@@ -86,13 +86,6 @@ func (p *permissionChecker) checkPermissions(rolePerms map[string]storage.Access
 	return nil
 }
 
-func evaluateAgainstPermissions(permissions map[string]storage.Access, perm permissions.ResourceWithAccess) bool {
-	hasAccess := permissions[string(perm.Resource.GetResource())] >= perm.Access
-
-	// In case the resource has a ReplacingResource, we accept access to either one of them.
-	if perm.Resource.ReplacingResource != nil {
-		return hasAccess || permissions[string(perm.Resource.ReplacingResource.GetResource())] >= perm.Access
-	}
-
-	return hasAccess
+func evaluateAgainstPermissions(perms map[string]storage.Access, perm permissions.ResourceWithAccess) bool {
+	return permissions.CheckResourceForAccess(perm.Resource, perms, perm.Access)
 }


### PR DESCRIPTION
## Description

We have added grouped resources within #1384 as a means to simplify the number of resources we currently expose. The main motivation behind this was to help the efforts within postgres SAC migration as well as help users simplify the creation of access scope, as the current resource model was confusing at times.

Now, we have added the concept of replacing resources for resources which are being deprecated as a field within each `ResourceMetadata`. We also adopted the `ResourceHelper`, which is most commonly used as a pattern to check for access to the resource within datastore implementations by conditionally creating a disjunction between two scope checkers: the one of the resource and, if given, the replacing resource.

What is still missing is the adoption of `ScopeCheckerCore` implementations to respect replaced resource.

Given the following example, which is a typical pattern within our code base:
```go
hasReadAccessToAPIToken := sac.WithGlobalAccessScopeChecker(context.Background(),
		sac.AllowFixedScopes(
			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
			sac.ResourceScopeKeys(resources.APIToken)))
```
We would expect that the `ScopeChecker` will correctly yield read access to both `APIToken` as well as its replacing resource `Integration`, but that's currently not the case.

Hence, we need to adopt the implementations of the `ScopeCheckerCore` to also take those into account.

Within this PR, the following has been done:
- Create helper function to check if a resource is contained within a permission map with the respective access.
- Adopt code to use the previously created helper function.
- Adopt the `BuiltInScopeChecker` to respect resource replacements.
- Add additional tests.

What has not been addressed within this PR and needs to be done going forward:
- Adopt `AllowFixedScopes` implementation.
- Adopt `ScopeCheckerCoreImpl` implementation.

## Testing Performed
- Unit tests (see CI).
