### PR TITLE
OSCI: Get junit XML results on unit test failures

### DIFF
--- a/scripts/ci/jobs/go-unit-tests.sh
+++ b/scripts/ci/jobs/go-unit-tests.sh
@@ -12,11 +12,13 @@ go_unit_tests() {
     else
         export ROX_IMAGE_FLAVOR=development_build
     fi
-    make go-unit-tests GOTAGS="${GOTAGS}"
+    make go-unit-tests GOTAGS="${GOTAGS}" || touch FAIL
     
     info "Saving junit XML report"
-    make generate-junit-reports
+    make generate-junit-reports || touch FAIL
     store_test_results junit-reports reports
+
+    [[ ! -f FAIL ]] || die "Unit tests failed"
 }
 
 go_unit_tests "$*"

--- a/scripts/ci/jobs/integration-unit-tests.sh
+++ b/scripts/ci/jobs/integration-unit-tests.sh
@@ -19,12 +19,14 @@ integration_unit_tests() {
     done
     if [[ "${success}" == 0 ]]; then
         echo "Failed after ${max_tries} tries"
-        exit 1
+        touch FAIL
     fi
     
     info "Saving junit XML report"
-    make generate-junit-reports
+    make generate-junit-reports || touch FAIL
     store_test_results junit-reports reports
+
+    [[ ! -f FAIL ]] || die "Unit tests failed"
 }
 
 integration_unit_tests "$*"

--- a/scripts/ci/jobs/shell-unit-tests.sh
+++ b/scripts/ci/jobs/shell-unit-tests.sh
@@ -7,10 +7,12 @@ set -euo pipefail
 
 shell_unit_tests() {
     info "Starting shell unit tests"
-    make shell-unit-tests
+    make shell-unit-tests || touch FAIL
     
     info "Saving junit XML report"
     store_test_results shell-test-output reports
+
+    [[ ! -f FAIL ]] || die "Unit tests failed"
 }
 
 shell_unit_tests "$*"

--- a/scripts/ci/jobs/ui-unit-tests.sh
+++ b/scripts/ci/jobs/ui-unit-tests.sh
@@ -7,10 +7,12 @@ set -euo pipefail
 
 ui_unit_tests() {
     info "Starting UI unit tests"
-    make ui-test
+    make ui-test || touch FAIL
     
     info "Saving junit XML report"
     store_test_results ui/test-results/reports reports
+
+    [[ ! -f FAIL ]] || die "Unit tests failed"
 }
 
 ui_unit_tests "$*"

--- a/sensor/admission-control/service/testdata/review_requests/pod_exec_event_review.json
+++ b/sensor/admission-control/service/testdata/review_requests/pod_exec_event_review.json
@@ -43,7 +43,7 @@
       "tty":true,
       "container":"sensor",
       "command":[
-        "/bin/bash"
+        "/bin/sh"
       ]
     },
     "oldObject":null,

--- a/sensor/admission-control/service/testdata/review_requests/pod_exec_event_review.json
+++ b/sensor/admission-control/service/testdata/review_requests/pod_exec_event_review.json
@@ -43,7 +43,7 @@
       "tty":true,
       "container":"sensor",
       "command":[
-        "/bin/sh"
+        "/bin/bash"
       ]
     },
     "oldObject":null,


### PR DESCRIPTION
## Description

If unit tests fail store the junit results. These will then show up in the spyglass view to help pinpoint the failure.

## Checklist
- [x] Investigated and inspected CI test results


## Testing Performed

CI is sufficient - With a forced failure the failed test is clear: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/1944/pull-ci-stackrox-stackrox-master-go-unit-tests-release/1532842981457924096