### PR TITLE
ROX-11266 Add severity toggle to Policy Category widget

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -147,27 +147,6 @@ function ViolationsByPolicyCategoryChart({
     const topOrderedGroups = sortedAlertGroups.slice(0, 5).reverse();
     const countsBySeverity = getCountsBySeverity(topOrderedGroups);
 
-    function getLegendData() {
-        return policySeverities.map((severity) => {
-            return {
-                name: severityLabels[severity],
-                ...getInteractiveLegendItemStyles(hiddenSeverities.has(severity)),
-            };
-        });
-    }
-
-    function onLegendClick({ index }: { index: number }) {
-        const newHidden = new Set(hiddenSeverities);
-        const targetSeverity = policySeverities[index];
-        if (newHidden.has(targetSeverity)) {
-            newHidden.delete(targetSeverity);
-            // Do not allow the user to disable all severities
-        } else if (hiddenSeverities.size < 3) {
-            newHidden.add(targetSeverity);
-        }
-        setHiddenSeverities(newHidden);
-    }
-
     const bars = policySeverities.map((severity) => {
         const counts = countsBySeverity[severity];
         const data = Object.entries(counts).map(([group, count]) => ({
@@ -192,6 +171,27 @@ function ViolationsByPolicyCategoryChart({
             />
         );
     });
+
+    function getLegendData() {
+        return policySeverities.map((severity) => {
+            return {
+                name: severityLabels[severity],
+                ...getInteractiveLegendItemStyles(hiddenSeverities.has(severity)),
+            };
+        });
+    }
+
+    function onLegendClick({ index }: { index: number }) {
+        const newHidden = new Set(hiddenSeverities);
+        const targetSeverity = policySeverities[index];
+        if (newHidden.has(targetSeverity)) {
+            newHidden.delete(targetSeverity);
+            // Do not allow the user to disable all severities
+        } else if (hiddenSeverities.size < 3) {
+            newHidden.add(targetSeverity);
+        }
+        setHiddenSeverities(newHidden);
+    }
 
     return (
         <div ref={setWidgetContainer} style={{ height }}>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -64,7 +64,7 @@ function zeroOutFilteredSeverities(
 
 function pluckSeverityCount(severity: PolicySeverity): (group: AlertGroup) => number {
     return ({ counts }) => {
-        const severityCount = counts.find((ct) => ct.severity === severity)?.count || '0';
+        const severityCount = counts.find((ct) => ct.severity === severity)?.count ?? '0';
         return -parseInt(severityCount, 10);
     };
 }

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -53,18 +53,13 @@ function zeroOutFilteredSeverities(
     groups: AlertGroup[],
     hiddenSeverities: Set<PolicySeverity>
 ): AlertGroup[] {
-    const filteredGroups: AlertGroup[] = [];
-    groups.forEach(({ group, counts }) => {
-        const filteredCounts = counts.map(({ severity, count }) => ({
+    return groups.map(({ group, counts }) => ({
+        group,
+        counts: counts.map(({ severity, count }) => ({
             severity,
             count: hiddenSeverities.has(severity) ? '0' : count,
-        }));
-        filteredGroups.push({
-            group,
-            counts: filteredCounts,
-        });
-    });
-    return filteredGroups;
+        })),
+    }));
 }
 
 function pluckSeverityCount(severity: PolicySeverity): (group: AlertGroup) => number {
@@ -178,7 +173,7 @@ function ViolationsByPolicyCategoryChart({
             name: severity,
             x: group,
             y: count,
-            label: `${severity}: ${count}`,
+            label: `${severityLabels[severity]}: ${count}`,
         }));
 
         return (

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -161,7 +161,8 @@ function ViolationsByPolicyCategoryChart({
         const targetSeverity = policySeverities[index];
         if (newHidden.has(targetSeverity)) {
             newHidden.delete(targetSeverity);
-        } else {
+            // Do not allow the user to disable all severities
+        } else if (hiddenSeverities.size < 3) {
             newHidden.add(targetSeverity);
         }
         setHiddenSeverities(newHidden);

--- a/ui/apps/platform/src/types/policy.proto.ts
+++ b/ui/apps/platform/src/types/policy.proto.ts
@@ -12,11 +12,13 @@ export type ListPolicy = {
 };
 
 // TODO supersedes src/Containers/Violations/PatternFly/types/violationTypes.ts
-export type PolicySeverity =
-    | 'LOW_SEVERITY'
-    | 'MEDIUM_SEVERITY'
-    | 'HIGH_SEVERITY'
-    | 'CRITICAL_SEVERITY';
+export const policySeverities = [
+    'LOW_SEVERITY',
+    'MEDIUM_SEVERITY',
+    'HIGH_SEVERITY',
+    'CRITICAL_SEVERITY',
+] as const;
+export type PolicySeverity = typeof policySeverities[number];
 
 // TODO supersedes src/Containers/Violations/PatternFly/types/violationTypes.ts
 export type LifecycleStage = 'DEPLOY' | 'BUILD' | 'RUNTIME';


### PR DESCRIPTION
## Description

This PR adds the ability to toggle chart severities by clicking an item in the legend. Toggling off a
severity will remove it from the display and resort the chart accordingly.

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Load the PF dashboard and click on the "Low" item in the legend:
<img width="587" alt="image" src="https://user-images.githubusercontent.com/1292638/173674627-516e0123-1344-4045-a1a9-1bab94c64f54.png">

Click the "Medium" item to hide both low and medium:
<img width="587" alt="image" src="https://user-images.githubusercontent.com/1292638/173674730-cb653ab4-eb88-415e-b85a-01968c86778b.png">

Again for Critical:
<img width="587" alt="image" src="https://user-images.githubusercontent.com/1292638/173675483-4348881e-e155-4974-8f61-d34a1b824af5.png">

Verify that clicking on "high" does not allow the user to disable all four severity items.

Turn items back on one at a time:
<img width="587" alt="image" src="https://user-images.githubusercontent.com/1292638/173675599-497a4aa2-e42f-4ecd-9015-277dd4fa127a.png">

Verify that selecting options from the dropdown, and filtering by Cluster/NS keeps the deselected severities hidden:
<img width="1140" alt="image" src="https://user-images.githubusercontent.com/1292638/173675745-b34b6454-9910-4fd1-9f07-0d15a610e0f5.png">



