### PR TITLE
Update prettier 2.7.1 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -157,7 +157,7 @@
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^2.6.2",
+        "prettier": "^2.7.1",
         "randomstring": "^1.2.1",
         "react-scripts": "^4.0.1",
         "react-test-renderer": "^17.0.2",

--- a/ui/packages/tailwind-config/package.json
+++ b/ui/packages/tailwind-config/package.json
@@ -38,7 +38,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^2.6.2",
+        "prettier": "^2.7.1",
         "tailwindcss": "^2.0.3"
     }
 }

--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -77,7 +77,7 @@
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^2.6.2",
+        "prettier": "^2.7.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-is": "^17.0.2",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -14500,10 +14500,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
-  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-bytes@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
## Description

https://prettier.io/blog/2022/06/14/2.7.0.html
* Support TypeScript 4.7
* Add `--cache` and `--cache-strategy` CLI options
* Preserve blank line between export specifiers
* Stop parsing invalid code

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui