### PR TITLE
Add tracing when Postgres is enabled for legacy storage

### DIFF
--- a/central/globaldb/bolt.go
+++ b/central/globaldb/bolt.go
@@ -3,6 +3,7 @@ package globaldb
 import (
 	"github.com/stackrox/rox/central/option"
 	"github.com/stackrox/rox/pkg/bolthelper"
+	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/sync"
 	bolt "go.etcd.io/bbolt"
 )
@@ -24,6 +25,7 @@ func initialize() {
 
 // GetGlobalDB returns a pointer to the global db.
 func GetGlobalDB() *bolt.DB {
+	postgres.LogCallerOnPostgres("GetGlobalDB")
 	once.Do(initialize)
 	return globalDB
 }

--- a/central/globaldb/dackbox/singleton.go
+++ b/central/globaldb/dackbox/singleton.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/pkg/dackbox/indexer"
 	"github.com/stackrox/rox/pkg/dackbox/utils/queue"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -35,6 +36,7 @@ var (
 
 // GetGlobalDackBox returns the global dackbox.DackBox instance.
 func GetGlobalDackBox() *dackbox.DackBox {
+	postgres.LogCallerOnPostgres("GetGlobalDackBox")
 	initializeDackBox()
 	return duckBox
 }

--- a/central/globaldb/rocksdb.go
+++ b/central/globaldb/rocksdb.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/central/option"
 	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	rocksMetrics "github.com/stackrox/rox/pkg/rocksdb/metrics"
 	"github.com/stackrox/rox/pkg/sync"
@@ -38,6 +39,7 @@ func RegisterBucket(bucketName []byte, objType string) {
 
 // GetRocksDB returns the global rocksdb instance
 func GetRocksDB() *rocksdb.RocksDB {
+	postgres.LogCallerOnPostgres("GetRocksDB")
 	rocksInit.Do(func() {
 		db, err := rocksdb.New(rocksMetrics.GetRocksDBPath(option.CentralOptions.DBPathBase))
 		if err != nil {

--- a/central/globalindex/singleton.go
+++ b/central/globalindex/singleton.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/blevesearch/bleve"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -44,6 +45,7 @@ func initialize() {
 
 // GetGlobalIndex provides the global bleve index to use for indexing.
 func GetGlobalIndex() bleve.Index {
+	postgres.LogCallerOnPostgres("GetGlobalIndex")
 	once.Do(initialize)
 
 	return globalIndex
@@ -51,22 +53,26 @@ func GetGlobalIndex() bleve.Index {
 
 // GetGlobalTmpIndex is used for objects that are rebuilt every Central startup
 func GetGlobalTmpIndex() bleve.Index {
+	postgres.LogCallerOnPostgres("GetGlobalTmpIndex")
 	once.Do(initialize)
 	return globalTmpIndex
 }
 
 // GetAlertIndex returns the alert index on a separate index path
 func GetAlertIndex() bleve.Index {
+	postgres.LogCallerOnPostgres("GetAlertIndex")
 	return getSeparateIndex("alert", v1.SearchCategory_ALERTS)
 }
 
 // GetPodIndex returns the pod index in a separate index
 func GetPodIndex() bleve.Index {
+	postgres.LogCallerOnPostgres("GetPodIndex")
 	return getSeparateIndex("pod", v1.SearchCategory_PODS)
 }
 
 // GetProcessIndex returns the process index in a separate index
 func GetProcessIndex() bleve.Index {
+	postgres.LogCallerOnPostgres("GetProcessIndex")
 	return getSeparateIndex("process", v1.SearchCategory_PROCESS_INDICATORS)
 }
 

--- a/pkg/postgres/log.go
+++ b/pkg/postgres/log.go
@@ -1,0 +1,22 @@
+package postgres
+
+import (
+	"runtime"
+
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+var log = logging.LoggerForModule()
+
+// LogCallerOnPostgres logs the caller of this function when Postgres is enabled
+// This helps trace where calls into deprecated features are coming from.
+// e.g. calls into RocksDB and BoltDB initialization
+func LogCallerOnPostgres(name string) {
+	if features.PostgresDatastore.Enabled() {
+		_, file, no, ok := runtime.Caller(2)
+		if ok {
+			log.Infof("%s called from %s#%d", name, file, no)
+		}
+	}
+}


### PR DESCRIPTION
## Description

Logs when on Postgres if we access Bolt, RocksDB or Bleve

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Will run postgres tests and see what log lines exist