### PR TITLE
ROX-11303: retry k8s requests in qa tests

### DIFF
--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -141,6 +141,7 @@ tasks.withType(Test) {
 }
 
 test {
+    systemProperty "kubernetes.request.retry.backoffLimit", "3"
     timeout = Duration.ofHours(3)
     testLogging.showStandardStreams = true
 


### PR DESCRIPTION
## Description

Configure k8s client to retry failed requests (500 and IOException). 
See: https://github.com/fabric8io/kubernetes-client#configuring-the-client

Refs: 
- https://github.com/fabric8io/kubernetes-client/pull/3293 
- https://github.com/fabric8io/kubernetes-client/pull/3164 


## Testing Performed

CI
