### PR TITLE
CI: Fix nightlies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -926,8 +926,8 @@ commands:
         type: string
         default: stackrox
     steps:
-      - continue-when-in-a-pr-or-nightly-context
       - checkout
+      - continue-when-in-a-pr-or-nightly-context
       - attach_workspace:
           at: /go/src/github.com/stackrox/rox
       - restore-npm-deps-cache


### PR DESCRIPTION
## Description

`continue-when-in-a-pr-or-nightly-context` relies on `.circleci/is-nightly-tag.sh` and requires `checkout` to run.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient - Test with a nightly tag on the PR branch: 