### PR TITLE
RS-519: Onboard unit tests to OpenShift CI

### DIFF
--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -34,6 +34,21 @@ case "$ci_job" in
     style-checks)
         make style
         ;;
+    go-unit-tests-release)
+        GOTAGS=release "$ROOT/scripts/ci/jobs/go-unit-tests.sh"
+        ;;
+    go-unit-tests)
+        GOTAGS='' "$ROOT/scripts/ci/jobs/go-unit-tests.sh"
+        ;;
+    integration-unit-tests)
+        "$ROOT/scripts/ci/jobs/integration-unit-tests.sh"
+        ;;
+    shell-unit-tests)
+        "$ROOT/scripts/ci/jobs/shell-unit-tests.sh"
+        ;;
+    ui-unit-tests)
+        "$ROOT/scripts/ci/jobs/ui-unit-tests.sh"
+        ;;
     push-images)
         "$ROOT/scripts/ci/jobs/push-images.sh"
         ;;

--- a/Makefile
+++ b/Makefile
@@ -487,7 +487,8 @@ ui-test:
 test: go-unit-tests ui-test shell-unit-tests
 
 .PHONY: integration-unit-tests
-integration-unit-tests: build-prep
+integration-unit-tests: build-prep test-prep
+	set -o pipefail ; \
 	GOTAGS=$(GOTAGS),test,integration scripts/go-test.sh -count=1 -v \
 		$(shell go list ./... | grep  "registries\|scanners\|notifiers") \
 		| tee test-output/test.log

--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,9 @@ test: go-unit-tests ui-test shell-unit-tests
 
 .PHONY: integration-unit-tests
 integration-unit-tests: build-prep
-	 GOTAGS=$(GOTAGS),test,integration scripts/go-test.sh -count=1 $(shell go list ./... | grep  "registries\|scanners\|notifiers")
+	GOTAGS=$(GOTAGS),test,integration scripts/go-test.sh -count=1 -v \
+		$(shell go list ./... | grep  "registries\|scanners\|notifiers") \
+		| tee test-output/test.log
 
 generate-junit-reports: $(GO_JUNIT_REPORT_BIN)
 	$(BASE_DIR)/scripts/generate-junit-reports.sh

--- a/scripts/ci/gate-jobs-config.json
+++ b/scripts/ci/gate-jobs-config.json
@@ -1,4 +1,36 @@
 {
+    "go-unit-tests": {
+        "run_with_labels": [],
+        "skip_with_label": "",
+        "run_with_changed_path": "^.*$",
+        "changed_path_to_ignore": "^ui/",
+        "run_on_master": "true",
+        "run_on_tags": "true"
+    },
+    "go-unit-tests-release": {
+        "run_with_labels": [],
+        "skip_with_label": "",
+        "run_with_changed_path": "^.*$",
+        "changed_path_to_ignore": "^ui/",
+        "run_on_master": "true",
+        "run_on_tags": "true"
+    },
+    "shell-unit-tests": {
+        "run_with_labels": [],
+        "skip_with_label": "",
+        "run_with_changed_path": "^.*$",
+        "changed_path_to_ignore": "^ui/",
+        "run_on_master": "true",
+        "run_on_tags": "true"
+    },
+    "ui-unit-tests": {
+        "run_with_labels": [],
+        "skip_with_label": "",
+        "run_with_changed_path": "^ui/",
+        "changed_path_to_ignore": "",
+        "run_on_master": "false",
+        "run_on_tags": "true"
+    },
     "gke-qa-e2e-tests": {
         "run_with_labels": [],
         "skip_with_label": "ci-no-qa-tests",

--- a/scripts/ci/jobs/go-unit-tests.sh
+++ b/scripts/ci/jobs/go-unit-tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+source "$ROOT/scripts/ci/lib.sh"
+
+set -euo pipefail
+
+go_unit_tests() {
+    info "Starting go unit tests (GOTAGS=${GOTAGS})"
+    if [[ "$GOTAGS" == "release" ]]; then
+        export ROX_IMAGE_FLAVOR=stackrox.io
+    else
+        export ROX_IMAGE_FLAVOR=development_build
+    fi
+    make go-unit-tests GOTAGS="${GOTAGS}"
+    
+    info "Saving junit XML report"
+    make generate-junit-reports
+    store_test_results junit-reports reports
+}
+
+go_unit_tests "$*"

--- a/scripts/ci/jobs/integration-unit-tests.sh
+++ b/scripts/ci/jobs/integration-unit-tests.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+source "$ROOT/scripts/ci/lib.sh"
+
+set -euo pipefail
+
+integration_unit_tests() {
+    info "Starting integration unit tests"
+    # Retry a few times if the tests fail since they can be flaky.
+    local success=0
+    local max_tries=5
+    for i in $(seq 1 "${max_tries}"); do
+        if make integration-unit-tests; then
+            success=1
+            break
+        fi
+        echo "Retrying (failed ${i} times)"
+    done
+    if [[ "${success}" == 0 ]]; then
+        echo "Failed after ${max_tries} tries"
+        exit 1
+    fi
+    
+    info "Saving junit XML report"
+    make generate-junit-reports
+    store_test_results junit-reports reports
+}
+
+integration_unit_tests "$*"

--- a/scripts/ci/jobs/shell-unit-tests.sh
+++ b/scripts/ci/jobs/shell-unit-tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+source "$ROOT/scripts/ci/lib.sh"
+
+set -euo pipefail
+
+shell_unit_tests() {
+    info "Starting shell unit tests"
+    make shell-unit-tests
+    
+    info "Saving junit XML report"
+    store_test_results shell-test-output reports
+}
+
+shell_unit_tests "$*"

--- a/scripts/ci/jobs/ui-unit-tests.sh
+++ b/scripts/ci/jobs/ui-unit-tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+source "$ROOT/scripts/ci/lib.sh"
+
+set -euo pipefail
+
+ui_unit_tests() {
+    info "Starting UI unit tests"
+    make ui-test
+    
+    info "Saving junit XML report"
+    store_test_results ui/test-results/reports reports
+}
+
+ui_unit_tests "$*"

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -247,7 +247,7 @@ install_metrics_server_and_deactivate() {
     # shellcheck disable=SC2034
     for i in $(seq 1 10); do
         kubectl api-resources >stdout.out 2>stderr.out || true
-        if grep 'metrics.k8s.io.*the server is currently unable to handle the request' stderr.out; then
+        if grep -q 'metrics.k8s.io.*the server is currently unable to handle the request' stderr.out; then
             success=1
             break
         fi


### PR DESCRIPTION
## Description

This PR adds support for running the missing unit tests under OpenShift CI. (postgres unit tests will require more work and are punted to a future PR). These tests are direct copies of the steps taken in `.circleci/config.yml`.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.

- [x] Happy path runs in openshift CI pj-rehearse. Junit XML properly parsed and displayed.

  - https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/28854/rehearse-28854-pull-ci-stackrox-stackrox-gavin-OSCI-onboard-star-unit-ui-unit-tests/1529300830295953408
  - https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/28854/rehearse-28854-pull-ci-stackrox-stackrox-gavin-OSCI-onboard-star-unit-shell-unit-tests/1529300830107209728
  - https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/28854/rehearse-28854-pull-ci-stackrox-stackrox-gavin-OSCI-onboard-star-unit-integration-unit-tests/1529300830073655296
  - https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/28854/rehearse-28854-pull-ci-stackrox-stackrox-gavin-OSCI-onboard-star-unit-go-unit-tests/1529300829851357184
  - https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/28854/rehearse-28854-pull-ci-stackrox-stackrox-gavin-OSCI-onboard-star-unit-go-unit-tests-release/1529300830006546432

- [x] Force failure in a particular test, junit XML should display the failed test.

  - https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/28854/rehearse-28854-pull-ci-stackrox-stackrox-gavin-OSCI-onboard-star-unit-go-unit-tests-release/1529541591272787968
  -   https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/28854/rehearse-28854-pull-ci-stackrox-stackrox-gavin-OSCI-onboard-star-unit-go-unit-tests/1529541591222456320
  - https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/28854/rehearse-28854-pull-ci-stackrox-stackrox-gavin-OSCI-onboard-star-unit-integration-unit-tests/1529541591365062656
  - https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/28854/rehearse-28854-pull-ci-stackrox-stackrox-gavin-OSCI-onboard-star-unit-shell-unit-tests/1529541591474114560
  - https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/28854/rehearse-28854-pull-ci-stackrox-stackrox-gavin-OSCI-onboard-star-unit-ui-unit-tests/1529541591604137984