### PR TITLE
ScopedAccessControl - Remove unused argument from postgres search helper constructor

### DIFF
--- a/central/pod/datastore/internal/search/searcher_impl.go
+++ b/central/pod/datastore/internal/search/searcher_impl.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	podsSACSearchHelper         = sac.ForResource(resources.Deployment).MustCreateSearchHelper(mappings.OptionsMap)
-	podsSACPostgresSearchHelper = sac.ForResource(resources.Deployment).MustCreatePgSearchHelper(mappings.OptionsMap)
+	podsSACPostgresSearchHelper = sac.ForResource(resources.Deployment).MustCreatePgSearchHelper()
 
 	defaultSortOption = &v1.QuerySortOption{
 		Field:    search.DeploymentID.String(),

--- a/central/processindicator/search/searcher_impl.go
+++ b/central/processindicator/search/searcher_impl.go
@@ -16,8 +16,7 @@ import (
 
 var (
 	indicatorSACSearchHelper         = sac.ForResource(resources.Indicator).MustCreateSearchHelper(processindicators.OptionsMap)
-	indicatorSACPostgresSearchHelper = sac.ForResource(resources.Indicator).
-						MustCreatePgSearchHelper(processindicators.OptionsMap)
+	indicatorSACPostgresSearchHelper = sac.ForResource(resources.Indicator).MustCreatePgSearchHelper()
 )
 
 // searcherImpl provides an intermediary implementation layer for ProcessStorage.

--- a/central/rbac/k8srole/search/searcher_impl.go
+++ b/central/rbac/k8srole/search/searcher_impl.go
@@ -3,7 +3,6 @@ package search
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/postgres/schema"
 	"github.com/stackrox/rox/central/rbac/k8srole/internal/index"
 	"github.com/stackrox/rox/central/rbac/k8srole/internal/store"
 	"github.com/stackrox/rox/central/rbac/k8srole/mappings"
@@ -17,7 +16,7 @@ import (
 
 var (
 	k8sRolesSACSearchHelper   = sac.ForResource(resources.K8sRole).MustCreateSearchHelper(mappings.OptionsMap)
-	k8sRolesSACPgSearchHelper = sac.ForResource(resources.K8sRole).MustCreatePgSearchHelper(schema.K8srolesSchema.OptionsMap)
+	k8sRolesSACPgSearchHelper = sac.ForResource(resources.K8sRole).MustCreatePgSearchHelper()
 )
 
 // searcherImpl provides an intermediary implementation layer for AlertStorage.

--- a/central/rbac/k8srolebinding/search/searcher_impl.go
+++ b/central/rbac/k8srolebinding/search/searcher_impl.go
@@ -18,7 +18,7 @@ var (
 	k8sRoleBindingsSACSearchHelper = sac.ForResource(resources.K8sRoleBinding).
 					MustCreateSearchHelper(mappings.OptionsMap)
 	k8sRoleBindingsSACPostgresSearchHelper = sac.ForResource(resources.K8sRoleBinding).
-						MustCreatePgSearchHelper(mappings.OptionsMap)
+						MustCreatePgSearchHelper()
 )
 
 // searcherImpl provides a search implementation for k8s role bindings.

--- a/central/secret/search/searcher_impl.go
+++ b/central/secret/search/searcher_impl.go
@@ -23,7 +23,7 @@ var (
 	}
 
 	secretSACSearchHelper         = sac.ForResource(resources.Secret).MustCreateSearchHelper(mappings.OptionsMap)
-	secretSACPostgresSearchHelper = sac.ForResource(resources.Secret).MustCreatePgSearchHelper(mappings.OptionsMap)
+	secretSACPostgresSearchHelper = sac.ForResource(resources.Secret).MustCreatePgSearchHelper()
 )
 
 // searcherImpl provides an intermediary implementation layer for secrets

--- a/central/serviceaccount/search/searcher_impl.go
+++ b/central/serviceaccount/search/searcher_impl.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	serviceAccountsSACSearchHelper         = sac.ForResource(resources.ServiceAccount).MustCreateSearchHelper(mappings.OptionsMap)
-	serviceAccountsSACPostgresSearchHelper = sac.ForResource(resources.ServiceAccount).MustCreatePgSearchHelper(mappings.OptionsMap)
+	serviceAccountsSACPostgresSearchHelper = sac.ForResource(resources.ServiceAccount).MustCreatePgSearchHelper()
 )
 
 type searcherImpl struct {

--- a/pkg/sac/for_resource_helpers.go
+++ b/pkg/sac/for_resource_helpers.go
@@ -63,8 +63,8 @@ func (h ForResourceHelper) MustCreateSearchHelper(options search.OptionsMap) Sea
 
 // MustCreatePgSearchHelper creates and returns a search helper with the given options, or panics if the
 // search helper could not be created.
-func (h ForResourceHelper) MustCreatePgSearchHelper(options search.OptionsMap) SearchHelper {
-	searchHelper, err := NewPgSearchHelper(h.resourceMD, options, h.ScopeChecker)
+func (h ForResourceHelper) MustCreatePgSearchHelper() SearchHelper {
+	searchHelper, err := NewPgSearchHelper(h.resourceMD, h.ScopeChecker)
 	utils.CrashOnError(err)
 	return searchHelper
 }

--- a/pkg/sac/search_helper.go
+++ b/pkg/sac/search_helper.go
@@ -211,11 +211,9 @@ type pgSearchHelper struct {
 }
 
 // NewPgSearchHelper returns a new search helper for the given resource.
-func NewPgSearchHelper(resourceMD permissions.ResourceMetadata, optionsMap search.OptionsMap,
-	factory scopeCheckerFactory) (SearchHelper, error) {
+func NewPgSearchHelper(resourceMD permissions.ResourceMetadata, factory scopeCheckerFactory) (SearchHelper, error) {
 	return &pgSearchHelper{
 		resourceMD:          resourceMD,
-		optionsMap:          optionsMap,
 		scopeCheckerFactory: factory,
 	}, nil
 }


### PR DESCRIPTION
## Description

The point here is to avoid looking up objects or passing misleading ones when instantiating a search helper.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI run is enough