### PR TITLE
Adds -rcX support for collector probe versions.

### DIFF
--- a/pkg/probeupload/names.go
+++ b/pkg/probeupload/names.go
@@ -3,7 +3,7 @@ package probeupload
 import "regexp"
 
 var (
-	moduleNameRegexStr = `(?:[0-9a-f]{64}|\d+\.\d+\.\d+)`
+	moduleNameRegexStr = `(?:[0-9a-f]{64}|\d+\.\d+\.\d+(?:-rc\d+)?)`
 	moduleNameRegex    = regexp.MustCompile(`^` + moduleNameRegexStr + `$`)
 
 	probeNameRegexStr = `collector-(?:ebpf-\d+\.[^/]+\.o|\d+\.[^/]+\.ko)\.gz`

--- a/pkg/probeupload/names_test.go
+++ b/pkg/probeupload/names_test.go
@@ -19,6 +19,8 @@ func TestIsValidModuleVersion_Valid(t *testing.T) {
 		"0.0.1",
 		"1.2.3",
 		"10.5.155",
+		"1.0.0-rc1",
+		"2.3.4-rc123",
 	}
 
 	for _, v := range values {
@@ -35,6 +37,8 @@ func TestIsValidModuleVersion_Invalid(t *testing.T) {
 		".2.3",
 		"2.3.",
 		"10.5.155.123",
+		"1.0.0-rc",
+		"2.0.0-invalid",
 		"latest",
 		"1123dde0458e72a49880b06922e135dbcd36fb784fed530ab84ddfa8924e5c050",
 		"95eb0815c4e7b59e0e5d0e53adb1a4",

--- a/pkg/probeupload/names_test.go
+++ b/pkg/probeupload/names_test.go
@@ -39,6 +39,8 @@ func TestIsValidModuleVersion_Invalid(t *testing.T) {
 		"10.5.155.123",
 		"1.0.0-rc",
 		"2.0.0-invalid",
+		"1.0.0-rc1-rc4",
+		"2.0.0-rc1invalid",
 		"latest",
 		"1123dde0458e72a49880b06922e135dbcd36fb784fed530ab84ddfa8924e5c050",
 		"95eb0815c4e7b59e0e5d0e53adb1a4",


### PR DESCRIPTION
## Description

To support new MODULE_VERSION strategy in collector, this adds support for release candidate (`rcX`) versions in sensor.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Added new unit test cases for release candidate versions, and tested locally end-to-end with a COLLECTOR_VERSION that contains a release candidate version. Note that until an rc version is merged to collector master, that version is not available for download (i.e. this process does not work with in-progress PRs) 
