### PR TITLE
Fred/rox 11155 add resync sensor options

### DIFF
--- a/sensor/kubernetes/listener/listener.go
+++ b/sensor/kubernetes/listener/listener.go
@@ -2,6 +2,7 @@ package listener
 
 import (
 	"context"
+	"time"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -25,7 +26,7 @@ type SensorEventListener interface {
 }
 
 // New returns a new kubernetes listener.
-func New(client client.Interface, configHandler config.Handler, detector detector.Detector, nodeName string) common.SensorComponent {
+func New(client client.Interface, configHandler config.Handler, detector detector.Detector, nodeName string, resyncPeriod time.Duration) common.SensorComponent {
 	k := &listenerImpl{
 		client:             client,
 		eventsC:            make(chan *central.MsgFromSensor, 10),
@@ -33,6 +34,7 @@ func New(client client.Interface, configHandler config.Handler, detector detecto
 		configHandler:      configHandler,
 		detector:           detector,
 		credentialsManager: createCredentialsManager(client, nodeName),
+		resyncPeriod:       resyncPeriod,
 	}
 	return k
 }

--- a/sensor/kubernetes/listener/listener_impl.go
+++ b/sensor/kubernetes/listener/listener_impl.go
@@ -16,7 +16,6 @@ const (
 	// See https://groups.google.com/forum/#!topic/kubernetes-sig-api-machinery/PbSCXdLDno0
 	// Kubernetes scheduler no longer uses a resync period and it seems like its usage doesn't apply to us
 	noResyncPeriod              = 0
-	resyncingPeriod             = 1 * time.Minute
 	clusterOperatorResourceName = "clusteroperators"
 	clusterOperatorGroupVersion = "config.openshift.io/v1"
 )
@@ -28,6 +27,7 @@ type listenerImpl struct {
 	credentialsManager awscredentials.RegistryCredentialsManager
 	configHandler      config.Handler
 	detector           detector.Detector
+	resyncPeriod       time.Duration
 }
 
 func (k *listenerImpl) Start() error {

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -23,17 +23,17 @@ import (
 
 func (k *listenerImpl) handleAllEvents() {
 	sif := informers.NewSharedInformerFactory(k.client.Kubernetes(), noResyncPeriod)
-	resyncingSif := informers.NewSharedInformerFactory(k.client.Kubernetes(), resyncingPeriod)
+	resyncingSif := informers.NewSharedInformerFactory(k.client.Kubernetes(), k.resyncPeriod)
 
 	// Create informer factories for needed orchestrators.
 	var osAppsFactory osAppsExtVersions.SharedInformerFactory
 	if k.client.OpenshiftApps() != nil {
-		osAppsFactory = osAppsExtVersions.NewSharedInformerFactory(k.client.OpenshiftApps(), resyncingPeriod)
+		osAppsFactory = osAppsExtVersions.NewSharedInformerFactory(k.client.OpenshiftApps(), k.resyncPeriod)
 	}
 
 	var osRouteFactory osRouteExtVersions.SharedInformerFactory
 	if k.client.OpenshiftRoute() != nil {
-		osRouteFactory = osRouteExtVersions.NewSharedInformerFactory(k.client.OpenshiftRoute(), resyncingPeriod)
+		osRouteFactory = osRouteExtVersions.NewSharedInformerFactory(k.client.OpenshiftRoute(), k.resyncPeriod)
 	}
 
 	// We want creates to be treated as updates while existing objects are loaded.

--- a/sensor/kubernetes/main.go
+++ b/sensor/kubernetes/main.go
@@ -51,7 +51,9 @@ func main() {
 		utils.CrashOnError(errors.Wrapf(err, "sensor failed to start while initializing gRPC client to endpoint %s", env.CentralEndpoint.Setting()))
 	}
 
-	s, err := sensor.CreateSensor(sharedClientInterface, workloadManager, centralConnFactory, false)
+	s, err := sensor.CreateSensor(sharedClientInterface, sensor.ConfigWithDefaults().
+		WithCentralConnectionFactory(centralConnFactory).
+		WithWorkloadManager(workloadManager))
 	utils.CrashOnError(err)
 
 	s.Start()

--- a/sensor/kubernetes/sensor/options.go
+++ b/sensor/kubernetes/sensor/options.go
@@ -1,0 +1,61 @@
+package sensor
+
+import (
+	"time"
+
+	"github.com/stackrox/rox/sensor/common/centralclient"
+	"github.com/stackrox/rox/sensor/kubernetes/fake"
+)
+
+// CreateOptions represents the custom configuration that can be provided when creating sensor
+// using CreateSensor.
+type CreateOptions struct {
+	workloadManager    *fake.WorkloadManager
+	centralConnFactory centralclient.CentralConnectionFactory
+	localSensor        bool
+	resyncPeriod       time.Duration
+}
+
+// ConfigWithDefaults creates a new config object with default properties.
+// CentralConnectionFactory is set to nil because the current constructor
+// requires an environment variable, and it starts an HTTP connection.
+// In order to add a default connection factory here, first the real
+// implementation should be refactored to not start an HTTP connection
+// before running CreateSensor.
+func ConfigWithDefaults() *CreateOptions {
+	return &CreateOptions{
+		workloadManager:    nil,
+		centralConnFactory: nil,
+		localSensor:        false,
+		resyncPeriod:       1 * time.Minute,
+	}
+}
+
+// WithWorkloadManager sets workload manager.
+// Default: nil
+func (cfg *CreateOptions) WithWorkloadManager(manager *fake.WorkloadManager) *CreateOptions {
+	cfg.workloadManager = manager
+	return cfg
+}
+
+// WithCentralConnectionFactory sets central connection factory.
+// Default: nil
+func (cfg *CreateOptions) WithCentralConnectionFactory(centralConnFactory centralclient.CentralConnectionFactory) *CreateOptions {
+	cfg.centralConnFactory = centralConnFactory
+	return cfg
+}
+
+// WithLocalSensor sets if sensor is running locally (local sensor or in tests) or if it's running
+// on a cluster.
+// Default: false
+func (cfg *CreateOptions) WithLocalSensor(flag bool) *CreateOptions {
+	cfg.localSensor = flag
+	return cfg
+}
+
+// WithResyncPeriod sets the resync period.
+// Default: 1 minute
+func (cfg *CreateOptions) WithResyncPeriod(duration time.Duration) *CreateOptions {
+	cfg.resyncPeriod = duration
+	return cfg
+}

--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -118,7 +118,9 @@ func main() {
 	defer shutdownFakeServer()
 	fakeConnectionFactory := centralDebug.MakeFakeConnectionFactory(conn)
 
-	s, err := sensor.CreateSensor(fakeClient, nil, fakeConnectionFactory, true)
+	s, err := sensor.CreateSensor(fakeClient, sensor.ConfigWithDefaults().
+		WithCentralConnectionFactory(fakeConnectionFactory).
+		WithLocalSensor(true))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Description

- Extracts `CreateSensor` parameters into a new options property called `CreateOptions`. 
- Adds a new create option for sensor `resyncPeriod` together with `-resync` flag for `local-sensor`.

Configuring resync period allows us two things:
1. Create tests that use a variable resync period, making them faster if the tests requires to test resync specific behavior. (i.e. it's better to wait 1 second than 1 minute to test resync behavior). 
2. Gracefully shutdown resync without removing the code that controls it. If resync is set to `0`, the informer is created without resync. This enables us to either have a higher resync period or set it to `0` with an env variable without removing the code entirely on the first iteration. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))


## Testing Performed

- Run local sensor with `-resync 1s` parameter to get events resynced every minute. 
