### PR TITLE
ROX-11131 Add deployments at most risk widget

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/DashboardPage.js
+++ b/ui/apps/platform/src/Containers/Dashboard/DashboardPage.js
@@ -12,7 +12,7 @@ import {
     fetchSummaryAlertCountsLegacy as fetchSummaryAlertCounts,
 } from 'services/AlertsService';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
-import { fetchDeployments } from 'services/DeploymentsService';
+import { fetchDeploymentsLegacy as fetchDeployments } from 'services/DeploymentsService';
 import AlertsByTimeseriesChart from './AlertsByTimeseriesChart';
 import SummaryCounts from './SummaryCounts';
 import ViolationsByClusterChart from './ViolationsByClusterChart';

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
@@ -13,6 +13,7 @@ import SummaryCounts from './SummaryCounts';
 import ScopeBar from './ScopeBar';
 
 import ViolationsByPolicyCategory from './Widgets/ViolationsByPolicyCategory';
+import DeploymentsAtMostRisk from './Widgets/DeploymentsAtMostRisk';
 
 function DashboardPage() {
     return (
@@ -41,6 +42,9 @@ function DashboardPage() {
             <Divider component="div" />
             <PageSection>
                 <Grid hasGutter>
+                    <GridItem lg={6}>
+                        <DeploymentsAtMostRisk />
+                    </GridItem>
                     <GridItem lg={6}>
                         <ViolationsByPolicyCategory />
                     </GridItem>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
@@ -41,7 +41,7 @@ function DashboardPage() {
             </PageSection>
             <Divider component="div" />
             <PageSection>
-                <Grid hasGutter>
+                <Grid hasGutter style={{ gridAutoRows: 'max-content' }}>
                     <GridItem lg={6}>
                         <DeploymentsAtMostRisk />
                     </GridItem>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRisk.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRisk.tsx
@@ -11,7 +11,7 @@ import useDeploymentsAtRisk from '../hooks/useDeploymentsAtRisk';
 
 function DeploymentsAtMostRisk() {
     const { searchFilter } = useURLSearch();
-    const { deployments, loading, error } = useDeploymentsAtRisk(searchFilter);
+    const { data: deployments, loading, error } = useDeploymentsAtRisk(searchFilter);
     const urlQueryString = getUrlQueryStringForSearchFilter(searchFilter);
     return (
         <WidgetCard
@@ -34,7 +34,10 @@ function DeploymentsAtMostRisk() {
                 </Flex>
             }
         >
-            <DeploymentsAtMostRiskTable deployments={deployments} searchFilter={searchFilter} />
+            <DeploymentsAtMostRiskTable
+                deployments={deployments ?? []}
+                searchFilter={searchFilter}
+            />
         </WidgetCard>
     );
 }

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRisk.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRisk.tsx
@@ -3,6 +3,7 @@ import { Flex, FlexItem, Title, Button } from '@patternfly/react-core';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
 import useURLSearch from 'hooks/useURLSearch';
+import { riskBasePath } from 'routePaths';
 import DeploymentsAtMostRiskTable from './DeploymentsAtMostRiskTable';
 import WidgetCard from './WidgetCard';
 import useDeploymentsAtRisk from '../hooks/useDeploymentsAtRisk';
@@ -20,7 +21,7 @@ function DeploymentsAtMostRisk() {
                         <Title headingLevel="h2">Deployments at most risk</Title>
                     </FlexItem>
                     <FlexItem>
-                        <Button variant="secondary" component={LinkShim} href="/main/risk">
+                        <Button variant="secondary" component={LinkShim} href={riskBasePath}>
                             View All
                         </Button>
                     </FlexItem>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRisk.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRisk.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Flex, FlexItem, Title, Button } from '@patternfly/react-core';
+
+import LinkShim from 'Components/PatternFly/LinkShim';
+import useURLSearch from 'hooks/useURLSearch';
+import DeploymentsAtMostRiskTable from './DeploymentsAtMostRiskTable';
+import WidgetCard from './WidgetCard';
+import useDeploymentsAtRisk from '../hooks/useDeploymentsAtRisk';
+
+function DeploymentsAtMostRisk() {
+    const { searchFilter } = useURLSearch();
+    const { deployments, loading, error } = useDeploymentsAtRisk(searchFilter);
+    return (
+        <WidgetCard
+            isLoading={loading}
+            error={error}
+            header={
+                <Flex direction={{ default: 'row' }}>
+                    <FlexItem grow={{ default: 'grow' }}>
+                        <Title headingLevel="h2">Deployments at most risk</Title>
+                    </FlexItem>
+                    <FlexItem>
+                        <Button variant="secondary" component={LinkShim} href="/main/risk">
+                            View All
+                        </Button>
+                    </FlexItem>
+                </Flex>
+            }
+        >
+            <DeploymentsAtMostRiskTable deployments={deployments} />
+        </WidgetCard>
+    );
+}
+
+export default DeploymentsAtMostRisk;

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRisk.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRisk.tsx
@@ -27,7 +27,7 @@ function DeploymentsAtMostRisk() {
                 </Flex>
             }
         >
-            <DeploymentsAtMostRiskTable deployments={deployments} />
+            <DeploymentsAtMostRiskTable deployments={deployments} searchFilter={searchFilter} />
         </WidgetCard>
     );
 }

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRisk.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRisk.tsx
@@ -4,6 +4,7 @@ import { Flex, FlexItem, Title, Button } from '@patternfly/react-core';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import useURLSearch from 'hooks/useURLSearch';
 import { riskBasePath } from 'routePaths';
+import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
 import DeploymentsAtMostRiskTable from './DeploymentsAtMostRiskTable';
 import WidgetCard from './WidgetCard';
 import useDeploymentsAtRisk from '../hooks/useDeploymentsAtRisk';
@@ -11,6 +12,7 @@ import useDeploymentsAtRisk from '../hooks/useDeploymentsAtRisk';
 function DeploymentsAtMostRisk() {
     const { searchFilter } = useURLSearch();
     const { deployments, loading, error } = useDeploymentsAtRisk(searchFilter);
+    const urlQueryString = getUrlQueryStringForSearchFilter(searchFilter);
     return (
         <WidgetCard
             isLoading={loading}
@@ -21,7 +23,11 @@ function DeploymentsAtMostRisk() {
                         <Title headingLevel="h2">Deployments at most risk</Title>
                     </FlexItem>
                     <FlexItem>
-                        <Button variant="secondary" component={LinkShim} href={riskBasePath}>
+                        <Button
+                            variant="secondary"
+                            component={LinkShim}
+                            href={`${riskBasePath}?${urlQueryString}`}
+                        >
                             View All
                         </Button>
                     </FlexItem>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRiskTable.tsx
@@ -36,7 +36,7 @@ function DeploymentsAtMostRiskTable({
                 <Tr>
                     <Th className="pf-u-pl-0">{columnNames.deployment}</Th>
                     <Th>{columnNames.resourceLocation}</Th>
-                    <Th className="pf-u-pr-0" textCenter>
+                    <Th className="pf-u-pr-0 pf-u-text-align-center-on-md">
                         {columnNames.riskPriority}
                     </Th>
                 </Tr>
@@ -58,7 +58,10 @@ function DeploymentsAtMostRiskTable({
                                 &rdquo;
                             </span>
                         </Td>
-                        <Td className="pf-u-pr-0" textCenter dataLabel={columnNames.riskPriority}>
+                        <Td
+                            className="pf-u-pr-0 pf-u-text-align-center-on-md"
+                            dataLabel={columnNames.riskPriority}
+                        >
                             {priority}
                         </Td>
                     </Tr>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRiskTable.tsx
@@ -4,13 +4,8 @@ import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-tab
 
 import { ListDeployment } from 'types/deployment.proto';
 import { networkBasePath, riskBasePath } from 'routePaths';
-import useURLSearch from 'hooks/useURLSearch';
 import { SearchFilter } from 'types/search';
 import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
-
-type DeploymentsAtMostRiskTableProps = {
-    deployments: ListDeployment[];
-};
 
 const columnNames = {
     deployment: 'Deployment',
@@ -26,8 +21,15 @@ function linkToDeployment(id: string, name: string, searchFilter: SearchFilter):
     return `${riskBasePath}/${id}?${query}`;
 }
 
-function DeploymentsAtMostRiskTable({ deployments }: DeploymentsAtMostRiskTableProps) {
-    const { searchFilter } = useURLSearch();
+type DeploymentsAtMostRiskTableProps = {
+    deployments: ListDeployment[];
+    searchFilter: SearchFilter;
+};
+
+function DeploymentsAtMostRiskTable({
+    deployments,
+    searchFilter,
+}: DeploymentsAtMostRiskTableProps) {
     return (
         <TableComposable
             aria-label="Deployments at most risk"

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRiskTable.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+
+import { ListDeployment } from 'types/deployment.proto';
+import { networkBasePath, riskBasePath } from 'routePaths';
+import useURLSearch from 'hooks/useURLSearch';
+import { SearchFilter } from 'types/search';
+import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
+
+type DeploymentsAtMostRiskTableProps = {
+    deployments: ListDeployment[];
+};
+
+const columnNames = {
+    deployment: 'Deployment',
+    resourceLocation: 'Resource location',
+    riskPriority: 'Risk priority',
+};
+
+function linkToDeployment(id: string, name: string, searchFilter: SearchFilter): string {
+    const query = getUrlQueryStringForSearchFilter({
+        ...searchFilter,
+        Deployment: name,
+    });
+    return `${riskBasePath}/${id}?${query}`;
+}
+
+function DeploymentsAtMostRiskTable({ deployments }: DeploymentsAtMostRiskTableProps) {
+    const { searchFilter } = useURLSearch();
+    return (
+        <TableComposable
+            aria-label="Deployments at most risk"
+            variant="compact"
+            borders={false}
+            gridBreakPoint="grid-md"
+        >
+            <Thead>
+                <Tr>
+                    <Th className="pf-u-pl-0">{columnNames.deployment}</Th>
+                    <Th>{columnNames.resourceLocation}</Th>
+                    <Th className="pf-u-pr-0" textCenter>
+                        {columnNames.riskPriority}
+                    </Th>
+                </Tr>
+            </Thead>
+            <Tbody>
+                {deployments.map(({ id, name, cluster, namespace, priority }) => (
+                    <Tr key={name}>
+                        <Td className="pf-u-pl-0" dataLabel={columnNames.deployment}>
+                            <Link to={linkToDeployment(id, name, searchFilter)}>{name}</Link>
+                        </Td>
+                        <Td dataLabel={columnNames.resourceLocation}>
+                            <span>
+                                in &ldquo;
+                                <Link
+                                    to={`${networkBasePath}/${id}`}
+                                >{`${cluster} / ${namespace}`}</Link>
+                                &rdquo;
+                            </span>
+                        </Td>
+                        <Td className="pf-u-pr-0" textCenter dataLabel={columnNames.riskPriority}>
+                            {priority}
+                        </Td>
+                    </Tr>
+                ))}
+            </Tbody>
+        </TableComposable>
+    );
+}
+
+export default DeploymentsAtMostRiskTable;

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRiskTable.tsx
@@ -13,7 +13,7 @@ const columnNames = {
     riskPriority: 'Risk priority',
 };
 
-function linkToDeployment(id: string, name: string, searchFilter: SearchFilter): string {
+function riskPageLinkToDeployment(id: string, name: string, searchFilter: SearchFilter): string {
     const query = getUrlQueryStringForSearchFilter({
         ...searchFilter,
         Deployment: name,
@@ -45,7 +45,9 @@ function DeploymentsAtMostRiskTable({
                 {deployments.map(({ id, name, cluster, namespace, priority }) => (
                     <Tr key={name}>
                         <Td className="pf-u-pl-0" dataLabel={columnNames.deployment}>
-                            <Link to={linkToDeployment(id, name, searchFilter)}>{name}</Link>
+                            <Link to={riskPageLinkToDeployment(id, name, searchFilter)}>
+                                {name}
+                            </Link>
                         </Td>
                         <Td dataLabel={columnNames.resourceLocation}>
                             <span>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRiskTable.tsx
@@ -31,12 +31,7 @@ function DeploymentsAtMostRiskTable({
     searchFilter,
 }: DeploymentsAtMostRiskTableProps) {
     return (
-        <TableComposable
-            aria-label="Deployments at most risk"
-            variant="compact"
-            borders={false}
-            gridBreakPoint="grid-md"
-        >
+        <TableComposable aria-label="Deployments at most risk" variant="compact" borders={false}>
             <Thead>
                 <Tr>
                     <Th className="pf-u-pl-0">{columnNames.deployment}</Th>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -152,7 +152,7 @@ function ViolationsByPolicyCategoryChart({
     });
 
     return (
-        <div ref={setWidgetContainer} style={{ height }}>
+        <div ref={setWidgetContainer}>
             <Chart
                 ariaDesc="Number of violation by policy category, grouped by severity"
                 ariaTitle="Policy Violations by Category"

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -208,7 +208,7 @@ function ViolationsByPolicyCategory() {
             isLoading={loading}
             error={error}
             header={
-                <Flex direction={{ default: 'row' }} className="pf-u-pb-md">
+                <Flex direction={{ default: 'row' }}>
                     <FlexItem grow={{ default: 'grow' }}>
                         <Title headingLevel="h2">Policy violations by category</Title>
                     </FlexItem>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -111,8 +111,6 @@ type ViolationsByPolicyCategoryChartProps = {
 
 const labelLinkCallback = ({ text }: ChartLabelProps) => linkForViolationsCategory(String(text));
 
-const height = `${chartHeight}px` as const;
-
 function ViolationsByPolicyCategoryChart({
     alertGroups,
     sortType,
@@ -201,7 +199,7 @@ function ViolationsByPolicyCategory() {
         queryFilter['Lifecycle Stage'] = LIFECYCLE_STAGES.RUNTIME;
     }
     const query = getRequestQueryStringForSearchFilter(queryFilter);
-    const { alertGroups, loading, error } = useAlertGroups('CATEGORY', query);
+    const { data: alertGroups, loading, error } = useAlertGroups('CATEGORY', query);
 
     return (
         <WidgetCard
@@ -275,7 +273,7 @@ function ViolationsByPolicyCategory() {
                 </Flex>
             }
         >
-            <ViolationsByPolicyCategoryChart alertGroups={alertGroups} sortType={sortType} />
+            <ViolationsByPolicyCategoryChart alertGroups={alertGroups ?? []} sortType={sortType} />
         </WidgetCard>
     );
 }

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetCard.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetCard.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { Skeleton, Card } from '@patternfly/react-core';
+import { Skeleton, Card, CardBody, CardHeader } from '@patternfly/react-core';
 
 import { defaultChartHeight } from 'utils/chartUtils';
 import WidgetErrorEmptyState from './WidgetErrorEmptyState';
@@ -29,9 +29,11 @@ function WidgetCard({ isLoading, error, header, children }: WidgetCardProps) {
     }
 
     return (
-        <Card className="pf-u-p-md">
-            {header}
-            {cardContent}
+        <Card>
+            <CardHeader>
+                <div className="pf-u-flex-grow-1">{header}</div>
+            </CardHeader>
+            <CardBody>{cardContent}</CardBody>
         </Card>
     );
 }

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetCard.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetCard.tsx
@@ -29,7 +29,7 @@ function WidgetCard({ isLoading, error, header, children }: WidgetCardProps) {
     }
 
     return (
-        <Card>
+        <Card className="pf-u-h-100">
             <CardHeader>
                 <div className="pf-u-flex-grow-1">{header}</div>
             </CardHeader>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/hooks/useAlertGroups.ts
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/hooks/useAlertGroups.ts
@@ -1,42 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useCallback } from 'react';
+import { AlertQueryGroupBy, fetchSummaryAlertCounts } from 'services/AlertsService';
+import useRestQuery from './useRestQuery';
 
-import { AlertGroup, AlertQueryGroupBy, fetchSummaryAlertCounts } from 'services/AlertsService';
+export default function useAlertGroups(groupBy: AlertQueryGroupBy, query: string) {
+    const restQuery = useCallback(
+        () => fetchSummaryAlertCounts({ 'request.query': query, group_by: groupBy }),
+        [groupBy, query]
+    );
 
-export type UseAlertGroupsReturn = {
-    alertGroups: AlertGroup[];
-    loading: boolean;
-    error: Error | null;
-};
-
-export default function useAlertGroups(
-    groupBy: AlertQueryGroupBy,
-    query: string
-): UseAlertGroupsReturn {
-    const [alertGroups, setAlertGroups] = useState<AlertGroup[]>([]);
-    const [loading, setLoading] = useState<boolean>(true);
-    const [error, setError] = useState<Error | null>(null);
-
-    useEffect(() => {
-        const { request, cancel } = fetchSummaryAlertCounts({
-            'request.query': query,
-            group_by: groupBy,
-        });
-
-        setError(null);
-
-        request
-            .then((groups) => {
-                setAlertGroups(groups);
-                setLoading(false);
-                setError(null);
-            })
-            .catch((err) => {
-                setLoading(true);
-                setError(err);
-            });
-
-        return cancel;
-    }, [groupBy, query]);
-
-    return { alertGroups, loading, error };
+    return useRestQuery(restQuery);
 }

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/hooks/useDeploymentsAtRisk.ts
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/hooks/useDeploymentsAtRisk.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { fetchDeployments } from 'services/DeploymentsService';
+import { ListDeployment } from 'types/deployment.proto';
+import { SearchFilter } from 'types/search';
+
+export type UseDeploymentsAtRiskReturn = {
+    deployments: ListDeployment[];
+    loading: boolean;
+    error: Error | null;
+};
+
+export default function useDeploymentsAtRisk(
+    searchFilter: SearchFilter
+): UseDeploymentsAtRiskReturn {
+    const [deployments, setDeployments] = useState<ListDeployment[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<Error | null>(null);
+
+    useEffect(() => {
+        const { request, cancel } = fetchDeployments(
+            searchFilter,
+            { field: 'Deployment Risk Priority', reversed: 'false' },
+            0,
+            6
+        );
+
+        setError(null);
+
+        request
+            .then((results) => {
+                setDeployments(results.map(({ deployment }) => deployment));
+                setLoading(false);
+                setError(null);
+            })
+            .catch((err) => {
+                setLoading(true);
+                setError(err);
+            });
+
+        return cancel;
+    }, [searchFilter]);
+
+    return { deployments, loading, error };
+}

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/hooks/useDeploymentsAtRisk.ts
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/hooks/useDeploymentsAtRisk.ts
@@ -10,7 +10,8 @@ export type UseDeploymentsAtRiskReturn = {
 };
 
 export default function useDeploymentsAtRisk(
-    searchFilter: SearchFilter
+    searchFilter: SearchFilter,
+    numberOfResults = 6
 ): UseDeploymentsAtRiskReturn {
     const [deployments, setDeployments] = useState<ListDeployment[]>([]);
     const [loading, setLoading] = useState<boolean>(true);
@@ -21,7 +22,7 @@ export default function useDeploymentsAtRisk(
             searchFilter,
             { field: 'Deployment Risk Priority', reversed: 'false' },
             0,
-            6
+            numberOfResults
         );
 
         setError(null);
@@ -38,7 +39,7 @@ export default function useDeploymentsAtRisk(
             });
 
         return cancel;
-    }, [searchFilter]);
+    }, [searchFilter, numberOfResults]);
 
     return { deployments, loading, error };
 }

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/hooks/useRestQuery.ts
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/hooks/useRestQuery.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { CancellableRequest } from 'services/cancellationUtils';
+
+export type UseRestQueryReturn<ReturnType> = {
+    data: ReturnType | undefined;
+    loading: boolean;
+    error: Error | null;
+};
+
+export default function useRestQuery<ReturnType>(
+    cancellableRequestFn: () => CancellableRequest<ReturnType>
+): UseRestQueryReturn<ReturnType> {
+    const [data, setData] = useState<ReturnType>();
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<Error | null>(null);
+
+    useEffect(() => {
+        const { request, cancel } = cancellableRequestFn();
+
+        setError(null);
+
+        request
+            .then((groups) => {
+                setData(groups);
+                setLoading(false);
+                setError(null);
+            })
+            .catch((err) => {
+                setLoading(true);
+                setError(err);
+            });
+
+        return cancel;
+    }, [cancellableRequestFn]);
+
+    return { data, loading, error };
+}

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/hooks/useRestQuery.ts
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/hooks/useRestQuery.ts
@@ -20,8 +20,8 @@ export default function useRestQuery<ReturnType>(
         setError(null);
 
         request
-            .then((groups) => {
-                setData(groups);
+            .then((result) => {
+                setData(result);
                 setLoading(false);
                 setError(null);
             })

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
@@ -20,7 +20,7 @@ import { ListDeployment } from 'types/deployment.proto';
 import { Cluster } from 'types/cluster.proto';
 import { fetchClustersAsArray } from 'services/ClustersService';
 import { fetchImages } from 'services/ImagesService';
-import { fetchDeployments } from 'services/DeploymentsService';
+import { fetchDeploymentsLegacy as fetchDeployments } from 'services/DeploymentsService';
 import PolicyScopeCard from './PolicyScopeCard';
 
 function PolicyScopeForm() {

--- a/ui/apps/platform/src/Containers/Risk/RiskTablePanel.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskTablePanel.js
@@ -11,7 +11,10 @@ import TablePagination from 'Components/TablePagination';
 import { DEFAULT_PAGE_SIZE } from 'Components/Table';
 import { searchParams, sortParams, pagingParams } from 'constants/searchParams';
 import workflowStateContext from 'Containers/workflowStateContext';
-import { fetchDeployments, fetchDeploymentsCount } from 'services/DeploymentsService';
+import {
+    fetchDeploymentsLegacy as fetchDeployments,
+    fetchDeploymentsCount,
+} from 'services/DeploymentsService';
 import { checkForPermissionErrorMessage } from 'utils/permissionUtils';
 import {
     filterAllowedSearch,

--- a/ui/apps/platform/src/utils/chartUtils.ts
+++ b/ui/apps/platform/src/utils/chartUtils.ts
@@ -9,7 +9,7 @@ const severityColorScale = Object.values(severityColors);
 // Clone default PatternFly chart themes
 const defaultTheme = getTheme(ChartThemeColor.multi);
 
-export const defaultChartHeight = 264;
+export const defaultChartHeight = 260;
 
 export const defaultChartBarWidth = 18;
 

--- a/ui/apps/platform/src/utils/chartUtils.ts
+++ b/ui/apps/platform/src/utils/chartUtils.ts
@@ -9,7 +9,7 @@ const severityColorScale = Object.values(severityColors);
 // Clone default PatternFly chart themes
 const defaultTheme = getTheme(ChartThemeColor.multi);
 
-export const defaultChartHeight = 260;
+export const defaultChartHeight = 264;
 
 export const defaultChartBarWidth = 18;
 


### PR DESCRIPTION
## Description

Adds Deployments at Most Risk widget (3). This widget is a rework of the one on the current dashboard, swapping out the datetime for risk priority and adding links to the network graph and risk pages.

[Original Sketch Mock](https://www.sketch.com/s/9d082d82-3515-40f2-875a-1b322a02bace/a/1KQykma)

This also includes some cleanup of the grid to ensure widgets are sized appropriately without explicit px values as well as use less padding overrides.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed
Test that on dashboard load, the top 6 risky deployments are displayed, in order.
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/1292638/173913473-d4c9b9b5-29ad-46d9-a31d-9f9da7a24b25.png">

Test that applying a cluster filter updates the list display with the top 6 risky deployments for the selected scope, in order.
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/1292638/173913820-0dcb7d67-a32d-42b9-84d0-dbd0cacd734c.png">

Again, with an applied namespace filter.
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/1292638/173913969-3a9eca71-8ef2-4db7-9948-12f274727d84.png">

Test that the "View All" link takes the user to the Risk page with the cluster/ns filters applied.
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/1292638/173914218-4245db9a-72ae-4510-8965-fdb3bfb19d4b.png">

Test that the links under the "Deployment" column take the user to the Risk page with the cluster/ns filters applied, as well as a "Deployment: <deployment_name>" filter, with the chosen deployment selected.
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/1292638/173914651-524c7836-bd39-4470-a06c-089c64699441.png">

Test that the links under the "Resource location" column take the user to the Network Graph, focused on the selected deployment.
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/1292638/173915321-0c311766-7ad7-4153-989f-e54c4784c229.png">

Test layout on small screen sizes:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/1292638/173916457-9a7bd34d-34cb-44cd-97f9-627b6a2fc17e.png">


