### PR TITLE
OSCI: collect policies-diff before exit!

### DIFF
--- a/scripts/ci/jobs/check-policy-files.sh
+++ b/scripts/ci/jobs/check-policy-files.sh
@@ -14,14 +14,15 @@ check_policy_files() {
     make policyutil
     policyutil upgrade -d pkg/defaults/policies/files -o /tmp/policies-in-standard-form --ensure-read-only mitre --ensure-read-only criteria
     diff pkg/defaults/policies/files /tmp/policies-in-standard-form > /tmp/policies-diff || true
+
+    store_test_results /tmp/policies-diff policies-diff
+
     if [[ -s /tmp/policies-diff ]]; then
         echo 'error: Found policies that are not in standard form.' \
             'Check "policies-diff" for affected policies; use "policyutil" to fix them.'
         cat /tmp/policies-diff
         exit 1
     fi
-
-    store_test_results /tmp/policies-diff policies-diff
 }
 
 check_policy_files


### PR DESCRIPTION
Fix policy check to include artifacts if failure.

This is to fix my mistake putting the artifacts collection at the end matching the yaml layout. I noticed it when making sure I had the artifacts for the mitre check.