### PR TITLE
ROX-11515: Support custom names in release versions

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Full RC number (A.B.C-rc.D)
+        description: Full RC version (A.B.C[-N]-rc.D)
         required: true
-        default: 0.0.0-rc.1
+        default: 0.0.0-test-rc.1
         type: string
       dry-run:
         description: Dry-run
@@ -41,7 +41,8 @@ jobs:
         env:
           JQL: >-
             project IN (${{env.jira_projects}})
-            AND fixVersion = \"${{needs.variables.outputs.release-patch}}\"
+            AND fixVersion IN (\"${{needs.variables.outputs.release-patch}}\",
+            \"${{needs.variables.outputs.release}}.${{needs.variables.outputs.patch}}\")
             AND status != CLOSED
             AND Component != Documentation AND type != Epic
             order by assignee

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Release number (A.B.C)
+        description: Release version (A.B.C[-N])
         required: true
         default: 0.0.0
         type: string

--- a/.github/workflows/variables.yml
+++ b/.github/workflows/variables.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       version:
-        description: Version (A.B.C or A.B.C-rc.D)
+        description: Version (A.B.C[-N][-rc.D])
         type: string
         required: true
 
@@ -17,21 +17,24 @@ on:
       rc:
         description: RC number (D)
         value: ${{jobs.parse.outputs.rc}}
+      name:
+        description: Release name (N)
+        value: ${{jobs.parse.outputs.name}}
       release-patch:
-        description: Release.patch numbers (A.B.C)
-        value: ${{format('{0}.{1}', jobs.parse.outputs.release, jobs.parse.outputs.patch)}}
+        description: Release.patch numbers (A.B.C[-N])
+        value: ${{format('{0}.{1}{2}', jobs.parse.outputs.release, jobs.parse.outputs.patch, jobs.parse.outputs.dash-name)}}
       branch:
-        description: Release branch name (release/A.B.x)
-        value: ${{format('release/{0}.x', jobs.parse.outputs.release)}}
+        description: Release branch name (release/A.B.x[-N])
+        value: ${{format('release/{0}.x{1}', jobs.parse.outputs.release, jobs.parse.outputs.dash-name)}}
       docs-branch:
         description: Documentation branch name
         value: ${{format('rhacs-docs-{0}.{1}', jobs.parse.outputs.release, jobs.parse.outputs.patch)}}
       milestone:
-        description: Milestone (A.B.C-rc.D)
-        value: ${{jobs.parse.outputs.milestone}}
+        description: Milestone (A.B.C[-N]-rc.D)
+        value: ${{format('{0}.{1}{2}-rc.{3}', jobs.parse.outputs.release, jobs.parse.outputs.patch, jobs.parse.outputs.dash-name, jobs.parse.outputs.rc)}}
       next-milestone:
-        description: Next milestone (A.B.C-rc.`D+1`)
-        value: ${{jobs.parse.outputs.next-milestone}}
+        description: Next milestone (A.B.C[-N]-rc.`D+1`)
+        value: ${{format('{0}.{1}{2}-rc.{3}', jobs.parse.outputs.release, jobs.parse.outputs.patch, jobs.parse.outputs.dash-name, jobs.parse.outputs.next-rc)}}
 
 jobs:
   parse:
@@ -41,13 +44,15 @@ jobs:
       release: ${{steps.parse.outputs.release}}
       patch: ${{steps.parse.outputs.patch}}
       rc: ${{steps.parse.outputs.rc}}
-      milestone: ${{steps.parse.outputs.milestone}}
-      next-milestone: ${{steps.parse.outputs.next-milestone}}
+      name: ${{steps.parse.outputs.name}}
+      dash-name: ${{steps.parse.outputs.dash-name}}
+      next-rc: ${{steps.parse.outputs.next-milestone}}
     steps:
       - id: parse
         run: |
-          read RELEASE PATCH_NUMBER RC_NUMBER <<< \
-          $(sed -rn 's/^([0-9]+\.[0-9]+)\.([0-9]+)(-rc\.([0-9]+))?$/\1 \2 \4/p' <<< ${{inputs.version}})
+          set -u
+          read RELEASE PATCH_NUMBER RELEASE_NAME RC_NUMBER <<< \
+          $(sed -rn 's/^([0-9]+\.[0-9]+)\.([0-9]+)(-([a-zA-Z0-9-]+))?(-rc\.([0-9]+))?$/\1 \2 \4 \6/p' <<< ${{inputs.version}})
           if [ -z "$RELEASE" -o -z "$PATCH_NUMBER"]; then
             echo "::error::Cannot parse ${{inputs.version}}: should be in a form of `X.X.X-rc.X`, where `X` is a decimal number."
             exit 1
@@ -57,5 +62,9 @@ jobs:
           echo "::set-output name=release::$RELEASE"
           echo "::set-output name=patch::$PATCH_NUMBER"
           echo "::set-output name=rc::$RC_NUMBER"
-          echo "::set-output name=milestone::$RELEASE.$PATCH_NUMBER-rc.$RC_NUMBER"
-          echo "::set-output name=next-milestone::$RELEASE.$PATCH_NUMBER-rc.$NEXT_RC_NUMBER"
+          echo "::set-output name=name::$RELEASE_NAME"
+          echo "::set-output name=next-rc::$NEXT_RC_NUMBER"
+
+          if [ -n "$RELEASE_NAME" ]; then
+            echo "::set-output name=dash-name::-$RELEASE_NAME"
+          fi


### PR DESCRIPTION
## Description

Support `A.B.C-N` versions in the upstream release workflow, where A, B, C are numbers and N - alphanumeric:

* The release branch will be formatted as `A.B.x-N`;
* The documentation submodule will still reference `rhacs-docs-A.B.C`;
* The milestones will look like `A.B.C-N-rc.D`.

*This PR does not include any changes in the produced image tags triggered by CI builds*. This will need to be done separately.

## Testing Performed

Manual testing in `stackrox/test-gh-actions` repository.
