### PR TITLE
ROX-11250: Scan images during admission request for image signature policy field

### DIFF
--- a/pkg/booleanpolicy/policyfields/fields.go
+++ b/pkg/booleanpolicy/policyfields/fields.go
@@ -106,9 +106,10 @@ func ContainsMemResourceLimit(p *storage.Policy) bool {
 	return booleanpolicy.ContainsValueWithFieldName(p, fieldnames.ContainerMemLimit)
 }
 
-// ContainsScanRelatedFields returns whether the policy contains fields related to image scanning,
-// i.e. fieldnames.UnscannedImage or fieldnames.ImageSignatureVerifiedBy.
-func ContainsScanRelatedFields(p *storage.Policy) bool {
+// ContainsScanRequiredFields returns whether the policy contains fields related to image scanning,
+// which require a scan result and may otherwise fail, i.e. fieldnames.UnscannedImage or
+// fieldnames.ImageSignatureVerifiedBy.
+func ContainsScanRequiredFields(p *storage.Policy) bool {
 	return booleanpolicy.ContainsValueWithFieldName(p, fieldnames.UnscannedImage) ||
 		booleanpolicy.ContainsValueWithFieldName(p, fieldnames.ImageSignatureVerifiedBy)
 }

--- a/pkg/booleanpolicy/policyfields/fields.go
+++ b/pkg/booleanpolicy/policyfields/fields.go
@@ -106,7 +106,9 @@ func ContainsMemResourceLimit(p *storage.Policy) bool {
 	return booleanpolicy.ContainsValueWithFieldName(p, fieldnames.ContainerMemLimit)
 }
 
-// ContainsUnscannedImageField returns whether the policy contains the unscanned image field.
-func ContainsUnscannedImageField(p *storage.Policy) bool {
-	return booleanpolicy.ContainsValueWithFieldName(p, fieldnames.UnscannedImage)
+// ContainsScanRelatedFields returns whether the policy contains fields related to image scanning,
+// i.e. fieldnames.UnscannedImage or fieldnames.ImageSignatureVerifiedBy.
+func ContainsScanRelatedFields(p *storage.Policy) bool {
+	return booleanpolicy.ContainsValueWithFieldName(p, fieldnames.UnscannedImage) ||
+		booleanpolicy.ContainsValueWithFieldName(p, fieldnames.ImageSignatureVerifiedBy)
 }

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerNoImageScanTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerNoImageScanTest.groovy
@@ -1,13 +1,16 @@
 import groups.BAT
 import io.stackrox.proto.storage.ClusterOuterClass.AdmissionControllerConfig
 import io.stackrox.proto.storage.PolicyOuterClass
+import io.stackrox.proto.storage.SignatureIntegrationOuterClass
 import objects.Deployment
 import objects.GCRImageIntegration
+import services.PolicyService
+import services.SignatureIntegrationService
+
 import org.junit.experimental.categories.Category
 import services.ClusterService
 import services.ImageIntegrationService
 import spock.lang.Shared
-import spock.lang.Unroll
 import util.Timer
 
 class AdmissionControllerNoImageScanTest extends BaseSpecification {
@@ -15,8 +18,22 @@ class AdmissionControllerNoImageScanTest extends BaseSpecification {
     private List<PolicyOuterClass.EnforcementAction> noImageScansEnforcements
     @Shared
     private boolean noImageScansPolicyWasDisabled
+    @Shared
+    private String imageSignaturePolicyID
+    @Shared
+    private String imageSignatureIntegrationID
 
+    // This key correlates to https://github.com/GoogleContainerTools/distroless/blob/main/cosign.pub.
+    private final static String PUBLIC_KEY = """\
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWZzVzkb8A+DbgDpaJId/bOmV8n7Q
+OqxYbK0Iro6GzSmOzxkn+N2AKawLyXi84WSwJQBK//psATakCgAQKkNTAA==
+-----END PUBLIC KEY-----"""
     private final static String NO_IMAGE_SCANS = "Images with no scans"
+    private final static String IMAGE_SIGNATURE = "Image Signature Test"
+
+    private final static String NON_EXISTENT_IMAGE = "non-existent:image"
+    private final static String IMAGE_WITH_SCANS = "us.gcr.io/stackrox-ci/nginx:1.12"
 
     def setupSpec() {
         noImageScansEnforcements = Services.updatePolicyEnforcement(
@@ -29,6 +46,8 @@ class AdmissionControllerNoImageScanTest extends BaseSpecification {
         def updatedPolicy = PolicyOuterClass.Policy.newBuilder(noImageScansPolicy)
             .setDisabled(false).build()
         Services.updatePolicy(updatedPolicy)
+
+        imageSignaturePolicyID = createImageSignaturePolicy()
     }
 
     def cleanupSpec() {
@@ -43,6 +62,10 @@ class AdmissionControllerNoImageScanTest extends BaseSpecification {
         def updatedPolicy = PolicyOuterClass.Policy.newBuilder(noImageScansPolicy)
                 .setDisabled(noImageScansPolicyWasDisabled).build()
         Services.updatePolicy(updatedPolicy)
+
+        PolicyService.deletePolicy(imageSignaturePolicyID)
+
+        SignatureIntegrationService.deleteSignatureIntegration(imageSignatureIntegrationID)
     }
 
     @Category([BAT])
@@ -64,11 +87,11 @@ class AdmissionControllerNoImageScanTest extends BaseSpecification {
 
         then:
         "Create deployment with a non-scannable image and inline scans disabled"
-        assert launchDeploymentWithImage("non-existent:image")
+        assert launchDeploymentWithImage(NON_EXISTENT_IMAGE)
 
         and:
         "Create deployment with a scannable image and inline scans disabled"
-        assert launchDeploymentWithImage("us.gcr.io/stackrox-ci/nginx:1.12")
+        assert launchDeploymentWithImage(IMAGE_WITH_SCANS)
 
         when:
         "Enable inline scans"
@@ -81,13 +104,18 @@ class AdmissionControllerNoImageScanTest extends BaseSpecification {
         gcrId = GCRImageIntegration.createDefaultIntegration()
         assert gcrId != ""
 
+        and:
+        "Disable image signature policy"
+        updateImageSignaturePolicy(true)
+        sleep 5000
+
         then:
         "Create deployment with a scannable image and inline scans enabled (w/ long timeout)"
-        assert launchDeploymentWithImage("us.gcr.io/stackrox-ci/nginx:1.12")
+        assert launchDeploymentWithImage(IMAGE_WITH_SCANS)
 
         and:
         "Create deployment with a non-scannable image and inline scans enabled (w/ long timeout)"
-        assert !launchDeploymentWithImage("non-existent:image")
+        assert !launchDeploymentWithImage(NON_EXISTENT_IMAGE)
 
         when:
         "Disable inline scans again"
@@ -95,13 +123,18 @@ class AdmissionControllerNoImageScanTest extends BaseSpecification {
         assert ClusterService.updateAdmissionController(ac)
         sleep 5000
 
+        and:
+        "Enable image signature policy"
+        updateImageSignaturePolicy(true)
+        sleep 5000
+
         then:
         "Create deployment with a non-scannable image and inline scans disabled"
-        assert launchDeploymentWithImage("non-existent:image")
+        assert launchDeploymentWithImage(NON_EXISTENT_IMAGE)
 
         and:
         "Create deployment with a scannable image and inline scans disabled"
-        assert launchDeploymentWithImage("us.gcr.io/stackrox-ci/nginx:1.12")
+        assert launchDeploymentWithImage(IMAGE_WITH_SCANS)
 
         cleanup:
         if (gcrId) {
@@ -133,5 +166,52 @@ class AdmissionControllerNoImageScanTest extends BaseSpecification {
             orchestrator.waitForDeploymentDeletion(deployment)
         }
         return created
+    }
+
+    private String createImageSignaturePolicy() {
+        String signatureIntegrationID = SignatureIntegrationService.createSignatureIntegration(
+                SignatureIntegrationOuterClass.SignatureIntegration.newBuilder()
+                        .setName("TEST")
+                        .setCosign(SignatureIntegrationOuterClass.CosignPublicKeyVerification.newBuilder()
+                                .addPublicKeys(SignatureIntegrationOuterClass.CosignPublicKeyVerification.PublicKey.
+                                        newBuilder().setName("key").setPublicKeyPemEnc(PUBLIC_KEY).build())
+                                .build()
+                        )
+                        .build()
+        )
+        assert signatureIntegrationID
+        imageSignatureIntegrationID = signatureIntegrationID
+        def policyValue = PolicyOuterClass.PolicyValue.newBuilder()
+                .setValue(imageSignatureIntegrationID)
+                .build()
+        def policyGroup = PolicyOuterClass.PolicyGroup.newBuilder()
+                .setFieldName("Image Signature Verified By")
+                .setBooleanOperator(PolicyOuterClass.BooleanOperator.OR)
+                .addValues(policyValue)
+                .setNegate(false)
+                .build()
+        def policy = PolicyOuterClass.Policy.newBuilder()
+            .addLifecycleStages(PolicyOuterClass.LifecycleStage.DEPLOY)
+            .addCategories("Test")
+            .setDisabled(false)
+            .setSeverityValue(2)
+            .setName(IMAGE_SIGNATURE)
+            .addPolicySections(PolicyOuterClass.PolicySection.newBuilder().addPolicyGroups(policyGroup))
+            .build()
+
+        String policyID = PolicyService.createNewPolicy(policy)
+        assert policyID
+
+        Services.updatePolicyEnforcement(IMAGE_SIGNATURE,
+                [PolicyOuterClass.EnforcementAction.SCALE_TO_ZERO_ENFORCEMENT,])
+
+        return policyID
+    }
+
+    private static updateImageSignaturePolicy(boolean disabled) {
+        def imageSignaturePolicy = Services.getPolicyByName(IMAGE_SIGNATURE)
+        def updatedImageSignaturePolicy = PolicyOuterClass.Policy.newBuilder(imageSignaturePolicy)
+                .setDisabled(disabled).build()
+        Services.updatePolicy(updatedImageSignaturePolicy)
     }
 }

--- a/sensor/admission-control/manager/evaluate_deploytime.go
+++ b/sensor/admission-control/manager/evaluate_deploytime.go
@@ -73,7 +73,7 @@ func (m *manager) shouldBypass(s *state, req *admission.AdmissionRequest) bool {
 // due to the absence (or presence) of image scans.
 func hasNonNoScanAlerts(alerts []*storage.Alert) bool {
 	for _, a := range alerts {
-		if !policyfields.ContainsScanRelatedFields(a.GetPolicy()) {
+		if !policyfields.ContainsScanRequiredFields(a.GetPolicy()) {
 			return true
 		}
 	}
@@ -85,7 +85,7 @@ func hasNonNoScanAlerts(alerts []*storage.Alert) bool {
 func filterOutNoScanAlerts(alerts []*storage.Alert) []*storage.Alert {
 	filteredAlerts := alerts[:0]
 	for _, a := range alerts {
-		if policyfields.ContainsScanRelatedFields(a.GetPolicy()) {
+		if policyfields.ContainsScanRequiredFields(a.GetPolicy()) {
 			continue
 		}
 		filteredAlerts = append(filteredAlerts, a)

--- a/sensor/admission-control/manager/evaluate_deploytime.go
+++ b/sensor/admission-control/manager/evaluate_deploytime.go
@@ -73,7 +73,7 @@ func (m *manager) shouldBypass(s *state, req *admission.AdmissionRequest) bool {
 // due to the absence (or presence) of image scans.
 func hasNonNoScanAlerts(alerts []*storage.Alert) bool {
 	for _, a := range alerts {
-		if !policyfields.ContainsUnscannedImageField(a.GetPolicy()) {
+		if !policyfields.ContainsScanRelatedFields(a.GetPolicy()) {
 			return true
 		}
 	}
@@ -85,7 +85,7 @@ func hasNonNoScanAlerts(alerts []*storage.Alert) bool {
 func filterOutNoScanAlerts(alerts []*storage.Alert) []*storage.Alert {
 	filteredAlerts := alerts[:0]
 	for _, a := range alerts {
-		if policyfields.ContainsUnscannedImageField(a.GetPolicy()) {
+		if policyfields.ContainsScanRelatedFields(a.GetPolicy()) {
 			continue
 		}
 		filteredAlerts = append(filteredAlerts, a)

--- a/sensor/admission-control/manager/manager_impl.go
+++ b/sensor/admission-control/manager/manager_impl.go
@@ -216,7 +216,7 @@ func (m *manager) ProcessNewSettings(newSettings *sensor.AdmissionControlSetting
 	allRuntimePolicySet := detection.NewPolicySet()
 	runtimePoliciesWithDeployFields, runtimePoliciesWithoutDeployFields := detection.NewPolicySet(), detection.NewPolicySet()
 	for _, policy := range newSettings.GetRuntimePolicies().GetPolicies() {
-		if policyfields.ContainsScanRelatedFields(policy) && !newSettings.GetClusterConfig().GetAdmissionControllerConfig().GetScanInline() {
+		if policyfields.ContainsScanRequiredFields(policy) && !newSettings.GetClusterConfig().GetAdmissionControllerConfig().GetScanInline() {
 			log.Warnf(errors.ImageScanUnavailableMsg(policy))
 			continue
 		}
@@ -243,7 +243,7 @@ func (m *manager) ProcessNewSettings(newSettings *sensor.AdmissionControlSetting
 	deployTimePolicySet := detection.NewPolicySet()
 	if enforceOnCreates || enforceOnUpdates {
 		for _, policy := range newSettings.GetEnforcedDeployTimePolicies().GetPolicies() {
-			if policyfields.ContainsScanRelatedFields(policy) &&
+			if policyfields.ContainsScanRequiredFields(policy) &&
 				!newSettings.GetClusterConfig().GetAdmissionControllerConfig().GetScanInline() {
 				log.Warnf(errors.ImageScanUnavailableMsg(policy))
 				continue

--- a/sensor/admission-control/manager/manager_impl.go
+++ b/sensor/admission-control/manager/manager_impl.go
@@ -216,7 +216,7 @@ func (m *manager) ProcessNewSettings(newSettings *sensor.AdmissionControlSetting
 	allRuntimePolicySet := detection.NewPolicySet()
 	runtimePoliciesWithDeployFields, runtimePoliciesWithoutDeployFields := detection.NewPolicySet(), detection.NewPolicySet()
 	for _, policy := range newSettings.GetRuntimePolicies().GetPolicies() {
-		if policyfields.ContainsUnscannedImageField(policy) && !newSettings.GetClusterConfig().GetAdmissionControllerConfig().GetScanInline() {
+		if policyfields.ContainsScanRelatedFields(policy) && !newSettings.GetClusterConfig().GetAdmissionControllerConfig().GetScanInline() {
 			log.Warnf(errors.ImageScanUnavailableMsg(policy))
 			continue
 		}
@@ -243,7 +243,7 @@ func (m *manager) ProcessNewSettings(newSettings *sensor.AdmissionControlSetting
 	deployTimePolicySet := detection.NewPolicySet()
 	if enforceOnCreates || enforceOnUpdates {
 		for _, policy := range newSettings.GetEnforcedDeployTimePolicies().GetPolicies() {
-			if policyfields.ContainsUnscannedImageField(policy) &&
+			if policyfields.ContainsScanRelatedFields(policy) &&
 				!newSettings.GetClusterConfig().GetAdmissionControllerConfig().GetScanInline() {
 				log.Warnf(errors.ImageScanUnavailableMsg(policy))
 				continue


### PR DESCRIPTION
## Description

When creating a policy for image signatures and enabling enforcement via the admission controller, the policy will currently fail although the image _does_ have a valid signature.

With the following image, `gcr.io/distroless:debug` and its [respective key](https://github.com/GoogleContainerTools/distroless/blob/main/cosign.pub), a policy with the image signature field will not create any alerts. When trying to create a deployment with that image and enforcement enabled, the following will be returned:
```bash
Error from server (Failed currently enforced policies from StackRox): error when creating "dep-distroless.yaml": admission webhook "policyeval.stackrox.io" denied the request:
The attempted operation violated 1 enforced policy, described below:

Policy: Image Signature Policy
- Description:
    ↳
- Rationale:
    ↳
- Remediation:
    ↳
- Violations:
    - Container 'base' image signature is unverified
```
_Note: As a caveat, when deploying the image consecutive and using SHA reference instead of tag reference, a cached image, if it exists, will return. When the enforcement was manually tested, within demo instances that were used the `unscanned image` policy was enabled, thus scanning and upserting the image in the cache, which lead to the cached image being returned during admission controller enforcement testing 😞 ._
 
The reason for this is due to the admission controller only waiting for the scan result if one of the alert's policy has the fieldname `Unscanned Image`:
```go
for !hasNonNoScanAlerts(alerts) && err == nil {
	// Wait for the result and re-evaluate the deployment
}
```

Since this is not the case, the admission controller will return the generated alerts and immediately fail.

To fix this behavior, the following has been done in the PR:
- Rename `ContainsUnscannedImageField` to `ContainsScanRelatedFields`.
- Within ^, add an additional check for the `ImageSignatureVerifiedBy` field. 

What will be done in a follow-up PR:
- Add more testcases to `ImageSignatureVerificationTests` to also cover the admission controller blocking / not blocking deployments, re-using the existing test cases done for alert matching. 

## Checklist
- [X] Investigated and inspected CI test results
- [X] Unit test and regression tests added

## Testing Performed
- Integration tests extended (`AdmissionControllerNoImageScanTest`).
- Manual testing
  - Create a signature integration + policy with enforcement mode usign [the distroless public key](https://github.com/GoogleContainerTools/distroless/blob/main/cosign.pub)
  - Two delpoyments for testing, one with an unsigned image, the other one with the distroless image:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    app: unsigned-image
  name: unsigned-image
  namespace: signature-testing
spec:
  replicas: 1
  selector:
    matchLabels:
      app: unsigned-image
  strategy: {}
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: unsigned-image
    spec:
      containers:
      - image: nginx:latest
        name: nginx
        resources: {}
status: {}
```
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    app: signed-image-distroless
  name: signed-image-distroless
  namespace: signature-testing
spec:
  replicas: 1
  selector:
    matchLabels:
      app: signed-image-distroless
  strategy: {}
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: signed-image-distroless
    spec:
      containers:
      - image: gcr.io/distroless/base:debug
        name: base
        command: ["sleep", "600000"]
        resources: {}
status: {}
```
  - Deploy the image without signature and observe the following output:
```bash
k create -f dep-unsigned.yaml
Error from server (Failed currently enforced policies from StackRox): error when creating "dep-unsigned.yaml": admission webhook "policyeval.stackrox.io" denied the request:
The attempted operation violated 1 enforced policy, described below:

Policy: SigPolicy
- Description:
    ↳
- Rationale:
    ↳
- Remediation:
    ↳
- Violations:
    - Container 'nginx' image signature is unverified


In case of emergency, add the annotation {"admission.stackrox.io/break-glass": "ticket-1234"} to your deployment with an updated ticket number
``` 
  - Deploy the distroless image and observe the following output:
```bash
k create -f dep-distroless.yaml
deployment.apps/signed-image-distroless created
```

