### PR TITLE
Fix the node search options in global search

### DIFF
--- a/central/globalindex/mapping/mapping.go
+++ b/central/globalindex/mapping/mapping.go
@@ -20,6 +20,7 @@ import (
 	imageCVEEdgeMapping "github.com/stackrox/rox/central/imagecveedge/mappings"
 	namespaceMapping "github.com/stackrox/rox/central/namespace/index/mappings"
 	nodeMapping "github.com/stackrox/rox/central/node/index/mappings"
+	nodeComponentEdgeMapping "github.com/stackrox/rox/central/nodecomponentedge/mappings"
 	nodeComponentEdgeMappings "github.com/stackrox/rox/central/nodecomponentedge/mappings"
 	podMapping "github.com/stackrox/rox/central/pod/mappings"
 	policyMapping "github.com/stackrox/rox/central/policy/index/mappings"
@@ -92,6 +93,14 @@ func singleTermAnalyzer() map[string]interface{} {
 
 // GetEntityOptionsMap is a mapping from search categories to the options
 func GetEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
+	nodeSearchOptions := search.CombineOptionsMaps(
+		nodeMapping.OptionsMap,
+		nodeComponentEdgeMapping.OptionsMap,
+		imageComponentMapping.OptionsMap,
+		componentVulnEdgeMapping.OptionsMap,
+		cveMapping.OptionsMap,
+	)
+
 	// Images in dackbox support an expanded set of search options
 	imageSearchOptions := search.CombineOptionsMaps(
 		imageMapping.OptionsMap,
@@ -133,7 +142,7 @@ func GetEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 		v1.SearchCategory_COMPLIANCE_CONTROL:    index.ControlOptions,
 		v1.SearchCategory_CLUSTERS:              clusterMapping.OptionsMap,
 		v1.SearchCategory_NAMESPACES:            namespaceMapping.OptionsMap,
-		v1.SearchCategory_NODES:                 nodeMapping.OptionsMap,
+		v1.SearchCategory_NODES:                 nodeSearchOptions,
 		v1.SearchCategory_PROCESS_BASELINES:     processBaselineMapping.OptionsMap,
 		v1.SearchCategory_REPORT_CONFIGURATIONS: reportConfigurationsMapping.OptionsMap,
 		v1.SearchCategory_RISKS:                 riskMappings.OptionsMap,

--- a/central/search/service/service_impl.go
+++ b/central/search/service/service_impl.go
@@ -14,11 +14,9 @@ import (
 	clusterDataStore "github.com/stackrox/rox/central/cluster/datastore"
 	"github.com/stackrox/rox/central/compliance/aggregation"
 	complianceSearch "github.com/stackrox/rox/central/compliance/search"
-	cveDataStore "github.com/stackrox/rox/central/cve/datastore"
 	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
 	"github.com/stackrox/rox/central/globalindex/mapping"
 	imageDataStore "github.com/stackrox/rox/central/image/datastore"
-	componentDataStore "github.com/stackrox/rox/central/imagecomponent/datastore"
 	namespaceDataStore "github.com/stackrox/rox/central/namespace/datastore"
 	nodeDataStore "github.com/stackrox/rox/central/node/globaldatastore"
 	policyDataStore "github.com/stackrox/rox/central/policy/datastore"
@@ -78,8 +76,6 @@ func (s *serviceImpl) getSearchFuncs() map[v1.SearchCategory]SearchFunc {
 		v1.SearchCategory_SERVICE_ACCOUNTS: s.serviceaccounts.SearchServiceAccounts,
 		v1.SearchCategory_ROLES:            s.roles.SearchRoles,
 		v1.SearchCategory_ROLEBINDINGS:     s.bindings.SearchRoleBindings,
-		v1.SearchCategory_IMAGE_COMPONENTS: s.components.SearchImageComponents,
-		v1.SearchCategory_VULNERABILITIES:  s.cves.SearchCVEs,
 		v1.SearchCategory_SUBJECTS:         service.NewSubjectSearcher(s.bindings).SearchSubjects,
 	}
 
@@ -101,8 +97,6 @@ func (s *serviceImpl) getAutocompleteSearchers() map[v1.SearchCategory]search.Se
 		v1.SearchCategory_SERVICE_ACCOUNTS: s.serviceaccounts,
 		v1.SearchCategory_ROLES:            s.roles,
 		v1.SearchCategory_ROLEBINDINGS:     s.bindings,
-		v1.SearchCategory_IMAGE_COMPONENTS: s.components,
-		v1.SearchCategory_VULNERABILITIES:  s.cves,
 		v1.SearchCategory_SUBJECTS:         service.NewSubjectSearcher(s.bindings),
 	}
 
@@ -131,8 +125,6 @@ type serviceImpl struct {
 	roles           roleDataStore.DataStore
 	bindings        roleBindingDataStore.DataStore
 	clusters        clusterDataStore.DataStore
-	cves            cveDataStore.DataStore
-	components      componentDataStore.DataStore
 
 	aggregator aggregation.Aggregator
 	authorizer authz.Authorizer

--- a/central/search/service/service_impl_test.go
+++ b/central/search/service/service_impl_test.go
@@ -10,14 +10,12 @@ import (
 	alertDatastore "github.com/stackrox/rox/central/alert/datastore"
 	alertMocks "github.com/stackrox/rox/central/alert/datastore/mocks"
 	clusterDataStoreMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
-	cveMocks "github.com/stackrox/rox/central/cve/datastore/mocks"
 	deploymentDackBox "github.com/stackrox/rox/central/deployment/dackbox"
 	deploymentDatastore "github.com/stackrox/rox/central/deployment/datastore"
 	deploymentMocks "github.com/stackrox/rox/central/deployment/datastore/mocks"
 	deploymentIndex "github.com/stackrox/rox/central/deployment/index"
 	"github.com/stackrox/rox/central/globalindex"
 	imageMocks "github.com/stackrox/rox/central/image/datastore/mocks"
-	componentMocks "github.com/stackrox/rox/central/imagecomponent/datastore/mocks"
 	namespaceMocks "github.com/stackrox/rox/central/namespace/datastore/mocks"
 	nodeMocks "github.com/stackrox/rox/central/node/globaldatastore/mocks"
 	policyDatastore "github.com/stackrox/rox/central/policy/datastore"
@@ -76,8 +74,6 @@ func TestSearchFuncs(t *testing.T) {
 		WithRoleStore(roleMocks.NewMockDataStore(mockCtrl)).
 		WithRoleBindingStore(roleBindingsMocks.NewMockDataStore(mockCtrl)).
 		WithClusterDataStore(clusterDataStoreMocks.NewMockDataStore(mockCtrl)).
-		WithCVEDataStore(cveMocks.NewMockDataStore(mockCtrl)).
-		WithImageComponentDataStore(componentMocks.NewMockDataStore(mockCtrl)).
 		WithAggregator(nil).
 		Build()
 
@@ -165,8 +161,6 @@ func (s *SearchOperationsTestSuite) TestAutocomplete() {
 		WithRoleStore(roleMocks.NewMockDataStore(s.mockCtrl)).
 		WithRoleBindingStore(roleBindingsMocks.NewMockDataStore(s.mockCtrl)).
 		WithClusterDataStore(clusterDataStoreMocks.NewMockDataStore(s.mockCtrl)).
-		WithCVEDataStore(cveMocks.NewMockDataStore(s.mockCtrl)).
-		WithImageComponentDataStore(componentMocks.NewMockDataStore(s.mockCtrl)).
 		WithAggregator(nil).
 		Build().(*serviceImpl)
 
@@ -245,8 +239,6 @@ func (s *SearchOperationsTestSuite) TestAutocompleteForEnums() {
 		WithRoleStore(roleMocks.NewMockDataStore(s.mockCtrl)).
 		WithRoleBindingStore(roleBindingsMocks.NewMockDataStore(s.mockCtrl)).
 		WithClusterDataStore(clusterDataStoreMocks.NewMockDataStore(s.mockCtrl)).
-		WithCVEDataStore(cveMocks.NewMockDataStore(s.mockCtrl)).
-		WithImageComponentDataStore(componentMocks.NewMockDataStore(s.mockCtrl)).
 		WithAggregator(nil).
 		Build().(*serviceImpl)
 
@@ -300,8 +292,6 @@ func (s *SearchOperationsTestSuite) TestAutocompleteAuthz() {
 		WithRoleStore(roleMocks.NewMockDataStore(s.mockCtrl)).
 		WithRoleBindingStore(roleBindingsMocks.NewMockDataStore(s.mockCtrl)).
 		WithClusterDataStore(clusterDataStoreMocks.NewMockDataStore(s.mockCtrl)).
-		WithCVEDataStore(cveMocks.NewMockDataStore(s.mockCtrl)).
-		WithImageComponentDataStore(componentMocks.NewMockDataStore(s.mockCtrl)).
 		WithAggregator(nil).
 		Build().(*serviceImpl)
 
@@ -374,8 +364,6 @@ func (s *SearchOperationsTestSuite) TestSearchAuthz() {
 		WithRoleStore(roleMocks.NewMockDataStore(s.mockCtrl)).
 		WithRoleBindingStore(roleBindingsMocks.NewMockDataStore(s.mockCtrl)).
 		WithClusterDataStore(clusterDataStoreMocks.NewMockDataStore(s.mockCtrl)).
-		WithCVEDataStore(cveMocks.NewMockDataStore(s.mockCtrl)).
-		WithImageComponentDataStore(componentMocks.NewMockDataStore(s.mockCtrl)).
 		WithAggregator(nil).
 		Build().(*serviceImpl)
 


### PR DESCRIPTION
## Description

- Fix node search options map in global search
- Remove registration of unnecessary searchers. Vulns and components search categories are not exposed
```
// GetGlobalSearchCategories returns a set of search categories
func GetGlobalSearchCategories() set.V1SearchCategorySet {
	// globalSearchCategories is exposed for e2e options test
	globalSearchCategories := set.NewV1SearchCategorySet(
		v1.SearchCategory_ALERTS,
		v1.SearchCategory_CLUSTERS,
		v1.SearchCategory_DEPLOYMENTS,
		v1.SearchCategory_IMAGES,
		v1.SearchCategory_NODES,
		v1.SearchCategory_NAMESPACES,
		v1.SearchCategory_POLICIES,
		v1.SearchCategory_SECRETS,
		v1.SearchCategory_SERVICE_ACCOUNTS,
		v1.SearchCategory_ROLES,
		v1.SearchCategory_ROLEBINDINGS,
		v1.SearchCategory_SUBJECTS,
	)
	return globalSearchCategories
}

```
## Checklist
- [ ] Investigated and inspected CI test results
- ~Unit test and regression tests added~
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
CI+Manual
- Verified that behavior is not different from that of the master.
- Note that the autocomplete on component and vuln fields did not work on master.
