### PR TITLE
Add options dropdown to violated policies widget

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -1,6 +1,17 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
+    Dropdown,
+    DropdownToggle,
+    Flex,
+    FlexItem,
+    Form,
+    FormGroup,
+    Title,
+    ToggleGroup,
+    ToggleGroupItem,
+} from '@patternfly/react-core';
+import {
     Chart,
     ChartAxis,
     ChartStack,
@@ -22,21 +33,12 @@ import {
 import { getQueryString } from 'utils/queryStringUtils';
 import { violationsBasePath } from 'routePaths';
 import useResizeObserver from 'hooks/useResizeObserver';
-import {
-    Dropdown,
-    DropdownToggle,
-    Flex,
-    FlexItem,
-    Form,
-    FormGroup,
-    Title,
-    ToggleGroup,
-    ToggleGroupItem,
-} from '@patternfly/react-core';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import useURLSearch from 'hooks/useURLSearch';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';
+import { LifecycleStage } from 'types/policy.proto';
+
 import useAlertGroups from '../hooks/useAlertGroups';
 import WidgetCard from './WidgetCard';
 
@@ -182,7 +184,7 @@ function ViolationsByPolicyCategoryChart({
     );
 }
 
-type LifecycleOption = 'All' | 'Deploy' | 'Runtime';
+type LifecycleOption = 'ALL' | Exclude<LifecycleStage, 'BUILD'>;
 
 const fieldIdPrefix = 'policy-category-violations';
 
@@ -190,12 +192,12 @@ function ViolationsByPolicyCategory() {
     const { isOpen: isOptionsOpen, onToggle: toggleOptionsOpen } = useSelectToggle();
     const { searchFilter } = useURLSearch();
     const [sortType, sortTypeOption] = useState<SortTypeOption>('Severity');
-    const [lifecycle, setLifecycle] = useState<LifecycleOption>('All');
+    const [lifecycle, setLifecycle] = useState<LifecycleOption>('ALL');
 
     const queryFilter = { ...searchFilter };
-    if (lifecycle === 'Deploy') {
+    if (lifecycle === 'DEPLOY') {
         queryFilter['Lifecycle Stage'] = LIFECYCLE_STAGES.DEPLOY;
-    } else if (lifecycle === 'Runtime') {
+    } else if (lifecycle === 'RUNTIME') {
         queryFilter['Lifecycle Stage'] = LIFECYCLE_STAGES.RUNTIME;
     }
     const query = getRequestQueryStringForSearchFilter(queryFilter);
@@ -250,20 +252,20 @@ function ViolationsByPolicyCategory() {
                                         <ToggleGroupItem
                                             text="All"
                                             buttonId={`${fieldIdPrefix}-lifecycle-all`}
-                                            isSelected={lifecycle === 'All'}
-                                            onChange={() => setLifecycle('All')}
+                                            isSelected={lifecycle === 'ALL'}
+                                            onChange={() => setLifecycle('ALL')}
                                         />
                                         <ToggleGroupItem
                                             text="Deploy"
                                             buttonId={`${fieldIdPrefix}-lifecycle-deploy`}
-                                            isSelected={lifecycle === 'Deploy'}
-                                            onChange={() => setLifecycle('Deploy')}
+                                            isSelected={lifecycle === 'DEPLOY'}
+                                            onChange={() => setLifecycle('DEPLOY')}
                                         />
                                         <ToggleGroupItem
                                             text="Runtime"
                                             buttonId={`${fieldIdPrefix}-lifecycle-runtime`}
-                                            isSelected={lifecycle === 'Runtime'}
-                                            onChange={() => setLifecycle('Runtime')}
+                                            isSelected={lifecycle === 'RUNTIME'}
+                                            onChange={() => setLifecycle('RUNTIME')}
                                         />
                                     </ToggleGroup>
                                 </FormGroup>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetCard.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetCard.tsx
@@ -29,7 +29,7 @@ function WidgetCard({ isLoading, error, header, children }: WidgetCardProps) {
     }
 
     return (
-        <Card>
+        <Card className="pf-u-p-md">
             {header}
             {cardContent}
         </Card>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetErrorEmptyState.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetErrorEmptyState.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { Divider, Flex } from '@patternfly/react-core';
+import { Flex } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
 
@@ -27,11 +27,9 @@ export default function WidgetErrorEmptyState({
 }: WidgetErrorEmptyStateProps) {
     return (
         <>
-            <Divider component="div" />
             <Flex
                 alignContent={{ default: 'alignContentCenter' }}
                 justifyContent={{ default: 'justifyContentCenter' }}
-                className="pf-u-px-sm"
                 style={{ height }}
             >
                 <EmptyStateTemplate icon={ErrorIcon} title={title} headingLevel="h3">

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -99,13 +99,18 @@ button.pf-c-tree-view__node {
     height: calc(100% - 112px) !important;
 }
 
-/* For classic components to equal or exceed z-index of PatternFly elements. */
+/* Overrides Tailwind bolding of PF ToggleGroup buttons */
+.pf-c-toggle-group__button {
+    font-weight: var(--pf-global--FontWeight--normal);
+}
 
 /* override PatternFly DescriptionList horizontal variant to allow long keys and values to wrap */
 .pf-c-description-list__term,
 .pf-c-description-list__description{
     word-break: break-all;
 }
+
+/* For classic components to equal or exceed z-index of PatternFly elements. */
 
 .z-xs-100 {
     z-index: 100; /* --pf-global--ZIndex--xs */

--- a/ui/apps/platform/src/utils/chartUtils.ts
+++ b/ui/apps/platform/src/utils/chartUtils.ts
@@ -9,7 +9,7 @@ const severityColorScale = Object.values(severityColors);
 // Clone default PatternFly chart themes
 const defaultTheme = getTheme(ChartThemeColor.multi);
 
-export const defaultChartHeight = 280;
+export const defaultChartHeight = 260;
 
 export const defaultChartBarWidth = 18;
 


### PR DESCRIPTION
## Description

*Note that this PR branches off dv/ROX-11130-action-widgets-scope-bar and will retarget to master when that branch is merged*

Adds a dropdown menu to the Policy Violations by Category widget to allow sorting by highest severity counts/total violations as well as filtering by policy lifecycle type.

Also makes minor adjustments to the formatting of new dashboard widget cards to better accommodate this menu and clean up unneeded style classes.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Test that the default options on page load are set to "Sort By: Severity" and "Policy Lifecycle: All"
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/1292638/173123578-5153492a-247e-4296-a567-819657cf424d.png">

Test that sorting by volume displays bars in descending order based on total violation counts.
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/1292638/173123673-fc43b021-3a90-4b53-aa4d-f7fc6290a554.png">
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/1292638/173123699-a6318fcb-f472-4a86-99af-f044604b1a59.png">

Test that changing the policy lifecycle filter reduces the number of Violations displayed in the chart.
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/1292638/173124311-e1949cfb-eeb0-41e0-aea0-343eb13f2ce0.png">
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/1292638/173123943-cb315242-3a7c-4cc3-af6c-41b8274b54dc.png">

Test that updating the cluster/namespace filters takes these new filter and sorting options into account.
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/1292638/173124149-f99d0072-b3cd-4e00-8335-9af47fb9e93b.png">

