### PR TITLE
[ROX-10969] : Change Vuln reporting to use imageComponents and imageVulnerabilities graphQL resolvers

### DIFF
--- a/central/reports/common/report_formatter.go
+++ b/central/reports/common/report_formatter.go
@@ -35,7 +35,7 @@ var (
 	}
 )
 
-type ImageVulnerabilityObj struct {
+type imageVulnerability struct {
 	Cve               string        `json:"cve,omitempty"`
 	Severity          string        `json:"severity,omitempty"`
 	FixedByVersion    string        `json:"fixedByVersion,omitempty"`
@@ -44,26 +44,26 @@ type ImageVulnerabilityObj struct {
 	Link              string        `json:"link,omitempty"`
 }
 
-type ImageComponentObj struct {
-	Name                 string                   `json:"name,omitempty"`
-	ImageVulnerabilities []*ImageVulnerabilityObj `json:"imageVulnerabilities,omitempty"`
+type imageComponent struct {
+	Name                 string                `json:"name,omitempty"`
+	ImageVulnerabilities []*imageVulnerability `json:"imageVulnerabilities,omitempty"`
 }
 
-type imgObj struct {
-	Name            *storage.ImageName   `json:"name,omitempty"`
-	ImageComponents []*ImageComponentObj `json:"imageComponents,omitempty"`
+type image struct {
+	Name            *storage.ImageName `json:"name,omitempty"`
+	ImageComponents []*imageComponent  `json:"imageComponents,omitempty"`
 }
 
-type depObj struct {
+type deployment struct {
 	Cluster        *storage.Cluster `json:"cluster,omitempty"`
 	Namespace      string           `json:"namespace,omitempty"`
 	DeploymentName string           `json:"name,omitempty"`
-	Images         []*imgObj        `json:"images,omitempty"`
+	Images         []*image         `json:"images,omitempty"`
 }
 
 // Result is the query results of running a single cvefields query and scope query combination
 type Result struct {
-	Deployments []*depObj `json:"deployments,omitempty"`
+	Deployments []*deployment `json:"deployments,omitempty"`
 }
 
 // Format takes in the results of vuln report query, converts to CSV and returns zipped CSV data and

--- a/central/reports/common/report_formatter.go
+++ b/central/reports/common/report_formatter.go
@@ -35,7 +35,7 @@ var (
 	}
 )
 
-type vulnObj struct {
+type ImageVulnerabilityObj struct {
 	Cve               string        `json:"cve,omitempty"`
 	Severity          string        `json:"severity,omitempty"`
 	FixedByVersion    string        `json:"fixedByVersion,omitempty"`
@@ -44,14 +44,14 @@ type vulnObj struct {
 	Link              string        `json:"link,omitempty"`
 }
 
-type compObj struct {
-	Name  string     `json:"name,omitempty"`
-	Vulns []*vulnObj `json:"vulns,omitempty"`
+type ImageComponentObj struct {
+	Name                 string                   `json:"name,omitempty"`
+	ImageVulnerabilities []*ImageVulnerabilityObj `json:"imageVulnerabilities,omitempty"`
 }
 
 type imgObj struct {
-	Name       *storage.ImageName `json:"name,omitempty"`
-	Components []*compObj         `json:"components,omitempty"`
+	Name            *storage.ImageName   `json:"name,omitempty"`
+	ImageComponents []*ImageComponentObj `json:"imageComponents,omitempty"`
 }
 
 type depObj struct {
@@ -73,8 +73,8 @@ func Format(results []Result) (*bytes.Buffer, error) {
 	for _, r := range results {
 		for _, d := range r.Deployments {
 			for _, i := range d.Images {
-				for _, c := range i.Components {
-					for _, v := range c.Vulns {
+				for _, c := range i.ImageComponents {
+					for _, v := range c.ImageVulnerabilities {
 						discoveredTs := "Not Available"
 						if v.DiscoveredAtImage != nil {
 							discoveredTs = v.DiscoveredAtImage.Time.Format("January 02, 2006")

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -49,16 +49,16 @@ const (
 									name {
 										full_name:fullName
 									}
-									components {
+									imageComponents {
 										name
-										vulns(query: $cvequery) {
+										imageVulnerabilities(query: $cvequery) {
 											...cveFields
 										}
 									}
 								}
 							}
 						}
-	fragment cveFields on EmbeddedVulnerability {
+	fragment cveFields on ImageVulnerability {
         cve
 	    severity
         fixedByVersion


### PR DESCRIPTION
## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Manual testing to check if vuln report is correctly generated

![4DEEEDF0-050A-4515-8818-626FA73E9C06_1_105_c](https://user-images.githubusercontent.com/101146970/173999786-5e228d28-0d78-4dc4-9f67-e966c3b0a4bc.jpeg)

