### PR TITLE
Fix ever increasing netpols by reseting resources variable

### DIFF
--- a/sensor/kubernetes/fake/networkpolicy.go
+++ b/sensor/kubernetes/fake/networkpolicy.go
@@ -67,8 +67,8 @@ func (w *WorkloadManager) manageNetworkPolicy(ctx context.Context, resources *ne
 	w.manageNetworkPolicyLifecycle(ctx, resources)
 
 	for count := 0; resources.workload.NumLifecycles == 0 || count < resources.workload.NumLifecycles; count++ {
-		np := w.getNetworkPolicy(resources.workload)
-		if _, err := w.client.Kubernetes().NetworkingV1().NetworkPolicies(np.networkPolicy.Namespace).Create(ctx, np.networkPolicy, metav1.CreateOptions{}); err != nil {
+		resources = w.getNetworkPolicy(resources.workload)
+		if _, err := w.client.Kubernetes().NetworkingV1().NetworkPolicies(resources.networkPolicy.Namespace).Create(ctx, resources.networkPolicy, metav1.CreateOptions{}); err != nil {
 			log.Errorf("error creating networkPolicy: %v", err)
 		}
 		w.manageNetworkPolicyLifecycle(ctx, resources)


### PR DESCRIPTION
## Description

Need to reset resources to the new value per lifecycle iteration

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Scale test
