### PR TITLE
ROX-11107: Test docs branch create access

### DIFF
--- a/.github/workflows/test-token.yaml
+++ b/.github/workflows/test-token.yaml
@@ -19,9 +19,28 @@ jobs:
       - name: Create test branch
         run: |
           git switch --create rhacs-automation-test-branch
-      - name: Push changes
-        run: |
           git push --set-upstream origin $(git branch --show-current)
       - name: Delete branch
         run: |
           git push origin --delete rhacs-automation-test-branch
+
+  another-token:
+    name: Create a branch of documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: openshift/openshift-docs
+          ref: main
+          token: ${{secrets.ROBOT_ROX_GITHUB_TOKEN}}
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "${{github.event.sender.login}}"
+          git config user.email noreply@github.com
+      - name: Create test branch
+        run: |
+          git switch --create rhacs-automation-test-branch-2
+          git push --set-upstream origin $(git branch --show-current)
+      - name: Delete branch
+        run: |
+          git push origin --delete rhacs-automation-test-branch-2

--- a/.github/workflows/test-token.yaml
+++ b/.github/workflows/test-token.yaml
@@ -1,0 +1,27 @@
+name: Test documentation repo access
+on:
+  workflow_dispatch
+
+jobs:
+  docs-branch:
+    name: Create a branch of documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: openshift/openshift-docs
+          ref: main
+          token: ${{secrets.ORG_TOKEN_FOR_GITHUB}}
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "${{github.event.sender.login}}"
+          git config user.email noreply@github.com
+      - name: Create test branch
+        run: |
+          git switch --create rhacs-automation-test-branch
+      - name: Push changes
+        run: |
+          git push --set-upstream origin $(git branch --show-current)
+      - name: Delete branch
+        run: |
+          git push origin --delete rhacs-automation-test-branch


### PR DESCRIPTION
As a step of upstream release automation, the workflow will create a release branch in the `openshift/openshift-docs` repository. The PR adds a manually triggered GitHub workflow to test if the `ORG_TOKEN_FOR_GITHUB` secret has enough access to do that.