### PR TITLE
CI: build CLI regardless of context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2652,7 +2652,6 @@ jobs:
       - EKS_AUTOMATION_VERSION: 0.2.17
     steps:
       - checkout
-      - continue-when-in-a-pr-or-nightly-context
       - attach_workspace:
           at: /go/src/github.com/stackrox/rox
       - restore-go-mod-cache


### PR DESCRIPTION
## Description

#1945 broke roxctl tests in merge CI. This PR fixes them by re-enabling the cli build regardless of context.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient