### PR TITLE
Add resource replacements within UI

### DIFF
--- a/ui/apps/platform/src/hooks/usePermissions.ts
+++ b/ui/apps/platform/src/hooks/usePermissions.ts
@@ -24,22 +24,88 @@ const stateSelector = createStructuredSelector<{
     isLoadingPermissions: selectors.getIsLoadingUserRolePermissions,
 });
 
+// TODO(ROX-11453): Remove this mapping once the old resources are fully deprecated.
+const replacedResourceMapping = new Map([
+    ['AllComments', 'Administration'],
+    ['APIToken', 'Integration'],
+    ['AuthPlugin', 'Access'],
+    ['AuthProvider', 'Access'],
+    ['BackupPlugins', 'Integration'],
+    ['ComplianceRuns', 'Compliance'],
+    ['ComplianceRunSchedule', 'Administration'],
+    ['Config', 'Administration'],
+    ['DebugLogs', 'Administration'],
+    ['Group', 'Access'],
+    ['ImageIntegration', 'Integration'],
+    ['Indicator', 'DeploymentExtension'],
+    ['Licenses', 'Access'],
+    ['NetworkBaseline', 'DeploymentExtension'],
+    ['NetworkGraphConfig', 'Administration'],
+    ['Notifier', 'Integration'],
+    ['ProbeUpload', 'Administration'],
+    ['ProcessWhitelist', 'DeploymentExtension'],
+    ['Risk', 'DeploymentExtension'],
+    ['Role', 'Access'],
+    ['ScannerBundle', 'Administration'],
+    ['ScannerDefinitions', 'Administration'],
+    ['SensorUpgradeConfig', 'Administration'],
+    ['ServiceIdentity', 'Administration'],
+    ['SignatureIntegration', 'Integration'],
+    ['User', 'Access'],
+]);
+
 const usePermissions = (): UsePermissionsResponse => {
     const { userRolePermissions, isLoadingPermissions } = useSelector(stateSelector);
 
     function hasNoAccess(resourceName: ResourceName) {
         const access = userRolePermissions?.resourceToAccess[resourceName];
-        return access === 'NO_ACCESS';
+        if (access === 'NO_ACCESS') {
+            return true;
+        }
+
+        if (replacedResourceMapping.has(resourceName)) {
+            const replacedResourceAccess =
+                userRolePermissions?.resourceToAccess[
+                    replacedResourceMapping.get(resourceName) as ResourceName
+                ];
+            return replacedResourceAccess === 'NO_ACCESS';
+        }
+        return false;
     }
 
     function hasReadAccess(resourceName: ResourceName) {
         const access = userRolePermissions?.resourceToAccess[resourceName];
-        return access === 'READ_ACCESS' || access === 'READ_WRITE_ACCESS';
+        if (access === 'READ_ACCESS' || access === 'READ_WRITE_ACCESS') {
+            return true;
+        }
+
+        if (replacedResourceMapping.has(resourceName)) {
+            const replacedResourceAccess =
+                userRolePermissions?.resourceToAccess[
+                    replacedResourceMapping.get(resourceName) as ResourceName
+                ];
+            return (
+                replacedResourceAccess === 'READ_ACCESS' ||
+                replacedResourceAccess === 'READ_WRITE_ACCESS'
+            );
+        }
+        return false;
     }
 
     function hasReadWriteAccess(resourceName: ResourceName) {
         const access = userRolePermissions?.resourceToAccess[resourceName];
-        return access === 'READ_WRITE_ACCESS';
+        if (access === 'READ_WRITE_ACCESS') {
+            return true;
+        }
+
+        if (replacedResourceMapping.has(resourceName)) {
+            const replacedResourceAccess =
+                userRolePermissions?.resourceToAccess[
+                    replacedResourceMapping.get(resourceName) as ResourceName
+                ];
+            return replacedResourceAccess === 'READ_WRITE_ACCESS';
+        }
+        return false;
     }
 
     return { hasNoAccess, hasReadAccess, hasReadWriteAccess, isLoadingPermissions };

--- a/ui/apps/platform/src/reducers/roles.js
+++ b/ui/apps/platform/src/reducers/roles.js
@@ -104,6 +104,36 @@ const getUserRolePermissions = (state) => state.userRolePermissions;
 const getUserRolePermissionsError = (state) => state.error;
 const getIsLoadingUserRolePermissions = (state) => state.isLoading;
 
+// TODO(ROX-11453): Remove this mapping once the old resources are fully deprecated.
+const replacedResourceMapping = new Map([
+    ['AllComments', 'Administration'],
+    ['APIToken', 'Integration'],
+    ['AuthPlugin', 'Access'],
+    ['AuthProvider', 'Access'],
+    ['BackupPlugins', 'Integration'],
+    ['ComplianceRuns', 'Compliance'],
+    ['ComplianceRunSchedule', 'Administration'],
+    ['Config', 'Administration'],
+    ['DebugLogs', 'Administration'],
+    ['Group', 'Access'],
+    ['ImageIntegration', 'Integration'],
+    ['Indicator', 'DeploymentExtension'],
+    ['Licenses', 'Access'],
+    ['NetworkBaseline', 'DeploymentExtension'],
+    ['NetworkGraphConfig', 'Administration'],
+    ['Notifier', 'Integration'],
+    ['ProbeUpload', 'Administration'],
+    ['ProcessWhitelist', 'DeploymentExtension'],
+    ['Risk', 'DeploymentExtension'],
+    ['Role', 'Access'],
+    ['ScannerBundle', 'Administration'],
+    ['ScannerDefinitions', 'Administration'],
+    ['SensorUpgradeConfig', 'Administration'],
+    ['ServiceIdentity', 'Administration'],
+    ['SignatureIntegration', 'Integration'],
+    ['User', 'Access'],
+]);
+
 /*
  * Given resource string (for example, "APIToken") and role or permissionSet object,
  * return access level (for example, "READ_ACCESS").
@@ -114,12 +144,39 @@ const getAccessForPermission = (resource, userRolePermissionsArg) => {
 
 export const getHasReadPermission = (resource, userRolePermissionsArg) => {
     const access = getAccessForPermission(resource, userRolePermissionsArg);
-    return access === ACCESS_LEVEL.READ_WRITE_ACCESS || access === ACCESS_LEVEL.READ_ACCESS;
+    if (access === ACCESS_LEVEL.READ_WRITE_ACCESS || access === ACCESS_LEVEL.READ_ACCESS) {
+        return true;
+    }
+    // If the given resource doesn't yield the required access, try with the replacing resource (if there is any).
+    if (replacedResourceMapping.has(resource)) {
+        const replacingResourceAccess = getAccessForPermission(
+            replacedResourceMapping.get(resource),
+            userRolePermissionsArg
+        );
+        return (
+            replacingResourceAccess === ACCESS_LEVEL.READ_WRITE_ACCESS ||
+            replacingResourceAccess === ACCESS_LEVEL.READ_ACCESS
+        );
+    }
+    // Return false if neither the resource nor the replacing resource have the correct access.
+    return false;
 };
 
 export const getHasReadWritePermission = (resource, userRolePermissionsArg) => {
     const access = getAccessForPermission(resource, userRolePermissionsArg);
-    return access === ACCESS_LEVEL.READ_WRITE_ACCESS;
+    if (access === ACCESS_LEVEL.READ_WRITE_ACCESS) {
+        return true;
+    }
+    // If the given resource doesn't yield the required access, try with the replacing resource (if there is any).
+    if (replacedResourceMapping.has(resource)) {
+        const replacingResourceAccess = getAccessForPermission(
+            replacedResourceMapping.get(resource),
+            userRolePermissionsArg
+        );
+        return replacingResourceAccess === ACCESS_LEVEL.READ_WRITE_ACCESS;
+    }
+    // Return false if neither the resource nor the replacing resource have the correct access.
+    return false;
 };
 
 export const selectors = {


### PR DESCRIPTION
## Description

Within the PR of [ROX-8520](https://github.com/stackrox/stackrox/pull/1384) some resources have been grouped and replaced. This will land within 3.71 release.
What's currently not done properly is to respect the newly created resources as replacements within the UI, i.e. allowing access to existing pages by
- either having access to the old, to-be-deprecated resource.
- having access to the newly introduced resource.

This PR adds the support for this, by maintaining a map of old, to-be-deprecated resources as well as their newly created counterparts.

Within [ROX-11453](https://issues.redhat.com/browse/ROX-11453), the plan is to fully deprecate the old resource once the grace period is over, and simplify existing authorization checks.
