### PR TITLE
OSCI: Get bin/ps

### DIFF
--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -10,4 +10,4 @@
 # - `make update` and commit the results
 # - run `/test pj-rehearse-max` on the openshift/release PR to validate the change
 
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.35
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.40


### PR DESCRIPTION
## Description

This will be useful for debugging running builds and tests. Other changes in 0.3.35..0.3.40 includes the addition of hub-comment and postgres 14.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient - Validated with the pj-rehearse CI: [prow](https://prow.ci.openshift.org/?job=rehearse-29121-pull-ci-stackrox-stackrox-gavin-OSCI-get-ps-*)