### PR TITLE
ROX-8051: make eBPF the default collection method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ## [NEXT RELEASE]
 
+- ROX-8051: The default collection method is changed from KernelModule to eBPF, following improved eBPF performance in collector.
 - ROX-11349: Updated rationale and remediation texts for default policy "Deployments should have at least one ingress Network Policy"
 - ROX-11443: The default value for `--include-snoozed` option of `roxctl image scan` command is set to `false`. The result of `roxctl image scan` execution without `--include-snoozed` flag will not include deferred CVEs anymore.
 - ROX-9292: The default expiration time of tokens issued by auth providers has been lowered to 12 hours.
@@ -26,7 +27,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - These endpoints are deprecated as license files are not required to run the platform
 - `firstNodeOccurrence` field of `storage.Node` object, which is in the response of Node endpoints, has been removed.
 - `vulns` fields of `storage.Node` object, which is in the response payload of `v1/nodes` is deprecated and will be removed in future release.
-- `/v1/cves/suppress` and `/v1/cves/unsuppress` has been deprecated and will be removed in the future. 
+- `/v1/cves/suppress` and `/v1/cves/unsuppress` has been deprecated and will be removed in the future.
   - Use `/v1/imagecves/suppress` and `/v1/imagecves/unsuppress` to snooze and unsnooze image  vulnerabilities.
   - Use `/v1/nodecves/suppress` and `/v1/nodecves/unsuppress` to snooze and unsnooze node/host vulnerabilities.
   - Use `/v1/platformcves/suppress` and `/v1/platformcves/unsuppress` to snooze and unsnooze platform (k8s, istio, and openshift) vulnerabilities.
@@ -53,7 +54,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - A new default policy added to detect Spring Cloud Function RCE vulnerability (CVE-2022-22963) and Spring Framework Spring4Shell RCE vulnerability (CVE-2022-22965).
 - Fixed permissions checks in the UI that prevented users with certain limited permissions from creating report configurations.
 - ROX-8957: A new default policy added to detect missing ingress NetworkPolicy associated with deployments. The policy is disabled by default.
-  - Two new policy criteria were added to alert on missing ingress or egress NetworkPolicy associations. 
+  - Two new policy criteria were added to alert on missing ingress or egress NetworkPolicy associations.
 - ROX-8789: Change operator catalog format from deprecated SQLite database format to new file-based format.
 - ROX-8331: Increase the front-end limit on rendered nodes in the Network Graph from 1100 to 2000
 - ROX-9792: Introduced central limit of 2000 nodes in a Network Graph to avoid out-of-memory crashes
@@ -69,7 +70,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-10097: Updated the base for the docs image from `nginx-118:1-46` to `nginx-120:latest`.
 - ROX-10666: `FROM` option will be deprecated from `Disallowed Dockerfile line` policy field and removed in a future release. Any policies containing `Disallowed dockerfile line` policy field with `FROM` option must be updated to remove those policy sections. For more information, please refer "Known Issues" section in Red-Hat ACS 3.69 release notes.
 - ROX-10270: The `RenamePolicyCategory` and `DeletePolicyCategory` methods in the
-`v1/policycategories` endpoint have been deprecated, and will be removed in future releases. 
+`v1/policycategories` endpoint have been deprecated, and will be removed in future releases.
   - For questions about this change, please contact the Red Hat support team at support@redhat.com.
 - ROX-10018: The policy `OpenShift: Kubeadmin Secret Accessed` will no longer trigger if the request was from the default OpenShift `oauth-apiserver-sa` service account, because this is an expected access pattern for the OpenShift apiserver.
 - Violation tags and process tags are deprecated, and will be removed in version 3.72.0.

--- a/deploy/k8s/deploy-local.sh
+++ b/deploy/k8s/deploy-local.sh
@@ -4,7 +4,7 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # assuming deployment on Kubernetes in Docker for Mac or Minikube
-export COLLECTION_METHOD="${COLLECTION_METHOD:-kernel-module}"
+export COLLECTION_METHOD="${COLLECTION_METHOD:-ebpf}"
 export MONITORING_SUPPORT="${MONITORING_SUPPORT:-false}"
 export POD_SECURITY_POLICIES="${POD_SECURITY_POLICIES:-false}"
 

--- a/image/templates/helm/stackrox-secured-cluster/README.md.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/README.md.htpl
@@ -272,7 +272,7 @@ chart and their default values:
 |`image.main.registry`| Address of the registry you are using for main image.|`[< required "" .MainRegistry >]` |
 |`image.collector.registry`| Address of the registry you are using for collector image.|`[< required "" .CollectorRegistry >]` |
 |`sensor.endpoint`| Address of the Sensor endpoint including port number. No trailing slash.|`sensor.stackrox.svc:443` |
-|`collector.collectionMethod`|Either `EBPF`, `KERNEL_MODULE`, or `NO_COLLECTION`. |`KERNEL_MODULE` |
+|`collector.collectionMethod`|Either `EBPF`, `KERNEL_MODULE`, or `NO_COLLECTION`. |`EBPF` |
 |`collector.disableTaintTolerations`|If you specify `false`, tolerations are applied to collector, and the collector pods can schedule onto all nodes with taints. If you specify it as `true`, no tolerations are applied, and the collector pods won't scheduled onto nodes with taints. |`false` |
 |`collector.slimMode`| Specify `true` if you want to use a slim Collector image for deploying Collector. Using slim Collector images requires Central to provide the matching kernel module or eBPF probe. If you are running the StackRox Kubernetes Security Platform in offline mode, you must download a kernel support package from [stackrox.io](https://install.stackrox.io/collector/support-packages/index.html) and upload it to Central for slim Collectors to function. Otherwise, you must ensure that Central can access the online probe repository hosted at https://collector-modules.stackrox.io/.|`false` |
 |`admissionControl.listenOnCreates`| This setting controls whether the cluster is configured to contact the StackRox Kubernetes Security Platform with `AdmissionReview` requests for `create` events on Kubernetes objects. |`false` |

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -44,7 +44,7 @@ admissionControl:
     enforceOnUpdates: false
 
 collector:
-  collectionMethod: "KERNEL_MODULE"
+  collectionMethod: "EBPF"
   disableTaintTolerations: false
 
 auditLogs:

--- a/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
+++ b/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
@@ -234,9 +234,9 @@
 #  #   - EBPF
 #  #   - KERNEL_MODULE
 #  #   - NO_COLLECTION
-#  collectionMethod: KERNEL_MODULE
+#  collectionMethod: EBPF
 #
-#  # Configure usage of taint tolerations. If `false`, tolerations are applied to collector, 
+#  # Configure usage of taint tolerations. If `false`, tolerations are applied to collector,
 #  # and the collector pods can schedule onto all nodes with taints. If `true`, no tolerations
 #  # are applied, and the collector pods won't scheduled onto nodes with taints.
 #  disableTaintTolerations: false

--- a/image/templates/helm/stackrox-secured-cluster/values.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/values.yaml.htpl
@@ -16,7 +16,7 @@ image:
     collector: [< required "" .CollectorRegistry >]
 
 config:
-  collectionMethod: [< default "KERNEL_MODULE" .CollectionMethod >]
+  collectionMethod: [< default "EBPF" .CollectionMethod >]
   admissionControl:
     createService: [< default false .AdmissionController >]
     listenOnUpdates: [< default false .AdmissionControlListenOnUpdates >]

--- a/operator/apis/platform/v1alpha1/securedcluster_types.go
+++ b/operator/apis/platform/v1alpha1/securedcluster_types.go
@@ -259,8 +259,8 @@ type CollectorContainerSpec struct {
 	// The method for system-level data collection. Kernel module is recommended.
 	// If you select "NoCollection", you will not be able to see any information about network activity
 	// and process executions. The remaining settings in these section will not have any effect.
-	//+kubebuilder:validation:Default=KernelModule
-	//+kubebuilder:default=KernelModule
+	//+kubebuilder:validation:Default=EBPF
+	//+kubebuilder:default=EBPF
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	Collection *CollectionMethod `json:"collection,omitempty"`
 

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -360,7 +360,7 @@ spec:
                       for collecting process and networking activity at the host level.
                     properties:
                       collection:
-                        default: KernelModule
+                        default: EBPF
                         description: The method for system-level data collection.
                           Kernel module is recommended. If you select "NoCollection",
                           you will not be able to see any information about network

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -362,7 +362,7 @@ spec:
                       for collecting process and networking activity at the host level.
                     properties:
                       collection:
-                        default: KernelModule
+                        default: EBPF
                         description: The method for system-level data collection.
                           Kernel module is recommended. If you select "NoCollection",
                           you will not be able to see any information about network

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -61,7 +61,7 @@ export const clusterTablePollingInterval = 5000; // milliseconds
 export const clusterDetailPollingInterval = 3000; // milliseconds
 
 const defaultNewClusterType = 'KUBERNETES_CLUSTER';
-const defaultCollectionMethod = 'KERNEL_MODULE';
+const defaultCollectionMethod = 'EBPF';
 
 export const newClusterDefault = {
     id: undefined,


### PR DESCRIPTION
## Description

Makes eBPF the default collection method, following from eBPF performance improvements in collector. This touches defaults in the helm charts, operator, deploy scripts, and the UI. 

I _think_ I've caught everything but it'd be useful to know if there's other parts that need changing.  

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Deployed locally on docker-desktop and on openshift 4 using infra. 
