### PR TITLE
CI: Fix Circle CI UI e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2690,7 +2690,6 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - continue-when-in-a-pr-or-nightly-context
       - attach_workspace:
           at: ~/go/src/github.com/stackrox/rox
       - run:


### PR DESCRIPTION
## Description

#2106 broke UI e2e tests on merge runs in Circle CI because that test requires `bin/upgrader`. This PR restores `pre-build-go-binaries` execution on merge (which is OK because these are not published).

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient