### PR TITLE
Set GOCACHE in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ GOPATH_VOLUME_SRC := $(GOPATH_VOLUME_NAME)
 endif
 
 LOCAL_VOLUME_ARGS := -v$(CURDIR):/src:delegated -v $(GOCACHE_VOLUME_SRC):/linux-gocache:delegated -v $(GOPATH_VOLUME_SRC):/go:delegated
-GOPATH_WD_OVERRIDES := -w /src -e GOPATH=/go
+GOPATH_WD_OVERRIDES := -w /src -e GOPATH=/go -e GOCACHE=/linux-gocache
 
 null :=
 space := $(null) $(null)


### PR DESCRIPTION
Currently, a Docker volume for the golang cache is mounted into the
build container, however the GOCACHE environment variable is unset. The
cache volume is therefore unused. By setting GOCACHE to the mounted
volume, the total time for a repeated `make image` decreased from 12
minutes to 5 minutes 30 seconds.

In general I think we should refactor the build pipeline to make use of Docker multi stage and layer caching. This way we could also cache the UI and other non-golang parts of the pipeline. But that is a more complex refactoring for another day.

## Checklist
- [ ] ~Investigated and inspected CI test results~
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran `make image` and timed execution. 
