### PR TITLE
Dashrews/ROX-11126 fix flaky network baseline test

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -322,7 +322,10 @@ class NetworkBaselineTest extends BaseSpecification {
         // Get the server baseline to simulate a user asking for a baseline prior to
         // observation ending.  This will generate a baseline at the time of request
         // instead of after observation.
-        assert NetworkBaselineService.getNetworkBaseline(userReqBaselineServerDeploymentID)
+        def userReqServerBaseline = NetworkBaselineService.getNetworkBaseline(userReqBaselineServerDeploymentID)
+        // Ensure the baseline is STILL in the observation window
+        def now = System.currentTimeSeconds()
+        assert userReqServerBaseline.getObservationPeriodEnd().getSeconds() > now
 
         // Add a client deployment
         def beforeClientDeploymentCreate = System.currentTimeSeconds()
@@ -346,7 +349,7 @@ class NetworkBaselineTest extends BaseSpecification {
         assert userReqBaselinedClientBaseline
 
         // Grab a fresh copy of the userReqServerBaseline after the client connection has been added.
-        def userReqServerBaseline = NetworkBaselineService.getNetworkBaseline(userReqBaselineServerDeploymentID)
+        userReqServerBaseline = NetworkBaselineService.getNetworkBaseline(userReqBaselineServerDeploymentID)
 
         log.info "Server Baseline: ${userReqServerBaseline}"
         log.info "Client Baseline: ${userReqBaselinedClientBaseline}"

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -57,7 +57,8 @@ class NetworkBaselineTest extends BaseSpecification {
                 .setImage(NGINX_IMAGE)
                 .addLabel("app", BASELINED_USER_CLIENT_DEP_NAME)
                 .setCommand(["/bin/sh", "-c",])
-                .setArgs(["for i in \$(seq 1 10); do wget -S http://${USER_DEP_NAME}; sleep 1; done; sleep 1000" as String])
+                .setArgs(["for i in \$(seq 1 10); do wget -S http://${USER_DEP_NAME};" +
+                    "sleep 1; done; sleep 1000" as String])
 
     static final private ANOMALOUS_CLIENT_DEP = createAndRegisterDeployment()
         .setName(ANOMALOUS_CLIENT_DEP_NAME)
@@ -334,15 +335,16 @@ class NetworkBaselineTest extends BaseSpecification {
         assert userRequestedBaselinedClientDeploymentID != null
         log.info "Client deployment: ${userRequestedBaselinedClientDeploymentID}"
 
-        def clientDeployment = DEPLOYMENTS.find { it.name == BASELINED_USER_CLIENT_DEP_NAME }
-
         assert retryUntilTrue({
-            return NetworkGraphUtil.checkForEdge(userRequestedBaselinedClientDeploymentID, userReqBaselineServerDeploymentID)
-                    .any { it.targetID == userReqBaselineServerDeploymentID}
+            return NetworkGraphUtil.checkForEdge(
+                userRequestedBaselinedClientDeploymentID,
+                userReqBaselineServerDeploymentID)
+                    .any { it.targetID == userReqBaselineServerDeploymentID }
         }, 15)
 
         // Grab the network baseline for the client.
-        def userReqBaselinedClientBaseline = NetworkBaselineService.getNetworkBaseline(userRequestedBaselinedClientDeploymentID)
+        def userReqBaselinedClientBaseline =
+            NetworkBaselineService.getNetworkBaseline(userRequestedBaselinedClientDeploymentID)
         assert userReqBaselinedClientBaseline
 
         // Grab a fresh copy of the userReqServerBaseline after the client connection has been added.

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -126,8 +126,6 @@ class NetworkBaselineTest extends BaseSpecification {
                          long justAfterCreate,
                          List<Tuple2<String, Boolean>> mustBeInBaseline,
                          List<String> mustNotBeInBaseline) {
-        log.info "Validate Baseline"
-        log.info "Baseline: ${baseline} expecting to find the following peers ${expectedPeers}"
         assert baseline.getObservationPeriodEnd().getSeconds() > beforeCreate - CLOCK_SKEW_ALLOWANCE_SECONDS
         assert baseline.getObservationPeriodEnd().getSeconds() <
             justAfterCreate + EXPECTED_BASELINE_DURATION_SECONDS + CLOCK_SKEW_ALLOWANCE_SECONDS

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -308,7 +308,6 @@ class NetworkBaselineTest extends BaseSpecification {
         )
         validateBaseline(postLockClientBaseline, beforeDeferredCreate, justAfterDeferredCreate,
             [], [])
-    }
 
         when:
         "Verify user get for non-existent baseline"

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -322,7 +322,7 @@ class NetworkBaselineTest extends BaseSpecification {
         // Get the server baseline to simulate a user asking for a baseline prior to
         // observation ending.  This will generate a baseline at the time of request
         // instead of after observation.
-        assert NetworkBaselineService.getNetworkBaseline(serverDeploymentID)
+        assert NetworkBaselineService.getNetworkBaseline(userReqBaselineServerDeploymentID)
 
         // Add a client deployment
         def beforeClientDeploymentCreate = System.currentTimeSeconds()
@@ -346,7 +346,7 @@ class NetworkBaselineTest extends BaseSpecification {
         assert userReqBaselinedClientBaseline
 
         // Grab a fresh copy of the userReqServerBaseline after the client connection has been added.
-        def userReqServerBaseline = NetworkBaselineService.getNetworkBaseline(serverDeploymentID)
+        def userReqServerBaseline = NetworkBaselineService.getNetworkBaseline(userReqBaselineServerDeploymentID)
 
         log.info "Server Baseline: ${userReqServerBaseline}"
         log.info "Client Baseline: ${userReqBaselinedClientBaseline}"

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -329,7 +329,7 @@ class NetworkBaselineTest extends BaseSpecification {
         batchCreate([BASELINED_USER_CLIENT_DEP])
         def justAfterClientDeploymentCreate = System.currentTimeSeconds()
 
-        userRequestedBaselinedClientDeploymentID = BASELINED_USER_CLIENT_DEP.deploymentUid
+        def userRequestedBaselinedClientDeploymentID = BASELINED_USER_CLIENT_DEP.deploymentUid
         assert userRequestedBaselinedClientDeploymentID != null
         log.info "Client deployment: ${userRequestedBaselinedClientDeploymentID}"
 


### PR DESCRIPTION
## Description

Updated the test `Verify user get for non-existent baseline` to more explicitly create network communication between 2 deployments.  Additionally added some logging to help us track some of these things when they do flake out and fail.  The focus of this test is on the test at hand.  Also made some changes where all the tests are run together now as that was causing some issues.  A later refactor may want to look at breaking them up individually instead of strung together, but that is a problem for another day, IMO.

The nongroovy test failure is unrelated to this PR as the whole purpose of this PR is a groovy test.  I used the `ci-no-api-tests` to skip the nongroovy tests, but I'm not sure that works currently in openshift ci.
The openshift test failure is ROX-9864 it appears.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
 The issue at hand is a flaky test so CI tests are sufficient.
