### PR TITLE
OSCI: Fix UI e2e failure

### DIFF
--- a/tests/e2e/run-ui-e2e.sh
+++ b/tests/e2e/run-ui-e2e.sh
@@ -40,10 +40,10 @@ run_ui_e2e_tests() {
         local hostname
         hostname=$("$ROOT/tests/e2e/get_hostname.py" "${API_HOSTNAME}")
         # echo "central-lb ${API_HOSTNAME}" > /tmp/hostaliases
-        # echo "central-lb ${hostname}" > /tmp/hostaliases
-        # export HOSTALIASES=/tmp/hostaliases
-        # export UI_BASE_URL="https://central-lb:443"
-        export UI_BASE_URL="https://${hostname}:443"
+        echo "central-lb ${hostname}" > /tmp/hostaliases
+        export HOSTALIASES=/tmp/hostaliases
+        export UI_BASE_URL="https://central-lb:443"
+        # export UI_BASE_URL="https://${hostname}:443"
     else
         export UI_BASE_URL="https://localhost:${LOCAL_PORT}"
     fi

--- a/tests/e2e/run-ui-e2e.sh
+++ b/tests/e2e/run-ui-e2e.sh
@@ -37,7 +37,10 @@ run_ui_e2e_tests() {
     info "Running UI e2e tests"
 
     if [[ "${LOAD_BALANCER}" == "lb" ]]; then
-        echo "central-lb ${API_HOSTNAME}" > /tmp/hostaliases
+        local hostname
+        hostname=$("$ROOT/tests/e2e/get_hostname.py" "${API_HOSTNAME}")
+        # echo "central-lb ${API_HOSTNAME}" > /tmp/hostaliases
+        echo "central-lb ${hostname}" > /tmp/hostaliases
         export HOSTALIASES=/tmp/hostaliases
         export UI_BASE_URL="https://central-lb:443"
     else

--- a/tests/e2e/run-ui-e2e.sh
+++ b/tests/e2e/run-ui-e2e.sh
@@ -40,9 +40,10 @@ run_ui_e2e_tests() {
         local hostname
         hostname=$("$ROOT/tests/e2e/get_hostname.py" "${API_HOSTNAME}")
         # echo "central-lb ${API_HOSTNAME}" > /tmp/hostaliases
-        echo "central-lb ${hostname}" > /tmp/hostaliases
-        export HOSTALIASES=/tmp/hostaliases
-        export UI_BASE_URL="https://central-lb:443"
+        # echo "central-lb ${hostname}" > /tmp/hostaliases
+        # export HOSTALIASES=/tmp/hostaliases
+        # export UI_BASE_URL="https://central-lb:443"
+        export UI_BASE_URL="https://${hostname}:443"
     else
         export UI_BASE_URL="https://localhost:${LOCAL_PORT}"
     fi

--- a/tests/e2e/run-ui-e2e.sh
+++ b/tests/e2e/run-ui-e2e.sh
@@ -39,11 +39,9 @@ run_ui_e2e_tests() {
     if [[ "${LOAD_BALANCER}" == "lb" ]]; then
         local hostname
         hostname=$("$ROOT/tests/e2e/get_hostname.py" "${API_HOSTNAME}")
-        # echo "central-lb ${API_HOSTNAME}" > /tmp/hostaliases
         echo "central-lb ${hostname}" > /tmp/hostaliases
         export HOSTALIASES=/tmp/hostaliases
         export UI_BASE_URL="https://central-lb:443"
-        # export UI_BASE_URL="https://${hostname}:443"
     else
         export UI_BASE_URL="https://localhost:${LOCAL_PORT}"
     fi


### PR DESCRIPTION
## Description

This PR fixes an issue connecting to central via HOSTALIASES. Some background: 

- A name is required for cypress due to: https://github.com/stackrox/rox/pull/1303
- A port-foward and `localhost` is not a good alternative due to its unreliability (I think related to GKE token refresh).
- I tried a HOSTALIASES with `central-lb <IP ADDR>` and this seemed to work on the original staging PR but quit working after merge.
- Using the reverse looked up hostname gets timeouts from cypress.
- Using a HOSTALIASES with `central-lb <hostname>` seems reliable 🤞 

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient - https://prow.ci.openshift.org/pr-history/?org=stackrox&repo=stackrox&pr=1960