### PR TITLE
CI: Set QA test group for merge and periodics

### DIFF
--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -88,9 +88,9 @@ run_tests_part_1() {
     elif is_tagged; then
         info "Tagged, running all QA tests..."
         make -C qa-tests-backend test || touch FAIL
-    elif [[ -n "${QA_TEST_GROUP:-}" ]]; then
-        info "Directed to run the '""${QA_TEST_GROUP:-}""' target..."
-        make -C qa-tests-backend "${QA_TEST_GROUP:-}" || touch FAIL
+    elif [[ -n "${QA_TEST_TARGET:-}" ]]; then
+        info "Directed to run the '""${QA_TEST_TARGET:-}""' target..."
+        make -C qa-tests-backend "${QA_TEST_TARGET:-}" || touch FAIL
     else
         info "An unexpected context. Defaulting to BAT tests only..."
         make -C qa-tests-backend bat-test || touch FAIL

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -79,7 +79,7 @@ run_tests_part_1() {
     if is_openshift_CI_rehearse_PR; then
         info "On an openshift rehearse PR, running BAT tests only..."
         make -C qa-tests-backend bat-test || touch FAIL
-    elif pr_has_label ci-all-qa-tests; then
+    elif is_in_PR_context && pr_has_label ci-all-qa-tests; then
         info "ci-all-qa-tests label was specified, so running all QA tests..."
         make -C qa-tests-backend test || touch FAIL
     elif is_in_PR_context; then
@@ -88,6 +88,9 @@ run_tests_part_1() {
     elif is_tagged; then
         info "Tagged, running all QA tests..."
         make -C qa-tests-backend test || touch FAIL
+    elif [[ -n "${QA_TEST_GROUP:-}" ]]; then
+        info "Directed to run the '""${QA_TEST_GROUP:-}""' target..."
+        make -C qa-tests-backend "${QA_TEST_GROUP:-}" || touch FAIL
     else
         info "An unexpected context. Defaulting to BAT tests only..."
         make -C qa-tests-backend bat-test || touch FAIL


### PR DESCRIPTION
## Description

per title. Once merged, this change will be applied here: https://github.com/openshift/release/pull/29155

## Checklist
- [x] Investigated and inspected CI test results


## Testing Performed

CI is sufficient.
- defaults to BAT only https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/stackrox_stackrox/1953/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1532912741969301504/artifacts/gke-qa-e2e-tests/stackrox-e2e/build-log.txt
- runs all when labeled. https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/stackrox_stackrox/1953/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1533100297537196032/artifacts/gke-qa-e2e-tests/stackrox-e2e/build-log.txt