### PR TITLE
Update AccessControl breadcrumb design to be consistent with UX mocks.

### DIFF
--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAccessScopes.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAccessScopes.test.js
@@ -68,9 +68,8 @@ describe('Access Control Access scopes', () => {
         const name = 'Deny All';
         cy.get(`${selectors.list.tdNameLink}:contains("${name}")`).click();
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h1}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(3):contains("${name}")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("${name}")`);
 
         cy.get(selectors.h1).should('not.exist');
         cy.get(selectors.navLinkCurrent).should('not.exist');
@@ -88,9 +87,8 @@ describe('Access Control Access scopes', () => {
         cy.visit(`${accessScopesUrl}/bogus`);
         cy.wait('@GetAccessScopes');
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h1}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(3)`).should('not.exist');
+        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(2)`).should('not.exist');
 
         cy.get(selectors.h1).should('not.exist');
         cy.get(selectors.navLinkCurrent).should('not.exist');

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -82,9 +82,8 @@ describe('Access Control Auth providers', () => {
         cy.get(selectors.list.createButton).click();
         cy.get(`${selectors.list.authProviders.createDropdownItem}:contains("${type}")`).click();
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h1}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(3):contains("Create ${type} provider")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("Create ${type} provider")`);
 
         cy.get(selectors.h1).should('not.exist');
         cy.get(selectors.navLinkCurrent).should('not.exist');
@@ -115,9 +114,8 @@ describe('Access Control Auth providers', () => {
         cy.get(selectors.list.createButton).click();
         cy.get(`${selectors.list.authProviders.createDropdownItem}:contains("${type}")`).click();
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h1}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(3):contains("Create ${type} provider")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("Create ${type} provider")`);
 
         cy.get(selectors.h1).should('not.exist');
         cy.get(selectors.navLinkCurrent).should('not.exist');
@@ -212,9 +210,8 @@ describe('Access Control Auth providers', () => {
         cy.get(selectors.list.createButton).click();
         cy.get(`${selectors.list.authProviders.createDropdownItem}:contains("${type}")`).click();
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h1}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(3):contains("Create ${type} provider")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("Create ${type} provider")`);
 
         cy.get(selectors.h1).should('not.exist');
         cy.get(selectors.navLinkCurrent).should('not.exist');
@@ -265,9 +262,8 @@ describe('Access Control Auth providers', () => {
         cy.get(selectors.list.createButton).click();
         cy.get(`${selectors.list.authProviders.createDropdownItem}:contains("${type}")`).click();
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h1}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(3):contains("Create ${type} provider")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("Create ${type} provider")`);
 
         cy.get(selectors.h1).should('not.exist');
         cy.get(selectors.navLinkCurrent).should('not.exist');
@@ -309,9 +305,8 @@ describe('Access Control Auth providers', () => {
         cy.get(selectors.list.createButton).click();
         cy.get(`${selectors.list.authProviders.createDropdownItem}:contains("${type}")`).click();
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h1}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(3):contains("Create ${type} provider")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("Create ${type} provider")`);
 
         cy.get(selectors.h1).should('not.exist');
         cy.get(selectors.navLinkCurrent).should('not.exist');
@@ -384,9 +379,8 @@ describe('Access Control Auth providers', () => {
         cy.visit(`${authProvidersUrl}/bogus`);
         cy.wait('@GetAuthProviders');
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h1}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(3)`).should('not.exist');
+        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(2)`).should('not.exist');
 
         cy.get(selectors.h1).should('not.exist');
         cy.get(selectors.navLinkCurrent).should('not.exist');

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
@@ -74,9 +74,8 @@ describe('Access Control Permission sets', () => {
         const name = 'Admin';
         cy.get(`${selectors.list.tdNameLink}:contains("${name}")`).click();
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h1}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(3):contains("${name}")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("${name}")`);
 
         cy.get(selectors.h1).should('not.exist');
         cy.get(selectors.navLinkCurrent).should('not.exist');
@@ -368,9 +367,8 @@ describe('Access Control Permission sets', () => {
         cy.visit(`${permissionSetsUrl}/bogus`);
         cy.wait('@GetAuthProviders');
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h1}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(3)`).should('not.exist');
+        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(2)`).should('not.exist');
 
         cy.get(selectors.h1).should('not.exist');
         cy.get(selectors.navLinkCurrent).should('not.exist');

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlRoles.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlRoles.test.js
@@ -180,9 +180,8 @@ describe('Access Control Roles', () => {
         cy.visit(`${rolesUrl}/bogus`);
         cy.wait('@GetAuthProviders');
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h1}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(3)`).should('not.exist');
+        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
+        cy.get(`${selectors.breadcrumbItem}:nth-child(2)`).should('not.exist');
 
         cy.get(selectors.h1).should('not.exist');
         cy.get(selectors.navLinkCurrent).should('not.exist');

--- a/ui/apps/platform/src/Components/BreadcrumbItemLink.tsx
+++ b/ui/apps/platform/src/Components/BreadcrumbItemLink.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { BreadcrumbItem } from '@patternfly/react-core';
+import { BreadcrumbItem, BreadcrumbItemProps } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 
 export type BreadcrumbItemLinkProps = {
     children: React.ReactNode;
     to: string;
-};
+} & BreadcrumbItemProps;
 
 function BreadcrumbItemLink({
     children,

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControlBreadcrumbs.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControlBreadcrumbs.tsx
@@ -9,38 +9,24 @@ import { accessControlLabels } from 'messages/common';
 import { getEntityPath } from './accessControlPaths';
 
 export type AccessControlBreadcrumbsProps = {
-    entityType?: AccessControlEntityType;
+    entityType: AccessControlEntityType;
     entityName?: string;
-    isDisabled?: boolean;
-    isList?: boolean;
 };
 
 function AccessControlBreadcrumbs({
     entityType,
     entityName,
-    isDisabled,
-    isList,
 }: AccessControlBreadcrumbsProps): ReactElement {
-    let entityTypeBreadcrumb;
     const entityTypeLabel = entityType ? pluralize(accessControlLabels[entityType]) : null;
-    if (entityType) {
-        entityTypeBreadcrumb =
-            isDisabled || isList ? (
-                <BreadcrumbItem isActive>{entityTypeLabel}</BreadcrumbItem>
-            ) : (
-                <BreadcrumbItemLink to={getEntityPath(entityType)}>
-                    {entityTypeLabel}
-                </BreadcrumbItemLink>
-            );
-    }
 
     return (
         <>
-            <PageSection variant="light">
+            <PageSection variant="light" className="pf-u-py-md">
                 <Breadcrumb>
-                    <BreadcrumbItem isActive>Access Control</BreadcrumbItem>
-                    {entityTypeBreadcrumb}
-                    {entityName && <BreadcrumbItem isActive>{entityName}</BreadcrumbItem>}
+                    <BreadcrumbItemLink to={getEntityPath(entityType)}>
+                        {entityTypeLabel}
+                    </BreadcrumbItemLink>
+                    {entityName && <BreadcrumbItem>{entityName}</BreadcrumbItem>}
                 </Breadcrumb>
             </PageSection>
             <Divider component="div" />

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
@@ -173,8 +173,6 @@ function AccessScopes(): ReactElement {
                 <AccessControlBreadcrumbs
                     entityType={entityType}
                     entityName={action === 'create' ? 'Create access scope' : accessScope?.name}
-                    isDisabled={hasAction}
-                    isList={isList}
                 />
             )}
             {alertAccessScopes}

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -181,8 +181,6 @@ function AuthProviders(): ReactElement {
                             ? `Create ${getProviderLabel()} provider`
                             : selectedAuthProvider?.name
                     }
-                    isDisabled={hasAction}
-                    isList={isList}
                 />
             )}
             <PageSection variant={isList ? 'default' : 'light'}>

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
@@ -200,8 +200,6 @@ function PermissionSets(): ReactElement {
                 <AccessControlBreadcrumbs
                     entityType={entityType}
                     entityName={action === 'create' ? 'Create permission set' : permissionSet?.name}
-                    isDisabled={hasAction}
-                    isList={isList}
                 />
             )}
             {alertPermissionSets}

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
@@ -248,8 +248,6 @@ function Roles(): ReactElement {
                 <AccessControlBreadcrumbs
                     entityType={entityType}
                     entityName={action === 'create' ? 'Create role' : role?.name}
-                    isDisabled={hasAction}
-                    isList={isList}
                 />
             )}
             <PageSection variant={isList ? PageSectionVariants.default : PageSectionVariants.light}>


### PR DESCRIPTION
## Description

Additional low hanging fruit from Access Control changes in February. This updates the breadcrumb navigation in Access Control pages to follow what is specified in the mocks: https://www.sketch.com/s/9d082d82-3515-40f2-875a-1b322a02bace/a/AxrGRdm

Note that this PR is stacked on https://github.com/stackrox/stackrox/pull/1781, so either will re-target `master` when the other is merged, or require a rebase if additional changes need to be made.

## TODO
- [x] Check with Docs team to coordinate changes

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

e2e tests update to reflect new breadcrumb structure.

Manual testing that "create" and "edit" pages for the Auth Provider, Roles, Permission Sets, and Access Control entity types contain breadcrumbs with the structure: "Link to Entity Type Page" -> "Text description of current page"

<img width="694" alt="image" src="https://user-images.githubusercontent.com/1292638/169401649-cf9eeac0-a5e8-4a0e-99c4-bd0b053835d9.png">

<img width="694" alt="image" src="https://user-images.githubusercontent.com/1292638/169401697-b2c48935-0844-439d-9662-437fa9670ac2.png">

Manual testing that the "not found" page for each entity type contains breadcrumbs with a single item: a link to the main entity page.

<img width="694" alt="image" src="https://user-images.githubusercontent.com/1292638/169401868-eeb64269-664b-47ca-b992-5cfd3102b6f9.png">

