### PR TITLE
ROX-11491: Upgrade base images to ubi9

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/nodejs-16:latest AS builder
+FROM registry.access.redhat.com/ubi9/nodejs-16:latest AS builder
 
 USER 0:0
 
@@ -10,7 +10,7 @@ COPY Makefile ./
 RUN npm install -g npm@8.10.0 && npm install -g yarn@1.22.18
 RUN make
 
-FROM registry.access.redhat.com/ubi8/nginx-120:latest
+FROM registry.access.redhat.com/ubi9/nginx-120:latest
 
 RUN echo "$(id -u):$(id -g)" > /tmp/container-uid
 

--- a/image/postgres/Dockerfile.envsubst
+++ b/image/postgres/Dockerfile.envsubst
@@ -1,6 +1,6 @@
 ARG BASE_REGISTRY=registry.access.redhat.com
-ARG BASE_IMAGE=ubi8/ubi
-ARG BASE_TAG=8.5
+ARG BASE_IMAGE=ubi9/ubi
+ARG BASE_TAG=9.0.0
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
 #WORKDIR /bundle

--- a/image/postgres/create-bundle.sh
+++ b/image/postgres/create-bundle.sh
@@ -30,9 +30,9 @@ chmod -R 755 "${bundle_root}"
 # =============================================================================
 # Get latest postgres minor version
 
-postgres_repo_url="https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
+postgres_repo_url="https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
 postgres_major="14"
-pg_rhel_version="8.5"
+pg_rhel_version="9"
 
 if [[ "${NATIVE_PG_INSTALL}" == "true" ]]; then
     dnf install --disablerepo='*' -y "${postgres_repo_url}"
@@ -41,7 +41,7 @@ if [[ "${NATIVE_PG_INSTALL}" == "true" ]]; then
 else
     build_dir="$(mktemp -d)"
     docker build -q -t postgres-minor-image "${build_dir}" -f - <<EOF
-FROM registry.access.redhat.com/ubi8/ubi:${pg_rhel_version}
+FROM registry.access.redhat.com/ubi9/ubi:9.0.0
 RUN dnf install --disablerepo='*' -y "${postgres_repo_url}"
 ENTRYPOINT dnf list --disablerepo='*' --enablerepo=pgdg${postgres_major} -y postgresql${postgres_major}-server.x86_64 | tail -n 1 | awk '{print \$2}'
 EOF

--- a/image/rhel/Dockerfile.envsubst
+++ b/image/rhel/Dockerfile.envsubst
@@ -1,6 +1,6 @@
 ARG BASE_REGISTRY=registry.access.redhat.com
-ARG BASE_IMAGE=ubi8-minimal
-ARG BASE_TAG=8.6
+ARG BASE_IMAGE=ubi9-minimal
+ARG BASE_TAG=9.0.0
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
 

--- a/image/rhel/Dockerfile.envsubst
+++ b/image/rhel/Dockerfile.envsubst
@@ -6,7 +6,7 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
 
 COPY bundle.tar.gz /
 WORKDIR /bundle
-RUN microdnf install tar gzip && tar -zxf /bundle.tar.gz
+RUN microdnf install -y tar gzip && tar -zxf /bundle.tar.gz
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
@@ -49,7 +49,7 @@ RUN ln -s entrypoint-wrapper.sh /stackrox/admission-control && \
     rpm -i /tmp/snappy.rpm && \
     rpm -i --nodeps /tmp/postgres-libs.rpm && \
     rpm -i --nodeps /tmp/postgres.rpm && \
-    microdnf install lz4 bzip2 util-linux && \
+    microdnf install -y lz4 bzip2 util-linux && \
     microdnf clean all && \
     rm /tmp/snappy.rpm /tmp/postgres.rpm /tmp/postgres-libs.rpm RPM-GPG-KEY-CentOS-Official && \
     # (Optional) Remove line below to keep package management utilities

--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -119,7 +119,7 @@ curl -s -f -o "${bundle_root}/snappy.rpm" "${rpm_base_url}/snappy-1.1.8-8.${rpm_
 postgres_major="14"
 pg_rhel_version="9"
 postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_version}-x86_64"
-postgres_minor="14.2-1PGDG.rhel9.x86_64"
+postgres_minor="14.4-1PGDG.rhel9.x86_64"
 
 curl -sS --fail -o "${bundle_root}/postgres.rpm" \
     "${postgres_url}/postgresql${postgres_major}-${postgres_minor}.rpm"

--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -109,7 +109,7 @@ else
 fi
 
 # Install all the required compression packages for RocksDB to compile
-rpm_base_url="http://mirror.stream.centos.org/centos/9-stream/BaseOS/x86_64/os/Packages"
+rpm_base_url="http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages"
 rpm_suffix="el9.x86_64.rpm"
 
 curl -s -f -o "${bundle_root}/snappy.rpm" "${rpm_base_url}/snappy-1.1.8-8.${rpm_suffix}"

--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -109,17 +109,17 @@ else
 fi
 
 # Install all the required compression packages for RocksDB to compile
-rpm_base_url="http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages"
-rpm_suffix="el8.x86_64.rpm"
+rpm_base_url="http://mirror.stream.centos.org/centos/9-stream/BaseOS/x86_64/os/Packages"
+rpm_suffix="el9.x86_64.rpm"
 
-curl -s -f -o "${bundle_root}/snappy.rpm" "${rpm_base_url}/snappy-1.1.8-3.${rpm_suffix}"
+curl -s -f -o "${bundle_root}/snappy.rpm" "${rpm_base_url}/snappy-1.1.8-8.${rpm_suffix}"
 
 # Install Postgres Client so central can initiate backups/restores
 # Get postgres RPMs directly
 postgres_major="14"
-pg_rhel_version="8.5"
+pg_rhel_version="9"
 postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_version}-x86_64"
-postgres_minor="14.2-1PGDG.rhel8.x86_64"
+postgres_minor="14.2-1PGDG.rhel9.x86_64"
 
 curl -sS --fail -o "${bundle_root}/postgres.rpm" \
     "${postgres_url}/postgresql${postgres_major}-${postgres_minor}.rpm"

--- a/image/roxctl/Dockerfile
+++ b/image/roxctl/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:latest AS certs
+FROM registry.access.redhat.com/ubi9-minimal:latest AS certs
 
 FROM scratch
 COPY ./roxctl-linux /roxctl

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -51,7 +51,7 @@ RUN GOOS=$(go env GOOS) scripts/go-build.sh operator
 # Copy the operator binary to a location from where it will be taken into the final image.
 RUN cp -a bin/$(go env GOOS)/operator stackrox-operator
 
-FROM registry.access.redhat.com/ubi8-micro:8.6
+FROM registry.access.redhat.com/ubi9-micro:9.0.0
 
 ARG roxpath
 

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -51,7 +51,7 @@ RUN GOOS=$(go env GOOS) scripts/go-build.sh operator
 # Copy the operator binary to a location from where it will be taken into the final image.
 RUN cp -a bin/$(go env GOOS)/operator stackrox-operator
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.0.0
+FROM registry.access.redhat.com/ubi9-micro:9.0.0
 
 ARG roxpath
 

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -51,7 +51,7 @@ RUN GOOS=$(go env GOOS) scripts/go-build.sh operator
 # Copy the operator binary to a location from where it will be taken into the final image.
 RUN cp -a bin/$(go env GOOS)/operator stackrox-operator
 
-FROM registry.access.redhat.com/ubi9-micro:9.0.0
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.0.0
 
 ARG roxpath
 

--- a/pkg/helm/charts/tests/centralservices/flavor/testdata/helmtest/rhacs/rhacs.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/flavor/testdata/helmtest/rhacs/rhacs.test.yaml
@@ -1,6 +1,6 @@
 tests:
 - name: validate image defaults
   expect: |
-    assertCentral("registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.0.99.0")
-    assertScanner("registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:3.0.99.0")
-    assertScannerDB("registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:3.0.99.0")
+    assertCentral("registry.redhat.io/advanced-cluster-security/rhacs-main-rhel9:3.0.99.0")
+    assertScanner("registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel9:3.0.99.0")
+    assertScannerDB("registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel9:3.0.99.0")

--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/rhacs/rhacs.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/rhacs/rhacs.test.yaml
@@ -3,15 +3,15 @@ tests:
   set:
     collector.slimMode: false
   expect: |
-    assertMainIs("registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.0.99.0")
-    assertCollectorIs("registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:3.0.99.0")
+    assertMainIs("registry.redhat.io/advanced-cluster-security/rhacs-main-rhel9:3.0.99.0")
+    assertCollectorIs("registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel9:3.0.99.0")
 
 - name: slim mode
   set:
     collector.slimMode: true
   expect: |
-    assertMainIs("registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.0.99.0")
-    assertCollectorIs("registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:3.0.99.0")
+    assertMainIs("registry.redhat.io/advanced-cluster-security/rhacs-main-rhel9:3.0.99.0")
+    assertCollectorIs("registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel9:3.0.99.0")
 
 - name: scanner image
   server:
@@ -22,5 +22,5 @@ tests:
   set:
     scanner.disable: false
   expect: |
-    assertScannerIs("registry.redhat.io/advanced-cluster-security/rhacs-scanner-slim-rhel8:3.0.99.0")
-    assertScannerDBIs("registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-slim-rhel8:3.0.99.0")
+    assertScannerIs("registry.redhat.io/advanced-cluster-security/rhacs-scanner-slim-rhel9:3.0.99.0")
+    assertScannerDBIs("registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-slim-rhel9:3.0.99.0")

--- a/pkg/images/defaults/flavor.go
+++ b/pkg/images/defaults/flavor.go
@@ -167,23 +167,23 @@ func RHACSReleaseImageFlavor() ImageFlavor {
 	v := version.GetAllVersionsUnified()
 	return ImageFlavor{
 		MainRegistry:  "registry.redhat.io/advanced-cluster-security",
-		MainImageName: "rhacs-main-rhel8",
+		MainImageName: "rhacs-main-rhel9",
 		MainImageTag:  v.MainVersion,
-		/* TODO(ROX-9858): Create repo rhacs-central-db-rhel8 when starting building rhacs */
+		/* TODO(ROX-9858): Create repo rhacs-central-db-rhel9 when starting building rhacs */
 		CentralDBImageTag:  v.MainVersion,
-		CentralDBImageName: "rhacs-central-db-rhel8",
+		CentralDBImageName: "rhacs-central-db-rhel9",
 
 		CollectorRegistry:      "registry.redhat.io/advanced-cluster-security",
-		CollectorImageName:     "rhacs-collector-rhel8",
+		CollectorImageName:     "rhacs-collector-rhel9",
 		CollectorImageTag:      v.CollectorVersion,
-		CollectorSlimImageName: "rhacs-collector-slim-rhel8",
+		CollectorSlimImageName: "rhacs-collector-slim-rhel9",
 		CollectorSlimImageTag:  v.CollectorVersion,
 
-		ScannerImageName:       "rhacs-scanner-rhel8",
-		ScannerSlimImageName:   "rhacs-scanner-slim-rhel8",
+		ScannerImageName:       "rhacs-scanner-rhel9",
+		ScannerSlimImageName:   "rhacs-scanner-slim-rhel9",
 		ScannerImageTag:        v.ScannerVersion,
-		ScannerDBImageName:     "rhacs-scanner-db-rhel8",
-		ScannerDBSlimImageName: "rhacs-scanner-db-slim-rhel8",
+		ScannerDBImageName:     "rhacs-scanner-db-rhel9",
+		ScannerDBSlimImageName: "rhacs-scanner-db-slim-rhel9",
 
 		ChartRepo: ChartRepo{
 			URL: "https://mirror.openshift.com/pub/rhacs/charts",

--- a/tests/roxctl/bats-tests/helpers.bash
+++ b/tests/roxctl/bats-tests/helpers.bash
@@ -238,7 +238,7 @@ image_reference_regex() {
       fi
       ;;
     registry.redhat.io)
-      echo "registry\.redhat\.io/advanced-cluster-security/rhacs-$component-rhel8:$version"
+      echo "registry\.redhat\.io/advanced-cluster-security/rhacs-$component-rhel9:$version"
       ;;
     example.com)
       echo "example\.com/$component:$version"

--- a/tests/roxctl/bats-tests/local/central-generate-interactive-flavors-postgres.bats
+++ b/tests/roxctl/bats-tests/local/central-generate-interactive-flavors-postgres.bats
@@ -67,9 +67,9 @@ assert_prompts_stackrox() {
 }
 
 assert_prompts_rhacs() {
-  assert_line --regexp 'Enter main .* "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:'
-  assert_line --regexp 'Enter scanner-db .* "registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:'
-  assert_line --regexp 'Enter scanner .* "registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:'
+  assert_line --regexp 'Enter main .* "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel9:'
+  assert_line --regexp 'Enter scanner-db .* "registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel9:'
+  assert_line --regexp 'Enter scanner .* "registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel9:'
 }
 
 @test "roxctl-development central generate interactive flavor=development_build" {

--- a/tests/roxctl/bats-tests/local/central-generate-interactive-flavors.bats
+++ b/tests/roxctl/bats-tests/local/central-generate-interactive-flavors.bats
@@ -65,9 +65,9 @@ assert_prompts_stackrox() {
 }
 
 assert_prompts_rhacs() {
-  assert_line --regexp 'Enter main .* "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:'
-  assert_line --regexp 'Enter scanner-db .* "registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:'
-  assert_line --regexp 'Enter scanner .* "registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:'
+  assert_line --regexp 'Enter main .* "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel9:'
+  assert_line --regexp 'Enter scanner-db .* "registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel9:'
+  assert_line --regexp 'Enter scanner .* "registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel9:'
 }
 
 @test "roxctl-development central generate interactive flavor=dummy should ask for valid value" {

--- a/tests/roxctl/bats-tests/local/expect/flavor-interactive.expect.tcl
+++ b/tests/roxctl/bats-tests/local/expect/flavor-interactive.expect.tcl
@@ -46,7 +46,7 @@ expect "Enter default container images settings*" { send "$flavor\n" }
 if {[info exists ::env(ROX_POSTGRES_DATASTORE)] && [string equal "$env(ROX_POSTGRES_DATASTORE)" true]} {
   # Enter central-db image to use (default: "docker.io/stackrox/central-db:2.21.0-15-g448f2dc8fa"):
   # Enter central-db image to use (default: "stackrox.io/central-db:3.67.x-296-g56df6a892d"):
-  # Enter central-db image to use (default: "registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8:3.68.x-30-g516b4e7a6c-dirty"):
+  # Enter central-db image to use (default: "registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel9:3.68.x-30-g516b4e7a6c-dirty"):
   expect {
     default {
       send_user "\nFATAL: No question about Central-DB image\n"
@@ -62,7 +62,7 @@ if {[info exists ::env(ROX_POSTGRES_DATASTORE)] && [string equal "$env(ROX_POSTG
       send "\n"
     }
     # Special case for RHACS to avoid writing a regexp in TCL
-    "Enter central-db * (default: \"$registry/rhacs-central-db-rhel8:*\"):" {
+    "Enter central-db * (default: \"$registry/rhacs-central-db-rhel9:*\"):" {
       send_user "roxctl suggests correct registry for central-db"
       send "\n"
     }
@@ -72,7 +72,7 @@ expect "Enter the method of exposing Central*" { send "none\n" }
 
 # Enter main image to use (default: "docker.io/stackrox/main:3.67.x-296-g56df6a892d"):
 # Enter main image to use (default: "stackrox.io/main:3.67.x-296-g56df6a892d")
-# Enter main image to use (default: "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.68.x-30-g516b4e7a6c-dirty"):
+# Enter main image to use (default: "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel9:3.68.x-30-g516b4e7a6c-dirty"):
 expect {
   default {
     send_user "\nFATAL: No question about main image\n"
@@ -88,7 +88,7 @@ expect {
     send "\n"
   }
   # Special case for RHACS to avoid writing a regexp in TCL
-  "Enter main * (default: \"$registry/rhacs-main-rhel8:*\"):" {
+  "Enter main * (default: \"$registry/rhacs-main-rhel9:*\"):" {
     send_user "roxctl suggests correct registry for main"
     send "\n"
   }
@@ -100,7 +100,7 @@ expect "Enter Istio version when deploying into an Istio-enabled cluster*:" { se
 
 # Enter scanner-db image to use (default: "docker.io/stackrox/scanner-db:2.21.0-15-g448f2dc8fa"):
 # Enter scanner-db image to use (default: "stackrox.io/scanner-db:3.67.x-296-g56df6a892d"):
-# Enter scanner-db image to use (default: "registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:3.68.x-30-g516b4e7a6c-dirty"):
+# Enter scanner-db image to use (default: "registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel9:3.68.x-30-g516b4e7a6c-dirty"):
 expect {
   default {
     send_user "\nFATAL: No question about Scanner-DB image\n"
@@ -116,7 +116,7 @@ expect {
     send "\n"
   }
   # Special case for RHACS to avoid writing a regexp in TCL
-  "Enter scanner-db * (default: \"$registry/rhacs-scanner-db-rhel8:*\"):" {
+  "Enter scanner-db * (default: \"$registry/rhacs-scanner-db-rhel9:*\"):" {
     send_user "roxctl suggests correct registry for scanner-db"
     send "\n"
   }
@@ -140,7 +140,7 @@ expect {
     send "\n"
   }
   # Special case for RHACS to avoid writing a regexp in TCL
-  "Enter scanner * (default: \"$registry/rhacs-scanner-rhel8:*\"):" {
+  "Enter scanner * (default: \"$registry/rhacs-scanner-rhel9:*\"):" {
     send_user "roxctl suggests correct registry for scanner"
     send "\n"
   }


### PR DESCRIPTION
The latest tag for `ubi9` is 9.0.0.