### PR TITLE
ROX-10993: Respect replaced resources within allow fixed scope checker.

### DIFF
--- a/central/graphql/resolvers/service_accounts_test.go
+++ b/central/graphql/resolvers/service_accounts_test.go
@@ -185,7 +185,7 @@ func (s *ServiceAccountResolverTestSuite) getMockContext(extraPerms ...permissio
 	resKeys := make([]permissions.ResourceHandle, 0, len(extraPerms))
 	for _, p := range extraPerms {
 		perms[p.String()] = storage.Access_READ_WRITE_ACCESS
-		resKeys = append(resKeys, p.GetResource())
+		resKeys = append(resKeys, p)
 	}
 	id.EXPECT().Permissions().Return(perms).AnyTimes()
 

--- a/central/networkbaseline/datastore/datastore_sac_test.go
+++ b/central/networkbaseline/datastore/datastore_sac_test.go
@@ -68,7 +68,7 @@ func (s *networkBaselineDatastoreSACTestSuite) SetupSuite() {
 	}
 	s.datastore = newNetworkBaselineDataStore(s.storage)
 
-	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.NetworkBaseline.GetResource())
+	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.NetworkBaseline)
 }
 
 func (s *networkBaselineDatastoreSACTestSuite) TearDownSuite() {

--- a/central/pod/datastore/datastore_sac_test.go
+++ b/central/pod/datastore/datastore_sac_test.go
@@ -88,7 +88,7 @@ func (s *podDatastoreSACSuite) SetupSuite() {
 	}
 
 	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(),
-		resources.Deployment.GetResource())
+		resources.Deployment)
 }
 
 func (s *podDatastoreSACSuite) TearDownSuite() {

--- a/central/processbaseline/datastore/datastore_sac_test.go
+++ b/central/processbaseline/datastore/datastore_sac_test.go
@@ -93,7 +93,7 @@ func (s *processBaselineSACTestSuite) SetupSuite() {
 	s.datastore = New(s.storage, s.indexer, s.search, s.processBaselineResultMock, s.processIndicatorMock)
 
 	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(),
-		resources.ProcessWhitelist.GetResource())
+		resources.ProcessWhitelist)
 }
 
 func (s *processBaselineSACTestSuite) TearDownSuite() {

--- a/central/processbaselineresults/datastore/datastore_sac_test.go
+++ b/central/processbaselineresults/datastore/datastore_sac_test.go
@@ -58,7 +58,7 @@ func (s *processBaselineResultsDatastoreSACSuite) SetupSuite() {
 	s.datastore = New(s.storage)
 
 	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(),
-		resources.ProcessWhitelist.GetResource())
+		resources.ProcessWhitelist)
 }
 
 func (s *processBaselineResultsDatastoreSACSuite) TearDownSuite() {

--- a/central/processindicator/datastore/datastore_sac_test.go
+++ b/central/processindicator/datastore/datastore_sac_test.go
@@ -83,7 +83,7 @@ func (s *processIndicatorDatastoreSACSuite) SetupSuite() {
 	s.Require().NoError(err)
 
 	s.testContexts = sacTestUtils.GetNamespaceScopedTestContexts(context.Background(), s.T(),
-		resources.Indicator.GetResource())
+		resources.Indicator)
 }
 
 func (s *processIndicatorDatastoreSACSuite) TearDownSuite() {

--- a/central/rbac/k8srole/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srole/datastore/datastore_sac_test.go
@@ -80,7 +80,7 @@ func (s *k8sRoleSACSuite) SetupSuite() {
 	s.Require().NoError(err)
 
 	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(),
-		resources.K8sRole.GetResource())
+		resources.K8sRole)
 }
 
 func (s *k8sRoleSACSuite) TearDownSuite() {

--- a/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
@@ -82,7 +82,7 @@ func (s *k8sRoleBindingSACSuite) SetupSuite() {
 	s.Require().NoError(err)
 
 	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(),
-		resources.K8sRoleBinding.GetResource())
+		resources.K8sRoleBinding)
 }
 
 func (s *k8sRoleBindingSACSuite) TearDownSuite() {

--- a/central/risk/datastore/datastore_sac_test.go
+++ b/central/risk/datastore/datastore_sac_test.go
@@ -82,7 +82,7 @@ func (s *riskDatastoreSACSuite) SetupSuite() {
 	s.Require().NoError(err)
 
 	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(),
-		resources.Risk.GetResource())
+		resources.Risk)
 }
 
 func (s *riskDatastoreSACSuite) TearDownSuite() {

--- a/central/sac/transitional/permission_recording_scc.go
+++ b/central/sac/transitional/permission_recording_scc.go
@@ -22,7 +22,7 @@ func newPermissionUseRecorder() *permissionUseRecorder {
 	}
 }
 
-func (r *permissionUseRecorder) RecordPermissionUse(resource permissions.Resource, am storage.Access) {
+func (r *permissionUseRecorder) RecordPermissionUse(resource permissions.ResourceMetadata, am storage.Access) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
@@ -92,9 +92,11 @@ func (s *permissionRecordingSCC) TryAllowed() sac.TryAllowedResult {
 	if s.am != nil {
 		am = *s.am
 	}
-	resources := resources2.ListAll()
+	resources := resources2.ListAllMetadata()
 	if s.res != nil {
-		resources = []permissions.Resource{*s.res}
+		if resourceMD, ok := resources2.MetadataForResource(*s.res); ok {
+			resources = []permissions.ResourceMetadata{resourceMD}
+		}
 	}
 
 	for _, resource := range resources {

--- a/central/secret/datastore/datastore_sac_test.go
+++ b/central/secret/datastore/datastore_sac_test.go
@@ -81,7 +81,7 @@ func (s *secretDatastoreSACTestSuite) SetupSuite() {
 	s.datastore, err = New(s.storage, s.indexer, s.search)
 	s.NoError(err)
 
-	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.Secret.GetResource())
+	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.Secret)
 }
 
 func (s *secretDatastoreSACTestSuite) TearDownSuite() {

--- a/central/serviceaccount/datastore/datastore_sac_test.go
+++ b/central/serviceaccount/datastore/datastore_sac_test.go
@@ -81,7 +81,7 @@ func (s *serviceAccountSACSuite) SetupSuite() {
 	s.Require().NoError(err)
 
 	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(),
-		resources.ServiceAccount.GetResource())
+		resources.ServiceAccount)
 }
 
 func (s *serviceAccountSACSuite) TearDownSuite() {

--- a/pkg/auth/permissions/resource.go
+++ b/pkg/auth/permissions/resource.go
@@ -43,6 +43,17 @@ func (m ResourceMetadata) GetResource() Resource {
 	return m.Resource
 }
 
+// GetReplacingResource returns the resource replacing the existing resource for this metadata object.
+// This is done in case of deprecation of the resource. In case no replacing resource is specified, nil will
+// be returned which must be handled by the caller.
+func (m ResourceMetadata) GetReplacingResource() *Resource {
+	if m.ReplacingResource != nil {
+		r := m.ReplacingResource.GetResource()
+		return &r
+	}
+	return nil
+}
+
 // GetScope returns the resource scope for this metadata object.
 func (m ResourceMetadata) GetScope() ResourceScope {
 	// Replacing resources _may_ have a different ResourceScope than the initial resource.
@@ -70,6 +81,7 @@ func (m ResourceMetadata) PerformLegacyAuthForSAC() bool {
 // or a ResourceMetadata object.
 type ResourceHandle interface {
 	GetResource() Resource
+	GetReplacingResource() *Resource
 }
 
 // WithLegacyAuthForSAC returns a resource metadata that instructs the legacy auth handler to either force or force

--- a/pkg/sac/allow_fixed_scopes_checker_core.go
+++ b/pkg/sac/allow_fixed_scopes_checker_core.go
@@ -87,7 +87,13 @@ func (c allowFixedScopesCheckerCore) getResourceEffectiveAccessScope(resource pe
 	}
 	_, resourceAllowed := c.topLevelKeys()[ResourceScopeKey(resource.Resource.GetResource())]
 	if !resourceAllowed {
-		return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
+		if resource.Resource.GetReplacingResource() == nil {
+			return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
+		}
+		_, resourceAllowed = c.topLevelKeys()[ResourceScopeKey(*resource.Resource.GetReplacingResource())]
+		if !resourceAllowed {
+			return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
+		}
 	}
 	return c.next().getClusterEffectiveAccessScope()
 }

--- a/pkg/sac/allow_fixed_scopes_checker_core.go
+++ b/pkg/sac/allow_fixed_scopes_checker_core.go
@@ -90,8 +90,8 @@ func (c allowFixedScopesCheckerCore) getResourceEffectiveAccessScope(resource pe
 		if resource.Resource.GetReplacingResource() == nil {
 			return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
 		}
-		_, resourceAllowed = c.topLevelKeys()[ResourceScopeKey(*resource.Resource.GetReplacingResource())]
-		if !resourceAllowed {
+		_, replacingResourceAllowed := c.topLevelKeys()[ResourceScopeKey(*resource.Resource.GetReplacingResource())]
+		if !replacingResourceAllowed {
 			return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
 		}
 	}

--- a/pkg/sac/for_resource_helpers.go
+++ b/pkg/sac/for_resource_helpers.go
@@ -24,9 +24,9 @@ func ForResource(resourceMD permissions.ResourceMetadata) ForResourceHelper {
 // ScopeChecker returns the scope checker for accessing the given resource in the specified way.
 func (h ForResourceHelper) ScopeChecker(ctx context.Context, am storage.Access, keys ...ScopeKey) ScopeChecker {
 	resourceScopeChecker := GlobalAccessScopeChecker(ctx).AccessMode(am).Resource(
-		h.resourceMD.GetResource()).SubScopeChecker(keys...)
+		h.resourceMD).SubScopeChecker(keys...)
 
-	if h.resourceMD.ReplacingResource == nil {
+	if h.resourceMD.GetReplacingResource() == nil {
 		return resourceScopeChecker
 	}
 	// Conditionally create a OR scope checker if a replacing resource is given. This way we check access to either
@@ -34,7 +34,7 @@ func (h ForResourceHelper) ScopeChecker(ctx context.Context, am storage.Access, 
 	return NewOrScopeChecker(
 		resourceScopeChecker,
 		GlobalAccessScopeChecker(ctx).AccessMode(am).
-			Resource(h.resourceMD.ReplacingResource.GetResource()).SubScopeChecker(keys...))
+			Resource(h.resourceMD.ReplacingResource).SubScopeChecker(keys...))
 }
 
 // AccessAllowed checks if in the given context, we have access of the specified kind to the resource or

--- a/pkg/sac/scope_key.go
+++ b/pkg/sac/scope_key.go
@@ -85,10 +85,11 @@ func (k ResourceScopeKey) String() string {
 }
 
 // ResourceScopeKeys wraps the given resources in a scope key slice.
+// Note: The returned scope keys _may_ be greater than the given resources,
+// since replacing resources will be taken into account and conditionally added
+// to the returned scope keys.
 func ResourceScopeKeys(resources ...permissions.ResourceHandle) []ScopeKey {
-	// keys := make([]ScopeKey, len(resources))
-	// TODO(dhaus): Not sure this semantic change will bear issues.
-	var keys []ScopeKey
+	keys := make([]ScopeKey, len(resources))
 	for _, resource := range resources {
 		keys = append(keys, ResourceScopeKey(resource.GetResource()))
 		if resource.GetReplacingResource() != nil {

--- a/pkg/sac/scope_key.go
+++ b/pkg/sac/scope_key.go
@@ -88,8 +88,10 @@ func (k ResourceScopeKey) String() string {
 // Note: The returned scope keys _may_ be greater than the given resources,
 // since replacing resources will be taken into account and conditionally added
 // to the returned scope keys.
+// This should be fine, as the ResourceScopeKeys is used in contexts which do not
+// specifically require a fixed length based on the number of permissions.ResourceHandle.
 func ResourceScopeKeys(resources ...permissions.ResourceHandle) []ScopeKey {
-	keys := make([]ScopeKey, len(resources))
+	keys := make([]ScopeKey, 0, len(resources))
 	for _, resource := range resources {
 		keys = append(keys, ResourceScopeKey(resource.GetResource()))
 		if resource.GetReplacingResource() != nil {

--- a/pkg/sac/scope_key.go
+++ b/pkg/sac/scope_key.go
@@ -86,9 +86,14 @@ func (k ResourceScopeKey) String() string {
 
 // ResourceScopeKeys wraps the given resources in a scope key slice.
 func ResourceScopeKeys(resources ...permissions.ResourceHandle) []ScopeKey {
-	keys := make([]ScopeKey, len(resources))
-	for i, resource := range resources {
-		keys[i] = ResourceScopeKey(resource.GetResource())
+	// keys := make([]ScopeKey, len(resources))
+	// TODO(dhaus): Not sure this semantic change will bear issues.
+	var keys []ScopeKey
+	for _, resource := range resources {
+		keys = append(keys, ResourceScopeKey(resource.GetResource()))
+		if resource.GetReplacingResource() != nil {
+			keys = append(keys, ResourceScopeKey(*resource.GetReplacingResource()))
+		}
 	}
 	return keys
 }

--- a/pkg/sac/tests/allow_fixed_scopes_checker_core_test.go
+++ b/pkg/sac/tests/allow_fixed_scopes_checker_core_test.go
@@ -13,9 +13,18 @@ import (
 func TestAllowFixedScopes(t *testing.T) {
 	t.Parallel()
 
-	resA := permissions.Resource("resA")
-	resB := permissions.Resource("resB")
-	resC := permissions.Resource("resC")
+	resA := permissions.ResourceMetadata{
+		Resource: permissions.Resource("resA"),
+	}
+	resB := permissions.ResourceMetadata{
+		Resource: permissions.Resource("resB"),
+		ReplacingResource: &permissions.ResourceMetadata{
+			Resource: permissions.Resource("resD"),
+		},
+	}
+	resC := permissions.ResourceMetadata{
+		Resource: permissions.Resource("resC"),
+	}
 
 	sc := NewScopeChecker(AllowFixedScopes(
 		AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
@@ -41,49 +50,49 @@ func TestAllowFixedScopes(t *testing.T) {
 		{
 			scope: []ScopeKey{
 				AccessModeScopeKey(storage.Access_READ_ACCESS),
-				ResourceScopeKey(resC),
+				ResourceScopeKey(resC.GetResource()),
 			},
 			expected: Deny,
 		},
 		{
 			scope: []ScopeKey{
 				AccessModeScopeKey(storage.Access_READ_WRITE_ACCESS),
-				ResourceScopeKey(resC),
+				ResourceScopeKey(resC.GetResource()),
 			},
 			expected: Deny,
 		},
 		{
 			scope: []ScopeKey{
 				AccessModeScopeKey(storage.Access_READ_ACCESS),
-				ResourceScopeKey(resA),
+				ResourceScopeKey(resA.GetResource()),
 			},
 			expected: Allow,
 		},
 		{
 			scope: []ScopeKey{
 				AccessModeScopeKey(storage.Access_READ_WRITE_ACCESS),
-				ResourceScopeKey(resA),
+				ResourceScopeKey(resA.GetResource()),
 			},
 			expected: Allow,
 		},
 		{
 			scope: []ScopeKey{
 				AccessModeScopeKey(storage.Access_READ_ACCESS),
-				ResourceScopeKey(resB),
+				ResourceScopeKey(resB.GetResource()),
 			},
 			expected: Allow,
 		},
 		{
 			scope: []ScopeKey{
 				AccessModeScopeKey(storage.Access_READ_WRITE_ACCESS),
-				ResourceScopeKey(resB),
+				ResourceScopeKey(resB.GetResource()),
 			},
 			expected: Allow,
 		},
 		{
 			scope: []ScopeKey{
 				AccessModeScopeKey(storage.Access_READ_ACCESS),
-				ResourceScopeKey(resC),
+				ResourceScopeKey(resC.GetResource()),
 				ClusterScopeKey("someCluster"),
 			},
 			expected: Deny,
@@ -91,7 +100,7 @@ func TestAllowFixedScopes(t *testing.T) {
 		{
 			scope: []ScopeKey{
 				AccessModeScopeKey(storage.Access_READ_WRITE_ACCESS),
-				ResourceScopeKey(resC),
+				ResourceScopeKey(resC.GetResource()),
 				ClusterScopeKey("someCluster"),
 			},
 			expected: Deny,
@@ -99,7 +108,7 @@ func TestAllowFixedScopes(t *testing.T) {
 		{
 			scope: []ScopeKey{
 				AccessModeScopeKey(storage.Access_READ_ACCESS),
-				ResourceScopeKey(resA),
+				ResourceScopeKey(resA.GetResource()),
 				ClusterScopeKey("someCluster"),
 			},
 			expected: Allow,
@@ -107,7 +116,7 @@ func TestAllowFixedScopes(t *testing.T) {
 		{
 			scope: []ScopeKey{
 				AccessModeScopeKey(storage.Access_READ_WRITE_ACCESS),
-				ResourceScopeKey(resA),
+				ResourceScopeKey(resA.GetResource()),
 				ClusterScopeKey("someCluster"),
 			},
 			expected: Allow,
@@ -115,7 +124,7 @@ func TestAllowFixedScopes(t *testing.T) {
 		{
 			scope: []ScopeKey{
 				AccessModeScopeKey(storage.Access_READ_ACCESS),
-				ResourceScopeKey(resB),
+				ResourceScopeKey(resB.GetResource()),
 				ClusterScopeKey("someCluster"),
 			},
 			expected: Allow,
@@ -123,7 +132,37 @@ func TestAllowFixedScopes(t *testing.T) {
 		{
 			scope: []ScopeKey{
 				AccessModeScopeKey(storage.Access_READ_WRITE_ACCESS),
-				ResourceScopeKey(resB),
+				ResourceScopeKey(resB.GetResource()),
+				ClusterScopeKey("someCluster"),
+			},
+			expected: Allow,
+		},
+		{
+			scope: []ScopeKey{
+				AccessModeScopeKey(storage.Access_READ_WRITE_ACCESS),
+				ResourceScopeKey(*resB.GetReplacingResource()),
+			},
+			expected: Allow,
+		},
+		{
+			scope: []ScopeKey{
+				AccessModeScopeKey(storage.Access_READ_ACCESS),
+				ResourceScopeKey(*resB.GetReplacingResource()),
+			},
+			expected: Allow,
+		},
+		{
+			scope: []ScopeKey{
+				AccessModeScopeKey(storage.Access_READ_ACCESS),
+				ResourceScopeKey(*resB.GetReplacingResource()),
+				ClusterScopeKey("someCluster"),
+			},
+			expected: Allow,
+		},
+		{
+			scope: []ScopeKey{
+				AccessModeScopeKey(storage.Access_READ_WRITE_ACCESS),
+				ResourceScopeKey(*resB.GetReplacingResource()),
 				ClusterScopeKey("someCluster"),
 			},
 			expected: Allow,
@@ -136,8 +175,15 @@ func TestAllowFixedScopes(t *testing.T) {
 }
 
 func TestAllowFixedScopesEffectiveAccessScope(t *testing.T) {
-	resA := permissions.Resource("resourceA")
-	resB := permissions.Resource("resourceB")
+	resA := permissions.ResourceMetadata{
+		Resource: permissions.Resource("resourceA"),
+		ReplacingResource: &permissions.ResourceMetadata{
+			Resource: permissions.Resource("resourceC"),
+		},
+	}
+	resB := permissions.ResourceMetadata{
+		Resource: permissions.Resource("resourceB"),
+	}
 	cluster1 := "cluster1"
 	namespaceA := "namespaceA"
 	namespaceB := "namespaceB"
@@ -181,139 +227,139 @@ func TestAllowFixedScopesEffectiveAccessScope(t *testing.T) {
 		{
 			name:           "EAS for empty fixed scope is Unrestricted for any resource and access (case read A)",
 			checker:        emptyAllowedScope,
-			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resA),
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resA.GetResource()),
 			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for empty fixed scope is Unrestricted for any resource and access (case write A)",
 			checker:        emptyAllowedScope,
-			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resA),
+			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resA.GetResource()),
 			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for empty fixed scope is Unrestricted for any resource and access (case read B)",
 			checker:        emptyAllowedScope,
-			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resB),
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resB.GetResource()),
 			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for empty fixed scope is Unrestricted for any resource and access (case write B)",
 			checker:        emptyAllowedScope,
-			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resB),
+			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resB.GetResource()),
 			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read fixed scope is Unrestricted for read on any resource (case read A)",
 			checker:        readAllAllowedScope,
-			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resA),
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resA.GetResource()),
 			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read fixed scope is Denied for write on any resource (case write A)",
 			checker:        readAllAllowedScope,
-			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resA),
+			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resA.GetResource()),
 			expectedScope:  effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read fixed scope is Unrestricted for read on any resource (case read B)",
 			checker:        readAllAllowedScope,
-			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resB),
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resB.GetResource()),
 			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read fixed scope is Denied for write on any resource (case write B)",
 			checker:        readAllAllowedScope,
-			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resB),
+			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resB.GetResource()),
 			expectedScope:  effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read-write fixed scope is Unrestricted for any resource and access (case read A)",
 			checker:        readWriteAllAllowedScope,
-			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resA),
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resA.GetResource()),
 			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read-write fixed scope is Unrestricted for any resource and access (case write A)",
 			checker:        readWriteAllAllowedScope,
-			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resA),
+			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resA.GetResource()),
 			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read-write fixed scope is Unrestricted for any resource and access (case read B)",
 			checker:        readWriteAllAllowedScope,
-			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resB),
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resB.GetResource()),
 			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read-write fixed scope is Unrestricted for any resource and access (case write B)",
 			checker:        readWriteAllAllowedScope,
-			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resB),
+			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resB.GetResource()),
 			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read resource fixed scope is Unrestricted for read on the resource (case read A)",
 			checker:        readResourceAScope,
-			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resA),
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resA.GetResource()),
 			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read resource fixed scope is denied for write on the resource (case write A)",
 			checker:        readResourceAScope,
-			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resA),
+			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resA.GetResource()),
 			expectedScope:  effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read resource fixed scope is denied for read on other resource (case read B)",
 			checker:        readResourceAScope,
-			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resB),
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resB.GetResource()),
 			expectedScope:  effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read resource fixed scope is denied for write on other resource (case write B)",
 			checker:        readResourceAScope,
-			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resB),
+			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resB.GetResource()),
 			expectedScope:  effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read-write resource fixed scope is Unrestricted for read on the resource (case read A)",
 			checker:        readWriteResourceAScope,
-			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resA),
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resA.GetResource()),
 			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read-write resource fixed scope is Unrestricted for write on the resource (case write A)",
 			checker:        readWriteResourceAScope,
-			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resA),
+			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resA.GetResource()),
 			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read-write resource fixed scope is denied for read on other resource (case read B)",
 			checker:        readWriteResourceAScope,
-			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resB),
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resB.GetResource()),
 			expectedScope:  effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read-write resource fixed scope is denied for write on other resource (case write B)",
 			checker:        readWriteResourceAScope,
-			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resB),
+			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resB.GetResource()),
 			expectedScope:  effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read resource cluster fixed scope is cluster scope for read on the resource",
 			checker:        readResourceACluster1Scope,
-			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resA),
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resA.GetResource()),
 			expectedScope:  effectiveaccessscope.FromClustersAndNamespacesMap([]string{cluster1}, nil),
 		},
 		{
 			name:           "EAS for read resource cluster fixed scope is denied for other resources",
 			checker:        readResourceACluster1Scope,
-			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resB),
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resB.GetResource()),
 			expectedScope:  effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
 			name:           "EAS for read resource cluster namespaces fixed scope is cluster namespaces scope for read on the resource",
 			checker:        readResourceACluster1NamespacesABScope,
-			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resA),
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resA.GetResource()),
 			expectedScope: effectiveaccessscope.FromClustersAndNamespacesMap(nil, map[string][]string{
 				cluster1: {namespaceA, namespaceB},
 			}),
@@ -321,8 +367,68 @@ func TestAllowFixedScopesEffectiveAccessScope(t *testing.T) {
 		{
 			name:           "EAS for read resource cluster namespaces fixed scope is denied for other resources",
 			checker:        readResourceACluster1NamespacesABScope,
-			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resB),
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, resB.GetResource()),
 			expectedScope:  effectiveaccessscope.DenyAllEffectiveAccessScope(),
+		},
+		{
+			name:           "EAS for empty fixed scope is Unrestricted for any resource and access (case read C)",
+			checker:        emptyAllowedScope,
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, *resA.GetReplacingResource()),
+			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
+		},
+		{
+			name:           "EAS for empty fixed scope is Unrestricted for any resource and access (case write C)",
+			checker:        emptyAllowedScope,
+			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, *resA.GetReplacingResource()),
+			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
+		},
+		{
+			name:           "EAS for read fixed scope is Unrestricted for read on any resource (case read C)",
+			checker:        readAllAllowedScope,
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, *resA.GetReplacingResource()),
+			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
+		},
+		{
+			name:           "EAS for read fixed scope is Denied for write on any resource (case write C)",
+			checker:        readAllAllowedScope,
+			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, *resA.GetReplacingResource()),
+			expectedScope:  effectiveaccessscope.DenyAllEffectiveAccessScope(),
+		},
+		{
+			name:           "EAS for read-write fixed scope is Unrestricted for any resource and access (case read C)",
+			checker:        readWriteAllAllowedScope,
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, *resA.GetReplacingResource()),
+			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
+		},
+		{
+			name:           "EAS for read-write fixed scope is Unrestricted for any resource and access (case write C)",
+			checker:        readWriteAllAllowedScope,
+			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, *resA.GetReplacingResource()),
+			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
+		},
+		{
+			name:           "EAS for read resource fixed scope is Unrestricted for read on the resource (case read C)",
+			checker:        readResourceAScope,
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, *resA.GetReplacingResource()),
+			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
+		},
+		{
+			name:           "EAS for read resource fixed scope is denied for write on the resource (case write C)",
+			checker:        readResourceAScope,
+			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, *resA.GetReplacingResource()),
+			expectedScope:  effectiveaccessscope.DenyAllEffectiveAccessScope(),
+		},
+		{
+			name:           "EAS for read-write resource fixed scope is Unrestricted for read on the resource (case read C)",
+			checker:        readWriteResourceAScope,
+			targetResource: resourceWithAccess(storage.Access_READ_ACCESS, *resA.GetReplacingResource()),
+			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
+		},
+		{
+			name:           "EAS for read-write resource fixed scope is Unrestricted for write on the resource (case write C)",
+			checker:        readWriteResourceAScope,
+			targetResource: resourceWithAccess(storage.Access_READ_WRITE_ACCESS, *resA.GetReplacingResource()),
+			expectedScope:  effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 	}
 	for ix := range testCases {

--- a/pkg/sac/tests/testutils.go
+++ b/pkg/sac/tests/testutils.go
@@ -13,3 +13,16 @@ func resourceWithAccess(access storage.Access, resource permissions.Resource) pe
 		},
 	}
 }
+
+func resourceWithAccessAndReplacingResource(access storage.Access, resource permissions.Resource,
+	replacingResource permissions.Resource) permissions.ResourceWithAccess {
+	return permissions.ResourceWithAccess{
+		Access: access,
+		Resource: permissions.ResourceMetadata{
+			Resource: resource,
+			ReplacingResource: &permissions.ResourceMetadata{
+				Resource: replacingResource,
+			},
+		},
+	}
+}

--- a/pkg/sac/testutils/test_contexts.go
+++ b/pkg/sac/testutils/test_contexts.go
@@ -33,7 +33,7 @@ const (
 )
 
 // GetNamespaceScopedTestContexts provides a set of pre-defined scoped contexts for use in scoped access control tests
-func GetNamespaceScopedTestContexts(ctx context.Context, t *testing.T, resource permissions.Resource) map[string]context.Context {
+func GetNamespaceScopedTestContexts(ctx context.Context, t *testing.T, resource permissions.ResourceMetadata) map[string]context.Context {
 	contextMap := make(map[string]context.Context, 0)
 
 	contextMap[UnrestrictedReadCtx] =
@@ -170,7 +170,7 @@ func GetNamespaceScopedTestContexts(ctx context.Context, t *testing.T, resource 
 			sac.TestScopeCheckerCoreFromFullScopeMap(t,
 				sac.TestScopeMap{
 					storage.Access_READ_ACCESS: {
-						resource: &sac.TestResourceScope{
+						resource.GetResource(): &sac.TestResourceScope{
 							Clusters: map[string]*sac.TestClusterScope{
 								testconsts.Cluster1: {Namespaces: []string{testconsts.NamespaceA}},
 								testconsts.Cluster2: {Included: true},


### PR DESCRIPTION
## Description

Continuation of a series of PRs to adapt `ScopeCheckerCore` implementations to respect replacing resources so that we can seamlessly deprecate resources now and in the future. For more general context, you can see the description of
#1756 .

This PR targets the `AllowedFixedScopes` implementation, which is usually used throughout our codebase like this:
```go
ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
		sac.AllowFixedScopes(
			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
			sac.ResourceScopeKeys(resources.APIToken)))
``` 

We expect the returned context `ctx` to have access to `resources.APIToken` as well as the replacing resource, `resources.Integration`. This has been achieved within this PR by:
- Adopting the interface `ResourceHandle` to include `GetReplacingResource`.
- Within `ResourceScopeKeys`, ensure we resolve replacing resources and conditionally add their scope keys as well.
- Adopt the `EffectiveAccessScope`, specifically the `getResourceEffectiveAccessScope` to conditionally verify replacing resources.

## Testing Performed
- Unit tests (see CI).
- Additionally running more QA tests (i.e. postgres) to ensure we don't have unexpected issues.
