### PR TITLE
Replace beforeEach in Vulnerability Management CVEs integration test

### DIFF
--- a/ui/apps/platform/cypress/constants/VulnManagementPage.js
+++ b/ui/apps/platform/cypress/constants/VulnManagementPage.js
@@ -32,6 +32,21 @@ export const url = {
     },
 };
 
+/*
+ * Headings on entities pages: uppercase style hides the inconsistencies.
+ * The keys correspond to url list object above.
+ */
+export const headingPlural = {
+    clusters: 'clusters',
+    components: 'components',
+    cves: 'CVES',
+    deployments: 'deployments',
+    images: 'images',
+    namespaces: 'namespaces',
+    nodes: 'nodes',
+    policies: 'policies',
+};
+
 export const vmHomePageSelectors = {
     // TODO: remove this selector, after at least one sub-menu is added to Vuln Mgmt menu
     vulnManagementNavLink: `${navigationSelectors.navLinks}:contains("Vulnerability Management")`,

--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -198,42 +198,49 @@ export const configMgmt = {
     // Use graphqlPluralEntity or graphqlSingularEntity.
 };
 
+/*
+ * The following keys correspond to url list object in VulnManagementPage.js file.
+ */
+
 const vulnMgmtEntityOp = {
-    CLUSTER: 'getCluster',
-    COMPONENT: 'getComponent',
-    CVE: 'getCve',
-    DEPLOYMENT: 'getDeployment',
-    IMAGE: 'getImage',
-    NAMESPACE: 'getNamespace',
-    NODE: 'getNode',
-    POLICY: 'getPolicy',
+    clusters: 'getCluster',
+    components: 'getComponent',
+    cves: 'getCve',
+    deployments: 'getDeployment',
+    images: 'getImage',
+    namespaces: 'getNamespace',
+    nodes: 'getNode',
+    policies: 'getPolicy',
 };
 
 const vulnMgmtEntitiesOp = {
-    CLUSTER: 'getClusters',
-    COMPONENT: 'getComponents',
-    CVE: 'getCves',
-    DEPLOYMENT: 'getDeployments',
-    IMAGE: 'getImages',
-    NAMESPACE: 'getNamespaces',
-    NODE: 'getNodes',
-    POLICY: 'getPolicies',
+    clusters: 'getClusters',
+    components: 'getComponents',
+    cves: 'getCves',
+    deployments: 'getDeployments',
+    images: 'getImages',
+    namespaces: 'getNamespaces',
+    nodes: 'getNodes',
+    policies: 'getPolicies',
 };
 
 const vulnMgmtEntitiesPrefix = {
-    CLUSTER: 'getCluster_',
-    COMPONENT: 'getComponentSubEntity',
-    CVE: 'getCve',
-    DEPLOYMENT: 'getDeployment',
-    IMAGE: 'getImage',
-    NAMESPACE: 'getNamespace',
-    NODE: 'getNode',
-    POLICY: 'getPolicy',
+    clusters: 'getCluster_',
+    components: 'getComponentSubEntity',
+    cves: 'getCve',
+    deployments: 'getDeployment',
+    images: 'getImage',
+    namespaces: 'getNamespace',
+    nodes: 'getNode',
+    policies: 'getPolicy',
 };
 
 export const vulnMgmt = {
+    // For example, graphqlEntity('clusters')
     graphqlEntity: (key) => graphql(vulnMgmtEntityOp[key]),
+    // For example, graphqlEntities('clusters')
     graphqlEntities: (key) => graphql(vulnMgmtEntitiesOp[key]),
+    // For example, graphqlEntities2('clusters', 'CVE')
     // prettier-ignore
     graphqlEntities2: (key1, key2) => graphql(`${vulnMgmtEntitiesPrefix[key1]}${key2}`),
     graphqlOps: {

--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -295,6 +295,7 @@ export const riskAcceptance = {
 
 export const system = {
     config: '/v1/config',
+    configPublic: '/v1/config/public',
 };
 
 export const extensions = {

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -7,6 +7,7 @@ import * as api from '../constants/apiEndpoints';
 export function visit(url) {
     cy.intercept('GET', api.featureFlags).as('getFeatureFlags');
     cy.intercept('GET', api.roles.mypermissions).as('getMyPermissions');
+    cy.intercept('GET', api.system.configPublic).as('getConfigPublic');
     cy.visit(url);
-    cy.wait(['@getFeatureFlags', '@getMyPermissions']);
+    cy.wait(['@getFeatureFlags', '@getMyPermissions', '@getConfigPublic']);
 }

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -41,8 +41,8 @@ export function visitVulnerabilityManagementDashboard() {
 }
 
 /*
- * For example, visitEntities('cves')
- * For example, visitEntities('policies', '?s[Policy]=Fixable Severity at least Important')
+ * For example, visitVulnerabilityManagementEntities('cves')
+ * For example, visitVulnerabilityManagementEntities('policies', '?s[Policy]=Fixable Severity at least Important')
  */
 export function visitVulnerabilityManagementEntities(entitiesKey, search = '') {
     cy.intercept('POST', api.graphql('searchOptions')).as('searchOptions');

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -1,0 +1,54 @@
+import * as api from '../../constants/apiEndpoints';
+import { headingPlural, url } from '../../constants/VulnManagementPage';
+
+import { visitFromLeftNavExpandable } from '../nav';
+import { visit } from '../visit';
+
+const opnamesForDashboard = [
+    'policiesCount',
+    'cvesCount',
+    'getNodes',
+    'getImages',
+    'topRiskyDeployments',
+    'topRiskiestImages',
+    'frequentlyViolatedPolicies',
+    'recentlyDetectedVulnerabilities',
+    'mostCommonVulnerabilities',
+    'deploymentsWithMostSeverePolicyViolations',
+];
+
+export function visitVulnerabilityManagementDashboardFromLeftNav() {
+    opnamesForDashboard.forEach((opname) => {
+        cy.intercept('POST', api.graphql(opname)).as(opname);
+    });
+
+    visitFromLeftNavExpandable('Vulnerability Management', 'Dashboard');
+
+    cy.wait(opnamesForDashboard.map((opname) => `@${opname}`));
+    cy.get('h1:contains("Vulnerability Management")');
+}
+
+export function visitVulnerabilityManagementDashboard() {
+    opnamesForDashboard.forEach((opname) => {
+        cy.intercept('POST', api.graphql(opname)).as(opname);
+    });
+
+    visit(url.dashboard);
+
+    cy.wait(opnamesForDashboard.map((opname) => `@${opname}`));
+    cy.get('h1:contains("Vulnerability Management")');
+}
+
+/*
+ * For example, visitEntities('cves')
+ * For example, visitEntities('policies', '?s[Policy]=Fixable Severity at least Important')
+ */
+export function visitVulnerabilityManagementEntities(entitiesKey, search = '') {
+    cy.intercept('POST', api.graphql('searchOptions')).as('searchOptions');
+    cy.intercept('POST', api.vulnMgmt.graphqlEntities(entitiesKey)).as(entitiesKey);
+
+    visit(`${url.list[entitiesKey]}${search}`);
+
+    cy.wait(['@searchOptions', `@${entitiesKey}`]);
+    cy.get(`h1:contains("${headingPlural[entitiesKey]}")`);
+}

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -15,6 +15,7 @@ const opnamesForDashboard = [
     'recentlyDetectedVulnerabilities',
     'mostCommonVulnerabilities',
     'deploymentsWithMostSeverePolicyViolations',
+    'clustersWithMostOrchestratorIstioVulnerabilities',
 ];
 
 export function visitVulnerabilityManagementDashboardFromLeftNav() {

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clustersListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clustersListPages.test.js
@@ -1,17 +1,18 @@
-import withAuth from '../../helpers/basicAuth';
 import { url, selectors } from '../../constants/VulnManagementPage';
+import withAuth from '../../helpers/basicAuth';
 import {
     hasExpectedHeaderColumns,
     allChecksForEntities,
     allCVECheck,
     allFixableCheck,
 } from '../../helpers/vmWorkflowUtils';
+import { visitVulnerabilityManagementEntities } from '../../helpers/vulnmanagement/entities';
 
 describe('Clusters list Page and its single entity detail page, and sub list validations ', () => {
     withAuth();
 
     it('should display all the columns and links expected in clusters list page', () => {
-        cy.visit(url.list.clusters);
+        visitVulnerabilityManagementEntities('clusters');
         hasExpectedHeaderColumns([
             'Cluster',
             'CVEs',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/componentsListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/componentsListPages.test.js
@@ -1,17 +1,18 @@
-import withAuth from '../../helpers/basicAuth';
 import { url, selectors } from '../../constants/VulnManagementPage';
+import withAuth from '../../helpers/basicAuth';
 import {
     hasExpectedHeaderColumns,
     allChecksForEntities,
     allCVECheck,
     // TBD - will be uncommented after issue is fixed - allFixableCheck
 } from '../../helpers/vmWorkflowUtils';
+import { visitVulnerabilityManagementEntities } from '../../helpers/vulnmanagement/entities';
 
 describe('Components list Page and its entity detail page, (related entities) sub list validations ', () => {
     withAuth();
 
     it('should display all the columns expected in components list page', () => {
-        cy.visit(url.list.components);
+        visitVulnerabilityManagementEntities('components');
         hasExpectedHeaderColumns([
             'Component',
             'CVEs',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/cvesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/cvesListPages.test.js
@@ -1,13 +1,13 @@
-import withAuth from '../../helpers/basicAuth';
 import { url, selectors } from '../../constants/VulnManagementPage';
+import withAuth from '../../helpers/basicAuth';
 import { hasExpectedHeaderColumns, allChecksForEntities } from '../../helpers/vmWorkflowUtils';
-import * as api from '../../constants/apiEndpoints';
+import { visitVulnerabilityManagementEntities } from '../../helpers/vulnmanagement/entities';
 
 describe('CVEs list Page and its entity detail page, sub list validations ', () => {
     withAuth();
 
     it('should display all the columns and links expected in cves list page', () => {
-        cy.visit(url.list.cves);
+        visitVulnerabilityManagementEntities('cves');
         hasExpectedHeaderColumns([
             'CVE',
             'Type',
@@ -42,14 +42,14 @@ describe('CVEs list Page and its entity detail page, sub list validations ', () 
     });
 
     it('should display Discovered in Image time column when appropriate', () => {
-        cy.visit(url.list.cves);
+        visitVulnerabilityManagementEntities('cves');
         cy.get(`${selectors.tableColumn}`)
             .invoke('text')
             .then((text) => {
                 expect(text).not.to.include('Discovered in Image');
             });
 
-        cy.visit(url.list.images);
+        visitVulnerabilityManagementEntities('images');
         cy.get(`${selectors.allCVEColumnLink}:eq(0)`).click({ force: true });
         cy.get(`[data-testid="side-panel"] ${selectors.tableColumn}`)
             .invoke('text')
@@ -57,7 +57,7 @@ describe('CVEs list Page and its entity detail page, sub list validations ', () 
                 expect(text).to.include('Discovered in Image');
             });
 
-        cy.visit(url.list.components);
+        visitVulnerabilityManagementEntities('components');
         cy.get(`${selectors.allCVEColumnLink}:eq(0)`).click({ force: true });
         cy.get(`[data-testid="side-panel"] ${selectors.tableColumn}`)
             .invoke('text')
@@ -67,7 +67,7 @@ describe('CVEs list Page and its entity detail page, sub list validations ', () 
     });
 
     it('should display correct CVE type', () => {
-        cy.visit(url.list.cves);
+        visitVulnerabilityManagementEntities('cves');
 
         cy.get(`${selectors.cveTypes}:first`)
             .invoke('text')
@@ -85,7 +85,7 @@ describe('CVEs list Page and its entity detail page, sub list validations ', () 
     });
 
     it('should suppress CVE', () => {
-        cy.visit(url.list.cves);
+        visitVulnerabilityManagementEntities('cves');
         cy.get(selectors.cveSuppressPanelButton).should('be.disabled');
 
         // Obtain the CVE to verify in suppressed view
@@ -114,7 +114,7 @@ describe('CVEs list Page and its entity detail page, sub list validations ', () 
     });
 
     it.skip('should unsuppress suppressed CVE', () => {
-        cy.visit(`${url.list.cves}?s[CVE%20Snoozed]=true`);
+        visitVulnerabilityManagementEntities('cves', '?s[CVE%20Snoozed]=true');
         cy.get(selectors.cveUnsuppressPanelButton).should('be.disabled');
 
         // Obtain the CVE to verify in unsuppressed view
@@ -139,13 +139,8 @@ describe('CVEs list Page and its entity detail page, sub list validations ', () 
     });
 
     describe('adding selected CVEs to policy', () => {
-        beforeEach(() => {
-            cy.intercept('POST', api.graphql(api.vulnMgmt.graphqlOps.getCves)).as('getCves');
-        });
-
         it('should add CVEs to new policies', () => {
-            cy.visit(url.list.cves);
-            cy.wait('@getCves');
+            visitVulnerabilityManagementEntities('cves');
 
             cy.get(selectors.cveAddToPolicyButton).should('be.disabled');
 
@@ -160,8 +155,7 @@ describe('CVEs list Page and its entity detail page, sub list validations ', () 
         });
 
         it('should add CVEs to existing policies', () => {
-            cy.visit(url.list.cves);
-            cy.wait('@getCves');
+            visitVulnerabilityManagementEntities('cves');
 
             cy.get(selectors.cveAddToPolicyButton).should('be.disabled');
 
@@ -177,8 +171,7 @@ describe('CVEs list Page and its entity detail page, sub list validations ', () 
         });
 
         it('should add CVEs to existing policies with CVEs', () => {
-            cy.visit(url.list.cves);
-            cy.wait('@getCves');
+            visitVulnerabilityManagementEntities('cves');
 
             cy.get(selectors.cveAddToPolicyButton).should('be.disabled');
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
@@ -1,8 +1,10 @@
+import * as api from '../../constants/apiEndpoints';
 import { url, selectors } from '../../constants/VulnManagementPage';
 import withAuth from '../../helpers/basicAuth';
+import { visitVulnerabilityManagementDashboard } from '../../helpers/vulnmanagement/entities';
 
 function validateTopRiskyEntities(entityName) {
-    cy.visit(url.dashboard);
+    visitVulnerabilityManagementDashboard();
     cy.get(selectors.topRiskyItems.select.value).should(
         'contain',
         'Top risky deployments by CVE count & CVSS score'
@@ -15,26 +17,19 @@ function validateTopRiskyEntities(entityName) {
         'contain',
         `Top risky ${entityName} by CVE count & CVSS score`
     );
+    cy.intercept('POST', api.vulnMgmt.graphqlEntities(entityName)).as('entities');
     cy.get(selectors.getWidget(`Top risky ${entityName} by CVE count & CVSS score`))
         .find(selectors.viewAllButton)
         .click();
-    cy.wait(500);
-    if (entityName === 'clusters') {
-        cy.url().should('contain', url.list.clusters);
-    } else if (entityName === 'images') {
-        cy.url().should('contain', url.list.images);
-    } else if (entityName === 'namespaces') {
-        cy.url().should('contain', url.list.namespaces);
-    } else if (entityName === 'deployments') {
-        cy.url().should('contain', url.list.deployments);
-    }
+    cy.wait('@entities');
+    cy.location('pathname').should('eq', url.list[entityName]);
 }
 
 describe('Vuln Management Dashboard Page', () => {
     withAuth();
 
     it('should show same number of policies between the tile and the policies list', () => {
-        cy.visit(url.dashboard);
+        visitVulnerabilityManagementDashboard();
         cy.get(selectors.tileLinks)
             .eq(0)
             .find(selectors.tileLinkValue)
@@ -51,7 +46,7 @@ describe('Vuln Management Dashboard Page', () => {
     });
 
     it('should show same number of cves between the tile and the cves list', () => {
-        cy.visit(url.dashboard);
+        visitVulnerabilityManagementDashboard();
         cy.get(selectors.tileLinks)
             .eq(1)
             .find(selectors.tileLinkValue)
@@ -68,7 +63,7 @@ describe('Vuln Management Dashboard Page', () => {
     });
 
     it('should show same number of images between the tile and the images list', () => {
-        cy.visit(url.dashboard);
+        visitVulnerabilityManagementDashboard();
         cy.get(selectors.tileLinks)
             .eq(2)
 
@@ -86,36 +81,36 @@ describe('Vuln Management Dashboard Page', () => {
     });
 
     it('should properly navigate to the policies list', () => {
-        cy.visit(url.dashboard);
+        visitVulnerabilityManagementDashboard();
         cy.get(selectors.tileLinks).eq(0).click();
-        cy.url().should('contain', url.list.policies);
+        cy.location('pathname').should('eq', url.list.policies);
     });
 
     it('should properly navigate to the clusters list', () => {
-        cy.visit(url.dashboard);
+        visitVulnerabilityManagementDashboard();
         cy.get(selectors.applicationAndInfrastructureDropdown).click();
         cy.get(selectors.getMenuListItem('clusters')).click();
-        cy.url().should('contain', url.list.clusters);
+        cy.location('pathname').should('eq', url.list.clusters);
     });
 
     it('should properly navigate to the namespaces list', () => {
-        cy.visit(url.dashboard);
+        visitVulnerabilityManagementDashboard();
         cy.get(selectors.applicationAndInfrastructureDropdown).click();
         cy.get(selectors.getMenuListItem('namespaces')).click();
-        cy.url().should('contain', url.list.namespaces);
+        cy.location('pathname').should('eq', url.list.namespaces);
     });
 
     it('should properly navigate to the deployments list', () => {
-        cy.visit(url.dashboard);
+        visitVulnerabilityManagementDashboard();
         cy.get(selectors.applicationAndInfrastructureDropdown).click();
         cy.get(selectors.getMenuListItem('deployments')).click();
-        cy.url().should('contain', url.list.deployments);
+        cy.location('pathname').should('eq', url.list.deployments);
     });
 
     // @TODO: add check that changing entity type re-displays the loader
     //   not reliable to test without a good way to mock GraphQL responses
     it('"Top Riskiest <entities>" widget should start with a loading indicator', () => {
-        cy.visit(url.dashboard);
+        cy.visit(url.dashboard); // do not call visit helper because it waits on the requests
         cy.get(selectors.getWidget('Top risky deployments by CVE count & CVSS score'))
             .find(selectors.widgetBody)
             .invoke('text')
@@ -124,61 +119,66 @@ describe('Vuln Management Dashboard Page', () => {
             });
     });
 
-    // TODO  add a check that there is a sort param on the link URL for sorting by the widget's appropriate sort
     it('clicking the "Top Riskiest Images" widget\'s "View All" button should take you to the images list', () => {
-        cy.visit(url.dashboard);
+        visitVulnerabilityManagementDashboard();
+        cy.intercept('POST', api.vulnMgmt.graphqlEntities('images')).as('images');
         cy.get(selectors.getWidget('Top Riskiest Images')).find(selectors.viewAllButton).click();
-        cy.url().should('contain', url.list.images);
+        cy.wait('@images');
+        cy.location('pathname').should('eq', url.list.images);
+        cy.location('search').should(
+            'eq',
+            '?sort[0][id]=Image%20Risk%20Priority&sort[0][desc]=false'
+        );
     });
 
     // TODO  change the sort param checked for, if a more desirable sort becomes available from the API
     //   see https://stack-rox.atlassian.net/browse/ROX-4295 for details
     it('clicking the "Frequently Violated Policies" widget\'s "View All" button should take you to the policies list', () => {
-        cy.visit(url.dashboard);
+        visitVulnerabilityManagementDashboard();
         cy.get(selectors.getWidget('Frequently Violated Policies'))
             .find(selectors.viewAllButton)
             .click();
-        cy.url().should('contain', url.list.policies);
-
-        // check sort requested
-        cy.url().should('contain', 'sort[0][id]=Severity');
-        cy.url().should('contain', 'sort[0][desc]=true');
+        cy.location('pathname').should('eq', url.list.policies);
+        cy.location('search').should('eq', '?sort[0][id]=Severity&sort[0][desc]=true');
     });
 
-    // TODO  add a check that there is a sort param on the link URL for sorting by the widget's appropriate sort
     it('clicking the "Recently Detected Vulnerabilities" widget\'s "View All" button should take you to the CVEs list', () => {
-        cy.visit(url.dashboard);
+        visitVulnerabilityManagementDashboard();
         cy.get(selectors.getWidget('Recently Detected Vulnerabilities'))
             .find(selectors.viewAllButton)
             .click();
-        cy.url().should('contain', url.list.cves);
+        cy.location('pathname').should('eq', url.list.cves);
+        cy.location('search').should('eq', '?sort[0][id]=CVE%20Created%20Time&sort[0][desc]=true');
     });
 
-    // TODO  add a check that there is a sort param on the link URL for sorting by the widget's appropriate sort
     it('clicking the "Most Common Vulnerabilities" widget\'s "View All" button should take you to the CVEs list', () => {
-        cy.visit(url.dashboard);
+        visitVulnerabilityManagementDashboard();
         cy.get(selectors.getWidget('Most Common Vulnerabilities'))
             .find(selectors.viewAllButton)
             .click();
-        cy.url().should('contain', url.list.cves);
+        cy.location('pathname').should('eq', url.list.cves);
+        cy.location('search').should(
+            'eq',
+            '?sort[0][id]=Deployment%20Count&sort[0][desc]=true&sort[1][id]=CVSS&sort[1][desc]=true'
+        );
     });
 
-    // TODO  add a check that there is a sort param on the link URL for sorting by the widget's appropriate sort
     it('clicking the "Deployments With Most Severe Policy Violations" widget\'s "View All" button should take you to the policies list', () => {
-        cy.visit(url.dashboard);
+        visitVulnerabilityManagementDashboard();
         cy.get(selectors.getWidget('Deployments With Most Severe Policy Violations'))
             .find(selectors.viewAllButton)
             .click();
-        cy.url().should('contain', url.list.deployments);
+        cy.location('pathname').should('eq', url.list.deployments);
+        cy.location('search').should('eq', '');
     });
 
-    // TODO  add a check that there is a sort param on the link URL for sorting by the widget's appropriate sort
     it('clicking the "Clusters With Most Orchestrator & Istio Vulnerabilities" widget\'s "View All" button should take you to the clusters list', () => {
-        cy.visit(url.dashboard);
+        visitVulnerabilityManagementDashboard();
         cy.get(selectors.getWidget('Clusters With Most Orchestrator & Istio Vulnerabilities'))
             .find(selectors.viewAllButton)
             .click();
-        cy.url().should('contain', url.list.clusters);
+        cy.location('pathname').should('eq', url.list.clusters);
+        cy.location('search').should('eq', '');
     });
 
     it('clicking the "Top risky deployments by CVE count & CVSS score" widget\'s "View All" button should take you to the deployments list', () => {

--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
@@ -107,8 +107,6 @@ describe('Vuln Management Dashboard Page', () => {
         cy.location('pathname').should('eq', url.list.deployments);
     });
 
-    // @TODO: add check that changing entity type re-displays the loader
-    //   not reliable to test without a good way to mock GraphQL responses
     it('"Top Riskiest <entities>" widget should start with a loading indicator', () => {
         cy.visit(url.dashboard); // do not call visit helper because it waits on the requests
         cy.get(selectors.getWidget('Top risky deployments by CVE count & CVSS score'))

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsListPages.test.js
@@ -1,17 +1,18 @@
-import withAuth from '../../helpers/basicAuth';
 import { url, selectors } from '../../constants/VulnManagementPage';
+import withAuth from '../../helpers/basicAuth';
 import {
     hasExpectedHeaderColumns,
     allChecksForEntities,
     allCVECheck,
     // uncomment after the issue fix  - allFixableCheck
 } from '../../helpers/vmWorkflowUtils';
+import { visitVulnerabilityManagementEntities } from '../../helpers/vulnmanagement/entities';
 
 describe('Deployments list Page and its entity detail page , (related entities) sub list  validations ', () => {
     withAuth();
 
     it('should display all the columns and links expected in deployments list page', () => {
-        cy.visit(url.list.deployments);
+        visitVulnerabilityManagementEntities('deployments');
         hasExpectedHeaderColumns([
             'Cluster',
             'CVEs',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
@@ -1,31 +1,30 @@
 import * as api from '../../constants/apiEndpoints';
-import { url, selectors } from '../../constants/VulnManagementPage';
+import { selectors } from '../../constants/VulnManagementPage';
 import withAuth from '../../helpers/basicAuth';
+import { visitVulnerabilityManagementEntities } from '../../helpers/vulnmanagement/entities';
 
 describe('Entities single views', () => {
     withAuth();
 
     it('related entities tile links should unset search params upon navigation', () => {
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities('CLUSTER')).as('getClusters');
-        cy.visit(url.list.clusters);
-        cy.wait('@getClusters');
+        visitVulnerabilityManagementEntities('clusters');
 
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('CLUSTER', 'CVE')).as('getClusterCVE');
+        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('clusters', 'CVE')).as('clustersCVE');
         cy.get(`${selectors.tableBodyRows} ${selectors.fixableCvesLink}:eq(0)`).click();
-        cy.wait('@getClusterCVE');
+        cy.wait('@clustersCVE');
 
-        cy.intercept('POST', api.vulnMgmt.graphqlEntity('CLUSTER')).as('getCluster');
+        cy.intercept('POST', api.vulnMgmt.graphqlEntity('clusters')).as('clusters');
         cy.get(selectors.backButton).click();
-        cy.wait('@getCluster');
+        cy.wait('@clusters');
 
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('CLUSTER', 'DEPLOYMENT')).as(
-            'getClusterDEPLOYMENT'
+        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('clusters', 'DEPLOYMENT')).as(
+            'clustersDEPLOYMENT'
         );
         cy.get(`${selectors.deploymentTileLink} ${selectors.tileLinkSuperText}`)
             .invoke('text')
             .then((numDeployments) => {
                 cy.get(selectors.deploymentTileLink).click();
-                cy.wait('@getClusterDEPLOYMENT');
+                cy.wait('@clustersDEPLOYMENT');
 
                 cy.get(`[data-testid="side-panel"] [data-testid="panel-header"]`)
                     .invoke('text')
@@ -38,15 +37,13 @@ describe('Entities single views', () => {
     });
 
     it('related entities table header should not say "0 entities" or have "page 0 of 0" if there are rows in the table', () => {
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities('POLICY')).as('getPolicies');
-        cy.visit(url.list.policies);
-        cy.wait('@getPolicies');
+        visitVulnerabilityManagementEntities('policies');
 
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('POLICY', 'DEPLOYMENT')).as(
-            'getPolicyDEPLOYMENT'
+        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('policies', 'DEPLOYMENT')).as(
+            'policiesDEPLOYMENT'
         );
         cy.get(`${selectors.tableBodyRows} ${selectors.failingDeploymentCountLink}:eq(0)`).click();
-        cy.wait('@getPolicyDEPLOYMENT');
+        cy.wait('@policiesDEPLOYMENT');
 
         cy.get(selectors.sidePanelTableBodyRows).then((value) => {
             const { length: numRows } = value;
@@ -70,16 +67,14 @@ describe('Entities single views', () => {
     it('should scope deployment data based on selected policy from table row click', () => {
         // policy -> related deployments list should scope policy status column by the policy x deployment row
         // in both side panel and entity page
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities('POLICY')).as('getPolicies');
-        cy.visit(url.list.policies);
-        cy.wait('@getPolicies');
+        visitVulnerabilityManagementEntities('policies');
 
-        cy.intercept('POST', api.vulnMgmt.graphqlEntity('POLICY')).as('getPolicy');
+        cy.intercept('POST', api.vulnMgmt.graphqlEntity('policies')).as('policy');
         cy.get(`${selectors.tableBodyRows}:eq(0) ${selectors.statusChips}`)
             .invoke('text')
             .then((firstPolicyStatus) => {
                 cy.get(`${selectors.tableBodyRows}:eq(0)`).click();
-                cy.wait('@getPolicy');
+                cy.wait('@policy');
 
                 cy.get(`${selectors.sidePanel} ${selectors.statusChips}:eq(0)`)
                     .invoke('text')
@@ -92,11 +87,12 @@ describe('Entities single views', () => {
                         `${selectors.emptyFindingsSection}:contains("No deployments have failed across this policy")`
                     );
 
-                    cy.intercept('POST', api.vulnMgmt.graphqlEntities2('POLICY', 'DEPLOYMENT')).as(
-                        'getPolicyDEPLOYMENT'
-                    );
+                    cy.intercept(
+                        'POST',
+                        api.vulnMgmt.graphqlEntities2('policies', 'DEPLOYMENT')
+                    ).as('policiesDEPLOYMENT');
                     cy.get(`${selectors.deploymentTileLink}:eq(0)`).click();
-                    cy.wait('@getPolicyDEPLOYMENT');
+                    cy.wait('@policiesDEPLOYMENT');
 
                     cy.get(
                         `${selectors.sidePanel} ${selectors.statusChips}:contains('pass')`
@@ -109,16 +105,14 @@ describe('Entities single views', () => {
     });
 
     it('should scope deployment data based on selected policy from table count link click', () => {
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities('POLICY')).as('getPolicies');
-        cy.visit(url.list.policies);
-        cy.wait('@getPolicies');
+        visitVulnerabilityManagementEntities('policies');
 
         // Assume at least one policy has failing deployments.
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('POLICY', 'DEPLOYMENT')).as(
-            'getPolicyDEPLOYMENT'
+        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('policies', 'DEPLOYMENT')).as(
+            'policiesDEPLOYMENT'
         );
         cy.get(`${selectors.failingDeploymentCountLink}:eq(0)`).click();
-        cy.wait('@getPolicyDEPLOYMENT');
+        cy.wait('@policiesDEPLOYMENT');
 
         cy.get(`${selectors.sidePanel} ${selectors.statusChips}:contains('fail')`).should('exist');
         cy.get(`${selectors.sidePanel} ${selectors.statusChips}:contains('pass')`).should(
@@ -126,20 +120,16 @@ describe('Entities single views', () => {
         );
     });
 
-    // TODO: track fixing this test under this bug ticket, https://stack-rox.atlassian.net/browse/ROX-8705
-    it.skip('should scope deployment data based on selected policy from entity page tab sublist', () => {
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities('POLICY')).as('getPolicies');
-        cy.visit(url.list.policies);
-        cy.wait('@getPolicies');
+    it('should scope deployment data based on selected policy from entity page tab sublist', () => {
+        visitVulnerabilityManagementEntities('policies');
 
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('POLICY', 'DEPLOYMENT')).as(
-            'getPolicyDEPLOYMENT'
+        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('policies', 'DEPLOYMENT')).as(
+            'policiesDEPLOYMENT'
         );
         cy.get(`${selectors.failingDeploymentCountLink}:eq(0)`).click();
-        cy.wait('@getPolicyDEPLOYMENT');
+        cy.wait('@policiesDEPLOYMENT');
 
         cy.get(selectors.sidePanelExpandButton).click();
-        cy.wait('@getPolicyDEPLOYMENT');
 
         // Entity single page, not side panel.
         cy.get(`${selectors.tableBodyRows} ${selectors.statusChips}:contains('fail')`).should(
@@ -152,7 +142,7 @@ describe('Entities single views', () => {
 
     // test skipped because we are not currently showing the Policy (count) column, until and if performance can be improved
     it.skip('should have consistent policy count number from namespace list to policy sublist for a specific namespace', () => {
-        cy.visit(url.list.namespaces);
+        visitVulnerabilityManagementEntities('namespaces');
 
         cy.get(selectors.policyCountLink)
             .eq(2)
@@ -176,34 +166,32 @@ describe('Entities single views', () => {
     });
 
     it('should have filtered deployments list in 3rd level of side panel (namespaces -> policies -> deployments)', () => {
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities('NAMESPACE')).as('getNamespaces');
-        cy.visit(url.list.namespaces);
-        cy.wait('@getNamespaces');
+        visitVulnerabilityManagementEntities('namespaces');
 
         cy.get(`${selectors.deploymentCountLink}:eq(0)`).as('firstDeploymentCountLink');
 
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('NAMESPACE', 'DEPLOYMENT')).as(
-            'getNamespaceDEPLOYMENT'
+        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('namespaces', 'DEPLOYMENT')).as(
+            'namespacesDEPLOYMENT'
         );
         cy.get('@firstDeploymentCountLink').click();
-        cy.wait('@getNamespaceDEPLOYMENT');
+        cy.wait('@namespacesDEPLOYMENT');
 
-        cy.intercept('POST', api.vulnMgmt.graphqlEntity('NAMESPACE')).as('getNamespace');
+        cy.intercept('POST', api.vulnMgmt.graphqlEntity('namespaces')).as('namespace');
         cy.get(selectors.parentEntityInfoHeader).click();
-        cy.wait('@getNamespace');
+        cy.wait('@namespace');
 
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('NAMESPACE', 'POLICY')).as(
-            'getNamespacePOLICY'
+        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('namespaces', 'POLICY')).as(
+            'namespacesPOLICY'
         );
         cy.get(selectors.policyTileLink).click();
-        cy.wait('@getNamespacePOLICY');
+        cy.wait('@namespacesPOLICY');
 
         cy.get('@firstDeploymentCountLink')
             .invoke('text')
             .then((deploymentCountText) => {
-                cy.intercept('POST', api.vulnMgmt.graphqlEntity('POLICY')).as('getPolicy');
+                cy.intercept('POST', api.vulnMgmt.graphqlEntity('policies')).as('policy');
                 cy.get(`${selectors.sidePanelTableBodyRows}:eq(0)`).click();
-                cy.wait('@getPolicy');
+                cy.wait('@policy');
 
                 cy.get(selectors.deploymentTileLink)
                     .invoke('text')
@@ -212,11 +200,11 @@ describe('Entities single views', () => {
                             deploymentCountText.replace(' ', '')
                         );
                     });
-                cy.intercept('POST', api.vulnMgmt.graphqlEntities2('POLICY', 'DEPLOYMENT')).as(
-                    'getPolicyDEPLOYMENT'
+                cy.intercept('POST', api.vulnMgmt.graphqlEntities2('policies', 'DEPLOYMENT')).as(
+                    'policiesDEPLOYMENT'
                 );
                 cy.get(selectors.deploymentTileLink).click();
-                cy.wait('@getPolicyDEPLOYMENT');
+                cy.wait('@policiesDEPLOYMENT');
 
                 cy.get(selectors.entityRowHeader)
                     .invoke('text')
@@ -228,7 +216,7 @@ describe('Entities single views', () => {
 
     // @TODO, test needs to be re-structured
     it.skip('should filter deployment count in failing policies section in namespace findings by namespace', () => {
-        cy.visit(url.list.namespaces);
+        visitVulnerabilityManagementEntities('namespaces');
 
         cy.get(`${selectors.deploymentCountLink}:eq(0)`).as('firstDeploymentCountLink');
 
@@ -260,29 +248,25 @@ describe('Entities single views', () => {
             });
     });
 
-    // TODO: track fixing this test under this bug ticket, https://stack-rox.atlassian.net/browse/ROX-8705
-    it.skip('should filter component count in images list and image overview by cve when coming from cve list', () => {
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities('CVE')).as('getCves');
-        cy.visit(url.list.cves);
-        cy.wait('@getCves');
+    it('should filter component count in images list and image overview by cve when coming from cve list', () => {
+        visitVulnerabilityManagementEntities('cves');
 
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('CVE', 'IMAGE')).as('getCveIMAGE');
+        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('cves', 'IMAGE')).as('cvesIMAGE');
         cy.get(`${selectors.imageCountLink}:eq(0)`).click();
-        cy.wait('@getCveIMAGE');
+        cy.wait('@cvesIMAGE');
 
-        cy.intercept('POST', api.vulnMgmt.graphqlEntity('CVE')).as('getCve');
+        cy.intercept('POST', api.vulnMgmt.graphqlEntity('cves')).as('cve');
         cy.get(selectors.parentEntityInfoHeader).click();
-        cy.wait('@getCve');
+        cy.wait('@cve');
 
         cy.get(selectors.imageTileLink).click();
-        cy.wait('@getCveIMAGE');
 
         cy.get(`${selectors.sidePanel} ${selectors.componentCountLink}:eq(0)`)
             .invoke('text')
             .then((componentCountText) => {
-                cy.intercept('POST', api.vulnMgmt.graphqlEntity('IMAGE')).as('getImage');
+                cy.intercept('POST', api.vulnMgmt.graphqlEntity('images')).as('image');
                 cy.get(`${selectors.sidePanelTableBodyRows}:eq(0)`).click();
-                cy.wait('@getImage');
+                cy.wait('@image');
 
                 cy.get(selectors.componentTileLink)
                     .invoke('text')
@@ -295,16 +279,14 @@ describe('Entities single views', () => {
     });
 
     it('should show a CVE description in overview when coming from cve list', () => {
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities('CVE')).as('getCves');
-        cy.visit(url.list.cves);
-        cy.wait('@getCves');
+        visitVulnerabilityManagementEntities('cves');
 
         cy.get(`${selectors.tableBodyRowGroups}:eq(0) ${selectors.cveDescription}`)
             .invoke('text')
             .then((descriptionInList) => {
-                cy.intercept('POST', api.vulnMgmt.graphqlEntity('CVE')).as('getCve');
+                cy.intercept('POST', api.vulnMgmt.graphqlEntity('cves')).as('cve');
                 cy.get(`${selectors.tableBodyRows}:eq(0)`).click();
-                cy.wait('@getCve');
+                cy.wait('@cve');
 
                 cy.get(`${selectors.entityOverview} ${selectors.cveDescription}`)
                     .invoke('text')
@@ -315,17 +297,15 @@ describe('Entities single views', () => {
     });
 
     it('should not filter cluster entity page regardless of entity context', () => {
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities('NAMESPACE')).as('getNamespaces');
-        cy.visit(url.list.namespaces);
-        cy.wait('@getNamespaces');
+        visitVulnerabilityManagementEntities('namespaces');
 
-        cy.intercept('POST', api.vulnMgmt.graphqlEntity('NAMESPACE')).as('getNamespace');
+        cy.intercept('POST', api.vulnMgmt.graphqlEntity('namespaces')).as('namespace');
         cy.get(`${selectors.tableRows}:contains("No deployments"):eq(0)`).click();
-        cy.wait('@getNamespace');
+        cy.wait('@namespace');
 
-        cy.intercept('POST', api.vulnMgmt.graphqlEntity('CLUSTER')).as('getCluster');
+        cy.intercept('POST', api.vulnMgmt.graphqlEntity('clusters')).as('cluster');
         cy.get(`${selectors.metadataClusterValue} a`).click();
-        cy.wait('@getCluster');
+        cy.wait('@cluster');
 
         cy.get(`${selectors.sidePanel} ${selectors.tableRows}`).should('exist');
         cy.get(`${selectors.sidePanel} ${selectors.tableRows}:contains("No deployments")`).should(
@@ -334,21 +314,22 @@ describe('Entities single views', () => {
     });
 
     it('should show the active state in Component overview when scoped under a deployment', () => {
-        const getDeploymentCOMPONENT = api.graphql(api.vulnMgmt.graphqlOps.getDeploymentCOMPONENT);
-        cy.intercept('POST', getDeploymentCOMPONENT).as('getDeploymentCOMPONENT');
-
-        cy.visit(url.list.deployments);
+        visitVulnerabilityManagementEntities('deployments');
 
         // click on the first deployment in the list
+        cy.intercept('POST', api.vulnMgmt.graphqlEntity('deployments')).as('deployment');
         cy.get(`${selectors.tableRows}`, { timeout: 10000 }).eq(1).click();
+        cy.wait('@deployment');
         // now, go the components for that deployment
+        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('deployments', 'COMPONENT')).as(
+            'deploymentsCOMPONENT'
+        );
         cy.get(selectors.componentTileLink).click();
+        cy.wait('@deploymentsCOMPONENT');
         // click on the first component in that list
         cy.get(`[data-testid="side-panel"] ${selectors.tableRows}`, { timeout: 10000 })
             .eq(1)
             .click();
-
-        cy.wait('@getDeploymentCOMPONENT');
 
         cy.get(`[data-testid="Active status-value"]`)
             .invoke('text')
@@ -357,9 +338,7 @@ describe('Entities single views', () => {
             });
     });
 
-    // TODO: when active status for CVEs becomes available
-    // unskip the following test
-    it.skip('should show the active state in the fixable CVES widget for a single deployment', () => {
+    it('should show the active state in the fixable CVES widget for a single deployment', () => {
         const getFixableCvesForEntity = api.graphql(
             api.vulnMgmt.graphqlOps.getFixableCvesForEntity
         );
@@ -367,9 +346,11 @@ describe('Entities single views', () => {
             fixture: 'vulnerabilities/fixableCvesForEntity.json',
         }).as('getFixableCvesForEntity');
 
-        cy.visit(url.list.deployments);
+        visitVulnerabilityManagementEntities('deployments');
 
+        cy.intercept('POST', api.vulnMgmt.graphqlEntity('deployments')).as('deployment');
         cy.get(`${selectors.tableRows}`, { timeout: 10000 }).eq(1).click();
+        cy.wait('@deployment');
         cy.get('button:contains("Fixable CVEs")').click();
         cy.wait('@getFixableCvesForEntity');
         cy.get(`${selectors.sidePanel} ${selectors.tableRows}:contains("CVE-2021-20231")`).contains(

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imagesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imagesListPages.test.js
@@ -1,21 +1,19 @@
-import withAuth from '../../helpers/basicAuth';
 import { url, selectors } from '../../constants/VulnManagementPage';
+import withAuth from '../../helpers/basicAuth';
 import {
     hasExpectedHeaderColumns,
     allChecksForEntities,
     allCVECheck,
     allFixableCheck,
 } from '../../helpers/vmWorkflowUtils';
-import * as api from '../../constants/apiEndpoints';
+import { visitVulnerabilityManagementEntities } from '../../helpers/vulnmanagement/entities';
 
-// TODO(ROX-8674): Enable this test.
-describe.skip('Images list page and its entity detail page, related entities sub list validations ', () => {
+describe('Images list page and its entity detail page, related entities sub list validations ', () => {
     withAuth();
 
-    it('should display all the columns and links expected in images list page', () => {
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities('IMAGE')).as('getImages');
-        cy.visit(url.list.images);
-        cy.wait('@getImages');
+    // TODO(ROX-8674): Enable this test.
+    it.skip('should display all the columns and links expected in images list page', () => {
+        visitVulnerabilityManagementEntities('images');
 
         hasExpectedHeaderColumns([
             'Image',
@@ -23,6 +21,7 @@ describe.skip('Images list page and its entity detail page, related entities sub
             'Top CVSS',
             'Created',
             'Scan Time',
+            'Image OS',
             'Image Status',
             'Deployments',
             'Components',
@@ -49,11 +48,12 @@ describe.skip('Images list page and its entity detail page, related entities sub
                     waitForAnimations: false,
                 });
 
-                cy.get('.pf-c-tabs .pf-c-tabs__item:eq(2):contains("False Positive CVEs")').click({
+                cy.get('.pf-c-tabs .pf-c-tabs__item:eq(2):contains("False positive CVEs")').click({
                     force: true,
                     waitForAnimations: false,
                 });
 
+                // TODO fix the following test problem: Expected to find element: [data-testid="tabs"]
                 allFixableCheck(url.list.images);
             }
             if (columnValue !== 'no cves' && columnValue.includes('cve')) {
@@ -65,9 +65,7 @@ describe.skip('Images list page and its entity detail page, related entities sub
     });
 
     it('should show entity icon, not back button, if there is only one item on the side panel stack', () => {
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities('IMAGE')).as('getImages');
-        cy.visit(url.list.images);
-        cy.wait('@getImages');
+        visitVulnerabilityManagementEntities('images');
 
         cy.get(`${selectors.deploymentCountLink}:eq(0)`).click({ force: true });
         cy.wait(1000);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespacesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespacesListPages.test.js
@@ -6,12 +6,13 @@ import {
     allCVECheck,
     allFixableCheck,
 } from '../../helpers/vmWorkflowUtils';
+import { visitVulnerabilityManagementEntities } from '../../helpers/vulnmanagement/entities';
 
 describe('Namespaces list Page and its entity detail page , (related entities) sub list  validations ', () => {
     withAuth();
 
     it('should display all the columns and links expected in namespaces list page', () => {
-        cy.visit(url.list.namespaces);
+        visitVulnerabilityManagementEntities('namespaces');
         hasExpectedHeaderColumns([
             'Cluster',
             'CVEs',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/policiesListpages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/policiesListpages.test.js
@@ -1,13 +1,14 @@
-import withAuth from '../../helpers/basicAuth';
 import { url, selectors } from '../../constants/VulnManagementPage';
 import { selectors as policySelectors } from '../../constants/PoliciesPagePatternFly';
+import withAuth from '../../helpers/basicAuth';
 import { hasExpectedHeaderColumns, allChecksForEntities } from '../../helpers/vmWorkflowUtils';
+import { visitVulnerabilityManagementEntities } from '../../helpers/vulnmanagement/entities';
 
 describe('Policies list Page and its entity detail page , related entities sub list  validations ', () => {
     withAuth();
 
     it('should display all the columns and links expected in clusters list page', () => {
-        cy.visit(url.list.policies);
+        visitVulnerabilityManagementEntities('policies');
         hasExpectedHeaderColumns([
             'Policy',
             'Description',
@@ -33,7 +34,7 @@ describe('Policies list Page and its entity detail page , related entities sub l
     describe('post-Boolean Policy Logic tests', () => {
         // regression test for ROX-4752
         it('should show Privileged criterion when present in the policy', () => {
-            cy.visit(url.list.policies);
+            visitVulnerabilityManagementEntities('policies');
 
             cy.get(`${selectors.tableRows}:contains('Privileged')`).click();
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/policyconfigure.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/policyconfigure.test.js
@@ -1,11 +1,12 @@
-import { url, selectors } from '../../constants/VulnManagementPage';
+import { selectors } from '../../constants/VulnManagementPage';
 import withAuth from '../../helpers/basicAuth';
+import { visitVulnerabilityManagementEntities } from '../../helpers/vulnmanagement/entities';
 
 describe('Policy Detail View Page', () => {
     withAuth();
 
     it('policy edit button on click goes to edit page of policy ', () => {
-        cy.visit(url.list.policies);
+        visitVulnerabilityManagementEntities('policies');
         cy.get(selectors.tableBodyColumn)
             .eq(0)
             .invoke('text')

--- a/ui/apps/platform/cypress/integration/vulnmanagement/tags.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/tags.test.js
@@ -1,8 +1,9 @@
 import randomstring from 'randomstring';
 
-import { url, selectors } from '../../constants/VulnManagementPage';
-import withAuth from '../../helpers/basicAuth';
 import * as api from '../../constants/apiEndpoints';
+import { selectors } from '../../constants/VulnManagementPage';
+import withAuth from '../../helpers/basicAuth';
+import { visitVulnerabilityManagementEntities } from '../../helpers/vulnmanagement/entities';
 
 // The majority of Violation Tags functionality is tested on Violations Page
 // Here it's mostly a sanity check that the corresponding widget on a page is shown
@@ -10,15 +11,16 @@ describe('Vuln Management Violation Tags', () => {
     withAuth();
 
     it('should add and save tag', () => {
-        cy.intercept('POST', api.graphql(api.vulnMgmt.graphqlOps.getPolicies)).as('getPolicies');
         cy.intercept('POST', api.graphql(api.vulnMgmt.graphqlOps.getPolicy)).as('getPolicy');
         cy.intercept('POST', api.graphql(api.alerts.graphqlOps.getTags)).as('getTags');
         cy.intercept('POST', api.graphql(api.alerts.graphqlOps.tagsAutocomplete)).as(
             'tagsAutocomplete'
         );
 
-        cy.visit(`${url.list.policies}?s[Policy]=Fixable Severity at least Important`);
-        cy.wait('@getPolicies');
+        visitVulnerabilityManagementEntities(
+            'policies',
+            '?s[Policy]=Fixable Severity at least Important'
+        );
 
         cy.get(`${selectors.mainTable.rows}:first`).click({ force: true });
         cy.wait('@getPolicy');

--- a/ui/apps/platform/cypress/integration/vulnmanagement/vmSmoke.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/vmSmoke.test.js
@@ -1,13 +1,12 @@
-import { url, selectors } from '../../constants/VulnManagementPage';
+import { url } from '../../constants/VulnManagementPage';
 import withAuth from '../../helpers/basicAuth';
+import { visitVulnerabilityManagementDashboardFromLeftNav } from '../../helpers/vulnmanagement/entities';
 
 describe('Smoke test for vulnmanagement', () => {
     withAuth();
 
     it('VulnManagement tile link is present and lands on dashboard page', () => {
-        cy.visit('/main/dashboard');
-        cy.get(selectors.vulnManagementExpandableNavLink).click({ force: true });
-        cy.get(selectors.vulnManagementExpandedDashboardNavLink).click({ force: true });
-        cy.url().should('contain', url.dashboard);
+        visitVulnerabilityManagementDashboardFromLeftNav();
+        cy.location('pathname').should('eq', url.dashboard);
     });
 });


### PR DESCRIPTION
## Description

### Goal

* For each test, decide which helper function to call for actual or mock requests instead of letting `beforeEach` decide.
* Group tests by subject instead of by shared setup.

Find `beforeEach` in cypress/integration: from 5 results in 4 files to 4 results in 3 files.

### Changed files

Call visit helper functions in a batch of tests files to increase benefit from the cost to achieve the goal.

Replace a tentative convention for entity keys uppercase singular (consistent with UI code) with lowercase plural (consistent with test url object).

1. Edit constants/apiEndpoints.js
    * Replace keys in `vulnMgmtEntityOp`
    * Replace keys in `vulnMgmtEntitiesOp`
    * Replace keys in `vulnMgmtEntitiesPrefix`
    * Add `configPublic` to `system`

2. Edit constants/VulnManagementPage.js
    * Add `headingPlural` object

3. Edit helpers/visit.js
    * Add intercept and wait for /v1/config/public request because it affects global rendering and UI might wait on it in the future

4. Add helpers/vulnmanagement/entities.js

5. Edit generically integration/vulnmanagement/whatever.test.js
    * Replace `cy.visit` with helper functions

6. Edit specifically integration/vulnmanagement/cvesListPages.test.js
    * Delete `beforeEach` and `cy.wait` because redundant with helper function

7. Edit specifically to replace keys
    * integration/vulnmanagement/entitypages.test.js
    * integration/vulnmanagement/imagesListPages.test.js

### Residue

1. Review `all` helper functions in vmWorkflowUtils: entitiesKey argument, intercept-wait for relevant requests, and heading assertion

2. Confirm reliability of 2 skipped tests in integration/vulnmanagement/entitypages.test.js after deleting wait for request which does not occur, and then close ROX-8705
    * `'should scope deployment data based on selected policy from entity page tab sublist'`
    * `'should filter component count in images list and image overview by cve when coming from cve list'`

3. Although visit helper functions and added wait for /v1/config/public request respond to the sympton of ROX-8674, leave open because the number of failures for the particular test in integration/vulnmanagement/imagesListPages.test.js point toward the more complicated than usual conditional logic
    ![ROX-8674](https://user-images.githubusercontent.com/11862657/169836510-ce588268-3eb8-45de-8d10-bbb2551a3353.png)

4. Investigate integration/vulnmanagement/policyconfigure.test.js
    * Code problem: `/edit` in url was superseded by `?action=edit`
    * Test problem: `value` in second assertion is empty string

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Ran tests one at a time in local deployment