### PR TITLE
ROX-11028: GraphQL subresolvers to include image/cluster prefix

### DIFF
--- a/central/graphql/resolvers/cluster_vulnerabilities.go
+++ b/central/graphql/resolvers/cluster_vulnerabilities.go
@@ -16,6 +16,7 @@ import (
 func init() {
 	schema := getBuilder()
 	utils.Must(
+		// NOTE: This list is and should remain alphabetically ordered
 		schema.AddType("ClusterVulnerability",
 			append(commonVulnerabilitySubResolvers,
 				"vulnerabilityType: String!",

--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -27,7 +27,8 @@ func init() {
 	schema := getBuilder()
 	utils.Must(
 		schema.AddType("PolicyStatus", []string{"status: String!", "failingPolicies: [Policy!]!"}),
-		schema.AddExtraResolvers("Cluster", []string{ // note: alphabetically ordered
+		// NOTE: This list is and should remain alphabetically ordered
+		schema.AddExtraResolvers("Cluster", []string{
 			"alerts(query: String, pagination: Pagination): [Alert!]!",
 			"alertCount(query: String): Int!",
 			"latestViolation(query: String): Time",
@@ -54,9 +55,9 @@ func init() {
 			"imageCount(query: String): Int!",
 			"components(query: String, pagination: Pagination): [EmbeddedImageScanComponent!]!",
 			"componentCount(query: String): Int!",
-			`nodeVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [NodeVulnerability!]!`,
-			`nodeVulnerabilityCount(query: String): Int!`,
-			`nodeVulnerabilityCounter(query: String): VulnerabilityCounter!`,
+			"nodeVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [NodeVulnerability!]!",
+			"nodeVulnerabilityCount(query: String): Int!",
+			"nodeVulnerabilityCounter(query: String): VulnerabilityCounter!",
 			"imageVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [ImageVulnerability!]!",
 			"imageVulnerabilityCount(query: String): Int!",
 			"imageVulnerabilityCounter(query: String): VulnerabilityCounter!",

--- a/central/graphql/resolvers/deployments.go
+++ b/central/graphql/resolvers/deployments.go
@@ -22,7 +22,8 @@ import (
 func init() {
 	schema := getBuilder()
 	utils.Must(
-		schema.AddExtraResolvers("Deployment", []string{ // note: alphabetically ordered
+		// NOTE: This list is and should remain alphabetically ordered
+		schema.AddExtraResolvers("Deployment", []string{
 			"cluster: Cluster",
 			"complianceResults(query: String): [ControlResult!]!",
 			"componentCount(query: String): Int!",
@@ -38,6 +39,9 @@ func init() {
 			"groupedProcesses: [ProcessNameGroup!]!",
 			"imageCount(query: String): Int!",
 			"images(query: String, pagination: Pagination): [Image!]!",
+			"imageVulnerabilityCount(query: String): Int!",
+			"imageVulnerabilityCounter(query: String): VulnerabilityCounter!",
+			"imageVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [ImageVulnerability!]!",
 			"latestViolation(query: String): Time",
 			"namespaceObject: Namespace",
 			"plottedVulns(query: String): PlottedVulnerabilities!",
@@ -51,15 +55,15 @@ func init() {
 			"serviceAccountID: String!",
 			"serviceAccountObject: ServiceAccount",
 			"unusedVarSink(query: String): Int",
-			"vulnerabilityCount(query: String): Int!",
-			"vulnerabilityCounter(query: String): VulnerabilityCounter!",
-			"vulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [ImageVulnerability!]!",
 		}),
 		// deprecated fields
 		schema.AddExtraResolvers("Deployment", []string{
-			"vulnCount(query: String): Int! @deprecated(reason: \"use 'vulnerabilityCount'\")",
-			"vulnCounter(query: String): VulnerabilityCounter! @deprecated(reason: \"use 'vulnerabilityCounter'\")",
-			"vulns(query: String, scopeQuery: String, pagination: Pagination): [EmbeddedVulnerability]! @deprecated(reason: \"use 'vulnerabilities'\")",
+			"vulnCount(query: String): Int! " +
+				"@deprecated(reason: \"use 'imageVulnerabilityCount'\")",
+			"vulnCounter(query: String): VulnerabilityCounter! " +
+				"@deprecated(reason: \"use 'imageVulnerabilityCounter'\")",
+			"vulns(query: String, scopeQuery: String, pagination: Pagination): [EmbeddedVulnerability]! " +
+				"@deprecated(reason: \"use 'imageVulnerabilities'\")",
 		}),
 		schema.AddQuery("deployment(id: ID): Deployment"),
 		schema.AddQuery("deployments(query: String, pagination: Pagination): [Deployment!]!"),
@@ -577,24 +581,24 @@ func (resolver *deploymentResolver) vulnQueryScoping(ctx context.Context) contex
 	return ctx
 }
 
-func (resolver *deploymentResolver) Vulnerabilities(ctx context.Context, args PaginatedQuery) ([]ImageVulnerabilityResolver, error) {
-	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "Vulnerabilities")
+func (resolver *deploymentResolver) ImageVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ImageVulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "ImageVulnerabilities")
 
 	ctx = resolver.vulnQueryScoping(ctx)
 
 	return resolver.root.ImageVulnerabilities(ctx, args)
 }
 
-func (resolver *deploymentResolver) VulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
-	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "VulnerabilityCount")
+func (resolver *deploymentResolver) ImageVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "ImageVulnerabilityCount")
 
 	ctx = resolver.vulnQueryScoping(ctx)
 
 	return resolver.root.ImageVulnerabilityCount(ctx, args)
 }
 
-func (resolver *deploymentResolver) VulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
-	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "VulnerabilityCounter")
+func (resolver *deploymentResolver) ImageVulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "ImageVulnerabilityCounter")
 
 	ctx = resolver.vulnQueryScoping(ctx)
 

--- a/central/graphql/resolvers/image_vulnerabilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities.go
@@ -17,6 +17,7 @@ import (
 func init() {
 	schema := getBuilder()
 	utils.Must(
+		// NOTE: This list is and should remain alphabetically ordered
 		schema.AddType("ImageVulnerability",
 			append(commonVulnerabilitySubResolvers,
 				"activeState(query: String): ActiveState",
@@ -85,7 +86,7 @@ func (resolver *Resolver) ImageVulnerabilityCount(ctx context.Context, args RawQ
 
 // ImageVulnerabilityCounter returns a VulnerabilityCounterResolver for the input query
 func (resolver *Resolver) ImageVulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
-	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "ImageVulnCounter")
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "ImageVulnerabilityCounter")
 	if !features.PostgresDatastore.Enabled() {
 		query := withImageTypeFiltering(args.String())
 		return resolver.vulnCounterV2(ctx, RawQuery{Query: &query})

--- a/central/graphql/resolvers/namespaces.go
+++ b/central/graphql/resolvers/namespaces.go
@@ -22,7 +22,8 @@ import (
 func init() {
 	schema := getBuilder()
 	utils.Must(
-		schema.AddExtraResolvers("Namespace", []string{ // note: alphabetically ordered
+		// NOTE: This list is and should remain alphabetically ordered
+		schema.AddExtraResolvers("Namespace", []string{
 			"cluster: Cluster!",
 			"complianceResults(query: String): [ControlResult!]!",
 			"componentCount(query: String): Int!",
@@ -32,6 +33,9 @@ func init() {
 			"failingPolicyCounter(query: String): PolicyCounter",
 			"imageCount(query: String): Int!",
 			"images(query: String, pagination: Pagination): [Image!]!",
+			"imageVulnerabilityCount(query: String): Int!",
+			"imageVulnerabilityCounter(query: String): VulnerabilityCounter!",
+			"imageVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [ImageVulnerability!]!",
 			"k8sRoleCount(query: String): Int!",
 			"k8sRoles(query: String, pagination: Pagination): [K8SRole!]!",
 			"latestViolation(query: String): Time",
@@ -47,16 +51,16 @@ func init() {
 			"serviceAccountCount(query: String): Int!",
 			"serviceAccounts(query: String, pagination: Pagination): [ServiceAccount!]!",
 			"unusedVarSink(query: String): Int",
-			"vulnerabilityCount(query: String): Int!",
-			"vulnerabilityCounter(query: String): VulnerabilityCounter!",
-			"vulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [ImageVulnerability!]!",
 			"risk: Risk",
 		}),
 		// deprecated fields
 		schema.AddExtraResolvers("Namespace", []string{
-			"vulnCount(query: String): Int! @deprecated(reason: \"use 'vulnerabilityCount'\")",
-			"vulnCounter(query: String): VulnerabilityCounter! @deprecated(reason: \"use 'vulnerabilityCounter'\")",
-			"vulns(query: String, scopeQuery: String, pagination: Pagination): [EmbeddedVulnerability]! @deprecated(reason: \"use 'vulnerabilities'\")",
+			"vulnCount(query: String): Int! " +
+				"@deprecated(reason: \"use 'imageVulnerabilityCount'\")",
+			"vulnCounter(query: String): VulnerabilityCounter! " +
+				"@deprecated(reason: \"use 'imageVulnerabilityCounter'\")",
+			"vulns(query: String, scopeQuery: String, pagination: Pagination): [EmbeddedVulnerability]! " +
+				"@deprecated(reason: \"use 'imageVulnerabilities'\")",
 		}),
 		schema.AddQuery("namespaces(query: String, pagination: Pagination): [Namespace!]!"),
 		schema.AddQuery("namespace(id: ID!): Namespace"),
@@ -514,24 +518,24 @@ func (resolver *namespaceResolver) vulnQueryScoping(ctx context.Context) context
 	return ctx
 }
 
-func (resolver *namespaceResolver) Vulnerabilities(ctx context.Context, args PaginatedQuery) ([]ImageVulnerabilityResolver, error) {
-	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Namespaces, "Vulnerabilities")
+func (resolver *namespaceResolver) ImageVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ImageVulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Namespaces, "ImageVulnerabilities")
 
 	ctx = resolver.vulnQueryScoping(ctx)
 
 	return resolver.root.ImageVulnerabilities(ctx, args)
 }
 
-func (resolver *namespaceResolver) VulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
-	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Namespaces, "VulnerabilityCount")
+func (resolver *namespaceResolver) ImageVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Namespaces, "ImageVulnerabilityCount")
 
 	ctx = resolver.vulnQueryScoping(ctx)
 
 	return resolver.root.ImageVulnerabilityCount(ctx, args)
 }
 
-func (resolver *namespaceResolver) VulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
-	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Namespaces, "VulnerabilityCounter")
+func (resolver *namespaceResolver) ImageVulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Namespaces, "ImageVulnerabilityCounter")
 
 	ctx = resolver.vulnQueryScoping(ctx)
 

--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -16,6 +16,7 @@ import (
 func init() {
 	schema := getBuilder()
 	utils.Must(
+		// NOTE: This list is and should remain alphabetically ordered
 		schema.AddType("NodeVulnerability",
 			append(commonVulnerabilitySubResolvers,
 				"nodeCount(query: String): Int!",
@@ -70,7 +71,7 @@ func (resolver *Resolver) NodeVulnerabilityCount(ctx context.Context, args RawQu
 
 // NodeVulnCounter returns a VulnerabilityCounterResolver for the input query.s
 func (resolver *Resolver) NodeVulnCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
-	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "NodeVulnCounter")
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "NodeVulnerabilityCounter")
 	if !features.PostgresDatastore.Enabled() {
 		query := withNodeTypeFiltering(args.String())
 		return resolver.vulnCounterV2(ctx, RawQuery{Query: &query})


### PR DESCRIPTION
As per UI request, all subresolvers should contain a prefix of `image`, `node`, or `cluster` to decrease confusion at the cost of verbosity