### PR TITLE
ROX-11314: add more info to reconciliation tests flake

### DIFF
--- a/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
@@ -1,8 +1,5 @@
-import static Services.getClusterClient
-import static Services.getPodClient
 import static Services.getViolationsWithTimeout
 
-import com.athaydes.spockframework.report.internal.StringFormatHelper
 import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.api.model.apps.Deployment as OrchestratorDeployment
 
@@ -57,7 +54,7 @@ class ReconciliationTest extends BaseSpecification {
     ]
 
     private Set<String> getPodsInCluster() {
-        Set<String> result = new HashSet<>()
+        Set<String> result = [] as Set
         for (namespace in orchestrator.getNamespaces()) {
             List<Pod> allPods = orchestrator.getPodsByLabel(namespace, new HashMap<String, String>())
             for (pod in allPods) {
@@ -171,7 +168,6 @@ class ReconciliationTest extends BaseSpecification {
             for (pod in podsBeforeDeleting) {
                 log.info pod
             }
-
 
             orchestrator.deleteAndWaitForDeploymentDeletion(sensorDeployment)
 

--- a/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
@@ -1,5 +1,9 @@
+import static Services.getClusterClient
+import static Services.getPodClient
 import static Services.getViolationsWithTimeout
 
+import com.athaydes.spockframework.report.internal.StringFormatHelper
+import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.api.model.apps.Deployment as OrchestratorDeployment
 
 import io.stackrox.proto.storage.AlertOuterClass
@@ -51,6 +55,23 @@ class ReconciliationTest extends BaseSpecification {
         // We create and delete an entire namespace, so we may see a lot of secrets being deleted, esp in OpenShift.
         "*central.SensorEvent_Secret": 5,
     ]
+
+    private Set<String> getPodsInCluster() {
+        Set<String> result = new HashSet<>()
+        for (namespace in orchestrator.getNamespaces()) {
+            List<Pod> allPods = orchestrator.getPodsByLabel(namespace, new HashMap<String, String>())
+            for (pod in allPods) {
+                result.add(namespace + ":" + pod.metadata.getName())
+            }
+        }
+        return result
+    }
+
+    private Set<String> getDifference(Set<String> list1, Set<String> list2) {
+        Set<String> result = list1.clone() as Set<String>
+        result.removeAll(list2)
+        return result
+    }
 
     private void verifyReconciliationStats(boolean verifyMin) {
         // Cannot verify this on a release build, since the API is not exposed.
@@ -112,6 +133,8 @@ class ReconciliationTest extends BaseSpecification {
         def namespaceID = orchestrator.createNamespace(ns)
         NamespaceService.waitForNamespace(namespaceID, 10)
 
+        Set<String> podsBeforeDeleting
+
         try {
             addStackroxImagePullSecret(ns)
 
@@ -143,6 +166,13 @@ class ReconciliationTest extends BaseSpecification {
             networkPolicyID = orchestrator.applyNetworkPolicy(policy)
             assert NetworkPolicyService.waitForNetworkPolicy(networkPolicyID)
 
+            podsBeforeDeleting = podsInCluster
+            log.info "Pods in cluster before deleting:"
+            for (pod in podsBeforeDeleting) {
+                log.info pod
+            }
+
+
             orchestrator.deleteAndWaitForDeploymentDeletion(sensorDeployment)
 
             orchestrator.waitForAllPodsToBeRemoved("stackrox", ["app": "sensor"])
@@ -157,6 +187,16 @@ class ReconciliationTest extends BaseSpecification {
             orchestrator.deleteNamespace(ns)
             // Just wait for the namespace to be deleted which is indicative that all of them have been deleted
             orchestrator.waitForNamespaceDeletion(ns)
+        }
+
+        Set<String> podsBeforeRestarting = podsInCluster
+        log.info "Pods in cluster before restarting:"
+        for (pod in podsBeforeRestarting) {
+            log.info pod
+        }
+        log.info "Pods that were likely deleted while sensor was down:"
+        for (pod in getDifference(podsBeforeDeleting, podsBeforeRestarting)) {
+            log.info pod
         }
 
         // Recreate sensor


### PR DESCRIPTION
## Description

In order to try to get more information into why is this test failing, I've added additional logs to the tests, which might be a bit verbose for now, but it could help us understand what's going on. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- Ran groovy tests locally

Here's an example of how the output looks like before Sensor get's removed:
```
10:59:59 | INFO  | ReconciliationTest        | Pods in cluster before deleting:
10:59:59 | INFO  | ReconciliationTest        | kube-system:calico-node-m8b5g
10:59:59 | INFO  | ReconciliationTest        | stackrox:collector-rmk7m
10:59:59 | INFO  | ReconciliationTest        | kube-system:calico-typha-69f8dcc469-rs7pt
10:59:59 | INFO  | ReconciliationTest        | kube-system:calico-typha-horizontal-autoscaler-79f4fdc8d5-ghpdn
10:59:59 | INFO  | ReconciliationTest        | kube-system:fluentbit-gke-v2x7s
10:59:59 | INFO  | ReconciliationTest        | kube-system:event-exporter-gke-5479fd58c8-6gdx2
10:59:59 | INFO  | ReconciliationTest        | kube-system:gke-metrics-agent-th525
10:59:59 | INFO  | ReconciliationTest        | stackrox:scanner-988498f65-mrqgj
10:59:59 | INFO  | ReconciliationTest        | stackrox:sensor-5f67dcf669-wd4bq
10:59:59 | INFO  | ReconciliationTest        | kube-system:kube-dns-697dc8fc8b-sq8dz
10:59:59 | INFO  | ReconciliationTest        | stackrox:collector-k8z4v
10:59:59 | INFO  | ReconciliationTest        | kube-system:kube-proxy-gke-fred-0610-9564-fred--default-pool-5d439f63-zz1p
10:59:59 | INFO  | ReconciliationTest        | kube-system:calico-typha-vertical-autoscaler-b54586f76-ch5c7
10:59:59 | INFO  | ReconciliationTest        | kube-system:fluentbit-gke-v59f2
10:59:59 | INFO  | ReconciliationTest        | stackrox:central-5c7864b679-jjhn7
10:59:59 | INFO  | ReconciliationTest        | kube-system:gke-metrics-agent-dhc6c
10:59:59 | INFO  | ReconciliationTest        | kube-system:metrics-server-v0.4.5-bbb794dcc-bt8tw
10:59:59 | INFO  | ReconciliationTest        | kube-system:ip-masq-agent-x2gmt
10:59:59 | INFO  | ReconciliationTest        | stackrox:monitoring-6b46dcbb87-mkwzk
10:59:59 | INFO  | ReconciliationTest        | kube-system:konnectivity-agent-5c678857b6-846h9
10:59:59 | INFO  | ReconciliationTest        | kube-system:kube-dns-697dc8fc8b-qkg76
10:59:59 | INFO  | ReconciliationTest        | kube-system:calico-typha-69f8dcc469-r8j8v
10:59:59 | INFO  | ReconciliationTest        | kube-system:pdcsi-node-hg96s
10:59:59 | INFO  | ReconciliationTest        | kube-system:ip-masq-agent-rbvvv
10:59:59 | INFO  | ReconciliationTest        | stackrox:admission-control-658d7d47c9-9n9z6
10:59:59 | INFO  | ReconciliationTest        | kube-system:gke-metrics-agent-ghjpb
10:59:59 | INFO  | ReconciliationTest        | kube-system:calico-node-vertical-autoscaler-7cf6d44df5-pvpq4
10:59:59 | INFO  | ReconciliationTest        | stackrox:admission-control-658d7d47c9-fn59j
10:59:59 | INFO  | ReconciliationTest        | kube-system:kube-proxy-gke-fred-0610-9564-fred--default-pool-5d439f63-c04n
10:59:59 | INFO  | ReconciliationTest        | kube-system:l7-default-backend-69fb9fd9f9-mmmsq
10:59:59 | INFO  | ReconciliationTest        | kube-system:kube-dns-autoscaler-844c9d9448-dfqcf
10:59:59 | INFO  | ReconciliationTest        | kube-system:pdcsi-node-99bsn
10:59:59 | INFO  | ReconciliationTest        | stackrox:admission-control-658d7d47c9-g88b8
10:59:59 | INFO  | ReconciliationTest        | kube-system:ip-masq-agent-zst9l
10:59:59 | INFO  | ReconciliationTest        | kube-system:konnectivity-agent-5c678857b6-5mm5t
10:59:59 | INFO  | ReconciliationTest        | kube-system:calico-node-lbrxs
10:59:59 | INFO  | ReconciliationTest        | kube-system:konnectivity-agent-5c678857b6-g9tj5
10:59:59 | INFO  | ReconciliationTest        | reconciliation:testing123-6cd6f97bfb-qjnjv
10:59:59 | INFO  | ReconciliationTest        | kube-system:kube-proxy-gke-fred-0610-9564-fred--default-pool-5d439f63-zbs9
10:59:59 | INFO  | ReconciliationTest        | kube-system:fluentbit-gke-xqmff
10:59:59 | INFO  | ReconciliationTest        | stackrox:scanner-988498f65-wmvgt
10:59:59 | INFO  | ReconciliationTest        | kube-system:konnectivity-agent-autoscaler-6b86f667c9-v9xv2
10:59:59 | INFO  | ReconciliationTest        | kube-system:pdcsi-node-wn7cg
10:59:59 | INFO  | ReconciliationTest        | stackrox:collector-sfm5x
10:59:59 | INFO  | ReconciliationTest        | stackrox:scanner-db-ffbb5b874-p4f6t
10:59:59 | INFO  | ReconciliationTest        | kube-system:calico-node-npqcc
```

I've also added a small utility function to compute what pods were removed from the first set give the second. In this case the output is:

```
11:00:44 | INFO  | ReconciliationTest        | Pods that were likely deleted while sensor was down:
11:00:44 | INFO  | ReconciliationTest        | stackrox:sensor-5f67dcf669-wd4bq
11:00:44 | INFO  | ReconciliationTest        | reconciliation:testing123-6cd6f97bfb-qjnjv
```
