### PR TITLE
Revert "Remove `clean-image` from `all-builds` target"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -510,15 +510,13 @@ generate-junit-reports: $(GO_JUNIT_REPORT_BIN)
 image: main-image
 
 .PHONY: all-builds
-all-builds: cli main-build $(MERGED_API_SWAGGER_SPEC) ui-build
+all-builds: cli main-build clean-image $(MERGED_API_SWAGGER_SPEC) ui-build
 
 .PHONY: main-image
 main-image: all-builds
 	make docker-build-main-image
 
-# Exclude ephemeral files in dependencies.
-IMAGE_RHEL_FILES = $(shell find $(CURDIR)/image/rhel/ -type f ! -name "bundle.tar.gz*" ! -name "Dockerfile.gen")
-$(CURDIR)/image/rhel/bundle.tar.gz: $(IMAGE_RHEL_FILES)
+$(CURDIR)/image/rhel/bundle.tar.gz:
 	/usr/bin/env DEBUG_BUILD="$(DEBUG_BUILD)" $(CURDIR)/image/rhel/create-bundle.sh $(CURDIR)/image stackrox-data:$(TAG) $(BUILD_IMAGE) $(CURDIR)/image/rhel
 
 .PHONY: $(CURDIR)/image/rhel/Dockerfile.gen
@@ -625,9 +623,7 @@ mock-grpc-server-image: mock-grpc-server-build clean-image
 		-t quay.io/rhacs-eng/grpc-server:$(TAG) \
 		integration-tests/mock-grpc-server/image
 
-# Exclude ephemeral files in dependencies.
-IMAGE_POSTGRES_FILES = $(shell find $(CURDIR)/image/postgres/ -type f ! -name "bundle.tar.gz*" ! -name "Dockerfile.gen")
-$(CURDIR)/image/postgres/bundle.tar.gz: $(IMAGE_POSTGRES_FILES)
+$(CURDIR)/image/postgres/bundle.tar.gz:
 	/usr/bin/env DEBUG_BUILD="$(DEBUG_BUILD)" $(CURDIR)/image/postgres/create-bundle.sh $(CURDIR)/image/postgres $(CURDIR)/image/postgres
 
 .PHONY: $(CURDIR)/image/postgres/Dockerfile.gen


### PR DESCRIPTION
## Description

This reverts commit 3149711ad41787b732c6afb674e5384848af6c9b. https://github.com/stackrox/stackrox/pull/1875

The reason is that `create-bundle.sh` looks not only in `image/rhel` directory, but also takes files from `image/bin`, `image/static-bin` and others.

As a result of the change, Makefile did not detect that bundle needs to be regenerated when, for example, new `roxctl` binaries
were built, and old binaries were packaged in the bundle tarball and then in image.

The bug can be reproduced by the following sequence:
1. Run `make image`
2. Make any changes in Go code and commit them
3. Run `make image` again
4. Compare results of `roxctl version --json` and `docker run --rm -it quay.io/stackrox-io/main:$(make tag) version --json`, notice reported commits are different.

See also https://srox.slack.com/archives/CELUQKESC/p1654264051403859

## Checklist
- [ ] Investigated and inspected CI test results

The following aren't needed
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

* Followed reproduction scenario above and saw that in-container and out-of-container commits are the same.