### PR TITLE
Update OCI image scan test

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -412,7 +412,7 @@ class ImageScanningTest extends BaseSpecification {
         scanner                          | component      | version            | idx | cve              | image       | registry
         new StackroxScannerIntegration() | "openssl-libs" | "1:1.0.1e-34.el7"  | 1   | "RHSA-2014:1052" | RHEL7_IMAGE | ""
         new StackroxScannerIntegration() | "openssl-libs" | "1:1.0.1e-34.el7"  | 1   | "CVE-2014-3509"  | RHEL7_IMAGE | ""
-        new StackroxScannerIntegration() | "glibc"        | "2.23-0ubuntu11.2" | 0   | "CVE-2015-8985"  | OCI_IMAGE   | ""
+        new StackroxScannerIntegration() | "systemd"      | "229-4ubuntu21.29" | 0   | "CVE-2021-33910" | OCI_IMAGE   | ""
         new ClairScannerIntegration()    | "apt"          | "1.4.8"            | 0   | "CVE-2011-3374"  | NGINX_IMAGE | ""
         new ClairScannerIntegration()    | "bash"         | "4.4-5"            | 0   | "CVE-2019-18276" | NGINX_IMAGE | ""
     }


### PR DESCRIPTION
## Description

As of a few days ago, xenial is not exactly affected by CVE-2015-8985 anymore (see https://git.launchpad.net/ubuntu-cve-tracker/commit/active/CVE-2015-8985?id=eff1fd1d3c4d578f77a57e5cb0a65f9bb8f58b96). Replace that vuln with another

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI
