### PR TITLE
Dashrews/ROX-10903 ROX-11357 flaky process baseline deletion test

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1726,7 +1726,7 @@ class Kubernetes implements OrchestratorMain {
 
     def execInContainerByPodName(String name, String namespace, String cmd, int retries = 1) {
         // Wait for container 0 to be running first.
-        def timer = new Timer(retries, 2)
+        def timer = new Timer(retries, 1)
         while (timer.IsValid()) {
             def p = client.pods().inNamespace(namespace).withName(name).get()
             if (p == null || p.status.containerStatuses.size() == 0) {

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1726,7 +1726,7 @@ class Kubernetes implements OrchestratorMain {
 
     def execInContainerByPodName(String name, String namespace, String cmd, int retries = 1) {
         // Wait for container 0 to be running first.
-        def timer = new Timer(retries, 1)
+        def timer = new Timer(retries, 2)
         while (timer.IsValid()) {
             def p = client.pods().inNamespace(namespace).withName(name).get()
             if (p == null || p.status.containerStatuses.size() == 0) {

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -473,8 +473,8 @@ class ProcessBaselinesTest extends BaseSpecification {
 
         log.info "Process Baseline before pwd: ${baselineAfterDelete}"
 
-        // sleep 5 seconds to allow for propagation to sensor
-        sleep 5000
+        // sleep 10 seconds to allow for propagation to sensor
+        sleep 10000
         orchestrator.execInContainer(deployment, "pwd")
 
         then:

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -153,6 +153,7 @@ class ProcessBaselinesTest extends BaseSpecification {
 
         cleanup:
         "Remove deployment"
+        log.info "Cleaning up deployment: ${deployment}"
         orchestrator.deleteDeployment(deployment)
 
         where:
@@ -487,6 +488,7 @@ class ProcessBaselinesTest extends BaseSpecification {
 
         cleanup:
         "Remove deployment"
+        log.info "Cleaning up deployment: ${deployment}"
         orchestrator.deleteDeployment(deployment)
 
         where:

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -476,7 +476,6 @@ class ProcessBaselinesTest extends BaseSpecification {
         sleep 5000
         orchestrator.execInContainer(deployment, "pwd")
 
-
         then:
         "verify for suspicious process in risk indicator"
         RiskOuterClass.Risk.Result result = waitForSuspiciousProcessInRiskIndicators(deploymentId, 240)

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -134,8 +134,10 @@ class ProcessBaselinesTest extends BaseSpecification {
         }
         assert baseline
 
-        // sleep 5 seconds to allow for propagation to sensor
-        sleep 5000
+        log.info "Baseline Before after observation: ${baseline}"
+
+        // sleep 10 seconds to allow for propagation to sensor
+        sleep 10000
         orchestrator.execInContainer(deployment, "pwd")
 
         then:

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -122,7 +122,7 @@ class ProcessBaselinesTest extends BaseSpecification {
         assert baseline.elementsList.find { it.element.processName == processName } != null
 
         // wait for baseline to come out of observation
-        baseline = evaluateWithRetry(30, 3) {
+        baseline = evaluateWithRetry(10, 10) {
             def tmpBaseline = ProcessBaselineService.getProcessBaseline(clusterId, deployment, containerName)
             def now = System.currentTimeSeconds()
             if (tmpBaseline.getStackRoxLockedTimestamp().getSeconds() > now) {
@@ -223,7 +223,7 @@ class ProcessBaselinesTest extends BaseSpecification {
 
         String containerName = deployment.getName()
         // Need to make sure the processes show up before we lock.
-        def baseline = evaluateWithRetry(30, 4) {
+        def baseline = evaluateWithRetry(10, 10) {
             def tmpBaseline = ProcessBaselineService.
                  getProcessBaseline(clusterId, deployment, containerName)
             if (tmpBaseline.elementsList.size() == 0) {
@@ -445,7 +445,7 @@ class ProcessBaselinesTest extends BaseSpecification {
         String containerName = deployment.getName()
 
         // Wait on the process to be baseline to come out of observation
-        ProcessBaselineOuterClass.ProcessBaseline baseline = evaluateWithRetry(30, 3) {
+        ProcessBaselineOuterClass.ProcessBaseline baseline = evaluateWithRetry(10, 10) {
             def tmpBaseline = ProcessBaselineService.getProcessBaseline(clusterId, deployment, containerName)
             def now = System.currentTimeSeconds()
             if (tmpBaseline.getStackRoxLockedTimestamp().getSeconds() > now) {
@@ -471,7 +471,7 @@ class ProcessBaselinesTest extends BaseSpecification {
         assert  ( baselineAfterDelete.elementsList == [] )
 
         // Give the baseline time to come back out of observation
-        baselineAfterDelete = evaluateWithRetry(30, 3) {
+        baselineAfterDelete = evaluateWithRetry(10, 10) {
             def tmpBaseline = ProcessBaselineService.getProcessBaseline(clusterId, deployment, containerName)
             def now = System.currentTimeSeconds()
             if (tmpBaseline.getStackRoxLockedTimestamp().getSeconds() > now) {

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -17,7 +17,6 @@ import org.apache.commons.lang3.StringUtils
 import org.junit.experimental.categories.Category
 
 import services.ProcessBaselineService
-import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Unroll
 
@@ -428,8 +427,6 @@ class ProcessBaselinesTest extends BaseSpecification {
     }
 
     @Category(BAT)
-    // TODO:  ROX-10903
-    @Ignore
     def "Processes come in after baseline deleted by API"() {
         when:
         def deployment = DEPLOYMENTS.find { it.name == deploymentName }

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -398,7 +398,6 @@ class ProcessBaselinesTest extends BaseSpecification {
         DEPLOYMENTNGINX_REMOVEPROCESS           |   "nginx"
     }
 
-    @Unroll
     @Category(BAT)
     def "Delete process baselines via API"() {
         given:

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -444,12 +444,13 @@ class ProcessBaselinesTest extends BaseSpecification {
 
         String containerName = deployment.getName()
 
-        // Wait on the process to be processed and added to the baseline
+        // Wait on the process to be baseline to come out of observation
         ProcessBaselineOuterClass.ProcessBaseline baseline = evaluateWithRetry(30, 3) {
             def tmpBaseline = ProcessBaselineService.getProcessBaseline(clusterId, deployment, containerName)
-            if (baseline.elementsList.find { it.element.processName == processName } == null) {
+            def now = System.currentTimeSeconds()
+            if (tmpBaseline.getStackRoxLockedTimestamp().getSeconds() > now) {
                 throw new RuntimeException(
-                    "Baseline ${deployment} is waiting to receive process. Baseline is ${tmpBaseline}."
+                    "Baseline ${deployment} is still in observation. Baseline is ${tmpBaseline}."
                 )
             }
             return tmpBaseline

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -430,7 +430,7 @@ class ProcessBaselinesTest extends BaseSpecification {
 
     @Unroll
     @Category(BAT)
-    def "Processes come in after baseline deleted by API"() {
+    def "Processes come in after baseline deleted by API for #deploymentName"() {
         when:
         def deployment = DEPLOYMENTS.find { it.name == deploymentName }
         assert deployment != null


### PR DESCRIPTION
## Description

A couple of process baseline tests were a little flaky on the timing of the processes being added to the baseline or processed as risks.  Turns out we were having issues with slow environments such that if an environment was being slow and an exec process would cause the test to fail, the subsequent retries would try to exec a process on the deployment of the failed attempt instead of the deployment of the retry attempt.  So I switched the cleanup to use deleteAndWaitForDeploymentDeletion and I have had successful runs since.

The test for `Processes come in after baseline deleted by API for #deploymentName` needed some adjustments to make sure the baseline was processing and completing observation before we delete it and again after to ensure the behavior is what we are looking for.

This PR only makes changes to Process Baseline Tests so any CI issues outside of that test are related to other issues that appear to have tickets associated with them already.  Since making the change to wait for deployment deletion, I've had 6 runs without the tests failing, particularly the openshift test as these flakes were more often seen there.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
-~~ [ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested some locally, but mostly the CI tests are sufficient here as that is where it most often failed.
