### PR TITLE
ROX-11007: Remove Clusters option from Top Riskiest scatterplot

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
@@ -190,8 +190,4 @@ describe('Vuln Management Dashboard Page', () => {
     it('clicking the "Top risky images by CVE count & CVSS score" widget\'s "View All" button should take you to the images list', () => {
         validateTopRiskyEntities('images');
     });
-
-    it('clicking the "Top risky clusters by CVE count & CVSS score" widget\'s "View All" button should take you to the clusters list', () => {
-        validateTopRiskyEntities('clusters');
-    });
 });

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.js
@@ -134,33 +134,6 @@ const TopRiskyEntitiesByVulnerabilities = ({
         ${VULN_FRAGMENT}
     `;
 
-    const CLUSTER_QUERY = gql`
-        query topRiskyClusters(
-            $query: String
-            $vulnQuery: String
-            $entityPagination: Pagination
-            $vulnPagination: Pagination
-        ) {
-            results: clusters(query: $query, pagination: $entityPagination) {
-                id
-                name
-                priority
-                plottedVulns(query: $vulnQuery) {
-                    basicVulnCounter {
-                        all {
-                            total
-                            fixable
-                        }
-                    }
-                    vulns(pagination: $vulnPagination) {
-                        ...vulnFields
-                    }
-                }
-            }
-        }
-        ${VULN_FRAGMENT}
-    `;
-
     const NAMESPACE_QUERY = gql`
         query topRiskyNamespaces(
             $query: String
@@ -250,7 +223,6 @@ const TopRiskyEntitiesByVulnerabilities = ({
     const queryMap = {
         [entityTypes.DEPLOYMENT]: DEPLOYMENT_QUERY,
         [entityTypes.NAMESPACE]: NAMESPACE_QUERY,
-        [entityTypes.CLUSTER]: CLUSTER_QUERY,
         [entityTypes.COMPONENT]: COMPONENT_QUERY,
         [entityTypes.IMAGE]: IMAGE_QUERY,
         [entityTypes.NODE]: NODE_QUERY,
@@ -433,12 +405,7 @@ TopRiskyEntitiesByVulnerabilities.propTypes = {
 
 TopRiskyEntitiesByVulnerabilities.defaultProps = {
     entityContext: {},
-    riskEntityTypes: [
-        entityTypes.DEPLOYMENT,
-        entityTypes.NAMESPACE,
-        entityTypes.IMAGE,
-        entityTypes.CLUSTER,
-    ],
+    riskEntityTypes: [entityTypes.DEPLOYMENT, entityTypes.NAMESPACE, entityTypes.IMAGE],
     cveFilter: 'All',
     small: false,
 };


### PR DESCRIPTION
## Description

With the splitting of CVEs related to clusters into Image, Node, and "Platform/K8S" types, this version of the scatterplot is no longer relevant.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests ~added~ removed



## Testing Performed

* Updated ui-e2e tests to remove test related to this dashboard scatterplot option
* Manual testing ("Look ma! no clusters!")

![Screen Shot 2022-06-01 at 12 03 31 PM](https://user-images.githubusercontent.com/715729/171470752-19e33fec-9826-4f79-bea9-540fa893a7f9.png)
