### PR TITLE
Adding an empty set of DocIDs should result in an empty search

### DIFF
--- a/pkg/search/postgres/query/test/index_test.go
+++ b/pkg/search/postgres/query/test/index_test.go
@@ -1,0 +1,111 @@
+//go:build sql_integration
+// +build sql_integration
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/blevesearch"
+	"github.com/stackrox/rox/pkg/testutils/envisolator"
+	"github.com/stackrox/rox/tools/generate-helpers/pg-table-bindings/test/postgres"
+	"github.com/stretchr/testify/suite"
+)
+
+var (
+	ctx = sac.WithAllAccess(context.Background())
+)
+
+type SingleIndexSuite struct {
+	suite.Suite
+	envIsolator *envisolator.EnvIsolator
+
+	pool    *pgxpool.Pool
+	store   postgres.Store
+	indexer interface {
+		Search(q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error)
+	}
+}
+
+func TestSingleIndex(t *testing.T) {
+	suite.Run(t, new(SingleIndexSuite))
+}
+
+func (s *SingleIndexSuite) SetupTest() {
+	s.envIsolator = envisolator.NewEnvIsolator(s.T())
+	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
+
+	if !features.PostgresDatastore.Enabled() {
+		s.T().Skip("Skip postgres index tests")
+		s.T().SkipNow()
+	}
+
+	source := pgtest.GetConnectionString(s.T())
+	config, err := pgxpool.ParseConfig(source)
+	s.Require().NoError(err)
+	s.pool, err = pgxpool.ConnectConfig(context.Background(), config)
+	s.Require().NoError(err)
+
+	postgres.Destroy(ctx, s.pool)
+	gormDB := pgtest.OpenGormDB(s.T(), source)
+	defer pgtest.CloseGormDB(s.T(), gormDB)
+	s.store = postgres.CreateTableAndNewStore(ctx, s.pool, gormDB)
+	s.indexer = postgres.NewIndexer(s.pool)
+}
+
+func (s *SingleIndexSuite) TearDownTest() {
+	if s.pool != nil {
+		s.pool.Close()
+	}
+	s.envIsolator.RestoreAll()
+}
+
+func getStruct(id int) *storage.TestSingleKeyStruct {
+	return &storage.TestSingleKeyStruct{
+		Key:  fmt.Sprintf("string-%d", id),
+		Name: fmt.Sprintf("name-%d", id),
+	}
+}
+
+func (s *SingleIndexSuite) TestDocIDs() {
+	var testStructs []*storage.TestSingleKeyStruct
+	for i := 0; i < 8; i++ {
+		testStructs = append(testStructs, getStruct(i))
+	}
+	s.NoError(s.store.UpsertMany(ctx, testStructs))
+
+	for _, testCase := range []struct {
+		desc   string
+		docIDs []string
+	}{
+		{
+			"none",
+			[]string{},
+		},
+		{
+			"one",
+			[]string{"string-1"},
+		},
+		{
+			"many",
+			[]string{"string-1", "string-3"},
+		},
+	} {
+		s.Run(testCase.desc, func() {
+			q := search.NewQueryBuilder().AddDocIDs(testCase.docIDs...).ProtoQuery()
+			results, err := s.indexer.Search(q)
+			s.Require().NoError(err)
+			s.Equal(testCase.docIDs, search.ResultsToIDs(results))
+		})
+	}
+
+}

--- a/pkg/search/postgres/query/test/test.go
+++ b/pkg/search/postgres/query/test/test.go
@@ -1,0 +1,3 @@
+package test
+
+// Make the compiler happy

--- a/pkg/search/querybuilder_test.go
+++ b/pkg/search/querybuilder_test.go
@@ -1,0 +1,43 @@
+package search
+
+import (
+	"testing"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDocIDs(t *testing.T) {
+	cases := []struct {
+		desc   string
+		docIDs []string
+	}{
+		{
+			desc:   "no doc ids",
+			docIDs: []string{},
+		},
+		{
+			desc:   "one doc id",
+			docIDs: []string{"1"},
+		},
+		{
+			desc:   "two doc ids",
+			docIDs: []string{"1", "2"},
+		},
+	}
+	for _, c := range cases {
+		q := NewQueryBuilder().AddDocIDs(c.docIDs...).ProtoQuery()
+		expected := &v1.Query{
+			Query: &v1.Query_BaseQuery{
+				BaseQuery: &v1.BaseQuery{
+					Query: &v1.BaseQuery_DocIdQuery{
+						DocIdQuery: &v1.DocIDQuery{
+							Ids: c.docIDs,
+						},
+					},
+				},
+			},
+		}
+		assert.Equal(t, expected, q)
+	}
+}

--- a/pkg/search/querybuilder_test.go
+++ b/pkg/search/querybuilder_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestEmptyQuery(t *testing.T) {
+	assert.Equal(t, &v1.Query{}, NewQueryBuilder().ProtoQuery())
+}
+
 func TestDocIDs(t *testing.T) {
 	cases := []struct {
 		desc   string


### PR DESCRIPTION
## Description

DocIDs are used for filtering of results. If a previous query or slice was empty, then the desired affect is to have 0 results. Currently, the query builder does not add a doc id query to the result

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests
