### PR TITLE
ROX-7834: Increase timeout for roxctl commands in flaky test

### DIFF
--- a/tests/roxctl/token-file.sh
+++ b/tests/roxctl/token-file.sh
@@ -15,7 +15,7 @@ eecho() {
 
 # Retrieve API token
 TOKEN_FILE=$(mktemp)
-curl -k -f \
+curl -k -f --silent \
   -u "admin:$ROX_PASSWORD" \
   -d '{"name": "test", "role": "Admin"}' \
   "https://$API_ENDPOINT/v1/apitokens/generate" \
@@ -29,6 +29,7 @@ test_roxctl_cmd() {
 
   # Verify that specifying a token file works.
   if OUTPUT=$(roxctl --insecure-skip-tls-verify --insecure -e "$API_ENDPOINT" \
+    --timeout 2m \
     --token-file "$TOKEN_FILE" \
     "$@" \
     2>&1); then
@@ -42,6 +43,7 @@ test_roxctl_cmd() {
 
   # Verify that specifying a token file and password at the same time fails.
   if OUTPUT=$(roxctl --insecure-skip-tls-verify --insecure -e "$API_ENDPOINT" \
+    --timeout 2m \
     --token-file "$TOKEN_FILE" \
     --password "secret" \
     "$@" \
@@ -61,6 +63,7 @@ test_roxctl_cmd() {
 
   # Verify that token on the command line has precedence over token in the environment
   if OUTPUT=$(ROX_API_TOKEN="invalid-token" roxctl --insecure-skip-tls-verify --insecure -e "$API_ENDPOINT" \
+    --timeout 2m \
     --token-file "$TOKEN_FILE" \
     "$@" \
     2>&1); then
@@ -74,6 +77,7 @@ test_roxctl_cmd() {
 
   # Verify that a password on the command line has precedence over token in the environment
   if OUTPUT=$(ROX_API_TOKEN="invalid-token" roxctl --insecure-skip-tls-verify --insecure -e "$API_ENDPOINT" \
+    --timeout 2m \
     --password "$ROX_PASSWORD" \
     "$@" \
     2>&1); then
@@ -93,6 +97,7 @@ test_roxctl_cmd() {
   fi
 
   if OUTPUT=$(roxctl --insecure-skip-tls-verify --insecure -e "$API_ENDPOINT" \
+    --timeout 2m \
     --token-file "$NON_EXISTING" \
     "$@" \
     2>&1); then


### PR DESCRIPTION
## Description

I wasn't able to reproduce this problem locally. I had 0/100 fails. The assumption is that we had timeouts in past and the only reasonable improvement is to increase the timeout for roxctl calls.

This change does not affect the correctness of tests.

## Considerations

We are currently running:
```
test_roxctl_cmd central whoami
test_roxctl_cmd central db backup
```

It could be that `db backup` is expensive in some cases. Would it be better to replace it with some less havier command, but with the same required auth rights?

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~ - not relevant
- ~[ ] Evaluated and added CHANGELOG entry if required~ - not relevant
- ~[ ] Determined and documented upgrade steps~ - not relevant
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~ - not relevant

## Testing Performed

Executed test in loop locally:
```
for _ in {1..2}; do tests/roxctl/token-file.sh; done | rg Passed | wc -l
```
