### PR TITLE
OSCI: handle 524 from definitions.io

### DIFF
--- a/image/fetch-stackrox-data.sh
+++ b/image/fetch-stackrox-data.sh
@@ -4,16 +4,24 @@
 
 set -euo pipefail
 
+wget_with_retries() {
+    wget --tries=5 --retry-on-http-error=524 -O "$1" "$2"
+}
+
+quiet_wget_with_retries() {
+    wget -q --tries=5 --retry-on-http-error=524 -O "$1" "$2"
+}
+
 fetch_stackrox_data() {
     mkdir -p /stackrox-data/cve/istio
-    wget -O /stackrox-data/cve/istio/checksum "https://definitions.stackrox.io/cve/istio/checksum"
-    wget -O /stackrox-data/cve/istio/cve-list.json "https://definitions.stackrox.io/cve/istio/cve-list.json"
+    wget_with_retries /stackrox-data/cve/istio/checksum "https://definitions.stackrox.io/cve/istio/checksum"
+    wget_with_retries /stackrox-data/cve/istio/cve-list.json "https://definitions.stackrox.io/cve/istio/cve-list.json"
 
     mkdir -p /tmp/external-networks
     local latest_prefix
-    latest_prefix="$(wget -q https://definitions.stackrox.io/external-networks/latest_prefix -O -)"
-    wget -O /tmp/external-networks/checksum "https://definitions.stackrox.io/${latest_prefix}/checksum"
-    wget -O /tmp/external-networks/networks "https://definitions.stackrox.io/${latest_prefix}/networks"
+    latest_prefix="$(quiet_wget_with_retries - https://definitions.stackrox.io/external-networks/latest_prefix)"
+    wget_with_retries /tmp/external-networks/checksum "https://definitions.stackrox.io/${latest_prefix}/checksum"
+    wget_with_retries /tmp/external-networks/networks "https://definitions.stackrox.io/${latest_prefix}/networks"
     test -s /tmp/external-networks/checksum
     test -s /tmp/external-networks/networks
     mkdir /stackrox-data/external-networks

--- a/image/fetch-stackrox-data.sh
+++ b/image/fetch-stackrox-data.sh
@@ -2,7 +2,7 @@
 
 # Fetches data used by the stackrox:main image
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/image/fetch-stackrox-data.sh
+++ b/image/fetch-stackrox-data.sh
@@ -2,14 +2,17 @@
 
 # Fetches data used by the stackrox:main image
 
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+source "$ROOT/scripts/ci/lib.sh"
+
 set -euo pipefail
 
 wget_with_retries() {
-    wget --tries=5 --retry-on-http-error=524 -O "$1" "$2"
+    retry 5 true wget -O "$1" "$2"
 }
 
 quiet_wget_with_retries() {
-    wget -q --tries=5 --retry-on-http-error=524 -O "$1" "$2"
+    retry 5 true wget -q -O "$1" "$2"
 }
 
 fetch_stackrox_data() {


### PR DESCRIPTION
## Description

A 524 error from definitions.stackrox.io has shown up in at least 1 instance of the build: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/1560/pull-ci-stackrox-stackrox-master-images/1530295040247599104

This PR tries to mitigate that.

## Checklist
- [x] Investigated and inspected CI test results


## Testing Performed

CI is sufficient
