### PR TITLE
Move check-docs and check-scanner-collector to OpenShift CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -816,28 +816,6 @@ commands:
         command: |
           git submodule update --init
 
-  check-docs-step:
-    parameters:
-      only-on-release:
-        type: boolean
-    steps:
-    - run:
-        name: Verify that docs are up to date
-        command: |
-          source scripts/ci/lib.sh
-          check_docs "${CIRCLE_TAG:-}" "<< parameters.only-on-release >>"
-
-  check-scanner-and-collector-release-step:
-    parameters:
-      fail-on-rc:
-        type: boolean
-    steps:
-    - run:
-        name: Check on release builds that COLLECTOR_VERSION and SCANNER_VERSION are release
-        command: |
-          source scripts/ci/lib.sh
-          check_scanner_and_collector "<< parameters.fail-on-rc >>"
-
   setup-go-build-env:
     steps:
       - run:
@@ -982,10 +960,6 @@ commands:
       - checkout-with-submodules
       - poll-for-builds-when-not-in-a-pr-or-nightly-context
       - continue-when-in-a-pr-or-nightly-context
-      - check-docs-step:
-          only-on-release: true
-      - check-scanner-and-collector-release-step:
-          fail-on-rc: false
 
       - setup_remote_docker:
           version: << pipeline.parameters.docker_version >>
@@ -2305,8 +2279,6 @@ jobs:
             # Cannot use .circleci/is-nightly-tag.sh because this job doesn't have access to git
             if [[ "$CIRCLE_TAG" =~ .*-nightly-.* ]]; then
               webhook_url="$NIGHTLY_WORKFLOW_NOTIFY_WEBHOOK"
-            elif [[ "$CIRCLE_TAG" =~ << pipeline.parameters.release_rc_tag_bash_regex >> ]]; then
-              webhook_url="$RELEASE_WORKFLOW_NOTIFY_WEBHOOK"
             else
               exit 0
             fi
@@ -2337,26 +2309,6 @@ jobs:
           make go-postgres-unit-tests
     - post-go-unit-tests:
         path: go-unit-release-junit-reports
-
-  # This job checks that the docs/content submodule is pointing to the correct branch in the openshift-docs repo,
-  # and that it is up-to-date. It only runs on RC builds, and is primarily intended as a reminder for the release
-  # manager to inquire about docs and, if available, update the submodule pointer.
-  check-docs-job:
-    executor: custom
-    resource_class: small
-    steps:
-    - checkout-with-submodules
-    - check-docs-step:
-        only-on-release: false
-
-  # This serves as a reminder for the release manager to make sure Scanner and Collector versions are set to release.
-  check-scanner-and-collector-release-job:
-    executor: custom
-    resource_class: small
-    steps:
-    - checkout
-    - check-scanner-and-collector-release-step:
-        fail-on-rc: true
 
   check-generated-files-up-to-date:
     executor: custom
@@ -4872,15 +4824,6 @@ workflows:
           context:
             - osd-cluster-manager
             - quay-rhacs-eng-readonly
-
-      - check-docs-job:
-          <<: *runOnlyOnReleaseCandidateBuilds
-          context:
-          - custom-executor-pull
-      - check-scanner-and-collector-release-job:
-          <<: *runOnlyOnReleaseCandidateBuilds
-          context:
-          - custom-executor-pull
 
       - provision-openshift-aro-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -67,6 +67,9 @@ case "$ci_job" in
     push-images)
         "$ROOT/scripts/ci/jobs/push-images.sh" "$@"
         ;;
+    release-mgmt)
+        "$ROOT/scripts/ci/jobs/release-mgmt.sh" "$@"
+        ;;
     gke-qa-e2e-tests)
         "$ROOT/.openshift-ci/gke_qa_e2e_test.py"
         ;;

--- a/scripts/ci/bats/lib_check_docs_test.bats
+++ b/scripts/ci/bats/lib_check_docs_test.bats
@@ -20,38 +20,11 @@ function setup() {
     assert_output --partial 'not a release or RC'
 }
 
-@test "exits early when only interested in releases and this is an RC" {
-    run check_docs "3.69.0-rc.10" "true"
-    assert_success
-    assert_output --partial 'Skipping'
-    assert_output --partial 'this is an RC'
-}
-
 function git_matches() {
     if [[ "$1" == "config" ]]; then
         echo "rhacs-docs-3.69.0"
     fi
     return 0
-}
-
-@test "does not exit early when only interested in releases and this is a release" {
-    function git() {
-        git_matches "$@"
-    }
-    run check_docs "3.69.0" "true"
-    assert_success
-    refute_output --partial 'Skipping'
-    refute_output --partial 'this is an RC'
-}
-
-@test "does not exit early when explicitly not only interested in releases and this is an RC" {
-    function git() {
-        git_matches "$@"
-    }
-    run check_docs "3.69.0-rc.10" "false"
-    assert_success
-    refute_output --partial 'Skipping'
-    refute_output --partial 'this is an RC'
 }
 
 @test "succeeds when versions match (RC)" {
@@ -85,7 +58,7 @@ function git_matches() {
     function git() {
         git_matches "$@"
     }
-    run check_docs "4.69.0" "true"
+    run check_docs "4.69.0"
     assert_failure
     assert_output --partial 'Expected docs/content'
 }

--- a/scripts/ci/bats/lib_release_version_test.bats
+++ b/scripts/ci/bats/lib_release_version_test.bats
@@ -51,7 +51,7 @@ function setup() {
     assert_failure 1
 }
 
-# check_scanner_and_collector() tests
+# check_scanner_and_collector_versions() tests
 
 function make() {
     echo "${tags[$2]}"
@@ -59,55 +59,39 @@ function make() {
 
 @test "spots unreleased collector tags when an RC" {
     declare -A tags=( [tag]="3.67.2-rc.2" [collector-tag]="3.68.x-23-g8a2e05d0ec" [scanner-tag]="3.45.1")
-    run check_scanner_and_collector "false"
-    assert_success
+    run check_scanner_and_collector_versions
+    assert_failure
     assert_output --partial 'Collector tag does not look like a release tag'
     refute_output --partial 'Scanner tag does not look like a release tag'
 }
 
 @test "spots unreleased scanner tags when an RC" {
     declare -A tags=( [tag]="3.67.2-rc.2" [collector-tag]="3.68.1" [scanner-tag]="3.45.1-rc.2")
-    run check_scanner_and_collector "false"
-    assert_success
-    refute_output --partial 'Collector tag does not look like a release tag'
-    assert_output --partial 'Scanner tag does not look like a release tag'
-}
-
-@test "spots unreleased collector tags when an RC and can fail" {
-    declare -A tags=( [tag]="3.67.2-rc.2" [collector-tag]="3.68.x-23-g8a2e05d0ec" [scanner-tag]="3.45.1")
-    run check_scanner_and_collector "true"
-    assert_failure
-    assert_output --partial 'Collector tag does not look like a release tag'
-    refute_output --partial 'Scanner tag does not look like a release tag'
-}
-
-@test "spots unreleased scanner tags when an RC and can fail" {
-    declare -A tags=( [tag]="3.67.2-rc.2" [collector-tag]="3.68.1" [scanner-tag]="3.45.1-rc.2")
-    run check_scanner_and_collector "true"
+    run check_scanner_and_collector_versions
     assert_failure
     refute_output --partial 'Collector tag does not look like a release tag'
     assert_output --partial 'Scanner tag does not look like a release tag'
 }
 
-@test "spots unreleased collector tags when a release and fails" {
+@test "spots unreleased collector tags when a release" {
     declare -A tags=( [tag]="3.67.2" [collector-tag]="3.68.23-rc.8" [scanner-tag]="3.45.1")
-    run check_scanner_and_collector "false"
+    run check_scanner_and_collector_versions
     assert_failure
     assert_output --partial 'Collector tag does not look like a release tag'
     refute_output --partial 'Scanner tag does not look like a release tag'
 }
 
-@test "spots unreleased scanner tags when a release and fails" {
+@test "spots unreleased scanner tags when a release" {
     declare -A tags=( [tag]="3.67.2" [collector-tag]="3.68.1" [scanner-tag]="3.45.x-23-g8a2e05d0ec")
-    run check_scanner_and_collector "false"
+    run check_scanner_and_collector_versions
     assert_failure
     refute_output --partial 'Collector tag does not look like a release tag'
     assert_output --partial 'Scanner tag does not look like a release tag'
 }
 
-@test "spots both unreleased tags when a release and fails" {
+@test "spots both unreleased tags when a release" {
     declare -A tags=( [tag]="3.67.2" [collector-tag]="3.68.23-rc.8" [scanner-tag]="3.45.x-23-g8a2e05d0ec")
-    run check_scanner_and_collector "false"
+    run check_scanner_and_collector_versions
     assert_failure
     assert_output --partial 'Collector tag does not look like a release tag'
     assert_output --partial 'Scanner tag does not look like a release tag'

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -93,6 +93,9 @@ create_cluster() {
     else
         die "Support is missing for this CI environment"
     fi
+    # . from branch names
+    tags="${tags//./-}"
+    labels="${labels//./-}"
     # lowercase
     tags="${tags,,}"
     labels="${labels,,}"

--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -17,6 +17,15 @@ push_images() {
 
     [[ "${OPENSHIFT_CI:-false}" == "true" ]] || { die "Only supported in OpenShift CI"; }
 
+    local tag
+    tag="$(make --quiet tag)"
+    if is_release_version "$tag"; then
+        check_docs "${tag}"
+        check_scanner_and_collector_versions
+    else
+        info "Not checking docs/ & version files for non releases"
+    fi
+
     local brand="$1"
     local push_context=""
     local base_ref

--- a/scripts/ci/jobs/release-mgmt.sh
+++ b/scripts/ci/jobs/release-mgmt.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+source "$ROOT/scripts/ci/lib.sh"
+
+set -euo pipefail
+
+release_mgmt() {
+    info "Release management steps"
+
+    local release_issues=()
+
+    local tag
+    tag="$(make --quiet tag)"
+
+    if is_RC_version "${tag}" && ! check_docs "${tag}"; then
+        release_issues+=("docs/ is not valid for a release.")
+    fi
+
+    if is_RC_version "${tag}" && ! check_scanner_and_collector_versions; then
+        release_issues+=("SCANNER_VERSION and COLLECTOR_VERSION need to also be release.")
+    fi
+
+    if [[ "${#release_issues[@]}" != "0" ]]; then
+        info "ERROR: Issues were found:"
+        for issue in "${release_issues[@]}"; do
+            echo -e "\t$issue"
+        done
+        exit 1
+    fi
+}
+
+release_mgmt "$@"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -314,76 +314,50 @@ check_docs() {
     fi
 
     local tag="$1"
-    local only_run_on_releases="${2:-false}"
 
     [[ "$tag" =~ $RELEASE_RC_TAG_BASH_REGEX ]] || {
         info "Skipping step as this is not a release or RC build"
-        exit 0
+        return 0
     }
 
-    if [[ "$only_run_on_releases" == "true" ]]; then
-        [[ -z "${BASH_REMATCH[3]}" ]] || {
-            info "Skipping as this is an RC build"
-            exit 0
-        }
-    fi
-
-    local version="${BASH_REMATCH[1]}"
-    local expected_content_branch="rhacs-docs-${version}"
+    local release_version="${BASH_REMATCH[1]}"
+    local expected_content_branch="rhacs-docs-${release_version}"
     local actual_content_branch
     actual_content_branch="$(git config -f .gitmodules submodule.docs/content.branch)"
     [[ "$actual_content_branch" == "$expected_content_branch" ]] || {
-        echo >&2 "Expected docs/content submodule to point to branch ${expected_content_branch}, got: ${actual_content_branch}"
-        exit 1
+        echo >&2 "ERROR: Expected docs/content submodule to point to branch ${expected_content_branch}, got: ${actual_content_branch}"
+        return 1
     }
 
     git submodule update --remote docs/content
     git diff --exit-code HEAD || {
-        echo >&2 "The docs/content submodule is out of date for the ${expected_content_branch} branch; please run"
+        echo >&2 "ERROR: The docs/content submodule is out of date for the ${expected_content_branch} branch; please run"
         echo >&2 "  git submodule update --remote docs/content"
         echo >&2 "and commit the result."
-        exit 1
+        return 1
     }
 
     info "The docs version is as expected"
-    exit 0
 }
 
-check_scanner_and_collector() {
-    info "Check on release builds that COLLECTOR_VERSION and SCANNER_VERSION are release"
-
-    if [[ "$#" -ne 1 ]]; then
-        die "missing arg. usage: check_scanner_and_collector <fail-on-rc>"
-    fi
-
-    local fail_on_rc="$1"
-    local main_release_like=0
-    local main_rc=0
-    local main_tag
-    main_tag="$(make --quiet tag)"
-    if is_release_version "$main_tag"; then
-        main_release_like=1
-    fi
-    if is_RC_version "$main_tag"; then
-        main_release_like=1
-        main_rc=1
-    fi
+check_scanner_and_collector_versions() {
+    info "Check on builds that COLLECTOR_VERSION and SCANNER_VERSION are release versions"
 
     local release_mismatch=0
-    if ! is_release_version "$(make --quiet collector-tag)" && [[ "$main_release_like" == "1" ]]; then
-        echo >&2 "Collector tag does not look like a release tag. Please update COLLECTOR_VERSION file before releasing."
+    if ! is_release_version "$(make --quiet collector-tag)"; then
+        echo >&2 "ERROR: Collector tag does not look like a release tag. Please update COLLECTOR_VERSION file before releasing."
         release_mismatch=1
     fi
-    if ! is_release_version "$(make --quiet scanner-tag)" && [[ "$main_release_like" == "1" ]]; then
-        echo >&2 "Scanner tag does not look like a release tag. Please update SCANNER_VERSION file before releasing."
+    if ! is_release_version "$(make --quiet scanner-tag)"; then
+        echo >&2 "ERROR: Scanner tag does not look like a release tag. Please update SCANNER_VERSION file before releasing."
         release_mismatch=1
     fi
 
-    if [[ "$release_mismatch" == "1" && ( "$main_rc" == "0" || "$fail_on_rc" == "true" ) ]]; then
-        # Note that the script avoids doing early exits in order for the most of its logic to be executed drung
-        # regular pipeline runs so that it does not get rusty by the time of the release.
-        exit 1
+    if [[ "$release_mismatch" == "1" ]]; then
+        return 1
     fi
+
+    info "The scanner and collector versions are release versions"
 }
 
 mark_collector_release() {
@@ -728,7 +702,7 @@ gate_merge_job() {
         return
     fi
 
-    info "$job will be skipped"
+    info "$job will be skipped - neither master/run_on_master or tagged/run_on_tags"
     exit 0
 }
 


### PR DESCRIPTION
## Description

Per title.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Tested on `release-0.1.x` branch:

- [x]: on an RC checks are skipped in push-image and run in release-mgmt.
  - if the docs are incorrect it is flagged:
  - https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-release-0.1.x-merge-release-mgmt/1537950998851489792
- [x]: on a release checks run in push-image and not in release-mgmt
  - if the docs are incorrect the release is not pushed:
  - https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-release-0.1.x-stackrox_branding-merge-push-images/1538218030469746688
  - https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-release-0.1.x-merge-push-images/1538218025423998976
