### PR TITLE
ROX-10736: Add PostgresSearchHelper to process baseline searcher.

### DIFF
--- a/central/processbaseline/search/searcher_impl.go
+++ b/central/processbaseline/search/searcher_impl.go
@@ -61,7 +61,15 @@ func (s *searcherImpl) buildIndex(ctx context.Context) error {
 }
 
 func (s *searcherImpl) SearchRawProcessBaselines(ctx context.Context, q *v1.Query) ([]*storage.ProcessBaseline, error) {
-	results, err := processBaselineSACSearchHelper.Apply(s.indexer.Search)(ctx, q)
+	var (
+		results []search.Result
+		err     error
+	)
+	if features.PostgresDatastore.Enabled() {
+		results, err = processBaselinePostgresSACSearchHelper.Apply(s.indexer.Search)(ctx, q)
+	} else {
+		results, err = processBaselineSACSearchHelper.Apply(s.indexer.Search)(ctx, q)
+	}
 	if err != nil || len(results) == 0 {
 		return nil, err
 	}

--- a/central/processbaseline/search/searcher_impl.go
+++ b/central/processbaseline/search/searcher_impl.go
@@ -3,7 +3,6 @@ package search
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/postgres/schema"
 	"github.com/stackrox/rox/central/processbaseline/index"
 	"github.com/stackrox/rox/central/processbaseline/index/mappings"
 	"github.com/stackrox/rox/central/processbaseline/store"
@@ -24,8 +23,7 @@ const (
 
 var (
 	processBaselineSACSearchHelper         = sac.ForResource(resources.ProcessWhitelist).MustCreateSearchHelper(mappings.OptionsMap)
-	processBaselinePostgresSACSearchHelper = sac.ForResource(resources.ProcessWhitelist).
-						MustCreatePgSearchHelper(schema.ProcessbaselinesSchema.OptionsMap)
+	processBaselinePostgresSACSearchHelper = sac.ForResource(resources.ProcessWhitelist).MustCreatePgSearchHelper()
 )
 
 type searcherImpl struct {


### PR DESCRIPTION
## Description

Conditionally add `PostgresSearchHelper` within the `searcher` for `process baseline` objects.

## Testing Performed
- Integration tests will be added in a follow-up PR in the scope of [ROX-10736](https://issues.redhat.com/browse/ROX-10736).
