### PR TITLE
ROX-11462: close grpc connections on sensor `Stop()`

### DIFF
--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -1,11 +1,25 @@
 package grpc
 
 import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
 	"os"
+	"path"
+	"runtime"
+	"syscall"
 	"testing"
+	"time"
 
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/grpc/authn"
+	"github.com/stackrox/rox/pkg/grpc/authz/allow"
+	"github.com/stackrox/rox/pkg/grpc/routes"
+	"github.com/stackrox/rox/pkg/mtls/verifier"
+	"github.com/stackrox/rox/pkg/testutils/envisolator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 func TestMaxResponseMsgSize_Unset(t *testing.T) {
@@ -30,4 +44,109 @@ func TestMaxResponseMsgSize_Valid(t *testing.T) {
 	require.NoError(t, os.Setenv(maxResponseMsgSizeSetting.EnvVar(), "1337"))
 
 	assert.Equal(t, 1337, maxResponseMsgSize())
+}
+
+type testHandler struct {
+	received concurrency.Signal
+}
+
+func (h *testHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	h.received.Signal()
+	_, _ = w.Write([]byte("ASCII response"))
+}
+
+func NewHandler(sig concurrency.Signal) *testHandler {
+	return &testHandler{
+		received: sig,
+	}
+}
+
+func fromRoot(p string) string {
+	_, file, _, _ := runtime.Caller(1)
+	d := path.Dir(file)
+	return path.Clean(fmt.Sprintf("%s/../../%s", d, p))
+}
+
+func TestGrpcServer(t *testing.T) {
+	suite.Run(t, new(serverSuite))
+}
+
+type serverSuite struct {
+	envIsolator    *envisolator.EnvIsolator
+	receivedSignal concurrency.Signal
+	api            API
+	endpoint       string
+
+	suite.Suite
+}
+
+var _ suite.SetupTestSuite = &serverSuite{}
+var _ suite.TearDownTestSuite = &serverSuite{}
+
+func (s *serverSuite) SetupTest() {
+	s.envIsolator = envisolator.NewEnvIsolator(s.T())
+	s.envIsolator.Setenv("ROX_MTLS_CERT_FILE", fromRoot("tools/local-sensor/certs/cert.pem"))
+	s.envIsolator.Setenv("ROX_MTLS_KEY_FILE", fromRoot("tools/local-sensor/certs/key.pem"))
+	s.envIsolator.Setenv("ROX_MTLS_CA_FILE", fromRoot("tools/local-sensor/certs/caCert.pem"))
+	s.envIsolator.Setenv("ROX_MTLS_CA_KEY_FILE", fromRoot("tools/local-sensor/certs/caKey.pem"))
+
+	s.receivedSignal = concurrency.NewSignal()
+	fakeHandler := NewHandler(s.receivedSignal)
+
+	conf := Config{
+		CustomRoutes: []routes.CustomRoute{
+			{
+				Route:         "/test",
+				Authorizer:    allow.Anonymous(),
+				ServerHandler: fakeHandler,
+				Compression:   false,
+			},
+		},
+		IdentityExtractors: []authn.IdentityExtractor{},
+		Endpoints: []*EndpointConfig{
+			{
+				ListenEndpoint: ":9999",
+				TLS:            verifier.NonCA{},
+				ServeGRPC:      true,
+				ServeHTTP:      true,
+			},
+		},
+	}
+	s.api = NewAPI(conf)
+
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+}
+
+func (s *serverSuite) TearDownTest() {
+	s.envIsolator.RestoreAll()
+	stopped := s.api.Stop()
+	stopped.Wait()
+}
+
+func (s *serverSuite) TestHTTPsServerReturnsResponse() {
+	started := s.api.Start()
+	started.Wait()
+
+	_, err := http.Get("https://localhost:9999/test")
+	s.NoError(err)
+	select {
+	case <-s.receivedSignal.Done():
+		break
+	case <-time.After(2 * time.Second):
+		s.Fail("timed-out (2s): should have received HTTPs request")
+	}
+}
+
+func (s *serverSuite) TestHTTPsStopsCompletelyAfterCallingStop() {
+	started := s.api.Start()
+	started.Wait()
+
+	_, err := http.Get("https://localhost:9999/test")
+	s.NoError(err)
+
+	stopped := s.api.Stop()
+	stopped.Wait()
+
+	_, err = http.Get("https://localhost:9999/test")
+	s.ErrorIs(err, syscall.ECONNREFUSED)
 }

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -85,6 +85,7 @@ var _ suite.TearDownTestSuite = &serverSuite{}
 
 func (s *serverSuite) SetupTest() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
+	// TODO(ROX-11015): remove dependency to local-sensor's certificates
 	s.envIsolator.Setenv("ROX_MTLS_CERT_FILE", fromRoot("tools/local-sensor/certs/cert.pem"))
 	s.envIsolator.Setenv("ROX_MTLS_KEY_FILE", fromRoot("tools/local-sensor/certs/key.pem"))
 	s.envIsolator.Setenv("ROX_MTLS_CA_FILE", fromRoot("tools/local-sensor/certs/caCert.pem"))


### PR DESCRIPTION
## Description

Another PR on the stream of work of making sensor more testable. 

In order to run multiple tests in the same package, we need to be able to stop sensor completely (i.e. call `Stop()`) and start it again in another test case. However, there's a lot of global state that is currently not being properly cleaned. For example, all the singletons in [ROX-11027](https://issues.redhat.com/browse/ROX-11027). 

This PR implements `Close()` functions for the `/pkg/grpc/server`, so the HTTPs and gRPC servers started by Sensor can also be killed during the test's lifecycle. 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

This is just a refactor, no docs or changelog updates are needed.

## Testing Performed

- Additional unit tests added