### PR TITLE
ROX-11061: option to disable offline_access scope request in OIDC auth provider

### DIFF
--- a/pkg/auth/authproviders/oidc/backend_impl.go
+++ b/pkg/auth/authproviders/oidc/backend_impl.go
@@ -34,7 +34,7 @@ const (
 	clientSecretConfigKey        = "client_secret"
 	dontUseClientSecretConfigKey = "do_not_use_client_secret"
 	modeConfigKey                = "mode"
-	disableOfflineAccessKey      = "disable_offline_access"
+	disableOfflineAccessScopeKey = "disable_offline_access_scope"
 
 	userInfoExpiration = 5 * time.Minute
 
@@ -306,13 +306,13 @@ func newBackend(ctx context.Context, id string, uiEndpoints []string, callbackUR
 
 	b.idTokenVerifier = provider.Verifier(&oidc.Config{ClientID: clientID})
 
-	disableOfflineAccess := config[disableOfflineAccessKey] == "true"
+	disableOfflineAccessScope := config[disableOfflineAccessScopeKey] == "true"
 	b.baseOauthConfig, err = createBaseOAuthConfig(
 		clientID,
 		clientSecret,
 		provider.Endpoint(),
 		issuerHelper,
-		!disableOfflineAccess && provider.SupportsScope(oidc.ScopeOfflineAccess),
+		!disableOfflineAccessScope && provider.SupportsScope(oidc.ScopeOfflineAccess),
 	)
 	if err != nil {
 		return nil, err
@@ -324,8 +324,8 @@ func newBackend(ctx context.Context, id string, uiEndpoints []string, callbackUR
 		clientSecretConfigKey: clientSecret,
 		modeConfigKey:         mode,
 	}
-	if disableOfflineAccess {
-		b.config[disableOfflineAccessKey] = "true"
+	if disableOfflineAccessScope {
+		b.config[disableOfflineAccessScopeKey] = "true"
 	}
 
 	return b, nil

--- a/pkg/auth/authproviders/oidc/backend_impl.go
+++ b/pkg/auth/authproviders/oidc/backend_impl.go
@@ -29,12 +29,12 @@ import (
 const (
 	fragmentCallbackURLPath = "/auth/response/oidc"
 
-	issuerConfigKey              = "issuer"
-	clientIDConfigKey            = "client_id"
-	clientSecretConfigKey        = "client_secret"
-	dontUseClientSecretConfigKey = "do_not_use_client_secret"
-	modeConfigKey                = "mode"
-	disableOfflineAccessScopeKey = "disable_offline_access_scope"
+	issuerConfigKey                    = "issuer"
+	clientIDConfigKey                  = "client_id"
+	clientSecretConfigKey              = "client_secret"
+	dontUseClientSecretConfigKey       = "do_not_use_client_secret"
+	modeConfigKey                      = "mode"
+	disableOfflineAccessScopeConfigKey = "disable_offline_access_scope"
 
 	userInfoExpiration = 5 * time.Minute
 
@@ -306,7 +306,7 @@ func newBackend(ctx context.Context, id string, uiEndpoints []string, callbackUR
 
 	b.idTokenVerifier = provider.Verifier(&oidc.Config{ClientID: clientID})
 
-	disableOfflineAccessScope := config[disableOfflineAccessScopeKey] == "true"
+	disableOfflineAccessScope := config[disableOfflineAccessScopeConfigKey] == "true"
 	b.baseOauthConfig, err = createBaseOAuthConfig(
 		clientID,
 		clientSecret,
@@ -325,7 +325,7 @@ func newBackend(ctx context.Context, id string, uiEndpoints []string, callbackUR
 		modeConfigKey:         mode,
 	}
 	if disableOfflineAccessScope {
-		b.config[disableOfflineAccessScopeKey] = "true"
+		b.config[disableOfflineAccessScopeConfigKey] = "true"
 	}
 
 	return b, nil

--- a/pkg/auth/authproviders/oidc/backend_impl_test.go
+++ b/pkg/auth/authproviders/oidc/backend_impl_test.go
@@ -744,11 +744,11 @@ func TestBackend(t *testing.T) {
 		},
 		"mode auto, with client secret, disable offline_access scope": {
 			config: map[string]string{
-				clientIDConfigKey:            "testclientid",
-				clientSecretConfigKey:        "testsecret",
-				issuerConfigKey:              "https://test-issuer",
-				modeConfigKey:                "",
-				disableOfflineAccessScopeKey: "true",
+				clientIDConfigKey:                  "testclientid",
+				clientSecretConfigKey:              "testsecret",
+				issuerConfigKey:                    "https://test-issuer",
+				modeConfigKey:                      "",
+				disableOfflineAccessScopeConfigKey: "true",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported:     allResponseTypes,

--- a/pkg/auth/authproviders/oidc/backend_impl_test.go
+++ b/pkg/auth/authproviders/oidc/backend_impl_test.go
@@ -744,11 +744,11 @@ func TestBackend(t *testing.T) {
 		},
 		"mode auto, with client secret, disable offline_access scope": {
 			config: map[string]string{
-				clientIDConfigKey:       "testclientid",
-				clientSecretConfigKey:   "testsecret",
-				issuerConfigKey:         "https://test-issuer",
-				modeConfigKey:           "",
-				disableOfflineAccessKey: "true",
+				clientIDConfigKey:            "testclientid",
+				clientSecretConfigKey:        "testsecret",
+				issuerConfigKey:              "https://test-issuer",
+				modeConfigKey:                "",
+				disableOfflineAccessScopeKey: "true",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported:     allResponseTypes,


### PR DESCRIPTION
## Description

Since sso.redhat.com has a pretty strict limit on the amount of offline tokens allowed to request, there is a big probability user can hit that limit when using Managed ACS. Users can log in multiple times, and use the "test login" functionality. Also, Centrals can be upgraded or restarted.

To avoid hitting that limit, we add an option to auth provider to control whether to request an `offline_access` scope OIDC identity provider.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Manual test(POST auth provider, verify no offline token is requested)
2. Added unit test
