### PR TITLE
Remove `clean-image` from `all-builds` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -505,13 +505,13 @@ generate-junit-reports: $(GO_JUNIT_REPORT_BIN)
 image: main-image
 
 .PHONY: all-builds
-all-builds: cli main-build clean-image $(MERGED_API_SWAGGER_SPEC) ui-build
+all-builds: cli main-build $(MERGED_API_SWAGGER_SPEC) ui-build
 
 .PHONY: main-image
 main-image: all-builds
 	make docker-build-main-image
 
-$(CURDIR)/image/rhel/bundle.tar.gz:
+$(CURDIR)/image/rhel/bundle.tar.gz: image/rhel/create-bundle.sh
 	/usr/bin/env DEBUG_BUILD="$(DEBUG_BUILD)" $(CURDIR)/image/rhel/create-bundle.sh $(CURDIR)/image stackrox-data:$(TAG) $(BUILD_IMAGE) $(CURDIR)/image/rhel
 
 .PHONY: $(CURDIR)/image/rhel/Dockerfile.gen
@@ -618,7 +618,7 @@ mock-grpc-server-image: mock-grpc-server-build clean-image
 		-t quay.io/rhacs-eng/grpc-server:$(TAG) \
 		integration-tests/mock-grpc-server/image
 
-$(CURDIR)/image/postgres/bundle.tar.gz:
+$(CURDIR)/image/postgres/bundle.tar.gz: image/postgres/create-bundle.sh
 	/usr/bin/env DEBUG_BUILD="$(DEBUG_BUILD)" $(CURDIR)/image/postgres/create-bundle.sh $(CURDIR)/image/postgres $(CURDIR)/image/postgres
 
 .PHONY: $(CURDIR)/image/postgres/Dockerfile.gen

--- a/Makefile
+++ b/Makefile
@@ -511,7 +511,9 @@ all-builds: cli main-build $(MERGED_API_SWAGGER_SPEC) ui-build
 main-image: all-builds
 	make docker-build-main-image
 
-$(CURDIR)/image/rhel/bundle.tar.gz: image/rhel/create-bundle.sh
+# Exclude ephemeral files in dependencies.
+IMAGE_RHEL_FILES = $(shell find $(CURDIR)/image/rhel/ -type f ! -name "bundle.tar.gz*" ! -name "Dockerfile.gen")
+$(CURDIR)/image/rhel/bundle.tar.gz: $(IMAGE_RHEL_FILES)
 	/usr/bin/env DEBUG_BUILD="$(DEBUG_BUILD)" $(CURDIR)/image/rhel/create-bundle.sh $(CURDIR)/image stackrox-data:$(TAG) $(BUILD_IMAGE) $(CURDIR)/image/rhel
 
 .PHONY: $(CURDIR)/image/rhel/Dockerfile.gen
@@ -618,7 +620,9 @@ mock-grpc-server-image: mock-grpc-server-build clean-image
 		-t quay.io/rhacs-eng/grpc-server:$(TAG) \
 		integration-tests/mock-grpc-server/image
 
-$(CURDIR)/image/postgres/bundle.tar.gz: image/postgres/create-bundle.sh
+# Exclude ephemeral files in dependencies.
+IMAGE_POSTGRES_FILES = $(shell find $(CURDIR)/image/postgres/ -type f ! -name "bundle.tar.gz*" ! -name "Dockerfile.gen")
+$(CURDIR)/image/postgres/bundle.tar.gz: $(IMAGE_POSTGRES_FILES)
 	/usr/bin/env DEBUG_BUILD="$(DEBUG_BUILD)" $(CURDIR)/image/postgres/create-bundle.sh $(CURDIR)/image/postgres $(CURDIR)/image/postgres
 
 .PHONY: $(CURDIR)/image/postgres/Dockerfile.gen


### PR DESCRIPTION
Currently the `clean-image` target is called on every invocation of `make image`. This causes a rebuild of the rhel and postgres bundles, which delays `make image` execution. To my understanding, the bundles do not require frequent rebuilding.

In the future we could look to remove the bundles altogether to make the build process more efficient and benefit more from Docker caching layers. However, dropping `clean-image` already speeds up `make image` by ~1-2 minutes on my machine.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
