### PR TITLE
Skip UI make targets

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -27,6 +27,7 @@ lint: deps $(SOURCES)
 build: deps $(SOURCES)
 	@echo "+ $@"
 	yarn build
+	@touch build
 
 .PHONY: start
 start: deps


### PR DESCRIPTION
The `touch build` seems to be required to properly skip UI make targets
if no change has been detected. Without it, the `make build` target in
`ui/Makefile` is always executed, regardless of actual changes to source
files.

As a result, this change decreases the execution time of `make image` in
most cases.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
