### PR TITLE
Move mark_collector_release support to OSCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4116,21 +4116,6 @@ jobs:
   # Post-build jobs to handle built artifacts (like tag, scan and publish images)
   ###
 
-  mark-collector-release:
-    executor: custom
-    resource_class: small
-    steps:
-      - checkout
-      - add_ssh_keys:
-          fingerprints:
-            - "7f:08:58:1e:80:80:6e:66:99:9a:37:cb:e9:96:0b:40"
-
-      - run:
-          name: Open a collector PR to add this release to RELEASED_VERSIONS
-          command: |
-            source scripts/ci/lib.sh
-            mark_collector_release "${CIRCLE_TAG}" "${CIRCLE_USERNAME}"
-
   push-release:
     executor: custom
     resource_class: small
@@ -4799,14 +4784,6 @@ workflows:
           <<: *runOnAllTagsWithQuayIOPullCtx
           requires:
             - pre-build-cli
-      - mark-collector-release:
-          <<: *runOnlyOnReleaseBuilds
-          context:
-            - custom-executor-pull
-          requires:
-            - build-stackrox
-            - build-rhacs
-            - push-release
 
       - provision-openshift-rosa-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx

--- a/scripts/ci/jobs/release-mgmt.sh
+++ b/scripts/ci/jobs/release-mgmt.sh
@@ -8,12 +8,16 @@ set -euo pipefail
 release_mgmt() {
     info "Release management steps"
 
-    local release_issues=()
-
     local tag
     tag="$(make --quiet tag)"
 
     slack_build_notice "$tag"
+
+    if is_release_version "$tag"; then
+        mark_collector_release "$tag"
+    fi
+
+    local release_issues=()
 
     if is_RC_version "${tag}" && ! check_docs "${tag}"; then
         release_issues+=("docs/ is not valid for a release.")


### PR DESCRIPTION
## Description

Per title.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested on release-0.1.x branch. 
- [OSCI](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/branch-ci-stackrox-stackrox-release-0.1.x-merge-release-mgmt/1539388253348564992/artifacts/merge-release-mgmt/stackrox-initial/build-log.txt) 
- Collector PR opened: https://github.com/stackrox/collector/pull/736