### PR TITLE
ROX-10824: Add CHANGELOG entry for deprecated resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-8277: changed UserAgent Header for all requests from stackrox operator to kubernetes API server to show appropriate version of the operator, for example: `rhacs-operator/v3.70.0 opensource (linux/amd64)`
 - `ids` field in `/v1/cves/suppress` and `/v1/cves/unsuppress` API payload will be renamed to `cves` in 72.0 release.
 - `cves.ids` field of `storage.VulnerabilityRequest` object, which is in the response of `VulnerabilityRequestService` endpoints, will be renamed to `cves.cves` in 72.0 release.
+- ROX-8520: Permissions for permission sets will be grouped for simplification. As a result, the following permissions will be deprecated in favor of a new permission:
+  - New permission `Access` will deprecate the permissions `AuthPlugin, AuthProvider, Group, Licenses, Role, User`.
+  - New permission `DeploymentExtension` will deprecate the permissions `Indicator, NetworkBaseline, ProcessWhitelist, Risk`.
+  - New permission `Integration` will deprecate the permissions `APIToken, BackupPlugins, ImageIntegration, Notifier, SignatureIntegration`.
+  Each deprecated permission will be removed in a future release.
 
 ## [70.0]
 


### PR DESCRIPTION
## Description

Added the list of to-be-deprecated resources within the changelog (Note: Potentially, this list _may_ be extended in case we decide to announce the deprecation of more resources with the `3.71.0` release).
