### PR TITLE
3.68.x: log.debug() is not supported here

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -157,7 +157,7 @@ class Kubernetes implements OrchestratorMain {
             if (kce.code != 409) {
                 throw kce
             }
-            log.debug("Namespace ${ns} already exists")
+            println "Namespace ${ns} already exists"
         }
     }
 


### PR DESCRIPTION
## Description

Fix.

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

CI is sufficient