### PR TITLE
Use setup func in SAC test

### DIFF
--- a/qa-tests-backend/src/test/groovy/SACv2Test.groovy
+++ b/qa-tests-backend/src/test/groovy/SACv2Test.groovy
@@ -118,9 +118,6 @@ class SACv2Test extends SACTest {
         def result = DeploymentService.listDeployments()
         assert result.find { it.name == DEPLOYMENT_QA2.name }
         assert !result.find { it.name == DEPLOYMENT_QA1.name }
-
-        cleanup:
-        BaseService.useBasicAuth()
     }
 
 }


### PR DESCRIPTION
## Description

In SAC test we have many repetitions of clenup func that does not perform anything.
This PR fixes it with a single setup method that ensure that we have proper token 
at the beggining of every test.


## Testing Performed

CI
