### PR TITLE
Small follow-ups for required attributes in auth providers.

### DIFF
--- a/pkg/auth/user/required_attribute_verifier.go
+++ b/pkg/auth/user/required_attribute_verifier.go
@@ -27,13 +27,19 @@ func (c *checkRequiredAttributesImpl) Verify(attributes map[string][]string) err
 		return fmt.Errorf("none of the required attributes [%s] are set", attributeKeysAsString(c.required))
 	}
 
+	var missingAttributes []string
 	for _, required := range c.required {
 		if observedValue, ok := attributes[required.GetAttributeKey()]; !ok || observedValue == nil {
-			return fmt.Errorf("missing required attribute %q", required.GetAttributeKey())
+			missingAttributes = append(missingAttributes, required.GetAttributeKey())
 		} else if ok && sliceutils.StringFind(observedValue, required.GetAttributeValue()) == -1 {
 			return fmt.Errorf("required attribute %q did not have the required value", required.GetAttributeKey())
 		}
 	}
+
+	if len(missingAttributes) > 0 {
+		return fmt.Errorf("missing required attributes [%s]", strings.Join(missingAttributes, ","))
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description

Small follow-ups from the changes made within #1716 :
- Return the list of missing attributes instead of the first missing attribute.
- Refactor `registry_httphandler` tests to not ignore errors and use `Require / Assert` where applicable; use `http` Status codes instead of integers.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
- Unit tests, see CI being successful.
