### PR TITLE
ROX-10914: relax the warning on missing certificates

### DIFF
--- a/sensor/kubernetes/localscanner/cert_refresher.go
+++ b/sensor/kubernetes/localscanner/cert_refresher.go
@@ -106,7 +106,7 @@ func getTimeToRefreshFromRepo(ctx context.Context, getCertsRenewalTime getCertsR
 		return 0, nil
 	}
 	if k8sErrors.IsNotFound(getCertsErr) {
-		log.Warnf("local scanner certificates not found, "+
+		log.Warnf("local scanner certificates not found (this is expected on a new deployment), "+
 			"will refresh certificates immediately: %s", getCertsErr)
 		return 0, nil
 	}


### PR DESCRIPTION
## Description

Make it clear that missing local scanner certificates is expected on initial sensor startup.
Hopefully this will help support team chasing this red herring.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI should be enough