### PR TITLE
OSCI: Use build_root for an external base image

### DIFF
--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -1,1 +1,13 @@
+# Changes to this file are not validated automatically by CI. That is because
+# the CI as defined in openshift/release runs against HEAD and uses the version
+# of this file found there.
+
+# In order to validate a change to this file i.e. a new version of the test environment:
+# - make the change on a stackrox/stackrox PR (do not use / in the branch name as it is not supported in openshift/release)
+# - open a PR in openshift/release (this is just for test. mark the PR with `/hold` and `/uncc` autoassigned reviewers to reduce noise)
+# - duplicate the main branch CI workflow to a workflow that tests the stackrox/stackrox PR branch
+# - run openshift/release automation to generate the prow config
+# - `make update` and commit the results
+# - run `/test pj-rehearse-max` on the openshift/release PR to validate the change
+
 FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.35

--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -1,0 +1,1 @@
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.35

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -728,27 +728,6 @@ openshift_ci_mods() {
         export OPENSHIFT_CI_NAMESPACE="$NAMESPACE"
         unset NAMESPACE
     fi
-
-    # Prow tests PRs rebased against master. This is a pain during migration
-    # because Circle CI does not and so images built in Circle CI have different
-    # tags.
-    local pr_details
-    local exitstatus=0
-    pr_details="${2:-$(get_pr_details)}" || exitstatus="$?"
-    if [[ "$exitstatus" == "0" && "$(jq -r .base.repo.full_name <<<"$pr_details")" == "stackrox/stackrox" ]]; then
-        info "Switching to the PR branch"
-
-        # Clone the target repo
-        cd ..
-        mv stackrox stackrox-osci
-        git clone https://github.com/stackrox/stackrox.git
-        cd stackrox
-
-        # Checkout the PR branch
-        head_ref="$(jq -r '.head.ref' <<<"$pr_details")"
-        info "Checking out a matching PR branch using: $head_ref"
-        git checkout "$head_ref"
-    fi
 }
 
 validate_expected_go_version() {

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -728,6 +728,27 @@ openshift_ci_mods() {
         export OPENSHIFT_CI_NAMESPACE="$NAMESPACE"
         unset NAMESPACE
     fi
+
+    # Prow tests PRs rebased against master. This is a pain during migration
+    # because Circle CI does not and so images built in Circle CI have different
+    # tags.
+    local pr_details
+    local exitstatus=0
+    pr_details="${2:-$(get_pr_details)}" || exitstatus="$?"
+    if [[ "$exitstatus" == "0" && "$(jq -r .base.repo.full_name <<<"$pr_details")" == "stackrox/stackrox" ]]; then
+        info "Switching to the PR branch"
+
+        # Clone the target repo
+        cd ..
+        mv stackrox stackrox-osci
+        git clone https://github.com/stackrox/stackrox.git
+        cd stackrox
+
+        # Checkout the PR branch
+        head_ref="$(jq -r '.head.ref' <<<"$pr_details")"
+        info "Checking out a matching PR branch using: $head_ref"
+        git checkout "$head_ref"
+    fi
 }
 
 validate_expected_go_version() {


### PR DESCRIPTION
## Description

A saner way to manage rox-ci-image dependency from openshift CI. The companion PR in openshift/release is https://github.com/openshift/release/pull/28986.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient - https://prow.ci.openshift.org/pr-history/?org=openshift&repo=release&pr=28986