### PR TITLE
Add retries to gorm connection

### DIFF
--- a/pkg/postgres/schema/schema_test.go
+++ b/pkg/postgres/schema/schema_test.go
@@ -126,6 +126,12 @@ func (s *SchemaTestSuite) TestGormConsistentWithSQL() {
 	})
 }
 
+// TestReentry checks if we can apply the schema multiple times.
+func (s *SchemaTestSuite) TestReentry() {
+	ApplyAllSchemas(s.ctx, s.gormDB)
+	ApplyAllSchemas(s.ctx, s.gormDB)
+}
+
 func (s *SchemaTestSuite) getAllTestCases() []string {
 	files, err := os.ReadDir(".")
 	s.Require().NoError(err)

--- a/tools/roxvet/analyzers/validateimports/analyzer.go
+++ b/tools/roxvet/analyzers/validateimports/analyzer.go
@@ -199,6 +199,7 @@ func verifyImportsFromAllowedPackagesOnly(pass *analysis.Pass, imports []*ast.Im
 			"pkg/postgres/pgutils",
 			"pkg/postgres/schema",
 			"pkg/process/id",
+			"pkg/retry",
 			"pkg/rocksdb",
 			"pkg/set",
 			"pkg/sliceutils",


### PR DESCRIPTION
## Description
When central boots up, central-db may not be ready for transactions. This change
makes central retries on connection failure.
I also add one reentry test for schema to make sure there is no failure if the tables have been created.
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
