### PR TITLE
Do not provision gke-postgres-tests on tags.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2969,7 +2969,7 @@ jobs:
       - check-to-run:
           label: ci-postgres-tests
           run-on-master: true
-          run-on-tags: true
+          run-on-tags: false
       - provision-gke-cluster:
           cluster-id: postgres-api-e2e-tests
 


### PR DESCRIPTION
## Description

Follow-up from #1793 , the provision step was missed. Ensure that it is not run on tags.