### PR TITLE
ROX-9620 [post-merge] Fix unit test build error

### DIFF
--- a/central/alert/datastore/datastore_sac_test.go
+++ b/central/alert/datastore/datastore_sac_test.go
@@ -91,7 +91,7 @@ func (s *alertDatastoreSACTestSuite) SetupSuite() {
 	s.datastore, err = New(s.storage, s.indexer, s.search)
 	s.NoError(err)
 
-	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.Alert.GetResource())
+	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.Alert)
 }
 
 func (s *alertDatastoreSACTestSuite) TearDownSuite() {


### PR DESCRIPTION
## Description

A concurrent merge changed the signature of one function used in the tests, causing unit test build to fail.
This change fixes the faulty caller code

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI run is enough
