### PR TITLE
ROX-11140: Fix Gorm schema test

### DIFF
--- a/central/postgres/schema/schema_test.go
+++ b/central/postgres/schema/schema_test.go
@@ -54,7 +54,6 @@ func (s *SchemaTestSuite) SetupTest() {
 
 	if !features.PostgresDatastore.Enabled() {
 		s.T().Skip("Skip postgres store tests")
-		s.T().SkipNow()
 	}
 
 	ctx := sac.WithAllAccess(context.Background())

--- a/central/postgres/schema/schema_test.go
+++ b/central/postgres/schema/schema_test.go
@@ -71,21 +71,20 @@ func (s *SchemaTestSuite) SetupTest() {
 	s.pool = pool
 	s.tmpDir, err = os.MkdirTemp("", "schema_test")
 	s.Require().NoError(err)
-	source = pgtest.GetGormConnectionString(s.T())
-	fmt.Println("source:", source)
 	s.gorm, err = gorm.Open(postgres.Open(source), &gorm.Config{})
 	s.Require().NoError(err)
 }
 
 func (s *SchemaTestSuite) TearDownTest() {
+	s.envIsolator.RestoreAll()
+	if s.pool == nil {
+		return
+	}
+	defer s.pool.Close()
 	_, err := s.pool.Exec(s.ctx, "DROP SCHEMA public CASCADE")
 	s.Require().NoError(err)
 	_, err = s.pool.Exec(s.ctx, "CREATE SCHEMA public")
 	s.Require().NoError(err)
-	if s.pool != nil {
-		s.pool.Close()
-	}
-	s.envIsolator.RestoreAll()
 }
 
 func (s *SchemaTestSuite) TestGormConsistentWithSQL() {

--- a/pkg/postgres/pgtest/conn.go
+++ b/pkg/postgres/pgtest/conn.go
@@ -17,16 +17,5 @@ func GetConnectionString(_ *testing.T) string {
 	pass := env.GetString("POSTGRES_PASSWORD", "")
 	database := env.GetString("POSTGRES_DB", "postgres")
 	host := env.GetString("POSTGRES_HOST", "localhost")
-	return fmt.Sprintf("host=%s port=5432 database=%s user=%s password=%s sslmode=disable statement_timeout=600000 pool_min_conns=1 pool_max_conns=90", host, database, user, pass)
-}
-
-// GetGormConnectionString returns a connection string for Gorm DB
-func GetGormConnectionString(_ *testing.T) string {
-	user := os.Getenv("USER")
-	if _, ok := os.LookupEnv("CI"); ok {
-		user = "postgres"
-	}
-	database := env.GetString("POSTGRES_DB", "postgres")
-	host := env.GetString("POSTGRES_HOST", "localhost")
-	return fmt.Sprintf("host=%s port=5432 database=%s user=%s sslmode=disable statement_timeout=600000", host, database, user)
+	return fmt.Sprintf("host=%s port=5432 database=%s user=%s password=%s sslmode=disable statement_timeout=600000", host, database, user, pass)
 }


### PR DESCRIPTION
## Description

In gorm test we don't check if pool was initialized  and that cause panic when test is skipped.
Unify gorm and pr connection string since pool_min/max_conns are not recognized by pg 14

```
2022-05-27 09:04:13.419 UTC [57] FATAL:  unrecognized configuration parameter "pool_min_conns"
2022-05-27 09:05:56.921 UTC [60] FATAL:  unrecognized configuration parameter "pool_max_conns"
```

## Testing Performed

CI