### PR TITLE
Improve duration of image signature verification tests.

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -1,4 +1,6 @@
+import static Services.checkForNoViolations
 import static Services.waitForViolation
+
 import groups.BAT
 import groups.Integration
 import io.stackrox.proto.storage.PolicyOuterClass
@@ -206,7 +208,11 @@ w9e2Azq1OYIh/pbeBMHARDrBaqqmuMR9+BfAaPAYdkNTU6f58M2zBbuL0A==
     def "Check violations of policy '#policyName' for deployment '#deployment.name'"() {
         expect:
         "Verify deployment has expected violations"
-        assert waitForViolation(deployment.name, policyName, WAIT_FOR_VIOLATION_TIMEOUT) == expectViolations
+        if (expectViolations) {
+            assert waitForViolation(deployment.name, policyName, WAIT_FOR_VIOLATION_TIMEOUT) == expectViolations
+        } else {
+            assert checkForNoViolations(deployment.name, policyName)
+        }
 
         where:
         policyName                                 | deployment                   | expectViolations

--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -9,7 +9,6 @@ import io.stackrox.proto.storage.ScopeOuterClass
 import io.stackrox.proto.storage.SignatureIntegrationOuterClass.CosignPublicKeyVerification
 import io.stackrox.proto.storage.SignatureIntegrationOuterClass.SignatureIntegration
 import objects.Deployment
-import orchestratormanager.OrchestratorTypes
 import org.junit.experimental.categories.Category
 import services.PolicyService
 import services.SignatureIntegrationService
@@ -21,9 +20,6 @@ import util.Env
 // Do not run tests on crio due to an issue with crio trying to pull images referenced by digest from gcr.io.
 @IgnoreIf({ Env.CI_JOBNAME.contains("crio") })
 class ImageSignatureVerificationTest extends BaseSpecification {
-    // https://issues.redhat.com/browse/ROX-6891
-    static final private Integer WAIT_FOR_VIOLATION_TIMEOUT =
-            isRaceBuild() ? 450 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 100 : 30)
 
     static final private String SIGNATURE_TESTING_NAMESPACE = "qa-signature-tests"
 
@@ -209,9 +205,9 @@ w9e2Azq1OYIh/pbeBMHARDrBaqqmuMR9+BfAaPAYdkNTU6f58M2zBbuL0A==
         expect:
         "Verify deployment has expected violations"
         if (expectViolations) {
-            assert waitForViolation(deployment.name, policyName, WAIT_FOR_VIOLATION_TIMEOUT) == expectViolations
+            assert waitForViolation(deployment.name, policyName, 15) == expectViolations
         } else {
-            assert checkForNoViolations(deployment.name, policyName)
+            assert checkForNoViolations(deployment.name, policyName, 15)
         }
 
         where:

--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -205,7 +205,7 @@ w9e2Azq1OYIh/pbeBMHARDrBaqqmuMR9+BfAaPAYdkNTU6f58M2zBbuL0A==
         expect:
         "Verify deployment has expected violations"
         if (expectViolations) {
-            assert waitForViolation(deployment.name, policyName, 15) == expectViolations
+            assert waitForViolation(deployment.name, policyName, 5)
         } else {
             assert checkForNoViolations(deployment.name, policyName, 15)
         }


### PR DESCRIPTION
## Description

Currently, ImageSignatureVerification tests within `race-condition-tests` take up to 47 minutes.
Although reprocessing takes a bit longer within the race build, this is not expected.

The test itself will deploy four deployments with four different image, three images will have a signature associated with them. Four policies will be created to test the alert creation based on the different images and their respective signature.
The exact number of violations will not be tested, but rather whether there are violations or not.

When looking at the test output, the following can be seen:
```
ImageSignatureVerificationTest > Check violations of policy 'Distroless+Tekton' for deployment 'with-signature-verified-by-distroless' STANDARD_OUT
    07:54:07 | INFO  | ImageSignatureVerificationTest | Starting testcase
    08:01:43 | INFO  | Services                  | Failed to trigger Distroless+Tekton after waiting 456 seconds
    08:01:43 | INFO  | ImageSignatureVerificationTest | Ending testcase
```

When no violations are expected, we _still_ wait the full amount of time. This has been changed now to increase the speed, as there are multiple cases where no violations are expected (to be exact: 6). This would lead to an overhead of `6 x 456 seconds = 2736 seconds = 45.7 minutes`. This would explain the long duration of those tests within the `race-condition-tests`, since for `race-condition-tests` the timeout is conditionally increased:
```groovy
    static final private Integer WAIT_FOR_VIOLATION_TIMEOUT =
            isRaceBuild() ? 450 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 100 : 30)
```

It would also explain why in the `gke-api-e2e-tests` / `openshift-4-tests` this overhead wasn't as painfully obvious as it was for race condition tests.

I've added a simple check to use `checkForNoViolations` in case no violations are expected.

## Testing Performed
- ImageSignatureVerificationTests should take significantly less time within `race-condition-tests` (the test should at most take 5-8 mins).

