### PR TITLE
ROX-10845: Move notifier scrubbing to datastore - port to 3.68

### DIFF
--- a/central/graphql/resolvers/notifiers.go
+++ b/central/graphql/resolvers/notifiers.go
@@ -27,7 +27,7 @@ func (resolver *Resolver) Notifiers(ctx context.Context) ([]*notifierResolver, e
 		return nil, err
 	}
 	return resolver.wrapNotifiers(
-		resolver.NotifierStore.GetNotifiers(ctx, &v1.GetNotifiersRequest{}))
+		resolver.NotifierStore.GetScrubbedNotifiers(ctx, &v1.GetNotifiersRequest{}))
 }
 
 // Notifier gets a single notifier by ID
@@ -37,5 +37,5 @@ func (resolver *Resolver) Notifier(ctx context.Context, args struct{ graphql.ID 
 		return nil, err
 	}
 	return resolver.wrapNotifier(
-		resolver.NotifierStore.GetNotifier(ctx, string(args.ID)))
+		resolver.NotifierStore.GetScrubbedNotifier(ctx, string(args.ID)))
 }

--- a/central/notifier/datastore/datastore.go
+++ b/central/notifier/datastore/datastore.go
@@ -12,7 +12,9 @@ import (
 //go:generate mockgen-wrapper
 type DataStore interface {
 	GetNotifier(ctx context.Context, id string) (*storage.Notifier, bool, error)
+	GetScrubbedNotifier(ctx context.Context, id string) (*storage.Notifier, bool, error)
 	GetNotifiers(ctx context.Context, request *v1.GetNotifiersRequest) ([]*storage.Notifier, error)
+	GetScrubbedNotifiers(ctx context.Context, request *v1.GetNotifiersRequest) ([]*storage.Notifier, error)
 	AddNotifier(ctx context.Context, notifier *storage.Notifier) (string, error)
 	UpdateNotifier(ctx context.Context, notifier *storage.Notifier) error
 	RemoveNotifier(ctx context.Context, id string) error

--- a/central/notifier/datastore/mocks/datastore.go
+++ b/central/notifier/datastore/mocks/datastore.go
@@ -82,6 +82,37 @@ func (mr *MockDataStoreMockRecorder) GetNotifiers(ctx, request interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotifiers", reflect.TypeOf((*MockDataStore)(nil).GetNotifiers), ctx, request)
 }
 
+// GetScrubbedNotifier mocks base method.
+func (m *MockDataStore) GetScrubbedNotifier(ctx context.Context, id string) (*storage.Notifier, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetScrubbedNotifier", ctx, id)
+	ret0, _ := ret[0].(*storage.Notifier)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetScrubbedNotifier indicates an expected call of GetScrubbedNotifier.
+func (mr *MockDataStoreMockRecorder) GetScrubbedNotifier(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScrubbedNotifier", reflect.TypeOf((*MockDataStore)(nil).GetScrubbedNotifier), ctx, id)
+}
+
+// GetScrubbedNotifiers mocks base method.
+func (m *MockDataStore) GetScrubbedNotifiers(ctx context.Context, request *v1.GetNotifiersRequest) ([]*storage.Notifier, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetScrubbedNotifiers", ctx, request)
+	ret0, _ := ret[0].([]*storage.Notifier)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetScrubbedNotifiers indicates an expected call of GetScrubbedNotifiers.
+func (mr *MockDataStoreMockRecorder) GetScrubbedNotifiers(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScrubbedNotifiers", reflect.TypeOf((*MockDataStore)(nil).GetScrubbedNotifiers), ctx, request)
+}
+
 // RemoveNotifier mocks base method.
 func (m *MockDataStore) RemoveNotifier(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()

--- a/central/notifier/service/service_impl.go
+++ b/central/notifier/service/service_impl.go
@@ -76,27 +76,25 @@ func (s *serviceImpl) GetNotifier(ctx context.Context, request *v1.ResourceByID)
 	if request.GetId() == "" {
 		return nil, errors.Wrap(errorhelpers.ErrInvalidArgs, "notifier id must be provided")
 	}
-	notifier, exists, err := s.storage.GetNotifier(ctx, request.GetId())
+	notifier, exists, err := s.storage.GetScrubbedNotifier(ctx, request.GetId())
 	if err != nil {
 		return nil, err
 	}
 	if !exists {
 		return nil, errors.Wrapf(errorhelpers.ErrNotFound, "notifier %v not found", request.GetId())
 	}
-	secrets.ScrubSecretsFromStructWithReplacement(notifier, secrets.ScrubReplacementStr)
+
 	return notifier, nil
 }
 
 // GetNotifiers retrieves all notifiers that match the request filters
 func (s *serviceImpl) GetNotifiers(ctx context.Context, request *v1.GetNotifiersRequest) (*v1.GetNotifiersResponse, error) {
-	notifiers, err := s.storage.GetNotifiers(ctx, request)
+	scrubbedNotifiers, err := s.storage.GetScrubbedNotifiers(ctx, request)
 	if err != nil {
 		return nil, err
 	}
-	for _, n := range notifiers {
-		secrets.ScrubSecretsFromStructWithReplacement(n, secrets.ScrubReplacementStr)
-	}
-	return &v1.GetNotifiersResponse{Notifiers: notifiers}, nil
+
+	return &v1.GetNotifiersResponse{Notifiers: scrubbedNotifiers}, nil
 }
 
 func validateNotifier(notifier *storage.Notifier) error {


### PR DESCRIPTION
## Description

Porting changes from master.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~


## Testing Performed

1. Login into UI as `admin`
2. Create a `test` PagerDuty notifier
3. Get Bearer token from Browser
```
export TOKEN='<my-bearer-token>'
```
5. Run the `curl` command to get data over REST API
```
curl --request GET --insecure --url https://localhost:8000/v1/notifiers --header "Authorization: Bearer ${TOKEN}" --silent --output -
```
6. Run the `curl` command to get data over GraphQL
```
curl --request POST --insecure --url https://localhost:8000/api/graphql --header "Authorization: Bearer ${TOKEN}" --header 'Content-Type: application/json' --data '{"query":"{notifiers{pagerduty{apiKey}}}"}' --silent --output -
```
