### PR TITLE
Use logger instead of print in qa tests

### DIFF
--- a/qa-tests-backend/codenarc-rules.groovy
+++ b/qa-tests-backend/codenarc-rules.groovy
@@ -299,10 +299,10 @@ ruleset {
     // rulesets/logging.xml
     // LoggerForDifferentClass
     // LoggerWithWrongModifiers
-    LoggingSwallowsStacktrace 
+    LoggingSwallowsStacktrace
     // MultipleLoggers
     PrintStackTrace
-    // Println
+    Println
     SystemErrPrint
     SystemOutPrint
     

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1081,7 +1081,7 @@ class Kubernetes implements OrchestratorMain {
         log.debug name + ": Secret removed."
     }
 
-    def getSecretCount(String ns = null) {
+    int getSecretCount(String ns = null) {
         return evaluateWithRetry(2, 3) {
             return client.secrets().inNamespace(ns).list().getItems().findAll {
                 !it.type.startsWith("kubernetes.io/service-account-token")

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
@@ -98,7 +98,7 @@ interface OrchestratorMain {
     def createImagePullSecret(String name, String username, String password, String namespace, String server)
     def createImagePullSecret(Secret secret)
     def deleteSecret(String name, String namespace)
-    def getSecretCount(String ns)
+    int getSecretCount(String ns)
     io.fabric8.kubernetes.api.model.Secret getSecret(String name, String namespace)
     def updateSecret(io.fabric8.kubernetes.api.model.Secret secret)
 

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerNoImageScanTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerNoImageScanTest.groovy
@@ -124,7 +124,7 @@ class AdmissionControllerNoImageScanTest extends BaseSpecification {
                     orchestrator.deleteDeployment(deployment)
                     deleted = true
                 } catch (NullPointerException ignore) {
-                    println "Caught NPE while deleting deployment, retrying in 1s..."
+                    log.info "Caught NPE while deleting deployment, retrying in 1s..."
                 }
             }
             if (!deleted) {

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -440,7 +440,7 @@ class AdmissionControllerTest extends BaseSpecification {
                 orchestrator.deleteDeployment(deployment)
                 deleted = true
             } catch (NullPointerException ignore) {
-                println "Caught NPE while deleting deployment, retrying in 1s..."
+                log.info "Caught NPE while deleting deployment, retrying in 1s..."
             }
         }
         if (!deleted) {

--- a/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
@@ -1,24 +1,21 @@
-import orchestratormanager.OrchestratorTypes
-
+import groups.BAT
+import groups.RUNTIME
 import io.stackrox.proto.storage.AlertOuterClass.ListAlert
 import io.stackrox.proto.storage.AlertOuterClass.ViolationState
 import io.stackrox.proto.storage.ClusterOuterClass.AdmissionControllerConfig
 import io.stackrox.proto.storage.PolicyOuterClass.EnforcementAction
 import io.stackrox.proto.storage.PolicyOuterClass.Policy
-
-import groups.BAT
-import groups.RUNTIME
 import objects.Deployment
+import orchestratormanager.OrchestratorTypes
+import org.junit.experimental.categories.Category
 import services.AlertService
 import services.ClusterService
-import util.Env
-
-import org.junit.experimental.categories.Category
 import spock.lang.IgnoreIf
 import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Stepwise
 import spock.lang.Unroll
+import util.Env
 
 @Stepwise
 class AttemptedAlertsTest extends BaseSpecification {

--- a/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
@@ -1,6 +1,5 @@
 import static Services.getAllResourceViolationsWithTimeout
 import static Services.getResourceViolationsWithTimeout
-
 import common.Constants
 import groups.BAT
 import groups.RUNTIME

--- a/qa-tests-backend/src/test/groovy/AuditScrubbingTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuditScrubbingTest.groovy
@@ -28,7 +28,7 @@ class AuditScrubbingTest extends BaseSpecification {
         sleep 3000
     }
 
-    private static getAuditEntry(String attemptId) {
+    private getAuditEntry(String attemptId) {
         def timer = new Timer(30, 1)
         while (timer.IsValid()) {
             def get = new URL("http://localhost:8080").openConnection()
@@ -39,7 +39,8 @@ class AuditScrubbingTest extends BaseSpecification {
                     def data = it["data"]["audit"]
                     return data["request"]["endpoint"] == ENDPOINT &&
                             (data["request"]["payload"]["state"] as String).endsWith(attemptId)
-                } catch (Exception _) {
+                } catch (Exception e) {
+                    log.warn("exception", e)
                     return false
                 }
             }

--- a/qa-tests-backend/src/test/groovy/AuthServiceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuthServiceTest.groovy
@@ -1,7 +1,6 @@
 import groups.BAT
 import io.stackrox.proto.api.v1.AuthServiceOuterClass
 import io.stackrox.proto.storage.RoleOuterClass
-
 import org.junit.Assume
 import org.junit.experimental.categories.Category
 import services.AuthService

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -50,8 +50,8 @@ class BaseSpecification extends Specification {
         String idStr
         try {
             idStr = new File("/proc/self").getCanonicalFile().getName()
-        } catch (Exception ignored) {
-            println "Could not determine pid, using a random ID"
+        } catch (Exception e) {
+            LOG.warn("Could not determine pid, using a random ID", e)
             idStr = new SecureRandom().nextInt().toString()
         }
         RUN_ID = idStr
@@ -70,12 +70,12 @@ class BaseSpecification extends Specification {
             return
         }
 
-        println "Performing global setup"
+        LOG.info "Performing global setup"
 
         if (!Env.IN_CI || Env.get("CIRCLE_TAG")) {
             // Strictly test integration with external services when running in
             // a dev environment or in CI against tagged builds (e.g. nightly builds).
-            println "Will perform strict integration testing (if any is required)"
+            LOG.info "Will perform strict integration testing (if any is required)"
             strictIntegrationTesting = true
         }
 
@@ -99,16 +99,16 @@ class BaseSpecification extends Specification {
             assert ClusterService.getClusterId(), "There is no default cluster. Check if all pods are running"
             try {
                 def metadata = MetadataService.getMetadataServiceClient().getMetadata()
-                println "Testing against:"
-                println metadata
-                println "isGKE: ${orchestrator.isGKE()}"
-                println "isEKS: ${ClusterService.isEKS()}"
-                println "isOpenShift3: ${ClusterService.isOpenShift3()}"
-                println "isOpenShift4: ${ClusterService.isOpenShift4()}"
+                LOG.info "Testing against:"
+                LOG.info metadata.toString()
+                LOG.info "isGKE: ${orchestrator.isGKE()}"
+                LOG.info "isEKS: ${ClusterService.isEKS()}"
+                LOG.info "isOpenShift3: ${ClusterService.isOpenShift3()}"
+                LOG.info "isOpenShift4: ${ClusterService.isOpenShift4()}"
             }
             catch (Exception ex) {
-                println "Cannot connect to central : ${ex.message}"
-                println "Check the test target deployment, auth credentials, kube service proxy, etc."
+                LOG.info "Cannot connect to central : ${ex.message}"
+                LOG.info "Check the test target deployment, auth credentials, kube service proxy, etc."
                 throw(ex)
             }
         }
@@ -139,7 +139,7 @@ class BaseSpecification extends Specification {
         allAccessToken = tokenResp.token
 
         addShutdownHook {
-            println "Performing global shutdown"
+            LOG.info "Performing global shutdown"
             BaseService.useBasicAuth()
             BaseService.setUseClientCert(false)
             withRetry(30, 1) {
@@ -211,7 +211,7 @@ class BaseSpecification extends Specification {
             try {
                 def response = SACService.addAuthPlugin()
                 pluginConfigID = response.getId()
-                println response.toString()
+                log.info response.toString()
             } catch (StatusRuntimeException e) {
                 log.error("Unable to enable the authz plugin, defaulting to basic auth", e)
             }
@@ -220,7 +220,7 @@ class BaseSpecification extends Specification {
         coreImageIntegrationId = ImageIntegrationService.getImageIntegrationByName(
                 Constants.CORE_IMAGE_INTEGRATION_NAME)
         if (!coreImageIntegrationId) {
-            println "Adding core image integration"
+            log.info "Adding core image integration"
             coreImageIntegrationId = ImageIntegrationService.createImageIntegration(
                     ImageIntegrationOuterClass.ImageIntegration.newBuilder()
                             .setName(Constants.CORE_IMAGE_INTEGRATION_NAME)
@@ -282,13 +282,13 @@ class BaseSpecification extends Specification {
         BaseService.useBasicAuth()
         BaseService.setUseClientCert(false)
 
-        println "Removing integration"
+        log.info "Removing integration"
         ImageIntegrationService.deleteImageIntegration(coreImageIntegrationId)
 
         try {
             orchestrator.cleanup()
         } catch (Exception e) {
-            println "Error to clean up orchestrator: ${e.message}"
+            log.error("Error to clean up orchestrator", e)
             throw e
         }
         disableAuthzPlugin()
@@ -307,8 +307,8 @@ class BaseSpecification extends Specification {
         List<String> namespaces = orchestrator.getNamespaces()
         Diff diff = javers.compare(resourceRecord["namespaces"], namespaces)
         if (diff.hasChanges()) {
-            println "There is a difference in namespaces between the start and end of this test spec:"
-            println diff.prettyPrint()
+            log.info "There is a difference in namespaces between the start and end of this test spec:"
+            log.info diff.prettyPrint()
             throw new TestSpecRuntimeException("Namespaces have changed. Ensure that any namespace created " +
                     "in a test spec is deleted in that test spec.")
         }
@@ -317,8 +317,8 @@ class BaseSpecification extends Specification {
                 orchestrator.getDeployments(Constants.ORCHESTRATOR_NAMESPACE)
         diff = javers.compare(resourceRecord["deployments"], deployments)
         if (diff.hasChanges()) {
-            println "There is a difference in deployments between the start and end of this test spec"
-            println diff.prettyPrint()
+            log.info "There is a difference in deployments between the start and end of this test spec"
+            log.info diff.prettyPrint()
             throw new TestSpecRuntimeException("Deployments have changed. Ensure that any deployments created " +
                     "in a test spec are destroyed in that test spec.")
         }

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -288,7 +288,7 @@ class BaseSpecification extends Specification {
         try {
             orchestrator.cleanup()
         } catch (Exception e) {
-            log.error("Error to clean up orchestrator", e)
+            log.error("Failed to clean up orchestrator", e)
             throw e
         }
         disableAuthzPlugin()

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -288,7 +288,7 @@ class BaseSpecification extends Specification {
         try {
             orchestrator.cleanup()
         } catch (Exception e) {
-            log.error("Failed to clean up orchestrator", e)
+            println "Error to clean up orchestrator: ${e.message}"
             throw e
         }
         disableAuthzPlugin()

--- a/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
@@ -1,15 +1,14 @@
 import static Services.getPolicies
 import static Services.waitForViolation
-
 import groups.BAT
+import io.stackrox.proto.api.v1.PolicyServiceOuterClass.PatchPolicyRequest
 import objects.Deployment
 import objects.SecretKeyRef
 import objects.Volume
 import org.junit.experimental.categories.Category
+import services.PolicyService
 import spock.lang.Shared
 import spock.lang.Unroll
-import services.PolicyService
-import io.stackrox.proto.api.v1.PolicyServiceOuterClass.PatchPolicyRequest
 
 class BuiltinPoliciesTest extends BaseSpecification {
     static final private String TRIGGER_MOST = "trigger-most"
@@ -65,7 +64,7 @@ class BuiltinPoliciesTest extends BaseSpecification {
         getPolicies().forEach {
             policy ->
             if (policy.disabled) {
-                println "Temporarily enabling a disabled policy for testing: ${policy.name}"
+                log.info "Temporarily enabling a disabled policy for testing: ${policy.name}"
                 PolicyService.patchPolicy(
                         PatchPolicyRequest.newBuilder().setId(policy.id).setDisabled(false).build()
                 )
@@ -76,13 +75,13 @@ class BuiltinPoliciesTest extends BaseSpecification {
         orchestrator.createSecret(TEST_PASSWORD)
 
         for (Deployment deployment : NO_WAIT_DEPLOYMENTS) {
-            println("Starting ${deployment.name} without waiting for deployment")
+            log.info("Starting ${deployment.name} without waiting for deployment")
             orchestrator.createDeploymentNoWait(deployment)
         }
 
         orchestrator.batchCreateDeployments(DEPLOYMENTS)
         for (Deployment deployment : DEPLOYMENTS) {
-            println("Waiting for ${deployment.name}")
+            log.info("Waiting for ${deployment.name}")
             assert Services.waitForDeployment(deployment)
         }
     }
@@ -90,7 +89,7 @@ class BuiltinPoliciesTest extends BaseSpecification {
     def cleanupSpec() {
         disabledPolicyIds.forEach {
             id ->
-            println "Re-disabling a policy after test"
+            log.info "Re-disabling a policy after test"
             PolicyService.patchPolicy(
                     PatchPolicyRequest.newBuilder().setId(id).setDisabled(true).build()
             )

--- a/qa-tests-backend/src/test/groovy/CSVTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CSVTest.groovy
@@ -143,7 +143,7 @@ class CSVTest extends BaseSpecification {
             }
         }
 
-        println "Number of CVEs received from CSV endpoint: " + lines.size()
+        log.info "Number of CVEs received from CSV endpoint: " + lines.size()
 
         def csvCVEs = new ArrayList<CVE>()
         for (int i = 1; i < lines.size(); i++) {

--- a/qa-tests-backend/src/test/groovy/CVETest.groovy
+++ b/qa-tests-backend/src/test/groovy/CVETest.groovy
@@ -1,11 +1,9 @@
 import com.google.protobuf.util.Timestamps
-
 import groups.BAT
 import objects.Deployment
+import org.junit.experimental.categories.Category
 import services.GraphQLService
 import services.ImageService
-
-import org.junit.experimental.categories.Category
 import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
@@ -210,7 +208,7 @@ class CVETest extends BaseSpecification {
         def resultRet = gqlService.Call(GET_CVES_QUERY,
                 [query: "Image:${image}+CVE:${cve}", scopeQuery: ""])
         assert resultRet.getCode() == 200
-        println "return code " + resultRet.getCode()
+        log.info "return code " + resultRet.getCode()
 
         then:
         "Verify specific CVE data"
@@ -256,7 +254,7 @@ class CVETest extends BaseSpecification {
 
         def resultRet = gqlService.Call(GET_CVES_QUERY, [query: "${query}", scopeQuery: ""])
         assert resultRet.getCode() == 200
-        println "return code " + resultRet.getCode()
+        log.info "return code " + resultRet.getCode()
 
         then:
         "Verify specific CVE data"

--- a/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
@@ -5,20 +5,18 @@ import io.fabric8.kubernetes.api.model.Secret
 import io.grpc.StatusRuntimeException
 import io.stackrox.proto.storage.ClusterOuterClass.ClusterUpgradeStatus.UpgradeProcessStatus.UpgradeProcessType
 import io.stackrox.proto.storage.ClusterOuterClass.UpgradeProgress.UpgradeState
+import java.nio.charset.Charset
+import java.security.cert.X509Certificate
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.asn1.x500.style.BCStyle
 import org.bouncycastle.asn1.x500.style.IETFUtils
 import org.junit.Assume
-import org.junit.AssumptionViolatedException
 import org.junit.experimental.categories.Category
 import org.yaml.snakeyaml.Yaml
 import services.ClusterService
 import services.DirectHTTPService
 import services.SensorUpgradeService
 import util.Cert
-
-import java.nio.charset.Charset
-import java.security.cert.X509Certificate
 
 @Category(BAT)
 class CertRotationTest extends BaseSpecification {
@@ -116,7 +114,7 @@ class CertRotationTest extends BaseSpecification {
         def admissionControlTLSSecret = orchestrator.getSecret("admission-control-tls", "stackrox")
         // Admission control secret may or may not be present, depending on how the cluster was deployed.
         def admissionControlSecretPresent = (admissionControlTLSSecret != null)
-        println "Admission control secret present: ${admissionControlSecretPresent}"
+        log.info "Admission control secret present: ${admissionControlSecretPresent}"
         def cluster = ClusterService.getCluster()
         assert cluster
         def reqObject = new JsonObject()

--- a/qa-tests-backend/src/test/groovy/ClientCertAuthTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ClientCertAuthTest.groovy
@@ -1,7 +1,8 @@
 import groups.BAT
 import io.grpc.StatusRuntimeException
 import io.stackrox.proto.api.v1.GroupServiceOuterClass
-
+import java.nio.file.Files
+import java.nio.file.Paths
 import org.junit.experimental.categories.Category
 import services.AuthProviderService
 import services.AuthService
@@ -11,9 +12,6 @@ import spock.lang.Shared
 import spock.lang.Stepwise
 import spock.lang.Unroll
 import util.Env
-
-import java.nio.file.Files
-import java.nio.file.Paths
 
 @Category(BAT)
 @Stepwise
@@ -37,10 +35,10 @@ class ClientCertAuthTest extends BaseSpecification {
         for (int i = 0; i < 2; i++) {
             providerIDs[i] = AuthProviderService.createAuthProvider(
                     "Test Client CA Auth ${i}", "userpki", ["keys": cert])
-            println "Client cert auth provider ID is ${providerIDs[i]}"
+            log.info "Client cert auth provider ID is ${providerIDs[i]}"
             GroupService.addDefaultMapping(providerIDs[i], "Continuous Integration")
             certTokens[i] = AuthProviderService.getAuthProviderLoginToken(providerIDs[i])
-            println "Certificate token is ${certTokens[i]}"
+            log.info "Certificate token is ${certTokens[i]}"
         }
     }
 

--- a/qa-tests-backend/src/test/groovy/ClusterInitBundleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ClusterInitBundleTest.groovy
@@ -1,14 +1,11 @@
 import static java.util.UUID.randomUUID
-
-import io.stackrox.proto.api.v1.ApiTokenService
-
 import groups.BAT
+import io.stackrox.proto.api.v1.ApiTokenService
+import org.junit.Assume
+import org.junit.experimental.categories.Category
 import services.BaseService
 import services.ClusterInitBundleService
 import services.ClusterService
-
-import org.junit.Assume
-import org.junit.experimental.categories.Category
 import spock.lang.Shared
 
 @Category(BAT)

--- a/qa-tests-backend/src/test/groovy/ClustersTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ClustersTest.groovy
@@ -1,7 +1,7 @@
 import groups.BAT
+import io.stackrox.proto.storage.ClusterOuterClass
 import org.junit.experimental.categories.Category
 import services.ClusterService
-import io.stackrox.proto.storage.ClusterOuterClass
 import spock.lang.Stepwise
 import util.Cert
 

--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -222,7 +222,7 @@ class ComplianceTest extends BaseSpecification {
             def standardId = result.aggregationKeysList.find { it.scope == Scope.STANDARD }?.id
 
             ComplianceRunResults run = BASE_RESULTS.get(standardId)
-            println "Verifying aggregate counts for ${standardId}"
+            log.info "Verifying aggregate counts for ${standardId}"
             run.clusterResults.controlResultsMap.each {
                 counts.get(it.value.overallState) ?
                         counts.get(it.value.overallState).add(it.key) :
@@ -438,7 +438,7 @@ class ComplianceTest extends BaseSpecification {
                     it.name == normalizedControlName
                 }
                 if (!control) {
-                    println "Couldn't find ${normalizedControlName} (row " +
+                    log.info "Couldn't find ${normalizedControlName} (row " +
                             "was ${row.cluster} ${row.standard} ${row.control}"
                 }
                 assert control
@@ -473,9 +473,9 @@ class ComplianceTest extends BaseSpecification {
                         break
                 }
                 if (!value) {
-                    println "Control: ${control} StandardId: ${standardId}" +
+                    log.info "Control: ${control} StandardId: ${standardId}" +
                             "Row: ${row.cluster}, ${row.standard}, ${row.objectType}, ${row.control}, ${row.evidence}"
-                    println result.clusterResults.controlResultsMap.keySet()
+                    log.info result.clusterResults.controlResultsMap.keySet()
                 }
                 assert value
                 assert convertStringState(row.state) ?
@@ -489,7 +489,7 @@ class ComplianceTest extends BaseSpecification {
                         .withZone(ZoneId.of("UTC"))
                 assert row.timestamp == formatter.format(i)
             }
-            println "Verified ${verifiedRows} out of ${rowNumber} total rows"
+            log.info "Verified ${verifiedRows} out of ${rowNumber} total rows"
         } catch (Exception e) {
             log.error("Exception", e)
         }
@@ -664,7 +664,7 @@ class ComplianceTest extends BaseSpecification {
 
         and:
         "verify standard started on schedule"
-        println "Waiting for schedule to start..."
+        log.info "Waiting for schedule to start..."
         while (now.get(Calendar.MINUTE) < minute) {
             sleep 1000
             now = Calendar.getInstance(TimeZone.getTimeZone("GMT"))
@@ -742,7 +742,7 @@ class ComplianceTest extends BaseSpecification {
         def missingControls = []
         for (Control control : controls) {
             if (clusterResults.keySet().contains(control.id)) {
-                println "Validating ${control.id}"
+                log.info "Validating ${control.id}"
                 ComplianceResultValue value = clusterResults.get(control.id)
                 assert value.overallState == control.state
                 assert value.evidenceList*.message.containsAll(control.evidenceMessages)
@@ -839,7 +839,7 @@ class ComplianceTest extends BaseSpecification {
             if (receivedProcessPaths.size() > 1) {
                 break
             }
-            println "Didn't find all the expected processes, retrying..."
+            log.info "Didn't find all the expected processes, retrying..."
         }
         assert receivedProcessPaths.size() > 1
 
@@ -859,7 +859,7 @@ class ComplianceTest extends BaseSpecification {
         def missingControls = []
         for (Control control : controls) {
             if (deploymentResults.keySet().contains(control.id)) {
-                println "Validating deployment control ${control.id}"
+                log.info "Validating deployment control ${control.id}"
                 ComplianceResultValue value = deploymentResults.get(control.id)
                 assert value.overallState == control.state
                 assert value.evidenceList*.message.containsAll(control.evidenceMessages)
@@ -981,7 +981,7 @@ class ComplianceTest extends BaseSpecification {
         def missingControls = []
         for (Control control : controls) {
             if (clusterResults.keySet().contains(control.id)) {
-                println "Validating deployment control ${control.id}"
+                log.info "Validating deployment control ${control.id}"
                 ComplianceResultValue value = clusterResults.get(control.id)
                 assert value.overallState == control.state
                 assert value.evidenceList*.message.containsAll(control.evidenceMessages)
@@ -1039,7 +1039,7 @@ class ComplianceTest extends BaseSpecification {
         def missingControls = []
         for (Control control : controls) {
             if (clusterResults.keySet().contains(control.id)) {
-                println "Validating cluster control ${control.id}"
+                log.info "Validating cluster control ${control.id}"
                 ComplianceResultValue value = clusterResults.get(control.id)
                 assert value.overallState == control.state
                 assert value.evidenceList*.message.containsAll(control.evidenceMessages)
@@ -1058,7 +1058,7 @@ class ComplianceTest extends BaseSpecification {
         Assume.assumeTrue(ClusterService.isOpenShift4())
         Assume.assumeTrue(Env.CI_JOBNAME == "openshift-4-api-e2e-tests")
 
-        println "Getting compliance results for ${standard}"
+        log.info "Getting compliance results for ${standard}"
         ComplianceRunResults run = BASE_RESULTS.get(standard)
 
         expect:
@@ -1068,7 +1068,7 @@ class ComplianceTest extends BaseSpecification {
         def machineConfigsWithResults = 0
         def numErrors = 0
         for (def entry in run.machineConfigResultsMap) {
-            println "Found machine config ${entry.key} with ${entry.value.controlResultsMap.size()} results"
+            log.info "Found machine config ${entry.key} with ${entry.value.controlResultsMap.size()} results"
             if (entry.value.controlResultsMap.size()  > 0) {
                 machineConfigsWithResults++
             }
@@ -1107,7 +1107,7 @@ class ComplianceTest extends BaseSpecification {
         def machineConfigsWithResults = 0
         def numErrors = 0
         for (def entry in run.machineConfigResultsMap) {
-            println "Found machine config ${entry.key} with ${entry.value.controlResultsMap.size()} results"
+            log.info "Found machine config ${entry.key} with ${entry.value.controlResultsMap.size()} results"
             if (entry.value.controlResultsMap.size()  > 0) {
                 machineConfigsWithResults++
             }
@@ -1125,7 +1125,7 @@ class ComplianceTest extends BaseSpecification {
         Assume.assumeTrue(ClusterService.isOpenShift4())
         Assume.assumeTrue(Env.CI_JOBNAME == "openshift-4-api-e2e-tests")
 
-        println "Getting compliance results for ocp4-cis"
+        log.info "Getting compliance results for ocp4-cis"
         ComplianceRunResults run = BASE_RESULTS.get("ocp4-cis")
 
         expect:
@@ -1174,12 +1174,12 @@ class ComplianceTest extends BaseSpecification {
         ImageOuterClass.ListImage image = null
 
         while (!image?.fixableCves && timer.IsValid()) {
-            println "Image not found or not scanned: ${image}"
+            log.info "Image not found or not scanned: ${image}"
             image = ImageService.getImages(imageQuery).find { it.name == cveDeployment.image }
         }
         assert image?.fixableCves
 
-        println "Found scanned image ${image}"
+        log.info "Found scanned image ${image}"
 
         when:
         "trigger compliance runs"
@@ -1195,7 +1195,7 @@ class ComplianceTest extends BaseSpecification {
         def missingControls = []
         for (Control control : controls) {
             if (clusterResults.keySet().contains(control.id)) {
-                println "Validating ${control.id}"
+                log.info "Validating ${control.id}"
                 ComplianceResultValue value = clusterResults.get(control.id)
                 assert value.overallState == control.state
 
@@ -1277,7 +1277,7 @@ class ComplianceTest extends BaseSpecification {
         "wait for sensor to come back up"
         def start = System.currentTimeMillis()
         orchestrator.waitForSensor()
-        println "waited ${System.currentTimeMillis() - start}ms for sensor to come back online"
+        log.info "waited ${System.currentTimeMillis() - start}ms for sensor to come back online"
     }
 
     @Category([BAT])
@@ -1311,7 +1311,7 @@ class ComplianceTest extends BaseSpecification {
                     break
                 }
             }
-            println "Didn't find an SSH processes, retrying..."
+            log.info "Didn't find an SSH processes, retrying..."
         }
         assert foundSSHProcess
 

--- a/qa-tests-backend/src/test/groovy/DeploymentEventGraphQLTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentEventGraphQLTest.groovy
@@ -1,13 +1,11 @@
 import static Services.getPolicies
 import static Services.waitForViolation
-
 import groups.GraphQL
-import objects.Deployment
-import services.GraphQLService
-import org.junit.experimental.categories.Category
-import util.Timer
-
 import java.util.stream.Collectors
+import objects.Deployment
+import org.junit.experimental.categories.Category
+import services.GraphQLService
+import util.Timer
 
 class DeploymentEventGraphQLTest extends BaseSpecification {
     private static final String DEPLOYMENT_NAME = "eventnginx"
@@ -121,7 +119,7 @@ class DeploymentEventGraphQLTest extends BaseSpecification {
         while (t.IsValid()) {
             def depEvents = gqlService.Call(GET_DEPLOYMENT_EVENTS_OVERVIEW, [deploymentId: deploymentUid])
             assert depEvents.getCode() == 200
-            println "return code " + depEvents.getCode()
+            log.info "return code " + depEvents.getCode()
             assert depEvents.getValue().result != null
             def events = depEvents.getValue().result
             assert events.numPolicyViolations == 1
@@ -134,7 +132,7 @@ class DeploymentEventGraphQLTest extends BaseSpecification {
 
             return true
         }
-        println "Unable to get deployment event for $deploymentUid in ${t.SecondsSince()} seconds"
+        log.info "Unable to get deployment event for $deploymentUid in ${t.SecondsSince()} seconds"
         return false
     }
 
@@ -143,7 +141,7 @@ class DeploymentEventGraphQLTest extends BaseSpecification {
         while (t.IsValid()) {
             def podEvents = gqlService.Call(GET_POD_EVENTS, [podsQuery: "Deployment ID: " + deploymentUid])
             assert podEvents.getCode() == 200
-            println "return code " + podEvents.getCode()
+            log.info "return code " + podEvents.getCode()
             assert podEvents.getValue().result != null
             assert podEvents.getValue().result.size() == 1
             def event = podEvents.getValue().result.get(0)
@@ -159,7 +157,7 @@ class DeploymentEventGraphQLTest extends BaseSpecification {
 
             return event.id
         }
-        println "Unable to get pod events for deployment $deploymentUid in ${t.SecondsSince()} seconds"
+        log.info "Unable to get pod events for deployment $deploymentUid in ${t.SecondsSince()} seconds"
         return null
     }
 
@@ -168,7 +166,7 @@ class DeploymentEventGraphQLTest extends BaseSpecification {
         while (t.IsValid()) {
             def containerEvents = gqlService.Call(GET_CONTAINER_EVENTS, [containersQuery: "Pod ID: " + podUid])
             assert containerEvents.getCode() == 200
-            println "return code " + containerEvents.getCode()
+            log.info "return code " + containerEvents.getCode()
             assert containerEvents.getValue().result != null
             assert containerEvents.getValue().result.size() == 1
             def event = containerEvents.getValue().result.get(0)
@@ -181,7 +179,7 @@ class DeploymentEventGraphQLTest extends BaseSpecification {
 
             return true
         }
-        println "Unable to get container events for pod $podUid in ${t.SecondsSince()} seconds"
+        log.info "Unable to get container events for pod $podUid in ${t.SecondsSince()} seconds"
         return false
     }
 }

--- a/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
@@ -1,13 +1,12 @@
 import static org.junit.Assume.assumeTrue
-
 import groups.BAT
 import io.stackrox.proto.api.v1.SearchServiceOuterClass.RawQuery
+import objects.Deployment
 import objects.Job
 import org.junit.experimental.categories.Category
 import services.ClusterService
 import services.DeploymentService
 import services.ImageService
-import objects.Deployment
 import spock.lang.Unroll
 import util.Timer
 

--- a/qa-tests-backend/src/test/groovy/DiagnosticBundleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DiagnosticBundleTest.groovy
@@ -1,20 +1,17 @@
 import static com.jayway.restassured.RestAssured.given
-
-import spock.lang.Shared
 import com.jayway.restassured.config.RestAssuredConfig
 import com.jayway.restassured.config.SSLConfig
 import groups.BAT
-import io.stackrox.proto.api.v1.ApiTokenService
 import io.stackrox.proto.api.v1.ApiTokenService.GenerateTokenResponse
 import io.stackrox.proto.storage.RoleOuterClass
 import io.stackrox.proto.storage.RoleOuterClass.Role
-import org.junit.experimental.categories.Category
-import services.RoleService
-import spock.lang.Unroll
-import util.Env
-
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
+import org.junit.experimental.categories.Category
+import services.RoleService
+import spock.lang.Shared
+import spock.lang.Unroll
+import util.Env
 
 @Category(BAT)
 class DiagnosticBundleTest extends BaseSpecification {
@@ -112,7 +109,7 @@ class DiagnosticBundleTest extends BaseSpecification {
             try {
                 ZipEntry entry
                 while ((entry = zis.nextEntry) != null) {
-                    print "Found file ${entry.name}"
+                    log.info "Found file ${entry.name}"
                     if (entry.name == "kubernetes/remote/stackrox/sensor/deployment-sensor.yaml") {
                         foundK8sInfo = true
                     }

--- a/qa-tests-backend/src/test/groovy/Enforcement.groovy
+++ b/qa-tests-backend/src/test/groovy/Enforcement.groovy
@@ -1,5 +1,4 @@
 import static Services.waitForViolation
-
 import groups.BAT
 import groups.Integration
 import groups.PolicyEnforcement
@@ -240,7 +239,7 @@ class Enforcement extends BaseSpecification {
             assert CREATED_POLICIES[label], "${label} policy should have been created"
         }
 
-        println "Waiting for policies to propagate..."
+        log.info "Waiting for policies to propagate..."
         sleep 10000
 
         orchestrator.batchCreateDeployments(DEPLOYMENTS.collect {
@@ -290,11 +289,11 @@ class Enforcement extends BaseSpecification {
         def startTime = System.currentTimeMillis()
         assert d.pods.size() > 0
         assert d.pods.collect {
-            it -> println "checking if ${it.name} was killed"
+            it -> log.info "checking if ${it.name} was killed"
             orchestrator.wasContainerKilled(it.name)
         }.find { it == true }
         assert alert.enforcement.action == EnforcementAction.KILL_POD_ENFORCEMENT
-        println "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
+        log.info "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
         assert Services.getAlertEnforcementCount(KILL_ENFORCEMENT, KILL_ENFORCEMENT) > 0
     }
 
@@ -326,7 +325,7 @@ class Enforcement extends BaseSpecification {
             sleep 1000
         }
         assert replicaCount == 0
-        println "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
+        log.info "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
         assert alert.enforcement.action == EnforcementAction.SCALE_TO_ZERO_ENFORCEMENT
         assert Services.getAlertEnforcementCount(
                 SCALE_DOWN_ENFORCEMENT,
@@ -362,7 +361,7 @@ class Enforcement extends BaseSpecification {
             sleep 1000
         }
         assert replicaCount == 0
-        println "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
+        log.info "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
         assert alert.enforcement.action == EnforcementAction.SCALE_TO_ZERO_ENFORCEMENT
         assert Services.getAlertEnforcementCount(
                 d.name,
@@ -398,7 +397,7 @@ class Enforcement extends BaseSpecification {
             sleep 1000
         }
         assert replicaCount == 0
-        println "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
+        log.info "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
         assert alert.enforcement.action == EnforcementAction.SCALE_TO_ZERO_ENFORCEMENT
         assert Services.getAlertEnforcementCount(
                 d.name,
@@ -433,7 +432,7 @@ class Enforcement extends BaseSpecification {
             sleep 1000
         }
         assert nodeSelectors != null
-        println "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
+        log.info "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
         assert orchestrator.getDeploymentUnavailableReplicaCount(d) >=
                 orchestrator.getDeploymentReplicaCount(d)
         assert alert.enforcement.action == EnforcementAction.UNSATISFIABLE_NODE_CONSTRAINT_ENFORCEMENT
@@ -502,7 +501,7 @@ class Enforcement extends BaseSpecification {
             sleep 1000
         }
         assert replicaCount == 0
-        println "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
+        log.info "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
         assert alert.enforcement.action == EnforcementAction.SCALE_TO_ZERO_ENFORCEMENT
         //Node Constraint should have been ignored
         assert orchestrator.getDeploymentNodeSelectors(d) == null
@@ -541,7 +540,7 @@ class Enforcement extends BaseSpecification {
             sleep 1000
         }
         assert nodeSelectors != null
-        println "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
+        log.info "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
         assert orchestrator.getDaemonSetUnavailableReplicaCount(d) ==
                 orchestrator.getDaemonSetReplicaCount(d)
         assert alert.enforcement.action == EnforcementAction.UNSATISFIABLE_NODE_CONSTRAINT_ENFORCEMENT
@@ -623,7 +622,6 @@ class Enforcement extends BaseSpecification {
         enforcements.remove(EnforcementAction.UNSET_ENFORCEMENT)
         enforcements.remove(EnforcementAction.UNRECOGNIZED)
         List<EnforcementAction> result = Services.updatePolicyEnforcement(policy, enforcements, false)
-        assert !result.contains("EXCEPTION")
 
         then:
         "verify if update was allowed"
@@ -633,9 +631,7 @@ class Enforcement extends BaseSpecification {
         cleanup:
         "revert policy lifecycle"
         Services.updatePolicyLifecycleStage(policy, originalStages)
-        if (!result.contains("EXCEPTION")) {
-            Services.updatePolicyEnforcement(policy, result, false)
-        }
+        Services.updatePolicyEnforcement(policy, result, false)
 
         where:
         "Data inputs:"
@@ -684,7 +680,7 @@ class Enforcement extends BaseSpecification {
         ProcessBaselineOuterClass.ProcessBaseline baseline = ProcessBaselineService.
                 getProcessBaseline(clusterId, d)
         assert (baseline != null)
-        println baseline
+        log.info baseline.toString()
         List<ProcessBaselineOuterClass.ProcessBaseline> lockProcessBaselines = ProcessBaselineService.
                 lockProcessBaselines(clusterId, d, "", true)
         assert lockProcessBaselines.size() ==  1
@@ -707,11 +703,11 @@ class Enforcement extends BaseSpecification {
         def startTime = System.currentTimeMillis()
         assert d.pods.collect {
             it ->
-            println "checking if ${it.name} was killed"
+            log.info "checking if ${it.name} was killed"
             orchestrator.wasContainerKilled(it.name)
         }.find { it == true }
         assert alert.enforcement.action == EnforcementAction.KILL_POD_ENFORCEMENT
-        println "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
+        log.info "Enforcement took ${(System.currentTimeMillis() - startTime) / 1000}s"
         assert Services.getAlertEnforcementCount(d.name, ALERT_AND_KILL_ENFORCEMENT_BASELINE_PROCESS) > 0
 
         cleanup:
@@ -761,7 +757,7 @@ class Enforcement extends BaseSpecification {
         // Wait for 10s to ensure that the deployment was not scaled down
 
         Timer t = new Timer(10, 1)
-        println "Verifying that enforcement action was not taken"
+        log.info "Verifying that enforcement action was not taken"
         while (t.IsValid()) {
             assert orchestrator.getDeploymentReplicaCount(d) != 0
         }

--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -1,14 +1,13 @@
 import com.google.protobuf.Timestamp
 import groups.NetworkFlowVisualization
 import io.stackrox.proto.storage.NetworkFlowOuterClass.NetworkEntity
+import java.util.concurrent.TimeUnit
 import objects.Deployment
 import objects.Edge
 import org.junit.experimental.categories.Category
 import services.ClusterService
 import services.NetworkGraphService
 import util.NetworkGraphUtil
-
-import java.util.concurrent.TimeUnit
 
 class ExternalNetworkSourcesTest extends BaseSpecification {
     // One of the outputs of: dig storage.googleapis.com
@@ -59,7 +58,7 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         String deploymentUid = DEP_EXTERNALCONNECTION.deploymentUid
         assert deploymentUid != null
 
-        println "Create a external source containing Google's IP address"
+        log.info "Create a external source containing Google's IP address"
         String externalSourceName = "external-source"
         NetworkEntity externalSource = createNetworkEntityExternalSource(externalSourceName, GOOGLE_CIDR_31)
         String externalSourceID = externalSource?.getInfo()?.getId()
@@ -82,16 +81,16 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         String deploymentUid = DEP_EXTERNALCONNECTION.deploymentUid
         assert deploymentUid != null
 
-        println "Create a smaller network external source containing Google's IP address"
+        log.info "Create a smaller network external source containing Google's IP address"
         String externalSource31Name = "external-source-31"
         NetworkEntity externalSource31 = createNetworkEntityExternalSource(externalSource31Name, GOOGLE_CIDR_31)
         String externalSource31ID = externalSource31?.getInfo()?.getId()
         assert externalSource31ID != null
 
-        println "Edge from deployment to external source ${externalSource31Name} should exist"
+        log.info "Edge from deployment to external source ${externalSource31Name} should exist"
         assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource31ID)
 
-        println "Create a supernet external source containing Google's IP address"
+        log.info "Create a supernet external source containing Google's IP address"
         String externalSource30Name = "external-source-30"
         NetworkEntity externalSource30 = createNetworkEntityExternalSource(externalSource30Name, GOOGLE_CIDR_30)
         String externalSource30ID = externalSource30?.getInfo()?.getId()
@@ -115,11 +114,11 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         when:
         "Supernet is added after subnet followed by subnet deletion"
 
-        println "Get ID of deployment which is communicating the external source"
+        log.info "Get ID of deployment which is communicating the external source"
         String deploymentUid = DEP_EXTERNALCONNECTION.deploymentUid
         assert deploymentUid != null
 
-        println "Create a smaller subnet network entities with Google's IP address"
+        log.info "Create a smaller subnet network entities with Google's IP address"
         String externalSource31Name = "external-source-31"
         NetworkEntity externalSource31 = createNetworkEntityExternalSource(externalSource31Name, GOOGLE_CIDR_31)
         String externalSource31ID = externalSource31?.getInfo()?.getId()
@@ -129,7 +128,7 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         "Verify edge from deployment to subnet exists before subnet deletion"
         assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource31ID)
 
-        println "Add supernet and remove subnet"
+        log.info "Add supernet and remove subnet"
         String externalSource30Name = "external-source-30"
         NetworkEntity externalSource30 = createNetworkEntityExternalSource(externalSource30Name, GOOGLE_CIDR_30)
         String externalSource30ID = externalSource30?.getInfo()?.getId()
@@ -163,10 +162,10 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         String externalSource30ID = externalSource30?.getInfo()?.getId()
         assert externalSource30ID != null
 
-        println "Verify edge exists from deployment to supernet external source"
+        log.info "Verify edge exists from deployment to supernet external source"
         assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource30ID)
 
-        println "Add smaller subnet subnet external source"
+        log.info "Add smaller subnet subnet external source"
         String externalSource31Name = "external-source-31"
         NetworkEntity externalSource31 = createNetworkEntityExternalSource(externalSource31Name, GOOGLE_CIDR_31)
         String externalSource31ID = externalSource31?.getInfo()?.getId()
@@ -208,9 +207,9 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         NetworkGraphService.deleteNetworkEntity(entityID)
     }
 
-    private static verifyNoEdge(String entityID1, String entityID2, Timestamp since) {
+    private verifyNoEdge(String entityID1, String entityID2, Timestamp since) {
         // First wait for some time to give time for network flow update
-        println "Wait a bit before checking graph to verify no edge..."
+        log.info "Wait a bit before checking graph to verify no edge..."
         TimeUnit.SECONDS.sleep(NetworkGraphUtil.NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS*2)
         // Shorter timeout for verifying no edge to save test time
         return !NetworkGraphUtil.checkForEdge(

--- a/qa-tests-backend/src/test/groovy/GlobalSearch.groovy
+++ b/qa-tests-backend/src/test/groovy/GlobalSearch.groovy
@@ -1,12 +1,11 @@
 import static Services.getSearchResponse
 import static Services.waitForViolation
-
-import objects.Deployment
-import util.Env
-import spock.lang.Unroll
-import io.stackrox.proto.api.v1.SearchServiceOuterClass
-import org.junit.experimental.categories.Category
 import groups.BAT
+import io.stackrox.proto.api.v1.SearchServiceOuterClass
+import objects.Deployment
+import org.junit.experimental.categories.Category
+import spock.lang.Unroll
+import util.Env
 
 class GlobalSearch extends BaseSpecification {
     static final private List<SearchServiceOuterClass.SearchCategory> EXPECTED_DEPLOYMENT_CATEGORIES = []
@@ -45,8 +44,8 @@ class GlobalSearch extends BaseSpecification {
         def foundViolation = waitForViolation(DEPLOYMENT.getName(), "Latest tag", WAIT_FOR_VIOLATION_TIMEOUT)
         if (!foundViolation) {
             def policy = Services.getPolicyByName("Latest tag")
-            println "'Latest tag' policy:"
-            println policy
+            log.info "'Latest tag' policy:"
+            log.info policy
         }
         assert foundViolation
     }
@@ -79,7 +78,7 @@ class GlobalSearch extends BaseSpecification {
         withRetry(30, 1) {
             searchResponse = getSearchResponse(query, searchCategories)
             searchResponse.countsList.forEach {
-                count -> println "Category: ${count.category}: ${count.count}"
+                count -> log.info "Category: ${count.category}: ${count.count}"
             }
             presentCategories = searchResponse.countsList.collectMany {
                 count -> count.count > 0 ? [count.category] : [] } .toSet()

--- a/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
@@ -30,7 +30,7 @@ class GraphQLResourcePaginationTest extends BaseSpecification {
         def objs = resultRet.getValue()["${topResource}s"]
         assert objs.size() != 0
 
-        println "Got top level objects: ${objs}"
+        log.info "Got top level objects: ${objs}"
 
         def sublistGraphQLQuery = "query get${topResource}_${subResource}(" +
                 "\$id: ID!, \$query: String, \$pagination: Pagination) {" +

--- a/qa-tests-backend/src/test/groovy/GroupsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/GroupsTest.groovy
@@ -52,7 +52,7 @@ class GroupsTest extends BaseSpecification {
             try {
                 GroupService.deleteGroup(group.props)
             } catch (Exception ex) {
-                print "Failed to delete group: ${ex.message}"
+                log.warn("Failed to delete group", ex)
             }
         }
     }

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -3,6 +3,7 @@ import groups.Integration
 import io.stackrox.proto.api.v1.Common
 import io.stackrox.proto.api.v1.PolicyServiceOuterClass
 import io.stackrox.proto.storage.PolicyOuterClass
+import io.stackrox.proto.storage.PolicyOuterClass.LifecycleStage
 import objects.Deployment
 import objects.GenericNotifier
 import org.junit.experimental.categories.Category
@@ -11,7 +12,6 @@ import services.ImageService
 import services.PolicyService
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
-import io.stackrox.proto.storage.PolicyOuterClass.LifecycleStage
 import util.Env
 
 class ImageManagementTest extends BaseSpecification {
@@ -310,7 +310,7 @@ class ImageManagementTest extends BaseSpecification {
         assert scanResults.getAlertsList().findAll { it.getPolicy().name == policyName }.size() == 1
         withRetry(2, 3) {
             def genericViolation = GenericNotifier.getMostRecentViolationAndValidateCommonFields()
-            println "Most recent violation sent: ${genericViolation}"
+            log.info "Most recent violation sent: ${genericViolation}"
             def alert = genericViolation["data"]["alert"]
             assert alert != null
             assert alert["policy"]["name"] == policyName

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -1,5 +1,4 @@
 import static services.ClusterService.DEFAULT_CLUSTER_NAME
-
 import common.Constants
 import groups.BAT
 import groups.Integration
@@ -8,9 +7,9 @@ import io.stackrox.proto.api.v1.SearchServiceOuterClass
 import io.stackrox.proto.storage.ImageIntegrationOuterClass
 import io.stackrox.proto.storage.ImageOuterClass
 import io.stackrox.proto.storage.Vulnerability
+import objects.AzureRegistryIntegration
 import objects.ClairScannerIntegration
 import objects.Deployment
-import objects.AzureRegistryIntegration
 import objects.ECRRegistryIntegration
 import objects.GCRImageIntegration
 import objects.GoogleArtifactRegistry
@@ -144,7 +143,7 @@ class ImageScanningTest extends BaseSpecification {
     }
 
     def cleanup() {
-        println "Post test cleanup:"
+        log.info "Post test cleanup:"
         if (secret != null) {
             orchestrator.deleteSecret(secret.name, secret.namespace)
         }
@@ -156,12 +155,12 @@ class ImageScanningTest extends BaseSpecification {
             ImageService.clearImageCaches()
             try {
                 // Sleep for 20s in order to avoid race condition with processing that is currently in progress
-                println "Sleeping to avoid race condition with reprocessing"
+                log.info "Sleeping to avoid race condition with reprocessing"
                 sleep(SLEEP_DURING_PROCESSING)
                 ImageService.deleteImagesWithRetry(SearchServiceOuterClass.RawQuery.newBuilder()
                         .setQuery("Image:${imageToCleanup}").build(), true)
             } catch (e) {
-                println "Image delete threw an exception: ${e}, this is OK for some retry cases."
+                log.info "Image delete threw an exception: ${e}, this is OK for some retry cases."
             }
         }
         integrationIds.each { ImageIntegrationService.deleteImageIntegration(it) }
@@ -242,7 +241,7 @@ class ImageScanningTest extends BaseSpecification {
         "validate scan results for the image"
         Timer t = new Timer(20, 3)
         while (imageDetail?.scan?.componentsCount == 0 && t.IsValid()) {
-            println "waiting on scan details..."
+            log.info "waiting on scan details..."
             sleep 3000
             ImageService.scanImage(deployment.image)
             imageDetail = ImageService.getImage(ImageService.getImages().find { it.name == deployment.image }?.id)
@@ -263,7 +262,7 @@ class ImageScanningTest extends BaseSpecification {
         and:
         "validate the existence of expected CVEs"
         for (String cve : cves) {
-            println "Validating existence of ${cve} cve..."
+            log.info "Validating existence of ${cve} cve..."
             ImageOuterClass.EmbeddedImageScanComponent component = imageDetail.scan.componentsList.find {
                 component -> component.vulnsList.find { vuln -> vuln.cve == cve }
             }
@@ -656,10 +655,10 @@ class ImageScanningTest extends BaseSpecification {
                 }
             }
             if (missingValues.containsKey(imageDetails.name)) {
-                println "Failing image: ${imageDetails}"
+                log.info "Failing image: ${imageDetails}"
             }
         }
-        println missingValues
+        log.info missingValues.toString()
         assert missingValues.size() == 0
     }
 

--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -1,7 +1,6 @@
 import static Services.waitForViolation
-
-import groups.Integration
 import groups.BAT
+import groups.Integration
 import io.stackrox.proto.storage.PolicyOuterClass
 import io.stackrox.proto.storage.PolicyOuterClass.Policy
 import io.stackrox.proto.storage.ScopeOuterClass

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -1,17 +1,13 @@
-import java.util.concurrent.TimeUnit
-
-import io.grpc.StatusRuntimeException
-import org.apache.commons.lang3.RandomStringUtils
-
-import io.stackrox.proto.storage.ClusterOuterClass
-import io.stackrox.proto.storage.NotifierOuterClass
-import io.stackrox.proto.storage.PolicyOuterClass
-import io.stackrox.proto.storage.ScopeOuterClass
-
 import common.Constants
 import groups.BAT
 import groups.Integration
 import groups.Notifiers
+import io.grpc.StatusRuntimeException
+import io.stackrox.proto.storage.ClusterOuterClass
+import io.stackrox.proto.storage.NotifierOuterClass
+import io.stackrox.proto.storage.PolicyOuterClass
+import io.stackrox.proto.storage.ScopeOuterClass
+import java.util.concurrent.TimeUnit
 import objects.AzureRegistryIntegration
 import objects.ClairScannerIntegration
 import objects.Deployment
@@ -26,23 +22,22 @@ import objects.QuayImageIntegration
 import objects.SlackNotifier
 import objects.SplunkNotifier
 import objects.StackroxScannerIntegration
-import objects.SyslogNotifier
+import org.apache.commons.lang3.RandomStringUtils
+import org.junit.Assume
+import org.junit.AssumptionViolatedException
+import org.junit.Rule
+import org.junit.experimental.categories.Category
+import org.junit.rules.Timeout
 import services.ClusterService
 import services.ExternalBackupService
 import services.ImageIntegrationService
 import services.NetworkPolicyService
 import services.NotifierService
 import services.PolicyService
-import util.Env
-import util.SplunkUtil
-
-import org.junit.Assume
-import org.junit.AssumptionViolatedException
-import org.junit.Rule
-import org.junit.experimental.categories.Category
-import org.junit.rules.Timeout
 import spock.lang.Ignore
 import spock.lang.Unroll
+import util.Env
+import util.SplunkUtil
 
 class IntegrationsTest extends BaseSpecification {
     static final private String NOTIFIERDEPLOYMENT = "netpol-notification-test-deployment"

--- a/qa-tests-backend/src/test/groovy/K8sEventDetectionTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sEventDetectionTest.groovy
@@ -84,7 +84,7 @@ class K8sEventDetectionTest extends BaseSpecification {
             assert violations != null && violations.size() == 1
             def fullViolation = AlertService.getViolation(violations.get(0).getId())
             assert fullViolation
-            print "Violation for ${violatingDeploymentName} while checking for" +
+            log.info "Violation for ${violatingDeploymentName} while checking for" +
                 "${expectedK8sViolationsCount} violations: ${fullViolation}"
             def k8sSubViolations = fullViolation.getViolationsList().findAll {
                 it.getType() == AlertOuterClass.Alert.Violation.Type.K8S_EVENT
@@ -110,7 +110,7 @@ class K8sEventDetectionTest extends BaseSpecification {
             if (violatingDeploymentNames.any { it == deploymentName }) {
                 continue
             }
-            println "Checking that deployment ${deploymentName} does NOT have a violation"
+            log.info "Checking that deployment ${deploymentName} does NOT have a violation"
             def deployment = DEPLOYMENTS.find { it.name == deploymentName }
             assert deployment
             assert Services.checkForNoViolationsByDeploymentID(deployment.deploymentUid, policyName)

--- a/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
@@ -1,21 +1,18 @@
 import com.google.common.base.CaseFormat
-
+import common.Constants
+import groups.BAT
 import io.stackrox.proto.api.v1.RbacServiceOuterClass
 import io.stackrox.proto.api.v1.ServiceAccountServiceOuterClass
 import io.stackrox.proto.storage.Rbac
-
-import common.Constants
-import groups.BAT
 import objects.Deployment
 import objects.K8sPolicyRule
 import objects.K8sRole
 import objects.K8sRoleBinding
 import objects.K8sServiceAccount
 import objects.K8sSubject
+import org.junit.experimental.categories.Category
 import services.RbacService
 import services.ServiceAccountService
-
-import org.junit.experimental.categories.Category
 import spock.lang.IgnoreIf
 import spock.lang.Stepwise
 import util.Env
@@ -79,14 +76,14 @@ class K8sRbacTest extends BaseSpecification {
             }
 
             if (!k8sMatch) {
-                println "SR serviceaccount ${sa.name} has no k8s match"
-                println "SR serviceaccount: " + sa
+                log.info "SR serviceaccount ${sa.name} has no k8s match"
+                log.info "SR serviceaccount: " + sa
                 K8sServiceAccount nameOnlyMatch = orchestratorSAs.find {
                     it.name == sa.name &&
                             it.namespace == sa.namespace
                 }
                 if (nameOnlyMatch) {
-                    println "K8S serviceaccount: " + nameOnlyMatch.dump()
+                    log.info "K8S serviceaccount: " + nameOnlyMatch.dump()
                 }
             }
 
@@ -166,7 +163,7 @@ class K8sRbacTest extends BaseSpecification {
 
             assert stackroxRoles.size() == orchestratorRoles.size()
             for (Rbac.K8sRole stackroxRole : stackroxRoles) {
-                println "Looking for SR Role: ${stackroxRole.name} (${stackroxRole.namespace})"
+                log.info "Looking for SR Role: ${stackroxRole.name} (${stackroxRole.namespace})"
                 K8sRole role = orchestratorRoles.find {
                     it.name == stackroxRole.name &&
                             it.clusterRole == stackroxRole.clusterRole &&

--- a/qa-tests-backend/src/test/groovy/LocalQaPropsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/LocalQaPropsTest.groovy
@@ -1,9 +1,9 @@
-import util.Env
-import spock.lang.Specification
-import spock.lang.IgnoreIf
-import org.apache.commons.codec.digest.DigestUtils
-import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import org.apache.commons.codec.digest.DigestUtils
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+import util.Env
 
 @IgnoreIf({ Env.IN_CI })
 class LocalQaPropsTest extends Specification {

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -1,14 +1,12 @@
+import groups.NetworkBaseline
 import io.stackrox.proto.storage.NetworkBaselineOuterClass
 import io.stackrox.proto.storage.NetworkFlowOuterClass
-
-import groups.NetworkBaseline
 import objects.Deployment
-import services.NetworkBaselineService
-import util.NetworkGraphUtil
-
 import org.junit.experimental.categories.Category
+import services.NetworkBaselineService
 import spock.lang.Ignore
 import spock.lang.Retry
+import util.NetworkGraphUtil
 
 @Retry(count = 0)
 class NetworkBaselineTest extends BaseSpecification {
@@ -121,7 +119,7 @@ class NetworkBaselineTest extends BaseSpecification {
 
         def anomalousClientDeploymentID = ANOMALOUS_CLIENT_DEP.deploymentUid
         assert anomalousClientDeploymentID != null
-        println "Deployment IDs Server: ${serverDeploymentID}, " +
+        log.info "Deployment IDs Server: ${serverDeploymentID}, " +
             "Baselined client: ${baselinedClientDeploymentID}, Anomalous client: ${anomalousClientDeploymentID}"
 
         assert NetworkGraphUtil.checkForEdge(baselinedClientDeploymentID, serverDeploymentID, null, 180)

--- a/qa-tests-backend/src/test/groovy/NetworkSimulator.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkSimulator.groovy
@@ -1,6 +1,8 @@
 import common.Constants
 import groups.BAT
 import groups.NetworkPolicySimulation
+import io.stackrox.proto.api.v1.NetworkPolicyServiceOuterClass
+import io.stackrox.proto.storage.NetworkPolicyOuterClass.NetworkPolicyReference
 import objects.Deployment
 import objects.NetworkPolicy
 import objects.NetworkPolicyTypes
@@ -10,8 +12,6 @@ import services.NetworkGraphService
 import services.NetworkPolicyService
 import spock.lang.Unroll
 import util.NetworkGraphUtil
-import io.stackrox.proto.api.v1.NetworkPolicyServiceOuterClass
-import io.stackrox.proto.storage.NetworkPolicyOuterClass.NetworkPolicyReference
 
 class NetworkSimulator extends BaseSpecification {
 

--- a/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
@@ -175,7 +175,7 @@ class PolicyConfigurationTest extends BaseSpecification {
         "Ensure that the latest tag violation shows up"
         def hasViolation =
                 waitForViolation(NGINX_LATEST_NAME, "Latest Tag", WAIT_FOR_VIOLATION_TIMEOUT)
-        println "Has violation ${hasViolation}"
+        log.info "Has violation ${hasViolation}"
         assert hasViolation
 
         cleanup:

--- a/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
@@ -1,15 +1,6 @@
-
 import static Services.waitForViolation
-
 import common.Constants
 import groups.BAT
-import objects.ConfigMapKeyRef
-import objects.Deployment
-import objects.SecretKeyRef
-import objects.Volume
-import orchestratormanager.OrchestratorTypes
-import org.junit.Assume
-import org.junit.experimental.categories.Category
 import io.stackrox.proto.api.v1.AlertServiceOuterClass.ListAlertsRequest
 import io.stackrox.proto.storage.PolicyOuterClass
 import io.stackrox.proto.storage.PolicyOuterClass.LifecycleStage
@@ -18,6 +9,13 @@ import io.stackrox.proto.storage.PolicyOuterClass.PolicyGroup
 import io.stackrox.proto.storage.PolicyOuterClass.PolicySection
 import io.stackrox.proto.storage.PolicyOuterClass.PolicyValue
 import io.stackrox.proto.storage.ScopeOuterClass
+import objects.ConfigMapKeyRef
+import objects.Deployment
+import objects.SecretKeyRef
+import objects.Volume
+import orchestratormanager.OrchestratorTypes
+import org.junit.Assume
+import org.junit.experimental.categories.Category
 import services.AlertService
 import services.PolicyService
 import spock.lang.Shared
@@ -842,7 +840,7 @@ class PolicyFieldsTest extends BaseSpecification {
         for (Deployment deployment : DEPLOYMENTS) {
             if (deployment.namespace != Constants.ORCHESTRATOR_NAMESPACE &&
                     !newNamespaces.contains(deployment.namespace)) {
-                println "Creating the test namespace ${deployment.namespace} with pull rights before deployment"
+                log.info "Creating the test namespace ${deployment.namespace} with pull rights before deployment"
                 orchestrator.ensureNamespaceExists(deployment.namespace)
                 addStackroxImagePullSecret(deployment.namespace)
                 addGCRImagePullSecret(deployment.namespace)

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -398,7 +398,7 @@ class ProcessBaselinesTest extends BaseSpecification {
 
         when:
         "delete the baselines"
-        println "ID: ${deployment.getDeploymentUid()}"
+        log.info "ID: ${deployment.getDeploymentUid()}"
         ProcessBaselineService.deleteProcessBaselines("Deployment Id:${deployment.getDeploymentUid()}")
 
         then:

--- a/qa-tests-backend/src/test/groovy/ProcessVisualizationReplicaTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessVisualizationReplicaTest.groovy
@@ -1,10 +1,9 @@
-import services.ProcessService
-
 import groups.BAT
 import groups.RUNTIME
-import spock.lang.Unroll
 import objects.Deployment
 import org.junit.experimental.categories.Category
+import services.ProcessService
+import spock.lang.Unroll
 import util.Timer
 
 class ProcessVisualizationReplicaTest extends BaseSpecification {
@@ -80,13 +79,13 @@ class ProcessVisualizationReplicaTest extends BaseSpecification {
             if (receivedProcessPaths.containsAll(expectedFilePaths) && observedPathOnEachContainer) {
                 break
             }
-            println "Didn't find all the expected processes, retrying..."
+            log.info "Didn't find all the expected processes, retrying..."
         }
-        println "ProcessVisualizationTest: Dep: " + depName + " Processes: " + receivedProcessPaths
+        log.info "ProcessVisualizationTest: Dep: " + depName + " Processes: " + receivedProcessPaths
 
         processContainerMap = ProcessService.getProcessContainerMap(uid, expectedFilePaths)
 
-        println processContainerMap
+        log.info processContainerMap.toString()
 
         processContainerMap.each { k, v ->
             // check that every path has k*REPLICACOUNT containerId's

--- a/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
@@ -1,10 +1,9 @@
-import services.ProcessService
-
 import groups.BAT
 import groups.RUNTIME
-import spock.lang.Unroll
 import objects.Deployment
 import org.junit.experimental.categories.Category
+import services.ProcessService
+import spock.lang.Unroll
 import util.Timer
 
 class ProcessVisualizationTest extends BaseSpecification {
@@ -98,9 +97,9 @@ class ProcessVisualizationTest extends BaseSpecification {
             if (receivedProcessPaths.containsAll(expectedFilePaths)) {
                 break
             }
-            println "Didn't find all the expected processes, retrying..."
+            log.info "Didn't find all the expected processes, retrying..."
         }
-        println "ProcessVisualizationTest: Dep: " + depName + " Processes: " + receivedProcessPaths
+        log.info "ProcessVisualizationTest: Dep: " + depName + " Processes: " + receivedProcessPaths
 
         then:
         "Verify process in added : : #depName"
@@ -157,10 +156,10 @@ class ProcessVisualizationTest extends BaseSpecification {
             if (containsAllProcessInfo(processToUserAndGroupIds, expectedFilePathAndUIDs)) {
                 break
             }
-            println "Didn't find all the expected processes in " + depName +
+            log.info "Didn't find all the expected processes in " + depName +
                     ", retrying... " + processToUserAndGroupIds
         }
-        println "ProcessVisualizationTest: Dep: " + depName +
+        log.info "ProcessVisualizationTest: Dep: " + depName +
                 " Processes and UIDs: " + processToUserAndGroupIds
 
         then:

--- a/qa-tests-backend/src/test/groovy/RbacAuthTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RbacAuthTest.groovy
@@ -1,8 +1,10 @@
 import groups.BAT
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
+import io.stackrox.proto.api.v1.ApiTokenService.GenerateTokenResponse
 import io.stackrox.proto.api.v1.AuthproviderService
 import io.stackrox.proto.storage.NetworkPolicyOuterClass
+import io.stackrox.proto.storage.RoleOuterClass
 import org.junit.experimental.categories.Category
 import services.ApiTokenService
 import services.AuthProviderService
@@ -11,8 +13,6 @@ import services.ClusterService
 import services.NetworkPolicyService
 import services.ProcessService
 import services.RoleService
-import io.stackrox.proto.api.v1.ApiTokenService.GenerateTokenResponse
-import io.stackrox.proto.storage.RoleOuterClass
 import spock.lang.Shared
 import spock.lang.Unroll
 
@@ -121,7 +121,7 @@ spec:
         def testRole = RoleService.createRoleWithScopeAndPermissionSet("Automation Role",
             UNRESTRICTED_SCOPE_ID, resourceAccess)
         assert RoleService.getRole(testRole.name)
-        println "Created Role:\n${testRole}"
+        log.info "Created Role:\n${testRole}"
 
         and:
         "Create test API token in that role"
@@ -133,10 +133,10 @@ spec:
         for (String resource : resourceTest) {
             def readFunction = RESOURCE_FUNCTION_MAP.get(resource).get(RoleOuterClass.Access.READ_ACCESS)
             def writeFunction = RESOURCE_FUNCTION_MAP.get(resource).get(RoleOuterClass.Access.READ_WRITE_ACCESS)
-            println "Testing read function for ${resource}"
+            log.info "Testing read function for ${resource}"
             def read = hasReadAccess(resource, resourceAccess) == canDo(readFunction, token.token)
             assert read
-            println "Testing write function for ${resource}"
+            log.info "Testing write function for ${resource}"
             def write = hasWriteAccess(resource, resourceAccess) == canDo(writeFunction, token.token)
             assert write
         }
@@ -191,7 +191,7 @@ spec:
             def role = RoleService.createRoleWithScopeAndPermissionSet("View ${it}",
                 UNRESTRICTED_SCOPE_ID, resourceToAccess)
             assert RoleService.getRole(role.name)
-            println "Created Role:\n${role.name}"
+            log.info "Created Role:\n${role.name}"
             role
         }
         assert roles.size() == 2
@@ -208,7 +208,7 @@ spec:
         then:
         "Call to RPC method should succeed iff token represents union role"
         for (def token : tokens) {
-            println "Checking behavior with token ${token.metadata.name}"
+            log.info "Checking behavior with token ${token.metadata.name}"
             assert canDo({
                 ProcessService.getGroupedProcessByDeploymentAndContainer("unknown")
             }, token.token, true) == (token.metadata.rolesCount > 1)
@@ -217,7 +217,7 @@ spec:
         and:
         "MyPermissions API should return the union of permissions"
         for (def token : tokens) {
-            println "Checking permissions for token ${token.metadata.name}"
+            log.info "Checking permissions for token ${token.metadata.name}"
             assert myPermissions(token.token).resourceToAccessMap.size() == token.metadata.rolesList.size()
         }
 

--- a/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
@@ -52,7 +52,7 @@ class ReconciliationTest extends BaseSpecification {
         "*central.SensorEvent_Secret": 5,
     ]
 
-    private static void verifyReconciliationStats(boolean verifyMin) {
+    private void verifyReconciliationStats(boolean verifyMin) {
         // Cannot verify this on a release build, since the API is not exposed.
         if (MetadataService.isReleaseBuild()) {
             return
@@ -65,7 +65,7 @@ class ReconciliationTest extends BaseSpecification {
             assert reconciliationStatsForCluster
             assert reconciliationStatsForCluster.getReconciliationDone()
         }
-        println "Reconciliation stats: ${reconciliationStatsForCluster.deletedObjectsByTypeMap}"
+        log.info "Reconciliation stats: ${reconciliationStatsForCluster.deletedObjectsByTypeMap}"
         for (def entry: reconciliationStatsForCluster.getDeletedObjectsByTypeMap().entrySet()) {
             def expectedMinDeletions = EXPECTED_MIN_DELETIONS_BY_KEY.get(entry.getKey())
             assert expectedMinDeletions != null : "Please add object type " +
@@ -187,7 +187,7 @@ class ReconciliationTest extends BaseSpecification {
             if (numDeployments + numPods + numNamespaces + numNetworkPolicies + numSecrets == 0) {
                 break
             }
-            println "Waiting for all resources to be reconciled"
+            log.info "Waiting for all resources to be reconciled"
         }
         assert numDeployments == 0
         assert numPods == 0

--- a/qa-tests-backend/src/test/groovy/RiskTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RiskTest.groovy
@@ -1,21 +1,18 @@
 import static io.stackrox.proto.api.v1.SearchServiceOuterClass.RawQuery.newBuilder
-
 import io.stackrox.proto.api.v1.DeploymentServiceOuterClass.ListDeploymentsWithProcessInfoResponse.DeploymentWithProcessInfo
 import io.stackrox.proto.storage.DeploymentOuterClass.ListDeployment
 import io.stackrox.proto.storage.ProcessBaselineOuterClass
-
 import objects.Deployment
 import orchestratormanager.OrchestratorTypes
 import services.ClusterService
 import services.DeploymentService
 import services.ProcessBaselineService
 import services.ProcessService
-import util.Env
-import util.Timer
-
 import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Stepwise
+import util.Env
+import util.Timer
 
 // RiskTest - Test coverage for functionality used on the Risk page and not covered elsewhere.
 // i.e.
@@ -90,11 +87,11 @@ class RiskTest extends BaseSpecification {
         while (t.IsValid()) {
             def response = listDeployments()
             if (!response || response.size() < DEPLOYMENTS.size()) {
-                println "not yet ready to test - no deployments found"
+                log.info "not yet ready to test - no deployments found"
                 continue
             }
             if (response.any { it.baselineStatusesList.size() == 0 }) {
-                println "not yet ready to test - container summary status are not set"
+                log.info "not yet ready to test - container summary status are not set"
                 continue
             }
 
@@ -102,19 +99,19 @@ class RiskTest extends BaseSpecification {
             for (int i = 0; i < DEPLOYMENTS.size(); i++) {
                 def processes = ProcessBaselineService.getProcessBaseline(clusterId, DEPLOYMENTS[i], null, 0)
                 if (!processes || processes.elementsList.size() == 0) {
-                    println "not yet ready to test - processes not found for ${DEPLOYMENTS[i].name}"
+                    log.info "not yet ready to test - processes not found for ${DEPLOYMENTS[i].name}"
                     processesFound = false
                 }
 
                 if (processes) {
                     processes.elementsList.forEach { element ->
-                        println "SR found ${element.element.processName} for ${DEPLOYMENTS[i].name}"
+                        log.info "SR found ${element.element.processName} for ${DEPLOYMENTS[i].name}"
                     }
                 }
             }
 
             if (!processesFound) {
-                println "not yet ready to test - processes not found"
+                log.info "not yet ready to test - processes not found"
                 continue
             }
 
@@ -125,11 +122,11 @@ class RiskTest extends BaseSpecification {
                     .collect { it.deployment.name }
 
             if (!deploymentNamesWithoutRisk.isEmpty()) {
-                print "not yet ready to test - risks not found ${deploymentNamesWithoutRisk}"
+                log.info "not yet ready to test - risks not found ${deploymentNamesWithoutRisk}"
                 continue
             }
 
-            println "ready to test"
+            log.info "ready to test"
             whenEquivalent = response
             break
         }
@@ -138,8 +135,8 @@ class RiskTest extends BaseSpecification {
 
         def one = whenEquivalent.get(0)
         def two = whenEquivalent.get(1)
-        println debugPriorityAndState(one)
-        println debugPriorityAndState(two)
+        log.info debugPriorityAndState(one)
+        log.info debugPriorityAndState(two)
 
         then:
         "should have the same risk"
@@ -176,13 +173,13 @@ class RiskTest extends BaseSpecification {
             for (int i = 0; i < DEPLOYMENTS.size(); i++) {
                 def processes = ProcessService.getGroupedProcessByDeploymentAndContainer(DEPLOYMENTS[i].deploymentUid)
                 if (!processes || processes.size() < 2) {
-                    println "not yet ready to test - all processes not found for ${DEPLOYMENTS[i].name}"
+                    log.info "not yet ready to test - all processes not found for ${DEPLOYMENTS[i].name}"
                     allFound = false
                 }
 
                 if (processes) {
                     processes.forEach { group ->
-                        println "SR found process ${group.name} for ${DEPLOYMENTS[i].name}"
+                        log.info "SR found process ${group.name} for ${DEPLOYMENTS[i].name}"
                     }
                 }
             }
@@ -198,7 +195,7 @@ class RiskTest extends BaseSpecification {
         // Note: This test (and ProcessWLTest.groovy) rely heavily on the deployed SR using an
         // artificially reduced process discovery phase. i.e. "1m" instead of the default 1 hour.
         // See ROX_BASELINE_GENERATION_DURATION.
-        println "sleeping for 60 seconds to ensure the discovery phase is over"
+        log.info "sleeping for 60 seconds to ensure the discovery phase is over"
         sleep(60000)
 
         def before = whenEquivalent
@@ -224,16 +221,16 @@ class RiskTest extends BaseSpecification {
             }
             debugBeforeAndAfter(before, after)
             if (after.get(withRiskIndex).deployment.priority == after.get(withoutRiskIndex).deployment.priority) {
-                println "not yet ready to test - there is no change yet to priorities"
+                log.info "not yet ready to test - there is no change yet to priorities"
                 after = null
                 continue
             }
             if (!after.get(withRiskIndex).baselineStatusesList.get(0).anomalousProcessesExecuted) {
-                println "not yet ready to test - there is no anomalous process spotted yet"
+                log.info "not yet ready to test - there is no anomalous process spotted yet"
                 after = null
                 continue
             }
-            println "ready to test"
+            log.info "ready to test"
             break
         }
         assert after
@@ -280,10 +277,10 @@ class RiskTest extends BaseSpecification {
                     [] as String
             )
             if (!response || response.size() == 0) {
-                println "not yet ready to test - could not update the baseline"
+                log.info "not yet ready to test - could not update the baseline"
                 continue
             }
-            println "the process baseline is updated"
+            log.info "the process baseline is updated"
             break
         }
         assert response && response.size() > 0
@@ -299,16 +296,16 @@ class RiskTest extends BaseSpecification {
             }
             debugBeforeAndAfter(before, after)
             if (risk(after.get(withRiskIndex).deployment) == riskBefore) {
-                println "not yet ready to test - there is no change yet to risk score"
+                log.info "not yet ready to test - there is no change yet to risk score"
                 after = null
                 continue
             }
             if (after.get(withRiskIndex).baselineStatusesList.get(0).anomalousProcessesExecuted) {
-                println "not yet ready to test - the process anomaly is not cleared"
+                log.info "not yet ready to test - the process anomaly is not cleared"
                 after = null
                 continue
             }
-            println "ready to test"
+            log.info "ready to test"
             break
         }
         assert after
@@ -334,15 +331,15 @@ class RiskTest extends BaseSpecification {
         def withRiskIndex = before.get(0).deployment.name == deploymentWithRisk.name ? 0 : 1
         def withoutRiskIndex = (withRiskIndex + 1) % 2
 
-        println "Before:"
-        println "\tDeployment with risk:    ${debugPriorityAndState(before.get(withRiskIndex))}"
-        println "\tDeployment without risk: ${debugPriorityAndState(before.get(withoutRiskIndex))}"
-        println "After:"
-        println "\tDeployment with risk:    ${debugPriorityAndState(after.get(withRiskIndex))}"
-        println "\tDeployment without risk: ${debugPriorityAndState(after.get(withoutRiskIndex))}"
-        println "Process List:"
-        println "\tDeployment with risk:    ${debugProcesses(deploymentWithRisk.deploymentUid)}"
-        println "\tDeployment without risk: ${debugProcesses(deploymentWithoutRisk.deploymentUid)}"
+        log.info "Before:"
+        log.info "\tDeployment with risk:    ${debugPriorityAndState(before.get(withRiskIndex))}"
+        log.info "\tDeployment without risk: ${debugPriorityAndState(before.get(withoutRiskIndex))}"
+        log.info "After:"
+        log.info "\tDeployment with risk:    ${debugPriorityAndState(after.get(withRiskIndex))}"
+        log.info "\tDeployment without risk: ${debugPriorityAndState(after.get(withoutRiskIndex))}"
+        log.info "Process List:"
+        log.info "\tDeployment with risk:    ${debugProcesses(deploymentWithRisk.deploymentUid)}"
+        log.info "\tDeployment without risk: ${debugProcesses(deploymentWithoutRisk.deploymentUid)}"
     }
 
     def debugPriorityAndState(DeploymentWithProcessInfo dpl) {

--- a/qa-tests-backend/src/test/groovy/RuntimePolicyTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RuntimePolicyTest.groovy
@@ -1,14 +1,14 @@
 import static Services.getPolicies
-import static Services.waitForViolation
 import static Services.waitForResolvedViolation
-import io.stackrox.proto.storage.PolicyOuterClass
-import services.PolicyService
+import static Services.waitForViolation
 import groups.BAT
 import groups.SMOKE
+import io.stackrox.proto.storage.PolicyOuterClass
+import java.util.stream.Collectors
 import objects.Deployment
 import org.junit.experimental.categories.Category
+import services.PolicyService
 import spock.lang.Unroll
-import java.util.stream.Collectors
 
 class RuntimePolicyTest extends BaseSpecification  {
     static final private String DEPLOYMENTAPTGET = "runtimenginx"

--- a/qa-tests-backend/src/test/groovy/RuntimeViolationLifecycleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RuntimeViolationLifecycleTest.groovy
@@ -3,16 +3,15 @@ import static Services.getViolationsByDeploymentID
 import static Services.roxDetectedDeployment
 import static Services.updatePolicy
 import static Services.updatePolicyToExclusionDeployment
-
-import util.Timer
-import services.AlertService
 import groups.BAT
-import java.util.stream.Collectors
-import objects.Deployment
-import org.junit.experimental.categories.Category
 import io.stackrox.proto.storage.AlertOuterClass.ViolationState
 import io.stackrox.proto.storage.PolicyOuterClass
 import io.stackrox.proto.storage.ProcessIndicatorOuterClass.ProcessIndicator
+import java.util.stream.Collectors
+import objects.Deployment
+import org.junit.experimental.categories.Category
+import services.AlertService
+import util.Timer
 
 class RuntimeViolationLifecycleTest extends BaseSpecification  {
     static final private String APTGETPOLICY = "Ubuntu Package Manager Execution"

--- a/qa-tests-backend/src/test/groovy/SACv2Test.groovy
+++ b/qa-tests-backend/src/test/groovy/SACv2Test.groovy
@@ -5,19 +5,16 @@ import static io.stackrox.proto.storage.RoleOuterClass.SimpleAccessScope.Rules
 import static io.stackrox.proto.storage.RoleOuterClass.SimpleAccessScope.newBuilder
 import static services.ApiTokenService.generateToken
 import static services.ClusterService.DEFAULT_CLUSTER_NAME
-
+import groups.BAT
 import io.stackrox.proto.api.v1.ApiTokenService
 import io.stackrox.proto.storage.RoleOuterClass
-
-import groups.BAT
+import org.junit.experimental.categories.Category
 import services.BaseService
 import services.DeploymentService
 import services.RoleService
-import util.Env
-
-import org.junit.experimental.categories.Category
 import spock.lang.IgnoreIf
 import spock.lang.Shared
+import util.Env
 
 @Category(BAT)
 @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })

--- a/qa-tests-backend/src/test/groovy/SecretsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SecretsTest.groovy
@@ -1,8 +1,8 @@
-import services.SecretService
-import org.junit.experimental.categories.Category
 import groups.BAT
-import objects.Deployment
 import io.stackrox.proto.storage.SecretOuterClass.Secret
+import objects.Deployment
+import org.junit.experimental.categories.Category
+import services.SecretService
 import spock.lang.Unroll
 import util.Timer
 

--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -372,7 +372,7 @@ class Services extends BaseService {
             getPolicyClient().putPolicy(policyDef)
         } catch (Exception e) {
             LOG.warn("updating policy failed", e)
-            return []
+            throw e
         }
 
         if (waitForPropagation) {

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -2,6 +2,7 @@ import common.Constants
 import groups.BAT
 import io.stackrox.proto.api.v1.NamespaceServiceOuterClass
 import io.stackrox.proto.api.v1.SearchServiceOuterClass
+import io.stackrox.proto.storage.NodeOuterClass.Node
 import objects.Namespace
 import org.javers.core.Javers
 import org.javers.core.JaversBuilder
@@ -12,7 +13,6 @@ import services.ClusterService
 import services.NamespaceService
 import services.NodeService
 import services.SummaryService
-import io.stackrox.proto.storage.NodeOuterClass.Node
 import spock.lang.IgnoreIf
 import util.Env
 
@@ -36,15 +36,15 @@ class SummaryTest extends BaseSpecification {
                     orchestrator.getJobCount()
 
             if (stackroxSummaryCounts.numDeployments != orchestratorResourceNames.size()) {
-                println "The summary count for deployments does not equate to the orchestrator count."
-                println "Stackrox count: ${stackroxSummaryCounts.numDeployments}, " +
+                log.info "The summary count for deployments does not equate to the orchestrator count."
+                log.info "Stackrox count: ${stackroxSummaryCounts.numDeployments}, " +
                         "orchestrator count ${orchestratorResourceNames.size()}"
-                println "This diff may help with debug, however deployment names may be different between APIs"
+                log.info "This diff may help with debug, however deployment names may be different between APIs"
                 List<String> stackroxDeploymentNames = Services.getDeployments()*.name
                 Javers javers = JaversBuilder.javers()
                         .withListCompareAlgorithm(ListCompareAlgorithm.AS_SET)
                         .build()
-                println javers.compare(stackroxDeploymentNames, orchestratorResourceNames).prettyPrint()
+                log.info javers.compare(stackroxDeploymentNames, orchestratorResourceNames).prettyPrint()
             }
 
             assert stackroxSummaryCounts.numDeployments == orchestratorResourceNames.size()
@@ -70,8 +70,8 @@ class SummaryTest extends BaseSpecification {
             assert stackroxNode.clusterId == ClusterService.getClusterId()
             assert stackroxNode.name == orchestratorNode.name
             if (stackroxNode.labelsMap != orchestratorNode.labels) {
-                println "There is a node label difference - StackRox -v- Orchestrator:"
-                println javers.compare(stackroxNode.labelsMap, orchestratorNode.labels).prettyPrint()
+                log.info "There is a node label difference - StackRox -v- Orchestrator:"
+                log.info javers.compare(stackroxNode.labelsMap, orchestratorNode.labels).prettyPrint()
                 diff = true
             }
             assert stackroxNode.labelsMap == orchestratorNode.labels
@@ -84,8 +84,8 @@ class SummaryTest extends BaseSpecification {
                     }
                 }
                 if (stackroxNode.annotationsMap != orchestratorTruncated) {
-                    println "There is a node annotation difference - StackRox -v- Orchestrator:"
-                    println javers.compare(stackroxNode.annotationsMap, orchestratorTruncated).prettyPrint()
+                    log.info "There is a node annotation difference - StackRox -v- Orchestrator:"
+                    log.info javers.compare(stackroxNode.annotationsMap, orchestratorTruncated).prettyPrint()
                     diff = true
                 }
             }
@@ -128,19 +128,19 @@ class SummaryTest extends BaseSpecification {
             while (stackroxNamespace.numDeployments != orchestratorNamespace.deploymentCount.size() &&
                 (System.currentTimeMillis() - start) < (30 * 1000)) {
                 stackroxNamespace = NamespaceService.getNamespace(stackroxNamespace.metadata.id)
-                println "There is a difference in the deployment count for namespace "+
+                log.info "There is a difference in the deployment count for namespace "+
                         stackroxNamespace.metadata.name
-                println "StackRox has ${stackroxNamespace.numDeployments}, "+
+                log.info "StackRox has ${stackroxNamespace.numDeployments}, "+
                         "the orchestrator has ${orchestratorNamespace.deploymentCount.size()}"
-                println "will retry to find equivalence in 5 seconds"
+                log.info "will retry to find equivalence in 5 seconds"
                 sleep(5000)
             }
             if (stackroxNamespace.numDeployments != orchestratorNamespace.deploymentCount.size()) {
-                println "There is a difference in the deployment count for namespace "+
+                log.info "There is a difference in the deployment count for namespace "+
                         stackroxNamespace.metadata.name
-                println "StackRox has ${stackroxNamespace.numDeployments}, "+
+                log.info "StackRox has ${stackroxNamespace.numDeployments}, "+
                         "the orchestrator has ${orchestratorNamespace.deploymentCount.size()}"
-                println "This diff may help with debug, however deployment names may be different between APIs"
+                log.info "This diff may help with debug, however deployment names may be different between APIs"
                 List<String> stackroxDeploymentNames = Services.getDeployments(
                         SearchServiceOuterClass.RawQuery.newBuilder().setQuery(
                                 "Namespace:${ stackroxNamespace.metadata.name }").build()
@@ -148,7 +148,7 @@ class SummaryTest extends BaseSpecification {
                 Javers javers = JaversBuilder.javers()
                         .withListCompareAlgorithm(ListCompareAlgorithm.AS_SET)
                         .build()
-                println javers.compare(stackroxDeploymentNames, orchestratorNamespace.deploymentCount).prettyPrint()
+                log.info javers.compare(stackroxDeploymentNames, orchestratorNamespace.deploymentCount).prettyPrint()
                 diff = true
             }
             assert stackroxNamespace.metadata.clusterId == ClusterService.getClusterId()

--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -141,7 +141,7 @@ class TLSChallengeTest extends BaseSpecification {
         }
 
         log.error("Could not establish connection to central ${CENTRAL_PROXY_ENDPOINT}")
-        println logs
+        log.info logs
         return false
     }
 

--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -72,7 +72,7 @@ class UpgradesTest extends BaseSpecification {
         def gqlService = new GraphQLService()
         def resultRet = gqlService.Call(getQuery(resourceType), [ query: searchQuery ])
         assert resultRet.getCode() == 200
-        println "return code " + resultRet.getCode()
+        log.info "return code " + resultRet.getCode()
 
         then:
         "Check that we got the correct number of #resourceType from GraphQL "
@@ -109,7 +109,7 @@ class UpgradesTest extends BaseSpecification {
         def gqlService = new GraphQLService()
         def resultRet = gqlService.Call(COMPLIANCE_QUERY, [ groupBy: groupBy, unit: unit ])
         assert resultRet.getCode() == 200
-        println "return code " + resultRet.getCode()
+        log.info "return code " + resultRet.getCode()
 
         then:
         "Check that we got the correct number of #unit from GraphQL "
@@ -207,15 +207,15 @@ class UpgradesTest extends BaseSpecification {
         "Upgraded default policies are fetched from central"
         def upgradedPolicies
         try {
-            println("Exporting policies: ${defaultPolicies.keySet().join(", ")}")
+            log.info("Exporting policies: ${defaultPolicies.keySet().join(", ")}")
             upgradedPolicies = PolicyService.getPolicyClient().exportPolicies(
                     PolicyServiceOuterClass.ExportPoliciesRequest.newBuilder().
                             addAllPolicyIds(defaultPolicies.keySet()).
                             build()
             ).getPoliciesList()
         } catch (StatusRuntimeException e) {
-            println "Exception in exportPolicies(): ${e.getStatus()}"
-            println "See central log for more details."
+            log.info "Exception in exportPolicies(): ${e.getStatus()}"
+            log.info "See central log for more details."
             throw(e)
         }
 

--- a/qa-tests-backend/src/test/groovy/VulnMgmtSACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtSACTest.groovy
@@ -1,14 +1,11 @@
 import static org.junit.Assume.assumeFalse
-
-import io.stackrox.proto.storage.RoleOuterClass
-import services.GraphQLService
-
 import groups.BAT
-import org.junit.experimental.categories.Category
-
 import io.stackrox.proto.api.v1.ApiTokenService.GenerateTokenResponse
+import io.stackrox.proto.storage.RoleOuterClass
+import org.junit.experimental.categories.Category
 import services.ApiTokenService
 import services.BaseService
+import services.GraphQLService
 import services.ImageIntegrationService
 import services.ImageService
 import services.RoleService
@@ -67,7 +64,7 @@ class VulnMgmtSACTest extends BaseSpecification {
         def testRole = RoleService.createRoleWithScopeAndPermissionSet(name,
             UNRESTRICTED_SCOPE_ID, resourceToAccess)
         assert RoleService.getRole(testRole.name)
-        println "Created Role:\n${testRole}"
+        log.info "Created Role:\n${testRole}"
     }
 
     def setupSpec() {

--- a/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
@@ -1,7 +1,7 @@
-import io.stackrox.proto.storage.Cve.VulnerabilitySeverity
-import services.GraphQLService
 import groups.BAT
+import io.stackrox.proto.storage.Cve.VulnerabilitySeverity
 import org.junit.experimental.categories.Category
+import services.GraphQLService
 import services.ImageIntegrationService
 import services.ImageService
 import spock.lang.IgnoreIf

--- a/qa-tests-backend/src/test/groovy/VulnScanWithGraphQLTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnScanWithGraphQLTest.groovy
@@ -1,12 +1,11 @@
 import static org.junit.Assume.assumeFalse
-
 import groups.GraphQL
 import objects.Deployment
 import org.apache.commons.lang3.StringUtils
+import org.junit.experimental.categories.Category
 import services.GraphQLService
 import spock.lang.Shared
 import spock.lang.Unroll
-import org.junit.experimental.categories.Category
 import util.Env
 import util.Timer
 
@@ -130,11 +129,11 @@ class VulnScanWithGraphQLTest extends BaseSpecification {
         String uid = DEPLOYMENTS.find { it.name == depName }.deploymentUid
         assert uid != null
         def imageId = waitForValidImageID(uid)
-        println "image id ..." + imageId
+        log.info "image id ..." + imageId
         assert !StringUtils.isEmpty(imageId)
         def resultRet = gqlService.Call(GET_CVES_INFO_WITH_IMAGE_QUERY, [ id: imageId ])
         assert resultRet.getCode() == 200
-        println "return code " + resultRet.getCode()
+        log.info "return code " + resultRet.getCode()
         then:
         assert resultRet.getValue() != null
         def image = resultRet.getValue().image
@@ -170,20 +169,20 @@ class VulnScanWithGraphQLTest extends BaseSpecification {
         while (t.IsValid()) {
             def result2Ret = gqlService.Call(GET_IMAGE_INFO_FROM_VULN_QUERY, [id: cveId])
             assert result2Ret.getCode() == 200
-            println "return code " + result2Ret.getCode()
+            log.info "return code " + result2Ret.getCode()
             if (result2Ret.getValue().result != null) {
-                println "images fetched from cve"
+                log.info "images fetched from cve"
                 return result2Ret
             }
         }
-        println "Unable to fetch images for $cveId in ${t.SecondsSince()} seconds"
+        log.info "Unable to fetch images for $cveId in ${t.SecondsSince()} seconds"
         return null
     }
 
     private String getImageIDFromDepId(String id) {
-        println "id " + id
+        log.info "id " + id
         def resultRet = gqlService.Call(DEP_QUERY, [ id: id ])
-        println "code " + resultRet.getCode()
+        log.info "code " + resultRet.getCode()
         assert resultRet.getCode() == 200
         String imageID
         assert resultRet.getValue() != null
@@ -191,7 +190,7 @@ class VulnScanWithGraphQLTest extends BaseSpecification {
         if (dep != null && dep.images != null) {
             for (Object img : dep.images) {
                 if (img.name != null && img.name.fullName.contains("struts") ) {
-                    println " img.name ..." + img.name
+                    log.info " img.name ..." + img.name
                     imageID = img.id
                     break
                 }
@@ -205,7 +204,7 @@ class VulnScanWithGraphQLTest extends BaseSpecification {
         for (List cves : vulns.cve) {
             numCVEs += cves.size()
         }
-        println "number of CVEs " + numCVEs
+        log.info "number of CVEs " + numCVEs
         return numCVEs
     }
 
@@ -215,12 +214,12 @@ class VulnScanWithGraphQLTest extends BaseSpecification {
         while (t.IsValid()) {
             imageID = getImageIDFromDepId(depID)
             if (!StringUtils.isEmpty(imageID)) {
-                println "imageID found using deployment query "
+                log.info "imageID found using deployment query "
                 return imageID
             }
-            println "imageID not found for ${depID} yet "
+            log.info "imageID not found for ${depID} yet "
         }
-        println "could not find  imageID from  ${depID} in ${t.SecondsSince()} seconds"
+        log.info "could not find  imageID from  ${depID} in ${t.SecondsSince()} seconds"
         return ""
     }
 


### PR DESCRIPTION
## Description

To get better logs in qa tests use logger instead of print and enable codenarc to prevent print in the future.
This PR also fixes issue introduced in https://github.com/stackrox/stackrox/pull/1737 where when error occured we returned empty list while we should throw exception because in other places we check if list contains `EXCEPTION` string.

## Testing Performed

CI