### PR TITLE
Make map queries null safe

### DIFF
--- a/pkg/search/postgres/query/map_query.go
+++ b/pkg/search/postgres/query/map_query.go
@@ -106,7 +106,7 @@ func newMapQuery(ctx *queryAndFieldContext) (*QueryEntry, error) {
 		keyEquivGoFunc = keyQuery.equivalentGoFunc
 		valueEquivGoFunc = valueQuery.equivalentGoFunc
 	}
-	combinedWhereClause.Query = fmt.Sprintf("exists (select * from jsonb_each_text(%s) elem where %s)", ctx.qualifiedColumnName, queryPortion)
+	combinedWhereClause.Query = fmt.Sprintf("(jsonb_typeof(%s) = 'object') and (exists (select * from jsonb_each_text(%s) elem where %s))", ctx.qualifiedColumnName, ctx.qualifiedColumnName, queryPortion)
 	return qeWithSelectFieldIfNeeded(ctx, combinedWhereClause, func(i interface{}) interface{} {
 		asMap := readMapValue(i)
 		var out []string


### PR DESCRIPTION
## Description

Map queries were logging errors like this when there were rows where the value was `null`:
```
2022-05-26 09:59:58.736 PDT [41166] ERROR:  cannot call jsonb_each_text on a non-object
2022-05-26 09:59:58.736 PDT [41166] STATEMENT:  select distinct(multikey.Key1,multikey.Key2) from multikey where (exists (select * from jsonb_each_text(multikey.Labels) elem where true));
ERROR:  cannot call jsonb_each_text on a non-object
```
## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests + manual