### PR TITLE
ROX-11053: Use v1.Query for for multikey resources

### DIFF
--- a/central/componentcveedge/datastore/internal/postgres/store.go
+++ b/central/componentcveedge/datastore/internal/postgres/store.go
@@ -26,10 +26,6 @@ import (
 const (
 	baseTable = "image_component_cve_edges"
 
-	existsStmt = "SELECT EXISTS(SELECT 1 FROM image_component_cve_edges WHERE Id = $1 AND ImageComponentId = $2 AND ImageCveId = $3)"
-	getStmt    = "SELECT serialized FROM image_component_cve_edges WHERE Id = $1 AND ImageComponentId = $2 AND ImageCveId = $3"
-	deleteStmt = "DELETE FROM image_component_cve_edges WHERE Id = $1 AND ImageComponentId = $2 AND ImageCveId = $3"
-
 	batchAfter = 100
 
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
@@ -81,27 +77,34 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 func (s *storeImpl) Exists(ctx context.Context, id string, imageComponentId string, imageCveId string) (bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Exists, "ComponentCVEEdge")
 
-	row := s.db.QueryRow(ctx, existsStmt, id, imageComponentId, imageCveId)
-	var exists bool
-	if err := row.Scan(&exists); err != nil {
-		return false, pgutils.ErrNilIfNoRows(err)
-	}
-	return exists, nil
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Component ID"), imageComponentId).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("CVE ID"), imageCveId).ProtoQuery(),
+	)
+
+	count, err := postgres.RunCountRequestForSchema(schema, q, s.db)
+	return count == 1, err
 }
 
 // Get returns the object, if it exists from the store
 func (s *storeImpl) Get(ctx context.Context, id string, imageComponentId string, imageCveId string) (*storage.ComponentCVEEdge, bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "ComponentCVEEdge")
 
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComponentCVEEdge")
-	if err != nil {
-		return nil, false, err
-	}
-	defer release()
+	var sacQueryFilter *v1.Query
 
-	row := conn.QueryRow(ctx, getStmt, id, imageComponentId, imageCveId)
-	var data []byte
-	if err := row.Scan(&data); err != nil {
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Component ID"), imageComponentId).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("CVE ID"), imageCveId).ProtoQuery(),
+	)
+
+	data, err := postgres.RunGetQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
 		return nil, false, pgutils.ErrNilIfNoRows(err)
 	}
 

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -26,10 +26,6 @@ import (
 const (
 	baseTable = "image_component_edges"
 
-	existsStmt = "SELECT EXISTS(SELECT 1 FROM image_component_edges WHERE Id = $1 AND ImageId = $2 AND ImageComponentId = $3)"
-	getStmt    = "SELECT serialized FROM image_component_edges WHERE Id = $1 AND ImageId = $2 AND ImageComponentId = $3"
-	deleteStmt = "DELETE FROM image_component_edges WHERE Id = $1 AND ImageId = $2 AND ImageComponentId = $3"
-
 	batchAfter = 100
 
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
@@ -81,27 +77,34 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 func (s *storeImpl) Exists(ctx context.Context, id string, imageId string, imageComponentId string) (bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Exists, "ImageComponentEdge")
 
-	row := s.db.QueryRow(ctx, existsStmt, id, imageId, imageComponentId)
-	var exists bool
-	if err := row.Scan(&exists); err != nil {
-		return false, pgutils.ErrNilIfNoRows(err)
-	}
-	return exists, nil
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Image Sha"), imageId).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Component ID"), imageComponentId).ProtoQuery(),
+	)
+
+	count, err := postgres.RunCountRequestForSchema(schema, q, s.db)
+	return count == 1, err
 }
 
 // Get returns the object, if it exists from the store
 func (s *storeImpl) Get(ctx context.Context, id string, imageId string, imageComponentId string) (*storage.ImageComponentEdge, bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "ImageComponentEdge")
 
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ImageComponentEdge")
-	if err != nil {
-		return nil, false, err
-	}
-	defer release()
+	var sacQueryFilter *v1.Query
 
-	row := conn.QueryRow(ctx, getStmt, id, imageId, imageComponentId)
-	var data []byte
-	if err := row.Scan(&data); err != nil {
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Image Sha"), imageId).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Component ID"), imageComponentId).ProtoQuery(),
+	)
+
+	data, err := postgres.RunGetQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
 		return nil, false, pgutils.ErrNilIfNoRows(err)
 	}
 

--- a/central/imagecveedge/datastore/internal/postgres/store.go
+++ b/central/imagecveedge/datastore/internal/postgres/store.go
@@ -26,10 +26,6 @@ import (
 const (
 	baseTable = "image_cve_edges"
 
-	existsStmt = "SELECT EXISTS(SELECT 1 FROM image_cve_edges WHERE Id = $1 AND ImageId = $2 AND ImageCveId = $3)"
-	getStmt    = "SELECT serialized FROM image_cve_edges WHERE Id = $1 AND ImageId = $2 AND ImageCveId = $3"
-	deleteStmt = "DELETE FROM image_cve_edges WHERE Id = $1 AND ImageId = $2 AND ImageCveId = $3"
-
 	batchAfter = 100
 
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
@@ -81,27 +77,34 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 func (s *storeImpl) Exists(ctx context.Context, id string, imageId string, imageCveId string) (bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Exists, "ImageCVEEdge")
 
-	row := s.db.QueryRow(ctx, existsStmt, id, imageId, imageCveId)
-	var exists bool
-	if err := row.Scan(&exists); err != nil {
-		return false, pgutils.ErrNilIfNoRows(err)
-	}
-	return exists, nil
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Image Sha"), imageId).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("CVE ID"), imageCveId).ProtoQuery(),
+	)
+
+	count, err := postgres.RunCountRequestForSchema(schema, q, s.db)
+	return count == 1, err
 }
 
 // Get returns the object, if it exists from the store
 func (s *storeImpl) Get(ctx context.Context, id string, imageId string, imageCveId string) (*storage.ImageCVEEdge, bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "ImageCVEEdge")
 
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ImageCVEEdge")
-	if err != nil {
-		return nil, false, err
-	}
-	defer release()
+	var sacQueryFilter *v1.Query
 
-	row := conn.QueryRow(ctx, getStmt, id, imageId, imageCveId)
-	var data []byte
-	if err := row.Scan(&data); err != nil {
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Image Sha"), imageId).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("CVE ID"), imageCveId).ProtoQuery(),
+	)
+
+	data, err := postgres.RunGetQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
 		return nil, false, pgutils.ErrNilIfNoRows(err)
 	}
 

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -26,10 +26,6 @@ import (
 const (
 	baseTable = "node_component_edges"
 
-	existsStmt = "SELECT EXISTS(SELECT 1 FROM node_component_edges WHERE Id = $1 AND NodeId = $2 AND NodeComponentId = $3)"
-	getStmt    = "SELECT serialized FROM node_component_edges WHERE Id = $1 AND NodeId = $2 AND NodeComponentId = $3"
-	deleteStmt = "DELETE FROM node_component_edges WHERE Id = $1 AND NodeId = $2 AND NodeComponentId = $3"
-
 	batchAfter = 100
 
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
@@ -81,27 +77,34 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 func (s *storeImpl) Exists(ctx context.Context, id string, nodeId string, nodeComponentId string) (bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Exists, "NodeComponentEdge")
 
-	row := s.db.QueryRow(ctx, existsStmt, id, nodeId, nodeComponentId)
-	var exists bool
-	if err := row.Scan(&exists); err != nil {
-		return false, pgutils.ErrNilIfNoRows(err)
-	}
-	return exists, nil
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Node ID"), nodeId).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Component ID"), nodeComponentId).ProtoQuery(),
+	)
+
+	count, err := postgres.RunCountRequestForSchema(schema, q, s.db)
+	return count == 1, err
 }
 
 // Get returns the object, if it exists from the store
 func (s *storeImpl) Get(ctx context.Context, id string, nodeId string, nodeComponentId string) (*storage.NodeComponentEdge, bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "NodeComponentEdge")
 
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NodeComponentEdge")
-	if err != nil {
-		return nil, false, err
-	}
-	defer release()
+	var sacQueryFilter *v1.Query
 
-	row := conn.QueryRow(ctx, getStmt, id, nodeId, nodeComponentId)
-	var data []byte
-	if err := row.Scan(&data); err != nil {
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Node ID"), nodeId).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Component ID"), nodeComponentId).ProtoQuery(),
+	)
+
+	data, err := postgres.RunGetQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
 		return nil, false, pgutils.ErrNilIfNoRows(err)
 	}
 

--- a/central/relations/nodecomponenttocve/datastore/store/postgres/store.go
+++ b/central/relations/nodecomponenttocve/datastore/store/postgres/store.go
@@ -26,10 +26,6 @@ import (
 const (
 	baseTable = "node_component_cve_edges"
 
-	existsStmt = "SELECT EXISTS(SELECT 1 FROM node_component_cve_edges WHERE Id = $1 AND ComponentId = $2 AND CveId = $3)"
-	getStmt    = "SELECT serialized FROM node_component_cve_edges WHERE Id = $1 AND ComponentId = $2 AND CveId = $3"
-	deleteStmt = "DELETE FROM node_component_cve_edges WHERE Id = $1 AND ComponentId = $2 AND CveId = $3"
-
 	batchAfter = 100
 
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
@@ -81,27 +77,34 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 func (s *storeImpl) Exists(ctx context.Context, id string, componentId string, cveId string) (bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Exists, "NodeComponentCVEEdge")
 
-	row := s.db.QueryRow(ctx, existsStmt, id, componentId, cveId)
-	var exists bool
-	if err := row.Scan(&exists); err != nil {
-		return false, pgutils.ErrNilIfNoRows(err)
-	}
-	return exists, nil
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Component ID"), componentId).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("CVE ID"), cveId).ProtoQuery(),
+	)
+
+	count, err := postgres.RunCountRequestForSchema(schema, q, s.db)
+	return count == 1, err
 }
 
 // Get returns the object, if it exists from the store
 func (s *storeImpl) Get(ctx context.Context, id string, componentId string, cveId string) (*storage.NodeComponentCVEEdge, bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "NodeComponentCVEEdge")
 
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NodeComponentCVEEdge")
-	if err != nil {
-		return nil, false, err
-	}
-	defer release()
+	var sacQueryFilter *v1.Query
 
-	row := conn.QueryRow(ctx, getStmt, id, componentId, cveId)
-	var data []byte
-	if err := row.Scan(&data); err != nil {
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Component ID"), componentId).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("CVE ID"), cveId).ProtoQuery(),
+	)
+
+	data, err := postgres.RunGetQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
 		return nil, false, pgutils.ErrNilIfNoRows(err)
 	}
 

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -94,7 +94,7 @@ func (q *query) getPortionBeforeFromClause() string {
 	case COUNT:
 		return "select count(*)"
 	case GET:
-		return "select serialized"
+		return fmt.Sprintf("select %q.serialized", q.From)
 	case SEARCH:
 		var primaryKeyPaths []string
 		// Always select the primary keys first.

--- a/tools/generate-helpers/pg-table-bindings/funcs.go
+++ b/tools/generate-helpers/pg-table-bindings/funcs.go
@@ -108,10 +108,11 @@ func concatWith(strs []string, sep string) string {
 }
 
 var funcMap = template.FuncMap{
-	"lowerCamelCase":    lowerCamelCase,
-	"upperCamelCase":    upperCamelCase,
-	"valueExpansion":    valueExpansion,
-	"lowerCase":         strings.ToLower,
-	"storageToResource": storageToResource,
-	"concatWith":        concatWith,
+	"lowerCamelCase":               lowerCamelCase,
+	"upperCamelCase":               upperCamelCase,
+	"valueExpansion":               valueExpansion,
+	"lowerCase":                    strings.ToLower,
+	"storageToResource":            storageToResource,
+	"concatWith":                   concatWith,
+	"searchFieldNameInOtherSchema": searchFieldNameInOtherSchema,
 }

--- a/tools/generate-helpers/pg-table-bindings/list.go
+++ b/tools/generate-helpers/pg-table-bindings/list.go
@@ -99,3 +99,18 @@ func namespaceGetter(prefix string, schema *walker.Schema) string {
 	}
 	panic(schema.TypeName + " has no namespace. Is it directly and namespace scoped?")
 }
+
+func searchFieldNameInOtherSchema(f walker.Field) string {
+	if searchFieldName(f) != "" {
+		return searchFieldName(f)
+	}
+	fieldInOtherSchema, err := f.Options.Reference.FieldInOtherSchema()
+	if err != nil {
+		panic(err)
+	}
+	return searchFieldName(fieldInOtherSchema)
+}
+
+func searchFieldName(f walker.Field) string {
+	return f.Search.FieldName
+}

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -26,10 +26,6 @@ import (
 const (
 	baseTable = "test_multi_key_structs"
 
-	existsStmt = "SELECT EXISTS(SELECT 1 FROM test_multi_key_structs WHERE Key1 = $1 AND Key2 = $2)"
-	getStmt    = "SELECT serialized FROM test_multi_key_structs WHERE Key1 = $1 AND Key2 = $2"
-	deleteStmt = "DELETE FROM test_multi_key_structs WHERE Key1 = $1 AND Key2 = $2"
-
 	batchAfter = 100
 
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
@@ -412,27 +408,32 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 func (s *storeImpl) Exists(ctx context.Context, key1 string, key2 string) (bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Exists, "TestMultiKeyStruct")
 
-	row := s.db.QueryRow(ctx, existsStmt, key1, key2)
-	var exists bool
-	if err := row.Scan(&exists); err != nil {
-		return false, pgutils.ErrNilIfNoRows(err)
-	}
-	return exists, nil
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(key1).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Test Key 2"), key2).ProtoQuery(),
+	)
+
+	count, err := postgres.RunCountRequestForSchema(schema, q, s.db)
+	return count == 1, err
 }
 
 // Get returns the object, if it exists from the store
 func (s *storeImpl) Get(ctx context.Context, key1 string, key2 string) (*storage.TestMultiKeyStruct, bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "TestMultiKeyStruct")
 
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestMultiKeyStruct")
-	if err != nil {
-		return nil, false, err
-	}
-	defer release()
+	var sacQueryFilter *v1.Query
 
-	row := conn.QueryRow(ctx, getStmt, key1, key2)
-	var data []byte
-	if err := row.Scan(&data); err != nil {
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(key1).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Test Key 2"), key2).ProtoQuery(),
+	)
+
+	data, err := postgres.RunGetQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
 		return nil, false, pgutils.ErrNilIfNoRows(err)
 	}
 
@@ -456,16 +457,15 @@ func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pg
 func (s *storeImpl) Delete(ctx context.Context, key1 string, key2 string) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TestMultiKeyStruct")
 
-	conn, release, err := s.acquireConn(ctx, ops.Remove, "TestMultiKeyStruct")
-	if err != nil {
-		return err
-	}
-	defer release()
+	var sacQueryFilter *v1.Query
 
-	if _, err := conn.Exec(ctx, deleteStmt, key1, key2); err != nil {
-		return err
-	}
-	return nil
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(key1).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.FieldLabel("Test Key 2"), key2).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
 }
 
 // GetIDs returns all the IDs for the store

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -47,13 +47,6 @@ import (
 const (
         baseTable = "{{.Table}}"
 
-{{/* TODO(ROX-10624): Remove this condition after all PKs fields were search tagged (PR #1653) */}}
-{{- if gt (len $pks) 1 }}
-        existsStmt = "SELECT EXISTS(SELECT 1 FROM {{.Table}} WHERE {{template "whereMatch" $pks}})"
-        getStmt = "SELECT serialized FROM {{.Table}} WHERE {{template "whereMatch" $pks}}"
-        deleteStmt = "DELETE FROM {{.Table}} WHERE {{template "whereMatch" $pks}}"
-{{- end }}
-
         batchAfter = 100
 
         // using copyFrom, we may not even want to batch.  It would probably be simpler
@@ -442,10 +435,8 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 // Exists returns if the id exists in the store
 func (s *storeImpl) Exists(ctx context.Context, {{template "paramList" $pks}}) (bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Exists, "{{.TrimmedType}}")
-{{/* TODO(ROX-10624): Remove this condition after all PKs fields were search tagged (PR #1653) */}}
-{{- if eq (len $pks) 1 }}
+
     var sacQueryFilter *v1.Query
-{{- end }}
     {{- if .PermissionChecker }}
     if ok, err := {{ .PermissionChecker }}.ExistsAllowed(ctx); err != nil || !ok {
         return false, err
@@ -473,38 +464,26 @@ func (s *storeImpl) Exists(ctx context.Context, {{template "paramList" $pks}}) (
 	}
     {{- end }}
 
-{{/* TODO(ROX-10624): Remove this condition after all PKs fields were search tagged (PR #1653) */}}
-{{- if eq (len $pks) 1 }}
     q := search.ConjunctionQuery(
         sacQueryFilter,
     {{- range $idx, $pk := $pks}}
         {{- if eq $pk.Name $singlePK.Name }}
         search.NewQueryBuilder().AddDocIDs({{ $singlePK.ColumnName|lowerCamelCase }}).ProtoQuery(),
         {{- else }}
-        search.NewQueryBuilder().AddExactMatches(search.FieldLabel("{{ $pk.Search.FieldName }}"), {{ $pk.ColumnName|lowerCamelCase }}).ProtoQuery(),
+        search.NewQueryBuilder().AddExactMatches(search.FieldLabel("{{ searchFieldNameInOtherSchema $pk }}"), {{ $pk.ColumnName|lowerCamelCase }}).ProtoQuery(),
         {{- end}}
     {{- end}}
     )
 
 	count, err := postgres.RunCountRequestForSchema(schema, q, s.db)
 	return count == 1, err
-{{- else }}
-    row := s.db.QueryRow(ctx, existsStmt, {{template "argList" $pks}})
-    var exists bool
-    if err := row.Scan(&exists); err != nil {
-    return false, pgutils.ErrNilIfNoRows(err)
-    }
-    return exists, nil
-{{- end }}
 }
 
 // Get returns the object, if it exists from the store
 func (s *storeImpl) Get(ctx context.Context, {{template "paramList" $pks}}) (*{{.Type}}, bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "{{.TrimmedType}}")
-{{/* TODO(ROX-10624): Remove this condition after all PKs fields were search tagged (PR #1653) */}}
-{{- if eq (len $pks) 1 }}
+
     var sacQueryFilter *v1.Query
-{{- end }}
     {{ if .PermissionChecker -}}
     if ok, err := {{ .PermissionChecker }}.GetAllowed(ctx); err != nil || !ok {
         return nil, false, err
@@ -531,15 +510,14 @@ func (s *storeImpl) Get(ctx context.Context, {{template "paramList" $pks}}) (*{{
         return nil, false, err
 	}
     {{- end }}
-{{/* TODO(ROX-10624): Remove this condition after all PKs fields were search tagged (PR #1653) */}}
-{{- if eq (len $pks) 1 }}
+
     q := search.ConjunctionQuery(
     sacQueryFilter,
     {{- range $idx, $pk := $pks}}
         {{- if eq $pk.Name $singlePK.Name }}
             search.NewQueryBuilder().AddDocIDs({{ $singlePK.ColumnName|lowerCamelCase }}).ProtoQuery(),
         {{- else }}
-            search.NewQueryBuilder().AddExactMatches(search.FieldLabel("{{ $pk.Search.FieldName }}"), {{ $pk.ColumnName|lowerCamelCase }}).ProtoQuery(),
+            search.NewQueryBuilder().AddExactMatches(search.FieldLabel("{{ searchFieldNameInOtherSchema $pk }}"), {{ $pk.ColumnName|lowerCamelCase }}).ProtoQuery(),
         {{- end}}
     {{- end}}
     )
@@ -548,19 +526,6 @@ func (s *storeImpl) Get(ctx context.Context, {{template "paramList" $pks}}) (*{{
 	if err != nil {
 		return nil, false, pgutils.ErrNilIfNoRows(err)
 	}
-{{- else }}
-	conn, release, err := s.acquireConn(ctx, ops.Get, "{{.TrimmedType}}")
-	if err != nil {
-	    return nil, false, err
-	}
-	defer release()
-
-	row := conn.QueryRow(ctx, getStmt, {{template "argList" $pks}})
-	var data []byte
-	if err := row.Scan(&data); err != nil {
-		return nil, false, pgutils.ErrNilIfNoRows(err)
-	}
-{{- end }}
 
 	var msg {{.Type}}
 	if err := proto.Unmarshal(data, &msg); err != nil {
@@ -595,10 +560,8 @@ func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pg
 // Delete removes the specified ID from the store
 func (s *storeImpl) Delete(ctx context.Context, {{template "paramList" $pks}}) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "{{.TrimmedType}}")
-{{/* TODO(ROX-10624): Remove this condition after all PKs fields were search tagged (PR #1653) */}}
-{{- if eq (len $pks) 1 }}
+
     var sacQueryFilter *v1.Query
-{{- end }}
     {{- if .PermissionChecker }}
     if ok, err := {{ .PermissionChecker }}.DeleteAllowed(ctx); err != nil {
         return err
@@ -628,32 +591,18 @@ func (s *storeImpl) Delete(ctx context.Context, {{template "paramList" $pks}}) e
 	}
     {{- end }}
 
-{{/* TODO(ROX-10624): Remove this condition after all PKs fields were search tagged (PR #1653) */}}
-{{- if eq (len $pks) 1 }}
     q := search.ConjunctionQuery(
         sacQueryFilter,
     {{- range $idx, $pk := $pks}}
         {{- if eq $pk.Name $singlePK.Name }}
         search.NewQueryBuilder().AddDocIDs({{ $singlePK.ColumnName|lowerCamelCase }}).ProtoQuery(),
         {{- else }}
-        search.NewQueryBuilder().AddExactMatches(search.FieldLabel("{{ $pk.Search.FieldName }}"), {{ $pk.ColumnName|lowerCamelCase }}).ProtoQuery(),
+        search.NewQueryBuilder().AddExactMatches(search.FieldLabel("{{ searchFieldNameInOtherSchema $pk }}"), {{ $pk.ColumnName|lowerCamelCase }}).ProtoQuery(),
         {{- end}}
     {{- end}}
     )
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
-{{- else }}
-    conn, release, err := s.acquireConn(ctx, ops.Remove, "{{.TrimmedType}}")
-	if err != nil {
-	    return err
-	}
-	defer release()
-
-	if _, err := conn.Exec(ctx, deleteStmt, {{template "argList" $pks}}); err != nil {
-		return err
-	}
-	return nil
-{{- end }}
 }
 {{- end}}
 

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -286,8 +286,6 @@ func (s *{{$namePrefix}}StoreSuite) TestSACGetIDs() {
 	}
 }
 
-{{/* TODO(ROX-10624): Remove this condition after all PKs fields were search tagged (PR #1653) */}}
-{{- if eq (len .Schema.PrimaryKeys) 1 }}
 func (s *{{$namePrefix}}StoreSuite) TestSACExists() {
 	objA := &{{.Type}}{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
@@ -447,7 +445,6 @@ func (s *{{$namePrefix}}StoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
-{{- end }}
 
 const (
 	withAllAccess = "AllAccess"


### PR DESCRIPTION
## Description

Use v1.Query for multikey resources instead of SQL string. This will unify generated code to use v1.Query for every operation (except methods generated for tests `DROP TABLE...`).

## Testing Performed

CI
