### PR TITLE
Add "Images at most risk" widget

### DIFF
--- a/ui/apps/platform/src/Components/CollapsibleSection/CollapsibleSection.js
+++ b/ui/apps/platform/src/Components/CollapsibleSection/CollapsibleSection.js
@@ -8,6 +8,7 @@ import CollapsibleAnimatedDiv from 'Components/animations/CollapsibleAnimatedDiv
 const iconClass = 'bg-base-100 border-2 border-base-400 rounded-full h-5 w-5';
 
 const CollapsibleSection = ({
+    id,
     title,
     children,
     headerComponents,
@@ -29,7 +30,7 @@ const CollapsibleSection = ({
     );
 
     return (
-        <div className="border-b border-base-300" data-testid={dataTestId}>
+        <div id={id} className="border-b border-base-300" data-testid={dataTestId}>
             <header className={`flex flex-1 w-full ${headerClassName}`}>
                 <div className="flex flex-1">
                     <div
@@ -49,6 +50,7 @@ const CollapsibleSection = ({
 };
 
 CollapsibleSection.propTypes = {
+    id: PropTypes.string,
     title: PropTypes.string.isRequired,
     children: PropTypes.node.isRequired,
     headerClassName: PropTypes.string,
@@ -59,6 +61,7 @@ CollapsibleSection.propTypes = {
 };
 
 CollapsibleSection.defaultProps = {
+    id: null,
     headerClassName: 'py-4',
     headerComponents: null,
     titleClassName: 'p-4 text-xl',

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
@@ -12,6 +12,7 @@ import {
 import SummaryCounts from './SummaryCounts';
 import ScopeBar from './ScopeBar';
 
+import ImagesAtMostRisk from './Widgets/ImagesAtMostRisk';
 import ViolationsByPolicyCategory from './Widgets/ViolationsByPolicyCategory';
 import DeploymentsAtMostRisk from './Widgets/DeploymentsAtMostRisk';
 import AgingImages from './Widgets/AgingImages';
@@ -43,6 +44,9 @@ function DashboardPage() {
             <Divider component="div" />
             <PageSection>
                 <Grid hasGutter style={{ gridAutoRows: 'max-content' }}>
+                    <GridItem lg={6}>
+                        <ImagesAtMostRisk />
+                    </GridItem>
                     <GridItem lg={6}>
                         <DeploymentsAtMostRisk />
                     </GridItem>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.tsx
@@ -30,6 +30,7 @@ import AgingImagesChart, {
     TimeRangeTuple,
     timeRangeTupleIndices,
 } from './AgingImagesChart';
+import isResourceScoped from '../utils';
 
 export const imageCountQuery = gql`
     query agingImagesQuery($query0: String, $query1: String, $query2: String, $query3: String) {
@@ -73,7 +74,7 @@ function getWidgetTitle(
             return selectedTimeRanges[index].enabled;
         }) ?? 0;
 
-    const isActiveImages = Boolean(searchFilter.Cluster) || Boolean(searchFilter['Namespace ID']);
+    const isActiveImages = isResourceScoped(searchFilter);
 
     if (isActiveImages) {
         return `${totalImages} Active aging ${pluralize('image', totalImages)}`;

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImagesChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImagesChart.tsx
@@ -14,6 +14,7 @@ import { LinkableChartLabel } from 'Components/PatternFly/Charts/LinkableChartLa
 import { SearchFilter } from 'types/search';
 import { vulnManagementImagesPath } from 'routePaths';
 import { getQueryString } from 'utils/queryStringUtils';
+import isResourceScoped from '../utils';
 
 // The available time buckets for this widget will always be a set of '4', so we can
 // narrow the types to a tuple here for safer indexing throughout this component.
@@ -48,9 +49,7 @@ function linkForAgingImages(searchFilter: SearchFilter, ageRange: number) {
 }
 
 function yAxisTitle(searchFilter: SearchFilter) {
-    const isActiveImages = Boolean(searchFilter.Cluster) || Boolean(searchFilter['Namespace ID']);
-
-    return isActiveImages ? 'Active images' : 'All images';
+    return isResourceScoped(searchFilter) ? 'Active images' : 'All images';
 }
 
 // `datum` for these callbacks will refer to the index number of the bar in the chart. This index

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
@@ -49,7 +49,7 @@ const mocks = [
         request: {
             query: imagesQuery,
             variables: {
-                query: 'Namespace:*',
+                query: '',
             },
         },
         result: {
@@ -86,16 +86,16 @@ describe('Images at most risk dashboard widget', () => {
 
         expect(
             await screen.findByRole('heading', {
-                name: 'Active images with most severe CVEs',
+                name: 'All images at most risk',
             })
         ).toBeInTheDocument();
 
         await user.click(await screen.findByRole('button', { name: `Options` }));
-        await user.click(await screen.findByRole('button', { name: `All images` }));
+        await user.click(await screen.findByRole('button', { name: `Active images` }));
 
         expect(
             await screen.findByRole('heading', {
-                name: 'Images with most severe CVEs',
+                name: 'Active images at most risk',
             })
         ).toBeInTheDocument();
     });
@@ -121,7 +121,7 @@ describe('Images at most risk dashboard widget', () => {
             utils: { history },
         } = setup();
 
-        await screen.findByRole('heading', { name: 'Active images with most severe CVEs' });
+        await screen.findByRole('heading', { name: 'All images at most risk' });
         await user.click(screen.getByRole('link', { name: 'reg/name-2:tag' }));
         expect(history.location.pathname).toBe('/main/vulnerability-management/image/2');
         expect(history.location.hash).toBe('#image-findings');

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { MockedProvider } from '@apollo/client/testing';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+
+import renderWithRouter from 'test-utils/renderWithRouter';
+import ImagesAtMostRisk, { imagesQuery } from './ImagesAtMostRisk';
+
+function makeMockImage(
+    id: string,
+    remote: string,
+    fullName: string,
+    priority: number,
+    vulnCounter: VulnCounts
+) {
+    return {
+        id,
+        name: { remote, fullName },
+        priority,
+        vulnCounter,
+    };
+}
+
+const totalImportant = 120;
+const fixableImportant = 80;
+const totalCritical = 100;
+const fixableCritical = 60;
+
+const vulnCounts = {
+    important: {
+        total: totalImportant,
+        fixable: fixableImportant,
+    },
+    critical: {
+        total: totalCritical,
+        fixable: fixableCritical,
+    },
+};
+
+type VulnCounts = typeof vulnCounts;
+
+const mockImages = [1, 2, 3, 4, 5, 6].map((n) =>
+    makeMockImage(`${n}`, `name-${n}`, `reg/name-${n}:tag`, n, vulnCounts)
+);
+
+const mocks = [
+    {
+        request: {
+            query: imagesQuery,
+            variables: {
+                query: 'Namespace:*',
+            },
+        },
+        result: {
+            data: {
+                images: mockImages,
+            },
+        },
+    },
+];
+
+jest.mock('hooks/useResizeObserver', () => ({
+    __esModule: true,
+    default: jest.fn().mockImplementation(jest.fn),
+}));
+
+beforeEach(() => {
+    jest.resetModules();
+});
+
+function setup() {
+    const user = userEvent.setup();
+    const utils = renderWithRouter(
+        <MockedProvider mocks={mocks} addTypename={false}>
+            <ImagesAtMostRisk />
+        </MockedProvider>
+    );
+
+    return { user, utils };
+}
+
+describe('Images at most risk dashboard widget', () => {
+    it('should render the correct title based on selected options', async () => {
+        const { user } = setup();
+
+        expect(
+            await screen.findByRole('heading', {
+                name: 'Active images with most severe CVEs',
+            })
+        ).toBeInTheDocument();
+
+        await user.click(await screen.findByRole('button', { name: `Options` }));
+        await user.click(await screen.findByRole('button', { name: `All images` }));
+
+        expect(
+            await screen.findByRole('heading', {
+                name: 'Images with most severe CVEs',
+            })
+        ).toBeInTheDocument();
+    });
+
+    it('should render the correct text and number of CVEs under each column', async () => {
+        const { user } = setup();
+
+        // Default should show fixable CVEs
+        expect(await screen.findAllByText(`${fixableCritical} fixable`)).toHaveLength(6);
+        expect(await screen.findAllByText(`${fixableImportant} fixable`)).toHaveLength(6);
+
+        // Switch to display all CVEs
+        await user.click(await screen.findByRole('button', { name: `Options` }));
+        await user.click(await screen.findByRole('button', { name: `All CVEs` }));
+
+        expect(await screen.findAllByText(`${totalCritical} CVEs`)).toHaveLength(6);
+        expect(await screen.findAllByText(`${totalImportant} CVEs`)).toHaveLength(6);
+    });
+
+    it('should link to the appropriate pages in VulnMgmt', async () => {
+        const {
+            user,
+            utils: { history },
+        } = setup();
+
+        await screen.findByRole('heading', { name: 'Active images with most severe CVEs' });
+        await user.click(screen.getByRole('link', { name: 'reg/name-2:tag' }));
+        expect(history.location.pathname).toBe('/main/vulnerability-management/image/2');
+        expect(history.location.hash).toBe('#image-findings');
+
+        await history.goBack();
+
+        await user.click(screen.getByRole('link', { name: 'View All' }));
+        expect(history.location.pathname).toBe('/main/vulnerability-management/images');
+    });
+});

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
@@ -136,7 +136,7 @@ describe('Images at most risk dashboard widget', () => {
         await screen.findByRole('heading', { name: 'All images at most risk' });
         // Click on the link matching the second image
         const secondImageInList = mockImages[1];
-        await user.click(screen.getByRole('link', { name: secondImageInList.name?.fullName }));
+        await user.click(screen.getByRole('link', { name: secondImageInList.name?.remote }));
         expect(history.location.pathname).toBe(
             `${vulnManagementPath}/image/${secondImageInList.id}`
         );

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { gql, useQuery } from '@apollo/client';
 import {
     Button,
     Dropdown,
@@ -12,14 +13,14 @@ import {
     ToggleGroupItem,
 } from '@patternfly/react-core';
 
-import useURLSearch from 'hooks/useURLSearch';
-import { SearchFilter } from 'types/search';
-import LinkShim from 'Components/PatternFly/LinkShim';
-import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { vulnManagementImagesPath } from 'routePaths';
+import useURLSearch from 'hooks/useURLSearch';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { SearchFilter } from 'types/search';
 import { getQueryString } from 'utils/queryStringUtils';
-import { gql, useQuery } from '@apollo/client';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import LinkShim from 'Components/PatternFly/LinkShim';
+
 import WidgetCard from './WidgetCard';
 import ImagesAtMostRiskTable, { CveStatusOption, ImageData } from './ImagesAtMostRiskTable';
 import isResourceScoped from '../utils';
@@ -64,6 +65,8 @@ export const imagesQuery = gql`
     }
 `;
 
+// If no resource scope is applied and the user selects "Active images" only, we
+// can use the wildcard query `Namespace:*` to return images part of any namespace i.e. active
 function getQueryVariables(searchFilter: SearchFilter, statusOption: ImageStatusOption) {
     const query =
         statusOption === 'Active' && !isResourceScoped(searchFilter)
@@ -72,7 +75,7 @@ function getQueryVariables(searchFilter: SearchFilter, statusOption: ImageStatus
     return { query };
 }
 
-const fieldIdPrefix = 'severe-cve-images';
+const fieldIdPrefix = 'images-at-most-risk';
 
 type ImageStatusOption = 'Active' | 'All';
 

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.tsx
@@ -1,0 +1,177 @@
+import React, { useState } from 'react';
+import {
+    Button,
+    Dropdown,
+    DropdownToggle,
+    Flex,
+    FlexItem,
+    Form,
+    FormGroup,
+    Title,
+    ToggleGroup,
+    ToggleGroupItem,
+} from '@patternfly/react-core';
+
+import useURLSearch from 'hooks/useURLSearch';
+import { SearchFilter } from 'types/search';
+import LinkShim from 'Components/PatternFly/LinkShim';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { vulnManagementImagesPath } from 'routePaths';
+import { getQueryString } from 'utils/queryStringUtils';
+import { gql, useQuery } from '@apollo/client';
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import WidgetCard from './WidgetCard';
+import ImagesAtMostRiskTable, { CveStatusOption, ImageData } from './ImagesAtMostRiskTable';
+
+function getTitle(searchFilter: SearchFilter, imageStatusOption: ImageStatusOption) {
+    return imageStatusOption === 'Active' || searchFilter.Cluster || searchFilter['Namespace ID']
+        ? 'Active images with most severe CVEs'
+        : 'Images with most severe CVEs';
+}
+
+function getViewAllLink(searchFilter: SearchFilter) {
+    const queryString = getQueryString({
+        s: searchFilter,
+        sort: [{ id: 'Image Risk Priority', desc: 'false' }],
+    });
+    return `${vulnManagementImagesPath}${queryString}`;
+}
+
+export const imagesQuery = gql`
+    query getImages($query: String) {
+        images(
+            query: $query
+            pagination: { limit: 6, sortOption: { field: "Image Risk Priority", reversed: false } }
+        ) {
+            id
+            name {
+                remote
+                fullName
+            }
+            priority
+            vulnCounter {
+                important {
+                    total
+                    fixable
+                }
+                critical {
+                    total
+                    fixable
+                }
+            }
+        }
+    }
+`;
+
+function getQueryVariables(searchFilter: SearchFilter, statusOption: ImageStatusOption) {
+    const hasUserAppliedFilter = searchFilter.Cluster || searchFilter['Namespace ID'];
+    const query =
+        statusOption === 'Active' && !hasUserAppliedFilter
+            ? 'Namespace:*'
+            : getRequestQueryStringForSearchFilter(searchFilter);
+    return { query };
+}
+
+const fieldIdPrefix = 'severe-cve-images';
+
+type ImageStatusOption = 'Active' | 'All';
+
+function ImagesAtMostRisk() {
+    const { isOpen: isOptionsOpen, onToggle: toggleOptionsOpen } = useSelectToggle();
+    const { searchFilter } = useURLSearch();
+
+    const [cveStatusOption, setCveStatusOption] = useState<CveStatusOption>('Fixable');
+    const [imageStatusOption, setImageStatusOption] = useState<ImageStatusOption>('Active');
+
+    const variables = getQueryVariables(searchFilter, imageStatusOption);
+    const { data, previousData, loading, error } = useQuery<ImageData>(imagesQuery, {
+        variables,
+    });
+
+    const imageData = data || previousData;
+
+    return (
+        <WidgetCard
+            isLoading={loading || !imageData}
+            error={error}
+            header={
+                <Flex direction={{ default: 'row' }}>
+                    <FlexItem grow={{ default: 'grow' }}>
+                        <Title headingLevel="h2">{getTitle(searchFilter, imageStatusOption)}</Title>
+                    </FlexItem>
+                    <FlexItem>
+                        <Dropdown
+                            className="pf-u-mr-sm"
+                            toggle={
+                                <DropdownToggle
+                                    id={`${fieldIdPrefix}-options-toggle`}
+                                    toggleVariant="secondary"
+                                    onToggle={toggleOptionsOpen}
+                                >
+                                    Options
+                                </DropdownToggle>
+                            }
+                            position="right"
+                            isOpen={isOptionsOpen}
+                        >
+                            <Form className="pf-u-px-md pf-u-py-sm" style={{ minWidth: '250px' }}>
+                                <FormGroup
+                                    fieldId={`${fieldIdPrefix}-fixable`}
+                                    label="Image vulnerabilities"
+                                >
+                                    <ToggleGroup aria-label="Show all CVEs or fixable CVEs only">
+                                        <ToggleGroupItem
+                                            className="pf-u-font-weight-normal"
+                                            text="Fixable CVEs"
+                                            buttonId={`${fieldIdPrefix}-fixable-only`}
+                                            isSelected={cveStatusOption === 'Fixable'}
+                                            onChange={() => setCveStatusOption('Fixable')}
+                                        />
+                                        <ToggleGroupItem
+                                            text="All CVEs"
+                                            buttonId={`${fieldIdPrefix}-all-cves`}
+                                            isSelected={cveStatusOption === 'All'}
+                                            onChange={() => setCveStatusOption('All')}
+                                        />
+                                    </ToggleGroup>
+                                </FormGroup>
+                                <FormGroup
+                                    fieldId={`${fieldIdPrefix}-lifecycle`}
+                                    label="Image status"
+                                >
+                                    <ToggleGroup aria-label="Show all images or active images only">
+                                        <ToggleGroupItem
+                                            text="Active Images"
+                                            buttonId={`${fieldIdPrefix}-status-active`}
+                                            isSelected={imageStatusOption === 'Active'}
+                                            onChange={() => setImageStatusOption('Active')}
+                                        />
+                                        <ToggleGroupItem
+                                            text="All images"
+                                            buttonId={`${fieldIdPrefix}-status-all`}
+                                            isSelected={imageStatusOption === 'All'}
+                                            onChange={() => setImageStatusOption('All')}
+                                        />
+                                    </ToggleGroup>
+                                </FormGroup>
+                            </Form>
+                        </Dropdown>
+                        <Button
+                            variant="secondary"
+                            component={LinkShim}
+                            href={getViewAllLink(searchFilter)}
+                        >
+                            View All
+                        </Button>
+                    </FlexItem>
+                </Flex>
+            }
+        >
+            {imageData && (
+                <ImagesAtMostRiskTable imageData={imageData} cveStatusOption={cveStatusOption} />
+            )}
+        </WidgetCard>
+    );
+}
+
+export default ImagesAtMostRisk;

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRiskTable.tsx
@@ -45,7 +45,7 @@ function linkToImage(id: string) {
 
 function ImagesAtMostRiskTable({ imageData: { images }, cveStatusOption }: ImagesAtMostRiskProps) {
     return (
-        <TableComposable aria-label="Images at most risk" variant="compact" borders={false}>
+        <TableComposable variant="compact" borders={false}>
             <Thead>
                 <Tr>
                     <Th width={35} className="pf-u-pl-0">

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRiskTable.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { HashLink as Link } from 'react-router-hash-link';
+import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { SecurityIcon } from '@patternfly/react-icons';
+
+import { ImageName } from 'types/image.proto';
+import { severityColors } from 'constants/visuals/colors';
+import { middleTruncate } from 'utils/textUtils';
+import { vulnManagementPath } from 'routePaths';
+
+type VulnCounts = {
+    total: number;
+    fixable: number;
+};
+
+export type ImageData = {
+    images: {
+        id: string;
+        name: Partial<ImageName>;
+        priority: number;
+        vulnCounter: {
+            important: VulnCounts;
+            critical: VulnCounts;
+        };
+    }[];
+};
+
+export type CveStatusOption = 'Fixable' | 'All';
+
+export type ImagesAtMostRiskProps = {
+    imageData: ImageData;
+    cveStatusOption: CveStatusOption;
+};
+
+const columnNames = {
+    imageName: 'Images',
+    riskPriority: 'Risk priority',
+    criticalCves: 'Critical CVEs',
+    importantCves: 'Important CVEs',
+};
+
+function linkToImage(id: string) {
+    return `${vulnManagementPath}/image/${id}#image-findings`;
+}
+
+function ImagesAtMostRiskTable({ imageData: { images }, cveStatusOption }: ImagesAtMostRiskProps) {
+    return (
+        <TableComposable aria-label="Images at most risk" variant="compact" borders={false}>
+            <Thead>
+                <Tr>
+                    <Th width={35} className="pf-u-pl-0">
+                        {columnNames.imageName}
+                    </Th>
+                    <Th className="pf-u-text-align-center-on-md">{columnNames.riskPriority}</Th>
+                    <Th>{columnNames.criticalCves}</Th>
+                    <Th className="pf-u-pr-0">{columnNames.importantCves}</Th>
+                </Tr>
+            </Thead>
+            <Tbody>
+                {images.map(({ id, name, priority, vulnCounter }) => (
+                    <Tr key={id}>
+                        <Td className="pf-u-pl-0" dataLabel={columnNames.imageName}>
+                            <Link
+                                to={linkToImage(id)}
+                                scroll={(el: HTMLElement) =>
+                                    // TODO This is a heavy handed way to scroll to the CVE section which is loaded on
+                                    // the target image page asynchronously
+                                    setTimeout(() => el.scrollIntoView(), 500)
+                                }
+                            >
+                                <span title={name.fullName}>{middleTruncate(name.remote)}</span>
+                            </Link>
+                        </Td>
+                        <Td
+                            className="pf-u-text-align-center-on-md"
+                            dataLabel={columnNames.riskPriority}
+                        >
+                            {priority}
+                        </Td>
+                        <Td dataLabel={columnNames.criticalCves}>
+                            <SecurityIcon
+                                className="pf-u-display-inline pf-u-mr-xs"
+                                color={severityColors.critical}
+                            />
+                            <span>
+                                {cveStatusOption === 'Fixable'
+                                    ? `${vulnCounter.critical.fixable} fixable`
+                                    : `${vulnCounter.critical.total} CVEs`}
+                            </span>
+                        </Td>
+                        <Td className="pf-u-pr-0" dataLabel={columnNames.importantCves}>
+                            <SecurityIcon
+                                className="pf-u-display-inline pf-u-mr-xs"
+                                color={severityColors.important}
+                            />
+                            {cveStatusOption === 'Fixable'
+                                ? `${vulnCounter.important.fixable} fixable`
+                                : `${vulnCounter.important.total} CVEs`}
+                        </Td>
+                    </Tr>
+                ))}
+            </Tbody>
+        </TableComposable>
+    );
+}
+
+export default ImagesAtMostRiskTable;

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRiskTable.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { HashLink as Link } from 'react-router-hash-link';
-import { Tooltip } from '@patternfly/react-core';
+import { Tooltip, Truncate } from '@patternfly/react-core';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { SecurityIcon } from '@patternfly/react-icons';
 
 import { ImageName } from 'types/image.proto';
 import { severityColors } from 'constants/visuals/colors';
-import { middleTruncate } from 'utils/textUtils';
 import { vulnManagementPath } from 'routePaths';
 
 type VulnCounts = {
@@ -71,7 +70,11 @@ function ImagesAtMostRiskTable({ imageData: { images }, cveStatusOption }: Image
                                 }
                             >
                                 <Tooltip content={<div>{name.fullName}</div>}>
-                                    <span title={name.fullName}>{middleTruncate(name.remote)}</span>
+                                    <Truncate
+                                        content={name.remote ?? ''}
+                                        position="middle"
+                                        trailingNumChars={13}
+                                    />
                                 </Tooltip>
                             </Link>
                         </Td>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRiskTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { HashLink as Link } from 'react-router-hash-link';
+import { Tooltip } from '@patternfly/react-core';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { SecurityIcon } from '@patternfly/react-icons';
 
@@ -7,7 +8,6 @@ import { ImageName } from 'types/image.proto';
 import { severityColors } from 'constants/visuals/colors';
 import { middleTruncate } from 'utils/textUtils';
 import { vulnManagementPath } from 'routePaths';
-import { Tooltip } from '@patternfly/react-core';
 
 type VulnCounts = {
     total: number;
@@ -67,11 +67,11 @@ function ImagesAtMostRiskTable({ imageData: { images }, cveStatusOption }: Image
                                     // TODO This is a heavy handed way to scroll to the CVE section which is loaded on
                                     // the target image page asynchronously. Without a delay, following data loads
                                     // scroll the target element back off the screen.
-                                    setTimeout(() => el.scrollIntoView(), 500)
+                                    setTimeout(() => el.scrollIntoView({ behavior: 'smooth' }), 500)
                                 }
                             >
                                 <Tooltip content={<div>{name.fullName}</div>}>
-                                    <span>{middleTruncate(name.remote)}</span>
+                                    <span title={name.fullName}>{middleTruncate(name.remote)}</span>
                                 </Tooltip>
                             </Link>
                         </Td>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRiskTable.tsx
@@ -7,6 +7,7 @@ import { ImageName } from 'types/image.proto';
 import { severityColors } from 'constants/visuals/colors';
 import { middleTruncate } from 'utils/textUtils';
 import { vulnManagementPath } from 'routePaths';
+import { Tooltip } from '@patternfly/react-core';
 
 type VulnCounts = {
     total: number;
@@ -64,11 +65,14 @@ function ImagesAtMostRiskTable({ imageData: { images }, cveStatusOption }: Image
                                 to={linkToImage(id)}
                                 scroll={(el: HTMLElement) =>
                                     // TODO This is a heavy handed way to scroll to the CVE section which is loaded on
-                                    // the target image page asynchronously
+                                    // the target image page asynchronously. Without a delay, following data loads
+                                    // scroll the target element back off the screen.
                                     setTimeout(() => el.scrollIntoView(), 500)
                                 }
                             >
-                                <span title={name.fullName}>{middleTruncate(name.remote)}</span>
+                                <Tooltip content={<div>{name.fullName}</div>}>
+                                    <span>{middleTruncate(name.remote)}</span>
+                                </Tooltip>
                             </Link>
                         </Td>
                         <Td

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/utils.ts
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/utils.ts
@@ -1,0 +1,7 @@
+import { SearchFilter } from 'types/search';
+
+function isResourceScoped(searchFilter: SearchFilter): boolean {
+    return Boolean(searchFilter.Cluster) || Boolean(searchFilter['Namespace ID']);
+}
+
+export default isResourceScoped;

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/utils.ts
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/utils.ts
@@ -1,5 +1,9 @@
 import { SearchFilter } from 'types/search';
 
+/**
+ * Given a searchFilter, determines whether or not a resource filter is applied to
+ * the page.
+ */
 function isResourceScoped(searchFilter: SearchFilter): boolean {
     return Boolean(searchFilter.Cluster) || Boolean(searchFilter['Namespace ID']);
 }

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
@@ -164,7 +164,7 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
                         />
                     </div>
                 </CollapsibleSection>
-                <CollapsibleSection title="Image Findings">
+                <CollapsibleSection id="image-findings" title="Image Findings">
                     <div className="flex pdf-page pdf-stretch pdf-new rounded relative mb-4 ml-4 mr-4 pb-20">
                         {/* TODO: replace these 3 repeated Fixable CVEs tabs with tabs for
                             Observed, Deferred, and False Postive CVEs tables */}

--- a/ui/apps/platform/src/utils/textUtils.js
+++ b/ui/apps/platform/src/utils/textUtils.js
@@ -12,17 +12,6 @@ export function truncate(str, maxLength = 200) {
     return `${truncatedStr}…`;
 }
 
-export function middleTruncate(str, maxLength = 22) {
-    if (str.length <= maxLength) {
-        return str;
-    }
-    const sideLength = maxLength / 2;
-    const left = str.substr(0, sideLength);
-    const right = str.substr(str.length - sideLength, str.length);
-    const ellipsis = '\u2026';
-    return `${left}${ellipsis}${right}`;
-}
-
 export function pluralizeHas(len) {
     return len === 1 ? 'has' : 'have';
 }

--- a/ui/apps/platform/src/utils/textUtils.js
+++ b/ui/apps/platform/src/utils/textUtils.js
@@ -12,6 +12,17 @@ export function truncate(str, maxLength = 200) {
     return `${truncatedStr}…`;
 }
 
+export function middleTruncate(str, maxLength = 22) {
+    if (str.length <= maxLength) {
+        return str;
+    }
+    const sideLength = maxLength / 2;
+    const left = str.substr(0, sideLength);
+    const right = str.substr(str.length - sideLength, str.length);
+    const ellipsis = '\u2026';
+    return `${left}${ellipsis}${right}`;
+}
+
 export function pluralizeHas(len) {
     return len === 1 ? 'has' : 'have';
 }


### PR DESCRIPTION
## Description

Adds the ["Images at Most Risk"](https://docs.google.com/document/d/1z8kQOGRkZaN_RnaG4_kKjZHMC2O5Z-hSfWM4sqhyzuI/edit#heading=h.gnwde7z6qg1o) widget.

This widget displays the top six images based on risk score along with the number of important and critical CVEs in those images. Users can toggle options to show all images or only active images, as well as toggle the display between all CVEs or _fixable_ CVEs only.

Each image name links to the VulnMgmt page, scrolled to the "Image Findings" CVE section.

## Follow Ups

- Add the blue information icon that indicates a non-default option has been applied to the table. (this may apply to other widgets as well)
- Fix the [Namespace ID filter bug](https://issues.redhat.com/browse/ROX-11510) when linking to the Vuln Mgmt page
- Sort the image list in the widget alphabetically to break ties when multiple images have the same risk priority
- General layout fixes that break widget headers in very specific screen sizes (multiple widgets)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added


## Testing Performed

Test that the default view of the widget shows "All images" in the table.
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/1292638/175196336-06d3a019-3241-4c03-b184-db381db570f0.png">

Test that applying a resource filter updates the widget to only show "Active images".
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/1292638/175196513-116cc148-7214-46cd-a3db-b6fc457a3666.png">

Test that the "Image status: All images" option is disabled when a resource filter is applied.
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/1292638/175196608-c21f362b-5c57-4a6d-8ca3-dbed7c1db046.png">
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/1292638/175196646-f884f7c3-900d-494c-a5eb-e78309897cbd.png">

Test that the "Image vulnerabilities: All CVEs" option updates the table to show _total_ CVE counts instead of _fixable_ CVE counts.
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/1292638/175196803-72f54926-e23b-45f7-9d1e-7d8a4303bdcf.png">

Test that the "View All" link takes the user to the Vuln Mgmt images page, with any selected filters applied:
<img width="1129" alt="image" src="https://user-images.githubusercontent.com/1292638/175197312-49a828e9-96ad-4ac8-944a-5c907c5de0f1.png">


Test that the individual image links in the table take the user to the Vuln Mgmt page for the individual image, focused on the "Image Findings" CVE table in the details page.
<img width="1129" alt="image" src="https://user-images.githubusercontent.com/1292638/175197067-a0bdc49e-edde-4ce2-892d-2d3b9c84168c.png">

