### PR TITLE
OSCI: Retry UI build flake

### DIFF
--- a/.openshift-ci/build/build-main-and-bundle.sh
+++ b/.openshift-ci/build/build-main-and-bundle.sh
@@ -36,7 +36,7 @@ UI_BUILD_LOG="/tmp/ui_build_log.txt"
 background_build_ui() {
     info "Building the UI in the background"
 
-    (make -C ui build > "$UI_BUILD_LOG" 2>&1)&
+    (retry 3 false make -C ui build > "$UI_BUILD_LOG" 2>&1)&
     ui_build_pid=$!
 }
 


### PR DESCRIPTION
## Description

The UI build has an odd [flake](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/1721/pull-ci-stackrox-stackrox-master-images/1529994046322249728#1:build-log.txt%3A513) under OpenShift CI build: 
```
error /go/src/github.com/stackrox/stackrox/ui/node_modules/postinstall-postinstall: Command failed.
Exit code: 1
Command: node ./run.js
Arguments: 
Directory: /go/src/github.com/stackrox/stackrox/ui/node_modules/postinstall-postinstall
Output:
/bin/real-bash: /tmp/yarn--1653614697147-0.110742682233689/yarn: Text file busy
```

This was see quite regularly in earlier development. This PR is a workaround adding a retry. 

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient