### PR TITLE
Do not enable authz plugin on pg test

### DIFF
--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -1369,6 +1369,7 @@ class ComplianceTest extends BaseSpecification {
     }
 
     @Category([BAT])
+    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
     def "Verify ComplianceRuns with SAC on clusters with wildcard"() {
         def otherClusterName = "disallowedCluster"
 


### PR DESCRIPTION
## Description

Postgres datastore SAC implementation is not supported by auth plugin.
This PR disables auth plugin if `ROX_POSTGRES_DATASTORE` is enabled. 

https://github.com/stackrox/stackrox/blob/0b6ed84bb99b54b4e4e6bc77a912a0d59c1a827f/pkg/sac/scope_checker_core_impl.go#L93-L96

## Testing Performed

CI