### PR TITLE
ROX-10980: Use CVE and not CVE ID in vulnerability requests

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
@@ -44,7 +44,7 @@ function DeferredCVEs({ imageId }: DeferredCVEsProps): ReactElement {
     });
 
     const itemCount = data?.image?.vulnCount || 0;
-    const rows = data?.image?.vulns || [];
+    const rows = data?.image?.imageVulnerabilities || [];
 
     return (
         <DeferredCVEsTable

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
@@ -238,7 +238,9 @@ function DeferredCVEsTable({
                                         )}
                                     </Td>
                                     <Td dataLabel="Affected components">
-                                        <AffectedComponentsButton components={row.components} />
+                                        <AffectedComponentsButton
+                                            components={row.imageComponents}
+                                        />
                                     </Td>
                                     <Td dataLabel="Comments">
                                         {row.vulnerabilityRequest ? (

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
@@ -44,7 +44,7 @@ function FalsePositiveCVEs({ imageId }: FalsePositiveCVEsProps): ReactElement {
     });
 
     const itemCount = data?.image?.vulnCount || 0;
-    const rows = data?.image?.vulns || [];
+    const rows = data?.image?.imageVulnerabilities || [];
 
     return (
         <FalsePositiveCVEsTable

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
@@ -223,7 +223,9 @@ function FalsePositiveCVEsTable({
                                         />
                                     </Td>
                                     <Td dataLabel="Affected components">
-                                        <AffectedComponentsButton components={row.components} />
+                                        <AffectedComponentsButton
+                                            components={row.imageComponents}
+                                        />
                                     </Td>
                                     <Td dataLabel="Comments">
                                         <RequestCommentsButton

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
@@ -44,7 +44,7 @@ function ObservedCVEs({ imageId }: ObservedCVEsProps): ReactElement {
     });
 
     const itemCount = data?.image?.vulnCount || 0;
-    const rows = data?.image?.vulns || [];
+    const rows = data?.image?.imageVulnerabilities || [];
     const registry = data?.image?.name?.registry || '';
     const remote = data?.image?.name?.remote || '';
     const tag = data?.image?.name?.tag || '';

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
@@ -41,7 +41,7 @@ import SearchFilterResults from '../SearchFilterResults';
 
 export type CVEsToBeAssessed = {
     type: 'DEFERRAL' | 'FALSE_POSITIVE';
-    ids: string[];
+    cves: string[];
 } | null;
 
 export type ObservedCVEsTableProps = {
@@ -84,13 +84,13 @@ function ObservedCVEsTable({
     } = useTableSelection<Vulnerability>(rows);
     const [cvesToBeAssessed, setCVEsToBeAssessed] = useState<CVEsToBeAssessed>(null);
     const requestDeferral = useDeferVulnerability({
-        cveIDs: cvesToBeAssessed?.ids || [],
+        cveIDs: cvesToBeAssessed?.cves || [],
         registry,
         remote,
         tag,
     });
     const requestFalsePositive = useMarkFalsePositive({
-        cveIDs: cvesToBeAssessed?.ids || [],
+        cveIDs: cvesToBeAssessed?.cves || [],
         registry,
         remote,
         tag,
@@ -115,7 +115,7 @@ function ObservedCVEsTable({
               .filter((row) => {
                   return selectedIds.includes(row.id);
               })
-              .map((row) => row.id)
+              .map((row) => row.cve)
         : [];
 
     return (
@@ -137,7 +137,7 @@ function ObservedCVEsTable({
                                 onClick={() =>
                                     setCVEsToBeAssessed({
                                         type: 'DEFERRAL',
-                                        ids: selectedVulnsToDeferOrMarkFalsePositive,
+                                        cves: selectedVulnsToDeferOrMarkFalsePositive,
                                     })
                                 }
                                 isDisabled={selectedVulnsToDeferOrMarkFalsePositive.length === 0}
@@ -150,7 +150,7 @@ function ObservedCVEsTable({
                                 onClick={() =>
                                     setCVEsToBeAssessed({
                                         type: 'FALSE_POSITIVE',
-                                        ids: selectedVulnsToDeferOrMarkFalsePositive,
+                                        cves: selectedVulnsToDeferOrMarkFalsePositive,
                                     })
                                 }
                                 isDisabled={selectedVulnsToDeferOrMarkFalsePositive.length === 0}
@@ -229,7 +229,7 @@ function ObservedCVEsTable({
                                     title: 'Defer CVE',
                                     onClick: (event) => {
                                         event.preventDefault();
-                                        setCVEsToBeAssessed({ type: 'DEFERRAL', ids: [row.cve] });
+                                        setCVEsToBeAssessed({ type: 'DEFERRAL', cves: [row.cve] });
                                     },
                                     isDisabled: !canCreateRequests,
                                 },
@@ -239,7 +239,7 @@ function ObservedCVEsTable({
                                         event.preventDefault();
                                         setCVEsToBeAssessed({
                                             type: 'FALSE_POSITIVE',
-                                            ids: [row.cve],
+                                            cves: [row.cve],
                                         });
                                     },
                                     isDisabled: !canCreateRequests,
@@ -279,7 +279,9 @@ function ObservedCVEsTable({
                                         <CVSSScoreLabel cvss={row.cvss} />
                                     </Td>
                                     <Td dataLabel="Affected components">
-                                        <AffectedComponentsButton components={row.components} />
+                                        <AffectedComponentsButton
+                                            components={row.imageComponents}
+                                        />
                                     </Td>
                                     <Td dataLabel="Discovered">
                                         <DateTimeFormat time={row.discoveredAtImage} />
@@ -298,14 +300,14 @@ function ObservedCVEsTable({
             </TableComposable>
             <DeferralFormModal
                 isOpen={cvesToBeAssessed?.type === 'DEFERRAL'}
-                numCVEsToBeAssessed={cvesToBeAssessed?.ids.length || 0}
+                numCVEsToBeAssessed={cvesToBeAssessed?.cves.length || 0}
                 onSendRequest={requestDeferral}
                 onCompleteRequest={completeAssessment}
                 onCancelDeferral={cancelAssessment}
             />
             <FalsePositiveRequestModal
                 isOpen={cvesToBeAssessed?.type === 'FALSE_POSITIVE'}
-                numCVEsToBeAssessed={cvesToBeAssessed?.ids.length || 0}
+                numCVEsToBeAssessed={cvesToBeAssessed?.cves.length || 0}
                 onSendRequest={requestFalsePositive}
                 onCompleteRequest={completeAssessment}
                 onCancelFalsePositive={cancelAssessment}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/imageVulnerabilities.graphql.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/imageVulnerabilities.graphql.ts
@@ -29,7 +29,7 @@ export type Vulnerability = {
     cvss: string;
     scoreVersion: string;
     discoveredAtImage: string;
-    components: EmbeddedImageScanComponent[];
+    imageComponents: EmbeddedImageScanComponent[];
     vulnerabilityRequest: VulnerabilityRequest;
 };
 
@@ -49,7 +49,7 @@ export type GetImageVulnerabilitiesData = {
             tag: string;
         };
         vulnCount: number;
-        vulns: Vulnerability[];
+        imageVulnerabilities: Vulnerability[];
     };
 };
 
@@ -76,15 +76,15 @@ export const GET_IMAGE_VULNERABILITIES = gql`
                 tag
             }
             vulnCount(query: $vulnsQuery)
-            vulns(query: $vulnsQuery, pagination: $pagination) {
-                id: cve
+            imageVulnerabilities(query: $vulnsQuery, pagination: $pagination) {
+                id
                 cve
                 isFixable
                 severity
                 scoreVersion
                 cvss
                 discoveredAtImage
-                components {
+                imageComponents {
                     id
                     name
                     version


### PR DESCRIPTION
## Description

JIRA + Context: https://issues.redhat.com/browse/ROX-10980

* Made a change in the GraphQL query to not create the `id` by aliasing the `cve` field.
* Using the non-deprecated `imageVulnerabilities` and `imageComponents` GraphQL fields instead of `vulns` and `components`. Was not aware they were deprecated 
* Apparently the row actions used the `cve` while the bulk actions used the `id` field. It wasn't a problem since they were the same value, but this should make it consistent when the Backend change happens

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* No visual changes
* Can't really test until backend makes changes. I suggest the backend uses the changes in this PR when they make the `cve` and `id` different, or we can push this in and backend can check it separately