### PR TITLE
Integration tests for NetworkPolicy

### DIFF
--- a/central/networkpolicies/datastore/datastore_impl.go
+++ b/central/networkpolicies/datastore/datastore_impl.go
@@ -109,7 +109,12 @@ func (ds *datastoreImpl) UpsertNetworkPolicy(ctx context.Context, np *storage.Ne
 }
 
 func (ds *datastoreImpl) RemoveNetworkPolicy(ctx context.Context, id string) error {
-	np, found, err := ds.getNetworkPolicy(ctx, id)
+	elevatedRemoveCheckCtx := sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.NetworkPolicy),
+		))
+	np, found, err := ds.getNetworkPolicy(elevatedRemoveCheckCtx, id)
 	if err != nil || !found {
 		return err
 	}

--- a/central/networkpolicies/datastore/datastore_impl_test.go
+++ b/central/networkpolicies/datastore/datastore_impl_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"testing"
+	"time"
 
 	timestamp "github.com/gogo/protobuf/types"
 	"github.com/golang/mock/gomock"
@@ -229,6 +230,7 @@ func (s *netPolDataStoreTestSuite) TestAllowUpdateUndoNewer() {
 
 func (s *netPolDataStoreTestSuite) TestDisallowUpdateUndoOlder() {
 	oldTS := timestamp.TimestampNow()
+	time.Sleep(2 * time.Microsecond)
 	newTS := timestamp.TimestampNow()
 	oldCluster := &storage.NetworkPolicyApplicationUndoRecord{ClusterId: FakeClusterID, ApplyTimestamp: newTS}
 	s.undoStorage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(oldCluster, true, nil)

--- a/central/networkpolicies/datastore/datastore_impl_test.go
+++ b/central/networkpolicies/datastore/datastore_impl_test.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"testing"
-	"time"
 
 	timestamp "github.com/gogo/protobuf/types"
 	"github.com/golang/mock/gomock"
@@ -230,8 +229,9 @@ func (s *netPolDataStoreTestSuite) TestAllowUpdateUndoNewer() {
 
 func (s *netPolDataStoreTestSuite) TestDisallowUpdateUndoOlder() {
 	oldTS := timestamp.TimestampNow()
-	time.Sleep(2 * time.Microsecond)
 	newTS := timestamp.TimestampNow()
+	// Ensure the timestamps differ
+	newTS.Nanos += 1000
 	oldCluster := &storage.NetworkPolicyApplicationUndoRecord{ClusterId: FakeClusterID, ApplyTimestamp: newTS}
 	s.undoStorage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(oldCluster, true, nil)
 

--- a/central/networkpolicies/datastore/datastore_sac_test.go
+++ b/central/networkpolicies/datastore/datastore_sac_test.go
@@ -73,7 +73,7 @@ func (s *networkPolicySACSuite) TearDownSuite() {
 	if features.PostgresDatastore.Enabled() {
 		s.pool.Close()
 	} else {
-		s.NoError(s.engine.Close())
+		s.Require().NoError(s.engine.Close())
 	}
 }
 
@@ -88,13 +88,13 @@ func (s *networkPolicySACSuite) TearDownTest() {
 }
 
 func (s *networkPolicySACSuite) deleteNetworkPolicy(id string) {
-	s.NoError(s.datastore.RemoveNetworkPolicy(s.testContexts[testutils.UnrestrictedReadWriteCtx], id))
+	s.Require().NoError(s.datastore.RemoveNetworkPolicy(s.testContexts[testutils.UnrestrictedReadWriteCtx], id))
 }
 
 func (s *networkPolicySACSuite) TestGetNetworkPolicy() {
 	networkPolicy := fixtures.GetScopedNetworkPolicy(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
 	err := s.datastore.UpsertNetworkPolicy(s.testContexts[testutils.UnrestrictedReadWriteCtx], networkPolicy)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.testNetworkPolicyIDs = append(s.testNetworkPolicyIDs, networkPolicy.GetId())
 	cases := map[string]struct {
 		scopeKey string
@@ -154,11 +154,11 @@ func (s *networkPolicySACSuite) TestGetNetworkPolicies() {
 	var err error
 	networkPolicy1 := fixtures.GetScopedNetworkPolicy(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
 	err = s.datastore.UpsertNetworkPolicy(s.testContexts[testutils.UnrestrictedReadWriteCtx], networkPolicy1)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.testNetworkPolicyIDs = append(s.testNetworkPolicyIDs, networkPolicy1.GetId())
 	networkPolicy2 := fixtures.GetScopedNetworkPolicy(uuid.NewV4().String(), testconsts.Cluster3, testconsts.NamespaceB)
 	err = s.datastore.UpsertNetworkPolicy(s.testContexts[testutils.UnrestrictedReadWriteCtx], networkPolicy2)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.testNetworkPolicyIDs = append(s.testNetworkPolicyIDs, networkPolicy2.GetId())
 	cases := map[string]struct {
 		scopeKey      string
@@ -212,11 +212,11 @@ func (s *networkPolicySACSuite) TestCountMatchingNetworkPolicies() {
 	var err error
 	networkPolicy1 := fixtures.GetScopedNetworkPolicy(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
 	err = s.datastore.UpsertNetworkPolicy(s.testContexts[testutils.UnrestrictedReadWriteCtx], networkPolicy1)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.testNetworkPolicyIDs = append(s.testNetworkPolicyIDs, networkPolicy1.GetId())
 	networkPolicy2 := fixtures.GetScopedNetworkPolicy(uuid.NewV4().String(), testconsts.Cluster3, testconsts.NamespaceB)
 	err = s.datastore.UpsertNetworkPolicy(s.testContexts[testutils.UnrestrictedReadWriteCtx], networkPolicy2)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.testNetworkPolicyIDs = append(s.testNetworkPolicyIDs, networkPolicy2.GetId())
 	cases := map[string]struct {
 		scopeKey      string
@@ -369,7 +369,7 @@ func (s *networkPolicySACSuite) TestRemoveNetworkPolicy() {
 			ctx := s.testContexts[c.scopeKey]
 			policy := fixtures.GetScopedNetworkPolicy(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
 			err := s.datastore.UpsertNetworkPolicy(unrestrictedCtx, policy)
-			s.NoError(err)
+			s.Require().NoError(err)
 			deleteErr := s.datastore.RemoveNetworkPolicy(ctx, policy.GetId())
 			defer s.deleteNetworkPolicy(policy.GetId())
 			if c.expectedError {

--- a/central/networkpolicies/datastore/datastore_sac_test.go
+++ b/central/networkpolicies/datastore/datastore_sac_test.go
@@ -1,0 +1,216 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/central/networkpolicies/datastore/internal/store"
+	boltStore "github.com/stackrox/rox/central/networkpolicies/datastore/internal/store/bolt"
+	pgdbStore "github.com/stackrox/rox/central/networkpolicies/datastore/internal/store/postgres"
+	"github.com/stackrox/rox/central/networkpolicies/datastore/internal/undodeploymentstore"
+	undodeploymentstoremock "github.com/stackrox/rox/central/networkpolicies/datastore/internal/undodeploymentstore/mocks"
+	"github.com/stackrox/rox/central/networkpolicies/datastore/internal/undostore"
+	undostoremock "github.com/stackrox/rox/central/networkpolicies/datastore/internal/undostore/mocks"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/bolthelper"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/sac/testutils"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+	bolt "go.etcd.io/bbolt"
+)
+
+func TestNetworkPolicySAC(t *testing.T) {
+	suite.Run(t, new(networkPolicySACSuite))
+}
+
+type networkPolicySACSuite struct {
+	suite.Suite
+
+	datastore DataStore
+
+	pool *pgxpool.Pool
+
+	engine *bolt.DB
+
+	storage             store.Store
+	undoStore           undostore.UndoStore
+	undoDeploymentStore undodeploymentstore.UndoDeploymentStore
+
+	mockCtrl *gomock.Controller
+
+	testContexts         map[string]context.Context
+	testNetworkPolicyIDs []string
+}
+
+func (s *networkPolicySACSuite) SetupSuite() {
+	var err error
+	if features.PostgresDatastore.Enabled() {
+		ctx := context.Background()
+		src := pgtest.GetConnectionString(s.T())
+		cfg, err := pgxpool.ParseConfig(src)
+		s.NoError(err)
+		s.pool, err = pgxpool.ConnectConfig(ctx, cfg)
+		s.NoError(err)
+		pgdbStore.Destroy(ctx, s.pool)
+		s.storage = pgdbStore.New(ctx, s.pool)
+	} else {
+		s.engine, err = bolthelper.NewTemp(s.T().Name() + ".db")
+		s.NoError(err)
+		s.storage = boltStore.New(s.engine)
+	}
+	s.mockCtrl = gomock.NewController(s.T())
+	undomock := undostoremock.NewMockUndoStore(s.mockCtrl)
+	undodeploymentmock := undodeploymentstoremock.NewMockUndoDeploymentStore(s.mockCtrl)
+
+	s.datastore = New(s.storage, undomock, undodeploymentmock)
+
+	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.NetworkPolicy)
+}
+
+func (s *networkPolicySACSuite) TearDownSuite() {
+	if features.PostgresDatastore.Enabled() {
+		s.pool.Close()
+	} else {
+		s.NoError(s.engine.Close())
+	}
+}
+
+func (s *networkPolicySACSuite) SetupTest() {
+	s.testNetworkPolicyIDs = make([]string, 0)
+}
+
+func (s *networkPolicySACSuite) TearDownTest() {
+	for _, id := range s.testNetworkPolicyIDs {
+		s.deleteNetworkPolicy(id)
+	}
+}
+
+func (s *networkPolicySACSuite) deleteNetworkPolicy(id string) {
+	s.NoError(s.datastore.RemoveNetworkPolicy(s.testContexts[testutils.UnrestrictedReadWriteCtx], id))
+}
+
+func (s *networkPolicySACSuite) TestGetNetworkPolicy() {
+	networkPolicy := fixtures.GetScopedNetworkPolicy(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
+	err := s.datastore.UpsertNetworkPolicy(s.testContexts[testutils.UnrestrictedReadWriteCtx], networkPolicy)
+	s.NoError(err)
+	s.testNetworkPolicyIDs = append(s.testNetworkPolicyIDs, networkPolicy.GetId())
+	cases := map[string]struct {
+		scopeKey string
+		found    bool
+	}{
+		"global read-only can get": {
+			scopeKey: testutils.UnrestrictedReadCtx,
+			found:    true,
+		},
+		"global read-write can get": {
+			scopeKey: testutils.UnrestrictedReadWriteCtx,
+			found:    true,
+		},
+		"read-write on wrong cluster cannot get": {
+			scopeKey: testutils.Cluster1ReadWriteCtx,
+		},
+		"read-write on wrong cluster and namespace cannot get": {
+			scopeKey: testutils.Cluster1NamespaceAReadWriteCtx,
+		},
+		"read-write on wrong cluster and matching namespace cannot get": {
+			scopeKey: testutils.Cluster1NamespaceBReadWriteCtx,
+		},
+		"read-write on matching cluster can get": {
+			scopeKey: testutils.Cluster2ReadWriteCtx,
+			found:    true,
+		},
+		"read-write on matching cluster but wrong namespace cannot get": {
+			scopeKey: testutils.Cluster2NamespaceAReadWriteCtx,
+		},
+		"read-write on matching cluster and namespace can get": {
+			scopeKey: testutils.Cluster2NamespaceBReadWriteCtx,
+			found:    true,
+		},
+		"read-write on matching cluster and at least one matching namespace can get": {
+			scopeKey: testutils.Cluster2NamespacesABReadWriteCtx,
+			found:    true,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[c.scopeKey]
+			policy, found, err := s.datastore.GetNetworkPolicy(ctx, networkPolicy.GetId())
+			if c.found {
+				s.True(found)
+				s.NoError(err)
+				s.Equal(networkPolicy, policy)
+			} else {
+				s.False(found)
+				s.NoError(err)
+				s.Nil(policy)
+			}
+		})
+	}
+}
+
+func (s *networkPolicySACSuite) TestGetNetworkPolicies() {
+	var err error
+	networkPolicy1 := fixtures.GetScopedNetworkPolicy(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
+	err = s.datastore.UpsertNetworkPolicy(s.testContexts[testutils.UnrestrictedReadWriteCtx], networkPolicy1)
+	s.NoError(err)
+	s.testNetworkPolicyIDs = append(s.testNetworkPolicyIDs, networkPolicy1.GetId())
+	networkPolicy2 := fixtures.GetScopedNetworkPolicy(uuid.NewV4().String(), testconsts.Cluster3, testconsts.NamespaceB)
+	err = s.datastore.UpsertNetworkPolicy(s.testContexts[testutils.UnrestrictedReadWriteCtx], networkPolicy2)
+	s.NoError(err)
+	s.testNetworkPolicyIDs = append(s.testNetworkPolicyIDs, networkPolicy2.GetId())
+	cases := map[string]struct {
+		scopeKey      string
+		expectedErr   error
+		expectedFound []*storage.NetworkPolicy
+	}{
+		"global read-only can get": {
+			scopeKey:      testutils.UnrestrictedReadCtx,
+			expectedFound: []*storage.NetworkPolicy{networkPolicy1},
+		},
+		"global read-write can get": {
+			scopeKey:      testutils.UnrestrictedReadWriteCtx,
+			expectedFound: []*storage.NetworkPolicy{networkPolicy1},
+		},
+		"read-write on wrong cluster cannot get": {
+			scopeKey: testutils.Cluster1ReadWriteCtx,
+		},
+		"read-write on wrong cluster and namespace cannot get": {
+			scopeKey: testutils.Cluster1NamespaceAReadWriteCtx,
+		},
+		"read-write on wrong cluster and matching namespace cannot get": {
+			scopeKey: testutils.Cluster1NamespaceBReadWriteCtx,
+		},
+		"read-write on matching cluster can get": {
+			scopeKey:      testutils.Cluster2ReadWriteCtx,
+			expectedFound: []*storage.NetworkPolicy{networkPolicy1},
+		},
+		"read-write on matching cluster but wrong namespace cannot get": {
+			scopeKey: testutils.Cluster2NamespaceAReadWriteCtx,
+		},
+		"read-write on matching cluster and namespace can get (partial)": {
+			scopeKey:      testutils.Cluster2NamespaceBReadWriteCtx,
+			expectedFound: []*storage.NetworkPolicy{networkPolicy1},
+		},
+		"read-write on matching cluster and at least one matching namespace can get (partial)": {
+			scopeKey:      testutils.Cluster2NamespacesABReadWriteCtx,
+			expectedFound: []*storage.NetworkPolicy{networkPolicy1},
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[c.scopeKey]
+			policies, err := s.datastore.GetNetworkPolicies(ctx, testconsts.Cluster2, testconsts.NamespaceB)
+			s.ElementsMatch(c.expectedFound, policies)
+			s.ErrorIs(err, c.expectedErr)
+		})
+	}
+}

--- a/central/networkpolicies/datastore/datastore_sac_test.go
+++ b/central/networkpolicies/datastore/datastore_sac_test.go
@@ -54,7 +54,9 @@ func (s *networkPolicySACSuite) SetupSuite() {
 		s.pool, err = pgxpool.ConnectConfig(ctx, cfg)
 		s.Require().NoError(err)
 		pgdbStore.Destroy(ctx, s.pool)
-		s.storage = pgdbStore.New(ctx, s.pool)
+		gormDB := pgtest.OpenGormDB(s.T(), src)
+		defer pgtest.CloseGormDB(s.T(), gormDB)
+		s.storage = pgdbStore.CreateTableAndNewStore(ctx, s.pool, gormDB)
 	} else {
 		s.engine, err = bolthelper.NewTemp(s.T().Name() + ".db")
 		s.Require().NoError(err)

--- a/pkg/fixtures/network_policy.go
+++ b/pkg/fixtures/network_policy.go
@@ -29,12 +29,17 @@ spec:
 
 // GetNetworkPolicy returns a network policy
 func GetNetworkPolicy() *storage.NetworkPolicy {
+	return GetScopedNetworkPolicy("network-policy-id", "cluster-id", "namespace")
+}
+
+// GetScopedNetworkPolicy returns a network policy holding the provided scope information
+func GetScopedNetworkPolicy(id string, clusterID string, namespace string) *storage.NetworkPolicy {
 	return &storage.NetworkPolicy{
-		Id:          "network-policy-id",
+		Id:          id,
 		Name:        "network-policy-name",
-		ClusterId:   "cluster-id",
+		ClusterId:   clusterID,
 		ClusterName: "",
-		Namespace:   "namespace",
+		Namespace:   namespace,
 		Labels:      nil,
 		Annotations: nil,
 		Spec: &storage.NetworkPolicySpec{

--- a/pkg/fixtures/network_policy.go
+++ b/pkg/fixtures/network_policy.go
@@ -4,7 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 )
 
-// GetYAML returns a network policy yaml
+// GetYAML returns a network policy yaml.
 func GetYAML() string {
 	return `kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -27,12 +27,12 @@ spec:
 						role: api`
 }
 
-// GetNetworkPolicy returns a network policy
+// GetNetworkPolicy returns a network policy.
 func GetNetworkPolicy() *storage.NetworkPolicy {
 	return GetScopedNetworkPolicy("network-policy-id", "cluster-id", "namespace")
 }
 
-// GetScopedNetworkPolicy returns a network policy holding the provided scope information
+// GetScopedNetworkPolicy returns a network policy holding the provided scope information.
 func GetScopedNetworkPolicy(id string, clusterID string, namespace string) *storage.NetworkPolicy {
 	return &storage.NetworkPolicy{
 		Id:          id,


### PR DESCRIPTION
## Description

New integration tests for `NetworkPolicy` in order to ensure some level of functional validation for the migration to postgres.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Added CI tests
