### PR TITLE
ROX-10790: Wire postgres service account search.

### DIFF
--- a/central/pod/datastore/internal/search/searcher_impl.go
+++ b/central/pod/datastore/internal/search/searcher_impl.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	podsSACSearchHelper   = sac.ForResource(resources.Deployment).MustCreateSearchHelper(mappings.OptionsMap)
-	podsSACPgSearchHelper = sac.ForResource(resources.Deployment).MustCreatePgSearchHelper(mappings.OptionsMap)
+	podsSACSearchHelper         = sac.ForResource(resources.Deployment).MustCreateSearchHelper(mappings.OptionsMap)
+	podsSACPostgresSearchHelper = sac.ForResource(resources.Deployment).MustCreatePgSearchHelper(mappings.OptionsMap)
 
 	defaultSortOption = &v1.QuerySortOption{
 		Field:    search.DeploymentID.String(),
@@ -55,7 +55,7 @@ func (ds *searcherImpl) SearchRawPods(ctx context.Context, q *v1.Query) ([]*stor
 func formatSearcher(podIndexer blevesearch.UnsafeSearcher) search.Searcher {
 	var filteredSearcher search.Searcher
 	if features.PostgresDatastore.Enabled() {
-		filteredSearcher = podsSACPgSearchHelper.FilteredSearcher(podIndexer) // Make the UnsafeSearcher safe.
+		filteredSearcher = podsSACPostgresSearchHelper.FilteredSearcher(podIndexer) // Make the UnsafeSearcher safe.
 	} else {
 		filteredSearcher = podsSACSearchHelper.FilteredSearcher(podIndexer) // Make the UnsafeSearcher safe.
 	}

--- a/central/processindicator/search/searcher_impl.go
+++ b/central/processindicator/search/searcher_impl.go
@@ -15,9 +15,9 @@ import (
 )
 
 var (
-	indicatorSACSearchHelper   = sac.ForResource(resources.Indicator).MustCreateSearchHelper(processindicators.OptionsMap)
-	indicatorSACPgSearchHelper = sac.ForResource(resources.Indicator).
-					MustCreatePgSearchHelper(processindicators.OptionsMap)
+	indicatorSACSearchHelper         = sac.ForResource(resources.Indicator).MustCreateSearchHelper(processindicators.OptionsMap)
+	indicatorSACPostgresSearchHelper = sac.ForResource(resources.Indicator).
+						MustCreatePgSearchHelper(processindicators.OptionsMap)
 )
 
 // searcherImpl provides an intermediary implementation layer for ProcessStorage.
@@ -38,7 +38,7 @@ func (s *searcherImpl) SearchRawProcessIndicators(ctx context.Context, q *v1.Que
 
 func (s *searcherImpl) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	if features.PostgresDatastore.Enabled() {
-		return indicatorSACPgSearchHelper.Apply(s.indexer.Search)(ctx, q)
+		return indicatorSACPostgresSearchHelper.Apply(s.indexer.Search)(ctx, q)
 	}
 	return indicatorSACSearchHelper.Apply(s.indexer.Search)(ctx, q)
 }
@@ -46,7 +46,7 @@ func (s *searcherImpl) Search(ctx context.Context, q *v1.Query) ([]search.Result
 // Count returns the number of search results from the query
 func (s *searcherImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 	if features.PostgresDatastore.Enabled() {
-		return indicatorSACPgSearchHelper.ApplyCount(s.indexer.Count)(ctx, q)
+		return indicatorSACPostgresSearchHelper.ApplyCount(s.indexer.Count)(ctx, q)
 	}
 	return indicatorSACSearchHelper.ApplyCount(s.indexer.Count)(ctx, q)
 }

--- a/central/rbac/k8srolebinding/search/searcher_impl.go
+++ b/central/rbac/k8srolebinding/search/searcher_impl.go
@@ -17,7 +17,7 @@ import (
 var (
 	k8sRoleBindingsSACSearchHelper = sac.ForResource(resources.K8sRoleBinding).
 					MustCreateSearchHelper(mappings.OptionsMap)
-	k8sRoleBindingsSACPgSearchHelper = sac.ForResource(resources.K8sRoleBinding).
+	k8sRoleBindingsSACPostgresSearchHelper = sac.ForResource(resources.K8sRoleBinding).
 						MustCreatePgSearchHelper(mappings.OptionsMap)
 )
 
@@ -39,7 +39,7 @@ func (ds *searcherImpl) SearchRoleBindings(ctx context.Context, q *v1.Query) ([]
 // Search returns the raw search results from the query.
 func (ds *searcherImpl) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	if features.PostgresDatastore.Enabled() {
-		return k8sRoleBindingsSACPgSearchHelper.Apply(ds.index.Search)(ctx, q)
+		return k8sRoleBindingsSACPostgresSearchHelper.Apply(ds.index.Search)(ctx, q)
 	}
 	return k8sRoleBindingsSACSearchHelper.Apply(ds.index.Search)(ctx, q)
 }
@@ -47,7 +47,7 @@ func (ds *searcherImpl) Search(ctx context.Context, q *v1.Query) ([]search.Resul
 // Count returns the number of search results from the query.
 func (ds *searcherImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 	if features.PostgresDatastore.Enabled() {
-		return k8sRoleBindingsSACPgSearchHelper.ApplyCount(ds.index.Count)(ctx, q)
+		return k8sRoleBindingsSACPostgresSearchHelper.ApplyCount(ds.index.Count)(ctx, q)
 	}
 	return k8sRoleBindingsSACSearchHelper.ApplyCount(ds.index.Count)(ctx, q)
 }

--- a/central/secret/search/searcher_impl.go
+++ b/central/secret/search/searcher_impl.go
@@ -22,8 +22,8 @@ var (
 		Field: search.CreatedTime.String(),
 	}
 
-	secretSACSearchHelper   = sac.ForResource(resources.Secret).MustCreateSearchHelper(mappings.OptionsMap)
-	secretSACPgSearchHelper = sac.ForResource(resources.Secret).MustCreatePgSearchHelper(mappings.OptionsMap)
+	secretSACSearchHelper         = sac.ForResource(resources.Secret).MustCreateSearchHelper(mappings.OptionsMap)
+	secretSACPostgresSearchHelper = sac.ForResource(resources.Secret).MustCreatePgSearchHelper(mappings.OptionsMap)
 )
 
 // searcherImpl provides an intermediary implementation layer for secrets
@@ -119,7 +119,7 @@ func formatSearcher(unsafeSearcher blevesearch.UnsafeSearcher) search.Searcher {
 	var filteredSearcher search.Searcher
 	if features.PostgresDatastore.Enabled() {
 		// Make the UnsafeSearcher safe.
-		filteredSearcher = secretSACPgSearchHelper.FilteredSearcher(unsafeSearcher)
+		filteredSearcher = secretSACPostgresSearchHelper.FilteredSearcher(unsafeSearcher)
 	} else {
 		filteredSearcher = secretSACSearchHelper.FilteredSearcher(unsafeSearcher) // Make the UnsafeSearcher safe.
 	}

--- a/central/serviceaccount/search/searcher_impl.go
+++ b/central/serviceaccount/search/searcher_impl.go
@@ -9,12 +9,14 @@ import (
 	"github.com/stackrox/rox/central/serviceaccount/mappings"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 )
 
 var (
-	serviceAccountsSACSearchHelper = sac.ForResource(resources.ServiceAccount).MustCreateSearchHelper(mappings.OptionsMap)
+	serviceAccountsSACSearchHelper         = sac.ForResource(resources.ServiceAccount).MustCreateSearchHelper(mappings.OptionsMap)
+	serviceAccountsSACPostgresSearchHelper = sac.ForResource(resources.ServiceAccount).MustCreatePgSearchHelper(mappings.OptionsMap)
 )
 
 type searcherImpl struct {
@@ -55,10 +57,16 @@ func (ds *searcherImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 }
 
 func (ds *searcherImpl) getSearchResults(ctx context.Context, q *v1.Query) ([]search.Result, error) {
+	if features.PostgresDatastore.Enabled() {
+		return serviceAccountsSACPostgresSearchHelper.Apply(ds.indexer.Search)(ctx, q)
+	}
 	return serviceAccountsSACSearchHelper.Apply(ds.indexer.Search)(ctx, q)
 }
 
 func (ds *searcherImpl) getCount(ctx context.Context, q *v1.Query) (int, error) {
+	if features.PostgresDatastore.Enabled() {
+		return serviceAccountsSACPostgresSearchHelper.ApplyCount(ds.indexer.Count)(ctx, q)
+	}
 	return serviceAccountsSACSearchHelper.ApplyCount(ds.indexer.Count)(ctx, q)
 }
 


### PR DESCRIPTION
## Description

Add `PostgresSearchHelper` to `serviceaccount/search`. 

Additionally, based on feedback within #1662 , renamed all instances of `<resource-name>PgSearchHelper` to `<resource-name>PostgresSearchHelper`.

## Testing Performed
- Integration tests will be done within [ROX-10789](https://issues.redhat.com/browse/ROX-10789)
