### PR TITLE
ROX-11274: Increase no output timeout for e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1558,6 +1558,7 @@ commands:
       - *restoreGradle
       - run:
           name: QA Automation Platform Part 1
+          no_output_timeout: 15m
           command: |
             if [[ "<< parameters.orchestrator-flavor >>" == "openshift" ]]; then
               export CLUSTER=OPENSHIFT
@@ -1590,6 +1591,7 @@ commands:
 
       - run:
           name: QA Automation Platform Part 2
+          no_output_timeout: 15m
           command: |
             if [[ "<< parameters.orchestrator-flavor >>" == "openshift" ]]; then
               export CLUSTER=OPENSHIFT


### PR DESCRIPTION
## Description

Circleci has 10m timeout on output after it job is cancelled.
This PR increases this timeout to 15m to allow single test to fail and be retried.

Refs: 
- https://github.com/stackrox/stackrox/commit/4cd1f7d0a8b5142c6ae346f43a62858c720fe980

## Testing Performed

CI
