### PR TITLE
ROX-11341 Dump sensor's messages in binary format

### DIFF
--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -6,14 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
-	"fmt"
 	"log"
 	"net"
 	"os"
 	"os/signal"
 	"path"
-	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -65,7 +62,7 @@ func createConnectionAndStartServer(fakeCentral *centralDebug.FakeService) (*grp
 
 type localSensorConfig struct {
 	Duration           time.Duration
-	BinaryOutput       bool
+	OutputFormat       string
 	CentralOutput      string
 	RecordK8sEnabled   bool
 	RecordK8sFile      string
@@ -77,11 +74,25 @@ type localSensorConfig struct {
 	Delay              time.Duration
 }
 
+const (
+	jsonFormat string = "json"
+	rawFormat  string = "raw"
+)
+
+func isValidOutputFormat(format string) bool {
+	var validFormats = map[string]struct{}{
+		jsonFormat: {},
+		rawFormat:  {},
+	}
+	_, ok := validFormats[format]
+	return ok
+}
+
 func mustGetCommandLineArgs() localSensorConfig {
 	sensorConfig := localSensorConfig{
 		Verbose:            false,
 		Duration:           0,
-		BinaryOutput:       false,
+		OutputFormat:       "json",
 		CentralOutput:      "central-out.json",
 		RecordK8sEnabled:   false,
 		RecordK8sFile:      "k8s-trace.jsonl",
@@ -94,7 +105,7 @@ func mustGetCommandLineArgs() localSensorConfig {
 	flag.BoolVar(&sensorConfig.Verbose, "verbose", sensorConfig.Verbose, "prints all messages to stdout as well as to the output file")
 	flag.DurationVar(&sensorConfig.Duration, "duration", sensorConfig.Duration, "duration that the scenario should run (leave it empty to run it without timeout)")
 	flag.StringVar(&sensorConfig.CentralOutput, "central-out", sensorConfig.CentralOutput, "file to store the events that would be sent to central")
-	flag.BoolVar(&sensorConfig.BinaryOutput, "binary", sensorConfig.BinaryOutput, "store all the events that would be sent to central in binary format")
+	flag.StringVar(&sensorConfig.OutputFormat, "format", sensorConfig.OutputFormat, "format of sensor's events file: 'raw' or 'json'")
 	flag.BoolVar(&sensorConfig.RecordK8sEnabled, "record", sensorConfig.RecordK8sEnabled, "whether to record a trace with k8s events")
 	flag.StringVar(&sensorConfig.RecordK8sFile, "record-out", sensorConfig.RecordK8sFile, "a file where recorded trace would be stored")
 	flag.BoolVar(&sensorConfig.ReplayK8sEnabled, "replay", sensorConfig.ReplayK8sEnabled, "whether to reply recorded a trace with k8s events")
@@ -117,11 +128,15 @@ func mustGetCommandLineArgs() localSensorConfig {
 		log.Fatalf("trace source empty")
 	}
 
+	if !isValidOutputFormat(sensorConfig.OutputFormat) {
+		log.Fatalf("invalid format '%s'", sensorConfig.OutputFormat)
+	}
+
 	sensorConfig.ReplayK8sTraceFile = path.Clean(sensorConfig.ReplayK8sTraceFile)
 	return sensorConfig
 }
 
-func registerHostKillSignals(startTime time.Time, fakeCentral *centralDebug.FakeService, outfile string, binary bool, cancelFunc context.CancelFunc) {
+func registerHostKillSignals(startTime time.Time, fakeCentral *centralDebug.FakeService, outfile string, outputFormat string, cancelFunc context.CancelFunc) {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 	<-ctx.Done()
@@ -129,7 +144,7 @@ func registerHostKillSignals(startTime time.Time, fakeCentral *centralDebug.Fake
 	cancelFunc()
 	endTime := time.Now()
 	allMessages := fakeCentral.GetAllMessages()
-	dumpMessages(allMessages, startTime, endTime, outfile, binary)
+	dumpMessages(allMessages, startTime, endTime, outfile, outputFormat)
 	os.Exit(0)
 }
 
@@ -167,7 +182,7 @@ func main() {
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
-	go registerHostKillSignals(startTime, fakeCentral, localConfig.CentralOutput, localConfig.BinaryOutput, cancelFunc)
+	go registerHostKillSignals(startTime, fakeCentral, localConfig.CentralOutput, localConfig.OutputFormat, cancelFunc)
 
 	conn, spyCentral, shutdownFakeServer := createConnectionAndStartServer(fakeCentral)
 	defer shutdownFakeServer()
@@ -239,7 +254,7 @@ func main() {
 	<-time.Tick(localConfig.Duration)
 	endTime := time.Now()
 	allMessages := fakeCentral.GetAllMessages()
-	dumpMessages(allMessages, startTime, endTime, localConfig.CentralOutput, localConfig.BinaryOutput)
+	dumpMessages(allMessages, startTime, endTime, localConfig.CentralOutput, localConfig.OutputFormat)
 
 	spyCentral.KillSwitch.Signal()
 }
@@ -250,12 +265,21 @@ type sensorMessagesJSONOutput struct {
 	MessagesFromSensor []*central.MsgFromSensor `json:"messages_from_sensor"`
 }
 
-func dumpMessages(messages []*central.MsgFromSensor, start, end time.Time, outfile string, binaryOutput bool) {
-	dateFormat := "02.01.15 11:06:39"
+func dumpMessages(messages []*central.MsgFromSensor, start, end time.Time, outfile string, outputFormat string) {
 	log.Printf("Dumping all sensor messages to file: %s\n", outfile)
-	if binaryOutput {
-		fname := strings.TrimSuffix(outfile, filepath.Ext(outfile))
-		file, err := os.OpenFile(fmt.Sprintf("%s.bin", fname), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	switch outputFormat {
+	case jsonFormat:
+		dateFormat := "02.01.15 11:06:39"
+		data, err := json.Marshal(&sensorMessagesJSONOutput{
+			ScenarioStart:      start.Format(dateFormat),
+			ScenarioEnd:        end.Format(dateFormat),
+			MessagesFromSensor: messages,
+		})
+		utils.CrashOnError(err)
+		utils.CrashOnError(os.WriteFile(outfile, data, 0644))
+	case rawFormat:
+		file, err := os.OpenFile(outfile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		defer file.Close()
 		utils.CrashOnError(err)
 		for _, m := range messages {
 			d, err := m.Marshal()
@@ -267,12 +291,6 @@ func dumpMessages(messages []*central.MsgFromSensor, start, end time.Time, outfi
 			_, err = file.Write(d)
 			utils.CrashOnError(err)
 		}
+		utils.CrashOnError(file.Sync())
 	}
-	data, err := json.Marshal(&sensorMessagesJSONOutput{
-		ScenarioStart:      start.Format(dateFormat),
-		ScenarioEnd:        end.Format(dateFormat),
-		MessagesFromSensor: messages,
-	})
-	utils.CrashOnError(err)
-	utils.CrashOnError(os.WriteFile(outfile, data, 0644))
 }

--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -279,7 +279,9 @@ func dumpMessages(messages []*central.MsgFromSensor, start, end time.Time, outfi
 		utils.CrashOnError(os.WriteFile(outfile, data, 0644))
 	case rawFormat:
 		file, err := os.OpenFile(outfile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		defer file.Close()
+		defer func() {
+			utils.CrashOnError(file.Close())
+		}()
 		utils.CrashOnError(err)
 		for _, m := range messages {
 			d, err := m.Marshal()


### PR DESCRIPTION
## Description

This PR aims to make the local-sensor output file easier to unmarshal in the automatic tests.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* The file is create in binary format with:

```
go run tools/local-sensor/main.go -binary
```

* Comparing that the results of `central-out.json` and `central-out.bin` are the same.