### PR TITLE
Add Aging Images widget to main dashboard

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -124,6 +124,7 @@
         "@testing-library/jest-dom": "^5.15.0",
         "@testing-library/react": "^12.1.2",
         "@testing-library/react-hooks": "^7.0.2",
+        "@testing-library/user-event": "^14.2.1",
         "@types/jest": "^27.4.0",
         "@types/lodash": "^4.14.176",
         "@types/node": "^17.0.16",

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
@@ -14,6 +14,7 @@ import ScopeBar from './ScopeBar';
 
 import ViolationsByPolicyCategory from './Widgets/ViolationsByPolicyCategory';
 import DeploymentsAtMostRisk from './Widgets/DeploymentsAtMostRisk';
+import AgingImages from './Widgets/AgingImages';
 
 function DashboardPage() {
     return (
@@ -47,6 +48,9 @@ function DashboardPage() {
                     </GridItem>
                     <GridItem lg={6}>
                         <ViolationsByPolicyCategory />
+                    </GridItem>
+                    <GridItem lg={6}>
+                        <AgingImages />
                     </GridItem>
                 </Grid>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { MockedProvider } from '@apollo/client/testing';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+
+import renderWithRouter from 'test-utils/renderWithRouter';
+import AgingImages, { imageCountQuery } from './AgingImages';
+
+const range0 = '30';
+const range1 = '90';
+const range2 = '180';
+const range3 = '365';
+
+const result0 = 40;
+const result1 = 32;
+const result2 = 31;
+const result3 = 18;
+
+const mocks = [
+    {
+        request: {
+            query: imageCountQuery,
+            variables: {
+                query0: `Image Created Time:>${range0}d`,
+                query1: `Image Created Time:>${range1}d`,
+                query2: `Image Created Time:>${range2}d`,
+                query3: `Image Created Time:>${range3}d`,
+            },
+        },
+        result: {
+            data: {
+                timeRange0: result0,
+                timeRange1: result1,
+                timeRange2: result2,
+                timeRange3: result3,
+            },
+        },
+    },
+];
+
+jest.mock('hooks/useResizeObserver', () => ({
+    __esModule: true,
+    default: jest.fn().mockImplementation(jest.fn),
+}));
+
+beforeEach(() => {
+    jest.resetModules();
+});
+
+describe('AgingImages dashboard widget', () => {
+    it('should render the correct number of images with default settings', async () => {
+        renderWithRouter(
+            <MockedProvider mocks={mocks} addTypename={false}>
+                <AgingImages />
+            </MockedProvider>
+        );
+
+        // When all items are selected, the total should be equal to the most recent time
+        // range returned by the server
+        const cardHeading = await screen.findByRole('heading', {
+            name: `${result0} Aging images`,
+        });
+        expect(cardHeading).toBeInTheDocument();
+
+        // Each bar should display text that is specific to that time bucket, not
+        // cumulative.
+        expect(await screen.findByText(result0 - result1)).toBeInTheDocument();
+        expect(await screen.findByText(result1 - result2)).toBeInTheDocument();
+        expect(await screen.findByText(result2 - result3)).toBeInTheDocument();
+        expect(await screen.findByText(result3)).toBeInTheDocument();
+    });
+
+    it('should render graph bars with the correct image counts when time buckets are toggled', async () => {
+        const user = userEvent.setup();
+        renderWithRouter(
+            <MockedProvider mocks={mocks} addTypename={false}>
+                <AgingImages />
+            </MockedProvider>
+        );
+
+        await user.click(await screen.findByRole('button', { name: `Options` }));
+        const checkboxes = await screen.findAllByRole('checkbox');
+        expect(checkboxes).toHaveLength(4);
+
+        // Disable the first bucket
+        await user.click(checkboxes[0]);
+
+        // With the first item deselected, aging images < 90 days should no longer be present
+        // in the chart or the card header
+        expect(
+            await screen.findByRole('heading', {
+                name: `${result1} Aging images`,
+            })
+        ).toBeInTheDocument();
+
+        // Test values at top of each bar
+        expect(() => screen.getByText(result0 - result1)).toThrow();
+        expect(await screen.findByText(result1 - result2)).toBeInTheDocument();
+        expect(await screen.findByText(result2 - result3)).toBeInTheDocument();
+        expect(await screen.findByText(result3)).toBeInTheDocument();
+
+        // Test display of x-axis
+        expect(await screen.findByText(`${range1}-${range2} days`)).toBeInTheDocument();
+        expect(await screen.findByText(`${range2}-${range3} days`)).toBeInTheDocument();
+        expect(await screen.findByText(`>1 year`)).toBeInTheDocument();
+
+        await user.click(checkboxes[0]);
+        await user.click(checkboxes[2]);
+
+        // With the first item re-selected (regardless of the other selected items), the heading total
+        // should revert to the original value.
+        expect(
+            await screen.findByRole('heading', {
+                name: `${result0} Aging images`,
+            })
+        ).toBeInTheDocument();
+
+        expect(await screen.findByText(result0 - result1)).toBeInTheDocument();
+        // The second bar in the chart should now contain values from the second and third buckets
+        expect(await screen.findByText(result1 - result3)).toBeInTheDocument();
+        expect(() => screen.getByText(result2 - result3)).toThrow();
+        expect(await screen.findByText(result3)).toBeInTheDocument();
+
+        // Test display of x-axis
+        expect(await screen.findByText(`${range0}-${range1} days`)).toBeInTheDocument();
+        expect(await screen.findByText(`${range1}-${range3} days`)).toBeInTheDocument();
+        expect(await screen.findByText(`>1 year`)).toBeInTheDocument();
+    });
+});

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.tsx
@@ -1,0 +1,252 @@
+import React, { useReducer } from 'react';
+import {
+    Flex,
+    FlexItem,
+    Title,
+    Button,
+    Dropdown,
+    DropdownToggle,
+    Form,
+    FormGroup,
+    Checkbox,
+    TextInput,
+    ValidatedOptions,
+} from '@patternfly/react-core';
+import { useQuery, gql } from '@apollo/client';
+import cloneDeep from 'lodash/cloneDeep';
+import pluralize from 'pluralize';
+
+import LinkShim from 'Components/PatternFly/LinkShim';
+import useURLSearch from 'hooks/useURLSearch';
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { SearchFilter } from 'types/search';
+import { vulnManagementImagesPath } from 'routePaths';
+import { getQueryString } from 'utils/queryStringUtils';
+import WidgetCard from './WidgetCard';
+import AgingImagesChart, {
+    TimeRangeCounts,
+    TimeRangeTupleIndex,
+    TimeRangeTuple,
+    timeRangeTupleIndices,
+} from './AgingImagesChart';
+
+export const imageCountQuery = gql`
+    query agingImagesQuery($query0: String, $query1: String, $query2: String, $query3: String) {
+        timeRange0: imageCount(query: $query0)
+        timeRange1: imageCount(query: $query1)
+        timeRange2: imageCount(query: $query2)
+        timeRange3: imageCount(query: $query3)
+    }
+`;
+
+function queryStringFor(timeRangeValue: number, searchFilter: SearchFilter) {
+    return getRequestQueryStringForSearchFilter({
+        ...searchFilter,
+        'Image Created Time': `>${timeRangeValue}d`,
+    });
+}
+
+type QueryVariables = Record<`query${TimeRangeTupleIndex}`, string>;
+
+function getQueryVariables(timeRanges: TimeRangeTuple, searchFilter: SearchFilter): QueryVariables {
+    return {
+        query0: queryStringFor(timeRanges[0].value, searchFilter),
+        query1: queryStringFor(timeRanges[1].value, searchFilter),
+        query2: queryStringFor(timeRanges[2].value, searchFilter),
+        query3: queryStringFor(timeRanges[3].value, searchFilter),
+    };
+}
+
+// Gets the header string title for the widget based on applied filters and resulting counts
+function getWidgetTitle(
+    searchFilter: SearchFilter,
+    selectedTimeRanges: TimeRangeTuple,
+    timeRangeCounts?: TimeRangeCounts
+): string {
+    if (!timeRangeCounts) {
+        return 'Aging images';
+    }
+
+    const totalImages =
+        Object.values(timeRangeCounts).find((range, index) => {
+            return selectedTimeRanges[index].enabled;
+        }) ?? 0;
+
+    const isActiveImages = Boolean(searchFilter.Cluster) || Boolean(searchFilter['Namespace ID']);
+
+    if (isActiveImages) {
+        return `${totalImages} Active aging ${pluralize('image', totalImages)}`;
+    }
+    return `${totalImages} Aging ${pluralize('image', totalImages)}`;
+}
+
+const defaultTimeRanges: TimeRangeTuple = [
+    { enabled: true, value: 30 },
+    { enabled: true, value: 90 },
+    { enabled: true, value: 180 },
+    { enabled: true, value: 365 },
+];
+
+type TimeRangeAction =
+    | {
+          type: 'toggle';
+          index: TimeRangeTupleIndex;
+      }
+    | {
+          type: 'update';
+          index: TimeRangeTupleIndex;
+          value: number;
+      };
+
+function timeRangeReducer(state: TimeRangeTuple, action: TimeRangeAction) {
+    const nextState = cloneDeep(state);
+    switch (action.type) {
+        case 'toggle':
+            nextState[action.index].enabled = !nextState[action.index].enabled;
+            return nextState;
+        case 'update':
+            nextState[action.index].value = action.value;
+            return nextState;
+        default:
+            return nextState;
+    }
+}
+
+const maxTimeRange = 366;
+
+// Tests if a user entered value in the options menu is a valid number and falls within
+// the range of the previous and following time range values in the list.
+function isNumberInRange(timeRanges: TimeRangeTuple, index: TimeRangeTupleIndex): boolean {
+    const { value } = timeRanges[index];
+    const rangeValues = timeRanges.map((r) => r.value);
+    const lowerBounds = [0, ...rangeValues.slice(0, 3)];
+    const upperBounds = [...rangeValues.slice(1, 4), maxTimeRange];
+
+    return value > lowerBounds[index] && value < upperBounds[index];
+}
+
+const fieldIdPrefix = 'aging-images';
+// TODO searchFilter
+
+function getViewAllLink(searchFilter: SearchFilter) {
+    const queryString = getQueryString({
+        s: searchFilter,
+        sort: [{ id: 'Image Created Time', desc: 'false' }],
+    });
+    return `${vulnManagementImagesPath}${queryString}`;
+}
+
+function AgingImages() {
+    const { isOpen: isOptionsOpen, onToggle: toggleOptionsOpen } = useSelectToggle();
+    const { searchFilter } = useURLSearch();
+    const [timeRanges, dispatch] = useReducer(timeRangeReducer, defaultTimeRanges);
+
+    const variables = getQueryVariables(timeRanges, searchFilter);
+    const { data, previousData, loading, error } = useQuery<TimeRangeCounts>(imageCountQuery, {
+        variables,
+    });
+    const timeRangeCounts = data ?? previousData;
+
+    const inputError = timeRangeTupleIndices.some((index) => !isNumberInRange(timeRanges, index))
+        ? new Error('Invalid image ages')
+        : undefined;
+
+    return (
+        <WidgetCard
+            isLoading={loading && !timeRangeCounts}
+            error={error || inputError}
+            errorTitle={inputError && 'Incorrect image age values'}
+            errorMessage={
+                inputError &&
+                'There was an error retrieving data. Image ages must be in ascending order.'
+            }
+            header={
+                <Flex direction={{ default: 'row' }}>
+                    <FlexItem grow={{ default: 'grow' }}>
+                        <Title headingLevel="h2">
+                            {getWidgetTitle(searchFilter, timeRanges, timeRangeCounts)}
+                        </Title>
+                    </FlexItem>
+                    <FlexItem>
+                        <Dropdown
+                            className="pf-u-mr-sm"
+                            toggle={
+                                <DropdownToggle
+                                    id={`${fieldIdPrefix}-options-toggle`}
+                                    toggleVariant="secondary"
+                                    onToggle={toggleOptionsOpen}
+                                >
+                                    Options
+                                </DropdownToggle>
+                            }
+                            position="right"
+                            isOpen={isOptionsOpen}
+                        >
+                            <Form className="pf-u-px-md pf-u-py-sm">
+                                <FormGroup
+                                    fieldId={`${fieldIdPrefix}-time-range-0`}
+                                    label="Image age values"
+                                >
+                                    {timeRangeTupleIndices.map((index) => (
+                                        <div key={index}>
+                                            <Checkbox
+                                                aria-label="Toggle image time range"
+                                                id={`${fieldIdPrefix}-time-range-${index}`}
+                                                name={`${fieldIdPrefix}-time-range-${index}`}
+                                                className="pf-u-mb-sm pf-u-display-flex pf-u-align-items-center"
+                                                isChecked={timeRanges[index].enabled}
+                                                onChange={() => dispatch({ type: 'toggle', index })}
+                                                label={
+                                                    <TextInput
+                                                        aria-label="Image age in days"
+                                                        style={{ minWidth: '100px' }}
+                                                        onChange={(val) => {
+                                                            const value = parseInt(val, 10);
+                                                            if (!(value >= maxTimeRange)) {
+                                                                dispatch({
+                                                                    type: 'update',
+                                                                    index,
+                                                                    value,
+                                                                });
+                                                            }
+                                                        }}
+                                                        validated={
+                                                            isNumberInRange(timeRanges, index)
+                                                                ? ValidatedOptions.default
+                                                                : ValidatedOptions.error
+                                                        }
+                                                        max={maxTimeRange}
+                                                        type="number"
+                                                        value={timeRanges[index].value}
+                                                    />
+                                                }
+                                            />
+                                        </div>
+                                    ))}
+                                </FormGroup>
+                            </Form>
+                        </Dropdown>
+                        <Button
+                            variant="secondary"
+                            component={LinkShim}
+                            href={getViewAllLink(searchFilter)}
+                        >
+                            View All
+                        </Button>
+                    </FlexItem>
+                </Flex>
+            }
+        >
+            {timeRangeCounts && (
+                <AgingImagesChart
+                    searchFilter={searchFilter}
+                    timeRanges={timeRanges}
+                    timeRangeCounts={timeRangeCounts}
+                />
+            )}
+        </WidgetCard>
+    );
+}
+
+export default AgingImages;

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImagesChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImagesChart.tsx
@@ -1,0 +1,177 @@
+import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { Chart, ChartAxis, ChartBar, ChartLabelProps } from '@patternfly/react-charts';
+
+import useResizeObserver from 'hooks/useResizeObserver';
+import {
+    defaultChartHeight,
+    defaultChartBarWidth,
+    patternflySeverityTheme,
+    navigateOnClickEvent,
+    severityColorScale,
+} from 'utils/chartUtils';
+import { LinkableChartLabel } from 'Components/PatternFly/Charts/LinkableChartLabel';
+import { SearchFilter } from 'types/search';
+import { vulnManagementImagesPath } from 'routePaths';
+import { getQueryString } from 'utils/queryStringUtils';
+
+// The available time buckets for this widget will always be a set of '4', so we can
+// narrow the types to a tuple here for safer indexing throughout this component.
+export type TimeRange = { enabled: boolean; value: number };
+export type TimeRangeTuple = [TimeRange, TimeRange, TimeRange, TimeRange];
+export const timeRangeTupleIndices = [0, 1, 2, 3] as const;
+export type TimeRangeTupleIndex = typeof timeRangeTupleIndices[number];
+export type TimeRangeCounts = Record<`timeRange${TimeRangeTupleIndex}`, number>;
+
+export type ChartData = {
+    barData: { x: string; y: number }[];
+    labelLink: string;
+    labelText: string;
+    fill: string;
+};
+
+export type AgingImagesChartProps = {
+    searchFilter: SearchFilter;
+    timeRanges: TimeRangeTuple;
+    timeRangeCounts: TimeRangeCounts;
+};
+
+function linkForAgingImages(searchFilter: SearchFilter, ageRange: number) {
+    const queryString = getQueryString({
+        s: {
+            ...searchFilter,
+            'Image Created Time': `>${ageRange}d`,
+        },
+        sort: [{ id: 'Image Created Time', desc: 'false' }],
+    });
+    return `${vulnManagementImagesPath}${queryString}`;
+}
+
+function yAxisTitle(searchFilter: SearchFilter) {
+    const isActiveImages = Boolean(searchFilter.Cluster) || Boolean(searchFilter['Namespace ID']);
+
+    return isActiveImages ? 'Active images' : 'All images';
+}
+
+// `datum` for these callbacks will refer to the index number of the bar in the chart. This index
+// value matches the index of the target `ChartData` item passed to the chart component.
+const labelLinkCallback = ({ datum }: ChartLabelProps, chartData: ChartData[]) => {
+    return typeof datum === 'number' ? chartData[datum - 1].labelLink : '';
+};
+
+const labelTextCallback = ({ datum }: ChartLabelProps, chartData: ChartData[]) => {
+    return typeof datum === 'number' ? chartData[datum - 1].labelText : '';
+};
+
+/**
+ * Chart data is constructed from a 4-tuple of time range configurations and a data
+ * object that contains image counts for each of the four time ranges.
+ *
+ * Since the incoming data contains overlapping image counts for each time range, we need
+ * to process the data to group into buckets.
+ *
+ * The algorithm:
+ * - Iterating over each time range, starting from the shortest.
+ * - If the current time bucket is disabled, skip it.
+ * - Find the next enabled time bucket after the current one
+ * -- If one exists, subtract the count from the current bucket
+ * -- If not, this is the last bucket so leave the count as-is
+ * - Return the again image count, color, text, and link for this bucket
+ */
+function makeChartData(
+    searchFilter: SearchFilter,
+    timeRanges: TimeRangeTuple,
+    data: TimeRangeCounts
+): ChartData[] {
+    const chartData: ChartData[] = [];
+
+    timeRangeTupleIndices.forEach((index) => {
+        const { value, enabled } = timeRanges[index];
+
+        if (enabled) {
+            const nextEnabledRange = timeRanges.slice(index + 1).find((range) => range.enabled);
+            const nextEnabledIndex = timeRanges.findIndex((range) => range === nextEnabledRange);
+            const x = String(value);
+            const y =
+                nextEnabledIndex !== -1
+                    ? data[`timeRange${index}`] - data[`timeRange${nextEnabledIndex}`]
+                    : data[`timeRange${index}`];
+            const barData = [{ x, y }];
+            const fill = severityColorScale[index];
+            const labelLink = linkForAgingImages(searchFilter, value);
+            let labelText: string;
+            if (typeof nextEnabledRange === 'undefined') {
+                // This is the last time range bucket
+                labelText = value === 365 ? `>1 year` : `>${value} days`;
+            } else {
+                labelText = `${value}-${nextEnabledRange.value} days`;
+            }
+
+            chartData.push({ barData, fill, labelLink, labelText });
+        }
+    });
+
+    return chartData;
+}
+
+function AgingImagesChart({ searchFilter, timeRanges, timeRangeCounts }: AgingImagesChartProps) {
+    const history = useHistory();
+    const [widgetContainer, setWidgetContainer] = useState<HTMLDivElement | null>(null);
+    const widgetContainerResizeEntry = useResizeObserver(widgetContainer);
+    const chartData = makeChartData(searchFilter, timeRanges, timeRangeCounts);
+
+    return (
+        <div ref={setWidgetContainer}>
+            <Chart
+                ariaDesc="Aging images grouped by date of last update"
+                ariaTitle="Aging images"
+                animate={{ duration: 300 }}
+                domainPadding={{ x: [50, 50] }}
+                height={defaultChartHeight}
+                width={widgetContainerResizeEntry?.contentRect.width} // Victory defaults to 450
+                padding={{
+                    top: 25,
+                    left: 55,
+                    right: 10,
+                    bottom: 60,
+                }}
+                theme={patternflySeverityTheme}
+            >
+                <ChartAxis
+                    label="Image age"
+                    tickLabelComponent={
+                        <LinkableChartLabel
+                            linkWith={(props) => labelLinkCallback(props, chartData)}
+                            text={(props) => labelTextCallback(props, chartData)}
+                        />
+                    }
+                />
+                <ChartAxis
+                    label={yAxisTitle(searchFilter)}
+                    padding={{ bottom: 10 }}
+                    dependentAxis
+                    showGrid
+                />
+                {chartData.map(({ barData, fill }) => {
+                    return (
+                        <ChartBar
+                            key={fill}
+                            barWidth={defaultChartBarWidth}
+                            data={barData}
+                            labels={({ datum }) => `${Math.round(parseInt(datum.y, 10))}`}
+                            style={{ data: { fill } }}
+                            events={[
+                                navigateOnClickEvent(history, (targetProps) => {
+                                    const range = targetProps?.datum?.xName;
+                                    return linkForAgingImages(searchFilter, range);
+                                }),
+                            ]}
+                        />
+                    );
+                })}
+            </Chart>
+        </div>
+    );
+}
+
+export default AgingImagesChart;

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetCard.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetCard.tsx
@@ -6,22 +6,31 @@ import WidgetErrorEmptyState from './WidgetErrorEmptyState';
 
 type WidgetCardProps = {
     isLoading: boolean;
-    error: Error | null;
+    error?: Error;
+    errorTitle?: string;
+    errorMessage?: string;
     header: ReactNode;
     children: ReactNode;
 };
 
 const height = `${defaultChartHeight}px` as const;
 
-function WidgetCard({ isLoading, error, header, children }: WidgetCardProps) {
+function WidgetCard({
+    isLoading,
+    error,
+    errorTitle,
+    errorMessage,
+    header,
+    children,
+}: WidgetCardProps) {
     let cardContent: ReactNode;
 
     if (isLoading && !error) {
         cardContent = <Skeleton height={height} screenreaderText="Loading widget data" />;
     } else if (error) {
         cardContent = (
-            <WidgetErrorEmptyState height={height} title="Unable to load data">
-                There was an error loading data for this widget
+            <WidgetErrorEmptyState height={height} title={errorTitle || 'Unable to load data'}>
+                {errorMessage || 'There was an error loading data for this widget'}
             </WidgetErrorEmptyState>
         );
     } else {

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/hooks/useRestQuery.ts
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/hooks/useRestQuery.ts
@@ -4,7 +4,7 @@ import { CancellableRequest } from 'services/cancellationUtils';
 export type UseRestQueryReturn<ReturnType> = {
     data: ReturnType | undefined;
     loading: boolean;
-    error: Error | null;
+    error: Error | undefined;
 };
 
 export default function useRestQuery<ReturnType>(
@@ -12,18 +12,18 @@ export default function useRestQuery<ReturnType>(
 ): UseRestQueryReturn<ReturnType> {
     const [data, setData] = useState<ReturnType>();
     const [loading, setLoading] = useState<boolean>(true);
-    const [error, setError] = useState<Error | null>(null);
+    const [error, setError] = useState<Error | undefined>();
 
     useEffect(() => {
         const { request, cancel } = cancellableRequestFn();
 
-        setError(null);
+        setError(undefined);
 
         request
             .then((result) => {
                 setData(result);
                 setLoading(false);
-                setError(null);
+                setError(undefined);
             })
             .catch((err) => {
                 setLoading(true);

--- a/ui/apps/platform/src/utils/chartUtils.ts
+++ b/ui/apps/platform/src/utils/chartUtils.ts
@@ -4,7 +4,7 @@ import { EventCallbackInterface, EventPropTypeInterface } from 'victory-core';
 
 import { severityColors } from 'constants/visuals/colors';
 
-const severityColorScale = Object.values(severityColors);
+export const severityColorScale = Object.values(severityColors);
 
 // Clone default PatternFly chart themes
 const defaultTheme = getTheme(ChartThemeColor.multi);

--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -51,7 +51,7 @@
         "@stackrox/tailwind-config": "^0.2.0",
         "@testing-library/jest-dom": "^5.15.0",
         "@testing-library/react": "^12.1.2",
-        "@testing-library/user-event": "^13.5.0",
+        "@testing-library/user-event": "^14.2.1",
         "@types/lodash": "^4.14.176",
         "@types/node": "^17.0.16",
         "@types/react": "^17.0.34",

--- a/ui/packages/ui-components/src/HelpIcon/HelpIcon.test.tsx
+++ b/ui/packages/ui-components/src/HelpIcon/HelpIcon.test.tsx
@@ -5,12 +5,12 @@ import userEvent from '@testing-library/user-event';
 import HelpIcon from './HelpIcon';
 
 describe('HelpIcon', () => {
-    test('show the help description', () => {
+    test('show the help description', async () => {
         render(<HelpIcon description="Remember to wash your hands" />);
 
         expect(screen.queryByText('Remember to wash your hands')).not.toBeInTheDocument();
 
-        userEvent.hover(screen.getByTestId('help-icon'));
+        await userEvent.hover(screen.getByTestId('help-icon'));
 
         expect(screen.getByText('Remember to wash your hands')).toBeInTheDocument();
     });

--- a/ui/packages/ui-components/src/ToggleButtonGroup/ToggleButtonGroup.test.tsx
+++ b/ui/packages/ui-components/src/ToggleButtonGroup/ToggleButtonGroup.test.tsx
@@ -26,12 +26,12 @@ describe('ToggleButtonGroup', () => {
         expect(container).toMatchSnapshot();
     });
 
-    test('toggles the active button when clicking the inactive button', () => {
+    test('toggles the active button when clicking the inactive button', async () => {
         render(<Component />);
 
         expect(screen.getByTestId('active-toggle-button')).toHaveTextContent('Lock');
 
-        userEvent.click(screen.getByText('Unlock'));
+        await userEvent.click(screen.getByText('Unlock'));
 
         expect(screen.getByTestId('active-toggle-button')).toHaveTextContent('Unlock');
     });

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3346,12 +3346,10 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
 
-"@testing-library/user-event@^13.5.0":
-  version "13.5.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
-  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
+"@testing-library/user-event@^14.2.1":
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.2.1.tgz#8c5ff2d004544bb2220e1d864f7267fe7eb6c556"
+  integrity sha512-HOr1QiODrq+0j9lKU5i10y9TbhxMBMRMGimNx10asdmau9cb8Xb1Vyg0GvTwyIL2ziQyh2kAloOtAQFBQVuecA==
 
 "@tippyjs/react@^4.2.5":
   version "4.2.5"


### PR DESCRIPTION
## Description

Adds an "Aging Images" widget to the dashboard. This widget displays the number of images that have an age range corresponding to one of four age range "buckets". Note that these buckets do not overlap, which is in contrast with the data that is returned from the server API, hence the amount of processing that needs to happen client side before display.

Users are able to customize the date ranges (maximum value of one year) and disable individual ranges.

## Additional notes

- [ ] TODO - Announce on team channel when this is merged so team can run `yarn` in repo root, otherwise unit tests will fail.
- Viswa is working [an extension of the query language](https://github.com/stackrox/stackrox/pull/2159) that will make the outbounds links to the Vuln Mgmt image page work correct as well as simplify the querying and client side processing that is done to group the counts into buckets. I'll put out a follow up PR when both of these are merged that uses the new API.
- I've used Jest/React Testing Library in this PR for a couple of reasons. IMO it is quicker to iterate and run tests and less prone to flakes when the browser/network combo is removed. The trade off being that we need to mock API requests which adds a little bit of verbosity. In think in the case of these dashboard widgets it is worthwhile since we aren't interacting with the server other than to pull data, and would otherwise be at the mercy of whatever data the CI system happens to have at the time tests run. 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added


## Testing Performed

On page load, the aging images data should be grouped into buckets. The total count displayed in the title should match the sum of all bars in the graph.
<img width="660" alt="image" src="https://user-images.githubusercontent.com/1292638/174886746-de2b6448-44a0-4030-aae0-21b7dcd0a408.png">

Open the option menu and disabled the first option. The grey bar should disappear and the widget title should update to reflect the new totals.
<img width="660" alt="image" src="https://user-images.githubusercontent.com/1292638/174886876-090e22cd-25fa-46ca-8220-fe5e4da3cb75.png">

Disabled the third option in the menu. The orange bar should disappear and the image counts for the yellow and orange bars should be summed in the yellow bar.
<img width="660" alt="image" src="https://user-images.githubusercontent.com/1292638/174887021-c7e76a76-3ebd-4114-acdc-2e529347ffb7.png">

Update the value of one of the inputs. The total image counts should update to reflect the new date ranges.
<img width="660" alt="image" src="https://user-images.githubusercontent.com/1292638/174887165-550bcc58-e4bf-43b3-9fa8-a6efc35f220a.png">

Update the value of one of the inputs so that the values in the options menu are no longer in ascending order. The graph should display an error and there should be an inline error state for the individual inputs.
<img width="660" alt="image" src="https://user-images.githubusercontent.com/1292638/174887307-72557a0a-0c1c-461e-844f-b3ff1139a930.png">

Update the values of the text inputs. The x-axis links should update to reflect the new date ranges.
<img width="660" alt="image" src="https://user-images.githubusercontent.com/1292638/174887453-a675a43b-0233-4d2c-a550-0fbd9f953c65.png">

Click one of the links in the x-axis labels. You should be take to the Vuln Mgmt image page with a pre-applied image age filter. The resulting table should also be sorted with oldest images first.
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/174887633-03b8cb50-a7ad-427f-8a32-1675e9b877a9.png">

Repeat this process by clicking on one of the bars in the graph.

Test that the "View All" link button takes you to the Vuln Mgmt image page with no filters applied, with images sorted by oldest age first.
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/174887833-88c93434-836e-4d3c-8864-9d30eceffa80.png">

Test that links from the widget also apply any selected cluster and namespace filters.
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/174888718-9cfd1953-eb3f-4167-b804-a3c486640eb2.png">

