### PR TITLE
Use Role instead of Access when creating diag bundle

### DIFF
--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -403,7 +403,7 @@ func (s *serviceImpl) getRoles(_ context.Context) (interface{}, error) {
 	accessRolesCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			sac.ResourceScopeKeys(resources.Access)))
+			sac.ResourceScopeKeys(resources.Role)))
 
 	roles, errGetRoles := s.roleDataStore.GetAllRoles(accessRolesCtx)
 	if errGetRoles != nil {


### PR DESCRIPTION
## Description

New resources types introduced in #1384 are not supported in Postgres SAC. This lead some e2e tests to fail.
This PR uses deprecated resources in diagnostic bundle in order to make code work and not panic.

Refs: https://github.com/stackrox/stackrox/pull/1597/files#r876980951

## Testing Performed

CI