### PR TITLE
OSCI: Remove gke-api-e2e-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2947,21 +2947,6 @@ jobs:
           cluster-id: ui-e2e-tests
           num-nodes: 2
 
-  provision-gke-api-e2e-tests:
-    executor: custom
-    resource_class: small
-    environment:
-      - GCP_IMAGE_TYPE: "COS"
-      - POD_SECURITY_POLICIES: "true"
-    steps:
-      - checkout
-      - check-backend-changes
-      - check-label-to-skip-tests:
-          label: ci-no-qa-tests
-
-      - provision-gke-cluster:
-          cluster-id: api-e2e-tests
-
   provision-gke-postgres-api-e2e-tests:
     executor: custom
     resource_class: small
@@ -3594,29 +3579,6 @@ jobs:
 
       - *storeUITestReports
       - *storeUITestArtifacts
-
-  gke-api-e2e-tests:
-    executor: custom
-    environment:
-      - LOCAL_PORT: 443
-      - COLLECTION_METHOD: ebpf
-      - GCP_IMAGE_TYPE: "COS"
-      - MONITORING_SUPPORT: false
-      - SCANNER_SUPPORT: true
-      - ROX_BASELINE_GENERATION_DURATION: 1m
-      - LOAD_BALANCER: lb
-      - ADMISSION_CONTROLLER: true
-      - ADMISSION_CONTROLLER_UPDATES: true
-      - ROX_NETWORK_BASELINE_OBSERVATION_PERIOD: 2m
-      - ROX_NEW_POLICY_CATEGORIES: true
-
-    steps:
-      - run-qa-tests:
-          cluster-id: api-e2e-tests
-          sensor-deploy-flavor: helm
-          determine-whether-to-run:
-            - check-label-to-skip-tests:
-                label: ci-no-qa-tests
 
   gke-postgres-api-e2e-tests:
     executor: custom
@@ -4815,15 +4777,6 @@ workflows:
             - build-rhacs
             - build-scale-monitoring-and-mock-server
             - provision-gke-ui-e2e-tests
-      - provision-gke-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-      - gke-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-          requires:
-            - build-stackrox
-            - build-rhacs
-            - build-scale-monitoring-and-mock-server
-            - provision-gke-api-e2e-tests
       - provision-gke-postgres-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
       - gke-postgres-api-e2e-tests:


### PR DESCRIPTION
## Description

These tests have run stably in prow for a week so its time to switch off Circle CI gke-api-e2e-tests.

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

CI is sufficient