### PR TITLE
Add all severities to chart tooltips

### DIFF
--- a/ui/apps/platform/cypress/constants/DashboardPage.js
+++ b/ui/apps/platform/cypress/constants/DashboardPage.js
@@ -47,12 +47,16 @@ export const selectors = {
  */
 const axisLabel = (axisIndex, labelIndex) => `#chart-axis-${axisIndex}-tickLabels-${labelIndex}`;
 
+const legendLabel = (labelIndex) => `#legend-labels-${labelIndex}`;
+
 // TODO Make `pfSelectors` the default once phase one of the PF Dashboard is enabled
 export const pfSelectors = {
     pageHeader: 'h1:contains("Dashboard")',
     violationsByCategory: scopeSelectors('article:contains("Policy violations by category")', {
         chart: '.pf-c-chart',
         optionsToggle: 'button:contains("Options")',
+        volumeOption: 'button:contains("Volume")',
         axisLabel,
+        legendLabel,
     }),
 };

--- a/ui/apps/platform/cypress/constants/DashboardPage.js
+++ b/ui/apps/platform/cypress/constants/DashboardPage.js
@@ -36,3 +36,23 @@ export const selectors = {
     topRiskyDeployments: '[data-testid="top-risky-deployments"] ul li a',
     policyCategoryViolations: '[data-testid="policy-category-violation"]',
 };
+
+/**
+ * Retrieves a selector for the axis label of a PatternFly/Victory chart. Note
+ * that Victory orders bar chart indices from the bottom up, so the last entry
+ * in the UI will be index 0.
+ *
+ * @param axisIndex The chart axis to select
+ * @param labelIndex The index of the label on the selected axis
+ */
+const axisLabel = (axisIndex, labelIndex) => `#chart-axis-${axisIndex}-tickLabels-${labelIndex}`;
+
+// TODO Make `pfSelectors` the default once phase one of the PF Dashboard is enabled
+export const pfSelectors = {
+    pageHeader: 'h1:contains("Dashboard")',
+    violationsByCategory: scopeSelectors('article:contains("Policy violations by category")', {
+        chart: '.pf-c-chart',
+        optionsToggle: 'button:contains("Options")',
+        axisLabel,
+    }),
+};

--- a/ui/apps/platform/cypress/constants/DashboardPage.js
+++ b/ui/apps/platform/cypress/constants/DashboardPage.js
@@ -2,7 +2,10 @@ import { severityColorMap } from '../../src/constants/severityColors';
 import scopeSelectors from '../helpers/scopeSelectors';
 import navigationSelectors from '../selectors/navigation';
 
+// TODO Make `pfUrl` the default url once phase one of the PF Dashboard is enabled
 export const url = '/main/dashboard';
+export const pfUrl = '/main/dashboard-pf';
+
 export const selectors = {
     navLink: `${navigationSelectors.navLinks}:contains("Dashboard")`,
     buttons: {

--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -1,5 +1,5 @@
 import * as api from '../constants/apiEndpoints';
-import { url } from '../constants/DashboardPage';
+import { pfUrl, url } from '../constants/DashboardPage';
 import navSelectors from '../selectors/navigation';
 
 import { visit } from './visit';
@@ -22,6 +22,11 @@ export function visitMainDashboard() {
 
     cy.wait('@riskyDeployments');
     cy.get('h1:contains("Dashboard")');
+}
+
+// TODO Make this the default once phase one of the PF Dashboard is enabled
+export function visitMainDashboardPF() {
+    visit(pfUrl);
 }
 
 export function visitMainDashboardViaRedirectFromUrl(redirectFromUrl) {

--- a/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
+++ b/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
@@ -1,0 +1,19 @@
+import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
+import { visitMainDashboardPF } from '../../helpers/main';
+
+describe('Dashboard security metrics phase one action widgets', () => {
+    withAuth();
+
+    before(function beforeHook() {
+        if (!hasFeatureFlag('ROX_SECURITY_METRICS_PHASE_ONE')) {
+            this.skip();
+        }
+    });
+
+    it('should visit patternfly dashboard', () => {
+        visitMainDashboardPF();
+
+        cy.get("h1:contains('Dashboard')");
+    });
+});

--- a/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
+++ b/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
@@ -40,7 +40,7 @@ describe('Dashboard security metrics phase one action widgets', () => {
         cy.get(selectors.pageHeader);
     });
 
-    it('should render a policy violations by category widget', () => {
+    it('should sort a policy violations by category widget by severity and volume of violations', () => {
         visitMainDashboardPF();
 
         cy.intercept('GET', api.alerts.countsByCategory, {
@@ -59,7 +59,7 @@ describe('Dashboard security metrics phase one action widgets', () => {
 
         // Switch to sort-by-volume, which orders the chart by total violations per category
         cy.get(widgetSelectors.optionsToggle).click();
-        cy.get("button:contains('Volume')").click();
+        cy.get(widgetSelectors.volumeOption).click();
         cy.get(widgetSelectors.optionsToggle).click();
 
         cy.get(`${widgetSelectors.axisLabel(0, 4)}:contains('Anomalous Activity')`);
@@ -67,5 +67,31 @@ describe('Dashboard security metrics phase one action widgets', () => {
         cy.get(`${widgetSelectors.axisLabel(0, 2)}:contains('Privileges')`);
         cy.get(`${widgetSelectors.axisLabel(0, 1)}:contains('Network Tools')`);
         cy.get(`${widgetSelectors.axisLabel(0, 0)}:contains('Vulnerability Management')`);
+    });
+
+    it('should allow toggling of severities for a policy violations by category widget', () => {
+        visitMainDashboardPF();
+
+        cy.intercept('GET', api.alerts.countsByCategory, {
+            body: policyViolationsByCategory,
+        }).as('getPolicyViolationsByCategory');
+        cy.wait('@getPolicyViolationsByCategory');
+
+        const widgetSelectors = selectors.violationsByCategory;
+
+        // Sort by volume, so that disabling lower severity bars changes the order of the chart
+        cy.get(widgetSelectors.optionsToggle).click();
+        cy.get(widgetSelectors.volumeOption).click();
+        cy.get(widgetSelectors.optionsToggle).click();
+
+        // Toggle off low and medium violations
+        cy.get(widgetSelectors.legendLabel(0)).click();
+        cy.get(widgetSelectors.legendLabel(1)).click();
+
+        cy.get(`${widgetSelectors.axisLabel(0, 4)}:contains('Network Tools')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 3)}:contains('Privileges')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 2)}:contains('Anomalous Activity')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 1)}:contains('Vulnerability Management')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 0)}:contains('Security Best Practices')`);
     });
 });

--- a/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
+++ b/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
@@ -1,6 +1,29 @@
+import * as api from '../../constants/apiEndpoints';
 import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
 import { visitMainDashboardPF } from '../../helpers/main';
+
+import { pfSelectors as selectors } from '../../constants/DashboardPage';
+
+function makeFixtureCounts(crit, high, med, low) {
+    return [
+        { severity: 'CRITICAL_SEVERITY', count: `${crit}` },
+        { severity: 'HIGH_SEVERITY', count: `${high}` },
+        { severity: 'MEDIUM_SEVERITY', count: `${med}` },
+        { severity: 'LOW_SEVERITY', count: `${low}` },
+    ];
+}
+
+const policyViolationsByCategory = {
+    groups: [
+        { counts: makeFixtureCounts(5, 20, 30, 10), group: 'Anomalous Activity' },
+        { counts: makeFixtureCounts(5, 2, 30, 5), group: 'Docker CIS' },
+        { counts: makeFixtureCounts(10, 20, 5, 5), group: 'Network Tools' },
+        { counts: makeFixtureCounts(15, 2, 10, 5), group: 'Security Best Practices' },
+        { counts: makeFixtureCounts(20, 10, 2, 10), group: 'Privileges' },
+        { counts: makeFixtureCounts(15, 8, 10, 5), group: 'Vulnerability Management' },
+    ],
+};
 
 describe('Dashboard security metrics phase one action widgets', () => {
     withAuth();
@@ -14,6 +37,35 @@ describe('Dashboard security metrics phase one action widgets', () => {
     it('should visit patternfly dashboard', () => {
         visitMainDashboardPF();
 
-        cy.get("h1:contains('Dashboard')");
+        cy.get(selectors.pageHeader);
+    });
+
+    it('should render a policy violations by category widget', () => {
+        visitMainDashboardPF();
+
+        cy.intercept('GET', api.alerts.countsByCategory, {
+            body: policyViolationsByCategory,
+        }).as('getPolicyViolationsByCategory');
+        cy.wait('@getPolicyViolationsByCategory');
+
+        const widgetSelectors = selectors.violationsByCategory;
+
+        // Default sorting should be by severity of Violations, with critical taking priority.
+        cy.get(`${widgetSelectors.axisLabel(0, 4)}:contains('Privileges')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 3)}:contains('Vulnerability Management')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 2)}:contains('Security Best Practices')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 1)}:contains('Network Tools')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 0)}:contains('Anomalous Activity')`);
+
+        // Switch to sort-by-volume, which orders the chart by total violations per category
+        cy.get(widgetSelectors.optionsToggle).click();
+        cy.get("button:contains('Volume')").click();
+        cy.get(widgetSelectors.optionsToggle).click();
+
+        cy.get(`${widgetSelectors.axisLabel(0, 4)}:contains('Anomalous Activity')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 3)}:contains('Docker CIS')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 2)}:contains('Privileges')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 1)}:contains('Network Tools')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 0)}:contains('Vulnerability Management')`);
     });
 });

--- a/ui/apps/platform/cypress/support/index.js
+++ b/ui/apps/platform/cypress/support/index.js
@@ -11,3 +11,17 @@ Cypress.on('scrolled', ($el) => {
         inline: 'center',
     });
 });
+
+// Fixes another long standing problem in Cypress where a Chrome specific error
+// is thrown due to multiple firings of a ResizeObserver that is benign in test execution.
+// There are multiple closed PRs to add this to Cypress core that were declined in favor
+// of recommending users add the following event handler to this `support` file instead.
+//
+//  See various Cypress threads:
+//  - PR to add in Cypress core: https://github.com/cypress-io/cypress/pull/20257 (closed)
+//  - PR to add in Cypress core: https://github.com/cypress-io/cypress/pull/20284 (closed)
+//  - Comment with the original fix recommendation: https://github.com/cypress-io/cypress/issues/8418#issuecomment-992564877
+Cypress.on(
+    'uncaught:exception',
+    (err) => !err.message.includes('ResizeObserver loop limit exceeded')
+);

--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
@@ -61,6 +61,7 @@ const ClustersPage = ({
                     searchCategory="CLUSTERS"
                     placeholder="Add one or more filters"
                     handleChangeSearchFilter={setSearchFilter}
+                    autoFocus={!selectedClusterId}
                 />
                 <div className="flex items-center ml-4 mr-3">
                     <HashLink

--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
@@ -61,7 +61,6 @@ const ClustersPage = ({
                     searchCategory="CLUSTERS"
                     placeholder="Add one or more filters"
                     handleChangeSearchFilter={setSearchFilter}
-                    autoFocus={!selectedClusterId}
                 />
                 <div className="flex items-center ml-4 mr-3">
                     <HashLink

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -126,6 +126,18 @@ type ViolationsByPolicyCategoryChartProps = {
 
 const labelLinkCallback = ({ text }: ChartLabelProps) => linkForViolationsCategory(String(text));
 
+function tooltipForCategory(
+    category: string,
+    countsBySeverity: CountsBySeverity,
+    hiddenSeverities: Set<PolicySeverity>
+): string {
+    return policySeverities
+        .filter((severity) => !hiddenSeverities.has(severity))
+        .reverse()
+        .map((severity) => `${severityLabels[severity]}: ${countsBySeverity[severity][category]}`)
+        .join('\n');
+}
+
 function ViolationsByPolicyCategoryChart({
     alertGroups,
     sortType,
@@ -151,7 +163,7 @@ function ViolationsByPolicyCategoryChart({
             name: severity,
             x: group,
             y: count,
-            label: `${severityLabels[severity]}: ${count}`,
+            label: tooltipForCategory(group, countsBySeverity, hiddenSeverities),
         }));
 
         return (

--- a/ui/apps/platform/src/utils/chartUtils.ts
+++ b/ui/apps/platform/src/utils/chartUtils.ts
@@ -24,6 +24,13 @@ export const patternflySeverityTheme = {
         ...defaultTheme.legend,
         colorScale: severityColorScale,
     },
+    tooltip: {
+        style: {
+            ...(defaultTheme.tooltip?.style ?? {}),
+            fontWeight: '600',
+            textAnchor: 'start',
+        },
+    },
 };
 
 /**

--- a/ui/apps/platform/src/utils/chartUtils.ts
+++ b/ui/apps/platform/src/utils/chartUtils.ts
@@ -30,6 +30,7 @@ export const patternflySeverityTheme = {
             fontWeight: '600',
             textAnchor: 'start',
         },
+        flyoutPadding: { top: 8, bottom: 8, left: 12, right: 12 },
     },
 };
 


### PR DESCRIPTION
## Description

Updates hover tooltips to contain all severities in the bar to ease usage when mouse hover targets are small.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Hover over a bar on the chart and verify that counts for every level of severity are displayed.
<img width="591" alt="image" src="https://user-images.githubusercontent.com/1292638/173840966-3d0bf9f1-314e-4680-9180-e78d5a8ff2d0.png">
<img width="591" alt="image" src="https://user-images.githubusercontent.com/1292638/173840944-50968c63-5500-4a4f-81df-5f48620fdab3.png">

Change search or sorting options and verify that the new counts are reflected in the tooltip.
<img width="591" alt="image" src="https://user-images.githubusercontent.com/1292638/173841208-5413f6f5-9c55-4965-9af7-9b2b25489748.png">


