### PR TITLE
CI: Get roxctl for e2e

### DIFF
--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -65,7 +65,7 @@ case "$ci_job" in
         "$ROOT/scripts/ci/jobs/ui-unit-tests.sh"
         ;;
     test-binary-build-commands)
-        make cli upgrader
+        "$ROOT/scripts/ci/jobs/test-binary-build-commands.sh"
         ;;
     push-images)
         "$ROOT/scripts/ci/jobs/push-images.sh" "$@"

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -64,6 +64,9 @@ case "$ci_job" in
     ui-unit-tests)
         "$ROOT/scripts/ci/jobs/ui-unit-tests.sh"
         ;;
+    test-binary-build-commands)
+        make cli upgrader
+        ;;
     push-images)
         "$ROOT/scripts/ci/jobs/push-images.sh" "$@"
         ;;

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -19,12 +19,6 @@ test_part_1() {
 
     export_test_environment
 
-    if is_OPENSHIFT_CI; then
-        # TODO(RS-494) may provide roxctl
-        make cli-linux
-        install_built_roxctl_in_gopath
-    fi
-
     setup_gcp
     setup_deployment_env false false
     remove_existing_stackrox_resources

--- a/scripts/ci/jobs/test-binary-build-commands.sh
+++ b/scripts/ci/jobs/test-binary-build-commands.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+source "$ROOT/scripts/ci/lib.sh"
+
+set -euo pipefail
+
+make_test_bin() {
+    info "Making test-bin"
+
+    make cli upgrader
+    install_built_roxctl_in_gopath
+}
+
+make_test_bin "$*"

--- a/tests/e2e/run-ui-e2e.sh
+++ b/tests/e2e/run-ui-e2e.sh
@@ -18,12 +18,6 @@ test_ui_e2e() {
 
     export_test_environment
 
-    if is_OPENSHIFT_CI; then
-        # TODO(RS-494) may provide roxctl
-        make cli-linux
-        install_built_roxctl_in_gopath
-    fi
-
     setup_deployment_env false false
     remove_existing_stackrox_resources
     setup_default_TLS_certs

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -65,12 +65,6 @@ test_e2e() {
 }
 
 test_preamble() {
-    if is_OPENSHIFT_CI; then
-        # TODO(RS-494) may provide roxctl
-        make cli-linux
-        install_built_roxctl_in_gopath
-    fi
-
     require_executable "roxctl"
 
     if ! is_CI; then

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -44,7 +44,6 @@ test_upgrade() {
 
     preamble
     setup_deployment_env false false
-    install_built_roxctl_in_gopath
     remove_existing_stackrox_resources
 
     info "Deploying central"
@@ -73,11 +72,6 @@ preamble() {
         TEST_HOST_OS="linux"
     else
         die "Only linux or darwin are supported for this test"
-    fi
-
-    if is_OPENSHIFT_CI; then
-        # TODO RS-494 will provide the binaries
-        make cli-linux upgrader
     fi
 
     require_executable "$TEST_ROOT/bin/$TEST_HOST_OS/roxctl"

--- a/ui/README.md
+++ b/ui/README.md
@@ -262,3 +262,4 @@ extensions installed:
 
 -   [React Developer Tools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en)
 -   [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en)
+


### PR DESCRIPTION
## Description

With https://github.com/openshift/release/pull/29752, e2e tests will run in a `test-bin`. This PR will give that container a `roxctl` and `upgrader`.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient