### PR TITLE
Dashrews/ROX-10955 racy upsert many

### DIFF
--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -61,10 +61,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -420,6 +417,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Alert) error
 		}
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -61,6 +62,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -414,6 +419,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Alert) error
 			return errors.Wrapf(sac.ErrResourceAccessDenied, "modifying alerts with IDs [%s] was denied", strings.Join(deniedIds, ", "))
 		}
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -24,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -22,6 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -59,6 +60,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -225,6 +230,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TokenMetadat
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -59,10 +59,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -231,6 +228,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TokenMetadat
 		return sac.ErrResourceAccessDenied
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -22,6 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -60,10 +60,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -237,6 +234,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.AuthProvider
 		return sac.ErrResourceAccessDenied
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -60,6 +61,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -231,6 +236,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.AuthProvider
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -61,6 +62,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -249,6 +254,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Cluster) err
 			return errors.Wrapf(sac.ErrResourceAccessDenied, "modifying clusters with IDs [%s] was denied", strings.Join(deniedIds, ", "))
 		}
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -24,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -240,6 +237,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ClusterHealthStatus
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterHealthStatus) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "ClusterHealthStatus")
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -234,6 +239,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ClusterHealthStatus
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterHealthStatus) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "ClusterHealthStatus")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -21,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -57,10 +57,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -227,6 +224,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.InitBundleMe
 		return sac.ErrResourceAccessDenied
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/componentcveedge/datastore/internal/postgres/store.go
+++ b/central/componentcveedge/datastore/internal/postgres/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 

--- a/central/componentcveedge/datastore/internal/postgres/store.go
+++ b/central/componentcveedge/datastore/internal/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/componentcveedge/datastore/internal/postgres/store.go
+++ b/central/componentcveedge/datastore/internal/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/cve/datastore/cluster/internal/store/postgres/store.go
+++ b/central/cve/datastore/cluster/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/cve/datastore/cluster/internal/store/postgres/store.go
+++ b/central/cve/datastore/cluster/internal/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -248,6 +253,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.CVE) error {
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.CVE) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "CVE")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/cve/image/datastore/internal/store/postgres/store.go
+++ b/central/cve/image/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/cve/image/datastore/internal/store/postgres/store.go
+++ b/central/cve/image/datastore/internal/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -248,6 +253,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.CVE) error {
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.CVE) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "CVE")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/cve/node/internal/store/postgres/store.go
+++ b/central/cve/node/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/cve/node/internal/store/postgres/store.go
+++ b/central/cve/node/internal/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -248,6 +253,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.CVE) error {
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.CVE) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "CVE")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -61,10 +61,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -976,6 +973,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Deployment) 
 		}
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -61,6 +62,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -970,6 +975,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Deployment) 
 			return errors.Wrapf(sac.ErrResourceAccessDenied, "modifying deployments with IDs [%s] was denied", strings.Join(deniedIds, ", "))
 		}
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -24,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/imagecomponent/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponent/datastore/internal/store/postgres/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -239,6 +236,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageComponent) err
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageComponent) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "ImageComponent")
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/imagecomponent/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponent/datastore/internal/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -233,6 +238,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageComponent) err
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageComponent) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "ImageComponent")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/imagecomponent/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponent/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/imagecveedge/datastore/internal/postgres/store.go
+++ b/central/imagecveedge/datastore/internal/postgres/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 

--- a/central/imagecveedge/datastore/internal/postgres/store.go
+++ b/central/imagecveedge/datastore/internal/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/imagecveedge/datastore/internal/postgres/store.go
+++ b/central/imagecveedge/datastore/internal/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -21,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -57,6 +58,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -221,6 +226,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.IntegrationH
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -57,10 +57,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -227,6 +224,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.IntegrationH
 		return sac.ErrResourceAccessDenied
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -61,10 +61,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -271,6 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NamespaceMet
 		}
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -61,6 +62,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -265,6 +270,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NamespaceMet
 			return errors.Wrapf(sac.ErrResourceAccessDenied, "modifying namespaceMetadatas with IDs [%s] was denied", strings.Join(deniedIds, ", "))
 		}
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -24,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -208,6 +213,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkBaseline) er
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkBaseline) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "NetworkBaseline")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -214,6 +211,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkBaseline) er
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkBaseline) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "NetworkBaseline")
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -219,6 +216,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkEntity) erro
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkEntity) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "NetworkEntity")
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -213,6 +218,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkEntity) erro
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkEntity) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "NetworkEntity")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/nodecomponent/datastore/postgres/store.go
+++ b/central/nodecomponent/datastore/postgres/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -239,6 +236,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageComponent) err
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageComponent) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "ImageComponent")
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/nodecomponent/datastore/postgres/store.go
+++ b/central/nodecomponent/datastore/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -233,6 +238,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageComponent) err
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageComponent) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "ImageComponent")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/nodecomponent/datastore/postgres/store.go
+++ b/central/nodecomponent/datastore/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -22,6 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -60,6 +61,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -231,6 +236,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Notifier) er
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -60,10 +60,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -237,6 +234,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Notifier) er
 		return sac.ErrResourceAccessDenied
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -61,6 +62,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -346,6 +351,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Pod) error {
 			return errors.Wrapf(sac.ErrResourceAccessDenied, "modifying pods with IDs [%s] was denied", strings.Join(deniedIds, ", "))
 		}
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -61,10 +61,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -352,6 +349,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Pod) error {
 		}
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -24,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -22,6 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -59,6 +60,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -280,6 +285,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) erro
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -59,10 +59,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -286,6 +283,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) erro
 		return sac.ErrResourceAccessDenied
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -61,10 +61,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -260,6 +257,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBasel
 		}
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -61,6 +62,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -254,6 +259,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBasel
 			return errors.Wrapf(sac.ErrResourceAccessDenied, "modifying processBaselines with IDs [%s] was denied", strings.Join(deniedIds, ", "))
 		}
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -24,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -214,6 +211,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaselineResu
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBaselineResults) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "ProcessBaselineResults")
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -208,6 +213,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaselineResu
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBaselineResults) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "ProcessBaselineResults")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -61,10 +61,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -300,6 +297,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessIndic
 		}
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -61,6 +62,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -294,6 +299,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessIndic
 			return errors.Wrapf(sac.ErrResourceAccessDenied, "modifying processIndicators with IDs [%s] was denied", strings.Join(deniedIds, ", "))
 		}
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -24,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -61,6 +62,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -274,6 +279,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRole) err
 			return errors.Wrapf(sac.ErrResourceAccessDenied, "modifying k8SRoles with IDs [%s] was denied", strings.Join(deniedIds, ", "))
 		}
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -24,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -61,10 +61,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -280,6 +277,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRole) err
 		}
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -61,10 +61,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -376,6 +373,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRoleBindi
 		}
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -61,6 +62,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -370,6 +375,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRoleBindi
 			return errors.Wrapf(sac.ErrResourceAccessDenied, "modifying k8SRoleBindings with IDs [%s] was denied", strings.Join(deniedIds, ", "))
 		}
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -24,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/relations/nodecomponenttocve/datastore/store/postgres/store.go
+++ b/central/relations/nodecomponenttocve/datastore/store/postgres/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 

--- a/central/relations/nodecomponenttocve/datastore/store/postgres/store.go
+++ b/central/relations/nodecomponenttocve/datastore/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/relations/nodecomponenttocve/datastore/store/postgres/store.go
+++ b/central/relations/nodecomponenttocve/datastore/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -22,6 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -59,6 +60,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -235,6 +240,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ReportConfig
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -59,10 +59,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -241,6 +238,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ReportConfig
 		return sac.ErrResourceAccessDenied
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -61,10 +61,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -265,6 +262,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Risk) error 
 		}
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -61,6 +62,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -259,6 +264,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Risk) error 
 			return errors.Wrapf(sac.ErrResourceAccessDenied, "modifying risks with IDs [%s] was denied", strings.Join(deniedIds, ", "))
 		}
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -24,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -59,10 +59,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -236,6 +233,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSe
 		return sac.ErrResourceAccessDenied
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -22,6 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -59,6 +60,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -230,6 +235,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSe
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -22,6 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -59,6 +60,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -225,6 +230,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Role) error 
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -59,10 +59,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -231,6 +228,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Role) error 
 		return sac.ErrResourceAccessDenied
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -22,6 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -59,10 +59,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -236,6 +233,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SimpleAccess
 		return sac.ErrResourceAccessDenied
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -59,6 +60,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -230,6 +235,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SimpleAccess
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -61,10 +61,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -452,6 +449,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Secret) erro
 		}
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -61,6 +62,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -446,6 +451,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Secret) erro
 			return errors.Wrapf(sac.ErrResourceAccessDenied, "modifying secrets with IDs [%s] was denied", strings.Join(deniedIds, ", "))
 		}
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -24,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -61,10 +61,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -275,6 +272,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceAccou
 		}
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -61,6 +62,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -269,6 +274,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceAccou
 			return errors.Wrapf(sac.ErrResourceAccessDenied, "modifying serviceAccounts with IDs [%s] was denied", strings.Join(deniedIds, ", "))
 		}
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -24,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -22,6 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -59,6 +60,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -230,6 +235,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SignatureInt
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -59,10 +59,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -236,6 +233,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SignatureInt
 		return sac.ErrResourceAccessDenied
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -21,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -57,6 +58,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -431,6 +436,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Vulnerabilit
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -57,10 +57,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -437,6 +434,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Vulnerabilit
 		return sac.ErrResourceAccessDenied
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -22,6 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -59,10 +59,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -231,6 +228,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.WatchedImage
 		return sac.ErrResourceAccessDenied
 	}
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -59,6 +60,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -225,6 +230,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.WatchedImage
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -60,6 +61,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -384,6 +389,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestMultiKeyStruct)
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestMultiKeyStruct) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestMultiKeyStruct")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -98,9 +98,6 @@ type Store interface {
 
 type storeImpl struct {
     db *pgxpool.Pool
-
-    // Lock since copyFrom requires a delete first before being executed we can get in odd states if
-    // multiple processes are trying to work on the same subsets of rows.
     mutex sync.Mutex
 }
 
@@ -401,6 +398,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*{{.Type}}) error {
     }
     {{- end }}
 
+    // Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+    // same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+    // violations
     s.mutex.Lock()
     defer s.mutex.Unlock()
 

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -40,6 +40,7 @@ import (
     "github.com/stackrox/rox/pkg/sac"
     "github.com/stackrox/rox/pkg/search"
     "github.com/stackrox/rox/pkg/search/postgres"
+    "github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -57,6 +58,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -259,6 +264,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestSingleKeyStruct
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestSingleKeyStruct) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestSingleKeyStruct")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -219,6 +216,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestChild1) error {
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild1) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestChild1")
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -231,6 +228,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestChild2) error {
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild2) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestChild2")
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -225,6 +230,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestChild2) error {
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild2) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestChild2")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -225,6 +230,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestG2GrandChild1) 
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestG2GrandChild1) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestG2GrandChild1")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -213,6 +218,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestG3GrandChild1) 
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestG3GrandChild1) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestG3GrandChild1")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -219,6 +216,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestG3GrandChild1) 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestG3GrandChild1) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestG3GrandChild1")
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -219,6 +216,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGGrandChild1) e
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGGrandChild1) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestGGrandChild1")
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -213,6 +218,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGGrandChild1) e
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGGrandChild1) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestGGrandChild1")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -225,6 +230,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGrandChild1) er
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandChild1) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestGrandChild1")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -231,6 +228,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGrandChild1) er
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandChild1) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestGrandChild1")
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -396,6 +393,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGrandparent) er
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandparent) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestGrandparent")
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -390,6 +395,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGrandparent) er
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandparent) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestGrandparent")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -311,6 +308,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent1) error 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent1) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestParent1")
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -305,6 +310,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent1) error 
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent1) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestParent1")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -225,6 +222,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent2) error 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent2) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestParent2")
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -219,6 +224,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent2) error 
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent2) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestParent2")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -56,6 +57,10 @@ type Store interface {
 
 type storeImpl struct {
 	db *pgxpool.Pool
+
+	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
+	// multiple processes are trying to work on the same subsets of rows.
+	mutex sync.Mutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -219,6 +224,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent3) error 
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent3) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestParent3")
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if len(objs) < batchAfter {
 		return s.upsert(ctx, objs...)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -20,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -56,10 +56,7 @@ type Store interface {
 }
 
 type storeImpl struct {
-	db *pgxpool.Pool
-
-	// Lock since copyFrom requires a delete first before being executed we can get in odd states if
-	// multiple processes are trying to work on the same subsets of rows.
+	db    *pgxpool.Pool
 	mutex sync.Mutex
 }
 
@@ -225,6 +222,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent3) error 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent3) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "TestParent3")
 
+	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+	// violations
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 


### PR DESCRIPTION
## Description

There is a potential race issue using copyFrom because we have to delete the conflicting rows first and then re-add them as opposed to using ON CONFLICT as we would in an insert call.  This change adds a lock to UpsertMany to alleviate this issue.  I did a performance run to ensure that with the lock it is still fast than just upserting one at a time.  In the stats below the old run is with a lock on UpsertMany and the new run is processing the updates one at a time.  As you can tell it is still much faster to use copyFrom than to process each insert individually.  

postgres_op_duration Operation=UpdateMany Type=NetworkBaseline (old: (298204.19/4315) 69.11, new (615005.18/3699) 166.26): change: 140.5811%
postgres_op_duration Operation=UpdateMany Type=ProcessIndicator (old: (15900.29/354) 44.92, new (683955.58/284) 2408.29): change: 5261.7640%

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs]~~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran some scale and long running jobs with a few variations to take a look at that performance metrics to ensure there was not too much degradation by adding this lock.
