### PR TITLE
Add permissions to buildIndex context

### DIFF
--- a/central/alert/datastore/datastore.go
+++ b/central/alert/datastore/datastore.go
@@ -9,10 +9,12 @@ import (
 	"github.com/stackrox/rox/central/alert/datastore/internal/store"
 	"github.com/stackrox/rox/central/alert/datastore/internal/store/rocksdb"
 	"github.com/stackrox/rox/central/globaldb"
+	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	rocksdbBase "github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
 	searchPkg "github.com/stackrox/rox/pkg/search"
 )
 
@@ -40,14 +42,18 @@ type DataStore interface {
 }
 
 // New returns a new soleInstance of DataStore using the input store, indexer, and searcher.
-func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
+func New(alertStore store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
 	ds := &datastoreImpl{
-		storage:    storage,
+		storage:    alertStore,
 		indexer:    indexer,
 		searcher:   searcher,
 		keyedMutex: concurrency.NewKeyedMutex(globaldb.DefaultDataStorePoolSize),
 	}
-	if err := ds.buildIndex(context.TODO()); err != nil {
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Alert)))
+	if err := ds.buildIndex(ctx); err != nil {
 		return nil, err
 	}
 	return ds, nil
@@ -55,12 +61,12 @@ func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) (
 
 // NewWithDb returns a new soleInstance of DataStore using the input indexer, and searcher.
 func NewWithDb(db *rocksdbBase.RocksDB, bIndex bleve.Index) DataStore {
-	store := store.NewFullStore(rocksdb.New(db))
+	alertStore := store.NewFullStore(rocksdb.New(db))
 	indexer := index.New(bIndex)
-	searcher := search.New(store, indexer)
+	searcher := search.New(alertStore, indexer)
 
 	return &datastoreImpl{
-		storage:    store,
+		storage:    alertStore,
 		indexer:    indexer,
 		searcher:   searcher,
 		keyedMutex: concurrency.NewKeyedMutex(globaldb.DefaultDataStorePoolSize),

--- a/central/cluster/datastore/datastore.go
+++ b/central/cluster/datastore/datastore.go
@@ -126,7 +126,11 @@ func New(
 	} else {
 		ds.searcher = search.New(clusterStorage, indexer, graphProvider, clusterRanker)
 	}
-	if err := ds.buildIndex(context.TODO()); err != nil {
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Cluster)))
+	if err := ds.buildIndex(ctx); err != nil {
 		return ds, err
 	}
 

--- a/central/processbaseline/search/searcher.go
+++ b/central/processbaseline/search/searcher.go
@@ -5,9 +5,11 @@ import (
 
 	"github.com/stackrox/rox/central/processbaseline/index"
 	"github.com/stackrox/rox/central/processbaseline/store"
+	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sac"
 	pkgSearch "github.com/stackrox/rox/pkg/search"
 )
 
@@ -24,14 +26,18 @@ type Searcher interface {
 }
 
 // New returns a new instance of Searcher for the given storage and indexer.
-func New(storage store.Store, indexer index.Indexer) (Searcher, error) {
+func New(processBaselineStore store.Store, indexer index.Indexer) (Searcher, error) {
 	ds := &searcherImpl{
-		storage:           storage,
+		storage:           processBaselineStore,
 		indexer:           indexer,
 		formattedSearcher: formatSearcher(indexer),
 	}
 
-	if err := ds.buildIndex(context.TODO()); err != nil {
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.DeploymentExtension)))
+	if err := ds.buildIndex(ctx); err != nil {
 		return nil, err
 	}
 	return ds, nil

--- a/central/processbaseline/search/searcher.go
+++ b/central/processbaseline/search/searcher.go
@@ -36,7 +36,7 @@ func New(processBaselineStore store.Store, indexer index.Indexer) (Searcher, err
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			sac.ResourceScopeKeys(resources.DeploymentExtension)))
+			sac.ResourceScopeKeys(resources.ProcessWhitelist)))
 	if err := ds.buildIndex(ctx); err != nil {
 		return nil, err
 	}

--- a/central/rbac/k8srole/datastore/datastore.go
+++ b/central/rbac/k8srole/datastore/datastore.go
@@ -10,9 +10,11 @@ import (
 	"github.com/stackrox/rox/central/rbac/k8srole/internal/store"
 	"github.com/stackrox/rox/central/rbac/k8srole/internal/store/rocksdb"
 	"github.com/stackrox/rox/central/rbac/k8srole/search"
+	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	pkgRocksDB "github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
 	searchPkg "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/testutils"
 )
@@ -31,13 +33,18 @@ type DataStore interface {
 }
 
 // New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
+func New(k8sRoleStore store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
 	d := &datastoreImpl{
-		storage:  storage,
+		storage:  k8sRoleStore,
 		indexer:  indexer,
 		searcher: searcher,
 	}
-	if err := d.buildIndex(context.TODO()); err != nil {
+
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Administration)))
+	if err := d.buildIndex(ctx); err != nil {
 		return nil, errors.Wrap(err, "failed to build index from existing store")
 	}
 	return d, nil
@@ -47,13 +54,13 @@ func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) (
 // To make this more explicit, we require passing a testing.T to this version.
 func NewForTestOnly(t *testing.T, db *pkgRocksDB.RocksDB, bleveIndex bleve.Index) (DataStore, error) {
 	testutils.MustBeInTest(t)
-	storage := rocksdb.New(db)
+	k8sRoleStore := rocksdb.New(db)
 	indexer := index.New(bleveIndex)
 
 	d := &datastoreImpl{
-		storage:  storage,
+		storage:  k8sRoleStore,
 		indexer:  indexer,
-		searcher: search.New(storage, indexer),
+		searcher: search.New(k8sRoleStore, indexer),
 	}
 
 	if err := d.buildIndex(context.TODO()); err != nil {

--- a/central/rbac/k8srole/datastore/datastore.go
+++ b/central/rbac/k8srole/datastore/datastore.go
@@ -43,7 +43,7 @@ func New(k8sRoleStore store.Store, indexer index.Indexer, searcher search.Search
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			sac.ResourceScopeKeys(resources.Administration)))
+			sac.ResourceScopeKeys(resources.K8sRole)))
 	if err := d.buildIndex(ctx); err != nil {
 		return nil, errors.Wrap(err, "failed to build index from existing store")
 	}

--- a/central/rbac/k8srolebinding/datastore/datastore.go
+++ b/central/rbac/k8srolebinding/datastore/datastore.go
@@ -10,9 +10,11 @@ import (
 	"github.com/stackrox/rox/central/rbac/k8srolebinding/internal/store"
 	"github.com/stackrox/rox/central/rbac/k8srolebinding/internal/store/rocksdb"
 	"github.com/stackrox/rox/central/rbac/k8srolebinding/search"
+	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	pkgRocksDB "github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
 	searchPkg "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/testutils"
 )
@@ -31,13 +33,17 @@ type DataStore interface {
 }
 
 // New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
+func New(k8sRoleBindingStore store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
 	d := &datastoreImpl{
-		storage:  storage,
+		storage:  k8sRoleBindingStore,
 		indexer:  indexer,
 		searcher: searcher,
 	}
-	if err := d.buildIndex(context.TODO()); err != nil {
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.K8sRoleBinding)))
+	if err := d.buildIndex(ctx); err != nil {
 		return nil, errors.Wrap(err, "failed to build index from existing store")
 	}
 	return d, nil
@@ -47,13 +53,13 @@ func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) (
 // To make this more explicit, we require passing a testing.T to this version.
 func NewForTestOnly(t *testing.T, db *pkgRocksDB.RocksDB, bleveIndex bleve.Index) (DataStore, error) {
 	testutils.MustBeInTest(t)
-	storage := rocksdb.New(db)
+	k8sRoleBindingStore := rocksdb.New(db)
 	indexer := index.New(bleveIndex)
 
 	d := &datastoreImpl{
-		storage:  storage,
+		storage:  k8sRoleBindingStore,
 		indexer:  indexer,
-		searcher: search.New(storage, indexer),
+		searcher: search.New(k8sRoleBindingStore, indexer),
 	}
 
 	if err := d.buildIndex(context.TODO()); err != nil {

--- a/central/reportconfigurations/datastore/datastore.go
+++ b/central/reportconfigurations/datastore/datastore.go
@@ -7,8 +7,10 @@ import (
 	"github.com/stackrox/rox/central/reportconfigurations/index"
 	"github.com/stackrox/rox/central/reportconfigurations/search"
 	"github.com/stackrox/rox/central/reportconfigurations/store"
+	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac"
 	searchPkg "github.com/stackrox/rox/pkg/search"
 )
 
@@ -32,7 +34,12 @@ func New(reportConfigStore store.Store, indexer index.Indexer, searcher search.S
 		searcher:          searcher,
 		indexer:           indexer,
 	}
-	if err := d.buildIndex(context.TODO()); err != nil {
+
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.VulnerabilityReports)))
+	if err := d.buildIndex(ctx); err != nil {
 		return nil, errors.Wrap(err, "failed to build index from existing store")
 	}
 	return d, nil

--- a/central/risk/datastore/datastore.go
+++ b/central/risk/datastore/datastore.go
@@ -47,7 +47,7 @@ func New(riskStore store.Store, indexer index.Indexer, searcher search.Searcher)
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			sac.ResourceScopeKeys(resources.DeploymentExtension)))
+			sac.ResourceScopeKeys(resources.Risk)))
 	if err := d.buildIndex(ctx); err != nil {
 		return nil, errors.Wrap(err, "failed to build index from existing store")
 	}

--- a/central/risk/datastore/datastore.go
+++ b/central/risk/datastore/datastore.go
@@ -8,8 +8,10 @@ import (
 	"github.com/stackrox/rox/central/risk/datastore/internal/index"
 	"github.com/stackrox/rox/central/risk/datastore/internal/search"
 	"github.com/stackrox/rox/central/risk/datastore/internal/store"
+	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac"
 	pkgSearch "github.com/stackrox/rox/pkg/search"
 )
 
@@ -27,9 +29,9 @@ type DataStore interface {
 }
 
 // New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(store store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
+func New(riskStore store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
 	d := &datastoreImpl{
-		storage:  store,
+		storage:  riskStore,
 		indexer:  indexer,
 		searcher: searcher,
 		subjectTypeToRanker: map[string]*ranking.Ranker{
@@ -42,7 +44,11 @@ func New(store store.Store, indexer index.Indexer, searcher search.Searcher) (Da
 			storage.RiskSubjectType_IMAGE_COMPONENT.String(): ranking.ComponentRanker(),
 		},
 	}
-	if err := d.buildIndex(context.TODO()); err != nil {
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.DeploymentExtension)))
+	if err := d.buildIndex(ctx); err != nil {
 		return nil, errors.Wrap(err, "failed to build index from existing store")
 	}
 	return d, nil

--- a/central/secret/datastore/datastore.go
+++ b/central/secret/datastore/datastore.go
@@ -4,11 +4,13 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/central/secret/internal/index"
 	"github.com/stackrox/rox/central/secret/internal/store"
 	"github.com/stackrox/rox/central/secret/search"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac"
 	searchPkg "github.com/stackrox/rox/pkg/search"
 )
 
@@ -28,13 +30,18 @@ type DataStore interface {
 }
 
 // New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
+func New(secretStore store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
 	d := &datastoreImpl{
-		storage:  storage,
+		storage:  secretStore,
 		indexer:  indexer,
 		searcher: searcher,
 	}
-	if err := d.buildIndex(context.TODO()); err != nil {
+
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Secret)))
+	if err := d.buildIndex(ctx); err != nil {
 		return nil, errors.Wrap(err, "failed to build index from existing store")
 	}
 	return d, nil

--- a/central/serviceaccount/datastore/datastore.go
+++ b/central/serviceaccount/datastore/datastore.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/blevesearch/bleve"
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/central/serviceaccount/internal/index"
 	"github.com/stackrox/rox/central/serviceaccount/internal/store"
 	"github.com/stackrox/rox/central/serviceaccount/internal/store/rocksdb"
@@ -13,6 +14,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	pkgRocksDB "github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
 	searchPkg "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/testutils"
 )
@@ -31,13 +33,18 @@ type DataStore interface {
 }
 
 // New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
+func New(saStore store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
 	d := &datastoreImpl{
-		storage:  storage,
+		storage:  saStore,
 		indexer:  indexer,
 		searcher: searcher,
 	}
-	if err := d.buildIndex(context.TODO()); err != nil {
+
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.ServiceAccount)))
+	if err := d.buildIndex(ctx); err != nil {
 		return nil, errors.Wrap(err, "failed to build index from existing store")
 	}
 	return d, nil
@@ -47,13 +54,13 @@ func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) (
 // To make this more explicit, we require passing a testing.T to this version.
 func NewForTestOnly(t *testing.T, db *pkgRocksDB.RocksDB, bleveIndex bleve.Index) (DataStore, error) {
 	testutils.MustBeInTest(t)
-	storage := rocksdb.New(db)
+	saStore := rocksdb.New(db)
 	indexer := index.New(bleveIndex)
 
 	d := &datastoreImpl{
-		storage:  storage,
+		storage:  saStore,
 		indexer:  indexer,
-		searcher: search.New(storage, indexer),
+		searcher: search.New(saStore, indexer),
 	}
 
 	if err := d.buildIndex(context.TODO()); err != nil {


### PR DESCRIPTION
## Description

In #740 we added context to stores but not used proper context there just `context.TODO()` this PR replaces some of that todos with context with proper permissions.

## Testing Performed

CI