### PR TITLE
Disable Splunk TA for Postgres until search after is implemented

### DIFF
--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -14,6 +14,8 @@ import groups.Integration
 import services.AlertService
 import services.ApiTokenService
 import services.NetworkBaselineService
+import spock.lang.IgnoreIf
+import util.Env
 import util.SplunkUtil
 import util.Timer
 
@@ -82,6 +84,7 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
     }
 
     @Category(Integration)
+    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") }) // TODO(ROX-11405) implement search after for Postgres
     def "Verify Splunk violations: StackRox violations reach Splunk TA"() {
         given:
         "Splunk TA is installed and configured, network and process violations triggered"


### PR DESCRIPTION
## Description

SearchAfter is required for the Splunk TA, but it has not been implemented yet. https://github.com/stackrox/stackrox/pull/2096 will fix this, but there are going to be some challenges so better to stop the noise 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

e2e in postgres-tests
