### PR TITLE
ROX-11260: graphQL resolver for cluster types (k8s, istio, openshift)

### DIFF
--- a/central/graphql/resolvers/cluster_vulnerabilities.go
+++ b/central/graphql/resolvers/cluster_vulnerabilities.go
@@ -25,6 +25,12 @@ func init() {
 		schema.AddQuery("clusterVulnerability(id: ID): ClusterVulnerability"),
 		schema.AddQuery("clusterVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [ClusterVulnerability!]!"),
 		schema.AddQuery("clusterVulnerabilityCount(query: String): Int!"),
+		schema.AddQuery("k8sClusterVulnerability(id: ID): ClusterVulnerability"),
+		schema.AddQuery("k8sClusterVulnerabilities(query: String, pagination: Pagination): [ClusterVulnerability!]!"),
+		schema.AddQuery("istioClusterVulnerability(id: ID): ClusterVulnerability"),
+		schema.AddQuery("istioClusterVulnerabilities(query: String, pagination: Pagination): [ClusterVulnerability!]!"),
+		schema.AddQuery("openShiftClusterVulnerability(id: ID): ClusterVulnerability"),
+		schema.AddQuery("openShiftClusterVulnerabilities(query: String, pagination: Pagination): [ClusterVulnerability!]!"),
 	)
 }
 
@@ -80,6 +86,69 @@ func (resolver *Resolver) ClusterVulnerabilityCounter(ctx context.Context, args 
 	return nil, errors.New("Resolver ClusterVulnerabilityCounter does not support postgres yet")
 }
 
+// K8sClusterVulnerability resolves a single k8s vulnerability based on an id (the CVE value).
+func (resolver *Resolver) K8sClusterVulnerability(ctx context.Context, args IDQuery) (ClusterVulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "K8sClusterVulnerability")
+	if !features.PostgresDatastore.Enabled() {
+		return resolver.vulnerabilityV2(ctx, args)
+	}
+	// TODO add postgres support
+	return nil, errors.New("Resolver K8sClusterVulnerability does not support postgres yet")
+}
+
+// K8sClusterVulnerabilities resolves a set of k8s vulnerabilities based on a query.
+func (resolver *Resolver) K8sClusterVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "K8sClusterVulnerabilities")
+	if !features.PostgresDatastore.Enabled() {
+		query := withK8sTypeFiltering(args.String())
+		return resolver.clusterVulnerabilitiesV2(ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
+	}
+	// TODO add postgres support
+	return nil, errors.New("Resolver K8sClusterVulnerabilities does not support postgres yet")
+}
+
+// IstioClusterVulnerability resolves a single k8s vulnerability based on an id (the CVE value).
+func (resolver *Resolver) IstioClusterVulnerability(ctx context.Context, args IDQuery) (ClusterVulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "IstioClusterVulnerability")
+	if !features.PostgresDatastore.Enabled() {
+		return resolver.vulnerabilityV2(ctx, args)
+	}
+	// TODO add postgres support
+	return nil, errors.New("Resolver IstioClusterVulnerability does not support postgres yet")
+}
+
+// IstioClusterVulnerabilities resolves a set of k8s vulnerabilities based on a query.
+func (resolver *Resolver) IstioClusterVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "IstioClusterVulnerabilities")
+	if !features.PostgresDatastore.Enabled() {
+		query := withIstioTypeFiltering(args.String())
+		return resolver.clusterVulnerabilitiesV2(ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
+	}
+	// TODO add postgres support
+	return nil, errors.New("Resolver IstioClusterVulnerabilities does not support postgres yet")
+}
+
+// OpenShiftClusterVulnerability resolves a single k8s vulnerability based on an id (the CVE value).
+func (resolver *Resolver) OpenShiftClusterVulnerability(ctx context.Context, args IDQuery) (ClusterVulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "OpenShiftClusterVulnerability")
+	if !features.PostgresDatastore.Enabled() {
+		return resolver.vulnerabilityV2(ctx, args)
+	}
+	// TODO add postgres support
+	return nil, errors.New("Resolver OpenShiftClusterVulnerability does not support postgres yet")
+}
+
+// OpenShiftClusterVulnerabilities resolves a set of k8s vulnerabilities based on a query.
+func (resolver *Resolver) OpenShiftClusterVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "OpenShiftClusterVulnerabilities")
+	if !features.PostgresDatastore.Enabled() {
+		query := withOpenShiftTypeFiltering(args.String())
+		return resolver.clusterVulnerabilitiesV2(ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
+	}
+	// TODO add postgres support
+	return nil, errors.New("Resolver OpenShiftClusterVulnerabilities does not support postgres yet")
+}
+
 // withClusterTypeFiltering adds a conjunction as a raw query to filter vulnerability type by cluster
 // this is needed to support pre postgres requests
 func withClusterTypeFiltering(q string) string {
@@ -88,4 +157,22 @@ func withClusterTypeFiltering(q string) string {
 			storage.CVE_ISTIO_CVE.String(),
 			storage.CVE_OPENSHIFT_CVE.String(),
 			storage.CVE_K8S_CVE.String()).Query())
+}
+
+// withK8sTypeFiltering adds a conjunction as a raw query to filter vulnerability k8s type
+func withK8sTypeFiltering(q string) string {
+	return search.AddRawQueriesAsConjunction(q,
+		search.NewQueryBuilder().AddExactMatches(search.CVEType, storage.CVE_K8S_CVE.String()).Query())
+}
+
+// withIstioTypeFiltering adds a conjunction as a raw query to filter vulnerability istio type
+func withIstioTypeFiltering(q string) string {
+	return search.AddRawQueriesAsConjunction(q,
+		search.NewQueryBuilder().AddExactMatches(search.CVEType, storage.CVE_ISTIO_CVE.String()).Query())
+}
+
+// withOpenShiftTypeFiltering adds a conjunction as a raw query to filter vulnerability open shift type
+func withOpenShiftTypeFiltering(q string) string {
+	return search.AddRawQueriesAsConjunction(q,
+		search.NewQueryBuilder().AddExactMatches(search.CVEType, storage.CVE_OPENSHIFT_CVE.String()).Query())
 }

--- a/central/graphql/resolvers/vulnerabilities.go
+++ b/central/graphql/resolvers/vulnerabilities.go
@@ -57,13 +57,13 @@ func init() {
 		schema.AddQuery("vulnerabilityCount(query: String): Int! "+
 			"@deprecated(reason: \"use 'imageVulnerabilityCount' or 'nodeVulnerabilityCount'\")"),
 		schema.AddQuery("k8sVulnerability(id: ID): EmbeddedVulnerability "+
-			"@deprecated(reason: \"use 'clusterVulnerability'\")"),
+			"@deprecated(reason: \"use 'k8sClusterVulnerability'\")"),
 		schema.AddQuery("k8sVulnerabilities(query: String, pagination: Pagination): [EmbeddedVulnerability!]! "+
-			"@deprecated(reason: \"use 'clusterVulnerabilities'\")"),
+			"@deprecated(reason: \"use 'k8sClusterVulnerabilities'\")"),
 		schema.AddQuery("istioVulnerability(id: ID): EmbeddedVulnerability "+
-			"@deprecated(reason: \"use 'clusterVulnerability'\")"),
+			"@deprecated(reason: \"use 'istioClusterVulnerability'\")"),
 		schema.AddQuery("istioVulnerabilities(query: String, pagination: Pagination): [EmbeddedVulnerability!]! "+
-			"@deprecated(reason: \"use 'clusterVulnerabilities'\")"),
+			"@deprecated(reason: \"use 'istioClusterVulnerabilities'\")"),
 		schema.AddExtraResolver("EmbeddedVulnerability", `unusedVarSink(query: String): Int`),
 	)
 }


### PR DESCRIPTION
## Description

Add support for cluster type endpoints (k8s, istio, openshift) and update the deprecation notice on the old endpoints.

## Checklist
- [ ] Investigated and inspected CI test results
