### PR TITLE
ROX-11059: Use errox sentinel errors within roxctl.

### DIFF
--- a/roxctl/central/backup/backup.go
+++ b/roxctl/central/backup/backup.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/mathutil"
@@ -66,7 +67,7 @@ func parseUserProvidedOutput(userProvidedOutput string) (string, error) {
 		}
 		// If they specified a directory, it must exist.
 		if strings.HasSuffix(userProvidedOutput, string(os.PathSeparator)) {
-			return "", errors.Errorf("invalid output %q: directory does not exist", userProvidedOutput)
+			return "", errox.InvalidArgs.Newf("invalid output %q: directory does not exist", userProvidedOutput)
 		}
 		// Now we know they've provided a filename. We check to make sure the containing directory exists.
 		containingDir := filepath.Dir(userProvidedOutput)
@@ -75,7 +76,8 @@ func parseUserProvidedOutput(userProvidedOutput string) (string, error) {
 			return "", err
 		}
 		if !dirExists {
-			return "", errors.Errorf("invalid output %q: containing directory %q does not exist", userProvidedOutput, containingDir)
+			return "", errox.InvalidArgs.Newf("invalid output %q: containing directory %q does not exist",
+				userProvidedOutput, containingDir)
 		}
 		return userProvidedOutput, nil
 	}
@@ -142,7 +144,7 @@ func (cmd *centralBackupCommand) backup(timeout time.Duration, full bool) error 
 	switch resp.StatusCode {
 	case http.StatusOK:
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return errors.New("Invalid credentials. Please add/fix your credentials")
+		return errox.NotAuthorized.New("Invalid credentials. Please add/fix your credentials")
 	default:
 		return errors.Wrap(httputil.ResponseToError(resp), "Error when trying to get a backup.")
 	}

--- a/roxctl/central/cert/cert.go
+++ b/roxctl/central/cert/cert.go
@@ -5,12 +5,12 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"io"
 	"os"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/errox"
 	pkgCommon "github.com/stackrox/rox/pkg/roxctl/common"
 	"github.com/stackrox/rox/pkg/tlsutils"
 	"github.com/stackrox/rox/pkg/utils"
@@ -75,7 +75,7 @@ func (cmd *centralCertCommand) certs() error {
 	// Verify that at least 1 certificate was obtained from the connection.
 	certs := conn.ConnectionState().PeerCertificates
 	if len(certs) == 0 {
-		return errors.New("server returned no certificates")
+		return errox.NotFound.New("server returned no certificates")
 	}
 
 	// "File" to output PEM certificate to.

--- a/roxctl/central/db/restore/v2.go
+++ b/roxctl/central/db/restore/v2.go
@@ -26,7 +26,7 @@ const (
 var (
 	// ErrV2RestoreNotSupported is the error returned to indicate that the server does not support the new
 	// backup/restore mechanism.
-	ErrV2RestoreNotSupported = errors.New("server does not support V2 restore functionality")
+	ErrV2RestoreNotSupported = errox.InvariantViolation.New("server does not support V2 restore functionality")
 )
 
 type centralDbRestoreCommand struct {
@@ -108,7 +108,7 @@ func findManifestFile(fileName string, manifest *v1.DBExportManifest) (*v1.DBExp
 			return mfFile, idx, nil
 		}
 	}
-	return nil, 0, errors.Errorf("file %s not found in manifest", fileName)
+	return nil, 0, errox.NotFound.Newf("file %s not found in manifest", fileName)
 }
 
 func dataReadersForManifest(file *os.File, manifest *v1.DBExportManifest) ([]func() io.Reader, error) {
@@ -145,15 +145,15 @@ func dataReadersForManifest(file *os.File, manifest *v1.DBExportManifest) ([]fun
 		}
 
 		if manifestFile.GetEncoding() != expectedCompressionType {
-			return nil, errors.Errorf("file %s is encoded as %v in ZIP file, but expected as %v per manifest", entry.Name, expectedCompressionType, manifestFile.GetEncoding())
+			return nil, errox.InvalidArgs.Newf("file %s is encoded as %v in ZIP file, but expected as %v per manifest", entry.Name, expectedCompressionType, manifestFile.GetEncoding())
 		}
 
 		if manifestFile.GetEncodedSize() != expectedEncodedSize {
-			return nil, errors.Errorf("file %s has an encoded length of %d in the ZIP file, but expected to be %d per manifest", entry.Name, expectedEncodedSize, manifestFile.GetEncodedSize())
+			return nil, errox.InvalidArgs.Newf("file %s has an encoded length of %d in the ZIP file, but expected to be %d per manifest", entry.Name, expectedEncodedSize, manifestFile.GetEncodedSize())
 		}
 
 		if manifestFile.GetDecodedCrc32() != entry.CRC32 {
-			return nil, errors.Errorf("file %s has mismatching CRC32 checksum: %x in ZIP file versus %x in manifest", entry.Name, entry.CRC32, manifestFile.GetDecodedCrc32())
+			return nil, errox.InvalidArgs.Newf("file %s has mismatching CRC32 checksum: %x in ZIP file versus %x in manifest", entry.Name, entry.CRC32, manifestFile.GetDecodedCrc32())
 		}
 
 		var readerFunc func() io.Reader
@@ -180,7 +180,7 @@ func dataReadersForManifest(file *os.File, manifest *v1.DBExportManifest) ([]fun
 
 	for idx, manifestFile := range manifest.GetFiles() {
 		if readers[idx] == nil {
-			return nil, errors.Errorf("file %s has no associated data reader", manifestFile.GetName())
+			return nil, errox.NotFound.Newf("file %s has no associated data reader", manifestFile.GetName())
 		}
 	}
 

--- a/roxctl/central/db/restore/v2_cancel.go
+++ b/roxctl/central/db/restore/v2_cancel.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/errox"
 	pkgCommon "github.com/stackrox/rox/pkg/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/flags"
@@ -62,7 +63,7 @@ func (cmd *centralRestoreCancelCommand) cancelActiveRestore() error {
 
 	processStatus := activeRestoreProcessResp.GetActiveStatus()
 	if processStatus == nil {
-		return errors.New("No restore process is currently in progress")
+		return errox.NotFound.New("no restore process is currently in progress")
 	}
 
 	cmd.env.Logger().PrintfLn("Active database restore process information")

--- a/roxctl/central/db/restore/v2_restorer.go
+++ b/roxctl/central/db/restore/v2_restorer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/ioutils"
 	"github.com/stackrox/rox/pkg/retry"
 	"github.com/stackrox/rox/pkg/sliceutils"
@@ -216,7 +217,7 @@ func (r *v2Restorer) Run(ctx context.Context, file *os.File) (*http.Response, er
 			r.errorLine.SetTextStatic(err.Error())
 
 			if !r.retryDeadline.IsZero() && time.Now().After(r.retryDeadline) {
-				return nil, errors.New("absolute retry deadline has passed, please restart roxctl to resume the restore")
+				return nil, errox.InvariantViolation.New("absolute retry deadline has passed, please restart roxctl to resume the restore")
 			}
 
 			if r.transferProgressBar == nil {
@@ -305,7 +306,7 @@ func (r *v2Restorer) initResume(ctx context.Context, file *os.File, activeStatus
 			}
 			resumeInfo = interruptResp.GetResumeInfo()
 		} else {
-			return nil, errors.Errorf("active restore process %s is not currently in resumable state. If you believe this process is stuck, use the `--interrupt` flag", activeStatus.GetMetadata().GetId())
+			return nil, errox.InvariantViolation.Newf("active restore process %s is not currently in resumable state. If you believe this process is stuck, use the `--interrupt` flag", activeStatus.GetMetadata().GetId())
 		}
 	}
 
@@ -408,7 +409,7 @@ func (r *v2Restorer) prepareResumeRequest(resumeInfo *v1.DBRestoreProcessStatus_
 	if pos, err := r.dataReader.Seek(resumeInfo.GetPos(), io.SeekStart); err != nil {
 		return nil, err
 	} else if pos != resumeInfo.GetPos() {
-		return nil, errors.Errorf("could not seek to resume position %d in data: data ends at position %d", resumeInfo.GetPos(), pos)
+		return nil, errox.NotFound.Newf("could not seek to resume position %d in data: data ends at position %d", resumeInfo.GetPos(), pos)
 	} else if r.transferProgressBar != nil {
 		// Interestingly, `SetCurrent` on a progress bar does not work as expected. It only works if it is used without
 		// ever using `Incr` beforehand.
@@ -450,7 +451,7 @@ func (r *v2Restorer) resumeAfterError(ctx context.Context) (*http.Request, error
 	activeProcess := resp.GetActiveStatus()
 
 	if activeProcess.GetMetadata().GetId() != r.processID {
-		return nil, errors.Errorf("active restore process has changed: expected %s, got %s", r.processID, activeProcess.GetMetadata().GetId())
+		return nil, errox.InvariantViolation.Newf("active restore process has changed: expected %s, got %s", r.processID, activeProcess.GetMetadata().GetId())
 	}
 
 	resumeInfo := activeProcess.GetResumeInfo()

--- a/roxctl/central/db/transfer/transfer.go
+++ b/roxctl/central/db/transfer/transfer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/vbauerster/mpb/v4"
@@ -65,7 +66,7 @@ func ViaHTTP(req *http.Request, client common.RoxctlHTTPClient, earliestDeadline
 	totalLen := req.ContentLength
 	name := "Uploading..."
 	if req.Body == nil {
-		return nil, errors.New("transfer request must have a non-nil body")
+		return nil, errox.InvalidArgs.New("transfer request must have a non-nil body")
 	}
 	if srcFile, ok := req.Body.(interface{ Stat() (os.FileInfo, error) }); ok {
 		srcFileStat, err := srcFile.Stat()

--- a/roxctl/central/generate/file_format.go
+++ b/roxctl/central/generate/file_format.go
@@ -1,10 +1,10 @@
 package generate
 
 import (
-	"fmt"
 	"strings"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/errox"
 )
 
 type fileFormatWrapper struct {
@@ -18,7 +18,7 @@ func (f *fileFormatWrapper) String() string {
 func (f *fileFormatWrapper) Set(input string) error {
 	val, ok := v1.DeploymentFormat_value[strings.Replace(strings.ToUpper(input), "-", "_", -1)]
 	if !ok {
-		return fmt.Errorf("%q is not a valid option", input)
+		return errox.InvalidArgs.Newf("%q is not a valid option", input)
 	}
 	*f.DeploymentFormat = v1.DeploymentFormat(val)
 	return nil

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/certgen"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/images/defaults"
 	"github.com/stackrox/rox/pkg/mtls"
@@ -119,7 +120,7 @@ func createBundle(logger common.Logger, config renderer.Config) (*zip.Wrapper, e
 	wrapper := zip.NewWrapper()
 
 	if config.ClusterType == storage.ClusterType_GENERIC_CLUSTER {
-		return nil, errors.Errorf("invalid cluster type: %s", config.ClusterType)
+		return nil, errox.InvalidArgs.Newf("invalid cluster type: %s", config.ClusterType)
 	}
 
 	config.SecretsByteMap = make(map[string][]byte)

--- a/roxctl/central/generate/istio.go
+++ b/roxctl/central/generate/istio.go
@@ -3,7 +3,7 @@ package generate
 import (
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/istioutils"
 )
 
@@ -18,7 +18,8 @@ func (w istioSupportWrapper) String() string {
 func (w istioSupportWrapper) Set(input string) error {
 	_, err := istioutils.GetAPIResourcesByVersion(input)
 	if err != nil {
-		return errors.Errorf("invalid Istio version %q. Valid versions are: %s (or leave empty for no Istio support)", input, strings.Join(istioutils.ListKnownIstioVersions(), ", "))
+		return errox.InvalidArgs.Newf("invalid Istio version %q. Valid versions are: %s (or leave empty "+
+			"for no Istio support)", input, strings.Join(istioutils.ListKnownIstioVersions(), ", "))
 	}
 	*w.istioSupport = input
 	return nil

--- a/roxctl/central/generate/k8s.go
+++ b/roxctl/central/generate/k8s.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/istioutils"
 	"github.com/stackrox/rox/pkg/renderer"
@@ -57,7 +58,7 @@ func orchestratorCommand(shortName, longName string) *cobra.Command {
 			categoryAnnotation: "Enter orchestrator",
 		},
 		RunE: util.RunENoArgs(func(*cobra.Command) error {
-			return errors.New("storage type must be specified")
+			return errox.InvalidArgs.New("storage type must be specified")
 		}),
 	}
 	if !roxctl.InMainImage() {

--- a/roxctl/central/generate/loadbalancer.go
+++ b/roxctl/central/generate/loadbalancer.go
@@ -1,10 +1,10 @@
 package generate
 
 import (
-	"fmt"
 	"strings"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/errox"
 )
 
 type loadBalancerWrapper struct {
@@ -35,7 +35,7 @@ func (f *loadBalancerWrapper) Set(input string) error {
 		*f.LoadBalancerType = val
 		return nil
 	}
-	return fmt.Errorf("invalid load balancer type: %q", input)
+	return errox.InvalidArgs.Newf("invalid load balancer type: %q", input)
 }
 
 func (f *loadBalancerWrapper) Type() string {

--- a/roxctl/central/generate/output_dir.go
+++ b/roxctl/central/generate/output_dir.go
@@ -1,8 +1,9 @@
 package generate
 
 import (
-	"fmt"
 	"os"
+
+	"github.com/stackrox/rox/pkg/errox"
 )
 
 const defaultPath = "central-bundle"
@@ -29,7 +30,7 @@ func (o *outputDirWrapper) Set(input string) error {
 	if _, err := os.Stat(input); err != nil && !os.IsNotExist(err) {
 		return err
 	} else if err == nil {
-		return fmt.Errorf("directory %q already exists. Please specify and new path to ensure expected results", input)
+		return errox.InvalidArgs.Newf("directory %q already exists. Please specify and new path to ensure expected results", input)
 	}
 	*o.OutputDir = input
 	return nil

--- a/roxctl/central/generate/validate.go
+++ b/roxctl/central/generate/validate.go
@@ -3,7 +3,7 @@ package generate
 import (
 	"crypto/tls"
 
-	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/renderer"
 )
 
@@ -26,7 +26,7 @@ func validateHostPath(hostpath *renderer.HostPathPersistence) error {
 		return nil
 	}
 	if (hostpath.NodeSelectorKey == "") != (hostpath.NodeSelectorValue == "") {
-		return errors.New("Both node selector key and node selector value must be specified when using a hostpath")
+		return errox.InvalidArgs.New("Both node selector key and node selector value must be specified when using a hostpath")
 	}
 	return nil
 }

--- a/roxctl/central/initbundles/fetch_ca.go
+++ b/roxctl/central/initbundles/fetch_ca.go
@@ -65,7 +65,7 @@ func fetchCACommand(cliEnvironment common.Environment) *cobra.Command {
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if outputFile == "" {
-				return errors.New("No output file specified with --output (for stdout, specify '-')")
+				return common.ErrInvalidCommandOption.New("no output file specified with --output (for stdout, specify '-')")
 			} else if outputFile == "-" {
 				outputFile = ""
 			}

--- a/roxctl/central/initbundles/generate.go
+++ b/roxctl/central/initbundles/generate.go
@@ -122,7 +122,7 @@ func generateCommand(cliEnvironment common.Environment) *cobra.Command {
 			}
 
 			if len(outputs) == 0 {
-				return errors.New("No output files specified with --output or --output-secrets (for stdout, specify '-')")
+				return common.ErrInvalidCommandOption.New("No output files specified with --output or --output-secrets (for stdout, specify '-')")
 			}
 			return generateInitBundle(cliEnvironment, name, outputs)
 		},

--- a/roxctl/central/initbundles/revoke.go
+++ b/roxctl/central/initbundles/revoke.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/errox"
 	pkgCommon "github.com/stackrox/rox/pkg/roxctl/common"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
@@ -27,7 +28,7 @@ func applyRevokeInitBundles(ctx context.Context, cliEnvironment common.Environme
 	}
 
 	if len(idsOrNames) != 0 {
-		return errors.Errorf("could not find init bundle(s) %s", strings.Join(idsOrNames.AsSlice(), ", "))
+		return errox.NotFound.Newf("could not find init bundle(s) %s", strings.Join(idsOrNames.AsSlice(), ", "))
 	}
 
 	revokeResp, err := svc.RevokeInitBundle(ctx, &v1.InitBundleRevokeRequest{Ids: revokeInitBundleIds})

--- a/roxctl/central/userpki/create/create.go
+++ b/roxctl/central/userpki/create/create.go
@@ -14,6 +14,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/authproviders/userpki"
+	"github.com/stackrox/rox/pkg/errox"
 	pkgCommon "github.com/stackrox/rox/pkg/roxctl/common"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common"
@@ -32,9 +33,9 @@ type centralUserPkiCreateCommand struct {
 }
 
 var (
-	errNoPEMFiles     = errors.New("no certificate files specified")
-	errNotCA          = errors.New("not a certificate authority")
-	errNoProviderName = errors.New("no provider name specified")
+	errNoPEMFiles     = errox.InvalidArgs.New("no certificate files specified")
+	errNotCA          = errox.InvalidArgs.New("not a certificate authority")
+	errNoProviderName = errox.InvalidArgs.New("no provider name specified")
 )
 
 // Command adds the userpki create command

--- a/roxctl/central/userpki/delete/delete.go
+++ b/roxctl/central/userpki/delete/delete.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/authproviders/userpki"
+	"github.com/stackrox/rox/pkg/errox"
 	pkgCommon "github.com/stackrox/rox/pkg/roxctl/common"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/uuid"
@@ -19,8 +19,8 @@ import (
 )
 
 var (
-	errNoProviderArg    = errors.New("provider ID/name parameter required")
-	errProviderNotFound = errors.New("provider doesn't exist")
+	errNoProviderArg    = errox.InvalidArgs.New("provider ID/name parameter required")
+	errProviderNotFound = errox.NotFound.New("provider doesn't exist")
 )
 
 type centralUserPkiDeleteCommand struct {

--- a/roxctl/collector/supportpackages/upload/command.go
+++ b/roxctl/collector/supportpackages/upload/command.go
@@ -1,8 +1,8 @@
 package upload
 
 import (
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/roxctl/common"
 )
 
@@ -38,10 +38,10 @@ func Command(cliEnvironment common.Environment) *cobra.Command {
 
 func validate(args []string) error {
 	if len(args) > 1 {
-		return errors.Errorf("too many positional arguments (expected 1, got %d)", len(args))
+		return errox.InvalidArgs.Newf("too many positional arguments (expected 1, got %d)", len(args))
 	}
 	if len(args) == 0 {
-		return errors.New("missing <package-file> argument")
+		return errox.InvalidArgs.New("missing <package-file> argument")
 	}
 	return nil
 }

--- a/roxctl/collector/supportpackages/upload/upload.go
+++ b/roxctl/collector/supportpackages/upload/upload.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/ioutils"
 	"github.com/stackrox/rox/pkg/probeupload"
@@ -176,7 +177,7 @@ func (cmd *collectorSPUploadCommand) uploadFilesFromPackage() error {
 	}
 
 	if len(probeFiles) == 0 {
-		return errors.New("the given support package contains no relevant files")
+		return errox.NotFound.New("the given support package contains no relevant files")
 	}
 
 	existingFiles, err := cmd.retrieveExistingProbeFiles(probeFiles)

--- a/roxctl/common/auth.go
+++ b/roxctl/common/auth.go
@@ -1,12 +1,12 @@
 package common
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/authn/basic"
 	"github.com/stackrox/rox/roxctl/common/flags"
 )
@@ -18,10 +18,10 @@ type Auth interface {
 
 func checkAuthParameters() error {
 	if flags.APITokenFile() != "" && flags.Password() != "" {
-		return errors.New("cannot use password- and token-based authentication at the same time")
+		return errox.InvalidArgs.New("cannot use password- and token-based authentication at the same time")
 	}
 	if flags.APITokenFile() == "" && env.TokenEnv.Setting() == "" && flags.Password() == "" {
-		return errors.New("no token set via either token file or the environment variable ROX_API_TOKEN")
+		return errox.InvalidArgs.New("no token set via either token file or the environment variable ROX_API_TOKEN")
 	}
 
 	return nil

--- a/roxctl/common/client.go
+++ b/roxctl/common/client.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/utils"
 	"golang.org/x/net/http2"
 )
@@ -72,7 +73,7 @@ func (client *roxctlClientImpl) DoReqAndVerifyStatusCode(path string, method str
 		if err != nil {
 			return nil, errors.Wrapf(err, "Expected status code %d, but received %d. Additionally, there was an error reading the response", code, resp.StatusCode)
 		}
-		return nil, errors.Errorf("Expected status code %d, but received %d. Response Body: %s", code, resp.StatusCode, string(data))
+		return nil, errox.InvariantViolation.Newf("expected status code %d, but received %d. Response Body: %s", code, resp.StatusCode, string(data))
 	}
 
 	return resp, nil
@@ -99,7 +100,7 @@ func (client *roxctlClientImpl) NewReq(method string, path string, body io.Reade
 	}
 
 	if req.URL.Scheme != "https" && !client.useInsecure {
-		return nil, errors.Errorf("URL %v uses insecure scheme %q, use --insecure flags to enable sending credentials", req.URL, req.URL.Scheme)
+		return nil, errox.InvalidArgs.Newf("URL %v uses insecure scheme %q, use --insecure flags to enable sending credentials", req.URL, req.URL.Scheme)
 	}
 	err = client.a.SetAuth(req)
 	if err != nil {

--- a/roxctl/common/download/parse_filename.go
+++ b/roxctl/common/download/parse_filename.go
@@ -1,11 +1,10 @@
 package download
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/errox"
 )
 
 const (
@@ -17,12 +16,12 @@ const (
 func ParseFilenameFromHeader(header http.Header) (string, error) {
 	data := header.Get(contentDispositionHeader)
 	if data == "" {
-		return data, errors.Errorf("missing %s header", contentDispositionHeader)
+		return data, errox.NotFound.Newf("missing %s header", contentDispositionHeader)
 	}
 	oldLen := len(data)
 	data = strings.TrimPrefix(data, "attachment; filename=")
 	if len(data) == oldLen {
-		return "", fmt.Errorf("failed to determine filename from %s header value %q", contentDispositionHeader, data)
+		return "", errox.NotFound.Newf("failed to determine filename from %s header value %q", contentDispositionHeader, data)
 	}
 	return strings.Trim(data, `"`), nil
 }

--- a/roxctl/common/exact_args.go
+++ b/roxctl/common/exact_args.go
@@ -1,9 +1,8 @@
 package common
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/errox"
 )
 
 // ExactArgsWithCustomErrMessage returns an error with a custom message
@@ -11,7 +10,7 @@ import (
 func ExactArgsWithCustomErrMessage(n int, msg string) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) != n {
-			return errors.New(msg)
+			return errox.InvalidArgs.New(msg)
 		}
 		return nil
 	}

--- a/roxctl/common/flags.go
+++ b/roxctl/common/flags.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/clientconn"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/alpn"
 	"github.com/stackrox/rox/pkg/grpc/authn/basic"
 	"github.com/stackrox/rox/pkg/mtls"
@@ -36,7 +37,7 @@ func GetGRPCConnection() (*grpc.ClientConn, error) {
 
 	if usePlaintext {
 		if !flags.UseInsecure() {
-			return nil, errors.New("plaintext connection mode must be used in conjunction with --insecure")
+			return nil, errox.InvalidArgs.New("plaintext connection mode must be used in conjunction with --insecure")
 		}
 		opts.InsecureNoTLS = true
 		opts.InsecureAllowCredsViaPlaintext = true
@@ -61,7 +62,7 @@ func GetGRPCConnection() (*grpc.ClientConn, error) {
 			return proxy, errors.Wrap(proxyErr, "could not connect via proxy")
 		}
 	} else if flags.ForceHTTP1() {
-		return nil, errors.New("cannot force HTTP/1 mode if direct gRPC is enabled")
+		return nil, errox.InvalidArgs.New("cannot force HTTP/1 mode if direct gRPC is enabled")
 	}
 
 	if err := checkAuthParameters(); err != nil {

--- a/roxctl/common/flags/api_token_file.go
+++ b/roxctl/common/flags/api_token_file.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/errox"
 )
 
 var (
@@ -36,5 +37,5 @@ func ReadTokenFromFile(fileName string) (string, error) {
 	if token != "" {
 		return token, nil
 	}
-	return "", errors.Errorf("failed to retrieve token from file %q: file is empty", fileName)
+	return "", errox.NotFound.Newf("failed to retrieve token from file %q: file is empty", fileName)
 }

--- a/roxctl/common/flags/confirm.go
+++ b/roxctl/common/flags/confirm.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -43,7 +44,7 @@ func CheckConfirmation(c *cobra.Command) error {
 	}
 	resp = strings.ToLower(strings.TrimSpace(resp))
 	if resp != "y" {
-		return errors.New("User rejected")
+		return errox.NotAuthorized.New("User rejected")
 	}
 	return nil
 }

--- a/roxctl/common/flags/endpoint.go
+++ b/roxctl/common/flags/endpoint.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/errox"
 )
 
 var (
@@ -52,7 +53,7 @@ func EndpointAndPlaintextSetting() (string, bool, error) {
 	}
 
 	if u.Path != "" && u.Path != "/" {
-		return "", false, errors.New("endpoint URL must not include a path component")
+		return "", false, errox.InvalidArgs.New("endpoint URL must not include a path component")
 	}
 
 	var usePlaintext bool
@@ -62,12 +63,12 @@ func EndpointAndPlaintextSetting() (string, bool, error) {
 	case "https":
 		usePlaintext = false
 	default:
-		return "", false, errors.Errorf("invalid scheme %q in endpoint URL", u.Scheme)
+		return "", false, errox.InvalidArgs.Newf("invalid scheme %q in endpoint URL", u.Scheme)
 	}
 
 	if *plaintextSet {
 		if plaintext != usePlaintext {
-			return "", false, errors.Errorf("endpoint URL scheme %q is incompatible with --plaintext=%v setting", u.Scheme, plaintext)
+			return "", false, errox.InvalidArgs.Newf("endpoint URL scheme %q is incompatible with --plaintext=%v setting", u.Scheme, plaintext)
 		}
 	}
 

--- a/roxctl/common/flags/imageFlavor.go
+++ b/roxctl/common/flags/imageFlavor.go
@@ -23,7 +23,7 @@ const (
 )
 
 var (
-	imageFlavorDefault string = defaults.ImageFlavorNameRHACSRelease
+	imageFlavorDefault = defaults.ImageFlavorNameRHACSRelease
 )
 
 // ImageDefaultsFlagName is a shared constant for --image-defaults command line flag.

--- a/roxctl/common/flags/persistence.go
+++ b/roxctl/common/flags/persistence.go
@@ -1,8 +1,7 @@
 package flags
 
 import (
-	"fmt"
-
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/renderer"
 )
 
@@ -20,7 +19,7 @@ func (f *PersistenceTypeWrapper) String() string {
 func (f *PersistenceTypeWrapper) Set(input string) error {
 	pt, ok := renderer.StringToPersistentTypes[input]
 	if !ok {
-		return fmt.Errorf("Invalid persistence type: %s", input)
+		return errox.InvalidArgs.Newf("invalid persistence type: %s", input)
 	}
 	*f.PersistenceType = pt
 	return nil

--- a/roxctl/common/util/wrap.go
+++ b/roxctl/common/util/wrap.go
@@ -1,15 +1,15 @@
 package util
 
 import (
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/errox"
 )
 
 // RunENoArgs is a wrapper for RunE that does not consult the args argument.
 func RunENoArgs(f func(*cobra.Command) error) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, args []string) error {
 		if len(args) > 0 {
-			return errors.New("expected no arguments; please check usage")
+			return errox.InvalidArgs.New("expected no arguments; please check usage")
 		}
 		return f(c)
 	}

--- a/roxctl/completion/completion_test.go
+++ b/roxctl/completion/completion_test.go
@@ -1,9 +1,9 @@
 package completion
 
 import (
-	"errors"
 	"testing"
 
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/printer"
 	"github.com/stretchr/testify/assert"
@@ -16,7 +16,7 @@ func TestCompletionCommand_InvalidArgs(t *testing.T) {
 	}{
 		"no args given": {
 			args: []string{},
-			err:  errors.New("Missing argument. Use one of the following: [bash|zsh|fish|powershell]"),
+			err:  errox.InvalidArgs,
 		},
 		"invalid args given": {
 			args: []string{"oh-my-zsh"},
@@ -24,7 +24,7 @@ func TestCompletionCommand_InvalidArgs(t *testing.T) {
 		},
 		"more than 1 arg given": {
 			args: []string{"zhs", "oh-my-zsh"},
-			err:  errors.New("Missing argument. Use one of the following: [bash|zsh|fish|powershell]"),
+			err:  errox.InvalidArgs,
 		},
 	}
 
@@ -34,7 +34,8 @@ func TestCompletionCommand_InvalidArgs(t *testing.T) {
 			cmd := Command(common.NewTestCLIEnvironment(t, io, nil))
 			cmd.SetArgs(c.args)
 			err := cmd.Execute()
-			assert.Equal(t, c.err, err, "expected %v to match %v", err, errInvalidArgs)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, c.err)
 		})
 	}
 }

--- a/roxctl/helm/derivelocalvalues/derivelocalvalues.go
+++ b/roxctl/helm/derivelocalvalues/derivelocalvalues.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/maputil"
 	env "github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/helm/internal/common"
@@ -30,10 +31,10 @@ func deriveLocalValuesForChart(logger env.Logger, namespace, chartName, input, o
 	default:
 		logger.ErrfLn("Deriving local values for chart %q is currently unsupported.", chartName)
 		logger.ErrfLn("Supported charts: %s", strings.Join(supportedCharts, ", "))
-		err = errors.Errorf("unsupported chart %q", chartName)
+		err = errox.InvalidArgs.Newf("unsupported chart %q", chartName)
 	}
 
-	return err
+	return errors.Wrap(err, "deriving local values for chart")
 }
 
 // Remove nils from the given map, serialize it as YAML and write it to the output stream.

--- a/roxctl/helm/derivelocalvalues/local.go
+++ b/roxctl/helm/derivelocalvalues/local.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -24,7 +25,7 @@ func (k localK8sObjectDescription) get(_ context.Context, kind string, name stri
 	}
 	resource, ok := resources[name]
 	if !ok {
-		return nil, errors.New("resource not found")
+		return nil, errox.NotFound.New("resource not found")
 	}
 
 	return &resource, nil

--- a/roxctl/logconvert/logconvert.go
+++ b/roxctl/logconvert/logconvert.go
@@ -2,11 +2,11 @@ package logconvert
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/util"
@@ -26,10 +26,10 @@ func Command(cliEnvironment common.Environment) *cobra.Command {
 		RunE: util.RunENoArgs(func(c *cobra.Command) error {
 			level, ok := logging.LevelForLabel(levelLabel)
 			if !ok {
-				return fmt.Errorf("unknown level %s", levelLabel)
+				return errox.InvalidArgs.Newf("unknown level %s", levelLabel)
 			}
 			if level > logging.WarnLevel {
-				return errors.New("only non-destructive log levels are supported")
+				return errox.InvalidArgs.New("only non-destructive log levels are supported")
 			}
 
 			scanner := bufio.NewScanner(cliEnvironment.InputOutput().In())

--- a/roxctl/scanner/clustertype/wrapper.go
+++ b/roxctl/scanner/clustertype/wrapper.go
@@ -1,10 +1,10 @@
 package clustertype
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
@@ -39,7 +39,7 @@ func (w wrapper) Set(input string) error {
 		*w.ClusterType = val
 		return nil
 	}
-	return fmt.Errorf("invalid cluster type: %q; valid values are %+v", input, validClusterStrings)
+	return errox.InvalidArgs.Newf("invalid cluster type: %q; valid values are %+v", input, validClusterStrings)
 }
 
 func (w wrapper) Type() string {

--- a/roxctl/sensor/generate/collection_method.go
+++ b/roxctl/sensor/generate/collection_method.go
@@ -1,10 +1,10 @@
 package generate
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/errox"
 )
 
 var (
@@ -42,7 +42,7 @@ func (f *collectionTypeWrapper) Set(input string) error {
 	}
 	pt, ok := humanReadableToEnum[inputNormalized]
 	if !ok {
-		return fmt.Errorf("Invalid collection method: %s", input)
+		return errox.InvalidArgs.Newf("invalid collection method: %s", input)
 	}
 	*f.CollectionMethod = pt
 	return nil

--- a/roxctl/sensor/getbundle/get_bundle.go
+++ b/roxctl/sensor/getbundle/get_bundle.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/apiparams"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/istioutils"
 	"github.com/stackrox/rox/pkg/pointers"
 	"github.com/stackrox/rox/roxctl/common"
@@ -94,7 +95,7 @@ func Command(cliEnvironment common.Environment) *cobra.Command {
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				_ = c.Help()
-				return errors.Errorf("Expected exactly one argument, but %d were provided", len(args))
+				return errox.InvalidArgs.Newf("Expected exactly one argument, but %d were provided", len(args))
 			}
 
 			if err := downloadBundle(outputDir, args[0], flags.Timeout(c), createUpgraderSA, slimCollector, istioVersion, cliEnvironment.Logger()); err != nil {

--- a/roxctl/sensor/util/resolve_id_or_name.go
+++ b/roxctl/sensor/util/resolve_id_or_name.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/errox"
 	pkgCommon "github.com/stackrox/rox/pkg/roxctl/common"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/uuid"
@@ -42,5 +42,5 @@ func ResolveClusterID(idOrName string, timeout time.Duration) (string, error) {
 			return cluster.GetId(), nil
 		}
 	}
-	return "", errors.Errorf("no cluster with name %q found", idOrName)
+	return "", errox.NotFound.Newf("no cluster with name %q found", idOrName)
 }


### PR DESCRIPTION
## Description

This is the third PR in a series of PRs to finish the migration of roxctl to use `Environment`.

For more context on the overall series of PRs, see #1933. For previous changes, see #1964 .

This PR will refactor all usages of `fmt.Errorf/ errors.New*` to `errrox sentinel errors` to have a consistent error output throughout roxctl.

Which PRs will follow after this:
- Enabled `forbidigo` to verify neither `fmt.*Print/os.Stdout/os.Stderr` is used within roxctl.