### PR TITLE
Additional check for resolved role in diagnostic bundle export

### DIFF
--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -416,7 +416,7 @@ func (s *serviceImpl) getRoles(_ context.Context) (interface{}, error) {
 			Role: role,
 		}
 
-		if resolvedRole, err := s.roleDataStore.GetAndResolveRole(accessRolesCtx, role.Name); err == nil {
+		if resolvedRole, err := s.roleDataStore.GetAndResolveRole(accessRolesCtx, role.Name); err == nil && resolvedRole != nil {
 			// Get better formatting of permission sets.
 			diagRole.PermissionSet = map[string]string{}
 			for permName, accessRight := range resolvedRole.GetPermissions() {


### PR DESCRIPTION
## Description

We are adding an additional check if a resolved role is not nil.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~ - not relevant
- ~[ ] Evaluated and added CHANGELOG entry if required~ - not relevant
- ~[ ] Determined and documented upgrade steps~ - not relevant
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~ - not relevant

## Testing Performed

- as admin - go to `/main/system-health` and create Diagnostic Bundle (upper left)
- check that the dump zip contains a roles file and that file contains a list of resolved roles (with permission sets and access scopes)
