### PR TITLE
Add image sha to vuln management image details page.

### DIFF
--- a/ui/apps/platform/src/Components/Metadata/Metadata.js
+++ b/ui/apps/platform/src/Components/Metadata/Metadata.js
@@ -27,7 +27,7 @@ const Metadata = ({
     const keyValueList = keyValuePairs.map(({ key, value }) => (
         <li className="flex border-b border-base-300 py-3" key={key}>
             <span className="text-base-600 font-700 mr-2">{key}:</span>
-            <span className="flex-grow font-600" data-testid={`${key}-value`}>
+            <span className="flex-grow font-600 min-w-0" data-testid={`${key}-value`}>
                 {value}
             </span>
         </li>

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
@@ -78,6 +78,10 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
 
     const metadataKeyValuePairs = [
         {
+            key: 'SHA',
+            value: safeData.id,
+        },
+        {
             key: 'Created',
             value: (metadata?.v1 && <DateTimeField date={metadata.v1.created} asString />) || '-',
         },


### PR DESCRIPTION
## Description

As described in PR title. For https://issues.redhat.com/browse/ROX-8054

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Test visiting the details page for a specific image in Vuln Management and see that the SHA is present in the UI
![image](https://user-images.githubusercontent.com/1292638/171270909-042e8ed9-b0d4-458a-8c96-de383bd8faae.png)

Test that the SHA is present when visiting an image details page from a different top level entity (e.g. CVEs):
![image](https://user-images.githubusercontent.com/1292638/171271033-ba99ec75-e504-4905-a0cc-e6eadd8fb788.png)

Note that a side effect of this is that the new wrapping behavior in the Metadata.js component will cause long lines for other detail entries to wrap to a new line. The previous behavior is that the text would be cut off for very long single words. See "Vector" in the below screenshots. The first is the behavior in this PR, the second is the old behavior on `master`.
<img src="https://user-images.githubusercontent.com/1292638/171271424-bbd1e8ef-a219-48ab-8561-b574ae2f540a.png" width="300">
<img src="https://user-images.githubusercontent.com/1292638/171271464-b7bc7269-9489-48e0-9507-01f5a68dd6cb.png" width="300">

