### PR TITLE
Clear selected net graph deployment when a user completes a new search query.

### DIFF
--- a/ui/apps/platform/src/Containers/Network/Header/NetworkSearch.js
+++ b/ui/apps/platform/src/Containers/Network/Header/NetworkSearch.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import { createStructuredSelector } from 'reselect';
 
 import { selectors } from 'reducers';
@@ -39,6 +40,7 @@ function NetworkSearch({
     closeSidePanel,
     isDisabled,
 }) {
+    const history = useHistory();
     const [searchOptions, setSearchOptions] = useState([]);
     const { searchFilter, setSearchFilter } = useURLSearch();
 
@@ -64,6 +66,7 @@ function NetworkSearch({
     function onSearch(options) {
         setSearchFilter(options);
         if (isCompleteSearchFilter(options)) {
+            history.push(`/main/network${history.location.search}`);
             closeSidePanel();
         }
     }


### PR DESCRIPTION
## Description

Clears the currently selected deployment from the URL and closes the sidebar panel when the user completes a search query on the Network Graph page.

This is a follow up improvement suggested by @pedrottimark in https://github.com/stackrox/stackrox/pull/1804#issuecomment-1135099111

Previously the behavior was to close the sidebar but leave the selected deployment in the URL, which would cause inconsistencies when navigating throughout the page and updating search parameters. This change cleans up this behavior and is more consistent with other behavior on the page (e.g. clicking on empty space in the graph clears the selected deployment).

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Test that selecting a deployment and then entering a search query clears the deployment id from the URL and closes the sidebar.
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/1292638/170265592-8a4483fb-e868-44ca-98c3-0839fe5ca66b.png">
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/1292638/170265802-2ddd7734-d3db-4c39-971f-75187dc54ff1.png">

Test the scenario described in  https://github.com/stackrox/stackrox/pull/1804#issuecomment-1135099111

1. Visit Network Graph
2. Select Namespaces: stackrox
3. Add Deployment: and scanner-db to search filter
4. Click scanner deployment in graph: side panel opens and url now has deployment id
5. Delete scanner-db from search filter
6. Add collector to search filter

The page URL should _not_ contain a deployment id, and the sidebar panel should be in a closed state.