### PR TITLE
ROX-11443: Change default value for roxctl image scan --include-snoozed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ## [NEXT RELEASE]
 
+- ROX-11443: The default value for `--include-snoozed` option of `roxctl image scan` command is set to `false`.
 - ROX-9760: The deployment tab on violation detail now contains a list of network policies in the deployment's namespace.
 - ROX-9358: The diagnostic bundle includes notifiers, auth providers and auth provider groups, access control roles with attached permission set and access scope, and system configuration. Users with `DebugLogs` permission will be able to read listed entities from a generated diagnostic bundle regardless of their respective permissions.
 - ROX-10819: The documentation for API v1/notifiers ("GetNotifiers") previously stated that the request could be filtered by name or type. This is incorrect as this API never allowed filtering. The documentation has been fixed to reflect that.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ## [NEXT RELEASE]
 
-- ROX-11443: The default value for `--include-snoozed` option of `roxctl image scan` command is set to `false`.
+- ROX-11443: The default value for `--include-snoozed` option of `roxctl image scan` command is set to `false`. The result of `roxctl image scan` execution without `--include-snoozed` flag will not include deferred CVEs anymore.
 - ROX-9760: The deployment tab on violation detail now contains a list of network policies in the deployment's namespace.
 - ROX-9358: The diagnostic bundle includes notifiers, auth providers and auth provider groups, access control roles with attached permission set and access scope, and system configuration. Users with `DebugLogs` permission will be able to read listed entities from a generated diagnostic bundle regardless of their respective permissions.
 - ROX-10819: The documentation for API v1/notifiers ("GetNotifiers") previously stated that the request could be filtered by name or type. This is incorrect as this API never allowed filtering. The documentation has been fixed to reflect that.

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -77,7 +77,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	c.Flags().StringVarP(&imageScanCmd.image, "image", "i", "", "image name and reference. (e.g. nginx:latest or nginx@sha256:...)")
 	c.Flags().BoolVarP(&imageScanCmd.force, "force", "f", false, "the --force flag ignores Central's cache for the scan and forces a fresh re-pull from Scanner")
-	c.Flags().BoolVarP(&imageScanCmd.includeSnoozed, "include-snoozed", "a", true, "the --include-snoozed flag returns both snoozed and unsnoozed CVEs if set to false")
+	c.Flags().BoolVarP(&imageScanCmd.includeSnoozed, "include-snoozed", "a", false, "the --include-snoozed flag returns both snoozed and unsnoozed CVEs if set")
 	c.Flags().IntVarP(&imageScanCmd.retryDelay, "retry-delay", "d", 3, "set time to wait between retries in seconds")
 	c.Flags().IntVarP(&imageScanCmd.retryCount, "retries", "r", 3, "Number of retries before exiting as error")
 

--- a/roxctl/image/scan/scan_test.go
+++ b/roxctl/image/scan/scan_test.go
@@ -588,3 +588,11 @@ func (s *imageScanTestSuite) runLegacyOutputTests(cases map[string]outputFormatT
 		})
 	}
 }
+
+func (s *imageScanTestSuite) TestScan_IncludeSnoozed() {
+	s.Run("disabled by default", func() {
+		envMock, _, _ := s.newTestMockEnvironmentWithConn(nil)
+		cobraCommand := Command(envMock)
+		s.Equal(false, cobraCommand.Flag("include-snoozed").Value)
+	})
+}

--- a/roxctl/image/scan/scan_test.go
+++ b/roxctl/image/scan/scan_test.go
@@ -593,6 +593,6 @@ func (s *imageScanTestSuite) TestScan_IncludeSnoozed() {
 	s.Run("disabled by default", func() {
 		envMock, _, _ := s.newTestMockEnvironmentWithConn(nil)
 		cobraCommand := Command(envMock)
-		s.Equal(false, cobraCommand.Flag("include-snoozed").Value)
+		s.Equal("false", cobraCommand.Flag("include-snoozed").Value.String())
 	})
 }


### PR DESCRIPTION
## Description

We are changing the default option for snoozed CVEs in order to match UI behaviour, where also snoozed CVEs are filtered by default.

This PR contains:
- change the default to `false`
- add a test for the default value
- add an entry into the changelog

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- ~[ ] Determined and documented upgrade steps~ - no need for upgrade steps
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~ - should not be relevant

## Testing Performed

1. Spin up local stackrox stack, make a port forward, and export password to `ROX_PASSWORD` environment variable
2. Run the following command:
```
./bin/darwin/roxctl --insecure-skip-tls-verify --insecure --endpoint https://localhost:8000 -p "${ROX_PASSWORD}" image scan --image debian:10.1
```
3. After that, log in to UI. Open: https://localhost:8000
4. Go to: `https://localhost:8000/main/vulnerability-management`
5. Click on `99 CVEs` next to `docker.io/library/debian:10.1`
6. Click on one CVE from the list and select `DEFER AND APPROVE` to snooze that CVE
7. If you go to: `https://localhost:8000/main/vulnerability-management` - you should see one CVE less for `docker.io/library/debian:10.1`
8. Run the following command:
```
./bin/darwin/roxctl --insecure-skip-tls-verify --insecure --endpoint https://localhost:8000 -p "${ROX_PASSWORD}" image scan --image debian:10.1
```
The number of CVEs should be the same as in UI.
9. Run the following command:
```
./bin/darwin/roxctl --insecure-skip-tls-verify --insecure --endpoint https://localhost:8000 -p "${ROX_PASSWORD}" image scan --image debian:10.1 --include-snoozed
```
The number of CVEs should be bigger by 1 because all CVEs are included.
