### PR TITLE
ROX-11165: Use sentinel errors instead of `fmt.Errorf`

### DIFF
--- a/central/group/datastore/internal/store/store_impl.go
+++ b/central/group/datastore/internal/store/store_impl.go
@@ -1,11 +1,10 @@
 package store
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	serializePkg "github.com/stackrox/rox/central/group/datastore/serialize"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/errox"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -150,7 +149,7 @@ func (s *storeImpl) Mutate(toRemove, toUpdate, toAdd []*storage.Group) error {
 func addInTransaction(tx *bolt.Tx, key, value []byte) error {
 	buc := tx.Bucket(groupsBucket)
 	if buc.Get(key) != nil {
-		return fmt.Errorf("group config for %q already exists", key)
+		return errox.AlreadyExists.Newf("group config for %q already exists", key)
 	}
 	return buc.Put(key, value)
 }
@@ -158,7 +157,7 @@ func addInTransaction(tx *bolt.Tx, key, value []byte) error {
 func updateInTransaction(tx *bolt.Tx, key, value []byte) error {
 	buc := tx.Bucket(groupsBucket)
 	if buc.Get(key) == nil {
-		return fmt.Errorf("group config for %q does not exist", key)
+		return errox.NotFound.Newf("group config for %q does not exist", key)
 	}
 	return buc.Put(key, value)
 }
@@ -166,7 +165,7 @@ func updateInTransaction(tx *bolt.Tx, key, value []byte) error {
 func removeInTransaction(tx *bolt.Tx, key []byte) error {
 	buc := tx.Bucket(groupsBucket)
 	if buc.Get(key) == nil {
-		return fmt.Errorf("group config for %q does not exist", key)
+		return errox.NotFound.Newf("group config for %q does not exist", key)
 	}
 	return buc.Delete(key)
 }

--- a/central/group/service/validate.go
+++ b/central/group/service/validate.go
@@ -1,11 +1,10 @@
 package service
 
 import (
-	"fmt"
-
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/errox"
 )
 
 func validate(group *storage.Group) error {
@@ -23,10 +22,10 @@ func validate(group *storage.Group) error {
 
 func validateProps(props *storage.GroupProperties) error {
 	if props.GetAuthProviderId() == "" {
-		return fmt.Errorf("authprovider ID must be set in {%s}", proto.MarshalTextString(props))
+		return errox.InvalidArgs.Newf("authprovider ID must be set in {%s}", proto.MarshalTextString(props))
 	}
 	if props.GetKey() == "" && props.GetValue() != "" {
-		return fmt.Errorf("cannot have a value without a key in {%s}", proto.MarshalTextString(props))
+		return errox.InvalidArgs.Newf("cannot have a value without a key in {%s}", proto.MarshalTextString(props))
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

A customer complained about `500 Internal Server Error` error returned instead of good errors from `/v1/groupsbatch` API calls. The PR makes use of sentinel errors instead of generic `fmt.Errorf`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

```
$ roxcurl /v1/groupsbatch -X POST -d '{"previousGroups": [], "requiredGroups": [{"props":{"authProviderId": "80966bf1-7518-490f-ba19-2731dc622e09"},"roleName": "None"}]}' -i
HTTP/2 200
content-type: application/json
grpc-metadata-content-type: application/grpc
vary: Accept-Encoding
content-length: 2
date: Mon, 13 Jun 2022 12:52:09 GMT

{}

$ roxcurl /v1/groupsbatch -X POST -d '{"previousGroups": [], "requiredGroups": [{"props":{"authProviderId": "80966bf1-7518-490f-ba19-2731dc622e09"},"roleName": "None"}]}' -i
HTTP/2 409
content-type: application/json
vary: Accept-Encoding
content-length: 273
date: Mon, 13 Jun 2022 12:52:12 GMT

{"error":"error adding during mutation: group config for \"$80966bf1-7518-490f-ba19-2731dc622e09\\x00\\x00\" already exists","code":6,"message":"error adding during mutation: group config for \"$80966bf1-7518-490f-ba19-2731dc622e09\\x00\\x00\" already exists","details":[]}
```