### PR TITLE
Dashrews/rox-10086 ROX-11144 add postgres restore capability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,9 +385,10 @@ restoreDB: &restoreDB
   run:
     name: Restore DB
     command: |
-      # TODO ROX-10087 figure out how to make it work for rocks and postgres
       if [ -z "${ROX_POSTGRES_DATASTORE}" ] || [ "${ROX_POSTGRES_DATASTORE}" == "false" ]; then
         roxctl -e "${API_ENDPOINT}" -p "${ROX_PASSWORD}" central db restore `ls -t central-backup/stackrox_db_* |head -n1`
+      else
+        roxctl -e "${API_ENDPOINT}" -p "${ROX_PASSWORD}" central db restore `ls -t central-backup/postgres_db_* |head -n1`
       fi
 
 getPrometheusMetricParser: &getPrometheusMetricParser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - Use `/v1/platformcves/suppress` and `/v1/platformcves/unsuppress` to snooze and unsnooze platform (k8s, istio, and openshift) vulnerabilities.
 - /v1/compliance/results was never implemented and will be removed in this release
 - In release 73.0, the /v1/compliance/runresults endpoint will contain a slimmed down version of the ComplianceDomain object. This allows for greater scalability and reduced memory usage.
+- /db/restore will not be updated to support the database change to Postgres.  This API will become unsupported and deprecated at that time.
 
 ## [70.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - Use `/v1/platformcves/suppress` and `/v1/platformcves/unsuppress` to snooze and unsnooze platform (k8s, istio, and openshift) vulnerabilities.
 - /v1/compliance/results was never implemented and will be removed in this release
 - In release 73.0, the /v1/compliance/runresults endpoint will contain a slimmed down version of the ComplianceDomain object. This allows for greater scalability and reduced memory usage.
-- /db/restore will not be updated to support the database change to Postgres.  This API will become unsupported and deprecated at that time.
+- `/db/restore` will not be updated to support the database change to Postgres.  This API will become unsupported and deprecated at that time.
+  - `roxctl` will be the supported mechanism for performing database restores with the change to Postgres
 
 ## [70.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - Use `/v1/platformcves/suppress` and `/v1/platformcves/unsuppress` to snooze and unsnooze platform (k8s, istio, and openshift) vulnerabilities.
 - /v1/compliance/results was never implemented and will be removed in this release
 - In release 73.0, the /v1/compliance/runresults endpoint will contain a slimmed down version of the ComplianceDomain object. This allows for greater scalability and reduced memory usage.
-- `/db/restore` will not be updated to support the database change to Postgres.  This API will become unsupported and deprecated at that time.
-  - `roxctl` will be the supported mechanism for performing database restores with the change to Postgres
+- When the underlying database changes to Postgres the api `/db/restore` will no longer be a supported means for database restores.  At that time using `roxctl` will be the supported mechanism for database restores.
 
 ## [70.0]
 

--- a/central/globaldb/export/backup.go
+++ b/central/globaldb/export/backup.go
@@ -49,7 +49,7 @@ func BackupPostgres(ctx context.Context, postgresDB *pgxpool.Pool, includeCerts 
 	zipWriter := zip.NewWriter(out)
 	defer utils.IgnoreError(zipWriter.Close)
 
-	if err := generators.PutTarInZip(generators.PutDirectoryInTar(dbs.NewPostgresBackup(postgresDB)), backup.PostgresFileName).WriteTo(ctx, zipWriter); err != nil {
+	if err := generators.PutStreamInZip(dbs.NewPostgresBackup(postgresDB), backup.PostgresFileName).WriteTo(ctx, zipWriter); err != nil {
 		return errors.Wrap(err, "backing up postgres")
 	}
 

--- a/central/globaldb/handlers/http_handler.go
+++ b/central/globaldb/handlers/http_handler.go
@@ -57,6 +57,12 @@ func deferredRestart(ctx context.Context) {
 func RestoreDB(boltDB *bolt.DB, rocksDB *rocksdb.RocksDB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		log.Info("Starting DB restore ...")
+		// This is the old v1 API.  No need to support that for Postgres
+		if features.PostgresDatastore.Enabled() {
+			logAndWriteErrorMsg(w, http.StatusInternalServerError, "api is deprecated and does not support Postgres.")
+			return
+		}
+
 		filename := filepath.Join(os.TempDir(), time.Now().Format(restoreFileFormat))
 
 		f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)

--- a/central/globaldb/postgres_test.go
+++ b/central/globaldb/postgres_test.go
@@ -1,0 +1,96 @@
+package globaldb
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/testutils/envisolator"
+	"github.com/stretchr/testify/suite"
+)
+
+type PostgresUtilitySuite struct {
+	suite.Suite
+	envIsolator *envisolator.EnvIsolator
+}
+
+func TestConfigSetup(t *testing.T) {
+	suite.Run(t, new(PostgresUtilitySuite))
+}
+
+func (s *PostgresUtilitySuite) SetupTest() {
+	s.envIsolator = envisolator.NewEnvIsolator(s.T())
+	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
+
+	if !features.PostgresDatastore.Enabled() {
+		s.T().Skip("Skip postgres store tests")
+		s.T().SkipNow()
+	}
+
+}
+
+func (s *PostgresUtilitySuite) TearDownTest() {
+	s.envIsolator.RestoreAll()
+}
+
+func (s *PostgresUtilitySuite) TestSourceParser() {
+	cases := []struct {
+		name        string
+		source      string
+		expectedMap map[string]string
+		err         error
+	}{
+		{
+			name:        "Case 1",
+			source:      "",
+			expectedMap: nil,
+			err:         errors.New("source string is empty"),
+		},
+		{
+			name:   "Case 2",
+			source: "host=testHost port=5432 database=testDB sensitiveField=testSensitive",
+			expectedMap: map[string]string{
+				"host":           "testHost",
+				"port":           "5432",
+				"database":       "testDB",
+				"sensitiveField": "testSensitive",
+			},
+			err: nil,
+		},
+		{
+			name:   "Case 3",
+			source: "host=testHost  port=5432  database=testDB   sensitiveField=testSensitive  ",
+			expectedMap: map[string]string{
+				"host":           "testHost",
+				"port":           "5432",
+				"database":       "testDB",
+				"sensitiveField": "testSensitive",
+			},
+			err: nil,
+		},
+		{
+			name:   "Case 4",
+			source: "host=testHost port=5432 database=testDB sensitiveField=testWith=InValue",
+			expectedMap: map[string]string{
+				"host":           "testHost",
+				"port":           "5432",
+				"database":       "testDB",
+				"sensitiveField": "testWith=InValue",
+			},
+			err: nil,
+		},
+	}
+
+	for _, c := range cases {
+		log.Info(c.name)
+		sourceMap, err := ParseSource(c.source)
+		if c.err != nil && err != nil {
+			s.Equal(c.err.Error(), err.Error())
+		} else if c.err != nil || err != nil {
+			s.Fail("expected error does not equal error received")
+		}
+
+		s.Equal(c.expectedMap, sourceMap)
+	}
+
+}

--- a/central/globaldb/v2backuprestore/backup/generators/dbs/rocks.go
+++ b/central/globaldb/v2backuprestore/backup/generators/dbs/rocks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/globaldb/v2backuprestore/common"
 	"github.com/stackrox/rox/central/option"
 	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stackrox/rox/pkg/rocksdb"
@@ -61,7 +62,7 @@ func findScratchPath() (string, error) {
 		return "", err
 	}
 
-	return findTmpPath(dbSize, tmpPath)
+	return common.FindTmpPath(dbSize, tmpPath)
 }
 
 // Get the number of bytes used by files stored for the db.

--- a/central/globaldb/v2backuprestore/common/common.go
+++ b/central/globaldb/v2backuprestore/common/common.go
@@ -1,4 +1,4 @@
-package dbs
+package common
 
 import (
 	"os"
@@ -14,7 +14,8 @@ const (
 	marginOfSafety = 0.5
 )
 
-func findTmpPath(dbSize int64, tmpLocation string) (string, error) {
+// FindTmpPath -- finds a temporary place to put a database dump
+func FindTmpPath(dbSize int64, tmpLocation string) (string, error) {
 	requiredBytes := float64(dbSize) * (1.0 + marginOfSafety)
 
 	// Check tmp for space to produce a backup.

--- a/central/globaldb/v2backuprestore/formats/all/all.go
+++ b/central/globaldb/v2backuprestore/formats/all/all.go
@@ -2,5 +2,6 @@ package all
 
 import (
 	// Register formats.
+	_ "github.com/stackrox/rox/central/globaldb/v2backuprestore/formats/postgresv1"
 	_ "github.com/stackrox/rox/central/globaldb/v2backuprestore/formats/roxdbv1"
 )

--- a/central/globaldb/v2backuprestore/formats/postgresv1/format.go
+++ b/central/globaldb/v2backuprestore/formats/postgresv1/format.go
@@ -1,0 +1,15 @@
+package postgresv1
+
+import (
+	"github.com/stackrox/rox/central/globaldb/v2backuprestore/common"
+	"github.com/stackrox/rox/central/globaldb/v2backuprestore/formats"
+	"github.com/stackrox/rox/pkg/backup"
+)
+
+func init() {
+	formats.MustRegisterNewFormat(
+		"postgresv1",
+		common.NewFileHandler(backup.PostgresFileName, false, restorePostgresDB),
+		// TODO: ROX-10087 deal with certs
+	)
+}

--- a/central/globaldb/v2backuprestore/formats/postgresv1/postgres.go
+++ b/central/globaldb/v2backuprestore/formats/postgresv1/postgres.go
@@ -1,0 +1,24 @@
+package postgresv1
+
+import (
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/globaldb/v2backuprestore/common"
+	"github.com/stackrox/rox/central/globaldb/v2backuprestore/restore"
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+var (
+	log = logging.LoggerForModule()
+)
+
+func restorePostgresDB(ctx common.RestoreFileContext, fileReader io.Reader, size int64) error {
+	log.Debugf("restorePostgresDB - dump size = %d", size)
+	err := restore.LoadRestoreStream(fileReader)
+	if err != nil {
+		return errors.Wrap(err, "unable to restore postgres")
+	}
+
+	return nil
+}

--- a/central/globaldb/v2backuprestore/restore/postgres.go
+++ b/central/globaldb/v2backuprestore/restore/postgres.go
@@ -1,0 +1,167 @@
+package restore
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"time"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/globaldb"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/postgres/pgadmin"
+	"github.com/stackrox/rox/pkg/retry"
+)
+
+const (
+	// restoreDB - temporary database to apply the postgres dump
+	restoreDB = "central_restore"
+	// createTemplate - template DB to base the temporary DB off of.
+	createTemplate = "template0"
+	// connectDB - database we can connect to in order to perform the rename
+	// TODO: ROX-11272 We should reserve a database for admin type functionality
+	// such as what we are doing with a restore.  This will need to be updated
+	// with that change.
+	connectDB = "template1"
+)
+
+var (
+	log = logging.LoggerForModule()
+
+	postgresOpenRetries        = 10
+	postgresTimeBetweenRetries = 10 * time.Second
+)
+
+// LoadRestoreStream a Postgres database from a dump
+func LoadRestoreStream(fileReader io.Reader) error {
+	log.Info("Starting Postgres Restore")
+
+	sourceMap, config, err := globaldb.GetPostgresConfig()
+	if err != nil {
+		return errors.Wrap(err, "Could not parse postgres config")
+	}
+
+	// Now recreate the DB
+	err = pgadmin.CreateDB(sourceMap, config, createTemplate, restoreDB)
+	if err != nil {
+		return errors.Wrap(err, "Could not create restore database")
+	}
+
+	// Execute the restore on the temporary restore database
+	err = runRestoreStream(fileReader, sourceMap, config)
+	if err != nil {
+		return errors.Wrap(err, "Could not load the Postgres backup")
+	}
+
+	log.Info("Postgres Restore Complete")
+	return nil
+}
+
+func runRestoreStream(fileReader io.Reader, sourceMap map[string]string, config *pgxpool.Config) error {
+	// Set the options for pg_dump from the connection config
+	options := []string{
+		"-d",
+		restoreDB,
+		"--no-owner",
+		"--clean",
+		"--if-exists",
+		"--exit-on-error",
+		"-Fc",
+		"-vvv",
+		"--single-transaction",
+	}
+
+	// Get the common DB connection info
+	options = append(options, pgadmin.GetConnectionOptions(config)...)
+
+	cmd := exec.Command("pg_restore", options...)
+
+	// Set stdin to be the incoming reader
+	cmd.Stdin = fileReader
+
+	pgadmin.SetPostgresCmdEnv(cmd, sourceMap, config)
+	err := pgadmin.ExecutePostgresCmd(cmd)
+
+	if err != nil {
+		// Clean up the restore DB since the restore failed
+		_ = pgadmin.DropDB(sourceMap, config, restoreDB)
+		return errors.Wrap(err, "Unable to restore the postgres dump")
+	}
+
+	return nil
+}
+
+// SwitchToRestoredDB - switches the restore DB to be the active DB
+func SwitchToRestoredDB(sourceMap map[string]string, config *pgxpool.Config) error {
+	log.Info("Switching to restored database")
+
+	// Connect to different database for admin functions
+	connectPool := adminPool(config)
+	// Close the admin connection pool
+	defer connectPool.Close()
+
+	// Restore succeeded to the separate DB, so we need to drop the original in order to rename
+	// the new one.
+	err := pgadmin.DropDB(sourceMap, config, config.ConnConfig.Database)
+	if err != nil {
+		log.Errorf("Could not drop the DB: %v", err)
+		return err
+	}
+
+	// rename central_restore to postgres
+	err = pgadmin.RenameDB(connectPool, restoreDB, config.ConnConfig.Database)
+	if err != nil {
+		log.Errorf("Could not rename the DB: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+func adminPool(config *pgxpool.Config) *pgxpool.Pool {
+	var err error
+	var postgresDB *pgxpool.Pool
+
+	// Clone config to connect to template DB
+	tempConfig := config.Copy()
+
+	// Need to connect on a static DB so we can rename the used DBs.
+	tempConfig.ConnConfig.Database = connectDB
+
+	if err := retry.WithRetry(func() error {
+		postgresDB, err = pgxpool.ConnectConfig(context.Background(), tempConfig)
+		return err
+	}, retry.Tries(postgresOpenRetries), retry.BetweenAttempts(func(attempt int) {
+		time.Sleep(postgresTimeBetweenRetries)
+	}), retry.OnFailedAttempts(func(err error) {
+		log.Errorf("open database: %v", err)
+	})); err != nil {
+		log.Fatalf("Timed out trying to open database: %v", err)
+	}
+
+	return postgresDB
+}
+
+// CheckIfRestoreDBExists - checks to see if a restore database exists
+func CheckIfRestoreDBExists(config *pgxpool.Config) bool {
+	log.Info("CheckIfRestoreDBExists")
+	ctx, cancel := context.WithTimeout(context.Background(), globaldb.PostgresQueryTimeout)
+	defer cancel()
+
+	// Connect to different database for admin functions
+	connectPool := adminPool(config)
+	// Close the admin connection pool
+	defer connectPool.Close()
+
+	existsStmt := "SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_database WHERE datname = $1)"
+
+	row := connectPool.QueryRow(ctx, existsStmt, restoreDB)
+	var exists bool
+	if err := row.Scan(&exists); err != nil {
+		return false
+	}
+
+	log.Infof("Restore database exists => %t", exists)
+	return exists
+}

--- a/central/globaldb/v2backuprestore/restore/postgres_test.go
+++ b/central/globaldb/v2backuprestore/restore/postgres_test.go
@@ -1,0 +1,94 @@
+package restore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/central/globaldb"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/postgres/pgadmin"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/testutils/envisolator"
+	"github.com/stretchr/testify/suite"
+)
+
+type PostgresRestoreSuite struct {
+	suite.Suite
+	envIsolator *envisolator.EnvIsolator
+	pool        *pgxpool.Pool
+	config      *pgxpool.Config
+	sourceMap   map[string]string
+}
+
+func TestRestore(t *testing.T) {
+	suite.Run(t, new(PostgresRestoreSuite))
+}
+
+func (s *PostgresRestoreSuite) SetupTest() {
+	s.envIsolator = envisolator.NewEnvIsolator(s.T())
+
+	if !features.PostgresDatastore.Enabled() {
+		s.T().Skip("Skip postgres store tests")
+		s.T().SkipNow()
+	}
+
+	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
+
+	ctx := sac.WithAllAccess(context.Background())
+
+	source := pgtest.GetConnectionString(s.T())
+	config, err := pgxpool.ParseConfig(source)
+	s.Require().NoError(err)
+	pool, err := pgxpool.ConnectConfig(ctx, config)
+	s.Require().NoError(err)
+
+	s.pool = pool
+	s.config = config
+	s.sourceMap, err = globaldb.ParseSource(source)
+	if err != nil {
+		log.Infof("Unable to parse source %q", source)
+	}
+}
+
+func (s *PostgresRestoreSuite) TearDownTest() {
+
+	if s.pool != nil {
+		s.pool.Close()
+	}
+	s.envIsolator.RestoreAll()
+}
+
+func (s *PostgresRestoreSuite) TestRestoreUtilities() {
+	// Drop the restore DB if it is lingering from a previous test.
+	// Clean up any databases that were created
+	_ = pgadmin.DropDB(s.sourceMap, s.config, restoreDB)
+
+	// Everything fresh.  A restore database should not exist.
+	s.False(CheckIfRestoreDBExists(s.config))
+
+	// Create a restore DB
+	err := pgadmin.CreateDB(s.sourceMap, s.config, createTemplate, restoreDB)
+	s.Nil(err)
+
+	// Verify restore DB was created
+	s.True(CheckIfRestoreDBExists(s.config))
+
+	// Make a copy of the config and set a user that does not have
+	// permissions to create, drop, etc
+	badConfig := s.config.Copy()
+	badConfig.ConnConfig.User = "baduser"
+
+	// Fail to create restore DB because of insufficient user permissions
+	err = pgadmin.CreateDB(s.sourceMap, badConfig, createTemplate, restoreDB)
+	s.NotNil(err)
+
+	// Fail to drop restore DB because of insufficient user permissions
+	err = pgadmin.DropDB(s.sourceMap, badConfig, restoreDB)
+	s.NotNil(err)
+
+	// Successfully drop the restore DB
+	err = pgadmin.DropDB(s.sourceMap, s.config, restoreDB)
+	s.Nil(err)
+}

--- a/pkg/backup/backup_bundle.go
+++ b/pkg/backup/backup_bundle.go
@@ -9,7 +9,7 @@ import (
 const (
 	BoltFileName     = "bolt.db"
 	RocksFileName    = "rocks.db"
-	PostgresFileName = "postgres.db.tar"
+	PostgresFileName = "postgres.dump"
 	KeysBaseFolder   = "keys"
 	CaKeyPem         = mtls.CAKeyFileName
 	CaCertPem        = mtls.CACertFileName

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -1,0 +1,73 @@
+package pgadmin
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+var (
+	log = logging.LoggerForModule()
+
+	postgresQueryTimeout = 5 * time.Second
+)
+
+// DropDB - drops a database.
+func DropDB(sourceMap map[string]string, adminConfig *pgxpool.Config, databaseName string) error {
+	// Set the options for pg_dump from the connection config
+	options := []string{
+		"-f",
+		"--if-exists",
+		databaseName,
+	}
+
+	// Get the common DB connection info
+	options = append(options, GetConnectionOptions(adminConfig)...)
+
+	cmd := exec.Command("dropdb", options...)
+
+	SetPostgresCmdEnv(cmd, sourceMap, adminConfig)
+	err := ExecutePostgresCmd(cmd)
+	if err != nil {
+		log.Errorf("Unable to drop database %s", databaseName)
+		return err
+	}
+
+	return nil
+}
+
+// CreateDB - creates a database from template with the given database name
+func CreateDB(sourceMap map[string]string, adminConfig *pgxpool.Config, dbTemplate, dbName string) error {
+	// Set the options for pg_dump from the connection config
+	options := []string{
+		"-T",
+		dbTemplate,
+		dbName,
+	}
+
+	// Get the common DB connection info
+	options = append(options, GetConnectionOptions(adminConfig)...)
+
+	cmd := exec.Command("createdb", options...)
+
+	SetPostgresCmdEnv(cmd, sourceMap, adminConfig)
+
+	return ExecutePostgresCmd(cmd)
+}
+
+// RenameDB - renames a database
+func RenameDB(adminPool *pgxpool.Pool, originalDB, newDB string) error {
+	log.Infof("Renaming database %q to %q", originalDB, newDB)
+	ctx, cancel := context.WithTimeout(context.Background(), postgresQueryTimeout)
+	defer cancel()
+
+	sqlStmt := fmt.Sprintf("ALTER DATABASE %s RENAME TO %s", originalDB, newDB)
+
+	_, err := adminPool.Exec(ctx, sqlStmt)
+
+	return err
+}

--- a/pkg/postgres/pgadmin/postgres_command_utils.go
+++ b/pkg/postgres/pgadmin/postgres_command_utils.go
@@ -1,0 +1,60 @@
+package pgadmin
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+// ExecutePostgresCmd -- executes a command
+func ExecutePostgresCmd(cmd *exec.Cmd) error {
+	log.Debug(cmd)
+
+	cmd.Stderr = os.Stderr
+
+	// Run the command
+	err := cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	err = cmd.Wait()
+	if exitError, ok := err.(*exec.ExitError); ok {
+		log.Errorf("Failure executing %q with %v", cmd, exitError)
+		return exitError
+	}
+
+	log.Debug("Exiting execution of command")
+	return nil
+}
+
+// SetPostgresCmdEnv - sets command environment for postgres commands
+func SetPostgresCmdEnv(cmd *exec.Cmd, sourceMap map[string]string, config *pgxpool.Config) {
+	cmd.Env = os.Environ()
+
+	if _, found := sourceMap["sslmode"]; found {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("PGSSLMODE=%s", sourceMap["sslmode"]))
+	}
+	if _, found := sourceMap["sslrootcert"]; found {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("PGSSLROOTCERT=%s", sourceMap["sslrootcert"]))
+	}
+	cmd.Env = append(cmd.Env, fmt.Sprintf("PGPASSWORD=%s", config.ConnConfig.Password))
+}
+
+// GetConnectionOptions - returns a string slice with the common postgres connection options
+func GetConnectionOptions(config *pgxpool.Config) []string {
+	// Set the options for pg_dump from the connection config
+	options := []string{
+		"-U",
+		config.ConnConfig.User,
+		"-h",
+		config.ConnConfig.Host,
+		"-p",
+		strconv.FormatUint(uint64(config.ConnConfig.Port), 10),
+	}
+
+	return options
+}

--- a/roxctl/central/db/db.go
+++ b/roxctl/central/db/db.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stackrox/rox/roxctl/common/flags"
 )
 
-// Command controls all of the functions being applied to a sensor
+// Command controls all of the functions being applied to a central-db
 func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
 		Use: "db",


### PR DESCRIPTION
## Description

Provides a postgres restore capability that builds upon the backup capability delivered with rox-10085.  This uses pg_restore in order to take a dump generated by pg_dump to restore to a database.  This restores to a separate database and if that is successful, it will then drop the active database and rename the restore database to be the active database.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Updated the posgrest CI tests to run a backup and restore from postgres vs rocksdb.  Additionally performed many iterations of running backups and restores.
