### PR TITLE
3.69.x: log.debug() is not supported here

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -159,7 +159,7 @@ class Kubernetes implements OrchestratorMain {
             if (kce.code != 409) {
                 throw kce
             }
-            log.debug("Namespace ${ns} already exists")
+            println "Namespace ${ns} already exists"
         }
     }
 


### PR DESCRIPTION
## Description

Fix

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient