### PR TITLE
Don't register unused buckets for dackbox in Postgres

### DIFF
--- a/central/deployment/dackbox/crud.go
+++ b/central/deployment/dackbox/crud.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/dackbox/crud"
 	"github.com/stackrox/rox/pkg/dbhelper"
+	"github.com/stackrox/rox/pkg/features"
 )
 
 var (
@@ -60,8 +61,10 @@ func ListAlloc() proto.Message {
 }
 
 func init() {
-	globaldb.RegisterBucket(Bucket, "Deployment")
-	globaldb.RegisterBucket(ListBucket, "List Deployment")
+	if !features.PostgresDatastore.Enabled() {
+		globaldb.RegisterBucket(Bucket, "Deployment")
+		globaldb.RegisterBucket(ListBucket, "List Deployment")
+	}
 }
 
 // KeyFunc returns the key for a deployment.

--- a/central/image/dackbox/crud.go
+++ b/central/image/dackbox/crud.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/dackbox/crud"
 	"github.com/stackrox/rox/pkg/dbhelper"
+	"github.com/stackrox/rox/pkg/features"
 )
 
 var (
@@ -49,8 +50,10 @@ var (
 )
 
 func init() {
-	globaldb.RegisterBucket(Bucket, "Image")
-	globaldb.RegisterBucket(ListBucket, "List Image")
+	if !features.PostgresDatastore.Enabled() {
+		globaldb.RegisterBucket(Bucket, "Image")
+		globaldb.RegisterBucket(ListBucket, "List Image")
+	}
 }
 
 // KeyFunc returns the key for an image object

--- a/central/imagecomponentedge/dackbox/crud.go
+++ b/central/imagecomponentedge/dackbox/crud.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/dackbox/crud"
 	"github.com/stackrox/rox/pkg/dbhelper"
+	"github.com/stackrox/rox/pkg/features"
 )
 
 var (
@@ -34,7 +35,9 @@ var (
 )
 
 func init() {
-	globaldb.RegisterBucket(Bucket, "Image Component Edge")
+	if !features.PostgresDatastore.Enabled() {
+		globaldb.RegisterBucket(Bucket, "Image Component Edge")
+	}
 }
 
 func keyFunc(msg proto.Message) []byte {

--- a/central/imagecveedge/dackbox/crud.go
+++ b/central/imagecveedge/dackbox/crud.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/dackbox/crud"
 	"github.com/stackrox/rox/pkg/dbhelper"
+	"github.com/stackrox/rox/pkg/features"
 )
 
 var (
@@ -34,7 +35,9 @@ var (
 )
 
 func init() {
-	globaldb.RegisterBucket(Bucket, "Image CVE Edge")
+	if !features.PostgresDatastore.Enabled() {
+		globaldb.RegisterBucket(Bucket, "Image CVE Edge")
+	}
 }
 
 func keyFunc(msg proto.Message) []byte {


### PR DESCRIPTION
## Description

Don't register things we have already ported over. This helps clean up the metrics which I'm partially using to ensure that all things are migrated over

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Trivial on CI
