### PR TITLE
OSCI: fix QA test level determination

### DIFF
--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -157,20 +157,20 @@ run_tests_part_1() {
 
     export CLUSTER="${ORCHESTRATOR_FLAVOR^^}"
 
-    local base_ref
-    base_ref="$(get_base_ref)"
-
     if is_openshift_CI_rehearse_PR; then
         info "On an openshift rehearse PR, running BAT tests only..."
         make -C qa-tests-backend bat-test || touch FAIL
-    elif [[ "$base_ref" == "master" ]] || is_tagged; then
-        info "On master or tagged, running all QA tests..."
-        make -C qa-tests-backend test || touch FAIL
     elif pr_has_label ci-all-qa-tests; then
         info "ci-all-qa-tests label was specified, so running all QA tests..."
         make -C qa-tests-backend test || touch FAIL
+    elif is_in_PR_context; then
+        info "In a PR context without ci-all-qa-tests, running BAT tests only..."
+        make -C qa-tests-backend bat-test || touch FAIL
+    elif is_tagged; then
+        info "Tagged, running all QA tests..."
+        make -C qa-tests-backend test || touch FAIL
     else
-        info "On a PR branch without ci-all-qa-tests, running BAT tests only..."
+        info "An unexpected context. Defaulting to BAT tests only..."
         make -C qa-tests-backend bat-test || touch FAIL
     fi
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -454,6 +454,10 @@ is_nightly_tag() {
     [[ "$tags" =~ nightly ]]
 }
 
+is_in_PR_context() {
+    (is_CIRCLECI && [[ -n "${CIRCLE_PULL_REQUEST:-}" ]]) || (is_OPENSHIFT_CI && [[ -n "${PULL_NUMBER:-}" ]])
+}
+
 is_openshift_CI_rehearse_PR() {
     [[ "$(get_repo_full_name)" == "openshift/release" ]]
 }


### PR DESCRIPTION
## Description

`base_ref` is always master for PRs, so the current logic would never have selected bat-tests. This change checks for a PR context and runs BAT tests in that case.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient - should run BAT.