### PR TITLE
OSCI: Switch images

### DIFF
--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -21,7 +21,7 @@ class PreSystemTests:
         subprocess.run(
             [
                 "scripts/ci/lib.sh",
-                "poll_for_opensource_images",
+                "poll_for_system_test_images",
                 str(PreSystemTests.POLL_TIMEOUT),
             ],
             check=True,

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -733,27 +733,6 @@ openshift_ci_mods() {
         export OPENSHIFT_CI_NAMESPACE="$NAMESPACE"
         unset NAMESPACE
     fi
-
-    # Prow tests PRs rebased against master. This is a pain during migration
-    # because Circle CI does not and so images built in Circle CI have different
-    # tags.
-    local pr_details
-    local exitstatus=0
-    pr_details="${2:-$(get_pr_details)}" || exitstatus="$?"
-    if [[ "$exitstatus" == "0" && "$(jq -r .base.repo.full_name <<<"$pr_details")" == "stackrox/stackrox" ]]; then
-        info "Switching to the PR branch"
-
-        # Clone the target repo
-        cd ..
-        mv stackrox stackrox-osci
-        git clone https://github.com/stackrox/stackrox.git
-        cd stackrox
-
-        # Checkout the PR branch
-        head_ref="$(jq -r '.head.ref' <<<"$pr_details")"
-        info "Checking out a matching PR branch using: $head_ref"
-        git checkout "$head_ref"
-    fi
 }
 
 validate_expected_go_version() {


### PR DESCRIPTION
## Description

This change will switch prow system tests to use images built in prow rather then circle CI. Additionally, this change polls for `rhacs-eng` images as they are the ones used in test. And the branch switch is removed as prow tests no longer require it to use Circle CI images.

Companion PR in: https://github.com/openshift/release/pull/29033

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient
