### PR TITLE
Global scope checker should drill down to get EAS for resource

### DIFF
--- a/central/sac/authorizer/builtin_scoped_authorizer.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer.go
@@ -92,7 +92,10 @@ func (a *globalScopeChecker) PerformChecks(_ context.Context) error {
 }
 
 func (a *globalScopeChecker) EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {
-	return nil, errNoGlobalEffectiveAccessScope
+	return a.
+		SubScopeChecker(sac.AccessModeScopeKey(resource.Access)).
+		SubScopeChecker(sac.ResourceScopeKey(resource.Resource.GetResource())).
+		EffectiveAccessScope(resource)
 }
 
 func (a *globalScopeChecker) SubScopeChecker(scopeKey sac.ScopeKey) sac.ScopeCheckerCore {


### PR DESCRIPTION
## Description

Currently global scope checker returns error when trying to get `EffectiveAccessScope` (EAS) for resource. This is counter intuitive as we pass resource with metadata and global scope checker can drill down to get proper sub scope checker for resource access pair. This behaviour is different what we have in tests with `allowFixedScopesCheckerCore` that drills down to get EAS.

## Testing Performed

CI