### PR TITLE
ROX-11019: Only run postgres tests on master.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3635,7 +3635,7 @@ jobs:
             - check-to-run:
                 label: ci-postgres-tests
                 run-on-master: true
-                run-on-tags: true
+                run-on-tags: false
           use-websocket: true
 
   gke-kernel-api-e2e-tests:


### PR DESCRIPTION
## Description

`gke-postgres-api-e2e-tests` depend on feature flags. Nightly tests run on tagged builds ( release builds), which do not include features flags, hence the tests are always failing.
