### PR TITLE
Bump version of helm-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -132,6 +132,18 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+// To bump the version of a replacement package, use:
+//
+//   $ go mod edit -replace <package>=<replacement>@<branch or commit reference>
+//   $ go mod tidy
+//
+// For example:
+//
+//   $ go mod edit -replace github.com/operator-framework/helm-operator-plugins=github.com/stackrox/helm-operator@main
+//   $ go mod tidy
+//
+// The `go mod tidy` takes care of normalizing the symbol version information (e.g. branch name) which is required
+// for Go build tools to accept the `go.mod`.
 replace (
 	github.com/blevesearch/bleve => github.com/stackrox/bleve v0.0.0-20200807170555-6c4fa9f5e726
 
@@ -151,7 +163,10 @@ replace (
 
 	github.com/nxadm/tail => github.com/stackrox/tail v1.4.9-0.20210831224919-407035634f5d
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc9
-	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.8-0.20220506091602-3764c49abfb3
+
+	// github.com/stackrox/helm-operator is a modified fork of github.com/operator-framework/helm-operator-plugins that
+	// we currently depend on.
+	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.8-0.20220608072809-e51d0173f4f0
 	// github.com/sigstore/rekor is a transitive dep pulled in by cosign. The version pulled in by cosign is using
 	// a vulnerable go-tuf version
 	// (https://github.com/theupdateframework/go-tuf/security/advisories/GHSA-66x3-6cw3-v5gj).

--- a/go.sum
+++ b/go.sum
@@ -2735,8 +2735,8 @@ github.com/stackrox/dotnet-scraper v0.0.0-20201023051640-72ef543323dd h1:vEjp7Q6
 github.com/stackrox/dotnet-scraper v0.0.0-20201023051640-72ef543323dd/go.mod h1:HILeV3i/EyJz844GcrC3+oU7oZONhjfujaIYBMJ/bZE=
 github.com/stackrox/external-network-pusher v0.0.0-20210419192707-074af92bbfa7 h1:F4Gq3G5G07HQ/ECrg/+EQxFBmCTcq9ZDyLPI5LaDUKI=
 github.com/stackrox/external-network-pusher v0.0.0-20210419192707-074af92bbfa7/go.mod h1:faUw9vx/mA7ql41Ftlst5MYar2DT3nnS6oK94lbaW0g=
-github.com/stackrox/helm-operator v0.0.8-0.20220506091602-3764c49abfb3 h1:+e7PRmOoQffO1anhbx35Y5i8lH6lyN0YFJpjDMixsws=
-github.com/stackrox/helm-operator v0.0.8-0.20220506091602-3764c49abfb3/go.mod h1:w+aTtmogp/HRpQcRouVHeNGHn80IrDMiWkWzmIOdcGE=
+github.com/stackrox/helm-operator v0.0.8-0.20220608072809-e51d0173f4f0 h1:CaPaWobP3a9kUjJmAOmxO21N7q7Skv7M0u+eM8ffhK0=
+github.com/stackrox/helm-operator v0.0.8-0.20220608072809-e51d0173f4f0/go.mod h1:w+aTtmogp/HRpQcRouVHeNGHn80IrDMiWkWzmIOdcGE=
 github.com/stackrox/helmtest v0.0.0-20220118100812-1ad97c4de347 h1:ByiXbT2lnhWmUlrpUCeQlk8hRZTFr6CPtTtpd7XlOGY=
 github.com/stackrox/helmtest v0.0.0-20220118100812-1ad97c4de347/go.mod h1:vWZFszN4CfxMWzzMI/XfrcG4kkoDIPdwfDry76nYIbo=
 github.com/stackrox/k8s-cves v0.0.0-20201110001126-cc333981eaab h1:77xJmm1YkqbgrQzHI3C4MyPckWL+PYRLWakQRC6Mzj8=


### PR DESCRIPTION
## Description

This is a version bump to the most recent helm-operator, which contains fixes.
Also adds instructions for bumping versions in the future to simplify the process.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [x] ~~Evaluated and added CHANGELOG entry if required~~ (n/a)
- [x] ~~Determined and documented upgrade steps~~ (n/a)
- [x] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~ (n/a)

If any of these don't apply, please comment below.

## Testing Performed

Relying solely on CI operator tests.