### PR TITLE
Fix: Revert to old access resources in diagnostic bundle dump

### DIFF
--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -388,7 +388,7 @@ func (s *serviceImpl) getGroups(_ context.Context) (interface{}, error) {
 	accessGroupsCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			sac.ResourceScopeKeys(resources.Access)))
+			sac.ResourceScopeKeys(resources.Group)))
 
 	return s.groupDataStore.GetAll(accessGroupsCtx)
 }
@@ -403,7 +403,7 @@ func (s *serviceImpl) getRoles(_ context.Context) (interface{}, error) {
 	accessRolesCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			sac.ResourceScopeKeys(resources.Access)))
+			sac.ResourceScopeKeys(resources.Role)))
 
 	roles, errGetRoles := s.roleDataStore.GetAllRoles(accessRolesCtx)
 	if errGetRoles != nil {
@@ -435,7 +435,7 @@ func (s *serviceImpl) getNotifiers(_ context.Context) (interface{}, error) {
 	accessNotifierCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			sac.ResourceScopeKeys(resources.Integration)))
+			sac.ResourceScopeKeys(resources.Notifier)))
 
 	notifiers, err := s.notifierDataStore.GetNotifiers(accessNotifierCtx)
 	if err != nil {
@@ -452,7 +452,7 @@ func (s *serviceImpl) getConfig(_ context.Context) (interface{}, error) {
 	accessConfigCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			sac.ResourceScopeKeys(resources.Administration)))
+			sac.ResourceScopeKeys(resources.Config)))
 
 	return s.configDataStore.GetConfig(accessConfigCtx)
 }


### PR DESCRIPTION
## Description

We had a problem with new permission resources when Postgres DB is used.

With this PR we are reverting to old permission resources.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~ - noting new
- ~[ ] Evaluated and added CHANGELOG entry if required~ - not relevant
- ~[ ] Determined and documented upgrade steps~ - not relevant
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~ - not relevant

## Testing Performed

1. Deploy local stack with Postgres
```
export ROX_POSTGRES_DATASTORE=true
STORAGE=pvc ./deploy/k8s/deploy-local.sh
# and port forward UI
```
2. Login to UI and go to the following page: `/main/system-health`
3. Click on "Diagnostic Bundle" on the top right corner of the page and download it
