### PR TITLE
ROX-11308: Minimum access role incorrectly displayed when auth provider is created via API

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/authProviders.utils.ts
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/authProviders.utils.ts
@@ -196,7 +196,7 @@ export function mergeGroupsWithAuthProviders(
 }
 
 export function getDefaultRoleByAuthProviderId(groups: Group[], id: string): string {
-    let defaultRoleGroups = groups.filter(
+    const defaultRoleGroups = groups.filter(
         (group) =>
             group.props &&
             group.props.authProviderId &&


### PR DESCRIPTION
## Description

UI set a hardcoded value 'Admin' for when there is no role group defined for a given auth provider, which looked misleading, as the provider still couldn't be used to login because of the missing role error.

The PR changes the value to 'Undefined, assuming None', so the behavior of such provider is functionally identical to one with the minimum access role set to 'None'.

For a new provider being created via UI the value will be set to 'Admin' as before.

Provider without minimum role will still show empty value in the list of providers in the UI, which seems logical for such providers.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~


## Testing Performed

Manual testing showed same login error for a provider without minimum access role and with 'None':
* Normal login;
* Test login on the provider editor page.

An example of a provider created via API without minimum access role defined:
![image](https://user-images.githubusercontent.com/20665445/174314070-5e251cf9-cc0f-4a2c-abf2-d52d75d35a81.png)
