### PR TITLE
Do not print missing signature errors.

### DIFF
--- a/pkg/signatures/public_key_fetcher.go
+++ b/pkg/signatures/public_key_fetcher.go
@@ -186,6 +186,10 @@ func isMissingSignatureError(err error) bool {
 		registryErr.Response.StatusCode == http.StatusNotFound {
 		return true
 	}
+
+	if transportErr, ok := err.(*transport.Error); ok && transportErr.StatusCode == http.StatusNotFound {
+		return true
+	}
 	return false
 }
 

--- a/pkg/signatures/public_key_fetcher.go
+++ b/pkg/signatures/public_key_fetcher.go
@@ -215,6 +215,10 @@ func errToURLError(err error) *url.Error {
 	if urlErr, ok := causeErr.(*url.Error); ok {
 		return urlErr
 	}
+	unwrapErr := errors.Unwrap(err)
+	if urlErr, ok := unwrapErr.(*url.Error); ok {
+		return urlErr
+	}
 	return nil
 }
 

--- a/pkg/signatures/public_key_fetcher_test.go
+++ b/pkg/signatures/public_key_fetcher_test.go
@@ -244,6 +244,17 @@ func TestIsMissingSignatureError(t *testing.T) {
 				Err: &unauthorizedErr,
 			}, "something went wrong"),
 		},
+		"transport error with status code unauthorized should not indicate missing signature": {
+			err: &transport.Error{
+				StatusCode: http.StatusUnauthorized,
+			},
+		},
+		"transport error with status code not found should indicate missing signature": {
+			err: &transport.Error{
+				StatusCode: http.StatusNotFound,
+			},
+			missingSignature: true,
+		},
 		"neither registry nor cosign error": {
 			err: errors.New("something error"),
 		},

--- a/pkg/signatures/public_key_fetcher_test.go
+++ b/pkg/signatures/public_key_fetcher_test.go
@@ -206,6 +206,19 @@ func TestPublicKey_FetchSignature_NoSignature(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestSomething(t *testing.T) {
+	cimg, err := imgUtils.GenerateImageFromString("docker.io/danielrox/testingprivate:1.0.0")
+	require.NoError(t, err, "creating test image")
+	img := types.ToImage(cimg)
+
+	f := newCosignPublicKeySignatureFetcher()
+	reg := &mockRegistry{cfg: &registryTypes.Config{RegistryHostname: "docker.io", Username: "danielrox", Password: "v4LeM8WmUHyT$"}}
+
+	result, err := f.FetchSignatures(context.Background(), img, reg)
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+}
+
 func TestIsMissingSignatureError(t *testing.T) {
 	notFoundErr := dockerRegistry.HttpStatusError{
 		Response: &http.Response{
@@ -243,6 +256,13 @@ func TestIsMissingSignatureError(t *testing.T) {
 			err: errors.Wrap(&url.Error{
 				Err: &unauthorizedErr,
 			}, "something went wrong"),
+		},
+		"wrapped registry error with status code not found should indicate missing signature": {
+			err:              fmt.Errorf("something went wrong %w", &url.Error{Err: &notFoundErr}),
+			missingSignature: true,
+		},
+		"wraooed registry error with status code unauthorized should not indicate missing signature": {
+			err: fmt.Errorf("something went wrong %w", &url.Error{Err: &unauthorizedErr}),
 		},
 		"transport error with status code unauthorized should not indicate missing signature": {
 			err: &transport.Error{


### PR DESCRIPTION
## Description

Cosign will return three types of errors when a signature is not found / the request was unauthorized:
- simply string error
- `transport.Error` from `go-containerregistry`
- `url.Error` from `heroku-client`, which is used as a transport

For the unauthorized part, the `transport.Error` and its status code was checked. This was not done for the not found error.

The root cause of why the missing signature logs suddenly occured was not due to not checking for the transport error, but rather because cosign stopped using `errors.Wrap` but instead switched to `fmt.Errorf`. Due to this, the unwrapping was not done correctly.

## Testing Performed
- CI (logs of central within `postgres-tests`)
