### PR TITLE
Allow running ignored postgres e2e tests locally

### DIFF
--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -21,7 +21,7 @@ class Env {
     ]
 
     static final IN_CI = (System.getenv("CI") != null)
-    static final CI_JOBNAME = System.getenv("CIRCLE_JOB")
+    static final CI_JOBNAME = System.getenv("CIRCLE_JOB") ?: ""
     static final CI_TAG = System.getenv("CIRCLE_TAG")
 
     private static final Env INSTANCE = new Env()


### PR DESCRIPTION
## Description

When using `CI_JOBNAME` locally it returns null.
This cause some tests to fail because of `@IgnoreIf` condition.
This PR makes `CI_JOBNAME` always return not null value.


```java
@IgnoreIf({ Env.CI_JOBNAME.contains("postgres") }) <-- missing null check
```

## Testing Performed

CI
