### PR TITLE
OSCI: Onboard go-postgres-tests

### DIFF
--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -46,6 +46,9 @@ case "$ci_job" in
     go-unit-tests)
         GOTAGS='' "$ROOT/scripts/ci/jobs/go-unit-tests.sh"
         ;;
+    go-postgres-tests)
+        GOTAGS='' "$ROOT/scripts/ci/jobs/go-postgres-tests.sh"
+        ;;
     integration-unit-tests)
         "$ROOT/scripts/ci/jobs/integration-unit-tests.sh"
         ;;

--- a/scripts/ci/gate-jobs-config.json
+++ b/scripts/ci/gate-jobs-config.json
@@ -15,6 +15,14 @@
         "run_on_master": "true",
         "run_on_tags": "true"
     },
+    "go-postgres-tests": {
+        "run_with_labels": [],
+        "skip_with_label": "",
+        "run_with_changed_path": "^.*$",
+        "changed_path_to_ignore": "^ui/",
+        "run_on_master": "true",
+        "run_on_tags": "true"
+    },
     "shell-unit-tests": {
         "run_with_labels": [],
         "skip_with_label": "",

--- a/scripts/ci/jobs/go-postgres-tests.sh
+++ b/scripts/ci/jobs/go-postgres-tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+source "$ROOT/scripts/ci/lib.sh"
+
+set -euo pipefail
+
+go_postgres_unit_tests() {
+    info "Starting go postgres unit tests"
+}
+
+go_postgres_unit_tests "$*"


### PR DESCRIPTION
## Description

This is the scaffolding for an OpenShift CI go-postgres-test.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient:

- [x] A rehearsed run in OpenShift CI: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/29384/rehearse-29384-pull-ci-stackrox-stackrox-gavin-OSCI-onboard-go-postgres-tests-go-postgres-tests/1535407098941149184