### PR TITLE
ROX-9760: Display Network Policies for namespace in violation deployment tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ## [NEXT RELEASE]
 
+- ROX-9760: The deployment tab on violation detail now contains a list of network policies in the deployment's namespace.
 - ROX-9358: The diagnostic bundle includes notifiers, auth providers and auth provider groups, access control roles with attached permission set and access scope, and system configuration. Users with `DebugLogs` permission will be able to read listed entities from a generated diagnostic bundle regardless of their respective permissions.
 - ROX-10819: The documentation for API v1/notifiers ("GetNotifiers") previously stated that the request could be filtered by name or type. This is incorrect as this API never allowed filtering. The documentation has been fixed to reflect that.
 - ROX-9614: Add `file` query parameter to Central's `/api/extensions/scannerdefinitions`, allowing retrieval of individual files (not directories) from Scanner's Definition bundle using their full path within the archive. Add `sensorEndpoint` to Scanner's configmap, so Scanner in slim mode knows how to reach Sensor from its cluster.

--- a/pkg/booleanpolicy/violationmessages/printer/network_policy.go
+++ b/pkg/booleanpolicy/violationmessages/printer/network_policy.go
@@ -19,10 +19,6 @@ const (
 	PolicyName = "Policy name"
 )
 
-// TODO(ROX-9760): Implement these functions according to UX decision on how to display violations for missing network policies.
-// This is implemented with place-holder messages for now just to unblock further developments on the evaluation of
-// this policy.
-
 func hasIngressNetworkPolicyPrinter(fieldMap map[string][]string) ([]string, error) {
 	type resultFields struct {
 		HasIngress bool

--- a/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
@@ -160,7 +160,7 @@ const DeploymentDetails = ({ deployment }) => {
                         <Card isFlat data-testid="network-policy">
                             <CardBody>
                                 {namespacePoliciesList?.length > 0 ? (
-                                    <TableComposable aria-label="Simple table" variant="compact">
+                                    <TableComposable variant="compact">
                                         <Caption>
                                             <Title headingLevel="h3">All network policies</Title>
                                             in &quot;{deploymentObj.namespace}&quot; namespace
@@ -183,8 +183,8 @@ const DeploymentDetails = ({ deployment }) => {
                                     </TableComposable>
                                 ) : (
                                     <>
-                                        No network policies found in namespace &quot;
-                                        {deploymentObj.namespace}&quot;
+                                        No network policies found in &quot;
+                                        {deploymentObj.namespace}&quot; namespace
                                     </>
                                 )}
                             </CardBody>

--- a/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
@@ -161,9 +161,9 @@ const DeploymentDetails = ({ deployment }) => {
                             <CardBody>
                                 {namespacePoliciesList?.length > 0 ? (
                                     <List>
-                                        {namespacePoliciesList.map((netpol) => (
+                                        {namespacePoliciesList?.map((netpol: any) => (
                                             // eslint-disable-next-line react/no-array-index-key
-                                            <ListItem key={netpol["id"]}>{netpol["name"]}</ListItem>
+                                            <ListItem key={netpol.id}>{netpol.name}</ListItem>
                                         ))}
                                     </List>
                                 ) : (

--- a/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
@@ -1,23 +1,19 @@
 import React, { useEffect, useState } from 'react';
-import {
-    Alert,
-    Flex,
-    FlexItem,
-    Card,
-    CardBody,
-    Title,
-    Divider,
-    List,
-    ListItem,
-} from '@patternfly/react-core';
+import { Alert, Flex, FlexItem, Card, CardBody, Title, Divider } from '@patternfly/react-core';
 
 import { fetchDeployment } from 'services/DeploymentsService';
 import { fetchNetworkPoliciesInNamespace } from 'services/NetworkService';
 import { portExposureLabels } from 'messages/common';
 import ObjectDescriptionList from 'Components/ObjectDescriptionList';
+import { TableComposable, Caption, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import DeploymentOverview from './Deployment/DeploymentOverview';
 import SecurityContext from './Deployment/SecurityContext';
 import ContainerConfiguration from './Deployment/ContainerConfiguration';
+
+type NetworkPolicy = {
+    id: string;
+    name: string;
+};
 
 type PortExposure = 'EXTERNAL' | 'NODE' | 'HOST' | 'INTERNAL' | 'UNSET';
 
@@ -68,6 +64,10 @@ export const formatDeploymentPorts = (ports: Port[] = []): FormattedPort[] => {
         formattedPorts.push(formattedPort);
     });
     return formattedPorts;
+};
+
+const sortNetworkPolicies = (a: NetworkPolicy, b: NetworkPolicy): number => {
+    return a.name.localeCompare(b.name);
 };
 
 const DeploymentDetails = ({ deployment }) => {
@@ -152,7 +152,7 @@ const DeploymentDetails = ({ deployment }) => {
                     </FlexItem>
                     <FlexItem>
                         <Title headingLevel="h3" className="pf-u-my-md">
-                            All Network Policies for {deploymentObj.namespace}
+                            Network Policy
                         </Title>
                         <Divider component="div" />
                     </FlexItem>
@@ -160,14 +160,31 @@ const DeploymentDetails = ({ deployment }) => {
                         <Card isFlat data-testid="network-policy">
                             <CardBody>
                                 {namespacePoliciesList?.length > 0 ? (
-                                    <List>
-                                        {namespacePoliciesList?.map((netpol: any) => (
-                                            // eslint-disable-next-line react/no-array-index-key
-                                            <ListItem key={netpol.id}>{netpol.name}</ListItem>
-                                        ))}
-                                    </List>
+                                    <TableComposable aria-label="Simple table" variant="compact">
+                                        <Caption>
+                                            <Title headingLevel="h3">
+                                                All network policies of deployment
+                                            </Title>
+                                            <br />
+                                            in {deploymentObj.namespace} namespace
+                                        </Caption>
+                                        <Thead>
+                                            <Tr>
+                                                <Th>Name</Th>
+                                            </Tr>
+                                        </Thead>
+                                        <Tbody>
+                                            {namespacePoliciesList
+                                                .sort(sortNetworkPolicies)
+                                                .map((netpol: NetworkPolicy) => (
+                                                    <Tr key={netpol.id}>
+                                                        <Td dataLabel="Name">{netpol.name}</Td>
+                                                    </Tr>
+                                                ))}
+                                        </Tbody>
+                                    </TableComposable>
                                 ) : (
-                                    'No Network Policies found'
+                                    'No network policies found'
                                 )}
                             </CardBody>
                         </Card>

--- a/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
@@ -66,7 +66,7 @@ export const formatDeploymentPorts = (ports: Port[] = []): FormattedPort[] => {
     return formattedPorts;
 };
 
-const sortNetworkPolicies = (a: NetworkPolicy, b: NetworkPolicy): number => {
+const compareNetworkPolicies = (a: NetworkPolicy, b: NetworkPolicy): number => {
     return a.name.localeCompare(b.name);
 };
 
@@ -162,11 +162,8 @@ const DeploymentDetails = ({ deployment }) => {
                                 {namespacePoliciesList?.length > 0 ? (
                                     <TableComposable aria-label="Simple table" variant="compact">
                                         <Caption>
-                                            <Title headingLevel="h3">
-                                                All network policies of deployment
-                                            </Title>
-                                            <br />
-                                            in {deploymentObj.namespace} namespace
+                                            <Title headingLevel="h3">All network policies</Title>
+                                            in &quot;{deploymentObj.namespace}&quot; namespace
                                         </Caption>
                                         <Thead>
                                             <Tr>
@@ -175,9 +172,9 @@ const DeploymentDetails = ({ deployment }) => {
                                         </Thead>
                                         <Tbody>
                                             {namespacePoliciesList
-                                                .sort(sortNetworkPolicies)
+                                                .sort(compareNetworkPolicies)
                                                 .map((netpol: NetworkPolicy) => (
-                                                    // TODO(ROX-11034): This should be a link to the Network Policy yaml or detail screen. 
+                                                    // TODO(ROX-11034): This should be a link to the Network Policy yaml or detail screen.
                                                     <Tr key={netpol.id}>
                                                         <Td dataLabel="Name">{netpol.name}</Td>
                                                     </Tr>
@@ -185,7 +182,10 @@ const DeploymentDetails = ({ deployment }) => {
                                         </Tbody>
                                     </TableComposable>
                                 ) : (
-                                    'No network policies found'
+                                    <>
+                                        No network policies found in namespace &quot;
+                                        {deploymentObj.namespace}&quot;
+                                    </>
                                 )}
                             </CardBody>
                         </Card>

--- a/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
@@ -177,6 +177,7 @@ const DeploymentDetails = ({ deployment }) => {
                                             {namespacePoliciesList
                                                 .sort(sortNetworkPolicies)
                                                 .map((netpol: NetworkPolicy) => (
+                                                    // TODO(ROX-11034): This should be a link to the Network Policy yaml or detail screen. 
                                                     <Tr key={netpol.id}>
                                                         <Td dataLabel="Name">{netpol.name}</Td>
                                                     </Tr>

--- a/ui/apps/platform/src/services/NetworkService.js
+++ b/ui/apps/platform/src/services/NetworkService.js
@@ -229,6 +229,22 @@ export function fetchNetworkFlowGraph(clusterId, namespaces, query, date, includ
 /**
  * Fetches policies details for given array of ids.
  *
+ * @param {!String} namespaceId
+ * @returns {Promise<Object, Error>}
+ */
+export function fetchNetworkPoliciesInNamespace(clusterId, namespaceId) {
+    const options = {
+        method: 'GET',
+        url: `${networkPoliciesBaseUrl}?cluster_id=${clusterId}&namespace=${namespaceId}`,
+    };
+    return axios(options).then((response) => ({
+        response: response.data,
+    }));
+}
+
+/**
+ * Fetches policies details for given array of ids.
+ *
  * @param {!array} policyIds
  * @returns {Promise<Object, Error>}
  */


### PR DESCRIPTION
## Description

This PR adds a Network Policy section to the deployment tab on the violations screen. 

~~@stackrox/ui: I need your help to figure out the best component to show the list of Network Policies. Right now I've used the patternfly `List`, but I'm not sure if there's one more suited for this.~~

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [x] Evaluated and added CHANGELOG entry if required
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

Check if violations for different deployments in different namespaces show up the Network Policies in that namespace:

1. Stackrox:
![image](https://user-images.githubusercontent.com/6811076/173375968-c210d475-3f6e-4d5b-8dff-2f8ee73775e4.png)

In the terminal:
```
$ kubectl -n stackrox get netpol
NAME                           POD-SELECTOR              AGE
admission-control-no-ingress   app=admission-control     6h45m
allow-ext-to-central           app=central               6h46m
allow-ext-to-monitoring        app=monitoring            6h47m
allow-monitoring               app in (central,sensor)   6h45m
collector-no-ingress           app=collector             6h45m
scanner                        app=scanner               6h46m
scanner-db                     app=scanner-db            6h46m
sensor                         app=sensor                6h45m
```

2. kube-system:
![image](https://user-images.githubusercontent.com/6811076/173767319-31698bea-d3d0-47f3-9a15-b1978dbb1826.png)


In the terminal:
```
$ kubectl -n kube-system get netpol
No resources found in kube-system namespace.                                                                                                                                                                                                                 
```

---

The card for Network Policy was added as the last card on the left column. Here's a portion of the screen with its position relative to the other cards:
![image](https://user-images.githubusercontent.com/6811076/173767454-3015a2a0-43f2-4a5f-9e5a-edb779aa6c32.png)

