### PR TITLE
Support range queries for numeric fields

### DIFF
--- a/pkg/search/blevesearch/numeric_query_test.go
+++ b/pkg/search/blevesearch/numeric_query_test.go
@@ -7,6 +7,11 @@ import (
 	"github.com/blevesearch/bleve"
 	"github.com/blevesearch/bleve/search/query"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	fakeFieldName = "blah"
 )
 
 func TestParseNumericPrefix(t *testing.T) {
@@ -59,56 +64,101 @@ func TestNumberDelta(t *testing.T) {
 			name:     fmt.Sprintf("less than %v", num1),
 			value:    floatPtr(num1),
 			prefix:   "<",
-			expected: getExpectedNumericQuery("blah", nil, floatPtr(num1-delta), nil, boolPtr(false)),
+			expected: getExpectedNumericQuery(nil, floatPtr(num1-delta), nil, boolPtr(false)),
 		},
 		{
 			name:     fmt.Sprintf("less than or equals to %v", num1),
 			value:    floatPtr(num1),
 			prefix:   "<=",
-			expected: getExpectedNumericQuery("blah", nil, floatPtr(num1+delta), nil, boolPtr(true)),
+			expected: getExpectedNumericQuery(nil, floatPtr(num1+delta), nil, boolPtr(true)),
 		},
 		{
 			name:     fmt.Sprintf("equals to %v", num1),
 			value:    floatPtr(num1),
 			prefix:   "=",
-			expected: getExpectedNumericQuery("blah", floatPtr(num1-delta), floatPtr(num1+delta), boolPtr(true), boolPtr(true)),
+			expected: getExpectedNumericQuery(floatPtr(num1-delta), floatPtr(num1+delta), boolPtr(true), boolPtr(true)),
 		},
 		{
 			name:     fmt.Sprintf("equals to %v", num2),
 			value:    floatPtr(num2),
 			prefix:   "=",
-			expected: getExpectedNumericQuery("blah", floatPtr(num2-delta), floatPtr(num2+delta), boolPtr(true), boolPtr(true)),
+			expected: getExpectedNumericQuery(floatPtr(num2-delta), floatPtr(num2+delta), boolPtr(true), boolPtr(true)),
 		},
 		{
 			name:     fmt.Sprintf("greater than or equals to %v", num1),
 			value:    floatPtr(num1),
 			prefix:   ">=",
-			expected: getExpectedNumericQuery("blah", floatPtr(num1-delta), nil, boolPtr(true), nil),
+			expected: getExpectedNumericQuery(floatPtr(num1-delta), nil, boolPtr(true), nil),
 		},
 		{
 			name:     fmt.Sprintf("greater than to %v", num2),
 			value:    floatPtr(num2),
 			prefix:   ">",
-			expected: getExpectedNumericQuery("blah", floatPtr(float64(num2+delta)), nil, boolPtr(false), nil),
+			expected: getExpectedNumericQuery(floatPtr(float64(num2+delta)), nil, boolPtr(false), nil),
 		},
 		{
 			name:     "no value",
 			value:    nil,
 			prefix:   ">=",
-			expected: getExpectedNumericQuery("blah", nil, nil, boolPtr(true), nil),
+			expected: getExpectedNumericQuery(nil, nil, boolPtr(true), nil),
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual := createNumericQuery("blah", c.prefix, c.value)
+			actual := createNumericQuery(fakeFieldName, c.prefix, c.value)
 			assert.Equal(t, c.expected, actual)
 		})
 	}
 }
 
-func getExpectedNumericQuery(field string, min, max *float64, minInclusive, maxInclusive *bool) query.Query {
+func TestCreateNumericQuery(t *testing.T) {
+	cases := []struct {
+		value     string
+		expectErr bool
+		expected  query.Query
+	}{
+		{
+			value:    "-1",
+			expected: getExpectedNumericQuery(floatPtr(-1), floatPtr(-1), boolPtr(true), boolPtr(true)),
+		},
+		{
+			value:     "-1--2",
+			expectErr: true,
+		},
+		{
+			value:    "-2--1",
+			expected: getExpectedNumericQuery(floatPtr(-2), floatPtr(-1), boolPtr(false), boolPtr(false)),
+		},
+		{
+			value:    "-2-1",
+			expected: getExpectedNumericQuery(floatPtr(-2), floatPtr(1), boolPtr(false), boolPtr(false)),
+		},
+		{
+			value:     "1-1",
+			expectErr: true,
+		},
+		{
+			value:     "2-1",
+			expectErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.value, func(t *testing.T) {
+			actual, err := newNumericQuery(0, "blah", c.value)
+			if c.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, c.expected, actual)
+		})
+	}
+}
+
+func getExpectedNumericQuery(min, max *float64, minInclusive, maxInclusive *bool) query.Query {
 	q := bleve.NewNumericRangeInclusiveQuery(min, max, minInclusive, maxInclusive)
-	q.SetField(field)
+	q.SetField(fakeFieldName)
 	return q
 }

--- a/pkg/search/blevesearch/time_query.go
+++ b/pkg/search/blevesearch/time_query.go
@@ -16,12 +16,15 @@ const (
 	dayDuration = 24 * time.Hour
 )
 
-func newTimeQuery(_ v1.SearchCategory, field string, value string, modifiers ...queryModifier) (query.Query, error) {
+func newTimeQuery(_ v1.SearchCategory, field string, value string, _ ...queryModifier) (query.Query, error) {
+	return newTimeQueryHelper(time.Now(), field, value)
+}
+
+func newTimeQueryHelper(now time.Time, field, value string) (query.Query, error) {
 	prefix, trimmedValue := parseNumericPrefix(value)
-	var seconds int64
 	if t, ok := parseTimeString(trimmedValue); ok {
 		// Adjust for the timezone offset when comparing
-		seconds = t.Unix() - timeutil.TimeToOffset(t)
+		seconds := t.Unix() - timeutil.TimeToOffset(t)
 
 		// If the date query is a singular date with no prefix, then need to create a numeric query with the min = date. max = date + 1
 		if prefix == "" {
@@ -29,24 +32,65 @@ func newTimeQuery(_ v1.SearchCategory, field string, value string, modifiers ...
 			q.SetField(field)
 			return q, nil
 		}
-	} else if d, ok := parseDuration(trimmedValue); ok {
-		seconds = time.Now().Add(-d).Unix()
+		return timeQueryWithSeconds(field, prefix, seconds), nil
+	}
+
+	lower, upper, err := maybeParseDurationAsRange(trimmedValue)
+	if err == nil {
+		q := bleve.NewNumericRangeInclusiveQuery(
+			floatPtr(float64(now.Add(-upper).Unix())), floatPtr(float64(now.Add(-lower).Unix())), boolPtr(false), boolPtr(false),
+		)
+		q.SetField(field)
+		return q, nil
+	} else if err != errNotARange {
+		return nil, errors.Wrapf(err, "tried to parse %s as a range, but it was not valid", value)
+	}
+
+	if d, ok := parseDuration(trimmedValue); ok {
 		// Invert the prefix in a duration query, since if someone queries for >=3d
 		// they mean more than 3 days ago, which means the timestamp should be
-		// < the timestamp of 3 days ago.
-		prefix = invertNumericPrefix(prefix)
-	} else {
-		return nil, errors.New("Invalid time query. Must be of the format (01/02/2006 or 1d)")
+		// <= the timestamp of 3 days ago.
+		return timeQueryWithSeconds(field, invertNumericPrefix(prefix), now.Add(-d).Unix()), nil
 	}
-	floatSeconds := float64(seconds)
-	return createNumericQuery(field, prefix, &floatSeconds), nil
+	return nil, errors.New("Invalid time query. Must be of the format (01/02/2006 or 1d)")
+}
+
+func timeQueryWithSeconds(field, prefix string, seconds int64) query.Query {
+	return createNumericQuery(field, prefix, floatPtr(float64(seconds)))
+}
+
+func maybeParseDurationAsRange(value string) (lower, upper time.Duration, err error) {
+	// Split the value into two parts, separated by a hyphen.
+	// We need to be careful to ensure that we don't mistake
+	// hyphens for minus signs.
+	for i, char := range value {
+		if i == 0 {
+			continue
+		}
+		if char == '-' {
+			var valid bool
+			lower, valid = parseDuration(value[:i])
+			if !valid {
+				return 0, 0, errNotARange
+			}
+			upper, valid = parseDuration(value[i+1:])
+			if !valid {
+				return 0, 0, errNotARange
+			}
+			if lower >= upper {
+				return 0, 0, errors.Errorf("invalid range %s (first value must be strictly less than the second)", value)
+			}
+			return lower, upper, nil
+		}
+	}
+	return 0, 0, errNotARange
 }
 
 func parseDuration(d string) (time.Duration, bool) {
 	d = strings.TrimSuffix(d, "d")
 	days, err := strconv.ParseInt(d, 10, 32)
 	if err != nil {
-		return time.Second, false
+		return 0, false
 	}
 	return time.Duration(days) * dayDuration, true
 }

--- a/pkg/search/blevesearch/time_query_test.go
+++ b/pkg/search/blevesearch/time_query_test.go
@@ -116,37 +116,6 @@ func floatToTime(val float64) time.Time {
 	return time.Unix(int64(seconds), nanos)
 }
 
-func TestParseDuration(t *testing.T) {
-	var cases = []struct {
-		value    string
-		duration time.Duration
-		valid    bool
-	}{
-		{
-			value:    "1",
-			duration: 24 * 60 * 60 * time.Second,
-			valid:    true,
-		},
-		{
-			value:    "1d",
-			duration: 24 * 60 * 60 * time.Second,
-			valid:    true,
-		},
-		{
-			value:    "lol",
-			duration: time.Second,
-			valid:    false,
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.value, func(t *testing.T) {
-			duration, valid := parseDuration(c.value)
-			require.Equal(t, c.valid, valid)
-			assert.Equal(t, c.duration, duration)
-		})
-	}
-}
-
 func TestTimeQuery(t *testing.T) {
 	fakeNow := timeutil.MustParse(time.RFC3339, "2022-06-24T12:00:00Z")
 	float1dayLater := float64(fakeNow.Add(24 * time.Hour).Unix())

--- a/pkg/search/blevesearch/time_query_test.go
+++ b/pkg/search/blevesearch/time_query_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/blevesearch/bleve/search/query"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/timeutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -144,4 +145,81 @@ func TestParseDuration(t *testing.T) {
 			assert.Equal(t, c.duration, duration)
 		})
 	}
+}
+
+func TestTimeQuery(t *testing.T) {
+	fakeNow := timeutil.MustParse(time.RFC3339, "2022-06-24T12:00:00Z")
+	float1dayLater := float64(fakeNow.Add(24 * time.Hour).Unix())
+	float1dayAgo := float64(fakeNow.Add(-24 * time.Hour).Unix())
+	float10daysAgo := float64(fakeNow.Add(-10 * 24 * time.Hour).Unix())
+	cases := []struct {
+		value                string
+		expectErr            bool
+		expectedMin          *float64
+		expectedMax          *float64
+		expectedInclusiveMin *bool
+		expectedInclusiveMax *bool
+	}{
+		{
+			value:                "1",
+			expectedMin:          &float1dayAgo,
+			expectedMax:          &float1dayAgo,
+			expectedInclusiveMin: boolPtr(true),
+			expectedInclusiveMax: boolPtr(true),
+		},
+		{
+			value:                "1d",
+			expectedMin:          &float1dayAgo,
+			expectedMax:          &float1dayAgo,
+			expectedInclusiveMin: boolPtr(true),
+			expectedInclusiveMax: boolPtr(true),
+		},
+		{
+			value:     ">lol",
+			expectErr: true,
+		},
+		{
+			value:                ">1",
+			expectedMax:          &float1dayAgo,
+			expectedInclusiveMax: boolPtr(true),
+		},
+		{
+			value:                "1-10",
+			expectedMax:          &float1dayAgo,
+			expectedInclusiveMax: boolPtr(false),
+			expectedMin:          &float10daysAgo,
+			expectedInclusiveMin: boolPtr(false),
+		},
+		{
+			value:                "1d-10d",
+			expectedMax:          &float1dayAgo,
+			expectedInclusiveMax: boolPtr(false),
+			expectedMin:          &float10daysAgo,
+			expectedInclusiveMin: boolPtr(false),
+		},
+		{
+			value:                "-1d-10d",
+			expectedMax:          &float1dayLater,
+			expectedInclusiveMax: boolPtr(false),
+			expectedMin:          &float10daysAgo,
+			expectedInclusiveMin: boolPtr(false),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.value, func(t *testing.T) {
+			actual, err := newTimeQueryHelper(fakeNow, fakeFieldName, c.value)
+			if c.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			actualTyped := actual.(*query.NumericRangeQuery)
+			assert.Equal(t, fakeFieldName, actualTyped.FieldVal)
+			assert.Equal(t, c.expectedMax, actualTyped.Max)
+			assert.Equal(t, c.expectedMin, actualTyped.Min)
+			assert.Equal(t, c.expectedInclusiveMax, actualTyped.InclusiveMax)
+			assert.Equal(t, c.expectedInclusiveMin, actualTyped.InclusiveMin)
+		})
+	}
+
 }

--- a/pkg/search/postgres/index_test.go
+++ b/pkg/search/postgres/index_test.go
@@ -558,7 +558,6 @@ func (s *IndexSuite) TestTime() {
 	testStruct2020Mar09Noon := s.getStruct(4, func(s *storage.TestMultiKeyStruct) {
 		s.Timestamp = ts2020Mar09Noon
 	})
-	_ = testStruct2029Mar09Noon
 
 	s.runTestCases([]testCase{
 		{
@@ -585,6 +584,16 @@ func (s *IndexSuite) TestTime() {
 			desc:            "> duration (this test will fail in 2029, but hopefully it's not still being run then)",
 			q:               search.NewQueryBuilder().AddStrings(search.TestTimestamp, "> 1d").ProtoQuery(),
 			expectedResults: []*storage.TestMultiKeyStruct{testStruct2021Mar09Noon, testStruct2020Mar09Noon, testStruct2022Feb09Noon, testStruct2022Mar09Noon},
+		},
+		{
+			desc:            "range duration (this test will fail in 2027, but hopefully it's not still being run then)",
+			q:               search.NewQueryBuilder().AddStrings(search.TestTimestamp, "1d-2500d").ProtoQuery(),
+			expectedResults: []*storage.TestMultiKeyStruct{testStruct2021Mar09Noon, testStruct2020Mar09Noon, testStruct2022Feb09Noon, testStruct2022Mar09Noon},
+		},
+		{
+			desc:            "range duration with negative (this test will fail in 2029, but hopefully it's not still being run then)",
+			q:               search.NewQueryBuilder().AddStrings(search.TestTimestamp, "-3000d-1d").ProtoQuery(),
+			expectedResults: []*storage.TestMultiKeyStruct{testStruct2029Mar09Noon},
 		},
 	})
 }

--- a/pkg/search/postgres/index_test.go
+++ b/pkg/search/postgres/index_test.go
@@ -405,6 +405,26 @@ func (s *IndexSuite) TestFloat() {
 			q:               search.NewQueryBuilder().AddStrings(search.TestFloat, ">=-2").ProtoQuery(),
 			expectedResults: []*storage.TestMultiKeyStruct{testStruct0, testStruct1},
 		},
+		{
+			desc:            "range (none matching)",
+			q:               search.NewQueryBuilder().AddStrings(search.TestFloat, "-2-5").ProtoQuery(),
+			expectedResults: []*storage.TestMultiKeyStruct{},
+		},
+		{
+			desc:            "range + exact match",
+			q:               search.NewQueryBuilder().AddStrings(search.TestFloat, "-2-5", "-2").ProtoQuery(),
+			expectedResults: []*storage.TestMultiKeyStruct{testStruct0},
+		},
+		{
+			desc:            "range matches one",
+			q:               search.NewQueryBuilder().AddStrings(search.TestFloat, "5-8").ProtoQuery(),
+			expectedResults: []*storage.TestMultiKeyStruct{testStruct1},
+		},
+		{
+			desc:            "range matches both",
+			q:               search.NewQueryBuilder().AddStrings(search.TestFloat, "-5-8").ProtoQuery(),
+			expectedResults: []*storage.TestMultiKeyStruct{testStruct0, testStruct1},
+		},
 	})
 }
 

--- a/pkg/search/postgres/query/common.go
+++ b/pkg/search/postgres/query/common.go
@@ -1,6 +1,8 @@
 package pgsearch
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/walker"
@@ -77,7 +79,7 @@ func NewTrueQuery() *QueryEntry {
 }
 
 // MatchFieldQuery is a simple query that performs operations on a single field.
-func MatchFieldQuery(dbField *walker.Field, value string, highlight bool) (*QueryEntry, error) {
+func MatchFieldQuery(dbField *walker.Field, value string, highlight bool, now time.Time) (*QueryEntry, error) {
 	if dbField == nil {
 		return nil, nil
 	}
@@ -89,5 +91,5 @@ func MatchFieldQuery(dbField *walker.Field, value string, highlight bool) (*Quer
 	if !ok {
 		return nil, nil
 	}
-	return matchFieldQuery(dbField, field, value, highlight)
+	return matchFieldQuery(dbField, field, value, highlight, now)
 }

--- a/pkg/search/postgres/query/enum_query.go
+++ b/pkg/search/postgres/query/enum_query.go
@@ -106,7 +106,7 @@ func newEnumQueryWhereClause(columnName string, field *pkgSearch.Field, value st
 		var values []interface{}
 		var equivalentGoFuncs []func(interface{}) bool
 		for _, s := range enumValues {
-			entry := createNumericQuery(columnName, prefix, float64(s))
+			entry := createNumericPrefixQuery(columnName, prefix, float64(s))
 			queries = append(queries, entry.Query)
 			values = append(values, entry.Values...)
 			equivalentGoFuncs = append(equivalentGoFuncs, entry.equivalentGoFunc)

--- a/pkg/search/postgres/query/query_functions.go
+++ b/pkg/search/postgres/query/query_functions.go
@@ -2,6 +2,7 @@ package pgsearch
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	pkgSearch "github.com/stackrox/rox/pkg/search"
@@ -16,6 +17,8 @@ type queryAndFieldContext struct {
 	value          string
 	highlight      bool
 	queryModifiers []pkgSearch.QueryModifier
+
+	now time.Time
 }
 
 func qeWithSelectFieldIfNeeded(ctx *queryAndFieldContext, whereClause *WhereClause, postTransformFunc func(interface{}) interface{}) *QueryEntry {
@@ -46,7 +49,7 @@ var datatypeToQueryFunc = map[walker.DataType]queryFunction{
 	// Map is handled separately.
 }
 
-func matchFieldQuery(dbField *walker.Field, field *pkgSearch.Field, value string, highlight bool) (*QueryEntry, error) {
+func matchFieldQuery(dbField *walker.Field, field *pkgSearch.Field, value string, highlight bool, now time.Time) (*QueryEntry, error) {
 	qualifiedColName := dbField.Schema.Table + "." + dbField.ColumnName
 
 	ctx := &queryAndFieldContext{
@@ -55,6 +58,7 @@ func matchFieldQuery(dbField *walker.Field, field *pkgSearch.Field, value string
 		dbField:             dbField,
 		highlight:           highlight,
 		value:               value,
+		now:                 now,
 	}
 
 	// Special case: wildcard

--- a/pkg/search/postgres/query/time_query.go
+++ b/pkg/search/postgres/query/time_query.go
@@ -19,7 +19,6 @@ func newTimeQuery(ctx *queryAndFieldContext) (*QueryEntry, error) {
 		return nil, errors.New("modifiers not supported for time query")
 	}
 	prefix, trimmedValue := parseNumericPrefix(ctx.value)
-	var formattedTime string
 	if t, ok := parseTimeString(trimmedValue); ok {
 		// If the date query is a singular datetime with no prefix, then need to create a numeric query with the min = date. max = date + 1
 		if prefix == "" {
@@ -28,21 +27,66 @@ func newTimeQuery(ctx *queryAndFieldContext) (*QueryEntry, error) {
 				Values: []interface{}{t.Format(sqlTimeStampFormat), t.Add(dayDuration).Format(sqlTimeStampFormat)},
 			}, nil), nil
 		}
-		formattedTime = t.Format(sqlTimeStampFormat)
-	} else if d, ok := parseDuration(trimmedValue); ok {
-		formattedTime = time.Now().Add(-d).Format(sqlTimeStampFormat)
+		return timeQueryEntry(ctx, prefix, t.Format(sqlTimeStampFormat)), nil
+	}
+
+	lower, upper, err := maybeParseDurationAsRange(trimmedValue)
+	if err == nil {
+		return qeWithSelectFieldIfNeeded(ctx, &WhereClause{
+			Query:  fmt.Sprintf("%s > $$ and %s < $$", ctx.qualifiedColumnName, ctx.qualifiedColumnName),
+			Values: []interface{}{ctx.now.Add(-upper).Format(sqlTimeStampFormat), ctx.now.Add(-lower).Format(sqlTimeStampFormat)},
+		}, nil), nil
+	} else if err != errNotARange {
+		return nil, fmt.Errorf("tried to parse %s as a range, but it was not valid: %w", ctx.value, err)
+	}
+
+	if d, ok := parseDuration(trimmedValue); ok {
 		// Invert the prefix in a duration query, since if someone queries for >=3d
 		// they mean more than 3 days ago, which means the timestamp should be
 		// < the timestamp of 3 days ago.
-		prefix = invertNumericPrefix(prefix)
-	} else {
-		return nil, fmt.Errorf("invalid time query (prefix: %s, value: %s). Must be of the format (01/02/2006 or 1d)", prefix, trimmedValue)
+		if prefix == "" || prefix == "==" {
+			prefix = "="
+		} else {
+			prefix = invertNumericPrefix(prefix)
+		}
+		return timeQueryEntry(ctx, prefix, ctx.now.Add(-d).Format(sqlTimeStampFormat)), nil
 	}
 
+	return nil, fmt.Errorf("invalid time query (prefix: %s, value: %s). Must be of the format (01/02/2006 or 1d)", prefix, trimmedValue)
+}
+
+func timeQueryEntry(ctx *queryAndFieldContext, prefix, formattedTime string) *QueryEntry {
 	return qeWithSelectFieldIfNeeded(ctx, &WhereClause{
 		Query:  fmt.Sprintf("%s %s $$", ctx.qualifiedColumnName, prefix),
 		Values: []interface{}{formattedTime},
-	}, nil), nil
+	}, nil)
+}
+
+func maybeParseDurationAsRange(value string) (lower, upper time.Duration, err error) {
+	// Split the value into two parts, separated by a hyphen.
+	// We need to be careful to ensure that we don't mistake
+	// hyphens for minus signs.
+	for i, char := range value {
+		if i == 0 {
+			continue
+		}
+		if char == '-' {
+			var valid bool
+			lower, valid = parseDuration(value[:i])
+			if !valid {
+				return 0, 0, errNotARange
+			}
+			upper, valid = parseDuration(value[i+1:])
+			if !valid {
+				return 0, 0, errNotARange
+			}
+			if lower >= upper {
+				return 0, 0, fmt.Errorf("invalid range %s (first value must be strictly less than the second)", value)
+			}
+			return lower, upper, nil
+		}
+	}
+	return 0, 0, errNotARange
 }
 
 func parseDuration(d string) (time.Duration, bool) {

--- a/pkg/search/postgres/query/time_query_test.go
+++ b/pkg/search/postgres/query/time_query_test.go
@@ -1,0 +1,76 @@
+package pgsearch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/timeutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeQuery(t *testing.T) {
+	fakeNow := timeutil.MustParse(time.RFC3339, "2022-06-24T12:00:00Z")
+	ts1dayLater := fakeNow.Add(24 * time.Hour).Format(sqlTimeStampFormat)
+	ts1dayAgo := fakeNow.Add(-24 * time.Hour).Format(sqlTimeStampFormat)
+	ts10daysAgo := fakeNow.Add(-10 * 24 * time.Hour).Format(sqlTimeStampFormat)
+
+	cases := []struct {
+		value          string
+		expectErr      bool
+		expectedQuery  string
+		expectedValues []interface{}
+	}{
+		{
+			value:          "1",
+			expectedQuery:  "blah = $$",
+			expectedValues: []interface{}{ts1dayAgo},
+		},
+		{
+			value:          "1d",
+			expectedQuery:  "blah = $$",
+			expectedValues: []interface{}{ts1dayAgo},
+		},
+		{
+			value:     ">lol",
+			expectErr: true,
+		},
+		{
+			value:          ">1",
+			expectedQuery:  "blah <= $$",
+			expectedValues: []interface{}{ts1dayAgo},
+		},
+		{
+			value:          "1-10",
+			expectedQuery:  "blah > $$ and blah < $$",
+			expectedValues: []interface{}{ts10daysAgo, ts1dayAgo},
+		},
+		{
+			value:          "1d-10d",
+			expectedQuery:  "blah > $$ and blah < $$",
+			expectedValues: []interface{}{ts10daysAgo, ts1dayAgo},
+		},
+		{
+			value:          "-1d-10d",
+			expectedQuery:  "blah > $$ and blah < $$",
+			expectedValues: []interface{}{ts10daysAgo, ts1dayLater},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.value, func(t *testing.T) {
+			actual, err := newTimeQuery(&queryAndFieldContext{
+				qualifiedColumnName: "blah",
+				value:               c.value,
+				now:                 fakeNow,
+			})
+			if c.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, c.expectedQuery, actual.Where.Query)
+			assert.Equal(t, c.expectedValues, actual.Where.Values)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add support for numeric queries which are ranges. This is done in a backward compatible way. You can say something like "1-2" for values between 1 and 2 (non-inclusive).

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests