### PR TITLE
ROX-11000: Use python3 explicitly

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -2,7 +2,7 @@
 
 function realpath {
 	[[ -n "$1" ]] || return 0
-	python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$1"
+	python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$1"
 }
 
 function launch_service {

--- a/qa-tests-backend/scripts/fix_lint.py
+++ b/qa-tests-backend/scripts/fix_lint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Script that fixes some lint issues automatically.
 """

--- a/scripts/certification/format_csv.py
+++ b/scripts/certification/format_csv.py
@@ -2,7 +2,7 @@ import heapq
 import sys
 
 def usage():
-    print('usage: python format_csv.py <input file>.csv <output file>.csv')
+    print('usage: python3 format_csv.py <input file>.csv <output file>.csv')
     sys.exit(1)
 
 if len(sys.argv) != 3:

--- a/tools/generate-helpers/blevebindings-wrapper
+++ b/tools/generate-helpers/blevebindings-wrapper
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 
 go run "$(dirname "${SCRIPT}")/blevebindings" --mockgen-executable-path "$(which mockgen-wrapper)" "$@"

--- a/tools/generate-helpers/boltbindings-wrapper
+++ b/tools/generate-helpers/boltbindings-wrapper
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 
 go run "$(dirname "${SCRIPT}")/boltbindings" "$@" --mockgen-executable-path "$(which mockgen-wrapper)"

--- a/tools/generate-helpers/notifier-wrapper
+++ b/tools/generate-helpers/notifier-wrapper
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 
 go run "$(dirname "${SCRIPT}")/notifier" "$@"

--- a/tools/import_validate.py
+++ b/tools/import_validate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
## Description

Use `python3` explicitly for python scripts in `stackrox`.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Manual, CI.