### PR TITLE
Dashrews/rox-10085 postgres backup capability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,7 +385,10 @@ restoreDB: &restoreDB
   run:
     name: Restore DB
     command: |
-      roxctl -e "${API_ENDPOINT}" -p "${ROX_PASSWORD}" central db restore `ls -t central-backup/stackrox_db_* |head -n1`
+      # TODO ROX-10087 figure out how to make it work for rocks and postgres
+      if [ -z "${ROX_POSTGRES_DATASTORE}" ] || [ "${ROX_POSTGRES_DATASTORE}" = false ]; then
+        roxctl -e "${API_ENDPOINT}" -p "${ROX_PASSWORD}" central db restore `ls -t central-backup/stackrox_db_* |head -n1`
+      fi
 
 getPrometheusMetricParser: &getPrometheusMetricParser
   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,7 @@ restoreDB: &restoreDB
     name: Restore DB
     command: |
       # TODO ROX-10087 figure out how to make it work for rocks and postgres
-      if [ -z "${ROX_POSTGRES_DATASTORE}" ] || [ "${ROX_POSTGRES_DATASTORE}" = false ]; then
+      if [ -z "${ROX_POSTGRES_DATASTORE}" ] || [ "${ROX_POSTGRES_DATASTORE}" == "false" ]; then
         roxctl -e "${API_ENDPOINT}" -p "${ROX_PASSWORD}" central db restore `ls -t central-backup/stackrox_db_* |head -n1`
       fi
 

--- a/central/globaldb/v2backuprestore/backup/generators/dbs/common.go
+++ b/central/globaldb/v2backuprestore/backup/generators/dbs/common.go
@@ -1,0 +1,48 @@
+package dbs
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/globaldb"
+	"github.com/stackrox/rox/pkg/fsutils"
+)
+
+const (
+	// marginOfSafety is how much more free space we want available then the current DB space used before we perform a
+	// backup.
+	marginOfSafety = 0.5
+)
+
+func findTmpPath(dbSize int64, tmpLocation string) (string, error) {
+	requiredBytes := float64(dbSize) * (1.0 + marginOfSafety)
+
+	// Check tmp for space to produce a backup.
+	tmpDir, err := os.MkdirTemp("", tmpLocation)
+	if err != nil {
+		return "", err
+	}
+	tmpBytesAvailable, err := fsutils.AvailableBytesIn(tmpDir)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to calculates size of %s", tmpDir)
+	}
+	if float64(tmpBytesAvailable) > requiredBytes {
+		return tmpDir, nil
+	}
+
+	// If there isn't enough space there, try using PVC to create it.
+	pvcDir, err := os.MkdirTemp(globaldb.PVCPath, tmpLocation)
+	if err != nil {
+		return "", err
+	}
+	pvcBytesAvailable, err := fsutils.AvailableBytesIn(pvcDir)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to calculates size of %s", pvcDir)
+	}
+	if float64(pvcBytesAvailable) > requiredBytes {
+		return pvcDir, nil
+	}
+
+	// If neither had enough space, return an error.
+	return "", errors.Errorf("required %f bytes of space, found %f bytes in %s and %f bytes on PVC, cannot backup", requiredBytes, float64(tmpBytesAvailable), os.TempDir(), float64(pvcBytesAvailable))
+}

--- a/central/globaldb/v2backuprestore/backup/generators/dbs/postgres.go
+++ b/central/globaldb/v2backuprestore/backup/generators/dbs/postgres.go
@@ -80,6 +80,8 @@ func (bu *PostgresBackup) WriteDirectory(ctx context.Context) (string, error) {
 		"-Fd",
 		"-f",
 		backupPath,
+		"-j",
+		"5",
 	}
 
 	cmd := exec.Command("pg_dump", options...)

--- a/central/globaldb/v2backuprestore/backup/generators/dbs/postgres.go
+++ b/central/globaldb/v2backuprestore/backup/generators/dbs/postgres.go
@@ -1,0 +1,159 @@
+package dbs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/globaldb"
+	"github.com/stackrox/rox/pkg/config"
+	"github.com/stackrox/rox/pkg/fsutils"
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+const (
+	dumpTmpPath    = "pg_backup"
+	dbPasswordFile = "/run/secrets/stackrox.io/db-password/password"
+
+	sizeBufferMargin = 0.5
+)
+
+var (
+	log = logging.LoggerForModule()
+)
+
+// NewPostgresBackup returns a generator for Postgres backups.
+// We take in the connection to connect to the DB
+func NewPostgresBackup(db *pgxpool.Pool) *PostgresBackup {
+	return &PostgresBackup{
+		db: db,
+	}
+}
+
+// PostgresBackup is an implementation of a postgres connection pool
+type PostgresBackup struct {
+	db *pgxpool.Pool
+}
+
+// getPostgresSize Method to calculate size
+func (bu *PostgresBackup) getPostgresSize(ctx context.Context) (int64, error) {
+	row := bu.db.QueryRow(ctx, "SELECT pg_database_size('postgres')")
+	var count int64
+	if err := row.Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// WriteDirectory writes a backup of RocksDB to the input path.
+func (bu *PostgresBackup) WriteDirectory(ctx context.Context) (string, error) {
+	centralConfig := config.GetConfig()
+	password, err := os.ReadFile(dbPasswordFile)
+	if err != nil {
+		log.Fatalf("pgsql: could not load password file %q: %v", dbPasswordFile, err)
+		return "", err
+	}
+	source := fmt.Sprintf("%s password=%s", centralConfig.CentralDB.Source, password)
+	log.Infof("SHREWS -- %s", source)
+
+	config, err := pgxpool.ParseConfig(source)
+	if err != nil {
+		log.Fatalf("Could not parse postgres config: %v", err)
+		return "", err
+	}
+
+	backupPath, err := bu.findScratchPath(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	log.Infof("SHREWS -- backup path -- %s", backupPath)
+
+	// Set the options for pg_dump from the connection config
+	options := []string{
+		"-U",
+		config.ConnConfig.User,
+		"-h",
+		config.ConnConfig.Host,
+		"-p",
+		strconv.FormatUint(uint64(config.ConnConfig.Port), 10),
+		"-d",
+		config.ConnConfig.Database,
+		"-Fd",
+		"-f",
+		backupPath,
+	}
+
+	cmd := exec.Command("/usr/bin/pg_dump", options...)
+	cmd.Env = os.Environ()
+
+	// TODO:  Try to parse source to set these.
+	// Setup the environment variables specific to the command
+	cmd.Env = append(cmd.Env, "PGSSLMODE=verify-full")
+	cmd.Env = append(cmd.Env, "PGSSLROOTCERT=/run/secrets/stackrox.io/certs/ca.pem")
+	//pwEnv := "PGPASSWORD=" + fmt.Sprintf("%s", pw)
+	pwEnv := "PGPASSWORD=" + fmt.Sprintf("%s", config.ConnConfig.Password)
+	cmd.Env = append(cmd.Env, pwEnv)
+
+	log.Info(cmd.String())
+	log.Info(cmd.Env)
+
+	// Direct the command stdout to the destination io.Writer
+	//cmd.Stdout = out
+
+	// Run the command
+	cmd.Start()
+	err = cmd.Wait()
+
+	if exitError, ok := err.(*exec.ExitError); ok {
+		log.Info(err)
+		log.Info(exitError)
+		return "", err
+	}
+
+	log.Infof("SHREWS -- Config => %s", config)
+	log.Info("Performed Dump")
+	return backupPath, nil
+}
+
+func (bu *PostgresBackup) findScratchPath(ctx context.Context) (string, error) {
+	dbSize, err := bu.getPostgresSize(ctx)
+	log.Infof("SHREWS => %d", dbSize)
+	if err != nil {
+		return "", err
+	}
+	requiredBytes := float64(dbSize) * (1.0 + sizeBufferMargin)
+
+	// Check tmp for space to produce a backup.
+	tmpDir, err := os.MkdirTemp("", dumpTmpPath)
+	if err != nil {
+		return "", err
+	}
+	tmpBytesAvailable, err := fsutils.AvailableBytesIn(tmpDir)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to calculates size of %s", tmpDir)
+	}
+	if float64(tmpBytesAvailable) > requiredBytes {
+		return tmpDir, nil
+	}
+
+	// If there isn't enough space there, try using PVC to create it.
+	pvcDir, err := os.MkdirTemp(globaldb.PVCPath, dumpTmpPath)
+	if err != nil {
+		return "", err
+	}
+	pvcBytesAvailable, err := fsutils.AvailableBytesIn(pvcDir)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to calculates size of %s", pvcDir)
+	}
+	if float64(pvcBytesAvailable) > requiredBytes {
+		return pvcDir, nil
+	}
+
+	// If neither had enough space, return an error.
+	return "", errors.Errorf("required %f bytes of space, found %f bytes in %s and %f bytes on PVC, cannot backup", requiredBytes, float64(tmpBytesAvailable), os.TempDir(), float64(pvcBytesAvailable))
+}

--- a/central/globaldb/v2backuprestore/backup/generators/dbs/postgres.go
+++ b/central/globaldb/v2backuprestore/backup/generators/dbs/postgres.go
@@ -96,7 +96,10 @@ func (bu *PostgresBackup) WriteDirectory(ctx context.Context) (string, error) {
 	cmd.Env = append(cmd.Env, fmt.Sprintf("PGPASSWORD=%s", config.ConnConfig.Password))
 
 	// Run the command
-	cmd.Start()
+	err = cmd.Start()
+	if err != nil {
+		return "", err
+	}
 	err = cmd.Wait()
 
 	if exitError, ok := err.(*exec.ExitError); ok {

--- a/central/globaldb/v2backuprestore/backup/generators/dbs/rocks.go
+++ b/central/globaldb/v2backuprestore/backup/generators/dbs/rocks.go
@@ -2,13 +2,10 @@ package dbs
 
 import (
 	"context"
-	"os"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/option"
 	"github.com/stackrox/rox/pkg/fileutils"
-	"github.com/stackrox/rox/pkg/fsutils"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/rocksdb/metrics"
 	"github.com/tecbot/gorocksdb"
@@ -17,10 +14,6 @@ import (
 const (
 	tmpPath = "rocksdb"
 )
-
-// marginOfSafety is how much more free space we want available then the current DB space used before we perform a
-// backup.
-var marginOfSafety = 0.5
 
 // NewRocksBackup returns a generator for RocksDB backups.
 // We take in the path that holds the DB as well so that we can estimate the db's size with statfs_t.
@@ -67,36 +60,8 @@ func findScratchPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	requiredBytes := float64(dbSize) * (1.0 + marginOfSafety)
 
-	// Check tmp for space to produce a backup.
-	tmpDir, err := os.MkdirTemp("", tmpPath)
-	if err != nil {
-		return "", err
-	}
-	tmpBytesAvailable, err := fsutils.AvailableBytesIn(tmpDir)
-	if err != nil {
-		return "", errors.Wrapf(err, "unable to calculates size of %s", tmpDir)
-	}
-	if float64(tmpBytesAvailable) > requiredBytes {
-		return tmpDir, nil
-	}
-
-	// If there isn't enough space there, try using PVC to create it.
-	pvcDir, err := os.MkdirTemp(globaldb.PVCPath, tmpPath)
-	if err != nil {
-		return "", err
-	}
-	pvcBytesAvailable, err := fsutils.AvailableBytesIn(pvcDir)
-	if err != nil {
-		return "", errors.Wrapf(err, "unable to calculates size of %s", pvcDir)
-	}
-	if float64(pvcBytesAvailable) > requiredBytes {
-		return pvcDir, nil
-	}
-
-	// If neither had enough space, return an error.
-	return "", errors.Errorf("required %f bytes of space, found %f bytes in %s and %f bytes on PVC, cannot backup", requiredBytes, float64(tmpBytesAvailable), os.TempDir(), float64(pvcBytesAvailable))
+	return findTmpPath(dbSize, tmpPath)
 }
 
 // Get the number of bytes used by files stored for the db.

--- a/central/main.go
+++ b/central/main.go
@@ -567,18 +567,6 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 			Compression:   true,
 		},
 		{
-			Route:         "/db/backup",
-			Authorizer:    dbAuthz.DBReadAccessAuthorizer(),
-			ServerHandler: globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), globaldb.GetPostgres(), false),
-			Compression:   true,
-		},
-		{
-			Route:         "/api/extensions/backup",
-			Authorizer:    user.WithRole(role.Admin),
-			ServerHandler: globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), globaldb.GetPostgres(), true),
-			Compression:   true,
-		},
-		{
 			Route:         "/db/restore",
 			Authorizer:    dbAuthz.DBWriteAccessAuthorizer(),
 			ServerHandler: globaldbHandlers.RestoreDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB()),
@@ -647,6 +635,34 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 			ServerHandler: logimbueHandler.Singleton(),
 			Compression:   false,
 		},
+	}
+
+	if features.PostgresDatastore.Enabled() {
+		customRoutes = append(customRoutes, routes.CustomRoute{
+			Route:         "/db/backup",
+			Authorizer:    dbAuthz.DBReadAccessAuthorizer(),
+			ServerHandler: globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), globaldb.GetPostgres(), false),
+			Compression:   true,
+		})
+		customRoutes = append(customRoutes, routes.CustomRoute{
+			Route:         "/api/extensions/backup",
+			Authorizer:    user.WithRole(role.Admin),
+			ServerHandler: globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), globaldb.GetPostgres(), true),
+			Compression:   true,
+		})
+	} else {
+		customRoutes = append(customRoutes, routes.CustomRoute{
+			Route:         "/db/backup",
+			Authorizer:    dbAuthz.DBReadAccessAuthorizer(),
+			ServerHandler: globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, false),
+			Compression:   true,
+		})
+		customRoutes = append(customRoutes, routes.CustomRoute{
+			Route:         "/api/extensions/backup",
+			Authorizer:    user.WithRole(role.Admin),
+			ServerHandler: globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, true),
+			Compression:   true,
+		})
 	}
 
 	customRoutes = append(customRoutes, routes.CustomRoute{

--- a/central/main.go
+++ b/central/main.go
@@ -569,13 +569,13 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 		{
 			Route:         "/db/backup",
 			Authorizer:    dbAuthz.DBReadAccessAuthorizer(),
-			ServerHandler: globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), false),
+			ServerHandler: globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), globaldb.GetPostgres(), false),
 			Compression:   true,
 		},
 		{
 			Route:         "/api/extensions/backup",
 			Authorizer:    user.WithRole(role.Admin),
-			ServerHandler: globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), true),
+			ServerHandler: globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), globaldb.GetPostgres(), true),
 			Compression:   true,
 		},
 		{

--- a/image/rhel/Dockerfile.envsubst
+++ b/image/rhel/Dockerfile.envsubst
@@ -35,6 +35,8 @@ COPY --from=extracted_bundle /bundle/THIRD_PARTY_NOTICES/ /THIRD_PARTY_NOTICES/
 COPY --from=extracted_bundle /bundle/ui/ /ui/
 COPY --from=extracted_bundle /bundle/usr/local/bin/ldb /usr/local/bin/
 COPY --from=extracted_bundle /bundle/snappy.rpm /tmp/
+COPY --from=extracted_bundle /bundle/postgres-libs.rpm /tmp/
+COPY --from=extracted_bundle /bundle/postgres.rpm /tmp/
 COPY --from=extracted_bundle /bundle/go/ /go/
 
 RUN ln -s entrypoint-wrapper.sh /stackrox/admission-control && \
@@ -45,9 +47,11 @@ RUN ln -s entrypoint-wrapper.sh /stackrox/admission-control && \
     rpm --import RPM-GPG-KEY-CentOS-Official && \
     microdnf upgrade && \
     rpm -i /tmp/snappy.rpm && \
+    rpm -i --nodeps /tmp/postgres-libs.rpm && \
+    rpm -i --nodeps /tmp/postgres.rpm && \
     microdnf install lz4 bzip2 util-linux && \
     microdnf clean all && \
-    rm /tmp/snappy.rpm RPM-GPG-KEY-CentOS-Official && \
+    rm /tmp/snappy.rpm /tmp/postgres.rpm /tmp/postgres-libs.rpm RPM-GPG-KEY-CentOS-Official && \
     # (Optional) Remove line below to keep package management utilities
     rpm -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum && \

--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -114,6 +114,26 @@ rpm_suffix="el8.x86_64.rpm"
 
 curl -s -f -o "${bundle_root}/snappy.rpm" "${rpm_base_url}/snappy-1.1.8-3.${rpm_suffix}"
 
+# Install Postgres Client so central can initiate backups/restores
+# Get postgres RPMs directly
+postgres_major="14"
+pg_rhel_version="8.5"
+postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_version}-x86_64"
+#postgres_repo_url="https://ftp.postgresql.org/pub/repos/yum/14/redhat/rhel-8-x86_64/"
+#postgres_rpm_suffix="rhel8.x86_64.rpm"
+#postgres_major="14"
+postgres_minor="14.2-1PGDG.rhel8.x86_64"
+
+#curl -s -f -o "${bundle_root}/postgresql14-libs.rpm" "${postgres_repo_url}/postgresql14-libs-14.2-1PGDG.${postgres_rpm_suffix}"
+#curl -s -f -o "${bundle_root}/postgresql14.rpm" "${postgres_repo_url}/postgresql14-contrib-14.2-1PGDG.${postgres_rpm_suffix}"
+echo "${postgres_url}/postgresql${postgres_major}-${postgres_minor}.rpm"
+echo "${postgres_url}/postgresql${postgres_major}-libs-${postgres_minor}.rpm"
+
+curl -sS --fail -o "${bundle_root}/postgres.rpm" \
+    "${postgres_url}/postgresql${postgres_major}-${postgres_minor}.rpm"
+curl -sS --fail -o "${bundle_root}/postgres-libs.rpm" \
+    "${postgres_url}/postgresql${postgres_major}-libs-${postgres_minor}.rpm"
+
 # =============================================================================
 
 # Files should have owner/group equal to root:root

--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -119,15 +119,7 @@ curl -s -f -o "${bundle_root}/snappy.rpm" "${rpm_base_url}/snappy-1.1.8-3.${rpm_
 postgres_major="14"
 pg_rhel_version="8.5"
 postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_version}-x86_64"
-#postgres_repo_url="https://ftp.postgresql.org/pub/repos/yum/14/redhat/rhel-8-x86_64/"
-#postgres_rpm_suffix="rhel8.x86_64.rpm"
-#postgres_major="14"
 postgres_minor="14.2-1PGDG.rhel8.x86_64"
-
-#curl -s -f -o "${bundle_root}/postgresql14-libs.rpm" "${postgres_repo_url}/postgresql14-libs-14.2-1PGDG.${postgres_rpm_suffix}"
-#curl -s -f -o "${bundle_root}/postgresql14.rpm" "${postgres_repo_url}/postgresql14-contrib-14.2-1PGDG.${postgres_rpm_suffix}"
-echo "${postgres_url}/postgresql${postgres_major}-${postgres_minor}.rpm"
-echo "${postgres_url}/postgresql${postgres_major}-libs-${postgres_minor}.rpm"
 
 curl -sS --fail -o "${bundle_root}/postgres.rpm" \
     "${postgres_url}/postgresql${postgres_major}-${postgres_minor}.rpm"

--- a/pkg/backup/backup_bundle.go
+++ b/pkg/backup/backup_bundle.go
@@ -9,6 +9,7 @@ import (
 const (
 	BoltFileName     = "bolt.db"
 	RocksFileName    = "rocks.db"
+	PostgresFileName = "postgres.db.tar"
 	KeysBaseFolder   = "keys"
 	CaKeyPem         = mtls.CAKeyFileName
 	CaCertPem        = mtls.CACertFileName

--- a/scripts/grab-data-from-central.sh
+++ b/scripts/grab-data-from-central.sh
@@ -40,13 +40,16 @@ main() {
 
     roxctl -e "${api_endpoint}" -p "${ROX_PASSWORD}" central backup --output "${dest}"
 
-    if ! [ -x "$(command -v rocksdbdump)" ]; then
-        go install ./tools/rocksdbdump
+    # With Postgres we no longer take RocksDB dumps
+    if [ -z "${ROX_POSTGRES_DATASTORE}" ] || [ "${ROX_POSTGRES_DATASTORE}" = false ]; then
+      if ! [ -x "$(command -v rocksdbdump)" ]; then
+          go install ./tools/rocksdbdump
+      fi
+
+      rocksdbdump -b "${dest}"/*.zip -o "${dest}"
     fi
 
-    rocksdbdump -b "${dest}"/*.zip -o "${dest}"
-
-    # Pull some data not found from rocksdbdump
+    # Pull some data not found from the database
 
     set +e
     curl -s --insecure -u "${ROX_USERNAME}:${ROX_PASSWORD}" "https://${api_endpoint}/v1/imageintegrations" | jq > "${dest}/imageintegrations.json"

--- a/scripts/grab-data-from-central.sh
+++ b/scripts/grab-data-from-central.sh
@@ -41,7 +41,7 @@ main() {
     roxctl -e "${api_endpoint}" -p "${ROX_PASSWORD}" central backup --output "${dest}"
 
     # With Postgres we no longer take RocksDB dumps
-    if [ -z "${ROX_POSTGRES_DATASTORE}" ] || [ "${ROX_POSTGRES_DATASTORE}" = false ]; then
+    if [ -z "${ROX_POSTGRES_DATASTORE}" ] || [ "${ROX_POSTGRES_DATASTORE}" == "false" ]; then
       if ! [ -x "$(command -v rocksdbdump)" ]; then
           go install ./tools/rocksdbdump
       fi


### PR DESCRIPTION
## Description

Added the ability to backup a postgres DB via the existing Backup APIs. These changes creates a Postgres backup by utilizing pg_dump.

Note:  This is take 2 on these changes.  First time I missed hiding a call to globaldb.GetPostgres() behind the feature flag.  That caused all sorts of problems with deployment so those changes had to be reverted.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran roxctl backups to produce the backups files. Visually looked at a few to see how they looked. This also helped me narrow down some of the options like writing it to a tar in compressed format and then exporting it as a zip. Further testing of the backup will be performed when [ROX-10086](https://issues.redhat.com/browse/ROX-10086) is worked which will restore from a backup.
