### PR TITLE
Move kernel-api tests to nightly only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2982,7 +2982,7 @@ jobs:
 
       - check-to-run:
           label: ci-kernel-module-tests
-          run-on-master: true
+          run-on-master: false
           run-on-tags: true
 
       - provision-gke-cluster:
@@ -3659,7 +3659,7 @@ jobs:
           determine-whether-to-run:
             - check-to-run:
                 label: ci-kernel-module-tests
-                run-on-master: true
+                run-on-master: false
                 run-on-tags: true
 
   gke-api-scale-tests:


### PR DESCRIPTION
## Description

Not a lot of value in the kernel tests and all it does is just run collector in kernel module mode. ebpf is now the default so that's more important to check anyways

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Straightforward