### PR TITLE
Add last updated time display at top of dashboard

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
     Divider,
     Flex,
@@ -6,9 +6,12 @@ import {
     Grid,
     GridItem,
     PageSection,
+    Split,
+    SplitItem,
     Text,
     Title,
 } from '@patternfly/react-core';
+import { format } from 'date-fns';
 import SummaryCounts from './SummaryCounts';
 import ScopeBar from './ScopeBar';
 
@@ -16,10 +19,22 @@ import ViolationsByPolicyCategory from './Widgets/ViolationsByPolicyCategory';
 import DeploymentsAtMostRisk from './Widgets/DeploymentsAtMostRisk';
 
 function DashboardPage() {
+    const [lastUpdate] = useState<Date>(new Date());
     return (
         <>
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
-                <SummaryCounts />
+                <Split className="pf-u-align-items-center">
+                    <SplitItem isFilled>
+                        <SummaryCounts />
+                    </SplitItem>
+                    <div
+                        style={{ fontStyle: 'italic' }}
+                        className="pf-u-color-200 pf-u-font-size-sm pf-u-mr-md pf-u-mr-lg-on-lg"
+                    >
+                        Last updated {format(lastUpdate, 'DD/MM/YYYY')} at{' '}
+                        {format(lastUpdate, 'hh:mm A')}
+                    </div>
+                </Split>
             </PageSection>
             <Divider component="div" />
             <PageSection variant="light">

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
     Divider,
     Flex,
@@ -6,12 +6,9 @@ import {
     Grid,
     GridItem,
     PageSection,
-    Split,
-    SplitItem,
     Text,
     Title,
 } from '@patternfly/react-core';
-import { format } from 'date-fns';
 import SummaryCounts from './SummaryCounts';
 import ScopeBar from './ScopeBar';
 
@@ -19,22 +16,10 @@ import ViolationsByPolicyCategory from './Widgets/ViolationsByPolicyCategory';
 import DeploymentsAtMostRisk from './Widgets/DeploymentsAtMostRisk';
 
 function DashboardPage() {
-    const [lastUpdate] = useState<Date>(new Date());
     return (
         <>
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
-                <Split className="pf-u-align-items-center">
-                    <SplitItem isFilled>
-                        <SummaryCounts />
-                    </SplitItem>
-                    <div
-                        style={{ fontStyle: 'italic' }}
-                        className="pf-u-color-200 pf-u-font-size-sm pf-u-mr-md pf-u-mr-lg-on-lg"
-                    >
-                        Last updated {format(lastUpdate, 'DD/MM/YYYY')} at{' '}
-                        {format(lastUpdate, 'hh:mm A')}
-                    </div>
-                </Split>
+                <SummaryCounts />
             </PageSection>
             <Divider component="div" />
             <PageSection variant="light">

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/SummaryCounts.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/SummaryCounts.tsx
@@ -54,8 +54,9 @@ const tileLinks: Record<TileEntity, string> = {
     Secret: `${configManagementPath}/${urlEntityListTypes[resourceTypes.SECRET]}`,
 };
 
-const dateFormatter = new Intl.DateTimeFormat('en-US');
-const timeFormatter = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' });
+const locale = window.navigator.language ?? 'en-US';
+const dateFormatter = new Intl.DateTimeFormat(locale);
+const timeFormatter = new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: 'numeric' });
 
 function SummaryCounts() {
     const [lastUpdate, setLastUpdate] = useState<Date>(new Date());

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/SummaryCounts.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/SummaryCounts.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { gql, useQuery } from '@apollo/client';
 import Raven from 'raven-js';
 import pluralize from 'pluralize';
-import { format } from 'date-fns';
 import {
     Alert,
     Button,
@@ -54,6 +53,9 @@ const tileLinks: Record<TileEntity, string> = {
     Image: vulnManagementImagesPath,
     Secret: `${configManagementPath}/${urlEntityListTypes[resourceTypes.SECRET]}`,
 };
+
+const dateFormatter = new Intl.DateTimeFormat('en-US');
+const timeFormatter = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' });
 
 function SummaryCounts() {
     const [lastUpdate, setLastUpdate] = useState<Date>(new Date());
@@ -118,7 +120,9 @@ function SummaryCounts() {
                 style={{ fontStyle: 'italic' }}
                 className="pf-u-color-200 pf-u-font-size-sm pf-u-mr-md pf-u-mr-lg-on-lg"
             >
-                Last updated {format(lastUpdate, 'DD/MM/YYYY')} at {format(lastUpdate, 'hh:mm A')}
+                {`Last updated ${dateFormatter.format(lastUpdate)} at ${timeFormatter.format(
+                    lastUpdate
+                )}`}
             </div>
         </Split>
     );

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/SummaryCounts.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/SummaryCounts.tsx
@@ -1,8 +1,17 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { gql, useQuery } from '@apollo/client';
 import Raven from 'raven-js';
 import pluralize from 'pluralize';
-import { Alert, Button, ButtonVariant, Skeleton, Split, Stack } from '@patternfly/react-core';
+import { format } from 'date-fns';
+import {
+    Alert,
+    Button,
+    ButtonVariant,
+    Skeleton,
+    Split,
+    SplitItem,
+    Stack,
+} from '@patternfly/react-core';
 
 import {
     clustersBasePath,
@@ -47,7 +56,10 @@ const tileLinks: Record<TileEntity, string> = {
 };
 
 function SummaryCounts() {
-    const { loading, error, data } = useQuery<SummaryCountsResponse>(SUMMARY_COUNTS);
+    const [lastUpdate, setLastUpdate] = useState<Date>(new Date());
+    const { loading, error, data } = useQuery<SummaryCountsResponse>(SUMMARY_COUNTS, {
+        onCompleted: () => setLastUpdate(new Date()),
+    });
 
     if (loading) {
         return (
@@ -80,24 +92,34 @@ function SummaryCounts() {
     };
 
     return (
-        <Split className="pf-u-flex-wrap">
-            {tileEntityTypes.map((tileEntity) => (
-                <Button
-                    key={tileEntity}
-                    variant={ButtonVariant.link}
-                    component={LinkShim}
-                    href={tileLinks[tileEntity]}
-                >
-                    <Stack className="pf-u-px-xs pf-u-px-sm-on-xl pf-u-align-items-center">
-                        <span className="pf-u-font-size-lg-on-md pf-u-font-size-sm pf-u-font-weight-bold">
-                            {tileData[tileEntity]}
-                        </span>
-                        <span className="pf-u-font-size-md-on-md pf-u-font-size-xs">
-                            {pluralize(tileEntity, tileData[tileEntity])}
-                        </span>
-                    </Stack>
-                </Button>
-            ))}
+        <Split className="pf-u-align-items-center">
+            <SplitItem isFilled>
+                <Split className="pf-u-flex-wrap">
+                    {tileEntityTypes.map((tileEntity) => (
+                        <Button
+                            key={tileEntity}
+                            variant={ButtonVariant.link}
+                            component={LinkShim}
+                            href={tileLinks[tileEntity]}
+                        >
+                            <Stack className="pf-u-px-xs pf-u-px-sm-on-xl pf-u-align-items-center">
+                                <span className="pf-u-font-size-lg-on-md pf-u-font-size-sm pf-u-font-weight-bold">
+                                    {tileData[tileEntity]}
+                                </span>
+                                <span className="pf-u-font-size-md-on-md pf-u-font-size-xs">
+                                    {pluralize(tileEntity, tileData[tileEntity])}
+                                </span>
+                            </Stack>
+                        </Button>
+                    ))}
+                </Split>
+            </SplitItem>
+            <div
+                style={{ fontStyle: 'italic' }}
+                className="pf-u-color-200 pf-u-font-size-sm pf-u-mr-md pf-u-mr-lg-on-lg"
+            >
+                Last updated {format(lastUpdate, 'DD/MM/YYYY')} at {format(lastUpdate, 'hh:mm A')}
+            </div>
         </Split>
     );
 }


### PR DESCRIPTION
## Description

As described in title. The timestamp will only update when the page is refreshed.

Note that UX has decided to not use the circular arrow icon shown in [the mocks](https://www.sketch.com/s/9d082d82-3515-40f2-875a-1b322a02bace/a/1KQPyRp).

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Load the new dashboard and view the time the summary count request completed in the top right of the page.
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/1292638/175350954-3b211bc6-7ae0-4ed2-90e7-770697f1d622.png">

