### PR TITLE
ROX-11246: Remove redux state from Raven logimbue POST calls

### DIFF
--- a/ui/apps/platform/src/store/configureStore.js
+++ b/ui/apps/platform/src/store/configureStore.js
@@ -15,7 +15,8 @@ const sagaMiddleware = createSagaMiddleware({
     onError: (error) => Raven.captureException(error),
 });
 
-const ravenMiddleware = createRavenMiddleware(Raven);
+// Omit Redux state to reduce size of payload in /api/logimbue request.
+const ravenMiddleware = createRavenMiddleware(Raven, { stateTransformer: () => null });
 
 export default function configureStore(initialState = {}, history) {
     const middlewares = [sagaMiddleware, routerMiddleware(history), ravenMiddleware];


### PR DESCRIPTION
## Description

### Problem

Need to reduce size of payload in /api/logimbue request.

### Solution

https://www.npmjs.com/package/raven-for-redux#statetransformer-function

> In some cases your state may be extremely large, or contain sensitive data. In those cases, you may want to transform your state before sending it to Sentry. This function allows you to do so. It is passed the current state object, and should return a serializable value.

> Be careful not to mutate your state within this function.

```js
createRavenMiddleware(Raven, { stateTransformer: () => null });
```

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

* 1 exception: same error as in #1961:
    Visit /main/configmanagement/subjects/id-does-not-exist
    Copy payload of /api/logimbue request without (after change) and with (before change) state.

* 3 exceptions: 3.68.2-rc.3 upstream build
    https://app.circleci.com/pipelines/github/stackrox/stackrox/12424/workflows/54cfd89f-1a51-45f4-891d-97c313c6a860/jobs/586272
    To simulate without state, run small script which has replacer `"state:{…}"` with `"state":null` in `JSON.stringify` call.

Unformatted file size

| exceptions | without |   with |   delta | delta / exceptions |
|       ---: |    ---: |   ---: |    ---: |               ---: |
|          1 |    7595 |  37429 |  -29834 |             -29834 |
|          3 |   40010 | 168989 | -128979 |             -42993 |

Formatted file lines (because I format the file when I investigate integration tests failures)

| exceptions | without |   with |   delta | delta / exceptions |
|       ---: |    ---: |   ---: |    ---: |               ---: |
|          1 |     434 |   2019 |   -1585 |              -1585 |
|          3 |    1864 |   8011 |   -6147 |              -2049 |
