### PR TITLE
OSCI: Onboard openshift-4-e2e with a cluster claim

### DIFF
--- a/.openshift-ci/base_qa_e2e_test.py
+++ b/.openshift-ci/base_qa_e2e_test.py
@@ -10,7 +10,7 @@ from runners import ClusterTestSetsRunner
 
 
 def make_qa_e2e_test_runner(cluster):
-    ClusterTestSetsRunner(
+    return ClusterTestSetsRunner(
         cluster=cluster,
         sets=[
             {

--- a/.openshift-ci/base_qa_e2e_test.py
+++ b/.openshift-ci/base_qa_e2e_test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run QA e2e tests against a given cluster.
+"""
+from pre_tests import PreSystemTests
+from ci_tests import QaE2eTestPart1, QaE2eTestPart2, QaE2eDBBackupRestoreTest
+from post_tests import PostClusterTest, CheckStackroxLogs, FinalPost
+from runners import ClusterTestSetsRunner
+
+
+def make_qa_e2e_test_runner(cluster):
+    ClusterTestSetsRunner(
+        cluster=cluster,
+        sets=[
+            {
+                "name": "QA tests part I",
+                "pre_test": PreSystemTests(),
+                "test": QaE2eTestPart1(),
+                "post_test": PostClusterTest(
+                    check_stackrox_logs=True,
+                    artifact_destination_prefix="part-1",
+                ),
+            },
+            {
+                "name": "QA tests part II",
+                "test": QaE2eTestPart2(),
+                "post_test": PostClusterTest(
+                    check_stackrox_logs=True,
+                    artifact_destination_prefix="part-2",
+                ),
+            },
+            {
+                "name": "DB backup and restore",
+                "test": QaE2eDBBackupRestoreTest(),
+                "post_test": CheckStackroxLogs(
+                    check_for_errors_in_stackrox_logs=True,
+                    artifact_destination_prefix="db-test",
+                ),
+                "always_run": False,
+            },
+        ],
+        final_post=FinalPost(
+            store_qa_test_debug_logs=True,
+            store_qa_spock_results=True,
+        ),
+    )

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -73,6 +73,9 @@ case "$ci_job" in
     gke-nongroovy-e2e-tests)
         "$ROOT/.openshift-ci/gke_nongroovy_e2e_test.py"
         ;;
+    openshift-4-qa-e2e-tests)
+        "$ROOT/.openshift-ci/openshift_4_qa_e2e_test.py"
+        ;;
     gke-upgrade-tests)
         "$ROOT/.openshift-ci/gke_upgrade_test.py"
         ;;

--- a/.openshift-ci/gke_qa_e2e_test.py
+++ b/.openshift-ci/gke_qa_e2e_test.py
@@ -4,11 +4,8 @@
 Run qa-tests-backend in a GKE cluster
 """
 import os
-from pre_tests import PreSystemTests
-from ci_tests import QaE2eTestPart1, QaE2eTestPart2, QaE2eDBBackupRestoreTest
-from post_tests import PostClusterTest, CheckStackroxLogs, FinalPost
+from base_qa_e2e_test import make_qa_e2e_test_runner
 from clusters import GKECluster
-from runners import ClusterTestSetsRunner
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
@@ -16,38 +13,4 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 # override default test environment
 os.environ["LOAD_BALANCER"] = "lb"
 
-ClusterTestSetsRunner(
-    cluster=GKECluster("qa-e2e-test"),
-    sets=[
-        {
-            "name": "QA tests part I",
-            "pre_test": PreSystemTests(),
-            "test": QaE2eTestPart1(),
-            "post_test": PostClusterTest(
-                check_stackrox_logs=True,
-                artifact_destination_prefix="part-1",
-            ),
-        },
-        {
-            "name": "QA tests part II",
-            "test": QaE2eTestPart2(),
-            "post_test": PostClusterTest(
-                check_stackrox_logs=True,
-                artifact_destination_prefix="part-2",
-            ),
-        },
-        {
-            "name": "DB backup and restore",
-            "test": QaE2eDBBackupRestoreTest(),
-            "post_test": CheckStackroxLogs(
-                check_for_errors_in_stackrox_logs=True,
-                artifact_destination_prefix="db-test",
-            ),
-            "always_run": False,
-        },
-    ],
-    final_post=FinalPost(
-        store_qa_test_debug_logs=True,
-        store_qa_spock_results=True,
-    ),
-).run()
+make_qa_e2e_test_runner(cluster=GKECluster("qa-e2e-test")).run()

--- a/.openshift-ci/openshift_4_qa_e2e_test.py
+++ b/.openshift-ci/openshift_4_qa_e2e_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S python3 -u
 
 """
-Run qa-tests-backend in the provided cluster
+Run qa-tests-backend in a openshift 4 cluster provided via a hive cluster_claim.
 """
 import os
 from base_qa_e2e_test import make_qa_e2e_test_runner
@@ -9,6 +9,7 @@ from clusters import NullCluster
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["OPENSHIFT_CI_CLUSTER_CLAIM"] = "openshift-4"
 
 # override default test environment
 os.environ["LOAD_BALANCER"] = "lb"

--- a/.openshift-ci/openshift_4_qa_e2e_test.py
+++ b/.openshift-ci/openshift_4_qa_e2e_test.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run qa-tests-backend in the provided cluster
+"""
+import os
+from base_qa_e2e_test import make_qa_e2e_test_runner
+from clusters import NullCluster
+
+# set required test parameters
+os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+
+# override default test environment
+os.environ["LOAD_BALANCER"] = "lb"
+
+make_qa_e2e_test_runner(cluster=NullCluster()).run()

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -285,7 +285,7 @@ class FinalPost(StoreArtifacts):
         if self._store_qa_spock_results:
             self.data_to_store.append(PostTestsConstants.QA_SPOCK_RESULTS)
 
-    def run(self):
+    def run(self, test_output_dirs=None):
         self.store_artifacts()
         self.fixup_artifacts_content_type()
         self.make_artifacts_help()

--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -15,7 +15,7 @@ class PreSystemTests:
     PreSystemTests - System tests (upgrade, e2e) need images.
     """
 
-    POLL_TIMEOUT = 30 * 60
+    POLL_TIMEOUT = 45 * 60
 
     def run(self):
         subprocess.run(

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -3,6 +3,7 @@
 # Tests part I of qa-tests-backend. Formerly CircleCI gke-api-e2e-tests.
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+source "$ROOT/scripts/ci/gcp.sh"
 source "$ROOT/scripts/ci/lib.sh"
 source "$ROOT/scripts/ci/sensor-wait.sh"
 source "$ROOT/tests/e2e/lib.sh"
@@ -24,6 +25,7 @@ test_part_1() {
         install_built_roxctl_in_gopath
     fi
 
+    setup_gcp
     setup_deployment_env false false
     remove_existing_stackrox_resources
     setup_default_TLS_certs

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -19,8 +19,8 @@ import util.Env
 class SummaryTest extends BaseSpecification {
 
     @Category([BAT])
-    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
-    @IgnoreIf({ System.getenv("OPENSHIFT_CI_CLUSTER_CLAIM") == "openshift-4" })
+    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") ||
+                System.getenv("OPENSHIFT_CI_CLUSTER_CLAIM") == "openshift-4" })
     def "Verify TopNav counts for Nodes, Deployments, and Secrets"() {
         expect:
         "Counts API should match orchestrator details"

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -20,10 +20,8 @@ class SummaryTest extends BaseSpecification {
 
     @Category([BAT])
     @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
+    @IgnoreIf({ System.getenv("OPENSHIFT_CI_CLUSTER_CLAIM") == "openshift-4" })
     def "Verify TopNav counts for Nodes, Deployments, and Secrets"() {
-        // https://stack-rox.atlassian.net/browse/ROX-6844
-        Assume.assumeFalse(ClusterService.isOpenShift4())
-
         expect:
         "Counts API should match orchestrator details"
 
@@ -102,10 +100,8 @@ class SummaryTest extends BaseSpecification {
     }
 
     @Category([BAT])
+    @IgnoreIf({ System.getenv("OPENSHIFT_CI_CLUSTER_CLAIM") == "openshift-4" })
     def "Verify namespace details"() {
-        // https://stack-rox.atlassian.net/browse/ROX-6844
-        Assume.assumeFalse(ClusterService.isOpenShift4())
-
         given:
         "fetch the list of namespace"
 

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -19,7 +19,7 @@ import util.Env
 class SummaryTest extends BaseSpecification {
 
     @Category([BAT])
-    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
+    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") || System.getenv("OPENSHIFT_CI_CLUSTER_CLAIM") == "openshift-4" })
     def "Verify TopNav counts for Nodes, Deployments, and Secrets"() {
         // https://issues.redhat.com/browse/ROX-6844
         Assume.assumeFalse(ClusterService.isOpenShift4())
@@ -102,6 +102,7 @@ class SummaryTest extends BaseSpecification {
     }
 
     @Category([BAT])
+    @IgnoreIf({ System.getenv("OPENSHIFT_CI_CLUSTER_CLAIM") == "openshift-4" })
     def "Verify namespace details"() {
         // https://issues.redhat.com/browse/ROX-6844
         Assume.assumeFalse(ClusterService.isOpenShift4())

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -7,7 +7,6 @@ import objects.Namespace
 import org.javers.core.Javers
 import org.javers.core.JaversBuilder
 import org.javers.core.diff.ListCompareAlgorithm
-import org.junit.Assume
 import org.junit.experimental.categories.Category
 import services.ClusterService
 import services.NamespaceService

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -7,6 +7,7 @@ import objects.Namespace
 import org.javers.core.Javers
 import org.javers.core.JaversBuilder
 import org.javers.core.diff.ListCompareAlgorithm
+import org.junit.Assume
 import org.junit.experimental.categories.Category
 import services.ClusterService
 import services.NamespaceService
@@ -18,9 +19,11 @@ import util.Env
 class SummaryTest extends BaseSpecification {
 
     @Category([BAT])
-    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") ||
-                System.getenv("OPENSHIFT_CI_CLUSTER_CLAIM") == "openshift-4" })
+    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
     def "Verify TopNav counts for Nodes, Deployments, and Secrets"() {
+        // https://issues.redhat.com/browse/ROX-6844
+        Assume.assumeFalse(ClusterService.isOpenShift4())
+
         expect:
         "Counts API should match orchestrator details"
 
@@ -99,8 +102,10 @@ class SummaryTest extends BaseSpecification {
     }
 
     @Category([BAT])
-    @IgnoreIf({ System.getenv("OPENSHIFT_CI_CLUSTER_CLAIM") == "openshift-4" })
     def "Verify namespace details"() {
+        // https://issues.redhat.com/browse/ROX-6844
+        Assume.assumeFalse(ClusterService.isOpenShift4())
+
         given:
         "fetch the list of namespace"
 


### PR DESCRIPTION
## Description

This PR adds an openshift 4 flavor of QA tests to OpenShift CI. It uses a cluster_claim from the shared pool. This test job is not gated using the labels we are familiar with using for Circle CI and instead will rely on prow commands to test on request (/test ...) and will run on merge.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient - Passing in [rehearsal](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/29431/rehearse-29431-pull-ci-stackrox-stackrox-gavin-OSCI-onboard-openshift-4-with-a-cluster-claim-openshift-4-qa-e2e-tests/1536823835888717824) and with existing CI.
