### PR TITLE
Update a comment on GroupProperties to match the reality

### DIFF
--- a/proto/api/v1/group_service.proto
+++ b/proto/api/v1/group_service.proto
@@ -37,6 +37,7 @@ message GroupBatchUpdateRequest {
     // 2) if in previous_groups and required_groups, it gets updated.
     // 3) if not in previous_groups but in required_groups, it gets added.
     repeated storage.Group previous_groups = 1;
+
     // Required groups are the groups we want to mutate the previous groups into.
     repeated storage.Group required_groups = 2;
 }

--- a/proto/storage/group.proto
+++ b/proto/storage/group.proto
@@ -14,13 +14,12 @@ message Group {
     string role_name = 3;
 }
 
-// GroupProperties defines the properties of a unique group.
-// Groups apply to users when their properties match. For instance:
-// If the GroupProperties on has a auth_provider_id, then that group applies to all users logged in
-// with that auth provider. If it has a claim key, then it applies to all users with that auth provider
-// and claim key, etc.
-// This can be used to create default groups/roles for All source provider (no fields set), a specific
-// auth provider (only auth_provider_id field set) etc.
+// GroupProperties defines the properties of a group. Groups apply to users when
+// their properties match. For instance:
+//   * If GroupProperties has an auth_provider_id, then that group applies to
+//     all users logged in with that auth provider.
+//   * If GroupProperties in addition has a claim key, then it applies to all
+//     users with that auth provider and the claim key, etc.
 message GroupProperties {
     string auth_provider_id = 1;
     string key = 2;


### PR DESCRIPTION
Since https://github.com/stackrox/rox/pull/8863, a group property must include an auth provider id. This adjusts the API comment to reflect this.

## Checklist
- [ ] ~Investigated and inspected CI test results~
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

None: not a functional change.
