### PR TITLE
Clean testutils dependencies to be used as imports in other projects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/cenkalti/backoff/v3 v3.2.2
 	github.com/ckaznocha/protoc-gen-lint v0.2.4
 	github.com/cloudflare/cfssl v1.6.1
-	github.com/commander-cli/cmd v1.3.0
 	github.com/containers/image/v5 v5.20.0
 	github.com/coreos/go-oidc/v3 v3.2.0
 	github.com/coreos/go-systemd/v22 v22.3.2

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/cenkalti/backoff/v3 v3.2.2
 	github.com/ckaznocha/protoc-gen-lint v0.2.4
 	github.com/cloudflare/cfssl v1.6.1
+	github.com/commander-cli/cmd v1.3.0
 	github.com/containers/image/v5 v5.20.0
 	github.com/coreos/go-oidc/v3 v3.2.0
 	github.com/coreos/go-systemd/v22 v22.3.2

--- a/go.sum
+++ b/go.sum
@@ -627,6 +627,8 @@ github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u9
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
+github.com/commander-cli/cmd v1.3.0 h1:9h3OKDKgTXGx+m9ulSjMgE5zmiXtDHMlIe7Nwt/NZPI=
+github.com/commander-cli/cmd v1.3.0/go.mod h1:0cuDhCU4dmkhdAp1AFMKeQhes11x0f2+5DJhw/QQnFs=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
 github.com/connorgorman/protobuf v1.2.2-0.20210115205927-b892c1b298f7 h1:YsgEuC8PhmdxkjGb3/l4inKcwVKuPXp1YELVPZkIByA=
 github.com/connorgorman/protobuf v1.2.2-0.20210115205927-b892c1b298f7/go.mod h1:4n/qquk+A505mqkK9+o7Xth9+UxUWFc4/5faDXkYyyU=

--- a/go.sum
+++ b/go.sum
@@ -627,8 +627,6 @@ github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u9
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/commander-cli/cmd v1.3.0 h1:9h3OKDKgTXGx+m9ulSjMgE5zmiXtDHMlIe7Nwt/NZPI=
-github.com/commander-cli/cmd v1.3.0/go.mod h1:0cuDhCU4dmkhdAp1AFMKeQhes11x0f2+5DJhw/QQnFs=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
 github.com/connorgorman/protobuf v1.2.2-0.20210115205927-b892c1b298f7 h1:YsgEuC8PhmdxkjGb3/l4inKcwVKuPXp1YELVPZkIByA=
 github.com/connorgorman/protobuf v1.2.2-0.20210115205927-b892c1b298f7/go.mod h1:4n/qquk+A505mqkK9+o7Xth9+UxUWFc4/5faDXkYyyU=

--- a/pkg/testutils/proto/time.go
+++ b/pkg/testutils/proto/time.go
@@ -1,4 +1,4 @@
-package testutils
+package proto
 
 import (
 	"testing"

--- a/tests/active_vuln_test.go
+++ b/tests/active_vuln_test.go
@@ -9,7 +9,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/retry"
 	"github.com/stackrox/rox/pkg/sync"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -219,7 +219,7 @@ func getImageActiveStates(t *testing.T, imageID, deploymentID string) Components
 
 func waitForImageScanned(t *testing.T) {
 	once.Do(func() {
-		conn := testutils.GRPCConnectionToCentral(t)
+		conn := centralgrpc.GRPCConnectionToCentral(t)
 		imageService := v1.NewImageServiceClient(conn)
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 		defer cancel()

--- a/tests/admctrl_configmap_test.go
+++ b/tests/admctrl_configmap_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/gziputil"
 	"github.com/stackrox/rox/pkg/namespaces"
 	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +46,7 @@ func TestAdmissionControllerConfigMap(t *testing.T) {
 	var config storage.DynamicClusterConfig
 	require.NoError(t, proto.Unmarshal(configData, &config), "could not unmarshal config")
 
-	cc := testutils.GRPCConnectionToCentral(t)
+	cc := centralgrpc.GRPCConnectionToCentral(t)
 
 	policyServiceClient := v1.NewPolicyServiceClient(cc)
 	newPolicy := &storage.Policy{

--- a/tests/api_kernel_support_available_test.go
+++ b/tests/api_kernel_support_available_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +16,7 @@ func TestKernelSupportAvailableApi(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 
 	service := v1.NewClustersServiceClient(conn)
 	resp, err := service.GetKernelSupportAvailable(ctx, &v1.Empty{})

--- a/tests/api_test.go
+++ b/tests/api_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +16,7 @@ func TestPing(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 
 	service := v1.NewPingServiceClient(conn)
 	_, err := service.Ping(ctx, &v1.Empty{})

--- a/tests/backup_test.go
+++ b/tests/backup_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/backup"
 	"github.com/stackrox/rox/pkg/migrations"
 	"github.com/stackrox/rox/pkg/tar"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,7 +40,7 @@ func doTestBackup(t *testing.T, includeCerts bool) {
 	out, err := os.Create(zipFilePath)
 	require.NoError(t, err)
 
-	client := testutils.HTTPClientForCentral(t)
+	client := centralgrpc.HTTPClientForCentral(t)
 	endpoint := "/db/backup"
 	if includeCerts {
 		endpoint = "/api/extensions/backup"

--- a/tests/ca_setup_test.go
+++ b/tests/ca_setup_test.go
@@ -7,7 +7,7 @@ import (
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -27,7 +27,7 @@ func centralIsReleaseBuild(conn *grpc.ClientConn, t *testing.T) bool {
 func TestCASetup(t *testing.T) {
 	t.Parallel()
 
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := central.NewDevelopmentServiceClient(conn)
 
 	isReleaseBuild := centralIsReleaseBuild(conn, t)

--- a/tests/cert_test.go
+++ b/tests/cert_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/pkg/mtls"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,7 +21,7 @@ func TestInternalCert(t *testing.T) {
 		ServerName:         "central.stackrox",
 	}
 
-	conn, err := tls.Dial("tcp", testutils.RoxAPIEndpoint(t), tlsConf)
+	conn, err := tls.Dial("tcp", centralgrpc.RoxAPIEndpoint(t), tlsConf)
 	require.NoError(t, err)
 	defer utils.IgnoreError(conn.Close)
 
@@ -54,7 +54,7 @@ func TestCustomCert(t *testing.T) {
 		RootCAs:            trustPool,
 	}
 
-	conn, err := tls.Dial("tcp", testutils.RoxAPIEndpoint(t), tlsConf)
+	conn, err := tls.Dial("tcp", centralgrpc.RoxAPIEndpoint(t), tlsConf)
 	require.NoError(t, err)
 	defer utils.IgnoreError(conn.Close)
 

--- a/tests/client_ca_test.go
+++ b/tests/client_ca_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authn/tokenbased"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/sliceutils"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -69,7 +69,7 @@ func generateCert(t *testing.T, parent *x509.Certificate, signer crypto.Signer, 
 }
 
 func getTokenForUserPKIAuthProvider(t *testing.T, authProviderID string, tlsConf *tls.Config) string {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s/sso/providers/userpki/%s/authenticate", testutils.RoxAPIEndpoint(t), authProviderID), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s/sso/providers/userpki/%s/authenticate", centralgrpc.RoxAPIEndpoint(t), authProviderID), nil)
 	require.NoError(t, err)
 
 	httpClient := &http.Client{
@@ -112,7 +112,7 @@ func getAuthStatus(t *testing.T, tlsConf *tls.Config, token string) (*v1.AuthSta
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	conn, err := clientconn.DialTLS(ctx, testutils.RoxAPIEndpoint(t), tlsConf, opts...)
+	conn, err := clientconn.DialTLS(ctx, centralgrpc.RoxAPIEndpoint(t), tlsConf, opts...)
 	require.NoError(t, err)
 	client := v1.NewAuthServiceClient(conn)
 	return client.GetAuthStatus(ctx, &v1.Empty{})
@@ -154,7 +154,7 @@ func TestClientCAAuthWithMultipleVerifiedChains(t *testing.T) {
 			},
 		},
 	}
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	authService := v1.NewAuthProviderServiceClient(conn)
 	groupService := v1.NewGroupServiceClient(conn)
 
@@ -222,7 +222,7 @@ func TestClientCARequested(t *testing.T) {
 		},
 	}
 
-	conn, err := tls.Dial("tcp", testutils.RoxAPIEndpoint(t), tlsConf)
+	conn, err := tls.Dial("tcp", centralgrpc.RoxAPIEndpoint(t), tlsConf)
 	require.NoError(t, err, "could not connect to central")
 	_ = conn.Handshake()
 	_ = conn.Close()

--- a/tests/cluster_delete_test.go
+++ b/tests/cluster_delete_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,7 +52,7 @@ func getSummaryCounts(t *testing.T) summaryCountsResp {
 
 func getAllCounts(t *testing.T) allCounts {
 	summaryCounts := getSummaryCounts(t)
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	podSvc := v1.NewPodServiceClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -75,7 +75,7 @@ func TestClusterDeletion(t *testing.T) {
 	assert.NotZero(t, counts.PodCount)
 	log.Infof("the initial counts are: %+v", counts)
 
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewClustersServiceClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	getClustersResp, err := service.GetClusters(ctx, &v1.GetClustersRequest{})

--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -32,7 +33,7 @@ var (
 
 //lint:ignore U1000 Ignore unused code check since this function could be useful in future.
 func assumeFeatureFlagHasValue(t *testing.T, featureFlag features.FeatureFlag, assumedValue bool) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	featureService := v1.NewFeatureFlagServiceClient(conn)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -72,7 +73,7 @@ func retrieveDeployments(service v1.DeploymentServiceClient, deps []*storage.Lis
 }
 
 func waitForDeployment(t testutils.T, deploymentName string) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 
 	service := v1.NewDeploymentServiceClient(conn)
 
@@ -118,7 +119,7 @@ func waitForDeployment(t testutils.T, deploymentName string) {
 }
 
 func waitForTermination(t testutils.T, deploymentName string) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 
 	service := v1.NewDeploymentServiceClient(conn)
 
@@ -184,7 +185,7 @@ func setImage(t *testing.T, deploymentName string, deploymentID string, containe
 	cmd := exec.Command(`kubectl`, `set`, `image`, fmt.Sprintf("deployment/%s", deploymentName), fmt.Sprintf("%s=%s", containerName, image))
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewDeploymentServiceClient(conn)
 
 	waitForCondition(t, func() bool {

--- a/tests/compliance_operator_test.go
+++ b/tests/compliance_operator_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/complianceoperator"
 	"github.com/stackrox/rox/pkg/retry"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,7 +44,7 @@ var (
 )
 
 func getCurrentComplianceResults(t *testing.T) (rhcos, ocp *storage.ComplianceRunResults) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	managementService := v1.NewComplianceManagementServiceClient(conn)
 
 	resp, err := managementService.TriggerRuns(context.Background(), &v1.TriggerComplianceRunsRequest{

--- a/tests/csv_utils.go
+++ b/tests/csv_utils.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,7 @@ func verifyRiskEventTimelineCSV(t testutils.T, deploymentID string, eventNamesEx
 	escapedURL := fmt.Sprintf("%s?%s", baseURL, params.Encode())
 
 	// Get an HTTP client and query for csv content response
-	client := testutils.HTTPClientForCentral(t)
+	client := centralgrpc.HTTPClientForCentral(t)
 	resp, err := client.Get(escapedURL)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)

--- a/tests/excluded_scopes_test.go
+++ b/tests/excluded_scopes_test.go
@@ -10,7 +10,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/search"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,7 +44,7 @@ func waitForAlert(t *testing.T, service v1.AlertServiceClient, req *v1.ListAlert
 }
 
 func verifyNoAlertForExcludedScopes(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 
 	service := v1.NewPolicyServiceClient(conn)
 
@@ -83,7 +83,7 @@ func verifyNoAlertForExcludedScopes(t *testing.T) {
 }
 
 func verifyAlertForExcludedScopesRemoval(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 
 	service := v1.NewPolicyServiceClient(conn)
 

--- a/tests/external_backup_test.go
+++ b/tests/external_backup_test.go
@@ -14,7 +14,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/retry"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/iterator"
@@ -55,7 +55,7 @@ func TestGCSExternalBackup(t *testing.T) {
 	client, err := googleStorage.NewClient(context.Background(), option.WithCredentialsJSON([]byte(serviceAccount)))
 	require.NoError(t, err)
 
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewExternalBackupServiceClient(conn)
 
 	externalBackup := &storage.ExternalBackup{

--- a/tests/feature_flag_test.go
+++ b/tests/feature_flag_test.go
@@ -7,7 +7,7 @@ import (
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/features"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +18,7 @@ func TestFeatureFlagSettings(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 
 	metadataService := v1.NewMetadataServiceClient(conn)
 	metadata, err := metadataService.GetMetadata(ctx, &v1.Empty{})

--- a/tests/graphql_utils.go
+++ b/tests/graphql_utils.go
@@ -7,6 +7,7 @@ import (
 	"github.com/machinebox/graphql"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +20,7 @@ var (
 
 func makeGraphQLRequest(t testutils.T, query string, vars map[string]interface{}, resp interface{}, timeout time.Duration) {
 	graphQLOnce.Do(func() {
-		graphqlClient = graphql.NewClient("/api/graphql", graphql.WithHTTPClient(testutils.HTTPClientForCentral(t)))
+		graphqlClient = graphql.NewClient("/api/graphql", graphql.WithHTTPClient(centralgrpc.HTTPClientForCentral(t)))
 		require.NotNil(t, graphqlClient)
 	})
 

--- a/tests/http_to_https_test.go
+++ b/tests/http_to_https_test.go
@@ -4,13 +4,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/require"
 )
 
 // Ensure HTTP/1.x requests to central's HTTPS endpoint result in `400`.
 func TestHttpToHttps(t *testing.T) {
-	url := "http://" + testutils.RoxAPIEndpoint(t)
+	url := "http://" + centralgrpc.RoxAPIEndpoint(t)
 
 	resp, err := http.Get(url)
 	require.NoError(t, err)

--- a/tests/metadata_test.go
+++ b/tests/metadata_test.go
@@ -8,7 +8,7 @@ import (
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/buildinfo"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stackrox/rox/pkg/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,13 +32,13 @@ func TestMetadataIsSetCorrectly(t *testing.T) {
 		return
 	}
 
-	metadataWithAuth := getMetadata(t, testutils.GRPCConnectionToCentral(t))
+	metadataWithAuth := getMetadata(t, centralgrpc.GRPCConnectionToCentral(t))
 	assert.Equal(t, buildinfo.BuildFlavor, metadataWithAuth.GetBuildFlavor())
 	assert.Equal(t, buildinfo.ReleaseBuild, metadataWithAuth.GetReleaseBuild())
 	assert.Equal(t, version.GetMainVersion(), metadataWithAuth.GetVersion())
 
 	// Test that an unauthenticated connection doesn't get the version.
-	metadataWithoutAuth := getMetadata(t, testutils.UnauthenticatedGRPCConnectionToCentral(t))
+	metadataWithoutAuth := getMetadata(t, centralgrpc.UnauthenticatedGRPCConnectionToCentral(t))
 	assert.Equal(t, buildinfo.BuildFlavor, metadataWithoutAuth.GetBuildFlavor())
 	assert.Equal(t, buildinfo.ReleaseBuild, metadataWithoutAuth.GetReleaseBuild())
 	assert.Equal(t, "", metadataWithoutAuth.GetVersion())

--- a/tests/networkflows_test.go
+++ b/tests/networkflows_test.go
@@ -9,7 +9,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,7 +26,7 @@ func hasEdges(graph *v1.NetworkGraph) bool {
 func TestStackroxNetworkFlows(t *testing.T) {
 	t.Parallel()
 
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 
 	clustersService := v1.NewClustersServiceClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -114,7 +115,7 @@ func CheckIfCentralHasFeatureFlag(t *testing.T, conn *grpc.ClientConn) bool {
 }
 
 func Test_GetViolationForIngressPolicy(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	if buildinfo.ReleaseBuild || !CheckIfCentralHasFeatureFlag(t, conn) {
 		t.Skip("Feature flag disabled")
 	}

--- a/tests/options_test.go
+++ b/tests/options_test.go
@@ -8,7 +8,7 @@ import (
 	search "github.com/stackrox/rox/central/search"
 	"github.com/stackrox/rox/central/search/options"
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,7 +16,7 @@ import (
 func TestOptions(t *testing.T) {
 	t.Parallel()
 
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 
 	service := v1.NewSearchServiceClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)

--- a/tests/policy_test.go
+++ b/tests/policy_test.go
@@ -9,7 +9,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/booleanpolicy/fieldnames"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,7 +56,7 @@ func TestPolicyFromSearch(t *testing.T) {
 }
 
 func tearDownImportExportTest(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	var cleanupErrors []error
@@ -228,7 +228,7 @@ func validateExclusionOrScopeOrNotifierRemoved(t *testing.T, importResp *v1.Impo
 }
 
 func verifyExportNonExistentFails(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	mockErrors := []*v1.ExportPolicyError{
@@ -238,7 +238,7 @@ func verifyExportNonExistentFails(t *testing.T) {
 }
 
 func verifyExportExistentSucceeds(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 
 	service := v1.NewPolicyServiceClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
@@ -253,7 +253,7 @@ func verifyExportExistentSucceeds(t *testing.T) {
 }
 
 func verifyMixedExportFails(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 
 	mockErrors := []*v1.ExportPolicyError{
 		makeError(notAnID, "not found"),
@@ -270,7 +270,7 @@ func verifyMixedExportFails(t *testing.T) {
 }
 
 func verifyImportSucceeds(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	policy := exportPolicy(t, service, knownPolicyID)
@@ -288,7 +288,7 @@ func verifyImportSucceeds(t *testing.T) {
 }
 
 func verifyDefaultPolicyDuplicateImportFails(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	policy := exportPolicy(t, service, knownPolicyID)
@@ -304,7 +304,7 @@ func verifyDefaultPolicyDuplicateImportFails(t *testing.T) {
 }
 
 func verifyImportInvalidFails(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	badPolicy := &storage.Policy{
@@ -322,7 +322,7 @@ func verifyImportInvalidFails(t *testing.T) {
 }
 
 func verifyImportDuplicateNameFails(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	policy := exportPolicy(t, service, knownPolicyID)
@@ -340,7 +340,7 @@ func verifyImportDuplicateNameFails(t *testing.T) {
 }
 
 func verifyImportDuplicateIDFails(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	policy := exportPolicy(t, service, knownPolicyID)
@@ -358,7 +358,7 @@ func verifyImportDuplicateIDFails(t *testing.T) {
 }
 
 func verifyImportDuplicateNameAndIDFails(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	policy := exportPolicy(t, service, knownPolicyID)
@@ -376,7 +376,7 @@ func verifyImportDuplicateNameAndIDFails(t *testing.T) {
 }
 
 func verifyImportNoIDSucceeds(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	policy := exportPolicy(t, service, knownPolicyID)
@@ -394,7 +394,7 @@ func verifyImportNoIDSucceeds(t *testing.T) {
 }
 
 func verifyImportMultipleSucceeds(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	validPolicy := exportPolicy(t, service, knownPolicyID)
@@ -418,7 +418,7 @@ func verifyImportMultipleSucceeds(t *testing.T) {
 }
 
 func verifyImportMixedSuccess(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	validPolicy := exportPolicy(t, service, knownPolicyID)
@@ -443,7 +443,7 @@ func verifyImportMixedSuccess(t *testing.T) {
 }
 
 func verifyNotifiersRemoved(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	validPolicy := exportPolicy(t, service, knownPolicyID)
@@ -469,7 +469,7 @@ func verifyNotifiersRemoved(t *testing.T) {
 }
 
 func verifyExclusionsRemoved(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	validPolicy := exportPolicy(t, service, knownPolicyID)
@@ -503,7 +503,7 @@ func verifyExclusionsRemoved(t *testing.T) {
 }
 
 func verifyScopesRemoved(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	validPolicy := exportPolicy(t, service, knownPolicyID)
@@ -533,7 +533,7 @@ func verifyScopesRemoved(t *testing.T) {
 }
 
 func verifyOverwriteNameSucceeds(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	// Create an existing policy so we don't change default policies
@@ -564,7 +564,7 @@ func verifyOverwriteNameSucceeds(t *testing.T) {
 }
 
 func verifyOverwriteIDSucceeds(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	// Create an existing policy so we don't change default policies
@@ -590,7 +590,7 @@ func verifyOverwriteIDSucceeds(t *testing.T) {
 }
 
 func verifyOverwriteNameAndIDSucceeds(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	// Create an existing policy so we don't change default policies
@@ -622,7 +622,7 @@ func verifyOverwriteNameAndIDSucceeds(t *testing.T) {
 }
 
 func verifyConvertSearchToPolicy(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	mockPolicySection := &storage.PolicySection{
@@ -662,7 +662,7 @@ func verifyConvertSearchToPolicy(t *testing.T) {
 }
 
 func verifyConvertInvalidSearchToPolicyFails(t *testing.T) {
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewPolicyServiceClient(conn)
 
 	queryString := "abc:def,not a valid search"

--- a/tests/scan_test.go
+++ b/tests/scan_test.go
@@ -9,7 +9,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/retry"
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,7 +39,7 @@ func TestScan(t *testing.T) {
 	setupDeployment(t, image, deployment)
 	defer teardownDeployment(t, deployment)
 
-	conn := testutils.GRPCConnectionToCentral(t)
+	conn := centralgrpc.GRPCConnectionToCentral(t)
 	imageService := v1.NewImageServiceClient(conn)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)

--- a/tests/versions_test.go
+++ b/tests/versions_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/version"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +15,7 @@ import (
 func TestVersions(t *testing.T) {
 	t.Parallel()
 
-	client := testutils.HTTPClientForCentral(t)
+	client := centralgrpc.HTTPClientForCentral(t)
 
 	resp, err := client.Get("/debug/versions.json")
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

This PR moves some testutils into separate packages to ensure repos using stackrox as a library don't dependent on other libs like grpc.
This allows testutils to be imported by external repos.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

 - CI