### PR TITLE
ROX-10987: Splitting Components into Node and Image Components

### DIFF
--- a/ui/apps/platform/src/Components/EntityIcon.js
+++ b/ui/apps/platform/src/Components/EntityIcon.js
@@ -21,6 +21,8 @@ const imageMap = {
     [entityTypes.SUBJECT]: group,
     [entityTypes.IMAGE]: image,
     [entityTypes.COMPONENT]: component,
+    [entityTypes.NODE_COMPONENT]: component,
+    [entityTypes.IMAGE_COMPONENT]: component,
     [entityTypes.CVE]: cve,
     [entityTypes.IMAGE_CVE]: cve,
     [entityTypes.NODE_CVE]: cve,

--- a/ui/apps/platform/src/Components/TileLink/TileLink.js
+++ b/ui/apps/platform/src/Components/TileLink/TileLink.js
@@ -45,6 +45,7 @@ const TileLink = ({
             icon={icon}
             subText={subText}
             short={short}
+            textWrap
         />
     );
     let classes = '';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.js
@@ -27,7 +27,8 @@ const entityMenuTypes = [
     entityTypes.CLUSTER,
     entityTypes.NAMESPACE,
     entityTypes.DEPLOYMENT,
-    entityTypes.COMPONENT,
+    entityTypes.NODE_COMPONENT,
+    entityTypes.IMAGE_COMPONENT,
 ];
 
 const VulnDashboardPage = ({ history }) => {

--- a/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.js
@@ -24,18 +24,21 @@ import MostCommonVulnerabilities from '../widgets/MostCommonVulnerabilities';
 import DeploymentsWithMostSeverePolicyViolations from '../widgets/DeploymentsWithMostSeverePolicyViolations';
 import ClustersWithMostOrchestratorIstioVulnerabilities from '../widgets/ClustersWithMostOrchestratorIstioVulnerabilities';
 
-const entityMenuTypes = [
-    entityTypes.CLUSTER,
-    entityTypes.NAMESPACE,
-    entityTypes.DEPLOYMENT,
-    entityTypes.NODE_COMPONENT,
-    entityTypes.IMAGE_COMPONENT,
-];
+const baseEntityMenuTypes = [entityTypes.CLUSTER, entityTypes.NAMESPACE, entityTypes.DEPLOYMENT];
+const componentMenuType = [entityTypes.COMPONENT];
+const splitComponentMenuTypes = [entityTypes.NODE_COMPONENT, entityTypes.IMAGE_COMPONENT];
 
 const VulnDashboardPage = ({ history }) => {
     const workflowState = useContext(workflowStateContext);
     const searchState = workflowState.getCurrentSearchState();
     const { isFeatureFlagEnabled } = useFeatureFlags();
+
+    let entityMenuTypes = [...baseEntityMenuTypes];
+    if (isFeatureFlagEnabled('ROX_FRONTEND_VM_UDPATES')) {
+        entityMenuTypes = [...baseEntityMenuTypes, ...splitComponentMenuTypes];
+    } else {
+        entityMenuTypes = [...baseEntityMenuTypes, ...componentMenuType];
+    }
 
     const cveFilterButtons = [
         {

--- a/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.js
@@ -11,6 +11,7 @@ import RadioButtonGroup from 'Components/RadioButtonGroup';
 import workflowStateContext from 'Containers/workflowStateContext';
 import { DASHBOARD_LIMIT } from 'constants/workflowPages.constants';
 import DashboardMenu from 'Components/DashboardMenu';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import PoliciesCountTile from '../Components/PoliciesCountTile';
 import CvesCountTile from '../Components/CvesCountTile';
 import ImagesCountTile from '../Components/ImagesCountTile';
@@ -34,6 +35,7 @@ const entityMenuTypes = [
 const VulnDashboardPage = ({ history }) => {
     const workflowState = useContext(workflowStateContext);
     const searchState = workflowState.getCurrentSearchState();
+    const { isFeatureFlagEnabled } = useFeatureFlags();
 
     const cveFilterButtons = [
         {

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.js
@@ -7,7 +7,7 @@ import TopCvssLabel from 'Components/TopCvssLabel';
 import RiskScore from 'Components/RiskScore';
 import Metadata from 'Components/Metadata';
 import CvesByCvssScore from 'Containers/VulnMgmt/widgets/CvesByCvssScore';
-import { entityGridContainerClassName } from 'Containers/Workflow/WorkflowEntityPage';
+import { entityGridContainerBaseClassName } from 'Containers/Workflow/WorkflowEntityPage';
 
 import RelatedEntitiesSideList from '../RelatedEntitiesSideList';
 import TableWidgetFixableCves from '../TableWidgetFixableCves';
@@ -27,6 +27,8 @@ const emptyComponent = {
 
 function VulnMgmtComponentOverview({ data, entityContext }) {
     const workflowState = useContext(workflowStateContext);
+
+    const currentEntityType = workflowState.getCurrentEntityType();
 
     // guard against incomplete GraphQL-cached data
     const safeData = { ...emptyComponent, ...data };
@@ -73,8 +75,10 @@ function VulnMgmtComponentOverview({ data, entityContext }) {
         );
     }
 
-    const currentEntity = { [entityTypes.COMPONENT]: id };
+    const currentEntity = { [currentEntityType]: id };
     const newEntityContext = { ...entityContext, ...currentEntity };
+
+    const entityGridContainerClassName = `${entityGridContainerBaseClassName} grid-columns-1 md:grid-columns-2 lg:grid-columns-2`;
 
     return (
         <div className="flex h-full">
@@ -102,7 +106,7 @@ function VulnMgmtComponentOverview({ data, entityContext }) {
                         <TableWidgetFixableCves
                             workflowState={workflowState}
                             entityContext={entityContext}
-                            entityType={entityTypes.COMPONENT}
+                            entityType={currentEntityType}
                             name={safeData?.name}
                             id={safeData?.id}
                         />
@@ -110,7 +114,7 @@ function VulnMgmtComponentOverview({ data, entityContext }) {
                 </CollapsibleSection>
             </div>
             <RelatedEntitiesSideList
-                entityType={entityTypes.COMPONENT}
+                entityType={currentEntityType}
                 entityContext={newEntityContext}
                 data={safeData}
             />

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtEntityImageComponent.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtEntityImageComponent.js
@@ -14,7 +14,13 @@ import {
     getScopeQuery,
 } from '../VulnMgmtPolicyQueryUtil';
 
-const VulnMgmtEntityComponent = ({
+// We want to override some values because the imageComponent object has different field names
+export const imageComponentCountKeyMap = {
+    ...defaultCountKeyMap,
+    [entityTypes.CVE]: 'vulnCount: imageVulnerabilityCount',
+};
+
+const VulnMgmtImageComponent = ({
     entityId,
     entityListType,
     search,
@@ -28,24 +34,16 @@ const VulnMgmtEntityComponent = ({
 
     const overviewQuery = gql`
         query getComponent($id: ID!, $query: String, $scopeQuery: String) {
-            result: component(id: $id) {
+            result: imageComponent(id: $id) {
                 id
                 name
                 version
                 fixedIn
                 location(query: $scopeQuery)
                 priority
-                vulnCount(query: $query, scopeQuery: $scopeQuery)
-                deploymentCount(query: $query)
+                vulnCount: imageVulnerabilityCount(query: $query, scopeQuery: $scopeQuery)
                 imageCount(query: $query)
-                nodeCount(query: $query)
-                activeState(query: $scopeQuery) {
-                    state
-                    activeContexts {
-                        containerName
-                    }
-                }
-                topVuln {
+                topVuln: topImageVulnerability {
                     cvss
                     scoreVersion
                 }
@@ -56,9 +54,9 @@ const VulnMgmtEntityComponent = ({
     function getListQuery(listFieldName, fragmentName, fragment) {
         return gql`
         query getComponentSubEntity${entityListType}($id: ID!, $pagination: Pagination, $query: String, $policyQuery: String, $scopeQuery: String) {
-            result: component(id: $id) {
+            result: imageComponent(id: $id) {
                 id
-                ${defaultCountKeyMap[entityListType]}(query: $query, scopeQuery: $scopeQuery)
+                ${imageComponentCountKeyMap[entityListType]}(query: $query, scopeQuery: $scopeQuery)
                 ${listFieldName}(query: $query, scopeQuery: $scopeQuery, pagination: $pagination) { ...${fragmentName} }
                 unusedVarSink(query: $policyQuery)
                 unusedVarSink(query: $scopeQuery)
@@ -82,7 +80,7 @@ const VulnMgmtEntityComponent = ({
     return (
         <WorkflowEntityPage
             entityId={entityId}
-            entityType={entityTypes.COMPONENT}
+            entityType={entityTypes.IMAGE_COMPONENT}
             entityListType={entityListType}
             useCase={useCases.VULN_MANAGEMENT}
             ListComponent={EntityList}
@@ -99,4 +97,4 @@ const VulnMgmtEntityComponent = ({
     );
 };
 
-export default VulnMgmtEntityComponent;
+export default VulnMgmtImageComponent;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtEntityNodeComponent.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtEntityNodeComponent.js
@@ -14,7 +14,13 @@ import {
     getScopeQuery,
 } from '../VulnMgmtPolicyQueryUtil';
 
-const VulnMgmtEntityComponent = ({
+// We want to override some values because the nodeComponent object has different field names
+export const nodeComponentCountKeyMap = {
+    ...defaultCountKeyMap,
+    [entityTypes.CVE]: 'vulnCount: nodeVulnerabilityCount',
+};
+
+const VulnMgmtNodeComponent = ({
     entityId,
     entityListType,
     search,
@@ -28,24 +34,16 @@ const VulnMgmtEntityComponent = ({
 
     const overviewQuery = gql`
         query getComponent($id: ID!, $query: String, $scopeQuery: String) {
-            result: component(id: $id) {
+            result: nodeComponent(id: $id) {
                 id
                 name
                 version
                 fixedIn
                 location(query: $scopeQuery)
                 priority
-                vulnCount(query: $query, scopeQuery: $scopeQuery)
-                deploymentCount(query: $query)
-                imageCount(query: $query)
+                vulnCount: nodeVulnerabilityCount(query: $query, scopeQuery: $scopeQuery)
                 nodeCount(query: $query)
-                activeState(query: $scopeQuery) {
-                    state
-                    activeContexts {
-                        containerName
-                    }
-                }
-                topVuln {
+                topVuln: topNodeVulnerability {
                     cvss
                     scoreVersion
                 }
@@ -55,10 +53,10 @@ const VulnMgmtEntityComponent = ({
 
     function getListQuery(listFieldName, fragmentName, fragment) {
         return gql`
-        query getComponentSubEntity${entityListType}($id: ID!, $pagination: Pagination, $query: String, $policyQuery: String, $scopeQuery: String) {
-            result: component(id: $id) {
+        query getNodeComponentSubEntity${entityListType}($id: ID!, $pagination: Pagination, $query: String, $policyQuery: String, $scopeQuery: String) {
+            result: nodeComponent(id: $id) {
                 id
-                ${defaultCountKeyMap[entityListType]}(query: $query, scopeQuery: $scopeQuery)
+                ${nodeComponentCountKeyMap[entityListType]}(query: $query, scopeQuery: $scopeQuery)
                 ${listFieldName}(query: $query, scopeQuery: $scopeQuery, pagination: $pagination) { ...${fragmentName} }
                 unusedVarSink(query: $policyQuery)
                 unusedVarSink(query: $scopeQuery)
@@ -82,7 +80,7 @@ const VulnMgmtEntityComponent = ({
     return (
         <WorkflowEntityPage
             entityId={entityId}
-            entityType={entityTypes.COMPONENT}
+            entityType={entityTypes.NODE_COMPONENT}
             entityListType={entityListType}
             useCase={useCases.VULN_MANAGEMENT}
             ListComponent={EntityList}
@@ -99,4 +97,4 @@ const VulnMgmtEntityComponent = ({
     );
 };
 
-export default VulnMgmtEntityComponent;
+export default VulnMgmtNodeComponent;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/RelatedEntitiesSideList.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/RelatedEntitiesSideList.js
@@ -48,7 +48,7 @@ const RelatedEntitiesSideList = ({ entityType, data, altCountKeyMap, entityConte
     }
     return (
         <div
-            className={` h-full relative border-base-100 border-l w-43 ${
+            className={`h-full relative border-base-100 border-l max-w-43 ${
                 !isDarkMode ? 'bg-primary-300' : 'bg-base-100'
             }`}
         >

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/RelatedEntitiesSideList.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/RelatedEntitiesSideList.js
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import pluralize from 'pluralize';
 
+import entityLabels from 'messages/entity';
 import { useTheme } from 'Containers/ThemeProvider';
 import workflowStateContext from 'Containers/workflowStateContext';
 import { getEntityTypesByRelationship } from 'utils/entityRelationships';
@@ -33,9 +34,10 @@ const RelatedEntitiesSideList = ({ entityType, data, altCountKeyMap, entityConte
     const contains = getEntityTypesByRelationship(entityType, relationshipTypes.CONTAINS, useCase)
         .map((containEntity) => {
             const count = data[countKeyMap[containEntity]];
+            const entityLabel = entityLabels[containEntity];
             return {
                 count,
-                label: pluralize(containEntity, count),
+                label: pluralize(entityLabel, count),
                 entity: containEntity,
                 url: workflowState.pushList(containEntity).setSearch('').toUrl(),
             };
@@ -46,7 +48,7 @@ const RelatedEntitiesSideList = ({ entityType, data, altCountKeyMap, entityConte
     }
     return (
         <div
-            className={` h-full relative border-base-100 border-l w-32 ${
+            className={` h-full relative border-base-100 border-l w-43 ${
                 !isDarkMode ? 'bg-primary-300' : 'bg-base-100'
             }`}
         >

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/RelatedEntitiesSideList.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/RelatedEntitiesSideList.js
@@ -34,7 +34,7 @@ const RelatedEntitiesSideList = ({ entityType, data, altCountKeyMap, entityConte
     const contains = getEntityTypesByRelationship(entityType, relationshipTypes.CONTAINS, useCase)
         .map((containEntity) => {
             const count = data[countKeyMap[containEntity]];
-            const entityLabel = entityLabels[containEntity];
+            const entityLabel = entityLabels[containEntity].toUpperCase();
             return {
                 count,
                 label: pluralize(entityLabel, count),

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.js
@@ -8,7 +8,7 @@ import Loader from 'Components/Loader';
 import { getCveTableColumns, defaultCveSort } from 'Containers/VulnMgmt/List/Cves/VulnMgmtListCves';
 import {
     NODE_CVE_LIST_FRAGMENT,
-    IMAGE_CVE_LIST_FRAGMENT,
+    VULN_IMAGE_CVE_LIST_FRAGMENT,
     VULN_CVE_LIST_FRAGMENT,
 } from 'Containers/VulnMgmt/VulnMgmt.fragments';
 import { LIST_PAGE_SIZE } from 'constants/workflowPages.constants';
@@ -51,7 +51,7 @@ const TableWidgetFixableCves = ({ workflowState, entityContext, entityType, name
         queryVulnCounterFieldName = 'imageVulnerabilityCounter';
         queryVulnsFieldName = 'imageVulnerabilities';
         queryCVEFieldsName = 'imageCVEFields';
-        queryFragment = IMAGE_CVE_LIST_FRAGMENT;
+        queryFragment = VULN_IMAGE_CVE_LIST_FRAGMENT;
     }
 
     // `id` field is not needed in result,

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/VulnMgmtEntity.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/VulnMgmtEntity.js
@@ -6,6 +6,8 @@ import PageNotFound from 'Components/PageNotFound';
 import VulnMgmtEntityDeployment from './Deployment/VulnMgmtEntityDeployment';
 import VulnMgmtEntityImage from './Image/VulnMgmtEntityImage';
 import VulnMgmtEntityComponent from './Component/VulnMgmtEntityComponent';
+import VulnMgmtEntityNodeComponent from './Component/VulnMgmtEntityNodeComponent';
+import VulnMgmtEntityImageComponent from './Component/VulnMgmtEntityImageComponent';
 import VulnMgmtEntityCve from './Cve/VulnMgmtEntityCve';
 import VulnMgmtEntityCluster from './Cluster/VulnMgmtEntityCluster';
 import VulnMgmtEntityNamespace from './Namespace/VulnMgmtEntityNamespace';
@@ -16,6 +18,8 @@ const entityComponentMap = {
     [entityTypes.DEPLOYMENT]: VulnMgmtEntityDeployment,
     [entityTypes.IMAGE]: VulnMgmtEntityImage,
     [entityTypes.COMPONENT]: VulnMgmtEntityComponent,
+    [entityTypes.NODE_COMPONENT]: VulnMgmtEntityNodeComponent,
+    [entityTypes.IMAGE_COMPONENT]: VulnMgmtEntityImageComponent,
     [entityTypes.CVE]: VulnMgmtEntityCve,
     [entityTypes.IMAGE_CVE]: VulnMgmtEntityCve,
     [entityTypes.NODE_CVE]: VulnMgmtEntityCve,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
@@ -38,6 +38,7 @@ import {
 } from 'Containers/VulnMgmt/VulnMgmt.fragments';
 
 import CVSSSeverityLabel from 'Components/CVSSSeverityLabel';
+import CveType from 'Components/CveType';
 import CveBulkActionDialogue from './CveBulkActionDialogue';
 
 import { getFilteredCVEColumns } from './ListCVEs.utils';
@@ -78,6 +79,22 @@ export function getCveTableColumns(workflowState) {
             id: cveSortFields.CVE,
             accessor: 'cve',
             sortField: cveSortFields.CVE,
+        },
+        {
+            Header: `Type`,
+            headerClassName: `w-1/10 text-center ${defaultHeaderClassName}`,
+            className: `w-1/10 ${defaultColumnClassName}`,
+            Cell: ({ original }) => {
+                return (
+                    <span className="mx-auto" data-testid="cve-type">
+                        <CveType types={original.vulnerabilityTypes} />
+                    </span>
+                );
+            },
+            id: cveSortFields.CVE_TYPE,
+            accessor: 'vulnerabilityTypes',
+            sortField: cveSortFields.CVE_TYPE,
+            sortable: true,
         },
         {
             Header: `Fixable`,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
@@ -318,7 +318,7 @@ const VulnMgmtCves = ({
             cveQuery = gql`
                 query getImageCves($query: String, $scopeQuery: String, $pagination: Pagination) {
                     results: imageVulnerabilities(query: $query, pagination: $pagination) {
-                        ...cveFields
+                        ...imageCVEFields
                     }
                     count: imageVulnerabilityCount(query: $query)
                 }

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
@@ -16,7 +16,6 @@ import DateTimeField from 'Components/DateTimeField';
 import LabelChip from 'Components/LabelChip';
 import Menu from 'Components/Menu';
 import TableCountLinks from 'Components/workflow/TableCountLinks';
-import CveType from 'Components/CveType';
 import TopCvssLabel from 'Components/TopCvssLabel';
 import PanelButton from 'Components/PanelButton';
 import WorkflowListPage from 'Containers/Workflow/WorkflowListPage';
@@ -79,22 +78,6 @@ export function getCveTableColumns(workflowState) {
             id: cveSortFields.CVE,
             accessor: 'cve',
             sortField: cveSortFields.CVE,
-        },
-        {
-            Header: `Type`,
-            headerClassName: `w-1/10 text-center ${defaultHeaderClassName}`,
-            className: `w-1/10 ${defaultColumnClassName}`,
-            Cell: ({ original }) => {
-                return (
-                    <span className="mx-auto" data-testid="cve-type">
-                        <CveType types={original.vulnerabilityTypes} />
-                    </span>
-                );
-            },
-            id: cveSortFields.CVE_TYPE,
-            accessor: 'vulnerabilityTypes',
-            sortField: cveSortFields.CVE_TYPE,
-            sortable: true,
         },
         {
             Header: `Fixable`,
@@ -294,7 +277,7 @@ const VulnMgmtCves = ({
             cveQuery = gql`
                 query getNodeCves($query: String, $scopeQuery: String, $pagination: Pagination) {
                     results: nodeVulnerabilities(query: $query, pagination: $pagination) {
-                        ...cveFields
+                        ...nodeCVEFields
                     }
                     count: nodeVulnerabilityCount(query: $query)
                 }
@@ -306,7 +289,7 @@ const VulnMgmtCves = ({
             cveQuery = gql`
                 query getClusterCves($query: String, $scopeQuery: String, $pagination: Pagination) {
                     results: clusterVulnerabilities(query: $query, pagination: $pagination) {
-                        ...cveFields
+                        ...clusterCVEFields
                     }
                     count: clusterVulnerabilityCount(query: $query)
                 }

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/ListImageComponents.utils.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/ListImageComponents.utils.js
@@ -1,0 +1,32 @@
+import entityTypes from 'constants/entityTypes';
+
+export function getFilteredComponentColumns(columns, workflowState) {
+    const shouldKeepActiveColumn =
+        workflowState.isCurrentSingle(entityTypes.DEPLOYMENT) ||
+        workflowState.isPrecedingSingle(entityTypes.DEPLOYMENT) ||
+        (workflowState.getSingleAncestorOfType(entityTypes.DEPLOYMENT) &&
+            workflowState.getSingleAncestorOfType(entityTypes.IMAGE));
+
+    const shouldRemoveColumns = !workflowState.isPreceding(entityTypes.IMAGE);
+
+    return columns.filter((col) => {
+        switch (col.accessor) {
+            case 'isActive': {
+                return !!shouldKeepActiveColumn;
+            }
+            case 'source': {
+                return !shouldRemoveColumns;
+            }
+            case 'location': {
+                return !shouldRemoveColumns;
+            }
+            default: {
+                return true;
+            }
+        }
+    });
+}
+
+export default {
+    getFilteredComponentColumns,
+};

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/ListImageComponents.utils.test.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/ListImageComponents.utils.test.js
@@ -1,0 +1,174 @@
+import entityTypes from 'constants/entityTypes';
+import { componentSortFields } from 'constants/sortFields';
+import useCases from 'constants/useCaseTypes';
+import WorkflowEntity from 'utils/WorkflowEntity';
+import { WorkflowState } from 'utils/WorkflowState';
+
+import { getFilteredComponentColumns } from './ListImageComponents.utils';
+
+describe('ListImageComponents.utils', () => {
+    describe('getFilteredComponentColumns', () => {
+        it('should return all the components columns when in a context that allows them', () => {
+            const stateStack = [
+                new WorkflowEntity(entityTypes.IMAGE, 'abcd-ef09'),
+                new WorkflowEntity(entityTypes.COMPONENT),
+            ];
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
+            const tableColumns = getComponentTableColumns(workflowState);
+
+            const filteredColumns = getFilteredComponentColumns(tableColumns, workflowState);
+
+            expect(filteredColumns).toEqual(tableColumns);
+        });
+
+        it('should remove the source and location columns when in Components main list context', () => {
+            const stateStack = [new WorkflowEntity(entityTypes.COMPONENT)];
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
+            const tableColumns = getComponentTableColumns(workflowState);
+
+            const filteredColumns = getFilteredComponentColumns(tableColumns, workflowState);
+
+            const sourceColumnPresent = filteredColumns.find((col) => col.accessor === 'source');
+            expect(sourceColumnPresent).toBeUndefined();
+            const locationColumnPresent = filteredColumns.find(
+                (col) => col.accessor === 'location'
+            );
+            expect(locationColumnPresent).toBeUndefined();
+        });
+
+        it('should remove the source and location columns when in Components sublist of CVE single context', () => {
+            const stateStack = [
+                new WorkflowEntity(entityTypes.CVE, 'abcd-ef09'),
+                new WorkflowEntity(entityTypes.COMPONENT),
+            ];
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
+            const tableColumns = getComponentTableColumns(workflowState);
+
+            const filteredColumns = getFilteredComponentColumns(tableColumns, workflowState);
+
+            const sourceColumnPresent = filteredColumns.find((col) => col.accessor === 'source');
+            expect(sourceColumnPresent).toBeUndefined();
+            const locationColumnPresent = filteredColumns.find(
+                (col) => col.accessor === 'location'
+            );
+            expect(locationColumnPresent).toBeUndefined();
+        });
+
+        it('should remove the source and location columns when in Components sublist of Deployment single context', () => {
+            const stateStack = [
+                new WorkflowEntity(entityTypes.DEPLOYMENT, 'abcd-ef09'),
+                new WorkflowEntity(entityTypes.COMPONENT),
+            ];
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
+            const tableColumns = getComponentTableColumns(workflowState);
+
+            const filteredColumns = getFilteredComponentColumns(tableColumns, workflowState);
+
+            const sourceColumnPresent = filteredColumns.find((col) => col.accessor === 'source');
+            expect(sourceColumnPresent).toBeUndefined();
+            const locationColumnPresent = filteredColumns.find(
+                (col) => col.accessor === 'location'
+            );
+            expect(locationColumnPresent).toBeUndefined();
+        });
+    });
+});
+
+function getComponentTableColumns(workflowState) {
+    const tableColumns = [
+        {
+            Header: 'Id',
+            headerClassName: 'hidden',
+            className: 'hidden',
+            accessor: 'id',
+        },
+        {
+            Header: `Component`,
+            headerClassName: `w-1/4`,
+            className: `w-1/4`,
+            Cell: ({ original }) => {
+                const { version, name } = original;
+                return `${name} ${version}`;
+            },
+            accessor: 'name',
+            sortField: componentSortFields.COMPONENT,
+        },
+        {
+            Header: `CVEs`,
+            entityType: entityTypes.CVE,
+            headerClassName: `w-1/8`,
+            className: `w-1/8`,
+            Cell: ({ original }) => {
+                const { vulnCounter, id } = original;
+                if (!vulnCounter || vulnCounter.all.total === 0) {
+                    return 'No CVEs';
+                }
+
+                const newState = workflowState.pushListItem(id).pushList(entityTypes.CVE);
+                const url = newState.toUrl();
+                const fixableUrl = newState.setSearch({ Fixable: true }).toUrl();
+
+                return `${vulnCounter}${url}${fixableUrl}`;
+            },
+            accessor: 'vulnCounter.all.total',
+            sortField: componentSortFields.CVE_COUNT,
+        },
+        {
+            Header: `Top CVSS`,
+            headerClassName: `w-1/10 text-center`,
+            className: `w-1/10`,
+            Cell: ({ original }) => {
+                const { topVuln } = original;
+                if (!topVuln) {
+                    return '–';
+                }
+                const { cvss, scoreVersion } = topVuln;
+                return `${cvss} ${scoreVersion}`;
+            },
+            accessor: 'topVuln.cvss',
+            sortField: componentSortFields.TOP_CVSS,
+        },
+        {
+            Header: `Source`,
+            headerClassName: `w-1/8`,
+            className: `w-1/8`,
+            accessor: 'source',
+            // @TODO uncomment once source is sortable on backend
+            // sortField: componentSortFields.SOURCE
+        },
+        {
+            Header: `Location`,
+            headerClassName: `w-1/8`,
+            className: `w-1/8`,
+            accessor: 'location',
+            sortable: false,
+        },
+        {
+            Header: `Images`,
+            entityType: entityTypes.IMAGE,
+            headerClassName: `w-1/8`,
+            className: `w-1/8`,
+            accessor: 'imageCount',
+            Cell: ({ original }) => original.imageCount,
+            sortField: componentSortFields.IMAGES,
+        },
+        {
+            Header: `Deployments`,
+            entityType: entityTypes.DEPLOYMENT,
+            headerClassName: `w-1/8`,
+            className: `w-1/8`,
+            accessor: 'deploymentCount',
+            Cell: ({ original }) => original.deploymentCount,
+            sortField: componentSortFields.DEPLOYMENTS,
+        },
+        {
+            Header: `Risk Priority`,
+            headerClassName: `w-1/10`,
+            className: `w-1/10`,
+            accessor: 'priority',
+            sortField: componentSortFields.PRIORITY,
+        },
+    ];
+
+    return [...tableColumns];
+}

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.js
@@ -1,0 +1,245 @@
+import React from 'react';
+import { gql } from '@apollo/client';
+
+import {
+    defaultHeaderClassName,
+    defaultColumnClassName,
+    nonSortableHeaderClassName,
+} from 'Components/Table';
+import LabelChip from 'Components/LabelChip';
+import TopCvssLabel from 'Components/TopCvssLabel';
+import WorkflowListPage from 'Containers/Workflow/WorkflowListPage';
+import entityTypes from 'constants/entityTypes';
+import { LIST_PAGE_SIZE } from 'constants/workflowPages.constants';
+import CVEStackedPill from 'Components/CVEStackedPill';
+import queryService from 'utils/queryService';
+
+import { VULN_IMAGE_COMPONENT_LIST_FRAGMENT } from 'Containers/VulnMgmt/VulnMgmt.fragments';
+import { workflowListPropTypes, workflowListDefaultProps } from 'constants/entityPageProps';
+import removeEntityContextColumns from 'utils/tableUtils';
+import { componentSortFields } from 'constants/sortFields';
+
+import TableCountLink from 'Components/workflow/TableCountLink';
+import { getFilteredComponentColumns } from './ListImageComponents.utils';
+
+export const defaultComponentSort = [
+    {
+        id: componentSortFields.PRIORITY,
+        desc: false,
+    },
+];
+
+export function getComponentTableColumns(workflowState) {
+    const tableColumns = [
+        {
+            Header: 'Id',
+            headerClassName: 'hidden',
+            className: 'hidden',
+            accessor: 'id',
+        },
+        {
+            Header: `Component`,
+            headerClassName: `w-1/4 ${defaultHeaderClassName}`,
+            className: `w-1/4 ${defaultColumnClassName}`,
+            Cell: ({ original }) => {
+                const { version, name } = original;
+                return `${name} ${version}`;
+            },
+            id: componentSortFields.COMPONENT,
+            accessor: 'name',
+            sortField: componentSortFields.COMPONENT,
+        },
+        {
+            Header: `CVEs`,
+            entityType: entityTypes.CVE,
+            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+            className: `w-1/8 ${defaultColumnClassName}`,
+            Cell: ({ original, pdf }) => {
+                const { vulnCounter, id } = original;
+                if (!vulnCounter || vulnCounter.all.total === 0) {
+                    return 'No CVEs';
+                }
+
+                const newState = workflowState.pushListItem(id).pushList(entityTypes.CVE);
+                const url = newState.toUrl();
+                const fixableUrl = newState.setSearch({ Fixable: true }).toUrl();
+
+                return (
+                    <CVEStackedPill
+                        vulnCounter={vulnCounter}
+                        url={url}
+                        fixableUrl={fixableUrl}
+                        hideLink={pdf}
+                    />
+                );
+            },
+            id: componentSortFields.CVE_COUNT,
+            accessor: 'vulnCounter.all.total',
+            sortField: componentSortFields.CVE_COUNT,
+        },
+        {
+            Header: `Active`,
+            headerClassName: `w-1/10 text-center ${nonSortableHeaderClassName}`,
+            className: `w-1/10 ${defaultColumnClassName}`,
+            // eslint-disable-next-line
+            Cell: ({ original }) => {
+                const activeStatus = original.activeState?.state || 'Undetermined';
+                switch (activeStatus) {
+                    case 'Active': {
+                        return (
+                            <div className="mx-auto">
+                                <LabelChip text={activeStatus} type="alert" size="large" />
+                            </div>
+                        );
+                    }
+                    case 'Inactive': {
+                        return <div className="mx-auto">{activeStatus}</div>;
+                    }
+                    case 'Undetermined':
+                    default: {
+                        return <div className="mx-auto">Undetermined</div>;
+                    }
+                }
+            },
+            id: componentSortFields.ACTIVE,
+            accessor: 'isActive',
+            sortField: componentSortFields.ACTIVE,
+            sortable: false,
+        },
+        {
+            Header: `Fixed In`,
+            headerClassName: `w-1/12 ${defaultHeaderClassName}`,
+            className: `w-1/12 word-break-all ${defaultColumnClassName}`,
+            Cell: ({ original }) =>
+                original.fixedIn || (original.vulnCounter.all.total === 0 ? 'N/A' : 'Not Fixable'),
+            id: componentSortFields.FIXEDIN,
+            accessor: 'fixedIn',
+            sortField: componentSortFields.FIXEDIN,
+            sortable: false,
+        },
+        {
+            Header: `Top CVSS`,
+            headerClassName: `w-1/10 text-center ${defaultHeaderClassName}`,
+            className: `w-1/10 ${defaultColumnClassName}`,
+            Cell: ({ original }) => {
+                const { topVuln } = original;
+                if (!topVuln) {
+                    return (
+                        <div className="mx-auto flex flex-col">
+                            <span>–</span>
+                        </div>
+                    );
+                }
+                const { cvss, scoreVersion } = topVuln;
+                return <TopCvssLabel cvss={cvss} version={scoreVersion} />;
+            },
+            id: componentSortFields.TOP_CVSS,
+            accessor: 'topVuln.cvss',
+            sortField: componentSortFields.TOP_CVSS,
+        },
+        {
+            Header: `Source`,
+            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+            className: `w-1/8 ${defaultColumnClassName}`,
+            id: componentSortFields.SOURCE,
+            accessor: 'source',
+            sortField: componentSortFields.SOURCE,
+        },
+        {
+            Header: `Location`,
+            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+            className: `w-1/8 word-break-all ${defaultColumnClassName}`,
+            Cell: ({ original }) => original.location || 'N/A',
+            id: componentSortFields.LOCATION,
+            accessor: 'location',
+            sortField: componentSortFields.LOCATION,
+        },
+        {
+            Header: `Images`,
+            entityType: entityTypes.IMAGE,
+            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+            className: `w-1/8 ${defaultColumnClassName}`,
+            id: componentSortFields.IMAGE_COUNT,
+            accessor: 'imageCount',
+            Cell: ({ original, pdf }) => (
+                <TableCountLink
+                    entityType={entityTypes.IMAGE}
+                    count={original.imageCount}
+                    textOnly={pdf}
+                    selectedRowId={original.id}
+                />
+            ),
+            sortField: componentSortFields.IMAGE_COUNT,
+        },
+        {
+            Header: `Deployments`,
+            entityType: entityTypes.DEPLOYMENT,
+            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+            className: `w-1/8 ${defaultColumnClassName}`,
+            id: componentSortFields.DEPLOYMENT_COUNT,
+            accessor: 'deploymentCount',
+            Cell: ({ original, pdf }) => (
+                <TableCountLink
+                    entityType={entityTypes.DEPLOYMENT}
+                    count={original.deploymentCount}
+                    textOnly={pdf}
+                    selectedRowId={original.id}
+                />
+            ),
+            sortField: componentSortFields.DEPLOYMENT_COUNT,
+        },
+        {
+            Header: `Risk Priority`,
+            headerClassName: `w-1/10 ${defaultHeaderClassName}`,
+            className: `w-1/10 ${defaultColumnClassName}`,
+            id: componentSortFields.PRIORITY,
+            accessor: 'priority',
+            sortField: componentSortFields.PRIORITY,
+        },
+    ];
+
+    const componentColumnsBasedOnContext = getFilteredComponentColumns(tableColumns, workflowState);
+
+    return removeEntityContextColumns(componentColumnsBasedOnContext, workflowState);
+}
+
+const VulnMgmtNodeComponents = ({ selectedRowId, search, sort, page, data, totalResults }) => {
+    const query = gql`
+        query getComponents($query: String, $pagination: Pagination) {
+            results: imageComponents(query: $query, pagination: $pagination) {
+                ...imageComponentFields
+            }
+            count: imageComponentCount(query: $query)
+        }
+        ${VULN_IMAGE_COMPONENT_LIST_FRAGMENT}
+    `;
+    const tableSort = sort || defaultComponentSort;
+    const queryOptions = {
+        variables: {
+            query: queryService.objectToWhereClause(search),
+            scopeQuery: '',
+            pagination: queryService.getPagination(tableSort, page, LIST_PAGE_SIZE),
+        },
+    };
+
+    return (
+        <WorkflowListPage
+            data={data}
+            totalResults={totalResults}
+            query={query}
+            queryOptions={queryOptions}
+            idAttribute="id"
+            entityListType={entityTypes.IMAGE_COMPONENT}
+            getTableColumns={getComponentTableColumns}
+            selectedRowId={selectedRowId}
+            search={search}
+            sort={tableSort}
+            page={page}
+        />
+    );
+};
+
+VulnMgmtNodeComponents.propTypes = workflowListPropTypes;
+VulnMgmtNodeComponents.defaultProps = workflowListDefaultProps;
+
+export default VulnMgmtNodeComponents;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.js
@@ -191,12 +191,12 @@ export function getCurriedImageTableColumns(watchedImagesTrigger) {
             },
             {
                 Header: `Components`,
-                entityType: entityTypes.COMPONENT,
+                entityType: entityTypes.IMAGE_COMPONENT,
                 headerClassName: `w-1/12 ${defaultHeaderClassName}`,
                 className: `w-1/12 ${defaultColumnClassName}`,
                 Cell: ({ original, pdf }) => (
                     <TableCountLink
-                        entityType={entityTypes.COMPONENT}
+                        entityType={entityTypes.IMAGE_COMPONENT}
                         count={original.componentCount}
                         textOnly={pdf}
                         selectedRowId={original.id}

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/ListNodeComponents.utils.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/ListNodeComponents.utils.js
@@ -1,0 +1,32 @@
+import entityTypes from 'constants/entityTypes';
+
+export function getFilteredComponentColumns(columns, workflowState) {
+    const shouldKeepActiveColumn =
+        workflowState.isCurrentSingle(entityTypes.DEPLOYMENT) ||
+        workflowState.isPrecedingSingle(entityTypes.DEPLOYMENT) ||
+        (workflowState.getSingleAncestorOfType(entityTypes.DEPLOYMENT) &&
+            workflowState.getSingleAncestorOfType(entityTypes.IMAGE));
+
+    const shouldRemoveColumns = !workflowState.isPreceding(entityTypes.IMAGE);
+
+    return columns.filter((col) => {
+        switch (col.accessor) {
+            case 'isActive': {
+                return !!shouldKeepActiveColumn;
+            }
+            case 'source': {
+                return !shouldRemoveColumns;
+            }
+            case 'location': {
+                return !shouldRemoveColumns;
+            }
+            default: {
+                return true;
+            }
+        }
+    });
+}
+
+export default {
+    getFilteredComponentColumns,
+};

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/ListNodeComponents.utils.test.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/ListNodeComponents.utils.test.js
@@ -1,0 +1,174 @@
+import entityTypes from 'constants/entityTypes';
+import { componentSortFields } from 'constants/sortFields';
+import useCases from 'constants/useCaseTypes';
+import WorkflowEntity from 'utils/WorkflowEntity';
+import { WorkflowState } from 'utils/WorkflowState';
+
+import { getFilteredComponentColumns } from './ListNodeComponents.utils';
+
+describe('ListNodeComponents.utils', () => {
+    describe('getFilteredComponentColumns', () => {
+        it('should return all the components columns when in a context that allows them', () => {
+            const stateStack = [
+                new WorkflowEntity(entityTypes.IMAGE, 'abcd-ef09'),
+                new WorkflowEntity(entityTypes.COMPONENT),
+            ];
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
+            const tableColumns = getComponentTableColumns(workflowState);
+
+            const filteredColumns = getFilteredComponentColumns(tableColumns, workflowState);
+
+            expect(filteredColumns).toEqual(tableColumns);
+        });
+
+        it('should remove the source and location columns when in Components main list context', () => {
+            const stateStack = [new WorkflowEntity(entityTypes.COMPONENT)];
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
+            const tableColumns = getComponentTableColumns(workflowState);
+
+            const filteredColumns = getFilteredComponentColumns(tableColumns, workflowState);
+
+            const sourceColumnPresent = filteredColumns.find((col) => col.accessor === 'source');
+            expect(sourceColumnPresent).toBeUndefined();
+            const locationColumnPresent = filteredColumns.find(
+                (col) => col.accessor === 'location'
+            );
+            expect(locationColumnPresent).toBeUndefined();
+        });
+
+        it('should remove the source and location columns when in Components sublist of CVE single context', () => {
+            const stateStack = [
+                new WorkflowEntity(entityTypes.CVE, 'abcd-ef09'),
+                new WorkflowEntity(entityTypes.COMPONENT),
+            ];
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
+            const tableColumns = getComponentTableColumns(workflowState);
+
+            const filteredColumns = getFilteredComponentColumns(tableColumns, workflowState);
+
+            const sourceColumnPresent = filteredColumns.find((col) => col.accessor === 'source');
+            expect(sourceColumnPresent).toBeUndefined();
+            const locationColumnPresent = filteredColumns.find(
+                (col) => col.accessor === 'location'
+            );
+            expect(locationColumnPresent).toBeUndefined();
+        });
+
+        it('should remove the source and location columns when in Components sublist of Deployment single context', () => {
+            const stateStack = [
+                new WorkflowEntity(entityTypes.DEPLOYMENT, 'abcd-ef09'),
+                new WorkflowEntity(entityTypes.COMPONENT),
+            ];
+            const workflowState = new WorkflowState(useCases.VULN_MANAGEMENT, stateStack);
+            const tableColumns = getComponentTableColumns(workflowState);
+
+            const filteredColumns = getFilteredComponentColumns(tableColumns, workflowState);
+
+            const sourceColumnPresent = filteredColumns.find((col) => col.accessor === 'source');
+            expect(sourceColumnPresent).toBeUndefined();
+            const locationColumnPresent = filteredColumns.find(
+                (col) => col.accessor === 'location'
+            );
+            expect(locationColumnPresent).toBeUndefined();
+        });
+    });
+});
+
+function getComponentTableColumns(workflowState) {
+    const tableColumns = [
+        {
+            Header: 'Id',
+            headerClassName: 'hidden',
+            className: 'hidden',
+            accessor: 'id',
+        },
+        {
+            Header: `Component`,
+            headerClassName: `w-1/4`,
+            className: `w-1/4`,
+            Cell: ({ original }) => {
+                const { version, name } = original;
+                return `${name} ${version}`;
+            },
+            accessor: 'name',
+            sortField: componentSortFields.COMPONENT,
+        },
+        {
+            Header: `CVEs`,
+            entityType: entityTypes.CVE,
+            headerClassName: `w-1/8`,
+            className: `w-1/8`,
+            Cell: ({ original }) => {
+                const { vulnCounter, id } = original;
+                if (!vulnCounter || vulnCounter.all.total === 0) {
+                    return 'No CVEs';
+                }
+
+                const newState = workflowState.pushListItem(id).pushList(entityTypes.CVE);
+                const url = newState.toUrl();
+                const fixableUrl = newState.setSearch({ Fixable: true }).toUrl();
+
+                return `${vulnCounter}${url}${fixableUrl}`;
+            },
+            accessor: 'vulnCounter.all.total',
+            sortField: componentSortFields.CVE_COUNT,
+        },
+        {
+            Header: `Top CVSS`,
+            headerClassName: `w-1/10 text-center`,
+            className: `w-1/10`,
+            Cell: ({ original }) => {
+                const { topVuln } = original;
+                if (!topVuln) {
+                    return '–';
+                }
+                const { cvss, scoreVersion } = topVuln;
+                return `${cvss} ${scoreVersion}`;
+            },
+            accessor: 'topVuln.cvss',
+            sortField: componentSortFields.TOP_CVSS,
+        },
+        {
+            Header: `Source`,
+            headerClassName: `w-1/8`,
+            className: `w-1/8`,
+            accessor: 'source',
+            // @TODO uncomment once source is sortable on backend
+            // sortField: componentSortFields.SOURCE
+        },
+        {
+            Header: `Location`,
+            headerClassName: `w-1/8`,
+            className: `w-1/8`,
+            accessor: 'location',
+            sortable: false,
+        },
+        {
+            Header: `Images`,
+            entityType: entityTypes.IMAGE,
+            headerClassName: `w-1/8`,
+            className: `w-1/8`,
+            accessor: 'imageCount',
+            Cell: ({ original }) => original.imageCount,
+            sortField: componentSortFields.IMAGES,
+        },
+        {
+            Header: `Deployments`,
+            entityType: entityTypes.DEPLOYMENT,
+            headerClassName: `w-1/8`,
+            className: `w-1/8`,
+            accessor: 'deploymentCount',
+            Cell: ({ original }) => original.deploymentCount,
+            sortField: componentSortFields.DEPLOYMENTS,
+        },
+        {
+            Header: `Risk Priority`,
+            headerClassName: `w-1/10`,
+            className: `w-1/10`,
+            accessor: 'priority',
+            sortField: componentSortFields.PRIORITY,
+        },
+    ];
+
+    return [...tableColumns];
+}

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.js
@@ -1,0 +1,228 @@
+import React from 'react';
+import { gql } from '@apollo/client';
+
+import {
+    defaultHeaderClassName,
+    defaultColumnClassName,
+    nonSortableHeaderClassName,
+} from 'Components/Table';
+import LabelChip from 'Components/LabelChip';
+import TopCvssLabel from 'Components/TopCvssLabel';
+import WorkflowListPage from 'Containers/Workflow/WorkflowListPage';
+import entityTypes from 'constants/entityTypes';
+import { LIST_PAGE_SIZE } from 'constants/workflowPages.constants';
+import CVEStackedPill from 'Components/CVEStackedPill';
+import TableCountLink from 'Components/workflow/TableCountLink';
+import queryService from 'utils/queryService';
+
+import { VULN_NODE_COMPONENT_LIST_FRAGMENT } from 'Containers/VulnMgmt/VulnMgmt.fragments';
+import { workflowListPropTypes, workflowListDefaultProps } from 'constants/entityPageProps';
+import removeEntityContextColumns from 'utils/tableUtils';
+import { componentSortFields } from 'constants/sortFields';
+
+import { getFilteredComponentColumns } from './ListNodeComponents.utils';
+
+export const defaultComponentSort = [
+    {
+        id: componentSortFields.PRIORITY,
+        desc: false,
+    },
+];
+
+export function getComponentTableColumns(workflowState) {
+    const tableColumns = [
+        {
+            Header: 'Id',
+            headerClassName: 'hidden',
+            className: 'hidden',
+            accessor: 'id',
+        },
+        {
+            Header: `Component`,
+            headerClassName: `w-1/4 ${defaultHeaderClassName}`,
+            className: `w-1/4 ${defaultColumnClassName}`,
+            Cell: ({ original }) => {
+                const { version, name } = original;
+                return `${name} ${version}`;
+            },
+            id: componentSortFields.COMPONENT,
+            accessor: 'name',
+            sortField: componentSortFields.COMPONENT,
+        },
+        {
+            Header: `CVEs`,
+            entityType: entityTypes.CVE,
+            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+            className: `w-1/8 ${defaultColumnClassName}`,
+            Cell: ({ original, pdf }) => {
+                const { vulnCounter, id } = original;
+                if (!vulnCounter || vulnCounter.all.total === 0) {
+                    return 'No CVEs';
+                }
+
+                const newState = workflowState.pushListItem(id).pushList(entityTypes.CVE);
+                const url = newState.toUrl();
+                const fixableUrl = newState.setSearch({ Fixable: true }).toUrl();
+
+                return (
+                    <CVEStackedPill
+                        vulnCounter={vulnCounter}
+                        url={url}
+                        fixableUrl={fixableUrl}
+                        hideLink={pdf}
+                    />
+                );
+            },
+            id: componentSortFields.CVE_COUNT,
+            accessor: 'vulnCounter.all.total',
+            sortField: componentSortFields.CVE_COUNT,
+        },
+        {
+            Header: `Active`,
+            headerClassName: `w-1/10 text-center ${nonSortableHeaderClassName}`,
+            className: `w-1/10 ${defaultColumnClassName}`,
+            // eslint-disable-next-line
+            Cell: ({ original }) => {
+                const activeStatus = original.activeState?.state || 'Undetermined';
+                switch (activeStatus) {
+                    case 'Active': {
+                        return (
+                            <div className="mx-auto">
+                                <LabelChip text={activeStatus} type="alert" size="large" />
+                            </div>
+                        );
+                    }
+                    case 'Inactive': {
+                        return <div className="mx-auto">{activeStatus}</div>;
+                    }
+                    case 'Undetermined':
+                    default: {
+                        return <div className="mx-auto">Undetermined</div>;
+                    }
+                }
+            },
+            id: componentSortFields.ACTIVE,
+            accessor: 'isActive',
+            sortField: componentSortFields.ACTIVE,
+            sortable: false,
+        },
+        {
+            Header: `Fixed In`,
+            headerClassName: `w-1/12 ${defaultHeaderClassName}`,
+            className: `w-1/12 word-break-all ${defaultColumnClassName}`,
+            Cell: ({ original }) =>
+                original.fixedIn || (original.vulnCounter.all.total === 0 ? 'N/A' : 'Not Fixable'),
+            id: componentSortFields.FIXEDIN,
+            accessor: 'fixedIn',
+            sortField: componentSortFields.FIXEDIN,
+            sortable: false,
+        },
+        {
+            Header: `Top CVSS`,
+            headerClassName: `w-1/10 text-center ${defaultHeaderClassName}`,
+            className: `w-1/10 ${defaultColumnClassName}`,
+            Cell: ({ original }) => {
+                const { topVuln } = original;
+                if (!topVuln) {
+                    return (
+                        <div className="mx-auto flex flex-col">
+                            <span>–</span>
+                        </div>
+                    );
+                }
+                const { cvss, scoreVersion } = topVuln;
+                return <TopCvssLabel cvss={cvss} version={scoreVersion} />;
+            },
+            id: componentSortFields.TOP_CVSS,
+            accessor: 'topVuln.cvss',
+            sortField: componentSortFields.TOP_CVSS,
+        },
+        {
+            Header: `Source`,
+            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+            className: `w-1/8 ${defaultColumnClassName}`,
+            id: componentSortFields.SOURCE,
+            accessor: 'source',
+            sortField: componentSortFields.SOURCE,
+        },
+        {
+            Header: `Location`,
+            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+            className: `w-1/8 word-break-all ${defaultColumnClassName}`,
+            Cell: ({ original }) => original.location || 'N/A',
+            id: componentSortFields.LOCATION,
+            accessor: 'location',
+            sortField: componentSortFields.LOCATION,
+        },
+        {
+            Header: `Nodes`,
+            entityType: entityTypes.NODE,
+            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+            className: `w-1/8 ${defaultColumnClassName}`,
+            id: componentSortFields.NODE_COUNT,
+            accessor: 'nodeCount',
+            Cell: ({ original, pdf }) => (
+                <TableCountLink
+                    entityType={entityTypes.NODE}
+                    count={original.nodeCount}
+                    textOnly={pdf}
+                    selectedRowId={original.id}
+                />
+            ),
+            sortField: componentSortFields.NODE_COUNT,
+        },
+        {
+            Header: `Risk Priority`,
+            headerClassName: `w-1/10 ${defaultHeaderClassName}`,
+            className: `w-1/10 ${defaultColumnClassName}`,
+            id: componentSortFields.PRIORITY,
+            accessor: 'priority',
+            sortField: componentSortFields.PRIORITY,
+        },
+    ];
+
+    const componentColumnsBasedOnContext = getFilteredComponentColumns(tableColumns, workflowState);
+
+    return removeEntityContextColumns(componentColumnsBasedOnContext, workflowState);
+}
+
+const VulnMgmtNodeComponents = ({ selectedRowId, search, sort, page, data, totalResults }) => {
+    const query = gql`
+        query getComponents($query: String, $pagination: Pagination) {
+            results: nodeComponents(query: $query, pagination: $pagination) {
+                ...nodeComponentFields
+            }
+            count: nodeComponentCount(query: $query)
+        }
+        ${VULN_NODE_COMPONENT_LIST_FRAGMENT}
+    `;
+    const tableSort = sort || defaultComponentSort;
+    const queryOptions = {
+        variables: {
+            query: queryService.objectToWhereClause(search),
+            scopeQuery: '',
+            pagination: queryService.getPagination(tableSort, page, LIST_PAGE_SIZE),
+        },
+    };
+
+    return (
+        <WorkflowListPage
+            data={data}
+            totalResults={totalResults}
+            query={query}
+            queryOptions={queryOptions}
+            idAttribute="id"
+            entityListType={entityTypes.NODE_COMPONENT}
+            getTableColumns={getComponentTableColumns}
+            selectedRowId={selectedRowId}
+            search={search}
+            sort={tableSort}
+            page={page}
+        />
+    );
+};
+
+VulnMgmtNodeComponents.propTypes = workflowListPropTypes;
+VulnMgmtNodeComponents.defaultProps = workflowListDefaultProps;
+
+export default VulnMgmtNodeComponents;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/VulnMgmtList.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/VulnMgmtList.js
@@ -6,6 +6,8 @@ import PageNotFound from 'Components/PageNotFound';
 import VulnMgmtListDeployments from './Deployments/VulnMgmtListDeployments';
 import VulnMgmtListImages from './Images/VulnMgmtListImages';
 import VulnMgmtListComponents from './Components/VulnMgmtListComponents';
+import VulnMgmtListNodeComponents from './NodeComponents/VulnMgmtListNodeComponents';
+import VulnMgmtListImageComponents from './ImageComponents/VulnMgmtListImageComponents';
 import VulnMgmtListCves from './Cves/VulnMgmtListCves';
 import VulnMgmtListClusters from './Clusters/VulnMgmtListClusters';
 import VulnMgmtListNamespaces from './Namespaces/VulnMgmtListNamespaces';
@@ -16,6 +18,8 @@ const entityComponentMap = {
     [entityTypes.DEPLOYMENT]: VulnMgmtListDeployments,
     [entityTypes.IMAGE]: VulnMgmtListImages,
     [entityTypes.COMPONENT]: VulnMgmtListComponents,
+    [entityTypes.NODE_COMPONENT]: VulnMgmtListNodeComponents,
+    [entityTypes.IMAGE_COMPONENT]: VulnMgmtListImageComponents,
     [entityTypes.CVE]: VulnMgmtListCves,
     [entityTypes.IMAGE_CVE]: VulnMgmtListCves,
     [entityTypes.NODE_CVE]: VulnMgmtListCves,

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.defaultSorts.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.defaultSorts.js
@@ -12,6 +12,8 @@ import { defaultNodeSort } from './List/Nodes/VulnMgmtListNodes';
 const vulnMgmtDefaultSorts = {
     [entityTypes.CLUSTER]: defaultClusterSort,
     [entityTypes.COMPONENT]: defaultComponentSort,
+    [entityTypes.NODE_COMPONENT]: defaultComponentSort,
+    [entityTypes.IMAGE_COMPONENT]: defaultComponentSort,
     [entityTypes.CVE]: defaultCveSort,
     [entityTypes.DEPLOYMENT]: defaultDeploymentSort,
     [entityTypes.IMAGE]: defaultImageSort,

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
@@ -243,7 +243,7 @@ export const VULN_CVE_LIST_FRAGMENT = gql`
 `;
 
 export const IMAGE_CVE_LIST_FRAGMENT = gql`
-    fragment cveFields on ImageVulnerability {
+    fragment imageCVEFields on ImageVulnerability {
         createdAt
         cve
         cvss
@@ -320,8 +320,8 @@ export const NODE_CVE_LIST_FRAGMENT = gql`
         suppressExpiry
         suppressed
         vulnerabilityState
-        componentCount: nodeComponentCount(query: $query)
-        nodeCount(query: $query)
+        componentCount: nodeComponentCount
+        nodeCount
     }
 `;
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
@@ -274,7 +274,7 @@ export const IMAGE_CVE_LIST_FRAGMENT = gql`
 `;
 
 export const CLUSTER_CVE_LIST_FRAGMENT = gql`
-    fragment cveFields on ClusterVulnerability {
+    fragment clusterCVEFields on ClusterVulnerability {
         createdAt
         cve
         cvss
@@ -300,7 +300,7 @@ export const CLUSTER_CVE_LIST_FRAGMENT = gql`
 `;
 
 export const NODE_CVE_LIST_FRAGMENT = gql`
-    fragment cveFields on NodeVulnerability {
+    fragment nodeCVEFields on NodeVulnerability {
         createdAt
         cve
         cvss
@@ -322,6 +322,33 @@ export const NODE_CVE_LIST_FRAGMENT = gql`
         vulnerabilityState
         componentCount: nodeComponentCount(query: $query)
         nodeCount(query: $query)
+    }
+`;
+
+export const VULN_IMAGE_CVE_LIST_FRAGMENT = gql`
+    fragment imageCVEFields on ImageVulnerability {
+        createdAt
+        cve
+        cvss
+        envImpact
+        fixedByVersion
+        id
+        impactScore
+        isFixable(query: $scopeQuery)
+        lastModified
+        lastScanned
+        link
+        publishedOn
+        scoreVersion
+        severity
+        summary
+        suppressActivation
+        suppressExpiry
+        suppressed
+        vulnerabilityState
+        componentCount: imageComponentCount
+        imageCount
+        deploymentCount
     }
 `;
 
@@ -506,6 +533,85 @@ export const VULN_COMPONENT_LIST_FRAGMENT = gql`
         imageCount(query: $query)
         deploymentCount(query: $query)
         nodeCount(query: $query)
+        priority
+    }
+`;
+
+export const VULN_NODE_COMPONENT_LIST_FRAGMENT = gql`
+    fragment nodeComponentFields on NodeComponent {
+        id
+        name
+        version
+        location
+        source
+        fixedIn
+        vulnCounter: nodeVulnerabilityCounter {
+            all {
+                total
+                fixable
+            }
+            low {
+                total
+                fixable
+            }
+            moderate {
+                total
+                fixable
+            }
+            important {
+                total
+                fixable
+            }
+            critical {
+                total
+                fixable
+            }
+        }
+        topVuln: topNodeVulnerability {
+            cvss
+            scoreVersion
+        }
+        nodeCount(query: $query)
+        priority
+    }
+`;
+
+export const VULN_IMAGE_COMPONENT_LIST_FRAGMENT = gql`
+    fragment imageComponentFields on ImageComponent {
+        id
+        name
+        version
+        location
+        source
+        fixedIn
+        vulnCounter: imageVulnerabilityCounter {
+            all {
+                total
+                fixable
+            }
+            low {
+                total
+                fixable
+            }
+            moderate {
+                total
+                fixable
+            }
+            important {
+                total
+                fixable
+            }
+            critical {
+                total
+                fixable
+            }
+        }
+        topVuln: topImageVulnerability {
+            cvss
+            scoreVersion
+        }
+        imageCount(query: $query)
+        deploymentCount(query: $query)
         priority
     }
 `;

--- a/ui/apps/platform/src/Containers/Workflow/WorkflowEntityPageLayout.js
+++ b/ui/apps/platform/src/Containers/Workflow/WorkflowEntityPageLayout.js
@@ -19,12 +19,23 @@ import useCaseLabels from 'messages/useCase';
 import useEntityName from 'hooks/useEntityName';
 import { exportCvesAsCsv } from 'services/VulnerabilitiesService';
 import { shouldUseOriginalCase } from 'utils/workflowUtils';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import entityTypes from 'constants/entityTypes';
 import WorkflowSidePanel from './WorkflowSidePanel';
 import { EntityComponentMap } from './UseCaseComponentMaps';
 
 const WorkflowEntityPageLayout = ({ location }) => {
     const { isDarkMode } = useTheme();
+    const { isFeatureFlagEnabled } = useFeatureFlags();
     const useCaseEntityMap = getUseCaseEntityMap();
+    if (isFeatureFlagEnabled('ROX_FRONTEND_VM_UDPATES')) {
+        const newTypes = useCaseEntityMap['vulnerability-management'].filter(
+            (entityType) => entityType !== entityTypes.COMPONENT
+        );
+        newTypes.push(entityTypes.NODE_COMPONENT);
+        newTypes.push(entityTypes.IMAGE_COMPONENT);
+        useCaseEntityMap['vulnerability-management'] = newTypes;
+    }
 
     const workflowState = parseURL(location);
     const { stateStack, useCase, search } = workflowState;

--- a/ui/apps/platform/src/Containers/Workflow/WorkflowListPageLayout.js
+++ b/ui/apps/platform/src/Containers/Workflow/WorkflowListPageLayout.js
@@ -16,11 +16,23 @@ import workflowStateContext from 'Containers/workflowStateContext';
 import { WorkflowState } from 'utils/WorkflowState';
 import { getUseCaseEntityMap } from 'utils/entityRelationships';
 import { exportCvesAsCsv } from 'services/VulnerabilitiesService';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import entityTypes from 'constants/entityTypes';
 import WorkflowSidePanel from './WorkflowSidePanel';
 import { EntityComponentMap, ListComponentMap } from './UseCaseComponentMaps';
 
 const WorkflowListPageLayout = ({ location }) => {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
     const useCaseEntityMap = getUseCaseEntityMap();
+    if (isFeatureFlagEnabled('ROX_FRONTEND_VM_UDPATES')) {
+        const newTypes = useCaseEntityMap['vulnerability-management'].filter(
+            (entityType) => entityType !== entityTypes.COMPONENT
+        );
+        newTypes.push(entityTypes.NODE_COMPONENT);
+        newTypes.push(entityTypes.IMAGE_COMPONENT);
+        useCaseEntityMap['vulnerability-management'] = newTypes;
+    }
+
     const { isDarkMode } = useTheme();
     const workflowState = parseURL(location);
     const { useCase, search, sort, paging } = workflowState;

--- a/ui/apps/platform/src/constants/entityTypes.ts
+++ b/ui/apps/platform/src/constants/entityTypes.ts
@@ -7,6 +7,8 @@ export type ResourceType =
     | 'SECRET'
     | 'IMAGE'
     | 'COMPONENT'
+    | 'NODE_COMPONENT'
+    | 'IMAGE_COMPONENT'
     | 'CVE'
     | 'IMAGE_CVE'
     | 'NODE_CVE'
@@ -23,6 +25,8 @@ export const resourceTypes: Record<ResourceType, ResourceType> = {
     SECRET: 'SECRET',
     IMAGE: 'IMAGE',
     COMPONENT: 'COMPONENT',
+    NODE_COMPONENT: 'NODE_COMPONENT',
+    IMAGE_COMPONENT: 'IMAGE_COMPONENT',
     CVE: 'CVE',
     IMAGE_CVE: 'IMAGE_CVE',
     NODE_CVE: 'NODE_CVE',

--- a/ui/apps/platform/src/constants/workflowPages.constants.js
+++ b/ui/apps/platform/src/constants/workflowPages.constants.js
@@ -10,6 +10,8 @@ export const LIST_PAGE_SIZE = 25;
 
 export const defaultCountKeyMap = {
     [entityTypes.COMPONENT]: 'componentCount',
+    [entityTypes.NODE_COMPONENT]: 'componentCount',
+    [entityTypes.IMAGE_COMPONENT]: 'componentCount',
     [entityTypes.CVE]: 'vulnCount',
     [entityTypes.K8S_CVE]: 'vulnCount: k8sVulnCount',
     [entityTypes.DEPLOYMENT]: 'deploymentCount',

--- a/ui/apps/platform/src/messages/common.ts
+++ b/ui/apps/platform/src/messages/common.ts
@@ -85,6 +85,8 @@ export const resourceLabels = Object.freeze({
     NODE_CVE: 'Node CVE',
     CLUSTER_CVE: 'Platform CVE',
     COMPONENT: 'component',
+    NODE_COMPONENT: 'node component',
+    IMAGE_COMPONENT: 'image component',
     IMAGE: 'image',
     POLICY: 'policy',
     CHECK: 'check',

--- a/ui/apps/platform/src/queries/components.js
+++ b/ui/apps/platform/src/queries/components.js
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client';
 
-const COMPONENT_NAME = gql`
+export const COMPONENT_NAME = gql`
     query getComponentName($id: ID!) {
         component(id: $id) {
             id
@@ -10,4 +10,22 @@ const COMPONENT_NAME = gql`
     }
 `;
 
-export default COMPONENT_NAME;
+export const NODE_COMPONENT_NAME = gql`
+    query getNodeComponentName($id: ID!) {
+        nodeComponent(id: $id) {
+            id
+            name
+            version
+        }
+    }
+`;
+
+export const IMAGE_COMPONENT_NAME = gql`
+    query getImageComponentName($id: ID!) {
+        imageComponent(id: $id) {
+            id
+            name
+            version
+        }
+    }
+`;

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -58,7 +58,10 @@ export const vulnManagementClustersPath = `${vulnManagementPath}/clusters`;
 export const vulnManagementNamespacesPath = `${vulnManagementPath}/namespaces`;
 export const vulnManagementDeploymentsPath = `${vulnManagementPath}/deployments`;
 export const vulnManagementImagesPath = `${vulnManagementPath}/images`;
+// TODO: Remove the /components path once we completely split the components into node and image components
 export const vulnManagementComponentsPath = `${vulnManagementPath}/components`;
+export const vulnManagementNodeComponentsPath = `${vulnManagementPath}/node-components`;
+export const vulnManagementImageComponentsPath = `${vulnManagementPath}/image-components`;
 export const vulnManagementNodesPath = `${vulnManagementPath}/nodes`;
 
 // The following paths are not part of the infinite nesting Workflow in Vuln Management
@@ -87,6 +90,8 @@ export const urlEntityListTypes = {
     [resourceTypes.NODE_CVE]: 'node-cves',
     [resourceTypes.CLUSTER_CVE]: 'cluster-cves',
     [resourceTypes.COMPONENT]: 'components',
+    [resourceTypes.NODE_COMPONENT]: 'node-components',
+    [resourceTypes.IMAGE_COMPONENT]: 'image-components',
     [standardEntityTypes.CONTROL]: 'controls',
     [rbacConfigTypes.SERVICE_ACCOUNT]: 'serviceaccounts',
     [rbacConfigTypes.SUBJECT]: 'subjects',
@@ -106,6 +111,8 @@ export const urlEntityTypes = {
     [resourceTypes.NODE_CVE]: 'node-cve',
     [resourceTypes.CLUSTER_CVE]: 'cluster-cve',
     [resourceTypes.COMPONENT]: 'component',
+    [resourceTypes.NODE_COMPONENT]: 'node-component',
+    [resourceTypes.IMAGE_COMPONENT]: 'image-component',
     [standardEntityTypes.CONTROL]: 'control',
     [standardEntityTypes.STANDARD]: 'standard',
     [rbacConfigTypes.SERVICE_ACCOUNT]: 'serviceaccount',

--- a/ui/apps/platform/src/types/risk.proto.ts
+++ b/ui/apps/platform/src/types/risk.proto.ts
@@ -30,6 +30,7 @@ export type RiskSubjectType =
     | 'CLUSTER'
     | 'NODE'
     | 'NODE_COMPONENT'
+    | 'IMAGE_COMPONENT'
     | 'IMAGE'
     | 'IMAGE_COMPONENT'
     | 'SERVICEACCOUNT';

--- a/ui/apps/platform/src/utils/entityRelationships.ts
+++ b/ui/apps/platform/src/utils/entityRelationships.ts
@@ -31,9 +31,6 @@ export const useCaseEntityMap = {
         ...baseEntities,
         entityTypes.IMAGE,
         entityTypes.COMPONENT,
-        // @TODO: Uncomment the following and delete the Component type when we move to the new types
-        // entityTypes.NODE_COMPONENT,
-        // entityTypes.IMAGE_COMPONENT,
     ],
 };
 

--- a/ui/apps/platform/src/utils/entityRelationships.ts
+++ b/ui/apps/platform/src/utils/entityRelationships.ts
@@ -31,8 +31,9 @@ export const useCaseEntityMap = {
         ...baseEntities,
         entityTypes.IMAGE,
         entityTypes.COMPONENT,
-        entityTypes.NODE_COMPONENT,
-        entityTypes.IMAGE_COMPONENT,
+        // @TODO: Uncomment the following and delete the Component type when we move to the new types
+        // entityTypes.NODE_COMPONENT,
+        // entityTypes.IMAGE_COMPONENT,
     ],
 };
 
@@ -88,7 +89,9 @@ const entityRelationshipMap: Record<string, EntityRelationshipData> = {
         // extendedMatches: [entityTypes.POLICY]
     },
     [entityTypes.NODE]: {
-        children: [entityTypes.NODE_COMPONENT],
+        // @TODO: Uncomment this once we're using the new entity
+        // children: [entityTypes.NODE_COMPONENT],
+        children: [entityTypes.COMPONENT],
         parents: [entityTypes.CLUSTER],
         matches: [entityTypes.CONTROL],
     },
@@ -109,7 +112,9 @@ const entityRelationshipMap: Record<string, EntityRelationshipData> = {
         ],
     },
     [entityTypes.IMAGE]: {
-        children: [entityTypes.IMAGE_COMPONENT],
+        // @TODO: Uncomment this once we're using the new entity
+        // children: [entityTypes.IMAGE_COMPONENT],
+        children: [entityTypes.COMPONENT],
         parents: [],
         matches: [entityTypes.DEPLOYMENT],
     },
@@ -122,13 +127,13 @@ const entityRelationshipMap: Record<string, EntityRelationshipData> = {
     [entityTypes.NODE_COMPONENT]: {
         children: [],
         parents: [],
-        matches: [entityTypes.IMAGE, entityTypes.CVE, entityTypes.NODE],
-        extendedMatches: [entityTypes.DEPLOYMENT],
+        matches: [entityTypes.CVE, entityTypes.NODE],
+        extendedMatches: [],
     },
     [entityTypes.IMAGE_COMPONENT]: {
         children: [],
         parents: [],
-        matches: [entityTypes.IMAGE, entityTypes.CVE, entityTypes.NODE],
+        matches: [entityTypes.IMAGE, entityTypes.CVE],
         extendedMatches: [entityTypes.DEPLOYMENT],
     },
     // TODO: remove this old CVE entity type which encompasses node CVEs, image/component CVEs, k8s CVEs (for clusters)

--- a/ui/apps/platform/src/utils/entityRelationships.ts
+++ b/ui/apps/platform/src/utils/entityRelationships.ts
@@ -31,6 +31,8 @@ export const useCaseEntityMap = {
         ...baseEntities,
         entityTypes.IMAGE,
         entityTypes.COMPONENT,
+        entityTypes.NODE_COMPONENT,
+        entityTypes.IMAGE_COMPONENT,
     ],
 };
 
@@ -86,7 +88,7 @@ const entityRelationshipMap: Record<string, EntityRelationshipData> = {
         // extendedMatches: [entityTypes.POLICY]
     },
     [entityTypes.NODE]: {
-        children: [entityTypes.COMPONENT],
+        children: [entityTypes.NODE_COMPONENT],
         parents: [entityTypes.CLUSTER],
         matches: [entityTypes.CONTROL],
     },
@@ -107,11 +109,23 @@ const entityRelationshipMap: Record<string, EntityRelationshipData> = {
         ],
     },
     [entityTypes.IMAGE]: {
-        children: [entityTypes.COMPONENT],
+        children: [entityTypes.IMAGE_COMPONENT],
         parents: [],
         matches: [entityTypes.DEPLOYMENT],
     },
     [entityTypes.COMPONENT]: {
+        children: [],
+        parents: [],
+        matches: [entityTypes.IMAGE, entityTypes.CVE, entityTypes.NODE],
+        extendedMatches: [entityTypes.DEPLOYMENT],
+    },
+    [entityTypes.NODE_COMPONENT]: {
+        children: [],
+        parents: [],
+        matches: [entityTypes.IMAGE, entityTypes.CVE, entityTypes.NODE],
+        extendedMatches: [entityTypes.DEPLOYMENT],
+    },
+    [entityTypes.IMAGE_COMPONENT]: {
         children: [],
         parents: [],
         matches: [entityTypes.IMAGE, entityTypes.CVE, entityTypes.NODE],

--- a/ui/apps/platform/src/utils/queryMap.js
+++ b/ui/apps/platform/src/utils/queryMap.js
@@ -16,7 +16,7 @@ import { IMAGE_QUERY, IMAGES_QUERY, IMAGE_NAME } from 'queries/image';
 import { NODES_QUERY, NODE_QUERY, NODE_NAME } from 'queries/node';
 import { SUBJECTS_QUERY, SUBJECT_QUERY, SUBJECT_NAME } from 'queries/subject';
 
-import COMPONENT_NAME from 'queries/components';
+import { COMPONENT_NAME, NODE_COMPONENT_NAME, IMAGE_COMPONENT_NAME } from 'queries/components';
 
 export const entityQueryMap = {
     [entityTypes.SERVICE_ACCOUNT]: SERVICE_ACCOUNT_QUERY,
@@ -63,4 +63,6 @@ export const entityNameQueryMap = {
     [entityTypes.POLICY]: POLICY_NAME,
     [entityTypes.SUBJECT]: SUBJECT_NAME,
     [entityTypes.COMPONENT]: COMPONENT_NAME,
+    [entityTypes.NODE_COMPONENT]: NODE_COMPONENT_NAME,
+    [entityTypes.IMAGE_COMPONENT]: IMAGE_COMPONENT_NAME,
 };

--- a/ui/apps/platform/src/utils/queryService.js
+++ b/ui/apps/platform/src/utils/queryService.js
@@ -21,6 +21,10 @@ import {
     DEPLOYMENT_LIST_FRAGMENT as VULN_DEPLOYMENT_LIST_FRAGMENT,
     NAMESPACE_LIST_FRAGMENT as VULN_NAMESPACE_LIST_FRAGMENT,
     POLICY_LIST_FRAGMENT as VULN_POLICY_LIST_FRAGMENT,
+    VULN_IMAGE_COMPONENT_LIST_FRAGMENT,
+    VULN_NODE_COMPONENT_LIST_FRAGMENT,
+    NODE_CVE_LIST_FRAGMENT,
+    VULN_IMAGE_CVE_LIST_FRAGMENT,
 } from 'Containers/VulnMgmt/VulnMgmt.fragments';
 import { DEFAULT_PAGE_SIZE } from 'Components/Table';
 
@@ -90,6 +94,18 @@ function getListFieldName(entityType, listType, useCase) {
         }
     }
 
+    if (entityType === entityTypes.NODE_COMPONENT) {
+        if (listType === entityTypes.CVE) {
+            return 'nodeVulnerabilities';
+        }
+    }
+
+    if (entityType === entityTypes.IMAGE_COMPONENT) {
+        if (listType === entityTypes.CVE) {
+            return 'imageVulnerabilities';
+        }
+    }
+
     if (entityType === entityTypes.IMAGE) {
         if (listType === entityTypes.CVE) {
             return 'vulns';
@@ -153,8 +169,8 @@ function getListFieldName(entityType, listType, useCase) {
     return parts.join('');
 }
 
-function getFragmentName(entityType) {
-    switch (entityType) {
+function getFragmentName(entityType, listType) {
+    switch (listType) {
         case entityTypes.IMAGE:
             return 'imageFields';
         case entityTypes.NODE:
@@ -176,15 +192,25 @@ function getFragmentName(entityType) {
         case entityTypes.CONTROL:
             return 'controlFields';
         case entityTypes.CVE:
+            if (entityType === entityTypes.NODE_COMPONENT) {
+                return 'nodeCVEFields';
+            }
+            if (entityType === entityTypes.IMAGE_COMPONENT) {
+                return 'imageCVEFields';
+            }
             return 'cveFields';
         case entityTypes.COMPONENT:
             return 'componentFields';
+        case entityTypes.NODE_COMPONENT:
+            return 'nodeComponentFields';
+        case entityTypes.IMAGE_COMPONENT:
+            return 'imageComponentFields';
         default:
             return '';
     }
 }
 
-function getFragment(entityType, useCase) {
+function getFragment(entityType, listType, useCase) {
     const defaultFragments = {
         [entityTypes.IMAGE]: IMAGE_FRAGMENT,
         [entityTypes.NODE]: NODE_FRAGMENT,
@@ -207,7 +233,11 @@ function getFragment(entityType, useCase) {
         [useCases.VULN_MANAGEMENT]: {
             ...defaultFragments,
             [entityTypes.COMPONENT]: VULN_COMPONENT_LIST_FRAGMENT,
+            [entityTypes.NODE_COMPONENT]: VULN_NODE_COMPONENT_LIST_FRAGMENT,
+            [entityTypes.IMAGE_COMPONENT]: VULN_IMAGE_COMPONENT_LIST_FRAGMENT,
             [entityTypes.CVE]: VULN_CVE_LIST_FRAGMENT,
+            [entityTypes.NODE_CVE]: NODE_CVE_LIST_FRAGMENT,
+            [entityTypes.IMAGE_CVE]: VULN_IMAGE_CVE_LIST_FRAGMENT,
             [entityTypes.IMAGE]: VULN_IMAGE_LIST_FRAGMENT,
             [entityTypes.CLUSTER]: VULN_CLUSTER_LIST_FRAGMENT,
             [entityTypes.NAMESPACE]: VULN_NAMESPACE_LIST_FRAGMENT,
@@ -218,13 +248,20 @@ function getFragment(entityType, useCase) {
 
     const fragmentMap = fragmentsByUseCase[useCase] || defaultFragments;
 
-    return fragmentMap[entityType];
+    if (entityType === entityTypes.NODE_COMPONENT && listType === entityTypes.CVE) {
+        return NODE_CVE_LIST_FRAGMENT;
+    }
+    if (entityType === entityTypes.IMAGE_COMPONENT && listType === entityTypes.CVE) {
+        return VULN_IMAGE_CVE_LIST_FRAGMENT;
+    }
+
+    return fragmentMap[listType];
 }
 
 function getFragmentInfo(entityType, listType, useCase) {
     const listFieldName = getListFieldName(entityType, listType, useCase);
-    const fragmentName = getFragmentName(listType);
-    const fragment = getFragment(listType, useCase);
+    const fragmentName = getFragmentName(entityType, listType);
+    const fragment = getFragment(entityType, listType, useCase);
 
     return {
         listFieldName,


### PR DESCRIPTION
## Description

* Added two new entity types: `IMAGE_COMPONENT` and `NODE_COMPONENT`
* It's difficult to feature flag the `entityRelationships.ts` because that module doesn't live within the React lifecycle so I'm open to suggestions on how to go about feature flagging it. For now, I commented out the changes so the entity relationships won't be updated right now

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed


<img width="1552" alt="Screen Shot 2022-06-24 at 4 28 44 PM" src="https://user-images.githubusercontent.com/4805485/175745629-b95c901e-1895-4aaf-b182-e152d1468deb.png">
<img width="1552" alt="Screen Shot 2022-06-24 at 4 29 02 PM" src="https://user-images.githubusercontent.com/4805485/175745668-b2b455d4-bd64-4a9c-baf1-5c465e167924.png">
<img width="1552" alt="Screen Shot 2022-06-24 at 4 29 20 PM" src="https://user-images.githubusercontent.com/4805485/175745690-add5372e-82e3-4567-9c8b-6538073791b3.png">
<img width="1552" alt="Screen Shot 2022-06-24 at 4 29 30 PM" src="https://user-images.githubusercontent.com/4805485/175745720-29a1fd9c-6a0e-473b-a853-7ecfb9d4dba5.png">
