### PR TITLE
Add Cypress test suite for Policy Violations by Category widget

### DIFF
--- a/ui/apps/platform/cypress/constants/DashboardPage.js
+++ b/ui/apps/platform/cypress/constants/DashboardPage.js
@@ -47,12 +47,16 @@ export const selectors = {
  */
 const axisLabel = (axisIndex, labelIndex) => `#chart-axis-${axisIndex}-tickLabels-${labelIndex}`;
 
+const legendLabel = (labelIndex) => `#legend-labels-${labelIndex}`;
+
 // TODO Make `pfSelectors` the default once phase one of the PF Dashboard is enabled
 export const pfSelectors = {
     pageHeader: 'h1:contains("Dashboard")',
     violationsByCategory: scopeSelectors('article:contains("Policy violations by category")', {
         chart: '.pf-c-chart',
         optionsToggle: 'button:contains("Options")',
+        volumeOption: 'button:contains("Volume")',
         axisLabel,
+        legendLabel,
     }),
 };

--- a/ui/apps/platform/cypress/constants/DashboardPage.js
+++ b/ui/apps/platform/cypress/constants/DashboardPage.js
@@ -36,3 +36,23 @@ export const selectors = {
     topRiskyDeployments: '[data-testid="top-risky-deployments"] ul li a',
     policyCategoryViolations: '[data-testid="policy-category-violation"]',
 };
+
+/**
+ * Retrieves a selector for the axis label of a PatternFly/Victory chart. Note
+ * that Victory orders bar chart indices from the bottom up, so the last entry
+ * in the UI will be index 0.
+ *
+ * @param axisIndex The chart axis to select
+ * @param labelIndex The index of the label on the selected axis
+ */
+const axisLabel = (axisIndex, labelIndex) => `#chart-axis-${axisIndex}-tickLabels-${labelIndex}`;
+
+// TODO Make `pfSelectors` the default once phase one of the PF Dashboard is enabled
+export const pfSelectors = {
+    pageHeader: 'h1:contains("Dashboard")',
+    violationsByCategory: scopeSelectors('article:contains("Policy violations by category")', {
+        chart: '.pf-c-chart',
+        optionsToggle: 'button:contains("Options")',
+        axisLabel,
+    }),
+};

--- a/ui/apps/platform/cypress/constants/DashboardPage.js
+++ b/ui/apps/platform/cypress/constants/DashboardPage.js
@@ -2,7 +2,10 @@ import { severityColorMap } from '../../src/constants/severityColors';
 import scopeSelectors from '../helpers/scopeSelectors';
 import navigationSelectors from '../selectors/navigation';
 
+// TODO Make `pfUrl` the default url once phase one of the PF Dashboard is enabled
 export const url = '/main/dashboard';
+export const pfUrl = '/main/dashboard-pf';
+
 export const selectors = {
     navLink: `${navigationSelectors.navLinks}:contains("Dashboard")`,
     buttons: {

--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -1,5 +1,5 @@
 import * as api from '../constants/apiEndpoints';
-import { url } from '../constants/DashboardPage';
+import { pfUrl, url } from '../constants/DashboardPage';
 import navSelectors from '../selectors/navigation';
 
 import { visit } from './visit';
@@ -22,6 +22,11 @@ export function visitMainDashboard() {
 
     cy.wait('@riskyDeployments');
     cy.get('h1:contains("Dashboard")');
+}
+
+// TODO Make this the default once phase one of the PF Dashboard is enabled
+export function visitMainDashboardPF() {
+    visit(pfUrl);
 }
 
 export function visitMainDashboardViaRedirectFromUrl(redirectFromUrl) {

--- a/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
+++ b/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
@@ -1,0 +1,19 @@
+import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
+import { visitMainDashboardPF } from '../../helpers/main';
+
+describe('Dashboard security metrics phase one action widgets', () => {
+    withAuth();
+
+    before(function beforeHook() {
+        if (!hasFeatureFlag('ROX_SECURITY_METRICS_PHASE_ONE')) {
+            this.skip();
+        }
+    });
+
+    it('should visit patternfly dashboard', () => {
+        visitMainDashboardPF();
+
+        cy.get("h1:contains('Dashboard')");
+    });
+});

--- a/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
+++ b/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
@@ -40,7 +40,7 @@ describe('Dashboard security metrics phase one action widgets', () => {
         cy.get(selectors.pageHeader);
     });
 
-    it('should render a policy violations by category widget', () => {
+    it('should sort a policy violations by category widget by severity and volume of violations', () => {
         visitMainDashboardPF();
 
         cy.intercept('GET', api.alerts.countsByCategory, {
@@ -59,7 +59,7 @@ describe('Dashboard security metrics phase one action widgets', () => {
 
         // Switch to sort-by-volume, which orders the chart by total violations per category
         cy.get(widgetSelectors.optionsToggle).click();
-        cy.get("button:contains('Volume')").click();
+        cy.get(widgetSelectors.volumeOption).click();
         cy.get(widgetSelectors.optionsToggle).click();
 
         cy.get(`${widgetSelectors.axisLabel(0, 4)}:contains('Anomalous Activity')`);
@@ -67,5 +67,31 @@ describe('Dashboard security metrics phase one action widgets', () => {
         cy.get(`${widgetSelectors.axisLabel(0, 2)}:contains('Privileges')`);
         cy.get(`${widgetSelectors.axisLabel(0, 1)}:contains('Network Tools')`);
         cy.get(`${widgetSelectors.axisLabel(0, 0)}:contains('Vulnerability Management')`);
+    });
+
+    it('should allow toggling of severities for a policy violations by category widget', () => {
+        visitMainDashboardPF();
+
+        cy.intercept('GET', api.alerts.countsByCategory, {
+            body: policyViolationsByCategory,
+        }).as('getPolicyViolationsByCategory');
+        cy.wait('@getPolicyViolationsByCategory');
+
+        const widgetSelectors = selectors.violationsByCategory;
+
+        // Sort by volume, so that disabling lower severity bars changes the order of the chart
+        cy.get(widgetSelectors.optionsToggle).click();
+        cy.get(widgetSelectors.volumeOption).click();
+        cy.get(widgetSelectors.optionsToggle).click();
+
+        // Toggle off low and medium violations
+        cy.get(widgetSelectors.legendLabel(0)).click();
+        cy.get(widgetSelectors.legendLabel(1)).click();
+
+        cy.get(`${widgetSelectors.axisLabel(0, 4)}:contains('Network Tools')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 3)}:contains('Privileges')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 2)}:contains('Anomalous Activity')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 1)}:contains('Vulnerability Management')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 0)}:contains('Security Best Practices')`);
     });
 });

--- a/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
+++ b/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
@@ -1,6 +1,29 @@
+import * as api from '../../constants/apiEndpoints';
 import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
 import { visitMainDashboardPF } from '../../helpers/main';
+
+import { pfSelectors as selectors } from '../../constants/DashboardPage';
+
+function makeFixtureCounts(crit, high, med, low) {
+    return [
+        { severity: 'CRITICAL_SEVERITY', count: `${crit}` },
+        { severity: 'HIGH_SEVERITY', count: `${high}` },
+        { severity: 'MEDIUM_SEVERITY', count: `${med}` },
+        { severity: 'LOW_SEVERITY', count: `${low}` },
+    ];
+}
+
+const policyViolationsByCategory = {
+    groups: [
+        { counts: makeFixtureCounts(5, 20, 30, 10), group: 'Anomalous Activity' },
+        { counts: makeFixtureCounts(5, 2, 30, 5), group: 'Docker CIS' },
+        { counts: makeFixtureCounts(10, 20, 5, 5), group: 'Network Tools' },
+        { counts: makeFixtureCounts(15, 2, 10, 5), group: 'Security Best Practices' },
+        { counts: makeFixtureCounts(20, 10, 2, 10), group: 'Privileges' },
+        { counts: makeFixtureCounts(15, 8, 10, 5), group: 'Vulnerability Management' },
+    ],
+};
 
 describe('Dashboard security metrics phase one action widgets', () => {
     withAuth();
@@ -14,6 +37,35 @@ describe('Dashboard security metrics phase one action widgets', () => {
     it('should visit patternfly dashboard', () => {
         visitMainDashboardPF();
 
-        cy.get("h1:contains('Dashboard')");
+        cy.get(selectors.pageHeader);
+    });
+
+    it('should render a policy violations by category widget', () => {
+        visitMainDashboardPF();
+
+        cy.intercept('GET', api.alerts.countsByCategory, {
+            body: policyViolationsByCategory,
+        }).as('getPolicyViolationsByCategory');
+        cy.wait('@getPolicyViolationsByCategory');
+
+        const widgetSelectors = selectors.violationsByCategory;
+
+        // Default sorting should be by severity of Violations, with critical taking priority.
+        cy.get(`${widgetSelectors.axisLabel(0, 4)}:contains('Privileges')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 3)}:contains('Vulnerability Management')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 2)}:contains('Security Best Practices')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 1)}:contains('Network Tools')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 0)}:contains('Anomalous Activity')`);
+
+        // Switch to sort-by-volume, which orders the chart by total violations per category
+        cy.get(widgetSelectors.optionsToggle).click();
+        cy.get("button:contains('Volume')").click();
+        cy.get(widgetSelectors.optionsToggle).click();
+
+        cy.get(`${widgetSelectors.axisLabel(0, 4)}:contains('Anomalous Activity')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 3)}:contains('Docker CIS')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 2)}:contains('Privileges')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 1)}:contains('Network Tools')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 0)}:contains('Vulnerability Management')`);
     });
 });

--- a/ui/apps/platform/cypress/support/index.js
+++ b/ui/apps/platform/cypress/support/index.js
@@ -11,3 +11,17 @@ Cypress.on('scrolled', ($el) => {
         inline: 'center',
     });
 });
+
+// Fixes another long standing problem in Cypress where a Chrome specific error
+// is thrown due to multiple firings of a ResizeObserver that is benign in test execution.
+// There are multiple closed PRs to add this to Cypress core that were declined in favor
+// of recommending users add the following event handler to this `support` file instead.
+//
+//  See various Cypress threads:
+//  - PR to add in Cypress core: https://github.com/cypress-io/cypress/pull/20257 (closed)
+//  - PR to add in Cypress core: https://github.com/cypress-io/cypress/pull/20284 (closed)
+//  - Comment with the original fix recommendation: https://github.com/cypress-io/cypress/issues/8418#issuecomment-992564877
+Cypress.on(
+    'uncaught:exception',
+    (err) => !err.message.includes('ResizeObserver loop limit exceeded')
+);

--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
@@ -61,6 +61,7 @@ const ClustersPage = ({
                     searchCategory="CLUSTERS"
                     placeholder="Add one or more filters"
                     handleChangeSearchFilter={setSearchFilter}
+                    autoFocus={!selectedClusterId}
                 />
                 <div className="flex items-center ml-4 mr-3">
                     <HashLink

--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
@@ -61,7 +61,6 @@ const ClustersPage = ({
                     searchCategory="CLUSTERS"
                     placeholder="Add one or more filters"
                     handleChangeSearchFilter={setSearchFilter}
-                    autoFocus={!selectedClusterId}
                 />
                 <div className="flex items-center ml-4 mr-3">
                     <HashLink


### PR DESCRIPTION
## Description

Adds Cypress tests to verify the core sorting functionality of the widget.

## Testing notes, follow ups

- A fixture is used for testing instead of hitting the backend API because by default a fresh stackrox installation will only report three categories of policy violations, and those categories each only have a single severity type. The impact of this is that none of the filters or sorting functionality has any effect on the chart display.
- There currently are no tests that use the scope bar cluster/ns filters nor the "Policy lifecycle" option. This is because these options only impact the query sent to the server and won't effectively test functionality with mocked data.
- It would be nice for the tests to validate the display of the bars in the chart, but the Victory library renders plain `<path>` SVG elements with very little metadata that can be used for validation. I'd like to revisit this post MVP and see if we can make these tests more robust.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

Run Cypress tests locally.
