### PR TITLE
Move Formik state from page to form in System Configuration

### DIFF
--- a/ui/apps/platform/cypress/constants/SystemConfigPage.js
+++ b/ui/apps/platform/cypress/constants/SystemConfigPage.js
@@ -11,9 +11,9 @@ const selectors = {
         logout: '.pf-c-page__header-tools-item button:contains("Log out")',
     },
     pageHeader: {
-        editButton: '[data-testid="edit-btn"]',
-        cancelButton: '[data-testid="cancel-btn"]',
-        saveButton: '[data-testid="save-btn"]',
+        editButton: 'button:contains("Edit")',
+        cancelButton: 'button:contains("Cancel")',
+        saveButton: 'button:contains("Save")',
     },
     header: {
         widget: '[data-testid="header-config"]',

--- a/ui/apps/platform/src/Containers/SystemConfig/SystemConfigForm/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/SystemConfigForm/SystemConfigForm.tsx
@@ -1,5 +1,7 @@
 import React, { ReactElement } from 'react';
 import {
+    ActionGroup,
+    Button,
     TextArea,
     Form,
     FormSection,
@@ -17,31 +19,75 @@ import {
     CardActions,
     Switch,
 } from '@patternfly/react-core';
+import { useFormik } from 'formik';
 
 import ColorPicker from 'Components/ColorPicker';
 import { getProductBranding } from 'constants/productBranding';
-import { PrivateConfig, PublicConfig } from 'types/config.proto';
+import { PrivateConfig, PublicConfig, SystemConfig } from 'types/config.proto';
 import { TelemetryConfig } from 'types/telemetry.proto';
 import { ConfigTelemetryDetailContent } from '../ConfigTelemetryDetailWidget';
 import FormSelect from './FormSelect';
 
-export type SystemConfigFormProps = {
-    values: {
-        privateConfig: PrivateConfig;
-        publicConfig: PublicConfig;
-        telemetryConfig: TelemetryConfig;
+function getCompletePublicConfig(systemConfig: SystemConfig): PublicConfig {
+    return {
+        header: {
+            color: systemConfig?.publicConfig?.header?.color || '#000000',
+            backgroundColor: systemConfig?.publicConfig?.header?.backgroundColor || '#FFFFFF',
+            text: systemConfig?.publicConfig?.header?.text || '',
+            enabled: systemConfig?.publicConfig?.header?.enabled || false,
+            size: systemConfig?.publicConfig?.header?.size || 'UNSET',
+        },
+        footer: {
+            color: systemConfig?.publicConfig?.footer?.color || '#000000',
+            backgroundColor: systemConfig?.publicConfig?.footer?.backgroundColor || '#FFFFFF',
+            text: systemConfig?.publicConfig?.footer?.text || '',
+            enabled: systemConfig?.publicConfig?.footer?.enabled || false,
+            size: systemConfig?.publicConfig?.footer?.size || 'UNSET',
+        },
+        loginNotice: {
+            text: systemConfig?.publicConfig?.loginNotice?.text || '',
+            enabled: systemConfig?.publicConfig?.loginNotice?.enabled || false,
+        },
     };
-    onSubmitForm: (event) => void;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void;
+}
+
+type Values = {
+    privateConfig: PrivateConfig;
+    publicConfig: PublicConfig;
+    telemetryConfig: TelemetryConfig;
+};
+
+export type SystemConfigFormProps = {
+    systemConfig: SystemConfig;
+    telemetryConfig: TelemetryConfig;
+    onCancel: () => void;
+    onSubmit: (
+        systemConfigSubmitted: SystemConfig,
+        telemetryConfigSubmitted: TelemetryConfig
+    ) => void;
 };
 
 const SystemConfigForm = ({
-    onSubmitForm,
-    values,
-    setFieldValue,
+    systemConfig,
+    telemetryConfig,
+    onCancel,
+    onSubmit,
 }: SystemConfigFormProps): ReactElement => {
     const { type } = getProductBranding();
+    const { privateConfig } = systemConfig;
+    const publicConfig = getCompletePublicConfig(systemConfig);
+    const { submitForm, setFieldValue, values, dirty, isValid, isSubmitting, setSubmitting } =
+        useFormik<Values>({
+            initialValues: { privateConfig, publicConfig, telemetryConfig },
+            onSubmit: () => {
+                // TODO next step will call save functions directly from services instead of indirectly via sagas.
+                onSubmit(
+                    { privateConfig: values.privateConfig, publicConfig: values.publicConfig },
+                    values.telemetryConfig
+                );
+                setSubmitting(false);
+            },
+        });
 
     function onChange(value, event) {
         return setFieldValue(event.target.id, value, false);
@@ -51,8 +97,13 @@ const SystemConfigForm = ({
         return setFieldValue(id, value, false);
     }
 
+    function onSubmitForm(event) {
+        event.preventDefault();
+        return submitForm();
+    }
+
     return (
-        <Form id="system-config-edit-form" onSubmit={onSubmitForm}>
+        <Form onSubmit={onSubmitForm}>
             <Grid hasGutter md={12}>
                 <GridItem md={12}>
                     <Card>
@@ -438,6 +489,19 @@ const SystemConfigForm = ({
                     </GridItem>
                 )}
             </Grid>
+            <ActionGroup>
+                <Button
+                    variant="primary"
+                    type="submit"
+                    isDisabled={!dirty || !isValid || isSubmitting}
+                    isLoading={isSubmitting}
+                >
+                    Save
+                </Button>
+                <Button variant="secondary" onClick={onCancel}>
+                    Cancel
+                </Button>
+            </ActionGroup>
         </Form>
     );
 };


### PR DESCRIPTION
## Description

Step 2 of general preparation for new data retention property

1. Move Formik state and also **Save** and **Cancel** buttons from `Page` to `SystemConfigForm` component.
2. There was a racing condition because `initialValues` in the page depends on the responses to different requests, but not if **Edit** button is disabled until `systemConfig` and `telemetryConfig` are both available.

### Changed files

1. cypress/constants/SystemConfigPage.js
    * Replace `data-testid` with button text in selectors

2. src/Containers/SystemConfig/Page.tsx
    * Replace combined `config` object with separate `(systemConfigSubmitted, telemetryConfigSubmitted)` arguments in `onSubmit` function to fix leak of telemetry config into payload for system config request

3. src/Containers/SystemConfig/SystemConfigForm/SystemConfigForm.tsx
    * Adapt `getCompletePublicConfig` from former `getInitialValues` function in Page
    * Rename `Values` from former `InitialValues` type in Page
    * Move `useFormik` and so on from Page
    * Move `ActionGroup` element from Page

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### manual testing

1. `yarn build` in ui
2. `yarn start` in ui

    * Visit /main/systemconfig: still makes requests indirectly via sagas.
        ![1-view-sagas](https://user-images.githubusercontent.com/11862657/169071089-037dd5fe-d323-4a51-81b3-05235da3364c.png)

    * Click **Edit**: see **Edit** button becomes disabled and **Save** button is disabled because no changes.
        ![2-Edit-Save-disabled](https://user-images.githubusercontent.com/11862657/169071133-ea1dd767-c584-420b-b800-0936ce223b3a.png)

    * Change **Expired Vulnerability Requests** from 90 to 99, and then click **Save**: see pair of PUT requests (with complete default `publicConfig` values) followed by pair of GET requests.
        ![3-Save](https://user-images.githubusercontent.com/11862657/169071171-e4b00218-ce1a-4e88-907a-aeedb282ebd5.png)

    * Click **Edit** again, enter **Text** under **Header Configuration**, and then click **Save**: see currently and previously changed values in response from PUT request.
        ![4-Edit-Save-header](https://user-images.githubusercontent.com/11862657/169071200-3b49e56a-e1c8-41cb-a04a-dd38ab0d90cf.png)

    * Click **Edit**, change a value under **Data Retention Settings**, and then click **Cancel**: see no request and unchanged value.

    * Click**Edit** again, and see unchanged value.

### integration testing

1. `yarn cypress-open` in ui/apps/platform
    * systemconfig.test.js