### PR TITLE
Optimize replaceVars a little bit more using strings.Builder

### DIFF
--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -39,11 +39,14 @@ const (
 )
 
 func replaceVars(s string) string {
+	if len(s) == 0 {
+		return ""
+	}
 	varNum := 1
 	var newString strings.Builder
 	newString.Grow(len(s))
-	for i := 0; i < len(s)-1; i++ {
-		if s[i] == '$' && s[i+1] == '$' {
+	for i := 0; i < len(s); i++ {
+		if i < len(s)-1 && s[i] == '$' && s[i+1] == '$' {
 			newString.WriteRune('$')
 			newString.WriteString(strconv.Itoa(varNum))
 			varNum++
@@ -52,7 +55,6 @@ func replaceVars(s string) string {
 			newString.WriteByte(s[i])
 		}
 	}
-	newString.WriteByte(s[len(s)-1])
 	return newString.String()
 }
 

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -40,15 +40,19 @@ const (
 
 func replaceVars(s string) string {
 	varNum := 1
+	var newString strings.Builder
+	newString.Grow(len(s))
 	for i := 0; i < len(s)-1; i++ {
 		if s[i] == '$' && s[i+1] == '$' {
-			varStr := strconv.Itoa(varNum)
-			s = s[:i+1] + varStr + s[i+2:]
-			i += len(varStr)
+			newString.WriteRune('$')
+			newString.WriteString(strconv.Itoa(varNum))
 			varNum++
+			i++
+		} else {
+			newString.WriteByte(s[i])
 		}
 	}
-	return s
+	return newString.String()
 }
 
 type innerJoin struct {

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -52,6 +52,7 @@ func replaceVars(s string) string {
 			newString.WriteByte(s[i])
 		}
 	}
+	newString.WriteByte(s[len(s)-1])
 	return newString.String()
 }
 

--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -34,6 +34,10 @@ func TestReplaceVars(t *testing.T) {
 			"$1",
 		},
 		{
+			query:  "select * from table where column > $$ and true",
+			result: "select * from table where column > $1 and true",
+		},
+		{
 			"$$ $$ $$ $$ $$ $$ $$ $$ $$ $$ $$",
 			"$1 $2 $3 $4 $5 $6 $7 $8 $9 $10 $11",
 		},

--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -5,6 +5,7 @@ package postgres
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -44,10 +45,18 @@ func TestReplaceVars(t *testing.T) {
 	}
 }
 
-func BenchmarkVarsBench(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		replaceVars("$$ $$ $$ $$ $$ $$ $$ $$ $$ $$ $$")
-	}
+func BenchmarkReplaceVars(b *testing.B) {
+	veryLongString := strings.Repeat("$$ ", 1000)
+	b.Run("short", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			replaceVars("$$ $$ $$ $$ $$ $$ $$ $$ $$ $$ $$")
+		}
+	})
+	b.Run("long", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			replaceVars(veryLongString)
+		}
+	})
 }
 
 func TestMultiTableQueries(t *testing.T) {

--- a/tools/roxvet/analyzers/uncheckederrors/analyzer.go
+++ b/tools/roxvet/analyzers/uncheckederrors/analyzer.go
@@ -43,6 +43,7 @@ var (
 		"strings": set.NewFrozenStringSet(
 			"(*Builder).WriteString",
 			"(*Builder).WriteRune",
+			"(*Builder).WriteByte",
 		),
 		"github.com/stackrox/rox/pkg/utils": set.NewFrozenStringSet(
 			"Should",


### PR DESCRIPTION
## Description

It's a significant speed up for this function. Probably has ~0 impact in practice since this function is likely negligible, but I was doing this for fun and figured why not merge it 😛
```
BenchmarkReplaceVars
BenchmarkReplaceVars/v1_short
BenchmarkReplaceVars/v1_short-12         	 2081013	       508.8 ns/op
BenchmarkReplaceVars/v2_short
BenchmarkReplaceVars/v2_short-12         	 7226134	       168.1 ns/op
BenchmarkReplaceVars/v1_long
BenchmarkReplaceVars/v1_long-12          	    1447	    773751 ns/op
BenchmarkReplaceVars/v2_long
BenchmarkReplaceVars/v2_long-12          	   36198	     34954 ns/op
PASS
```
## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Unit test