### PR TITLE
Dashrews/ROX-11143 optimize timing in flaky process baseline test for nightly tests

### DIFF
--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -240,7 +240,6 @@ func (m *managerImpl) buildMapAndCheckBaseline(indicatorSlice []*storage.Process
 }
 
 func (m *managerImpl) checkAndUpdateBaseline(baselineKey processBaselineKey, indicators []*storage.ProcessIndicator) (bool, error) {
-
 	key := &storage.ProcessBaselineKey{
 		DeploymentId:  baselineKey.deploymentID,
 		ContainerName: baselineKey.containerName,

--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -183,14 +183,7 @@ func (m *managerImpl) flushIndicatorQueue() {
 	// Map copiedQueue to slice
 	indicatorSlice := make([]*storage.ProcessIndicator, 0, len(copiedQueue))
 	for _, indicator := range copiedQueue {
-		if indicator.ContainerName == "pb-deploymentnginx-violation-resolve" {
-			log.Info("SHREWS -- we have the pb-deploymentnginx-violation-resolve add indicator")
-			log.Infof("SHREWS -- %s", indicator.Signal.Name)
-		}
 		if deleted, _ := m.deletedDeploymentsCache.Get(indicator.GetDeploymentId()).(bool); deleted {
-			if indicator.ContainerName == "pb-deploymentnginx-violation-resolve" {
-				log.Info("SHREWS -- we have the pb-deploymentnginx-violation-resolve but the deployment is deletd already")
-			}
 			continue
 		}
 		indicatorSlice = append(indicatorSlice, indicator)
@@ -235,10 +228,6 @@ func (m *managerImpl) buildMapAndCheckBaseline(indicatorSlice []*storage.Process
 	// Group the processes into particular baseline segments
 	baselineMap := make(map[processBaselineKey][]*storage.ProcessIndicator)
 	for _, indicator := range indicatorSlice {
-		if indicator.ContainerName == "pb-deploymentnginx-violation-resolve" {
-			log.Info("SHREWS -- we have the pb-deploymentnginx-violation-resolve -- adding it to the map to check for")
-			log.Infof("SHREWS -- %s", indicator.Signal.Name)
-		}
 		key := indicatorToBaselineKey(indicator)
 		baselineMap[key] = append(baselineMap[key], indicator)
 	}
@@ -251,10 +240,6 @@ func (m *managerImpl) buildMapAndCheckBaseline(indicatorSlice []*storage.Process
 }
 
 func (m *managerImpl) checkAndUpdateBaseline(baselineKey processBaselineKey, indicators []*storage.ProcessIndicator) (bool, error) {
-
-	if baselineKey.containerName == "pb-deploymentnginx-violation-resolve" {
-		log.Info("SHREWS -- baseline key for pb-deploymentnginx-violation-resolve")
-	}
 
 	key := &storage.ProcessBaselineKey{
 		DeploymentId:  baselineKey.deploymentID,
@@ -272,19 +257,12 @@ func (m *managerImpl) checkAndUpdateBaseline(baselineKey processBaselineKey, ind
 	// If the baseline does not exist AND this deployment is in the observation period, we
 	// need not process further at this time.
 	if !exists && m.deploymentObservationQueue.InObservation(key.GetDeploymentId()) {
-		if baselineKey.containerName == "pb-deploymentnginx-violation-resolve" {
-			log.Info("SHREWS -- baseline key for pb-deploymentnginx-violation-resolve BUT it either does not exist or in observation")
-		}
 		return false, nil
 	}
 
 	existingProcess := set.NewStringSet()
 	for _, element := range baseline.GetElements() {
 		existingProcess.Add(element.GetElement().GetProcessName())
-		if baselineKey.containerName == "pb-deploymentnginx-violation-resolve" {
-			log.Info("SHREWS -- baseline key for pb-deploymentnginx-violation-resolve existing")
-			log.Infof("SHREWS -- %s", element.GetElement().GetProcessName())
-		}
 	}
 
 	var elements []*storage.BaselineItem
@@ -295,10 +273,6 @@ func (m *managerImpl) checkAndUpdateBaseline(baselineKey processBaselineKey, ind
 		}
 		baselineItem := processBaselinePkg.BaselineItemFromProcess(indicator)
 		if !existingProcess.Add(baselineItem) {
-			if baselineKey.containerName == "pb-deploymentnginx-violation-resolve" {
-				log.Info("SHREWS -- baseline key for pb-deploymentnginx-violation-resolve could not add to existing process list")
-				log.Infof("SHREWS -- %s", baselineItem)
-			}
 			continue
 		}
 		insertableElement := &storage.BaselineItem{Item: &storage.BaselineItem_ProcessName{ProcessName: baselineItem}}
@@ -315,17 +289,9 @@ func (m *managerImpl) checkAndUpdateBaseline(baselineKey processBaselineKey, ind
 	userBaseline := processbaseline.IsUserLocked(baseline)
 	roxBaseline := processbaseline.IsRoxLocked(baseline) && hasNonStartupProcess
 	if userBaseline || roxBaseline {
-		if baselineKey.containerName == "pb-deploymentnginx-violation-resolve" {
-			log.Info("SHREWS -- baseline key for pb-deploymentnginx-violation-resolve reprocess risks")
-			log.Infof("SHREWS -- %s", baseline)
-		}
 		// We already checked if it's in the baseline and it is not, so reprocess risk to mark the results are suspicious if necessary
 		m.reprocessor.ReprocessRiskForDeployments(baselineKey.deploymentID)
 	} else {
-		if baselineKey.containerName == "pb-deploymentnginx-violation-resolve" {
-			log.Info("SHREWS -- baseline key for pb-deploymentnginx-violation-resolve add to baseline")
-			log.Infof("SHREWS -- %s", baseline)
-		}
 		// So we have a baseline, but not locked.  Now we need to add these elements to the unlocked baseline
 		_, err = m.baselines.UpdateProcessBaselineElements(lifecycleMgrCtx, key, elements, nil, true)
 	}

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -221,6 +221,7 @@ class ProcessBaselinesTest extends BaseSpecification {
         ProcessBaselineOuterClass.ProcessBaseline baseline = ProcessBaselineService.
                  getProcessBaseline(clusterId, deployment, containerName)
         assert (baseline != null)
+        log.info "Baseline Before locking: ${baseline}"
         assert ((baseline.key.deploymentId.equalsIgnoreCase(deploymentId)) &&
                  (baseline.key.containerName.equalsIgnoreCase(containerName)))
         assert baseline.elementsList.find { it.element.processName == processName } != null
@@ -228,11 +229,12 @@ class ProcessBaselinesTest extends BaseSpecification {
         List<ProcessBaselineOuterClass.ProcessBaseline> lockProcessBaselines = ProcessBaselineService.
                  lockProcessBaselines(clusterId, deployment, containerName, true)
         assert (!StringUtils.isEmpty(lockProcessBaselines.get(0).getElements(0).getElement().processName))
-        // sleep 30 seconds to allow for propagation to sensor
-        sleep 30000
+        log.info "Locked Process Baseline before pwd: ${lockProcessBaselines}"
+        // sleep 5 seconds to allow for propagation to sensor
+        sleep 5000
         orchestrator.execInContainer(deployment, "pwd")
 
-        log.info "Locked Process Baseline: ${lockProcessBaselines}"
+        log.info "Locked Process Baseline after pwd: ${lockProcessBaselines}"
 
         // Give the reprocessing some time.
         sleep 30000

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -229,8 +229,7 @@ class ProcessBaselinesTest extends BaseSpecification {
             }
             return tmpBaseline
         }
-//         ProcessBaselineOuterClass.ProcessBaseline baseline = ProcessBaselineService.
-//                  getProcessBaseline(clusterId, deployment, containerName)
+
         assert (baseline != null)
         log.info "Baseline Before locking: ${baseline}"
         assert ((baseline.key.deploymentId.equalsIgnoreCase(deploymentId)) &&
@@ -240,7 +239,7 @@ class ProcessBaselinesTest extends BaseSpecification {
         List<ProcessBaselineOuterClass.ProcessBaseline> lockProcessBaselines = ProcessBaselineService.
                  lockProcessBaselines(clusterId, deployment, containerName, true)
         assert (!StringUtils.isEmpty(lockProcessBaselines.get(0).getElements(0).getElement().processName))
-        log.info "Locked Process Baseline before pwd: ${lockProcessBaselines}"
+
         // sleep 5 seconds to allow for propagation to sensor
         sleep 5000
         orchestrator.execInContainer(deployment, "pwd")

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -246,9 +246,6 @@ class ProcessBaselinesTest extends BaseSpecification {
 
         log.info "Locked Process Baseline after pwd: ${lockProcessBaselines}"
 
-        // Give the reprocessing some time.
-//         sleep 30000
-
         // check for process baseline violation
         assert waitForViolation(containerName, "Unauthorized Process Execution", 240)
         List<AlertOuterClass.ListAlert> alertList = AlertService.getViolations(AlertServiceOuterClass.ListAlertsRequest

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -247,7 +247,7 @@ class ProcessBaselinesTest extends BaseSpecification {
         log.info "Locked Process Baseline after pwd: ${lockProcessBaselines}"
 
         // Give the reprocessing some time.
-        sleep 30000
+//         sleep 30000
 
         // check for process baseline violation
         assert waitForViolation(containerName, "Unauthorized Process Execution", 240)


### PR DESCRIPTION
## Description

Looked like a large part of the problem is that in these nightly environments the deployments would sometimes take a while to come up.  The test would continue while the deployment was not necessarily running its containers yet.  So I made an adjustment to wait on a process to show up and be part of the baseline before proceeding.  I've run this successfully all week except for the environments that won't provision.  So I think it is pretty stable.  If not, we can always ignore it and go back to the drawing board.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Set up labels to run the tests for the larger environments that the nightly tests use.  
