### PR TITLE
Migrate flags package to environment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,9 +20,6 @@ issues:
     - path: roxctl/common/io/io\.go # io.go will by default use os.Stdin/os.StdErr.
       linters:
         - forbidigo
-    - path: "roxctl/common/flags/" # flags package is currently not using environment.Logger due to a cyclic import.
-      linters:
-        - forbidigo
     - linters:
         - revive
       text: "should have a package comment, unless it's in another file for this package"

--- a/roxctl/central/db/restore/v2.go
+++ b/roxctl/central/db/restore/v2.go
@@ -86,7 +86,7 @@ func validate(cbr *cobra.Command, args []string) error {
 
 func (cmd *centralDbRestoreCommand) construct(cbr *cobra.Command, args []string) error {
 	cmd.confirm = func() error {
-		return flags.CheckConfirmation(cbr)
+		return flags.CheckConfirmation(cbr, cmd.env.Logger(), cmd.env.InputOutput())
 	}
 	cmd.timeout = flags.Timeout(cbr)
 	if cmd.file == "" {

--- a/roxctl/central/db/restore/v2_cancel.go
+++ b/roxctl/central/db/restore/v2_cancel.go
@@ -38,7 +38,7 @@ func makeCentralRestoreCancelCommand(cliEnvironment environment.Environment, cbr
 		env:     cliEnvironment,
 		timeout: flags.Timeout(cbr),
 		confirm: func() error {
-			return flags.CheckConfirmation(cbr)
+			return flags.CheckConfirmation(cbr, cliEnvironment.Logger(), cliEnvironment.InputOutput())
 		},
 	}
 }

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -296,7 +296,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	)
 
 	c.PersistentFlags().VarPF(
-		flags.ForSetting(env.PlaintextEndpoints), "plaintext-endpoints", "",
+		flags.ForSetting(env.PlaintextEndpoints, cliEnvironment.Logger()), "plaintext-endpoints", "",
 		"The ports or endpoints to use for plaintext (unencrypted) exposure; comma-separated list.")
 	utils.Must(
 		c.PersistentFlags().SetAnnotation("plaintext-endpoints", flags.NoInteractiveKey, []string{"true"}))

--- a/roxctl/central/userpki/delete/delete.go
+++ b/roxctl/central/userpki/delete/delete.go
@@ -46,7 +46,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := flags.CheckConfirmation(cmd); err != nil {
+			if err := flags.CheckConfirmation(cmd, cliEnvironment.Logger(), cliEnvironment.InputOutput()); err != nil {
 				return err
 			}
 			return deleteProvider()

--- a/roxctl/common/flags/confirm.go
+++ b/roxctl/common/flags/confirm.go
@@ -2,23 +2,18 @@ package flags
 
 import (
 	"bufio"
-	"fmt"
-	"os"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/errox"
-	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/roxctl/common/io"
+	"github.com/stackrox/rox/roxctl/common/logger"
 )
 
 const (
 	forceFlag = "force"
-)
-
-var (
-	log = logging.LoggerForModule()
 )
 
 // AddForce adds a parameter for bypassing interactive confirmation
@@ -27,18 +22,18 @@ func AddForce(c *cobra.Command) {
 }
 
 // CheckConfirmation requires that the force argument has been passed or that the user interactively confirms the action
-func CheckConfirmation(c *cobra.Command) error {
+func CheckConfirmation(c *cobra.Command, logger logger.Logger, io io.IO) error {
 	f, err := c.Flags().GetBool(forceFlag)
 	if err != nil {
-		log.Errorf("Error checking value of --force flag: %v", err)
+		logger.ErrfLn("Error checking value of --force flag: %w", err)
 		utils.Should(err)
 		f = false
 	}
 	if f {
 		return nil
 	}
-	fmt.Print("Are you sure? [y/N] ")
-	resp, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	logger.PrintfLn("Are you sure? [y/N] ")
+	resp, err := bufio.NewReader(io.In()).ReadString('\n')
 	if err != nil {
 		return errors.Wrap(err, "could not read answer")
 	}

--- a/roxctl/common/flags/settings_var.go
+++ b/roxctl/common/flags/settings_var.go
@@ -1,12 +1,12 @@
 package flags
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/roxctl/common/logger"
 )
 
 // SettingVarOpts specifies options for a settings flag variable.
@@ -17,6 +17,7 @@ type SettingVarOpts struct {
 
 type settingVar struct {
 	setting env.Setting
+	log     logger.Logger
 	opts    SettingVarOpts
 }
 
@@ -37,20 +38,21 @@ func (v settingVar) Set(value string) error {
 			return err
 		}
 	} else {
-		fmt.Println("no validator")
+		v.log.PrintfLn("no validator")
 	}
 	return errors.Wrap(os.Setenv(v.setting.EnvVar(), value), "could not set env")
 }
 
 // ForSetting returns a pflag.Value that acts on the given setting, using default options.
-func ForSetting(s env.Setting) pflag.Value {
-	return ForSettingWithOptions(s, SettingVarOpts{})
+func ForSetting(s env.Setting, log logger.Logger) pflag.Value {
+	return ForSettingWithOptions(s, SettingVarOpts{}, log)
 }
 
 // ForSettingWithOptions returns a pflag.Value that acts on the given setting with the specified options.
-func ForSettingWithOptions(s env.Setting, opts SettingVarOpts) pflag.Value {
+func ForSettingWithOptions(s env.Setting, opts SettingVarOpts, log logger.Logger) pflag.Value {
 	return settingVar{
 		setting: s,
 		opts:    opts,
+		log:     log,
 	}
 }


### PR DESCRIPTION
## Description

Migrate the remaining package `flags` to environment / logger instead of directly using `fmt.Print* / os.Stdin`.

This way the output will be the same across roxctl.
