### PR TITLE
Update SearchFilter to increase type saftey against undefined keys

### DIFF
--- a/ui/apps/platform/src/Components/SearchFilterInput/SearchFilterInput.tsx
+++ b/ui/apps/platform/src/Components/SearchFilterInput/SearchFilterInput.tsx
@@ -115,7 +115,7 @@ function getSearchEntriesForFilter(
                         value,
                     });
                 });
-            } else if (valueOrValues.length !== 0) {
+            } else if (valueOrValues && valueOrValues.length !== 0) {
                 searchEntries.push({
                     label: valueOrValues,
                     value: valueOrValues,
@@ -130,7 +130,7 @@ function getSearchEntriesForFilter(
 /*
  * Return search filter object for changed search entries.
  *
- * Assume search enries have been filtered to include only categoryOption in search options.
+ * Assume search entries have been filtered to include only categoryOption in search options.
  */
 function getSearchFilterForEntries(searchEntries: SearchEntry[]): SearchFilter {
     const searchFilter: SearchFilter = {};

--- a/ui/apps/platform/src/types/search.ts
+++ b/ui/apps/platform/src/types/search.ts
@@ -3,7 +3,7 @@
  * 'Lifecycle Stage': 'BUILD' from 's[Lifecycle Stage]=BUILD
  * 'Lifecycle Stage': ['BUILD', 'DEPLOY'] from 's[Lifecycle Stage]=BUILD&s[Lifecycle State]=DEPLOY'
  */
-export type SearchFilter = Record<string, string | string[]>;
+export type SearchFilter = Partial<Record<string, string | string[]>>;
 
 /*
  * For array values of SearchInput props: searchModifiers and searchOptions.

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -117,13 +117,22 @@ export function isCompleteSearchFilter(searchFilter: SearchFilter) {
     );
 }
 
+/**
+ * Type Guard to determine if a 2-tuple SearchFilter entry contains a non-empty value
+ */
+function isNonEmptySearchEntry<Key>(
+    entry: [Key, string | string[] | undefined]
+): entry is [Key, string | string[]] {
+    return typeof entry[1] !== 'undefined' && entry[1].length !== 0;
+}
+
 /*
  * Return request query string for search filter. Omit filter criterion:
  * If option does not have value.
  */
 export function getRequestQueryStringForSearchFilter(searchFilter: SearchFilter): string {
     return Object.entries(searchFilter)
-        .filter(([, value]) => value.length !== 0)
+        .filter(isNonEmptySearchEntry)
         .map(([key, value]) => `${key}:${Array.isArray(value) ? value.join(',') : value}`)
         .join('+');
 }


### PR DESCRIPTION
## Description

This is something I ran into during dashboard work. The type
` type SearchFilter = Record<string, string | string[]>` asserts that _every_ string key will return a `string | string[]` on a given SearchFilter object, which is not the case. Almost all uses of the SearchFilter type access the keys/values via `Object.entries` which avoids the issue as a side effect, but this change will ensure that direct key access does not type check by default.

The trade off is that before this change you could not assign a value of `undefined` to a search filter object, but you could incorrectly read an `undefined` value.

```typescript
    const oldSearch: SearchFilter = {};
    const test: string | string[] = oldSearch.doesNotExist; // `test` is actually undefined at this point leading to runtime errors
    oldSearch.b = undefined; // Type 'undefined' is not assignable to type 'string | string[]'
```

After this change, the behavior is reversed:
```typescript
    const newSearch: SearchFilter = {};
    const test: string | string[] = newSearch.doesNotExist; // Error - Type 'undefined' is not assignable to type 'string | string[]'.
    newSearch.b = undefined; // This is fine
```

This makes the writing of values to a `SearchFilter` more permissive, but makes reading values more restrictive (also correct), which IMO is a better trade.

## Checklist
- [ ] Investigated and inspected CI test results

If any of these don't apply, please comment below.

## Testing Performed

Automated testing only.

The only non-type level change here is in a function that constructs a query string from a `SearchFilter`. In the previous behavior this would result in backend queries that looked like `"Cluster:undefined+Namespace:stackrox"`, while the new behavior would result in `"Namespace:stackrox"`, as the `undefined` value would be filtered out.
