### PR TITLE
Fix name change of risk schema.

### DIFF
--- a/central/risk/datastore/datastore_sac_test.go
+++ b/central/risk/datastore/datastore_sac_test.go
@@ -64,7 +64,7 @@ func (s *riskDatastoreSACSuite) SetupSuite() {
 		pgStore.Destroy(ctx, s.pool)
 		s.storage = pgStore.New(ctx, s.pool)
 		s.indexer = pgStore.NewIndexer(s.pool)
-		s.optionsMap = schema.RiskSchema.OptionsMap
+		s.optionsMap = schema.RisksSchema.OptionsMap
 	} else {
 		s.engine, err = rocksdb.NewTemp("riskSACTest")
 		s.Require().NoError(err)


### PR DESCRIPTION
## Description

The `schema.RisksSchema` got renamed in a previous change, no rebase happened before merging, thus the integration tests are now failing.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
