### PR TITLE
Use single table for PG store test suite

### DIFF
--- a/central/alert/datastore/internal/store/postgres/store_test.go
+++ b/central/alert/datastore/internal/store/postgres/store_test.go
@@ -31,7 +31,7 @@ func TestAlertsStore(t *testing.T) {
 	suite.Run(t, new(AlertsStoreSuite))
 }
 
-func (s *AlertsStoreSuite) SetupTest() {
+func (s *AlertsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -56,7 +56,14 @@ func (s *AlertsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *AlertsStoreSuite) TearDownTest() {
+func (s *AlertsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE alerts CASCADE")
+	s.T().Log("alerts", tag)
+	s.NoError(err)
+}
+
+func (s *AlertsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/apitoken/datastore/internal/store/postgres/store_test.go
+++ b/central/apitoken/datastore/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestApiTokensStore(t *testing.T) {
 	suite.Run(t, new(ApiTokensStoreSuite))
 }
 
-func (s *ApiTokensStoreSuite) SetupTest() {
+func (s *ApiTokensStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ApiTokensStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ApiTokensStoreSuite) TearDownTest() {
+func (s *ApiTokensStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE api_tokens CASCADE")
+	s.T().Log("api_tokens", tag)
+	s.NoError(err)
+}
+
+func (s *ApiTokensStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/authprovider/datastore/internal/store/postgres/store_test.go
+++ b/central/authprovider/datastore/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestAuthProvidersStore(t *testing.T) {
 	suite.Run(t, new(AuthProvidersStoreSuite))
 }
 
-func (s *AuthProvidersStoreSuite) SetupTest() {
+func (s *AuthProvidersStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *AuthProvidersStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *AuthProvidersStoreSuite) TearDownTest() {
+func (s *AuthProvidersStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE auth_providers CASCADE")
+	s.T().Log("auth_providers", tag)
+	s.NoError(err)
+}
+
+func (s *AuthProvidersStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/cluster/store/cluster/postgres/store_test.go
+++ b/central/cluster/store/cluster/postgres/store_test.go
@@ -31,7 +31,7 @@ func TestClustersStore(t *testing.T) {
 	suite.Run(t, new(ClustersStoreSuite))
 }
 
-func (s *ClustersStoreSuite) SetupTest() {
+func (s *ClustersStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -56,7 +56,14 @@ func (s *ClustersStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ClustersStoreSuite) TearDownTest() {
+func (s *ClustersStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE clusters CASCADE")
+	s.T().Log("clusters", tag)
+	s.NoError(err)
+}
+
+func (s *ClustersStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/cluster/store/clusterhealth/postgres/store_test.go
+++ b/central/cluster/store/clusterhealth/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestClusterHealthStatusesStore(t *testing.T) {
 	suite.Run(t, new(ClusterHealthStatusesStoreSuite))
 }
 
-func (s *ClusterHealthStatusesStoreSuite) SetupTest() {
+func (s *ClusterHealthStatusesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ClusterHealthStatusesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ClusterHealthStatusesStoreSuite) TearDownTest() {
+func (s *ClusterHealthStatusesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE cluster_health_statuses CASCADE")
+	s.T().Log("cluster_health_statuses", tag)
+	s.NoError(err)
+}
+
+func (s *ClusterHealthStatusesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/clusterinit/store/postgres/store_test.go
+++ b/central/clusterinit/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestClusterInitBundlesStore(t *testing.T) {
 	suite.Run(t, new(ClusterInitBundlesStoreSuite))
 }
 
-func (s *ClusterInitBundlesStoreSuite) SetupTest() {
+func (s *ClusterInitBundlesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ClusterInitBundlesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ClusterInitBundlesStoreSuite) TearDownTest() {
+func (s *ClusterInitBundlesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE cluster_init_bundles CASCADE")
+	s.T().Log("cluster_init_bundles", tag)
+	s.NoError(err)
+}
+
+func (s *ClusterInitBundlesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/complianceoperator/checkresults/store/postgres/store_test.go
+++ b/central/complianceoperator/checkresults/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestComplianceOperatorCheckResultsStore(t *testing.T) {
 	suite.Run(t, new(ComplianceOperatorCheckResultsStoreSuite))
 }
 
-func (s *ComplianceOperatorCheckResultsStoreSuite) SetupTest() {
+func (s *ComplianceOperatorCheckResultsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ComplianceOperatorCheckResultsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ComplianceOperatorCheckResultsStoreSuite) TearDownTest() {
+func (s *ComplianceOperatorCheckResultsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE compliance_operator_check_results CASCADE")
+	s.T().Log("compliance_operator_check_results", tag)
+	s.NoError(err)
+}
+
+func (s *ComplianceOperatorCheckResultsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/complianceoperator/profiles/store/postgres/store_test.go
+++ b/central/complianceoperator/profiles/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestComplianceOperatorProfilesStore(t *testing.T) {
 	suite.Run(t, new(ComplianceOperatorProfilesStoreSuite))
 }
 
-func (s *ComplianceOperatorProfilesStoreSuite) SetupTest() {
+func (s *ComplianceOperatorProfilesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ComplianceOperatorProfilesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ComplianceOperatorProfilesStoreSuite) TearDownTest() {
+func (s *ComplianceOperatorProfilesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE compliance_operator_profiles CASCADE")
+	s.T().Log("compliance_operator_profiles", tag)
+	s.NoError(err)
+}
+
+func (s *ComplianceOperatorProfilesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/complianceoperator/rules/store/postgres/store_test.go
+++ b/central/complianceoperator/rules/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestComplianceOperatorRulesStore(t *testing.T) {
 	suite.Run(t, new(ComplianceOperatorRulesStoreSuite))
 }
 
-func (s *ComplianceOperatorRulesStoreSuite) SetupTest() {
+func (s *ComplianceOperatorRulesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ComplianceOperatorRulesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ComplianceOperatorRulesStoreSuite) TearDownTest() {
+func (s *ComplianceOperatorRulesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE compliance_operator_rules CASCADE")
+	s.T().Log("compliance_operator_rules", tag)
+	s.NoError(err)
+}
+
+func (s *ComplianceOperatorRulesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/complianceoperator/scans/store/postgres/store_test.go
+++ b/central/complianceoperator/scans/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestComplianceOperatorScansStore(t *testing.T) {
 	suite.Run(t, new(ComplianceOperatorScansStoreSuite))
 }
 
-func (s *ComplianceOperatorScansStoreSuite) SetupTest() {
+func (s *ComplianceOperatorScansStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ComplianceOperatorScansStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ComplianceOperatorScansStoreSuite) TearDownTest() {
+func (s *ComplianceOperatorScansStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE compliance_operator_scans CASCADE")
+	s.T().Log("compliance_operator_scans", tag)
+	s.NoError(err)
+}
+
+func (s *ComplianceOperatorScansStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/complianceoperator/scansettingbinding/store/postgres/store_test.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestComplianceOperatorScanSettingBindingsStore(t *testing.T) {
 	suite.Run(t, new(ComplianceOperatorScanSettingBindingsStoreSuite))
 }
 
-func (s *ComplianceOperatorScanSettingBindingsStoreSuite) SetupTest() {
+func (s *ComplianceOperatorScanSettingBindingsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ComplianceOperatorScanSettingBindingsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ComplianceOperatorScanSettingBindingsStoreSuite) TearDownTest() {
+func (s *ComplianceOperatorScanSettingBindingsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE compliance_operator_scan_setting_bindings CASCADE")
+	s.T().Log("compliance_operator_scan_setting_bindings", tag)
+	s.NoError(err)
+}
+
+func (s *ComplianceOperatorScanSettingBindingsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/componentcveedge/datastore/internal/postgres/store_test.go
+++ b/central/componentcveedge/datastore/internal/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestImageComponentCveEdgesStore(t *testing.T) {
 	suite.Run(t, new(ImageComponentCveEdgesStoreSuite))
 }
 
-func (s *ImageComponentCveEdgesStoreSuite) SetupTest() {
+func (s *ImageComponentCveEdgesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ImageComponentCveEdgesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ImageComponentCveEdgesStoreSuite) TearDownTest() {
+func (s *ImageComponentCveEdgesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE image_component_cve_edges CASCADE")
+	s.T().Log("image_component_cve_edges", tag)
+	s.NoError(err)
+}
+
+func (s *ImageComponentCveEdgesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/cve/datastore/cluster/internal/store/postgres/store_test.go
+++ b/central/cve/datastore/cluster/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestClusterCvesStore(t *testing.T) {
 	suite.Run(t, new(ClusterCvesStoreSuite))
 }
 
-func (s *ClusterCvesStoreSuite) SetupTest() {
+func (s *ClusterCvesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ClusterCvesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ClusterCvesStoreSuite) TearDownTest() {
+func (s *ClusterCvesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE cluster_cves CASCADE")
+	s.T().Log("cluster_cves", tag)
+	s.NoError(err)
+}
+
+func (s *ClusterCvesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/cve/image/datastore/internal/store/postgres/store_test.go
+++ b/central/cve/image/datastore/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestImageCvesStore(t *testing.T) {
 	suite.Run(t, new(ImageCvesStoreSuite))
 }
 
-func (s *ImageCvesStoreSuite) SetupTest() {
+func (s *ImageCvesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ImageCvesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ImageCvesStoreSuite) TearDownTest() {
+func (s *ImageCvesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE image_cves CASCADE")
+	s.T().Log("image_cves", tag)
+	s.NoError(err)
+}
+
+func (s *ImageCvesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/cve/node/internal/store/postgres/store_test.go
+++ b/central/cve/node/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestNodeCvesStore(t *testing.T) {
 	suite.Run(t, new(NodeCvesStoreSuite))
 }
 
-func (s *NodeCvesStoreSuite) SetupTest() {
+func (s *NodeCvesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *NodeCvesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *NodeCvesStoreSuite) TearDownTest() {
+func (s *NodeCvesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE node_cves CASCADE")
+	s.T().Log("node_cves", tag)
+	s.NoError(err)
+}
+
+func (s *NodeCvesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/deployment/store/postgres/store_test.go
+++ b/central/deployment/store/postgres/store_test.go
@@ -31,7 +31,7 @@ func TestDeploymentsStore(t *testing.T) {
 	suite.Run(t, new(DeploymentsStoreSuite))
 }
 
-func (s *DeploymentsStoreSuite) SetupTest() {
+func (s *DeploymentsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -56,7 +56,14 @@ func (s *DeploymentsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *DeploymentsStoreSuite) TearDownTest() {
+func (s *DeploymentsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE deployments CASCADE")
+	s.T().Log("deployments", tag)
+	s.NoError(err)
+}
+
+func (s *DeploymentsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/externalbackups/internal/store/postgres/store_test.go
+++ b/central/externalbackups/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestExternalBackupsStore(t *testing.T) {
 	suite.Run(t, new(ExternalBackupsStoreSuite))
 }
 
-func (s *ExternalBackupsStoreSuite) SetupTest() {
+func (s *ExternalBackupsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ExternalBackupsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ExternalBackupsStoreSuite) TearDownTest() {
+func (s *ExternalBackupsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE external_backups CASCADE")
+	s.T().Log("external_backups", tag)
+	s.NoError(err)
+}
+
+func (s *ExternalBackupsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/imagecomponent/datastore/internal/store/postgres/store_test.go
+++ b/central/imagecomponent/datastore/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestImageComponentsStore(t *testing.T) {
 	suite.Run(t, new(ImageComponentsStoreSuite))
 }
 
-func (s *ImageComponentsStoreSuite) SetupTest() {
+func (s *ImageComponentsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ImageComponentsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ImageComponentsStoreSuite) TearDownTest() {
+func (s *ImageComponentsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE image_components CASCADE")
+	s.T().Log("image_components", tag)
+	s.NoError(err)
+}
+
+func (s *ImageComponentsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store_test.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestImageComponentEdgesStore(t *testing.T) {
 	suite.Run(t, new(ImageComponentEdgesStoreSuite))
 }
 
-func (s *ImageComponentEdgesStoreSuite) SetupTest() {
+func (s *ImageComponentEdgesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ImageComponentEdgesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ImageComponentEdgesStoreSuite) TearDownTest() {
+func (s *ImageComponentEdgesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE image_component_edges CASCADE")
+	s.T().Log("image_component_edges", tag)
+	s.NoError(err)
+}
+
+func (s *ImageComponentEdgesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/imagecveedge/datastore/internal/postgres/store_test.go
+++ b/central/imagecveedge/datastore/internal/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestImageCveEdgesStore(t *testing.T) {
 	suite.Run(t, new(ImageCveEdgesStoreSuite))
 }
 
-func (s *ImageCveEdgesStoreSuite) SetupTest() {
+func (s *ImageCveEdgesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ImageCveEdgesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ImageCveEdgesStoreSuite) TearDownTest() {
+func (s *ImageCveEdgesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE image_cve_edges CASCADE")
+	s.T().Log("image_cve_edges", tag)
+	s.NoError(err)
+}
+
+func (s *ImageCveEdgesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/imageintegration/store/postgres/store_test.go
+++ b/central/imageintegration/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestImageIntegrationsStore(t *testing.T) {
 	suite.Run(t, new(ImageIntegrationsStoreSuite))
 }
 
-func (s *ImageIntegrationsStoreSuite) SetupTest() {
+func (s *ImageIntegrationsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ImageIntegrationsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ImageIntegrationsStoreSuite) TearDownTest() {
+func (s *ImageIntegrationsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE image_integrations CASCADE")
+	s.T().Log("image_integrations", tag)
+	s.NoError(err)
+}
+
+func (s *ImageIntegrationsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/integrationhealth/store/postgres/store_test.go
+++ b/central/integrationhealth/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestIntegrationHealthsStore(t *testing.T) {
 	suite.Run(t, new(IntegrationHealthsStoreSuite))
 }
 
-func (s *IntegrationHealthsStoreSuite) SetupTest() {
+func (s *IntegrationHealthsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *IntegrationHealthsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *IntegrationHealthsStoreSuite) TearDownTest() {
+func (s *IntegrationHealthsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE integration_healths CASCADE")
+	s.T().Log("integration_healths", tag)
+	s.NoError(err)
+}
+
+func (s *IntegrationHealthsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/namespace/store/postgres/store_test.go
+++ b/central/namespace/store/postgres/store_test.go
@@ -31,7 +31,7 @@ func TestNamespacesStore(t *testing.T) {
 	suite.Run(t, new(NamespacesStoreSuite))
 }
 
-func (s *NamespacesStoreSuite) SetupTest() {
+func (s *NamespacesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -56,7 +56,14 @@ func (s *NamespacesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *NamespacesStoreSuite) TearDownTest() {
+func (s *NamespacesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE namespaces CASCADE")
+	s.T().Log("namespaces", tag)
+	s.NoError(err)
+}
+
+func (s *NamespacesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/networkbaseline/store/postgres/store_test.go
+++ b/central/networkbaseline/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestNetworkBaselinesStore(t *testing.T) {
 	suite.Run(t, new(NetworkBaselinesStoreSuite))
 }
 
-func (s *NetworkBaselinesStoreSuite) SetupTest() {
+func (s *NetworkBaselinesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *NetworkBaselinesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *NetworkBaselinesStoreSuite) TearDownTest() {
+func (s *NetworkBaselinesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE network_baselines CASCADE")
+	s.T().Log("network_baselines", tag)
+	s.NoError(err)
+}
+
+func (s *NetworkBaselinesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/networkgraph/config/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestNetworkGraphConfigsStore(t *testing.T) {
 	suite.Run(t, new(NetworkGraphConfigsStoreSuite))
 }
 
-func (s *NetworkGraphConfigsStoreSuite) SetupTest() {
+func (s *NetworkGraphConfigsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *NetworkGraphConfigsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *NetworkGraphConfigsStoreSuite) TearDownTest() {
+func (s *NetworkGraphConfigsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE network_graph_configs CASCADE")
+	s.T().Log("network_graph_configs", tag)
+	s.NoError(err)
+}
+
+func (s *NetworkGraphConfigsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestNetworkEntitiesStore(t *testing.T) {
 	suite.Run(t, new(NetworkEntitiesStoreSuite))
 }
 
-func (s *NetworkEntitiesStoreSuite) SetupTest() {
+func (s *NetworkEntitiesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *NetworkEntitiesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *NetworkEntitiesStoreSuite) TearDownTest() {
+func (s *NetworkEntitiesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE network_entities CASCADE")
+	s.T().Log("network_entities", tag)
+	s.NoError(err)
+}
+
+func (s *NetworkEntitiesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/networkpolicies/datastore/internal/store/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestNetworkpoliciesStore(t *testing.T) {
 	suite.Run(t, new(NetworkpoliciesStoreSuite))
 }
 
-func (s *NetworkpoliciesStoreSuite) SetupTest() {
+func (s *NetworkpoliciesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *NetworkpoliciesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *NetworkpoliciesStoreSuite) TearDownTest() {
+func (s *NetworkpoliciesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE networkpolicies CASCADE")
+	s.T().Log("networkpolicies", tag)
+	s.NoError(err)
+}
+
+func (s *NetworkpoliciesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestNetworkpoliciesundodeploymentsStore(t *testing.T) {
 	suite.Run(t, new(NetworkpoliciesundodeploymentsStoreSuite))
 }
 
-func (s *NetworkpoliciesundodeploymentsStoreSuite) SetupTest() {
+func (s *NetworkpoliciesundodeploymentsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *NetworkpoliciesundodeploymentsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *NetworkpoliciesundodeploymentsStoreSuite) TearDownTest() {
+func (s *NetworkpoliciesundodeploymentsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE networkpoliciesundodeployments CASCADE")
+	s.T().Log("networkpoliciesundodeployments", tag)
+	s.NoError(err)
+}
+
+func (s *NetworkpoliciesundodeploymentsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestNetworkpolicyapplicationundorecordsStore(t *testing.T) {
 	suite.Run(t, new(NetworkpolicyapplicationundorecordsStoreSuite))
 }
 
-func (s *NetworkpolicyapplicationundorecordsStoreSuite) SetupTest() {
+func (s *NetworkpolicyapplicationundorecordsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *NetworkpolicyapplicationundorecordsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *NetworkpolicyapplicationundorecordsStoreSuite) TearDownTest() {
+func (s *NetworkpolicyapplicationundorecordsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE networkpolicyapplicationundorecords CASCADE")
+	s.T().Log("networkpolicyapplicationundorecords", tag)
+	s.NoError(err)
+}
+
+func (s *NetworkpolicyapplicationundorecordsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/nodecomponent/datastore/postgres/store_test.go
+++ b/central/nodecomponent/datastore/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestNodeComponentsStore(t *testing.T) {
 	suite.Run(t, new(NodeComponentsStoreSuite))
 }
 
-func (s *NodeComponentsStoreSuite) SetupTest() {
+func (s *NodeComponentsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *NodeComponentsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *NodeComponentsStoreSuite) TearDownTest() {
+func (s *NodeComponentsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE node_components CASCADE")
+	s.T().Log("node_components", tag)
+	s.NoError(err)
+}
+
+func (s *NodeComponentsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/nodecomponentedge/store/postgres/store_test.go
+++ b/central/nodecomponentedge/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestNodeComponentEdgesStore(t *testing.T) {
 	suite.Run(t, new(NodeComponentEdgesStoreSuite))
 }
 
-func (s *NodeComponentEdgesStoreSuite) SetupTest() {
+func (s *NodeComponentEdgesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *NodeComponentEdgesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *NodeComponentEdgesStoreSuite) TearDownTest() {
+func (s *NodeComponentEdgesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE node_component_edges CASCADE")
+	s.T().Log("node_component_edges", tag)
+	s.NoError(err)
+}
+
+func (s *NodeComponentEdgesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/notifier/datastore/internal/store/postgres/store_test.go
+++ b/central/notifier/datastore/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestNotifiersStore(t *testing.T) {
 	suite.Run(t, new(NotifiersStoreSuite))
 }
 
-func (s *NotifiersStoreSuite) SetupTest() {
+func (s *NotifiersStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *NotifiersStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *NotifiersStoreSuite) TearDownTest() {
+func (s *NotifiersStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE notifiers CASCADE")
+	s.T().Log("notifiers", tag)
+	s.NoError(err)
+}
+
+func (s *NotifiersStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/pod/store/postgres/store_test.go
+++ b/central/pod/store/postgres/store_test.go
@@ -31,7 +31,7 @@ func TestPodsStore(t *testing.T) {
 	suite.Run(t, new(PodsStoreSuite))
 }
 
-func (s *PodsStoreSuite) SetupTest() {
+func (s *PodsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -56,7 +56,14 @@ func (s *PodsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *PodsStoreSuite) TearDownTest() {
+func (s *PodsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE pods CASCADE")
+	s.T().Log("pods", tag)
+	s.NoError(err)
+}
+
+func (s *PodsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/policy/store/postgres/store_test.go
+++ b/central/policy/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestPoliciesStore(t *testing.T) {
 	suite.Run(t, new(PoliciesStoreSuite))
 }
 
-func (s *PoliciesStoreSuite) SetupTest() {
+func (s *PoliciesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *PoliciesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *PoliciesStoreSuite) TearDownTest() {
+func (s *PoliciesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE policies CASCADE")
+	s.T().Log("policies", tag)
+	s.NoError(err)
+}
+
+func (s *PoliciesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/processbaseline/store/postgres/store_test.go
+++ b/central/processbaseline/store/postgres/store_test.go
@@ -31,7 +31,7 @@ func TestProcessBaselinesStore(t *testing.T) {
 	suite.Run(t, new(ProcessBaselinesStoreSuite))
 }
 
-func (s *ProcessBaselinesStoreSuite) SetupTest() {
+func (s *ProcessBaselinesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -56,7 +56,14 @@ func (s *ProcessBaselinesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ProcessBaselinesStoreSuite) TearDownTest() {
+func (s *ProcessBaselinesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE process_baselines CASCADE")
+	s.T().Log("process_baselines", tag)
+	s.NoError(err)
+}
+
+func (s *ProcessBaselinesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestProcessBaselineResultsStore(t *testing.T) {
 	suite.Run(t, new(ProcessBaselineResultsStoreSuite))
 }
 
-func (s *ProcessBaselineResultsStoreSuite) SetupTest() {
+func (s *ProcessBaselineResultsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ProcessBaselineResultsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ProcessBaselineResultsStoreSuite) TearDownTest() {
+func (s *ProcessBaselineResultsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE process_baseline_results CASCADE")
+	s.T().Log("process_baseline_results", tag)
+	s.NoError(err)
+}
+
+func (s *ProcessBaselineResultsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/processindicator/store/postgres/store_test.go
+++ b/central/processindicator/store/postgres/store_test.go
@@ -31,7 +31,7 @@ func TestProcessIndicatorsStore(t *testing.T) {
 	suite.Run(t, new(ProcessIndicatorsStoreSuite))
 }
 
-func (s *ProcessIndicatorsStoreSuite) SetupTest() {
+func (s *ProcessIndicatorsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -56,7 +56,14 @@ func (s *ProcessIndicatorsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ProcessIndicatorsStoreSuite) TearDownTest() {
+func (s *ProcessIndicatorsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE process_indicators CASCADE")
+	s.T().Log("process_indicators", tag)
+	s.NoError(err)
+}
+
+func (s *ProcessIndicatorsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/rbac/k8srole/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srole/internal/store/postgres/store_test.go
@@ -31,7 +31,7 @@ func TestK8sRolesStore(t *testing.T) {
 	suite.Run(t, new(K8sRolesStoreSuite))
 }
 
-func (s *K8sRolesStoreSuite) SetupTest() {
+func (s *K8sRolesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -56,7 +56,14 @@ func (s *K8sRolesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *K8sRolesStoreSuite) TearDownTest() {
+func (s *K8sRolesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE k8s_roles CASCADE")
+	s.T().Log("k8s_roles", tag)
+	s.NoError(err)
+}
+
+func (s *K8sRolesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
@@ -31,7 +31,7 @@ func TestRoleBindingsStore(t *testing.T) {
 	suite.Run(t, new(RoleBindingsStoreSuite))
 }
 
-func (s *RoleBindingsStoreSuite) SetupTest() {
+func (s *RoleBindingsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -56,7 +56,14 @@ func (s *RoleBindingsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *RoleBindingsStoreSuite) TearDownTest() {
+func (s *RoleBindingsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE role_bindings CASCADE")
+	s.T().Log("role_bindings", tag)
+	s.NoError(err)
+}
+
+func (s *RoleBindingsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/relations/nodecomponenttocve/datastore/store/postgres/store_test.go
+++ b/central/relations/nodecomponenttocve/datastore/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestNodeComponentCveEdgesStore(t *testing.T) {
 	suite.Run(t, new(NodeComponentCveEdgesStoreSuite))
 }
 
-func (s *NodeComponentCveEdgesStoreSuite) SetupTest() {
+func (s *NodeComponentCveEdgesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *NodeComponentCveEdgesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *NodeComponentCveEdgesStoreSuite) TearDownTest() {
+func (s *NodeComponentCveEdgesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE node_component_cve_edges CASCADE")
+	s.T().Log("node_component_cve_edges", tag)
+	s.NoError(err)
+}
+
+func (s *NodeComponentCveEdgesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/reportconfigurations/store/postgres/store_test.go
+++ b/central/reportconfigurations/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestReportConfigurationsStore(t *testing.T) {
 	suite.Run(t, new(ReportConfigurationsStoreSuite))
 }
 
-func (s *ReportConfigurationsStoreSuite) SetupTest() {
+func (s *ReportConfigurationsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ReportConfigurationsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ReportConfigurationsStoreSuite) TearDownTest() {
+func (s *ReportConfigurationsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE report_configurations CASCADE")
+	s.T().Log("report_configurations", tag)
+	s.NoError(err)
+}
+
+func (s *ReportConfigurationsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/risk/datastore/internal/store/postgres/store_test.go
+++ b/central/risk/datastore/internal/store/postgres/store_test.go
@@ -31,7 +31,7 @@ func TestRisksStore(t *testing.T) {
 	suite.Run(t, new(RisksStoreSuite))
 }
 
-func (s *RisksStoreSuite) SetupTest() {
+func (s *RisksStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -56,7 +56,14 @@ func (s *RisksStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *RisksStoreSuite) TearDownTest() {
+func (s *RisksStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE risks CASCADE")
+	s.T().Log("risks", tag)
+	s.NoError(err)
+}
+
+func (s *RisksStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/role/store/permissionset/postgres/store_test.go
+++ b/central/role/store/permissionset/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestPermissionSetsStore(t *testing.T) {
 	suite.Run(t, new(PermissionSetsStoreSuite))
 }
 
-func (s *PermissionSetsStoreSuite) SetupTest() {
+func (s *PermissionSetsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *PermissionSetsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *PermissionSetsStoreSuite) TearDownTest() {
+func (s *PermissionSetsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE permission_sets CASCADE")
+	s.T().Log("permission_sets", tag)
+	s.NoError(err)
+}
+
+func (s *PermissionSetsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/role/store/role/postgres/store_test.go
+++ b/central/role/store/role/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestRolesStore(t *testing.T) {
 	suite.Run(t, new(RolesStoreSuite))
 }
 
-func (s *RolesStoreSuite) SetupTest() {
+func (s *RolesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *RolesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *RolesStoreSuite) TearDownTest() {
+func (s *RolesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE roles CASCADE")
+	s.T().Log("roles", tag)
+	s.NoError(err)
+}
+
+func (s *RolesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/role/store/simpleaccessscope/postgres/store_test.go
+++ b/central/role/store/simpleaccessscope/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestSimpleAccessScopesStore(t *testing.T) {
 	suite.Run(t, new(SimpleAccessScopesStoreSuite))
 }
 
-func (s *SimpleAccessScopesStoreSuite) SetupTest() {
+func (s *SimpleAccessScopesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *SimpleAccessScopesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *SimpleAccessScopesStoreSuite) TearDownTest() {
+func (s *SimpleAccessScopesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE simple_access_scopes CASCADE")
+	s.T().Log("simple_access_scopes", tag)
+	s.NoError(err)
+}
+
+func (s *SimpleAccessScopesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/secret/internal/store/postgres/store_test.go
+++ b/central/secret/internal/store/postgres/store_test.go
@@ -31,7 +31,7 @@ func TestSecretsStore(t *testing.T) {
 	suite.Run(t, new(SecretsStoreSuite))
 }
 
-func (s *SecretsStoreSuite) SetupTest() {
+func (s *SecretsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -56,7 +56,14 @@ func (s *SecretsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *SecretsStoreSuite) TearDownTest() {
+func (s *SecretsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE secrets CASCADE")
+	s.T().Log("secrets", tag)
+	s.NoError(err)
+}
+
+func (s *SecretsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/serviceaccount/internal/store/postgres/store_test.go
+++ b/central/serviceaccount/internal/store/postgres/store_test.go
@@ -31,7 +31,7 @@ func TestServiceAccountsStore(t *testing.T) {
 	suite.Run(t, new(ServiceAccountsStoreSuite))
 }
 
-func (s *ServiceAccountsStoreSuite) SetupTest() {
+func (s *ServiceAccountsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -56,7 +56,14 @@ func (s *ServiceAccountsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ServiceAccountsStoreSuite) TearDownTest() {
+func (s *ServiceAccountsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE service_accounts CASCADE")
+	s.T().Log("service_accounts", tag)
+	s.NoError(err)
+}
+
+func (s *ServiceAccountsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/serviceidentities/internal/store/postgres/store_test.go
+++ b/central/serviceidentities/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestServiceIdentitiesStore(t *testing.T) {
 	suite.Run(t, new(ServiceIdentitiesStoreSuite))
 }
 
-func (s *ServiceIdentitiesStoreSuite) SetupTest() {
+func (s *ServiceIdentitiesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *ServiceIdentitiesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *ServiceIdentitiesStoreSuite) TearDownTest() {
+func (s *ServiceIdentitiesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE service_identities CASCADE")
+	s.T().Log("service_identities", tag)
+	s.NoError(err)
+}
+
+func (s *ServiceIdentitiesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/signatureintegration/store/postgres/store_test.go
+++ b/central/signatureintegration/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestSignatureIntegrationsStore(t *testing.T) {
 	suite.Run(t, new(SignatureIntegrationsStoreSuite))
 }
 
-func (s *SignatureIntegrationsStoreSuite) SetupTest() {
+func (s *SignatureIntegrationsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *SignatureIntegrationsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *SignatureIntegrationsStoreSuite) TearDownTest() {
+func (s *SignatureIntegrationsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE signature_integrations CASCADE")
+	s.T().Log("signature_integrations", tag)
+	s.NoError(err)
+}
+
+func (s *SignatureIntegrationsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestVulnerabilityRequestsStore(t *testing.T) {
 	suite.Run(t, new(VulnerabilityRequestsStoreSuite))
 }
 
-func (s *VulnerabilityRequestsStoreSuite) SetupTest() {
+func (s *VulnerabilityRequestsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *VulnerabilityRequestsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *VulnerabilityRequestsStoreSuite) TearDownTest() {
+func (s *VulnerabilityRequestsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE vulnerability_requests CASCADE")
+	s.T().Log("vulnerability_requests", tag)
+	s.NoError(err)
+}
+
+func (s *VulnerabilityRequestsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/central/watchedimage/datastore/internal/store/postgres/store_test.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestWatchedImagesStore(t *testing.T) {
 	suite.Run(t, new(WatchedImagesStoreSuite))
 }
 
-func (s *WatchedImagesStoreSuite) SetupTest() {
+func (s *WatchedImagesStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *WatchedImagesStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *WatchedImagesStoreSuite) TearDownTest() {
+func (s *WatchedImagesStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE watched_images CASCADE")
+	s.T().Log("watched_images", tag)
+	s.NoError(err)
+}
+
+func (s *WatchedImagesStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/pkg/postgres/schema/schema_test.go
+++ b/pkg/postgres/schema/schema_test.go
@@ -68,14 +68,8 @@ func (s *SchemaTestSuite) SetupSuite() {
 	s.pool = pool
 	s.Require().NoError(err)
 	s.gormDB = pgtest.OpenGormDB(s.T(), source)
-}
 
-func (s *SchemaTestSuite) TearDownTest() {
-	s.envIsolator.RestoreAll()
-	if s.pool == nil {
-		return
-	}
-	_, err := s.pool.Exec(s.ctx, "DROP SCHEMA public CASCADE")
+	_, err = s.pool.Exec(s.ctx, "DROP SCHEMA public CASCADE")
 	s.Require().NoError(err)
 	_, err = s.pool.Exec(s.ctx, "CREATE SCHEMA public")
 	s.Require().NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestTestMultiKeyStructsStore(t *testing.T) {
 	suite.Run(t, new(TestMultiKeyStructsStoreSuite))
 }
 
-func (s *TestMultiKeyStructsStoreSuite) SetupTest() {
+func (s *TestMultiKeyStructsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *TestMultiKeyStructsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *TestMultiKeyStructsStoreSuite) TearDownTest() {
+func (s *TestMultiKeyStructsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE test_multi_key_structs CASCADE")
+	s.T().Log("test_multi_key_structs", tag)
+	s.NoError(err)
+}
+
+func (s *TestMultiKeyStructsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -22,7 +22,6 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/testutils/envisolator"
-	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -38,7 +37,7 @@ func Test{{$namePrefix}}Store(t *testing.T) {
 	suite.Run(t, new({{$namePrefix}}StoreSuite))
 }
 
-func (s *{{$namePrefix}}StoreSuite) SetupTest() {
+func (s *{{$namePrefix}}StoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -63,7 +62,14 @@ func (s *{{$namePrefix}}StoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *{{$namePrefix}}StoreSuite) TearDownTest() {
+func (s *{{$namePrefix}}StoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE {{ .Schema.Table }} CASCADE")
+	s.T().Log("{{ .Schema.Table }}", tag)
+	s.NoError(err)
+}
+
+func (s *{{$namePrefix}}StoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
@@ -29,7 +29,7 @@ func TestTestSingleKeyStructsStore(t *testing.T) {
 	suite.Run(t, new(TestSingleKeyStructsStoreSuite))
 }
 
-func (s *TestSingleKeyStructsStoreSuite) SetupTest() {
+func (s *TestSingleKeyStructsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *TestSingleKeyStructsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *TestSingleKeyStructsStoreSuite) TearDownTest() {
+func (s *TestSingleKeyStructsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE test_single_key_structs CASCADE")
+	s.T().Log("test_single_key_structs", tag)
+	s.NoError(err)
+}
+
+func (s *TestSingleKeyStructsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
@@ -29,7 +29,7 @@ func TestTestChild1Store(t *testing.T) {
 	suite.Run(t, new(TestChild1StoreSuite))
 }
 
-func (s *TestChild1StoreSuite) SetupTest() {
+func (s *TestChild1StoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *TestChild1StoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *TestChild1StoreSuite) TearDownTest() {
+func (s *TestChild1StoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE test_child1 CASCADE")
+	s.T().Log("test_child1", tag)
+	s.NoError(err)
+}
+
+func (s *TestChild1StoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store_test.go
@@ -29,7 +29,7 @@ func TestTestChild2Store(t *testing.T) {
 	suite.Run(t, new(TestChild2StoreSuite))
 }
 
-func (s *TestChild2StoreSuite) SetupTest() {
+func (s *TestChild2StoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *TestChild2StoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *TestChild2StoreSuite) TearDownTest() {
+func (s *TestChild2StoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE test_child2 CASCADE")
+	s.T().Log("test_child2", tag)
+	s.NoError(err)
+}
+
+func (s *TestChild2StoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store_test.go
@@ -29,7 +29,7 @@ func TestTestG2GrandChild1Store(t *testing.T) {
 	suite.Run(t, new(TestG2GrandChild1StoreSuite))
 }
 
-func (s *TestG2GrandChild1StoreSuite) SetupTest() {
+func (s *TestG2GrandChild1StoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *TestG2GrandChild1StoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *TestG2GrandChild1StoreSuite) TearDownTest() {
+func (s *TestG2GrandChild1StoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE test_g2_grand_child1 CASCADE")
+	s.T().Log("test_g2_grand_child1", tag)
+	s.NoError(err)
+}
+
+func (s *TestG2GrandChild1StoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
@@ -29,7 +29,7 @@ func TestTestG3GrandChild1Store(t *testing.T) {
 	suite.Run(t, new(TestG3GrandChild1StoreSuite))
 }
 
-func (s *TestG3GrandChild1StoreSuite) SetupTest() {
+func (s *TestG3GrandChild1StoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *TestG3GrandChild1StoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *TestG3GrandChild1StoreSuite) TearDownTest() {
+func (s *TestG3GrandChild1StoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE test_g3_grand_child1 CASCADE")
+	s.T().Log("test_g3_grand_child1", tag)
+	s.NoError(err)
+}
+
+func (s *TestG3GrandChild1StoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
@@ -29,7 +29,7 @@ func TestTestGGrandChild1Store(t *testing.T) {
 	suite.Run(t, new(TestGGrandChild1StoreSuite))
 }
 
-func (s *TestGGrandChild1StoreSuite) SetupTest() {
+func (s *TestGGrandChild1StoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *TestGGrandChild1StoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *TestGGrandChild1StoreSuite) TearDownTest() {
+func (s *TestGGrandChild1StoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE test_g_grand_child1 CASCADE")
+	s.T().Log("test_g_grand_child1", tag)
+	s.NoError(err)
+}
+
+func (s *TestGGrandChild1StoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store_test.go
@@ -29,7 +29,7 @@ func TestTestGrandChild1Store(t *testing.T) {
 	suite.Run(t, new(TestGrandChild1StoreSuite))
 }
 
-func (s *TestGrandChild1StoreSuite) SetupTest() {
+func (s *TestGrandChild1StoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *TestGrandChild1StoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *TestGrandChild1StoreSuite) TearDownTest() {
+func (s *TestGrandChild1StoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE test_grand_child1 CASCADE")
+	s.T().Log("test_grand_child1", tag)
+	s.NoError(err)
+}
+
+func (s *TestGrandChild1StoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
@@ -29,7 +29,7 @@ func TestTestGrandparentsStore(t *testing.T) {
 	suite.Run(t, new(TestGrandparentsStoreSuite))
 }
 
-func (s *TestGrandparentsStoreSuite) SetupTest() {
+func (s *TestGrandparentsStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *TestGrandparentsStoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *TestGrandparentsStoreSuite) TearDownTest() {
+func (s *TestGrandparentsStoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE test_grandparents CASCADE")
+	s.T().Log("test_grandparents", tag)
+	s.NoError(err)
+}
+
+func (s *TestGrandparentsStoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store_test.go
@@ -29,7 +29,7 @@ func TestTestParent1Store(t *testing.T) {
 	suite.Run(t, new(TestParent1StoreSuite))
 }
 
-func (s *TestParent1StoreSuite) SetupTest() {
+func (s *TestParent1StoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *TestParent1StoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *TestParent1StoreSuite) TearDownTest() {
+func (s *TestParent1StoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE test_parent1 CASCADE")
+	s.T().Log("test_parent1", tag)
+	s.NoError(err)
+}
+
+func (s *TestParent1StoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store_test.go
@@ -29,7 +29,7 @@ func TestTestParent2Store(t *testing.T) {
 	suite.Run(t, new(TestParent2StoreSuite))
 }
 
-func (s *TestParent2StoreSuite) SetupTest() {
+func (s *TestParent2StoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *TestParent2StoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *TestParent2StoreSuite) TearDownTest() {
+func (s *TestParent2StoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE test_parent2 CASCADE")
+	s.T().Log("test_parent2", tag)
+	s.NoError(err)
+}
+
+func (s *TestParent2StoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store_test.go
@@ -29,7 +29,7 @@ func TestTestParent3Store(t *testing.T) {
 	suite.Run(t, new(TestParent3StoreSuite))
 }
 
-func (s *TestParent3StoreSuite) SetupTest() {
+func (s *TestParent3StoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
 
@@ -54,7 +54,14 @@ func (s *TestParent3StoreSuite) SetupTest() {
 	s.store = CreateTableAndNewStore(ctx, pool, gormDB)
 }
 
-func (s *TestParent3StoreSuite) TearDownTest() {
+func (s *TestParent3StoreSuite) SetupTest() {
+	ctx := sac.WithAllAccess(context.Background())
+	tag, err := s.pool.Exec(ctx, "TRUNCATE test_parent3 CASCADE")
+	s.T().Log("test_parent3", tag)
+	s.NoError(err)
+}
+
+func (s *TestParent3StoreSuite) TearDownSuite() {
 	if s.pool != nil {
 		s.pool.Close()
 	}


### PR DESCRIPTION
## Description

We can save some time in CI by reusing same table for different tests in the suite.
This PR replaces `drop` with `truncate` to save some time.

## Testing Performed

CI
