### PR TITLE
ROX-11442: Increase default roxctl timeout

### DIFF
--- a/roxctl/common/flags/timeout.go
+++ b/roxctl/common/flags/timeout.go
@@ -18,7 +18,7 @@ func AddTimeoutWithDefault(c *cobra.Command, defaultDuration time.Duration) {
 
 // AddTimeout adds a timeout flag to the given command, with the global default value.
 func AddTimeout(c *cobra.Command) {
-	AddTimeoutWithDefault(c, 10*time.Second)
+	AddTimeoutWithDefault(c, 30*time.Second)
 }
 
 // Timeout returns the set timeout.


### PR DESCRIPTION
The timeout has been hit in this [CI flake](https://issues.redhat.com/browse/ROX-11442).
The root cause of the timeout is hard to find because the issue is not
reproduced in subsequent CI runs. To decrease the probability of
further issues, the default timeout is increased to 30 seconds. I
believe this is still a reasonable value for roxctl commands.


## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

* CI