### PR TITLE
Fix job test by pinning perl version

### DIFF
--- a/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
@@ -24,7 +24,7 @@ class DeploymentTest extends BaseSpecification {
 
     private static final Job JOB = new Job()
             .setName("test-job-pi")
-            .setImage("perl")
+            .setImage("perl:5.32.1")
             .addLabel("app", "test")
             .setCommand(["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"])
 


### PR DESCRIPTION
## Description

Test using job was failing because perl upgrade was causing job to go to error instead of job going to completed, which is what we are testing

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
