### PR TITLE
Fix gRPC data race

### DIFF
--- a/sensor/common/centralclient/grpc_connection.go
+++ b/sensor/common/centralclient/grpc_connection.go
@@ -20,8 +20,8 @@ import (
 // more easily mocked when writing unit/integration tests.
 type CentralConnectionFactory interface {
 	SetCentralConnectionWithRetries(ptr *util.LazyClientConn)
-	StopSignal() concurrency.ErrorSignal
-	OkSignal() concurrency.Signal
+	StopSignal() *concurrency.ErrorSignal
+	OkSignal() *concurrency.Signal
 }
 
 type centralConnectionFactoryImpl struct {
@@ -49,13 +49,13 @@ func NewCentralConnectionFactory(endpoint string) (*centralConnectionFactoryImpl
 
 // OkSignal returns a concurrency.Signal that is sends signal once connection object is successfully established
 // and the util.LazyClientConn pointer is swapped.
-func (f *centralConnectionFactoryImpl) OkSignal() concurrency.Signal {
-	return f.okSignal
+func (f *centralConnectionFactoryImpl) OkSignal() *concurrency.Signal {
+	return &f.okSignal
 }
 
 // StopSignal returns a concurrency.Signal that alerts if there is an error trying to establish gRPC connection.
-func (f *centralConnectionFactoryImpl) StopSignal() concurrency.ErrorSignal {
-	return f.stopSignal
+func (f *centralConnectionFactoryImpl) StopSignal() *concurrency.ErrorSignal {
+	return &f.stopSignal
 }
 
 func (f *centralConnectionFactoryImpl) pollMetadata() error {

--- a/sensor/debugger/central/grpc_client.go
+++ b/sensor/debugger/central/grpc_client.go
@@ -30,12 +30,12 @@ func (f *fakeGRPCClient) SetCentralConnectionWithRetries(ptr *util.LazyClientCon
 
 // StopSignal returns a signal that is sent if there is an error.
 // This signal is never called.
-func (f *fakeGRPCClient) StopSignal() concurrency.ErrorSignal {
-	return f.stopSig
+func (f *fakeGRPCClient) StopSignal() *concurrency.ErrorSignal {
+	return &f.stopSig
 }
 
 // OkSignal returns a signal that is sent if connection was swapped.
 // This signal is triggered instantly on calling SetCentralConnectionWithRetries.
-func (f *fakeGRPCClient) OkSignal() concurrency.Signal {
-	return f.okSig
+func (f *fakeGRPCClient) OkSignal() *concurrency.Signal {
+	return &f.okSig
 }


### PR DESCRIPTION
## Description

Use pointers as return methods to factory interface. This fixes gRPC data race in tests since the `select` block in sensor fetches the signal before using it:

```go
func (s *Sensor) Start() {
        // ...
	okSig := s.centralConnectionFactory.OkSignal()
	errSig := s.centralConnectionFactory.StopSignal()

	select {
	case <-errSig.Done():
		s.stoppedSig.SignalWithErrorWrap(errSig.Err(), "getting connection from connection factory")
		return
	case <-okSig.Done():
	case <-s.stoppedSig.Done():
		return
	}
}
```

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

No docs are needed.

## Testing Performed

- `ci-race-tests`
