### PR TITLE
ROX-11042: Fix typo in run-openshift-tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1858,7 +1858,7 @@ commands:
             if [[ "$CIRCLE_TAG" =~ .*-nightly-.* ]]; then
               echo "On nightly tag, running all QA tests but failing fast..."
               make -C qa-tests-backend test FAIL_FAST=true || touch FAIL
-            elif [[ "${CIRCLE_BRANCH}" == "master" || -n "${CIRCLE_TAG}" ]]; the
+            elif [[ "${CIRCLE_BRANCH}" == "master" || -n "${CIRCLE_TAG}" ]]; then
               echo "On master, running all QA tests..."
               make -C qa-tests-backend test || touch FAIL
             elif .circleci/pr_has_label.sh ci-all-qa-tests; then


### PR DESCRIPTION
## Description

Fix typo in `if / elif/ else` clause that turned into a syntax error when executing tests.

## Testing Performed
- see CI (`openshift-4-tests / crio` tests should run)
