### PR TITLE
ROX-10205: Add a graphQL resolver that returns image components only

### DIFF
--- a/central/graphql/resolvers/cluster_vulnerabilities.go
+++ b/central/graphql/resolvers/cluster_vulnerabilities.go
@@ -25,12 +25,15 @@ func init() {
 		schema.AddQuery("clusterVulnerability(id: ID): ClusterVulnerability"),
 		schema.AddQuery("clusterVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [ClusterVulnerability!]!"),
 		schema.AddQuery("clusterVulnerabilityCount(query: String): Int!"),
-		schema.AddQuery("k8sClusterVulnerability(id: ID): ClusterVulnerability"),
 		schema.AddQuery("k8sClusterVulnerabilities(query: String, pagination: Pagination): [ClusterVulnerability!]!"),
-		schema.AddQuery("istioClusterVulnerability(id: ID): ClusterVulnerability"),
+		schema.AddQuery("k8sClusterVulnerability(id: ID): ClusterVulnerability"),
+		schema.AddQuery("k8sClusterVulnerabilityCount(query: String): Int!"),
 		schema.AddQuery("istioClusterVulnerabilities(query: String, pagination: Pagination): [ClusterVulnerability!]!"),
-		schema.AddQuery("openShiftClusterVulnerability(id: ID): ClusterVulnerability"),
+		schema.AddQuery("istioClusterVulnerability(id: ID): ClusterVulnerability"),
+		schema.AddQuery("istioClusterVulnerabilityCount(query: String): Int!"),
 		schema.AddQuery("openShiftClusterVulnerabilities(query: String, pagination: Pagination): [ClusterVulnerability!]!"),
+		schema.AddQuery("openShiftClusterVulnerability(id: ID): ClusterVulnerability"),
+		schema.AddQuery("openShiftClusterVulnerabilityCount(query: String): Int!"),
 	)
 }
 
@@ -107,6 +110,17 @@ func (resolver *Resolver) K8sClusterVulnerabilities(ctx context.Context, args Pa
 	return nil, errors.New("Resolver K8sClusterVulnerabilities does not support postgres yet")
 }
 
+// K8sClusterVulnerabilityCount returns count of image vulnerabilities for the input query
+func (resolver *Resolver) K8sClusterVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "K8sClusterVulnerabilityCount")
+	if !features.PostgresDatastore.Enabled() {
+		query := withK8sTypeFiltering(args.String())
+		return resolver.vulnerabilityCountV2(ctx, RawQuery{Query: &query})
+	}
+	// TODO add postgres support
+	return 0, errors.New("Resolver K8sClusterVulnerabilityCount does not support postgres yet")
+}
+
 // IstioClusterVulnerability resolves a single k8s vulnerability based on an id (the CVE value).
 func (resolver *Resolver) IstioClusterVulnerability(ctx context.Context, args IDQuery) (ClusterVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "IstioClusterVulnerability")
@@ -128,6 +142,17 @@ func (resolver *Resolver) IstioClusterVulnerabilities(ctx context.Context, args 
 	return nil, errors.New("Resolver IstioClusterVulnerabilities does not support postgres yet")
 }
 
+// IstioClusterVulnerabilityCount returns count of image vulnerabilities for the input query
+func (resolver *Resolver) IstioClusterVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "IstioClusterVulnerabilityCount")
+	if !features.PostgresDatastore.Enabled() {
+		query := withIstioTypeFiltering(args.String())
+		return resolver.vulnerabilityCountV2(ctx, RawQuery{Query: &query})
+	}
+	// TODO add postgres support
+	return 0, errors.New("Resolver IstioClusterVulnerabilityCount does not support postgres yet")
+}
+
 // OpenShiftClusterVulnerability resolves a single k8s vulnerability based on an id (the CVE value).
 func (resolver *Resolver) OpenShiftClusterVulnerability(ctx context.Context, args IDQuery) (ClusterVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "OpenShiftClusterVulnerability")
@@ -147,6 +172,17 @@ func (resolver *Resolver) OpenShiftClusterVulnerabilities(ctx context.Context, a
 	}
 	// TODO add postgres support
 	return nil, errors.New("Resolver OpenShiftClusterVulnerabilities does not support postgres yet")
+}
+
+// OpenShiftClusterVulnerabilityCount returns count of image vulnerabilities for the input query
+func (resolver *Resolver) OpenShiftClusterVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "OpenShiftClusterVulnerabilityCount")
+	if !features.PostgresDatastore.Enabled() {
+		query := withOpenShiftTypeFiltering(args.String())
+		return resolver.vulnerabilityCountV2(ctx, RawQuery{Query: &query})
+	}
+	// TODO add postgres support
+	return 0, errors.New("Resolver OpenShiftClusterVulnerabilityCount does not support postgres yet")
 }
 
 // withClusterTypeFiltering adds a conjunction as a raw query to filter vulnerability type by cluster

--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -42,14 +42,20 @@ func init() {
 			"deploymentCount(query: String): Int!",
 			"failingControls(query: String): [ComplianceControl!]!",
 			"failingPolicyCounter(query: String): PolicyCounter",
-			"images(query: String, pagination: Pagination): [Image!]!",
+			"imageComponentCount(query: String): Int!",
+			"imageComponents(query: String, pagination: Pagination): [ImageComponent!]!",
 			"imageCount(query: String): Int!",
+			"images(query: String, pagination: Pagination): [Image!]!",
 			"imageVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [ImageVulnerability!]!",
 			"imageVulnerabilityCount(query: String): Int!",
 			"imageVulnerabilityCounter(query: String): VulnerabilityCounter!",
 			"isGKECluster: Boolean!",
 			"isOpenShiftCluster: Boolean!",
+			"istioClusterVulnerabilities(query: String, pagination: Pagination): [ClusterVulnerability!]!",
+			"istioClusterVulnerabilityCount(query: String): Int!",
 			"istioEnabled: Boolean!",
+			"k8sClusterVulnerabilities(query: String, pagination: Pagination): [ClusterVulnerability!]!",
+			"k8sClusterVulnerabilityCount(query: String): Int!",
 			"k8sRoles(query: String, pagination: Pagination): [K8SRole!]!",
 			"k8sRole(role: ID!): K8SRole",
 			"k8sRoleCount(query: String): Int!",
@@ -65,8 +71,9 @@ func init() {
 			"nodeVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [NodeVulnerability!]!",
 			"nodeVulnerabilityCount(query: String): Int!",
 			"nodeVulnerabilityCounter(query: String): VulnerabilityCounter!",
+			"openShiftClusterVulnerabilities(query: String, pagination: Pagination): [ClusterVulnerability!]!",
+			"openShiftClusterVulnerabilityCount(query: String): Int!",
 			"passingControls(query: String): [ComplianceControl!]!",
-			"plottedVulns(query: String): PlottedVulnerabilities!",
 			"policies(query: String, pagination: Pagination): [Policy!]!",
 			"policyCount(query: String): Int!",
 			"policyStatus(query: String): PolicyStatus!",
@@ -80,6 +87,8 @@ func init() {
 			"subject(name: String!): Subject",
 			"subjectCount(query: String): Int!",
 			"unusedVarSink(query: String): Int",
+
+			"plottedVulns(query: String): PlottedVulnerabilities!", // TODO
 		}),
 
 		// deprecated fields
@@ -95,17 +104,17 @@ func init() {
 			"vulns(query: String, scopeQuery: String, pagination: Pagination): [EmbeddedVulnerability]! " +
 				"@deprecated(reason: \"use 'imageVulnerabilities' or 'nodeVulnerabilities'\")",
 			"k8sVulns(query: String, pagination: Pagination): [EmbeddedVulnerability!]! " +
-				"@deprecated(reason: \"use 'clusterVulnerabilities'\")",
+				"@deprecated(reason: \"use 'k8sClusterVulnerabilities'\")",
 			"k8sVulnCount(query: String): Int! " +
-				"@deprecated(reason: \"use 'clusterVulnerabilityCount'\")",
+				"@deprecated(reason: \"use 'k8sClusterVulnerabilityCount'\")",
 			"istioVulns(query: String, pagination: Pagination): [EmbeddedVulnerability!]! " +
-				"@deprecated(reason: \"use 'clusterVulnerabilities'\")",
+				"@deprecated(reason: \"use 'istioClusterVulnerabilities'\")",
 			"istioVulnCount(query: String): Int!" +
-				"@deprecated(reason: \"use 'clusterVulnerabilityCount'\")",
+				"@deprecated(reason: \"use 'istioClusterVulnerabilityCount'\")",
 			"openShiftVulns(query: String, pagination: Pagination): [EmbeddedVulnerability!]! " +
-				"@deprecated(reason: \"use 'clusterVulnerabilities'\")",
+				"@deprecated(reason: \"use 'openShiftClusterVulnerabilities'\")",
 			"openShiftVulnCount(query: String): Int! " +
-				"@deprecated(reason: \"use 'clusterVulnerabilityCount'\")",
+				"@deprecated(reason: \"use 'openShiftClusterVulnerabilityCount'\")",
 		}),
 		schema.AddQuery("clusters(query: String, pagination: Pagination): [Cluster!]!"),
 		schema.AddQuery("clusterCount(query: String): Int!"),
@@ -559,6 +568,18 @@ func (resolver *clusterResolver) ComponentCount(ctx context.Context, args RawQue
 	return resolver.root.ComponentCount(ctx, RawQuery{Query: &query})
 }
 
+func (resolver *clusterResolver) ImageComponents(ctx context.Context, args PaginatedQuery) ([]ImageComponentResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ImageComponents")
+
+	return resolver.root.ImageComponents(resolver.clusterScopeContext(ctx), args)
+}
+
+func (resolver *clusterResolver) ImageComponentCount(ctx context.Context, args RawQuery) (int32, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ImageComponents")
+
+	return resolver.root.ImageComponentCount(resolver.clusterScopeContext(ctx), args)
+}
+
 // NodeComponents returns the node components in the cluster.
 func (resolver *clusterResolver) NodeComponents(ctx context.Context, args PaginatedQuery) ([]NodeComponentResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "NodeComponents")
@@ -643,61 +664,83 @@ func (resolver *clusterResolver) NodeVulnerabilityCounter(ctx context.Context, a
 	return nil, errors.New("Sub-resolver NodeVulnerabilityCounter in Cluster does not support postgres yet")
 }
 
-func (resolver *clusterResolver) vulnQueryScoping(ctx context.Context, query string) (context.Context, string) {
-	ctx = scoped.Context(ctx, scoped.Scope{
+func (resolver *clusterResolver) clusterQueryScoping(ctx context.Context) context.Context {
+	return scoped.Context(ctx, scoped.Scope{
 		Level: v1.SearchCategory_CLUSTERS,
 		ID:    resolver.data.GetId(),
 	})
-
-	return ctx, query
 }
 
 func (resolver *clusterResolver) ImageVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ImageVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ImageVulnerabilities")
 
-	ctx, query := resolver.vulnQueryScoping(ctx, args.String())
-
-	return resolver.root.ImageVulnerabilities(ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
+	return resolver.root.ImageVulnerabilities(resolver.clusterQueryScoping(ctx), args)
 }
 
 func (resolver *clusterResolver) ImageVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ImageVulnerabilityCount")
 
-	ctx, query := resolver.vulnQueryScoping(ctx, args.String())
-
-	return resolver.root.ImageVulnerabilityCount(ctx, RawQuery{Query: &query})
+	return resolver.root.ImageVulnerabilityCount(resolver.clusterQueryScoping(ctx), args)
 }
 
 func (resolver *clusterResolver) ImageVulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ImageVulnerabilityCounter")
 
-	ctx, query := resolver.vulnQueryScoping(ctx, args.String())
-
-	return resolver.root.ImageVulnerabilityCounter(ctx, RawQuery{Query: &query})
+	return resolver.root.ImageVulnerabilityCounter(resolver.clusterQueryScoping(ctx), args)
 }
 
 func (resolver *clusterResolver) ClusterVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ClusterVulnerabilities")
 
-	ctx, query := resolver.vulnQueryScoping(ctx, args.String())
-
-	return resolver.root.ClusterVulnerabilities(ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
+	return resolver.root.ClusterVulnerabilities(resolver.clusterQueryScoping(ctx), args)
 }
 
 func (resolver *clusterResolver) ClusterVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ClusterVulnerabilityCount")
 
-	ctx, query := resolver.vulnQueryScoping(ctx, args.String())
-
-	return resolver.root.ClusterVulnerabilityCount(ctx, RawQuery{Query: &query})
+	return resolver.root.ClusterVulnerabilityCount(resolver.clusterQueryScoping(ctx), args)
 }
 
 func (resolver *clusterResolver) ClusterVulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ClusterVulnerabilityCounter")
 
-	ctx, query := resolver.vulnQueryScoping(ctx, args.String())
+	return resolver.root.ClusterVulnerabilityCounter(resolver.clusterQueryScoping(ctx), args)
+}
 
-	return resolver.root.ClusterVulnerabilityCounter(ctx, RawQuery{Query: &query})
+func (resolver *clusterResolver) K8sClusterVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "K8sClusterVulnerabilities")
+
+	return resolver.root.K8sClusterVulnerabilities(resolver.clusterQueryScoping(ctx), args)
+}
+
+func (resolver *clusterResolver) K8sClusterVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "K8sClusterVulnerabilityCount")
+
+	return resolver.root.K8sClusterVulnerabilityCount(resolver.clusterQueryScoping(ctx), args)
+}
+
+func (resolver *clusterResolver) IstioClusterVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "IstioClusterVulnerabilities")
+
+	return resolver.root.IstioClusterVulnerabilities(resolver.clusterQueryScoping(ctx), args)
+}
+
+func (resolver *clusterResolver) IstioClusterVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "IstioClusterVulnerabilityCount")
+
+	return resolver.root.IstioClusterVulnerabilityCount(resolver.clusterQueryScoping(ctx), args)
+}
+
+func (resolver *clusterResolver) OpenShiftClusterVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "OpenShiftClusterVulnerabilities")
+
+	return resolver.root.OpenShiftClusterVulnerabilities(resolver.clusterQueryScoping(ctx), args)
+}
+
+func (resolver *clusterResolver) OpenShiftClusterVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "OpenShiftClusterVulnerabilityCount")
+
+	return resolver.root.OpenShiftClusterVulnerabilityCount(resolver.clusterQueryScoping(ctx), args)
 }
 
 func (resolver *clusterResolver) K8sVulns(ctx context.Context, args PaginatedQuery) ([]VulnerabilityResolver, error) {

--- a/central/graphql/resolvers/components_v2.go
+++ b/central/graphql/resolvers/components_v2.go
@@ -40,6 +40,33 @@ func (resolver *Resolver) componentsV2(ctx context.Context, args PaginatedQuery)
 	return resolver.componentsV2Query(ctx, query)
 }
 
+func (resolver *Resolver) imageComponentV2(ctx context.Context, args IDQuery) (ImageComponentResolver, error) {
+	res, err := resolver.imageComponentDataStoreQuery(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	res.ctx = ctx
+	return res, nil
+}
+func (resolver *Resolver) imageComponentsV2(ctx context.Context, args PaginatedQuery) ([]ImageComponentResolver, error) {
+	query, err := args.AsV1QueryOrEmpty()
+	if err != nil {
+		return nil, err
+	}
+
+	resolvers, err := resolver.imageComponentsLoaderQuery(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]ImageComponentResolver, 0, len(resolvers))
+	for _, res := range resolvers {
+		res.ctx = ctx
+		ret = append(ret, res)
+	}
+	return ret, err
+}
+
 func (resolver *Resolver) nodeComponentV2(ctx context.Context, args IDQuery) (NodeComponentResolver, error) {
 	nodeCompRes, err := resolver.imageComponentDataStoreQuery(ctx, args)
 	if err != nil {
@@ -197,6 +224,19 @@ func (eicr *imageComponentResolver) TopVuln(ctx context.Context) (VulnerabilityR
 	return vulnResolver, nil
 }
 
+func (eicr *imageComponentResolver) TopImageVulnerability(ctx context.Context) (ImageVulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageComponents, "TopImageVulnerability")
+	if !features.PostgresDatastore.Enabled() {
+		vulnResolver, err := eicr.unwrappedTopVulnQuery(ctx)
+		if err != nil || vulnResolver == nil {
+			return nil, err
+		}
+		return vulnResolver, nil
+	}
+	// TODO : Add postgres support
+	return nil, errors.New("Sub-resolver TopImageVulnerability in ImageComponent does not support postgres yet")
+}
+
 // TopNodeVulnerability returns the first node component vulnerability with the top CVSS score.
 func (eicr *imageComponentResolver) TopNodeVulnerability(ctx context.Context) (NodeVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageComponents, "TopNodeVulnerability")
@@ -330,6 +370,21 @@ func (eicr *imageComponentResolver) VulnCounter(ctx context.Context, args RawQue
 		return nil, err
 	}
 	return mapCVEsToVulnerabilityCounter(fixableVulns, unFixableCVEs), nil
+}
+
+func (eicr *imageComponentResolver) ImageVulnerabilities(_ context.Context, args PaginatedQuery) ([]ImageVulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageComponents, "ImageVulnerabilities")
+	return eicr.root.ImageVulnerabilities(eicr.imageComponentScopeContext(), args)
+}
+
+func (eicr *imageComponentResolver) ImageVulnerabilityCount(_ context.Context, args RawQuery) (int32, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageComponents, "ImageVulnerabilityCount")
+	return eicr.root.ImageVulnerabilityCount(eicr.imageComponentScopeContext(), args)
+}
+
+func (eicr *imageComponentResolver) ImageVulnerabilityCounter(_ context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageComponents, "ImageVulnerabilityCounter")
+	return eicr.root.ImageVulnerabilityCounter(eicr.imageComponentScopeContext(), args)
 }
 
 // NodeVulnerabilities resolves the node vulnerabilities contained in the node component.

--- a/central/graphql/resolvers/image_components.go
+++ b/central/graphql/resolvers/image_components.go
@@ -32,8 +32,7 @@ func init() {
 			"topImageVulnerability: ImageVulnerability",
 			"unusedVarSink(query: String): Int",
 
-			// TODO
-			//"plottedVulns(query: String): PlottedVulnerabilities!",
+			"plottedVulns(query: String): PlottedVulnerabilities!", // TODO
 		}),
 		schema.AddQuery("imageComponent(id: ID): ImageComponent"),
 		schema.AddQuery("imageComponents(query: String, scopeQuery: String, pagination: Pagination): [ImageComponent!]!"),
@@ -108,11 +107,10 @@ func (resolver *Resolver) ImageComponentCount(ctx context.Context, args RawQuery
 		return resolver.componentCountV2(ctx, RawQuery{Query: &query})
 	}
 	// TODO : Add postgres support
-	return 0, errors.New("Resolver NodeComponentCount does not support postgres yet")
+	return 0, errors.New("Resolver ImageComponentCount does not support postgres yet")
 }
 
 func queryWithImageIDRegexFilter(q string) string {
 	return search.AddRawQueriesAsConjunction(q,
-		// TODO check the search field
 		search.NewQueryBuilder().AddRegexes(search.ImageLabel, ".+").Query())
 }

--- a/central/graphql/resolvers/image_components.go
+++ b/central/graphql/resolvers/image_components.go
@@ -1,0 +1,118 @@
+package resolvers
+
+import (
+	"context"
+	"time"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/metrics"
+	"github.com/stackrox/rox/pkg/features"
+	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+func init() {
+	schema := getBuilder()
+	utils.Must(
+		// NOTE: This list is and should remain alphabetically ordered
+		schema.AddExtraResolvers("ImageComponent", []string{
+			"activeState(query: String): ActiveState",
+			"deploymentCount(query: String, scopeQuery: String): Int!",
+			"deployments(query: String, scopeQuery: String, pagination: Pagination): [Deployment!]!",
+			"fixedIn: String!",
+			"imageCount(query: String, scopeQuery: String): Int!",
+			"images(query: String, scopeQuery: String, pagination: Pagination): [Image!]!",
+			"imageVulnerabilityCount(query: String, scopeQuery: String): Int!",
+			"imageVulnerabilityCounter(query: String): VulnerabilityCounter!",
+			"imageVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [ImageVulnerability]!",
+			"lastScanned: Time",
+			"location(query: String): String!",
+			"topImageVulnerability: ImageVulnerability",
+			"unusedVarSink(query: String): Int",
+
+			// TODO
+			//"plottedVulns(query: String): PlottedVulnerabilities!",
+		}),
+		schema.AddQuery("imageComponent(id: ID): ImageComponent"),
+		schema.AddQuery("imageComponents(query: String, scopeQuery: String, pagination: Pagination): [ImageComponent!]!"),
+		schema.AddQuery("imageComponentCount(query: String): Int!"),
+
+		// TODO
+		schema.AddExtraResolver("ImageScan", `components(query: String, pagination: Pagination): [EmbeddedImageScanComponent!]!`),
+		schema.AddExtraResolver("ImageScan", `componentCount(query: String): Int!`),
+	)
+}
+
+// ImageComponentResolver represents a generic resolver of image component fields.
+// Values may come from either an embedded component context, or a top level component context.
+// NOTE: This list is and should remain alphabetically ordered
+type ImageComponentResolver interface {
+	ActiveState(ctx context.Context, args RawQuery) (*activeStateResolver, error)
+	DeploymentCount(ctx context.Context, args RawQuery) (int32, error)
+	Deployments(ctx context.Context, args PaginatedQuery) ([]*deploymentResolver, error)
+	FixedIn(ctx context.Context) string
+	FixedBy(ctx context.Context) string
+	ID(ctx context.Context) graphql.ID
+	ImageCount(ctx context.Context, args RawQuery) (int32, error)
+	Images(ctx context.Context, args PaginatedQuery) ([]*imageResolver, error)
+	ImageVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error)
+	ImageVulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error)
+	ImageVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ImageVulnerabilityResolver, error)
+	LastScanned(ctx context.Context) (*graphql.Time, error)
+	LayerIndex() *int32
+	License(ctx context.Context) (*licenseResolver, error)
+	Location(ctx context.Context, args RawQuery) (string, error)
+	Name(ctx context.Context) string
+	OperatingSystem(ctx context.Context) string
+	Priority(ctx context.Context) int32
+	RiskScore(ctx context.Context) float64
+	Source(ctx context.Context) string
+	TopImageVulnerability(ctx context.Context) (ImageVulnerabilityResolver, error)
+	UnusedVarSink(ctx context.Context, args RawQuery) *int32
+	Version(ctx context.Context) string
+
+	// TODO
+	//PlottedVulns(ctx context.Context, args RawQuery) (*PlottedVulnerabilitiesResolver, error)
+}
+
+// ImageComponent returns an image component based on an input id (name:version)
+func (resolver *Resolver) ImageComponent(ctx context.Context, args IDQuery) (ImageComponentResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "ImageComponent")
+	if !features.PostgresDatastore.Enabled() {
+		return resolver.imageComponentV2(ctx, args)
+	}
+	// TODO : Add postgres support
+	return nil, errors.New("Resolver ImageComponent does not support postgres yet")
+}
+
+// ImageComponents returns image components that match the input query.
+func (resolver *Resolver) ImageComponents(ctx context.Context, q PaginatedQuery) ([]ImageComponentResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "ImageComponents")
+	if !features.PostgresDatastore.Enabled() {
+		query := queryWithImageIDRegexFilter(q.String())
+
+		return resolver.imageComponentsV2(ctx, PaginatedQuery{Query: &query, Pagination: q.Pagination})
+	}
+	// TODO : Add postgres support
+	return nil, errors.New("Resolver ImageComponents does not support postgres yet")
+}
+
+// ImageComponentCount returns count of image components that match the input query
+func (resolver *Resolver) ImageComponentCount(ctx context.Context, args RawQuery) (int32, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "ImageComponentCount")
+	if !features.PostgresDatastore.Enabled() {
+		query := queryWithImageIDRegexFilter(args.String())
+
+		return resolver.componentCountV2(ctx, RawQuery{Query: &query})
+	}
+	// TODO : Add postgres support
+	return 0, errors.New("Resolver NodeComponentCount does not support postgres yet")
+}
+
+func queryWithImageIDRegexFilter(q string) string {
+	return search.AddRawQueriesAsConjunction(q,
+		// TODO check the search field
+		search.NewQueryBuilder().AddRegexes(search.ImageLabel, ".+").Query())
+}

--- a/central/graphql/resolvers/namespaces.go
+++ b/central/graphql/resolvers/namespaces.go
@@ -26,11 +26,11 @@ func init() {
 		schema.AddExtraResolvers("Namespace", []string{
 			"cluster: Cluster!",
 			"complianceResults(query: String): [ControlResult!]!",
-			"componentCount(query: String): Int!",
-			"components(query: String, pagination: Pagination): [EmbeddedImageScanComponent!]!",
 			"deploymentCount(query: String): Int!",
 			"deployments(query: String, pagination: Pagination): [Deployment!]!",
 			"failingPolicyCounter(query: String): PolicyCounter",
+			"imageComponentCount(query: String): Int!",
+			"imageComponents(query: String, pagination: Pagination): [ImageComponent!]!",
 			"imageCount(query: String): Int!",
 			"images(query: String, pagination: Pagination): [Image!]!",
 			"imageVulnerabilityCount(query: String): Int!",
@@ -39,7 +39,6 @@ func init() {
 			"k8sRoleCount(query: String): Int!",
 			"k8sRoles(query: String, pagination: Pagination): [K8SRole!]!",
 			"latestViolation(query: String): Time",
-			"plottedVulns(query: String): PlottedVulnerabilities!",
 			"policies(query: String, pagination: Pagination): [Policy!]!",
 			"policyCount(query: String): Int!",
 			"policyStatus(query: String): PolicyStatus!",
@@ -52,6 +51,8 @@ func init() {
 			"serviceAccounts(query: String, pagination: Pagination): [ServiceAccount!]!",
 			"unusedVarSink(query: String): Int",
 			"risk: Risk",
+
+			"plottedVulns(query: String): PlottedVulnerabilities!", // TODO
 		}),
 		// deprecated fields
 		schema.AddExtraResolvers("Namespace", []string{
@@ -61,11 +62,15 @@ func init() {
 				"@deprecated(reason: \"use 'imageVulnerabilityCounter'\")",
 			"vulns(query: String, scopeQuery: String, pagination: Pagination): [EmbeddedVulnerability]! " +
 				"@deprecated(reason: \"use 'imageVulnerabilities'\")",
+			"componentCount(query: String): Int!" +
+				"@deprecated(reason: \"use 'imageComponentCount'\")",
+			"components(query: String, pagination: Pagination): [EmbeddedImageScanComponent!]!" +
+				"@deprecated(reason: \"use 'imageComponents'\")",
 		}),
-		schema.AddQuery("namespaces(query: String, pagination: Pagination): [Namespace!]!"),
 		schema.AddQuery("namespace(id: ID!): Namespace"),
 		schema.AddQuery("namespaceByClusterIDAndName(clusterID: ID!, name: String!): Namespace"),
 		schema.AddQuery("namespaceCount(query: String): Int!"),
+		schema.AddQuery("namespaces(query: String, pagination: Pagination): [Namespace!]!"),
 	)
 }
 
@@ -485,6 +490,25 @@ func (resolver *namespaceResolver) getActiveDeployAlerts(ctx context.Context, q 
 				AddExactMatches(search.Namespace, namespace.GetMetadata().GetName()).
 				AddStrings(search.ViolationState, storage.ViolationState_ACTIVE.String()).
 				AddStrings(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).ProtoQuery()))
+}
+
+func (resolver *namespaceResolver) ImageComponents(ctx context.Context, args PaginatedQuery) ([]ImageComponentResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Namespaces, "ImageComponents")
+
+	return resolver.root.ImageComponents(resolver.namespaceScopeContext(ctx), args)
+}
+
+func (resolver *namespaceResolver) ImageComponentCount(ctx context.Context, args RawQuery) (int32, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Namespaces, "ImageComponents")
+
+	return resolver.root.ImageComponentCount(resolver.namespaceScopeContext(ctx), args)
+}
+
+func (resolver *namespaceResolver) namespaceScopeContext(ctx context.Context) context.Context {
+	return scoped.Context(ctx, scoped.Scope{
+		Level: v1.SearchCategory_NAMESPACES,
+		ID:    resolver.data.GetMetadata().GetId(),
+	})
 }
 
 func (resolver *namespaceResolver) Components(ctx context.Context, args PaginatedQuery) ([]ComponentResolver, error) {


### PR DESCRIPTION
## Description

Add support for cluster type endpoints (k8s, istio, openshift) and update the deprecation notice on the old endpoints.

## Checklist
- [ ] Investigated and inspected CI test results
