### PR TITLE
ROX-10079: oss helm charts publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4339,8 +4339,10 @@ jobs:
             roxctl="./bin/$(uname | tr A-Z a-z)/roxctl"
             "$roxctl" helm output central-services --image-defaults=stackrox.io --output-dir "${central_services_chart_dir}/stackrox"
             "$roxctl" helm output central-services --image-defaults=rhacs --output-dir "${central_services_chart_dir}/rhacs"
+            "$roxctl" helm output central-services --image-defaults=opensource --output-dir "${central_services_chart_dir}/opensource"
             "$roxctl" helm output secured-cluster-services --image-defaults=stackrox.io --output-dir "${secured_cluster_services_chart_dir}/stackrox"
             "$roxctl" helm output secured-cluster-services --image-defaults=rhacs --output-dir "${secured_cluster_services_chart_dir}/rhacs"
+            "$roxctl" helm output secured-cluster-services --image-defaults=opensource --output-dir "${secured_cluster_services_chart_dir}/opensource"
             .circleci/publish-helm-charts "$(make --quiet tag)" "${central_services_chart_dir}" "${secured_cluster_services_chart_dir}"
 
   scan-images-in-quay:

--- a/.circleci/publish-helm-charts
+++ b/.circleci/publish-helm-charts
@@ -46,12 +46,15 @@ mkdir "${tmp_remote_repository}/${remote_subdirectory}/rhacs/${version}"
 cp -a "${central_services_chart}/rhacs" "${tmp_remote_repository}/${remote_subdirectory}/rhacs/${version}/central-services"
 cp -a "${secured_cluster_services_chart}/rhacs" "${tmp_remote_repository}/${remote_subdirectory}/rhacs/${version}/secured-cluster-services"
 
-mkdir "${tmp_remote_repository}/${remote_subdirectory}/opensource"
+mkdir -p "${tmp_remote_repository}/${remote_subdirectory}/opensource"
 
-helm package -d "${tmp_remote_repository}/${remote_subdirectory}/opensource" "${central_services_chart}/opensource/Chart.yaml" || die "Failed to package Helm chart for file ${central_services_chart}/opensource/Chart.yaml"
-helm package -d "${tmp_remote_repository}/${remote_subdirectory}/opensource" "${secured_cluster_services_chart}/opensource/Chart.yaml" || die "Failed to package Helm chart for file ${secured_cluster_services_chart}/opensource/Chart.yaml"
+echo "Packaging Helm chart for file ${central_services_chart}/opensource/Chart.yaml"
+helm package -d "${tmp_remote_repository}/${remote_subdirectory}/opensource" "${central_services_chart}/opensource/Chart.yaml"
+echo "Packaging Helm chart for file ${secured_cluster_services_chart}/opensource/Chart.yaml"
+helm package -d "${tmp_remote_repository}/${remote_subdirectory}/opensource" "${secured_cluster_services_chart}/opensource/Chart.yaml"
 
-helm repo index "${tmp_remote_repository}/${remote_subdirectory}/opensource" || die "Failed to build helm index"
+echo "Building OSS helm repo index"
+helm repo index "${tmp_remote_repository}/${remote_subdirectory}/opensource"
 
 git -C "$tmp_remote_repository" add -A
 git -C "$tmp_remote_repository" -c "user.name=${user_name}" -c "user.email=${user_email}" commit -m "Publish Helm Charts for version ${version}"

--- a/.circleci/publish-helm-charts
+++ b/.circleci/publish-helm-charts
@@ -49,9 +49,9 @@ cp -a "${secured_cluster_services_chart}/rhacs" "${tmp_remote_repository}/${remo
 mkdir -p "${tmp_remote_repository}/${remote_subdirectory}/opensource"
 
 echo "Packaging Helm chart for file ${central_services_chart}/opensource/Chart.yaml"
-helm package -d "${tmp_remote_repository}/${remote_subdirectory}/opensource" "${central_services_chart}/opensource/Chart.yaml"
+helm package -d "${tmp_remote_repository}/${remote_subdirectory}/opensource" "${central_services_chart}/opensource"
 echo "Packaging Helm chart for file ${secured_cluster_services_chart}/opensource/Chart.yaml"
-helm package -d "${tmp_remote_repository}/${remote_subdirectory}/opensource" "${secured_cluster_services_chart}/opensource/Chart.yaml"
+helm package -d "${tmp_remote_repository}/${remote_subdirectory}/opensource" "${secured_cluster_services_chart}/opensource"
 
 echo "Building OSS helm repo index"
 helm repo index "${tmp_remote_repository}/${remote_subdirectory}/opensource"

--- a/.circleci/publish-helm-charts
+++ b/.circleci/publish-helm-charts
@@ -46,6 +46,13 @@ mkdir "${tmp_remote_repository}/${remote_subdirectory}/rhacs/${version}"
 cp -a "${central_services_chart}/rhacs" "${tmp_remote_repository}/${remote_subdirectory}/rhacs/${version}/central-services"
 cp -a "${secured_cluster_services_chart}/rhacs" "${tmp_remote_repository}/${remote_subdirectory}/rhacs/${version}/secured-cluster-services"
 
+mkdir "${tmp_remote_repository}/${remote_subdirectory}/opensource"
+
+helm package -d "${tmp_remote_repository}/${remote_subdirectory}/opensource" "${central_services_chart}/opensource/Chart.yaml" || die "Failed to package Helm chart for file ${central_services_chart}/opensource/Chart.yaml"
+helm package -d "${tmp_remote_repository}/${remote_subdirectory}/opensource" "${secured_cluster_services_chart}/opensource/Chart.yaml" || die "Failed to package Helm chart for file ${secured_cluster_services_chart}/opensource/Chart.yaml"
+
+helm repo index "${tmp_remote_repository}/${remote_subdirectory}/opensource" || die "Failed to build helm index"
+
 git -C "$tmp_remote_repository" add -A
 git -C "$tmp_remote_repository" -c "user.name=${user_name}" -c "user.email=${user_email}" commit -m "Publish Helm Charts for version ${version}"
 git -C "$tmp_remote_repository" push origin "$branch_name"

--- a/pkg/images/defaults/flavor.go
+++ b/pkg/images/defaults/flavor.go
@@ -218,7 +218,7 @@ func OpenSourceImageFlavor() ImageFlavor {
 		ScannerDBSlimImageName: "scanner-db-slim",
 
 		ChartRepo: ChartRepo{
-			URL: "https://github.com/stackrox/helm-charts/opensource/",
+			URL: "https://raw.githubusercontent.com/stackrox/helm-charts/main/opensource/",
 		},
 		ImagePullSecrets: ImagePullSecrets{
 			AllowNone: true,

--- a/pkg/images/defaults/flavor.go
+++ b/pkg/images/defaults/flavor.go
@@ -218,8 +218,7 @@ func OpenSourceImageFlavor() ImageFlavor {
 		ScannerDBSlimImageName: "scanner-db-slim",
 
 		ChartRepo: ChartRepo{
-			// TODO(ROX-10079): establish a place where open source users will be able to download Helm charts.
-			URL: "https://charts.stackrox.io",
+			URL: "https://github.com/stackrox/helm-charts/opensource/",
 		},
 		ImagePullSecrets: ImagePullSecrets{
 			AllowNone: true,


### PR DESCRIPTION
## Description

So far we publish helm charts for `rhacs`and `stackrox.io` flavors, this adds helm charts for `opensource` flavor. Unlike the other two we want to package these charts in .tgz archives with helm publish in order to be able to point `helm repo add` at them.

The charts should be published at "https://github.com/stackrox/helm-charts/opensource/" in the correct way so that `helm repo add`works.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

I'll have to do some manual testing to ensure that helm repo add works here I think. A working example of helm chart publishing to compare to can be found at https://github.com/stackrox/release-artifacts/blob/main/scripts/publish-helm-charts.sh

## TODO
ROX-10079 further asks for creating [artifacthub.io](https://artifacthub.io/ ) entries for these charts, I will look at this together with Matthias on Monday.