### PR TITLE
CI: Refactor scripts

### DIFF
--- a/scripts/ci/bats/lib_check_docs_test.bats
+++ b/scripts/ci/bats/lib_check_docs_test.bats
@@ -1,10 +1,10 @@
 #!/usr/bin/env bats
 # shellcheck disable=SC1091
 
-load "../test_helpers.bats"
+load "../../test_helpers.bats"
 
 function setup() {
-    source "${BATS_TEST_DIRNAME}/lib.sh"
+    source "${BATS_TEST_DIRNAME}/../lib.sh"
 }
 
 @test "missing tag argument" {

--- a/scripts/ci/bats/lib_get_base_ref.bats
+++ b/scripts/ci/bats/lib_get_base_ref.bats
@@ -4,6 +4,9 @@
 load "../../test_helpers.bats"
 
 function setup() {
+    unset OPENSHIFT_CI
+    unset PULL_BASE_REF
+    unset JOB_SPEC
     source "${BATS_TEST_DIRNAME}/../lib.sh"
 }
 

--- a/scripts/ci/bats/lib_get_base_ref.bats
+++ b/scripts/ci/bats/lib_get_base_ref.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC1091
+
+load "../../test_helpers.bats"
+
+function setup() {
+    source "${BATS_TEST_DIRNAME}/../lib.sh"
+}
+
+@test "without any env" {
+    run get_base_ref
+    assert_failure 1
+    assert_output --partial 'unsupported'
+}
+
+@test "OPENSHIFT_CI but nothing else" {
+    export OPENSHIFT_CI=true
+    run get_base_ref
+    assert_failure 1
+    assert_output --partial 'Expect PULL_BASE_REF or JOB_SPEC'
+}
+
+@test "with PULL_BASE_REF" {
+    export OPENSHIFT_CI=true
+    export PULL_BASE_REF="main"
+    run get_base_ref
+    assert_success
+    assert_output 'main'
+}
+
+@test "with invalid JOB_SPEC I" {
+    export OPENSHIFT_CI=true
+    export JOB_SPEC='{}'
+    run get_base_ref
+    assert_failure 1
+    assert_output --partial 'expect: base_ref'
+}
+
+@test "with invalid JOB_SPEC II" {
+    export OPENSHIFT_CI=true
+    export JOB_SPEC='{ "extra_refs": [] }'
+    run get_base_ref
+    assert_failure 1
+    assert_output --partial 'expect: base_ref'
+}
+
+@test "with invalid JOB_SPEC III" {
+    export OPENSHIFT_CI=true
+    export JOB_SPEC='{ "not yamls" }'
+    run get_base_ref
+    assert_failure 1
+    assert_output --partial 'invalid JOB_SPEC yaml'
+}
+
+@test "with invalid JOB_SPEC IV" {
+    export OPENSHIFT_CI=true
+    export JOB_SPEC='{ "extra_refs": "" }'
+    run get_base_ref
+    assert_failure 1
+    assert_output --partial 'invalid JOB_SPEC yaml'
+}
+
+@test "with valid JOB_SPEC" {
+    export OPENSHIFT_CI=true
+    export JOB_SPEC='{ "extra_refs": [{ "base_ref": "main" }] }'
+    run get_base_ref
+    assert_success
+    assert_output 'main'
+}
+

--- a/scripts/ci/bats/lib_get_repo_full_name.bats
+++ b/scripts/ci/bats/lib_get_repo_full_name.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC1091
+
+load "../../test_helpers.bats"
+
+function setup() {
+    source "${BATS_TEST_DIRNAME}/../lib.sh"
+}
+
+@test "without any env" {
+    run get_repo_full_name
+    assert_failure 1
+    assert_output --partial 'unsupported'
+}
+
+@test "OPENSHIFT_CI but nothing else" {
+    export OPENSHIFT_CI=true
+    run get_repo_full_name
+    assert_failure 1
+    assert_output --partial 'Expect REPO_OWNER/NAME or JOB_SPEC'
+}
+
+@test "REPO_OWNER without REPO_NAME" {
+    export OPENSHIFT_CI=true
+    export REPO_OWNER="acme"
+    run get_repo_full_name
+    assert_failure 1
+    assert_output --partial 'expect: REPO_NAME'
+}
+
+@test "with REPO_OWNER & NAME" {
+    export OPENSHIFT_CI=true
+    export REPO_OWNER="acme"
+    export REPO_NAME="products"
+    run get_repo_full_name
+    assert_success
+    assert_output 'acme/products'
+}
+
+@test "with invalid JOB_SPEC I" {
+    export OPENSHIFT_CI=true
+    export JOB_SPEC='{ }'
+    run get_repo_full_name
+    assert_failure 1
+    assert_output --partial 'expect: org and repo'
+}
+
+@test "with invalid JOB_SPEC II" {
+    export OPENSHIFT_CI=true
+    export JOB_SPEC='{ "extra_refs": [] }'
+    run get_repo_full_name
+    assert_failure 1
+    assert_output --partial 'expect: org and repo'
+}
+
+@test "with invalid JOB_SPEC III" {
+    export OPENSHIFT_CI=true
+    export JOB_SPEC='{ "extra_refs": [{ "org": "acme" }] }'
+    run get_repo_full_name
+    assert_failure 1
+    assert_output --partial 'expect: org and repo'
+}
+
+@test "with invalid JOB_SPEC IV" {
+    export OPENSHIFT_CI=true
+    export JOB_SPEC='{ "not yamls" }'
+    run get_repo_full_name
+    assert_failure 1
+    assert_output --partial 'invalid JOB_SPEC yaml'
+}
+
+@test "with invalid JOB_SPEC V" {
+    export OPENSHIFT_CI=true
+    export JOB_SPEC='{ "extra_refs": "" }'
+    run get_repo_full_name
+    assert_failure 1
+    assert_output --partial 'invalid JOB_SPEC yaml'
+}
+
+@test "with valid JOB_SPEC" {
+    export OPENSHIFT_CI=true
+    export JOB_SPEC='{ "extra_refs": [{ "org": "acme", "repo": "products" }] }'
+    run get_repo_full_name
+    assert_success
+    assert_output 'acme/products'
+}
+

--- a/scripts/ci/bats/lib_get_repo_full_name.bats
+++ b/scripts/ci/bats/lib_get_repo_full_name.bats
@@ -4,6 +4,10 @@
 load "../../test_helpers.bats"
 
 function setup() {
+    unset OPENSHIFT_CI
+    unset REPO_OWNER
+    unset REPO_NAME
+    unset JOB_SPEC
     source "${BATS_TEST_DIRNAME}/../lib.sh"
 }
 

--- a/scripts/ci/bats/lib_release_version_test.bats
+++ b/scripts/ci/bats/lib_release_version_test.bats
@@ -1,10 +1,10 @@
 #!/usr/bin/env bats
 # shellcheck disable=SC1091
 
-load "../test_helpers.bats"
+load "../../test_helpers.bats"
 
 function setup() {
-    source "${BATS_TEST_DIRNAME}/lib.sh"
+    source "${BATS_TEST_DIRNAME}/../lib.sh"
 }
 
 # is_{release,RC}_version() helper tests

--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -18,15 +18,20 @@ push_images() {
     [[ "${OPENSHIFT_CI:-false}" == "true" ]] || { die "Only supported in OpenShift CI"; }
 
     local brand="$1"
-    local branch
-    branch=$(get_pr_details | jq -r '.head.ref')
-    if [[ "$branch" == "null" ]]; then
-        branch="master"
+    local push_context=""
+    local base_ref
+    base_ref="$(get_base_ref)" || {
+        info "Warning: error running get_base_ref():"
+        echo "${base_ref}"
+        info "will continue with pushing images."
+    }
+    if ! is_in_PR_context && [[ "${base_ref}" == "master" ]]; then
+        push_context="merge-to-master"
     fi
 
-    push_main_image_set "$branch" "$brand"
+    push_main_image_set "$push_context" "$brand"
 
-    if [[ "$branch" != "master" && "$brand" == "STACKROX_BRANDING" ]]; then
+    if is_in_PR_context && [[ "$brand" == "STACKROX_BRANDING" ]]; then
         comment_on_pr
     fi
 }

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -135,10 +135,10 @@ push_main_image_set() {
     info "Pushing main and roxctl images"
 
     if [[ "$#" -ne 2 ]]; then
-        die "missing arg. usage: push_main_image_set <branch> <brand>"
+        die "missing arg. usage: push_main_image_set <push_context> <brand>"
     fi
 
-    local branch="$1"
+    local push_context="$1"
     local brand="$2"
 
     local main_image_set=("main" "roxctl" "central-db")
@@ -207,7 +207,7 @@ push_main_image_set() {
             _tag_main_image_set "$tag" "$registry" "$tag"
             _push_main_image_set "$registry" "$tag"
         fi
-        if [[ "$branch" == "master" ]]; then
+        if [[ "$push_context" == "merge-to-master" ]]; then
             if is_OPENSHIFT_CI; then
                 _mirror_main_image_set "$registry" "latest"
             else
@@ -712,7 +712,11 @@ gate_merge_job() {
     run_on_tags="$(get_var_from_job_config run_on_tags "$job_config")"
 
     local base_ref
-    base_ref="$(get_base_ref)"
+    base_ref="$(get_base_ref)" || {
+        info "Warning: error running get_base_ref():"
+        echo "${base_ref}"
+        info "will continue with tests."
+    }
 
     if [[ "${base_ref}" == "master" && "${run_on_master}" == "true" ]]; then
         info "$job will run because this is master and run_on_master==true"


### PR DESCRIPTION
## Description

Last weeks attempt (#1945) to disable image builds in Circle CI highlighted some flakiness in CI scripts. This PR refactors `get_base_ref()` and `get_repo_full_name()` so that they cover known OpenShift CI states.. Creates unit test for the same. And moves unit tests for `scripts/ci/lib.sh` into `scripts/ci/bats`.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient