### PR TITLE
ROX-10845: Refactor notifier scrubbing

### DIFF
--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -44,7 +44,6 @@ import (
 	"github.com/stackrox/rox/pkg/prometheusutil"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/observe"
-	"github.com/stackrox/rox/pkg/secrets"
 	"github.com/stackrox/rox/pkg/telemetry/data"
 	"github.com/stackrox/rox/pkg/version"
 	"google.golang.org/grpc"
@@ -437,12 +436,9 @@ func (s *serviceImpl) getNotifiers(_ context.Context) (interface{}, error) {
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
 			sac.ResourceScopeKeys(resources.Notifier)))
 
-	notifiers, err := s.notifierDataStore.GetNotifiers(accessNotifierCtx)
+	notifiers, err := s.notifierDataStore.GetScrubbedNotifiers(accessNotifierCtx)
 	if err != nil {
 		return nil, err
-	}
-	for _, n := range notifiers {
-		secrets.ScrubSecretsFromStructWithReplacement(n, secrets.ScrubReplacementStr)
 	}
 
 	return notifiers, nil

--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -436,12 +436,7 @@ func (s *serviceImpl) getNotifiers(_ context.Context) (interface{}, error) {
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
 			sac.ResourceScopeKeys(resources.Notifier)))
 
-	notifiers, err := s.notifierDataStore.GetScrubbedNotifiers(accessNotifierCtx)
-	if err != nil {
-		return nil, err
-	}
-
-	return notifiers, nil
+	return s.notifierDataStore.GetScrubbedNotifiers(accessNotifierCtx)
 }
 
 func (s *serviceImpl) getConfig(_ context.Context) (interface{}, error) {

--- a/central/debug/service/service_test.go
+++ b/central/debug/service/service_test.go
@@ -126,24 +126,10 @@ func (s *DebugServiceTestSuite) TestGetRoles() {
 }
 
 func (s *DebugServiceTestSuite) TestGetNotifiers() {
-	s.notifiersMock.EXPECT().GetNotifiers(gomock.Any()).Return(nil, errors.New("Test"))
+	s.notifiersMock.EXPECT().GetScrubbedNotifiers(gomock.Any()).Return(nil, errors.New("Test"))
 	_, err := s.service.getNotifiers(s.noneCtx)
 	s.Error(err, "expected error propagation")
 
-	notifiers := []*storage.Notifier{
-		{
-			Name: "test",
-			Config: &storage.Notifier_Pagerduty{
-				Pagerduty: &storage.PagerDuty{
-					ApiKey: "test",
-				},
-			},
-		},
-	}
-	s.notifiersMock.EXPECT().GetNotifiers(gomock.Any()).Return(notifiers, nil)
-	actualNotifiers, err := s.service.getNotifiers(s.noneCtx)
-
-	// Set new value in order to avoid comparing with referenced objects.
 	expectedNotifiers := []*storage.Notifier{
 		{
 			Name: "test",
@@ -154,6 +140,8 @@ func (s *DebugServiceTestSuite) TestGetNotifiers() {
 			},
 		},
 	}
+	s.notifiersMock.EXPECT().GetScrubbedNotifiers(gomock.Any()).Return(expectedNotifiers, nil)
+	actualNotifiers, err := s.service.getNotifiers(s.noneCtx)
 
 	s.NoError(err)
 	s.EqualValues(expectedNotifiers, actualNotifiers)

--- a/central/graphql/resolvers/notifiers.go
+++ b/central/graphql/resolvers/notifiers.go
@@ -26,7 +26,7 @@ func (resolver *Resolver) Notifiers(ctx context.Context) ([]*notifierResolver, e
 		return nil, err
 	}
 	return resolver.wrapNotifiers(
-		resolver.NotifierStore.GetNotifiers(ctx))
+		resolver.NotifierStore.GetScrubbedNotifiers(ctx))
 }
 
 // Notifier gets a single notifier by ID
@@ -36,5 +36,5 @@ func (resolver *Resolver) Notifier(ctx context.Context, args struct{ graphql.ID 
 		return nil, err
 	}
 	return resolver.wrapNotifier(
-		resolver.NotifierStore.GetNotifier(ctx, string(args.ID)))
+		resolver.NotifierStore.GetScrubbedNotifier(ctx, string(args.ID)))
 }

--- a/central/notifier/datastore/datastore.go
+++ b/central/notifier/datastore/datastore.go
@@ -11,7 +11,9 @@ import (
 //go:generate mockgen-wrapper
 type DataStore interface {
 	GetNotifier(ctx context.Context, id string) (*storage.Notifier, bool, error)
+	GetScrubbedNotifier(ctx context.Context, id string) (*storage.Notifier, bool, error)
 	GetNotifiers(ctx context.Context) ([]*storage.Notifier, error)
+	GetScrubbedNotifiers(ctx context.Context) ([]*storage.Notifier, error)
 	AddNotifier(ctx context.Context, notifier *storage.Notifier) (string, error)
 	UpdateNotifier(ctx context.Context, notifier *storage.Notifier) error
 	RemoveNotifier(ctx context.Context, id string) error

--- a/central/notifier/datastore/datastsore_test.go
+++ b/central/notifier/datastore/datastsore_test.go
@@ -91,6 +91,23 @@ func (s *notifierDataStoreTestSuite) TestAllowsGet() {
 	s.True(exists, "expected exists to be set to false")
 }
 
+func (s *notifierDataStoreTestSuite) TestGetScrubbedNotifier() {
+	testNotifier := &storage.Notifier{
+		Config: &storage.Notifier_Generic{
+			Generic: &storage.Generic{
+				Password: "test",
+			},
+		},
+	}
+
+	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(testNotifier, true, nil).Times(1)
+
+	scrubbedNotifier, exists, err := s.dataStore.GetScrubbedNotifier(s.hasReadCtx, "test")
+	s.NoError(err, "expected no error trying to read with permissions")
+	s.True(exists, "expected exists to be set to false")
+	s.Equal("******", scrubbedNotifier.Config.(*storage.Notifier_Generic).Generic.Password)
+}
+
 func (s *notifierDataStoreTestSuite) TestEnforcesGetMany() {
 	s.storage.EXPECT().GetAll(gomock.Any()).Times(0)
 
@@ -115,6 +132,23 @@ func (s *notifierDataStoreTestSuite) TestAllowsGetMany() {
 
 	_, err = s.dataStore.GetNotifiers(s.hasWriteIntegrationsCtx)
 	s.NoError(err, "expected no error trying to read with Integration permissions")
+}
+
+func (s *notifierDataStoreTestSuite) TestGetScrubbedNotifiers() {
+	testNotifier := &storage.Notifier{
+		Config: &storage.Notifier_Generic{
+			Generic: &storage.Generic{
+				Password: "test",
+			},
+		},
+	}
+
+	s.storage.EXPECT().GetAll(gomock.Any()).Return([]*storage.Notifier{testNotifier}, nil).Times(1)
+
+	scrubbedNotifiers, err := s.dataStore.GetScrubbedNotifiers(s.hasReadCtx)
+	s.NoError(err, "expected no error trying to read with permissions")
+	s.Equal(1, len(scrubbedNotifiers), "expected one notifier in the list")
+	s.Equal("******", scrubbedNotifiers[0].Config.(*storage.Notifier_Generic).Generic.Password)
 }
 
 func (s *notifierDataStoreTestSuite) TestEnforcesAdd() {

--- a/central/notifier/datastore/mocks/datastore.go
+++ b/central/notifier/datastore/mocks/datastore.go
@@ -81,6 +81,37 @@ func (mr *MockDataStoreMockRecorder) GetNotifiers(ctx interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotifiers", reflect.TypeOf((*MockDataStore)(nil).GetNotifiers), ctx)
 }
 
+// GetScrubbedNotifier mocks base method.
+func (m *MockDataStore) GetScrubbedNotifier(ctx context.Context, id string) (*storage.Notifier, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetScrubbedNotifier", ctx, id)
+	ret0, _ := ret[0].(*storage.Notifier)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetScrubbedNotifier indicates an expected call of GetScrubbedNotifier.
+func (mr *MockDataStoreMockRecorder) GetScrubbedNotifier(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScrubbedNotifier", reflect.TypeOf((*MockDataStore)(nil).GetScrubbedNotifier), ctx, id)
+}
+
+// GetScrubbedNotifiers mocks base method.
+func (m *MockDataStore) GetScrubbedNotifiers(ctx context.Context) ([]*storage.Notifier, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetScrubbedNotifiers", ctx)
+	ret0, _ := ret[0].([]*storage.Notifier)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetScrubbedNotifiers indicates an expected call of GetScrubbedNotifiers.
+func (mr *MockDataStoreMockRecorder) GetScrubbedNotifiers(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScrubbedNotifiers", reflect.TypeOf((*MockDataStore)(nil).GetScrubbedNotifiers), ctx)
+}
+
 // RemoveNotifier mocks base method.
 func (m *MockDataStore) RemoveNotifier(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()

--- a/central/notifier/service/service_impl.go
+++ b/central/notifier/service/service_impl.go
@@ -77,27 +77,25 @@ func (s *serviceImpl) GetNotifier(ctx context.Context, request *v1.ResourceByID)
 	if request.GetId() == "" {
 		return nil, errors.Wrap(errox.InvalidArgs, "notifier id must be provided")
 	}
-	notifier, exists, err := s.storage.GetNotifier(ctx, request.GetId())
+	notifier, exists, err := s.storage.GetScrubbedNotifier(ctx, request.GetId())
 	if err != nil {
 		return nil, err
 	}
 	if !exists {
 		return nil, errors.Wrapf(errox.NotFound, "notifier %v not found", request.GetId())
 	}
-	secrets.ScrubSecretsFromStructWithReplacement(notifier, secrets.ScrubReplacementStr)
+
 	return notifier, nil
 }
 
 // GetNotifiers retrieves all notifiers that match the request filters
 func (s *serviceImpl) GetNotifiers(ctx context.Context, _ *v1.GetNotifiersRequest) (*v1.GetNotifiersResponse, error) {
-	notifiers, err := s.storage.GetNotifiers(ctx)
+	scrubbedNotifiers, err := s.storage.GetScrubbedNotifiers(ctx)
 	if err != nil {
 		return nil, err
 	}
-	for _, n := range notifiers {
-		secrets.ScrubSecretsFromStructWithReplacement(n, secrets.ScrubReplacementStr)
-	}
-	return &v1.GetNotifiersResponse{Notifiers: notifiers}, nil
+
+	return &v1.GetNotifiersResponse{Notifiers: scrubbedNotifiers}, nil
 }
 
 func validateNotifier(notifier *storage.Notifier) error {


### PR DESCRIPTION
## Description

We have moved logic for scrubbing of notifiers to the datastore and introduced pair interface functions with and without scrubbing.

**NOTE:** for more information, please check the related ticket.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~ - not relevant
- ~[ ] Determined and documented upgrade steps~ - not relevant
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~ - not relevant

## Testing Performed

1. Login into UI as `admin`
2. Create a `test` PagerDuty notifier
3. Get Bearer token from Browser
```
export TOKEN='<my-bearer-token>'
```
5. Run the `curl` command to get data over REST API
```
curl --request GET --insecure --url https://localhost:8000/v1/notifiers --header "Authorization: Bearer ${TOKEN}" --silent --output -
```
6. Run the `curl` command to get data over GraphQL
```
curl --request POST --insecure --url https://localhost:8000/api/graphql --header "Authorization: Bearer ${TOKEN}" --header 'Content-Type: application/json' --data '{"query":"{notifiers{pagerduty{apiKey}}}"}' --silent --output -
```
