### PR TITLE
Post-merge review comments for built-in scope checker.

### DIFF
--- a/central/sac/authorizer/builtin_scoped_authorizer.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer.go
@@ -133,7 +133,7 @@ func (a *accessModeLevelScopeCheckerCore) SubScopeChecker(scopeKey sac.ScopeKey)
 	}
 	filteredRoles := make([]permissions.ResolvedRole, 0, len(a.roles))
 	for _, role := range a.roles {
-		if permissions.CheckResourceForAccess(resource, role.GetPermissions(), a.access) {
+		if resource.IsPermittedBy(role.GetPermissions(), a.access) {
 			filteredRoles = append(filteredRoles, role)
 		}
 	}

--- a/pkg/auth/permissions/resource_test.go
+++ b/pkg/auth/permissions/resource_test.go
@@ -83,7 +83,7 @@ func TestCheckResourceForAccess(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, c.expectedRes, CheckResourceForAccess(c.resource, c.permissions, c.access))
+			assert.Equal(t, c.expectedRes, c.resource.IsPermittedBy(c.permissions, c.access))
 		})
 	}
 }

--- a/pkg/grpc/authz/user/user.go
+++ b/pkg/grpc/authz/user/user.go
@@ -87,5 +87,5 @@ func (p *permissionChecker) checkPermissions(rolePerms map[string]storage.Access
 }
 
 func evaluateAgainstPermissions(perms map[string]storage.Access, perm permissions.ResourceWithAccess) bool {
-	return permissions.CheckResourceForAccess(perm.Resource, perms, perm.Access)
+	return perm.Resource.IsPermittedBy(perms, perm.Access)
 }


### PR DESCRIPTION
## Description

Address post-merge review comments from #1756 .

In particular, these two comments:
- [Comment on conditionally broading the scope for replaced resources](https://github.com/stackrox/stackrox/pull/1756#discussion_r880697275)
- [Comment on changing function signature to a receiver function](https://github.com/stackrox/stackrox/pull/1756#discussion_r880732190)

