### PR TITLE
Only provision clusters after compilation is successful

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,13 @@ runOnAllTagsWithQuayIOPullCtx: &runOnAllTagsWithQuayIOPullCtx
   <<: *runOnAllTags
   context: quay-rhacs-eng-readonly
 
+ensureCompilation: &ensureCompilation
+  requires:
+  - pre-build-go-binaries
+  - pre-build-ui-rhacs
+  - pre-build-cli
+  - pre-build-ui-stackrox
+
 runOnAllTagsWithPushCtx: &runOnAllTagsWithPushCtx
   <<: *runOnAllTags
   context:
@@ -4788,6 +4795,7 @@ workflows:
           <<: *runOnAllTagsWithPushCtx
       - provision-gke-api-nongroovy-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
+          <<: *ensureCompilation
       - gke-api-nongroovy-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
@@ -4801,6 +4809,7 @@ workflows:
             - pre-build-cli
       - provision-gke-ui-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
+          <<: *ensureCompilation
       - gke-ui-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
@@ -4810,6 +4819,7 @@ workflows:
             - provision-gke-ui-e2e-tests
       - provision-gke-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
+          <<: *ensureCompilation
       - gke-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
@@ -4819,6 +4829,7 @@ workflows:
             - provision-gke-api-e2e-tests
       - provision-gke-postgres-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
+          <<: *ensureCompilation
       - gke-postgres-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
@@ -4828,6 +4839,7 @@ workflows:
             - provision-gke-postgres-api-e2e-tests
       - provision-gke-kernel-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
+          <<: *ensureCompilation
       - gke-kernel-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
@@ -4837,6 +4849,7 @@ workflows:
             - provision-gke-kernel-api-e2e-tests
       - provision-gke-api-scale-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
+          <<: *ensureCompilation
       - gke-api-scale-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
@@ -4846,6 +4859,7 @@ workflows:
             - provision-gke-api-scale-tests
       - provision-gke-postgres-api-scale-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
+          <<: *ensureCompilation
       - gke-postgres-api-scale-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
@@ -4855,6 +4869,8 @@ workflows:
           - provision-gke-postgres-api-scale-tests
       - provision-openshift-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
+          <<: *ensureCompilation
+
       - openshift-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
@@ -4864,6 +4880,8 @@ workflows:
             - provision-openshift-api-e2e-tests
       - provision-openshift-crio-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
+          <<: *ensureCompilation
+
       - openshift-crio-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
@@ -4873,6 +4891,8 @@ workflows:
             - provision-openshift-crio-api-e2e-tests
       - provision-eks-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
+          <<: *ensureCompilation
+
       - eks-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
@@ -4892,6 +4912,8 @@ workflows:
       #       - provision-aks-api-e2e-tests
       - provision-openshift-4-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
+          <<: *ensureCompilation
+
       - openshift-4-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
@@ -4901,8 +4923,10 @@ workflows:
             - provision-openshift-4-api-e2e-tests
       - provision-openshift-4-operator-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
+          <<: *ensureCompilation
       - provision-openshift-4-6-operator-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
+          <<: *ensureCompilation
       - openshift-4-operator-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
@@ -4919,6 +4943,8 @@ workflows:
             - provision-openshift-4-6-operator-e2e-tests
       - provision-race-condition-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
+          <<: *ensureCompilation
+
       - race-condition-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
@@ -4945,6 +4971,7 @@ workflows:
           context:
             - osd-cluster-manager
             - quay-rhacs-eng-readonly
+          <<: *ensureCompilation
 
       - openshift-rosa-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
@@ -4974,6 +5001,7 @@ workflows:
             - azure-ci
             - aro-cluster-manager
             - osd-cluster-manager
+          <<: *ensureCompilation
 
       - openshift-aro-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
@@ -4994,6 +5022,7 @@ workflows:
           context:
             - quay-rhacs-eng-readonly
             - osd-cluster-manager
+          <<: *ensureCompilation
 
       - osd-aws-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
@@ -5011,6 +5040,7 @@ workflows:
           context:
             - quay-rhacs-eng-readonly
             - osd-cluster-manager
+          <<: *ensureCompilation
 
       - osd-gcp-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx

--- a/roxctl/central/cert/cert.go
+++ b/roxctl/central/cert/cert.go
@@ -42,6 +42,8 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		}),
 	}
 
+	This is bad code
+
 	cbr.Flags().StringVar(&centralCertCommand.filename, "output", "-", "Filename to output PEM certificate to; '-' for stdout")
 	flags.AddTimeout(cbr)
 	return cbr


### PR DESCRIPTION
## Description

This should help prevent clusters unnecessarily being spun up by getting to the compilation step, but also still running in parallel with image build which changes much less frequently

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
