### PR TITLE
Update Network Graph to use URL parameters for search.

### DIFF
--- a/ui/apps/platform/src/Components/NetworkGraph/NetworkGraph.js
+++ b/ui/apps/platform/src/Components/NetworkGraph/NetworkGraph.js
@@ -86,6 +86,7 @@ const NetworkGraph = ({
     selectedClusterName,
     showNamespaceFlows,
     history,
+    location,
     match,
     featureFlags,
     lastUpdatedTimestamp,
@@ -273,7 +274,7 @@ const NetworkGraph = ({
                 setSelectedNode();
                 setSelectedNodeInGraph();
                 onClickOutside();
-                history.push('/main/network');
+                history.push(`/main/network${location.search}`);
                 return;
             }
 
@@ -314,7 +315,7 @@ const NetworkGraph = ({
                 if (type === nodeTypes.EXTERNAL_ENTITIES || type === nodeTypes.CIDR_BLOCK) {
                     onExternalEntitiesClick();
                 } else {
-                    history.push(`/main/network/${id}`);
+                    history.push(`/main/network/${id}${location.search}`);
                     onNodeClick(evData);
                 }
             }
@@ -734,6 +735,7 @@ NetworkGraph.propTypes = {
     setNetworkGraphRef: PropTypes.func.isRequired,
     setSelectedNamespace: PropTypes.func.isRequired,
     history: ReactRouterPropTypes.history.isRequired,
+    location: ReactRouterPropTypes.location.isRequired,
     match: ReactRouterPropTypes.match.isRequired,
     setSelectedNodeInGraph: PropTypes.func,
     isReadOnly: PropTypes.bool,

--- a/ui/apps/platform/src/Containers/Network/Header/NetworkSearch.js
+++ b/ui/apps/platform/src/Containers/Network/Header/NetworkSearch.js
@@ -1,29 +1,69 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 
 import { selectors } from 'reducers';
 import { actions as pageActions } from 'reducers/network/page';
 import { actions as searchActions } from 'reducers/network/search';
+import useURLSearch from 'hooks/useURLSearch';
+import searchOptionsToQuery from 'services/searchOptionsToQuery';
+import { getSearchOptionsForCategory } from 'services/SearchService';
+import { isCompleteSearchFilter } from 'utils/searchUtils';
+import SearchFilterInput from 'Components/SearchFilterInput';
 import {
     ORCHESTRATOR_COMPONENT_KEY,
     orchestratorComponentOption,
 } from 'Containers/Navigation/OrchestratorComponentsToggle';
-import ReduxSearchInput from 'Containers/Search/ReduxSearchInput';
 
 import './NetworkSearch.css';
 
+function searchFilterToSearchEntries(searchFilter) {
+    const entries = [];
+    Object.entries(searchFilter).forEach(([key, value]) => {
+        entries.push({ label: `${key}:`, value: `${key}:`, type: 'categoryOption' });
+        if (value !== '') {
+            const values = Array.isArray(value) ? value : [value];
+            const valueOptions = values.map((v) => ({ label: v, value: v }));
+            entries.push(...valueOptions);
+        }
+    });
+    return entries;
+}
+
+const searchCategory = 'DEPLOYMENTS';
+const searchOptionExclusions = ['Cluster', 'Namespace', 'Namespace ID', 'Orchestrator Component'];
+
 function NetworkSearch({
-    searchOptions,
-    searchModifiers,
     selectedNamespaceFilters,
-    setSearchOptions,
-    setSearchSuggestions,
+    dispatchSearchFilter,
     closeSidePanel,
     isDisabled,
 }) {
+    const [searchOptions, setSearchOptions] = useState([]);
+    const { searchFilter, setSearchFilter } = useURLSearch();
+
+    useEffect(() => {
+        const { request, cancel } = getSearchOptionsForCategory(searchCategory);
+        request
+            .then((options) => {
+                const filteredOptions = options.filter((o) => !searchOptionExclusions.includes(o));
+                setSearchOptions(filteredOptions);
+            })
+            .catch(() => {
+                // A request error will disable the search filter.
+            });
+
+        return cancel;
+    }, [setSearchOptions]);
+
+    // Keep the Redux store in sync with the URL Search Filter
+    useEffect(() => {
+        dispatchSearchFilter(searchFilterToSearchEntries(searchFilter));
+    }, [searchFilter, dispatchSearchFilter]);
+
     function onSearch(options) {
-        if (options.length && !options[options.length - 1].type) {
+        setSearchFilter(options);
+        if (isCompleteSearchFilter(options)) {
             closeSidePanel();
         }
     }
@@ -40,30 +80,25 @@ function NetworkSearch({
     }
 
     return (
-        <ReduxSearchInput
+        <SearchFilterInput
             className="pf-u-w-100 pf-search-shim"
             placeholder="Add one or more deployment filters"
+            searchFilter={searchFilter}
+            searchCategory="DEPLOYMENTS"
             searchOptions={searchOptions}
-            searchModifiers={searchModifiers}
-            setSearchOptions={setSearchOptions}
-            setSearchSuggestions={setSearchSuggestions}
-            onSearch={onSearch}
+            handleChangeSearchFilter={onSearch}
+            autocompleteQueryPrefix={searchOptionsToQuery(prependAutocompleteQuery)}
             isDisabled={isDisabled}
-            prependAutocompleteQuery={prependAutocompleteQuery}
-            autoCompleteCategories={['DEPLOYMENTS']}
         />
     );
 }
 
 const mapStateToProps = createStructuredSelector({
-    searchOptions: selectors.getNetworkSearchOptions,
-    searchModifiers: selectors.getNetworkSearchModifiers,
     selectedNamespaceFilters: selectors.getSelectedNamespaceFilters,
 });
 
 const mapDispatchToProps = {
-    setSearchOptions: searchActions.setNetworkSearchOptions,
-    setSearchSuggestions: searchActions.setNetworkSearchSuggestions,
+    dispatchSearchFilter: searchActions.setNetworkSearchOptions,
     closeSidePanel: pageActions.closeSidePanel,
 };
 

--- a/ui/apps/platform/src/Containers/Network/Header/SimulatorButton.tsx
+++ b/ui/apps/platform/src/Containers/Network/Header/SimulatorButton.tsx
@@ -32,7 +32,7 @@ function SimulatorButton({
 
     function toggleSimulation() {
         // @TODO: This isn't very nice. We'll have  to revisit this in the future. But adding this fix to address a customer issue (https://stack-rox.atlassian.net/browse/ROX-3118)
-        history.push('/main/network');
+        history.push(`/main/network${history.location.search as string}`);
         if (creatingOrSimulating) {
             closeSidePanel();
         } else {

--- a/ui/apps/platform/src/Containers/Network/SidePanel/useNavigateToEntity.ts
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/useNavigateToEntity.ts
@@ -9,9 +9,9 @@ function useNavigateToEntity(): NavigateToEntityHook {
     const history = useHistory();
     return function onNavigateToEntityById(entityId: string, type: EntityType): void {
         if (type === nodeTypes.CIDR_BLOCK || type === nodeTypes.EXTERNAL_ENTITIES) {
-            history.push(`/main/network/${entityId}/${type}`);
+            history.push(`/main/network/${entityId}/${type}${history.location.search as string}`);
         } else {
-            history.push(`/main/network/${entityId}`);
+            history.push(`/main/network/${entityId}${history.location.search as string}`);
         }
     };
 }

--- a/ui/apps/platform/src/Containers/Search/SearchResults.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchResults.tsx
@@ -227,15 +227,7 @@ function SearchResults({
             const searchOptions = amendSearchOptions(searchCategory, name);
             passthroughGlobalSearchOptions(searchOptions, category);
             const searchFilter = searchOptionsToSearchFilter(searchOptions);
-            let queryString = '';
-            // TODO Once Violations, Risk, and Network Graph are all using URL Search Params this can be simplified
-            if (category === 'ALERTS' || category === 'DEPLOYMENTS') {
-                queryString = getUrlQueryStringForSearchFilter(searchFilter);
-            } else if (category === 'NETWORK') {
-                // Do nothing, until Network Graph moves from Redux to URL Params
-            } else {
-                // This should never happen, the only three "filter on" pages are the ones listed above
-            }
+            const queryString = getUrlQueryStringForSearchFilter(searchFilter);
             onClose(`${toURL}?${queryString}`);
         };
 

--- a/ui/apps/platform/src/reducers/network/search.js
+++ b/ui/apps/platform/src/reducers/network/search.js
@@ -17,20 +17,6 @@ const getNetworkSearchActions = getSearchActions('network');
 
 const networkSearchActions = { ...getNetworkSearchActions };
 
-// Network search should not show the following categories
-const searchOptionExclusions = [
-    'Cluster:',
-    'Namespace:',
-    'Namespace ID:',
-    'Orchestrator Component:',
-];
-const filterSearchOptions = (options) =>
-    options.filter((obj) => !searchOptionExclusions.includes(obj.value));
-networkSearchActions.setNetworkSearchModifiers = (options) =>
-    getNetworkSearchActions.setNetworkSearchModifiers(filterSearchOptions(options));
-networkSearchActions.setNetworkSearchSuggestions = (options) =>
-    getNetworkSearchActions.setNetworkSearchSuggestions(filterSearchOptions(options));
-
 // Actions
 //---------
 

--- a/ui/apps/platform/src/sagas/globalSearchSagas.js
+++ b/ui/apps/platform/src/sagas/globalSearchSagas.js
@@ -1,7 +1,6 @@
 import { takeLatest, all, call, fork, put, select } from 'redux-saga/effects';
 import { fetchGlobalSearchResults } from 'services/SearchService';
 import { actions, types } from 'reducers/globalSearch';
-import { actions as networkActions } from 'reducers/network/search';
 import { actions as secretsActions } from 'reducers/secrets';
 import { actions as policiesActions } from 'reducers/policies/search';
 import { selectors } from 'reducers';
@@ -36,9 +35,6 @@ export function* passthroughGlobalSearchOptions({ searchOptions, category }) {
     switch (category) {
         case 'SECRETS':
             yield put(secretsActions.setSecretsSearchOptions(searchOptions));
-            break;
-        case 'NETWORK':
-            yield put(networkActions.setNetworkSearchOptions(searchOptions));
             break;
         case 'POLICIES':
             yield put(policiesActions.setPoliciesSearchOptions(searchOptions));

--- a/ui/apps/platform/src/sagas/searchSagas.js
+++ b/ui/apps/platform/src/sagas/searchSagas.js
@@ -1,10 +1,9 @@
 import { all, put, call } from 'redux-saga/effects';
 
-import { mainPath, policiesPath, secretsPath, networkPath } from 'routePaths';
+import { mainPath, policiesPath, secretsPath } from 'routePaths';
 import { takeEveryNewlyMatchedLocation } from 'utils/sagaEffects';
 import { actions as policiesActions } from 'reducers/policies/search';
 import { actions as secretsActions } from 'reducers/secrets';
-import { actions as networkActions } from 'reducers/network/search';
 import { actions as globalSearchActions } from 'reducers/globalSearch';
 import { fetchOptions } from 'services/SearchService';
 import capitalize from 'lodash/capitalize';
@@ -90,14 +89,6 @@ export default function* searches() {
             secretsActions.setSecretsSearchSuggestions,
             secretsActions.setSecretsSearchOptions,
             'categories=SECRETS'
-        ),
-        takeEveryNewlyMatchedLocation(
-            networkPath,
-            getSearchOptions,
-            networkActions.setNetworkSearchModifiers,
-            networkActions.setNetworkSearchSuggestions,
-            networkActions.setNetworkSearchOptions,
-            'categories=DEPLOYMENTS'
         ),
     ]);
 }

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -107,6 +107,16 @@ export function searchOptionsToSearchFilter(searchOptions: SearchEntry[]): Searc
     return searchFilter;
 }
 
+/**
+ * Determines whether or not a SearchFilter contains a valid value for
+ * all keys. A valid value is either a non-empty string or non-empty array.
+ */
+export function isCompleteSearchFilter(searchFilter: SearchFilter) {
+    return Object.values(searchFilter).every(
+        (o) => Boolean(o) && (!Array.isArray(o) || o.length > 0)
+    );
+}
+
 /*
  * Return request query string for search filter. Omit filter criterion:
  * If option does not have value.


### PR DESCRIPTION
## Description

This updates the Network Graph page to use URL parameters for search filters to match the functionality and conventions used on other pages. This does not store other Network Graph state in the URL; in order to keep the scope of changes small this has been extracted from the larger WIP PR https://github.com/stackrox/stackrox/pull/1532.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Test that applying a search filter correctly filters the graph display and tracks search filters in the URL.
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/1292638/169842461-af99d6f5-8f6c-4377-8feb-18a23afebf31.png">

Test that applying multiple search filters correctly filters the graphs and tracks entries in the URL:
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/1292638/169842799-c696cfc9-0ea3-4f6f-a9ba-2209a6df4c92.png">

Test that the back button correctly removes one filter at a time:
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/1292638/169842900-92b511c6-fa76-444b-8382-7b9b6089e29c.png">

Test that global search correctly applies the search filters to the graph and URL when visiting via the "Filter On" link:
(Note that the selected cluster and namespaces _will not_ change with these searches, and functions identically to `master`. Work to get context aware switching of clusters/namespaces is part of https://github.com/stackrox/stackrox/pull/1532) 
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/1292638/169843115-dcedfcd0-e20c-41d6-aaf9-db0d0619b2d8.png">
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/1292638/169843150-a097c5d8-4de7-4d1b-a024-47e38875eea1.png">

Test that clicking a namespace or deployment within the graph correctly updates the URL and page state without clearing search parameters.
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/1292638/169843583-561f81a2-a2ae-4b0c-b7e2-38f7b355d231.png">

Test that opening the CIDR block side panel does not clear search results:
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/1292638/170088940-d1a41951-f00c-490d-9184-3e80c81e4a12.png">

Test the opening the Net Policy Simulator does not clear search results:
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/1292638/170088998-a0f3ca08-718b-4b32-9c9c-32afb76fcc65.png">

