### PR TITLE
Fix missing log method

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
@@ -41,7 +41,7 @@ class GraphQLService {
             return response
         }
 
-        log.warnf("There were errors in the graph QL response: %s", response.toString())
+        log.warn("There were errors in the graph QL response: ${response}")
 
         return response
     }


### PR DESCRIPTION
## Description

There is no `warnf` method in log. Let's use `warn` and GString.

## Testing Performed
CI