### PR TITLE
ROX-11138: fix splunk e2e test

### DIFF
--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -304,7 +304,7 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         NetworkBaselineService.getNetworkBaseline(uid)
         NetworkBaselineService.lockNetworkBaseline(uid)
         orchestrator.execInContainer(splunkDeployment.deployment,
-                "for i in `seq 100`; do curl http://${centralHost}:443 --max-time 1; sleep 1; done")
+                "for i in `seq 100`; do  wget -S http://${centralHost}:443; sleep 1; done")
 
         // TODO: this code is flaky; see https://stack-rox.atlassian.net/browse/ROX-7772
         assert waitForAlertWithPolicyId("1b74ffdd-8e67-444c-9814-1c23863c8ccb")

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -11,18 +11,15 @@ import com.jayway.restassured.response.Response
 import io.stackrox.proto.api.v1.AlertServiceOuterClass
 
 import groups.Integration
-import objects.Deployment
 import services.AlertService
 import services.ApiTokenService
 import services.NetworkBaselineService
-import util.NetworkGraphUtil
 import util.SplunkUtil
 import util.Timer
 
 import org.junit.Rule
 import org.junit.experimental.categories.Category
 import org.junit.rules.Timeout
-import spock.lang.Ignore
 
 class IntegrationsSplunkViolationsTest extends BaseSpecification {
     @Rule
@@ -221,7 +218,7 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
     private static String extractNestedString(JsonPath jsonPath, String path) {
         try {
             return jsonPath.getString(path)
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException ignored) {
             return null
         }
     }


### PR DESCRIPTION
## Description

In May 2022, IntegrationsSplunkViolationsTest stopped working as expected with an error

```
io.grpc.StatusRuntimeException: INVALID_ARGUMENT: no baseline with given deployment ID found: invalid arguments
	at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:235)
	at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:216)
	at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:141)
	at io.stackrox.proto.api.v1.NetworkBaselineServiceGrpc$NetworkBaselineServiceBlockingStub.lockNetworkBaseline(NetworkBaselineServiceGrpc.java:394)
	at services.NetworkBaselineService.lockNetworkBaseline(NetworkBaselineService.groovy:17)
	at IntegrationsSplunkViolationsTest.triggerNetworkFlowViolation(IntegrationsSplunkViolationsTest.groovy:303)
	at IntegrationsSplunkViolationsTest.Verify Splunk violations: StackRox violations reach Splunk TA(IntegrationsSplunkViolationsTest.groovy:98)
```

The root cause of that was change in a network baseline behaviour implemented here: https://github.com/stackrox/stackrox/pull/1489

```
We are moving to a model where we do not build network baselines by default as flows come in. We will be a network baseline under 2 circumstances:

* The observation window for a deployment expires
* The user requests to view a network baseline
```

This PR fixes an error by adding the `NetworkBaselineService.getNetworkBaseline` call before calling `NetworkBaselineService.lockNetworkBaseline`.

There are also two other small improvements made within this PR:
* when triggering process violation, time for `curl` operation is now limited since endpoint we are calling is unreachable - we are only using `curl` because it's a command triggering violation
* to be more aligned with `NetworkBaselineTest`, we switched from `curl` to `wget`

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Ran locally 3 times
2. CI should be sufficient - if we see an error returned, we will disable the test again