### PR TITLE
ROX-10947: Empty name under spec.customresourcedefinitions.owned.resources

### DIFF
--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -342,7 +342,7 @@ type CentralComponentStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1,central},{Deployment,v1,scanner},{Deployment,v1,scanner-db},{Secret,v1,central-htpasswd},{Service,v1,central-loadbalancer},{Route,v1,central}}
+//+operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1,""},{Secret,v1,""},{Service,v1,""},{Route,v1,""}}
 //+genclient
 
 // Central is the configuration template for the central services. This includes the API server, persistent storage,

--- a/operator/apis/platform/v1alpha1/securedcluster_types.go
+++ b/operator/apis/platform/v1alpha1/securedcluster_types.go
@@ -360,7 +360,7 @@ type SecuredClusterStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1,admission-control},{DaemonSet,v1,collector},{Deployment,v1,sensor}}
+//+operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1,""},{DaemonSet,v1,""}}
 //+genclient
 
 // SecuredCluster is the configuration template for the secured cluster services. These include Sensor, which is

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -36,22 +36,16 @@ spec:
       name: centrals.platform.stackrox.io
       resources:
       - kind: Deployment
-        name: central
+        name: ''
         version: v1
       - kind: Route
-        name: central
+        name: ''
         version: v1
       - kind: Secret
-        name: central-htpasswd
+        name: ''
         version: v1
       - kind: Service
-        name: central-loadbalancer
-        version: v1
-      - kind: Deployment
-        name: scanner
-        version: v1
-      - kind: Deployment
-        name: scanner-db
+        name: ''
         version: v1
       specDescriptors:
       - description: Settings for the Central component, which is responsible for
@@ -324,14 +318,11 @@ spec:
       kind: SecuredCluster
       name: securedclusters.platform.stackrox.io
       resources:
-      - kind: Deployment
-        name: admission-control
-        version: v1
       - kind: DaemonSet
-        name: collector
+        name: ''
         version: v1
       - kind: Deployment
-        name: sensor
+        name: ''
         version: v1
       specDescriptors:
       - description: 'The unique name of this cluster, as it will be shown in the

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -26,22 +26,16 @@ spec:
       name: centrals.platform.stackrox.io
       resources:
       - kind: Deployment
-        name: central
+        name: ""
         version: v1
       - kind: Route
-        name: central
+        name: ""
         version: v1
       - kind: Secret
-        name: central-htpasswd
+        name: ""
         version: v1
       - kind: Service
-        name: central-loadbalancer
-        version: v1
-      - kind: Deployment
-        name: scanner
-        version: v1
-      - kind: Deployment
-        name: scanner-db
+        name: ""
         version: v1
       specDescriptors:
       - description: Settings for the Central component, which is responsible for
@@ -314,14 +308,11 @@ spec:
       kind: SecuredCluster
       name: securedclusters.platform.stackrox.io
       resources:
-      - kind: Deployment
-        name: admission-control
-        version: v1
       - kind: DaemonSet
-        name: collector
+        name: ""
         version: v1
       - kind: Deployment
-        name: sensor
+        name: ""
         version: v1
       specDescriptors:
       - description: Set this to 'true' to enable preventive policy enforcement for


### PR DESCRIPTION
## Description

Change [CustomResource]_types.go to empty the "name" value spec.customresourcedefinitions.owned.resources otherwise this will cause https://bugzilla.redhat.com/show_bug.cgi?id=2082491

A copy of #1779 by @cchen666 to let CI pass

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
- [x] Check that the related resources links now work in the console

## Testing Performed

Relying on CI.

Also installed the operator, provisioned a central and made sure at least a few of the following links work OK:

![Screenshot from 2022-06-06 13-37-55](https://user-images.githubusercontent.com/489420/172153645-63905599-024d-4482-ae52-11c97dd3e7ef.png)
