### PR TITLE
Add request helpers especially for visit function in integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -87,6 +87,7 @@ export const clusters = {
     single: 'v1/clusters/**',
     list: 'v1/clusters',
     clusterDefaults: '/v1/cluster-defaults',
+    sensorUpgradesConfig: '/v1/sensorupgrades/config',
     zip: 'api/extensions/clusters/zip',
 };
 

--- a/ui/apps/platform/cypress/helpers/clusters.js
+++ b/ui/apps/platform/cypress/helpers/clusters.js
@@ -38,7 +38,7 @@ export function visitClusterById(clusterId, staticResponseMap) {
         ...routeMatcherMap,
         cluster: {
             method: 'GET',
-            url: api.clusters.single,
+            url: `${api.clusters.list}/${clusterId}`,
         },
     };
     visit(

--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -7,20 +7,20 @@ import { visit } from './visit';
 // visit helpers
 
 export function visitMainDashboardFromLeftNav() {
-    cy.intercept('GET', api.risks.riskyDeployments).as('riskyDeployments');
+    cy.intercept('GET', api.risks.riskyDeployments).as('deploymentswithprocessinfo');
 
     cy.get(`${navSelectors.navLinks}:contains("Dashboard")`).click();
 
-    cy.wait('@riskyDeployments');
+    cy.wait('@deploymentswithprocessinfo');
     cy.get('h1:contains("Dashboard")');
 }
 
-export function visitMainDashboard() {
-    cy.intercept('GET', api.risks.riskyDeployments).as('riskyDeployments');
+export function visitMainDashboard(requestConfig, staticResponseMap) {
+    cy.intercept('GET', api.risks.riskyDeployments).as('deploymentswithprocessinfo');
 
-    visit(url);
+    visit(url, requestConfig, staticResponseMap);
 
-    cy.wait('@riskyDeployments');
+    cy.wait('@deploymentswithprocessinfo');
     cy.get('h1:contains("Dashboard")');
 }
 
@@ -30,11 +30,11 @@ export function visitMainDashboardPF() {
 }
 
 export function visitMainDashboardViaRedirectFromUrl(redirectFromUrl) {
-    cy.intercept('GET', api.risks.riskyDeployments).as('riskyDeployments');
+    cy.intercept('GET', api.risks.riskyDeployments).as('deploymentswithprocessinfo');
 
     visit(redirectFromUrl);
 
-    cy.wait('@riskyDeployments');
+    cy.wait('@deploymentswithprocessinfo');
     cy.location('pathname').should('eq', url);
     cy.get('h1:contains("Dashboard")');
 }

--- a/ui/apps/platform/cypress/helpers/nav.js
+++ b/ui/apps/platform/cypress/helpers/nav.js
@@ -1,20 +1,27 @@
 import navSelectors from '../selectors/navigation';
 import { visitMainDashboard } from './main';
+import { interceptRequests, waitForResponses } from './request';
 
 /*
  * For example, visitFromLeftNav('Violations');
  */
-export function visitFromLeftNav(itemText) {
+export function visitFromLeftNav(itemText, requestConfig) {
     visitMainDashboard();
+
+    interceptRequests(requestConfig);
     cy.get(`${navSelectors.navLinks}:contains("${itemText}")`).click();
+    waitForResponses(requestConfig);
 }
 
 /*
  * For example, visitFromLeftNavExpandable('Vulnerability Management', 'Reporting');
  * For example, visitFromLeftNavExpandable('Platform Configuration', 'Integrations');
  */
-export function visitFromLeftNavExpandable(expandableTitle, itemText) {
+export function visitFromLeftNavExpandable(expandableTitle, itemText, requestConfig) {
     visitMainDashboard();
+
+    interceptRequests(requestConfig);
     cy.get(`${navSelectors.navExpandable}:contains("${expandableTitle}")`).click();
     cy.get(`${navSelectors.nestedNavLinks}:contains("${itemText}")`).click();
+    waitForResponses(requestConfig);
 }

--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -1,0 +1,61 @@
+/*
+ * Intercept requests before initial page visit or subsequent interaction:
+ * routeMatcherMap: { key: routeMatcher, … }
+ *
+ * Optionally replace responses with stub for routeMatcher alias key:
+ * staticResponseMap: { alias: { body }, … }
+ * staticResponseMap: { alias: { fixture }, … }
+ *
+ * Optionally assign aliases for multiple GraphQL requests with routeMatcher opname key:
+ * opnameAliasesMap: { opname: { aliases, routeHandler }, … }
+ */
+export function interceptRequests(requestConfig, staticResponseMap) {
+    if (requestConfig?.routeMatcherMap) {
+        const { opnameAliasesMap, routeMatcherMap } = requestConfig;
+
+        Object.entries(routeMatcherMap).forEach(([key, routeMatcher]) => {
+            if (opnameAliasesMap?.[key]) {
+                const aliasesMap = opnameAliasesMap[key];
+                const routeHandler = (req) => {
+                    const aliasFound = Object.keys(aliasesMap).find((alias) => {
+                        const aliasReqPredicate = aliasesMap[alias];
+                        return aliasReqPredicate(req);
+                    });
+                    if (typeof aliasFound === 'string') {
+                        req.alias = aliasFound;
+                    }
+                };
+                cy.intercept(routeMatcher, routeHandler);
+            } else if (staticResponseMap?.[key]) {
+                const staticResponse = staticResponseMap[key];
+                cy.intercept(routeMatcher, staticResponse).as(key);
+            } else {
+                cy.intercept(routeMatcher).as(key);
+            }
+        });
+    }
+}
+
+/*
+ * Wait for responses after initial page visit or subsequent interaction.
+ *
+ * Optionally wait with waitOptions: { requestTimeout, responseTimeout }
+ */
+export function waitForResponses(requestConfig) {
+    if (requestConfig?.routeMatcherMap) {
+        const { opnameAliasesMap, routeMatcherMap, waitOptions } = requestConfig;
+
+        const aliases = Object.keys(routeMatcherMap)
+            .map((key) => {
+                const aliasesMap = opnameAliasesMap?.[key];
+                if (aliasesMap) {
+                    return Object.keys(aliasesMap);
+                }
+                return key;
+            })
+            .flat()
+            .map((alias) => `@${alias}`);
+
+        cy.wait(aliases, waitOptions);
+    }
+}

--- a/ui/apps/platform/cypress/helpers/risk.js
+++ b/ui/apps/platform/cypress/helpers/risk.js
@@ -4,42 +4,49 @@ import selectors from '../selectors/index';
 
 import { visit } from './visit';
 
+// visit
+
+const routeMatcherMap = {
+    deploymentswithprocessinfo: {
+        method: 'GET',
+        url: api.risks.riskyDeployments,
+    },
+    deploymentscount: {
+        method: 'GET',
+        url: api.risks.deploymentsCount,
+    },
+};
+
 export function visitRiskDeployments() {
-    cy.intercept('GET', api.risks.riskyDeployments).as('getDeploymentsWithProcessInfo');
-    cy.intercept('GET', api.risks.deploymentsCount).as('getDeploymentsCount');
-    cy.intercept('POST', api.graphql('searchOptions')).as('postSearchOptions');
-    visit(riskURL);
-    cy.wait(['@getDeploymentsWithProcessInfo', '@getDeploymentsCount', '@postSearchOptions']);
+    visit(riskURL, { routeMatcherMap });
+
     cy.get('h1:contains("Risk")');
 }
 
 export function visitRiskDeploymentsWithSearchQuery(search) {
-    cy.intercept('GET', api.risks.riskyDeployments).as('getDeploymentsWithProcessInfo');
-    cy.intercept('GET', api.risks.deploymentsCount).as('getDeploymentsCount');
-    cy.intercept('POST', api.graphql('searchOptions')).as('postSearchOptions');
-    visit(`${riskURL}${search}`);
-    // Future improvements to RiskTablePanel might fix double requests.
-    // Incorrect pair of requests without search filter before response for search options:
-    cy.wait(['@getDeploymentsWithProcessInfo', '@getDeploymentsCount', '@postSearchOptions']);
-    // Correct pair of requests with search filter after response for search options:
-    cy.wait(['@getDeploymentsWithProcessInfo', '@getDeploymentsCount']);
+    visit(`${riskURL}${search}`, { routeMatcherMap });
+
     cy.get('h1:contains("Risk")');
 }
 
 export function viewRiskDeploymentByName(deploymentName) {
     // Assume location is risk deployments table.
-    cy.intercept('GET', api.risks.fetchDeploymentWithRisk).as('getDeploymentWithRisk');
+    cy.intercept('GET', api.risks.fetchDeploymentWithRisk).as('deploymentswithrisk/id');
+
     cy.get(
         `${selectors.table.rows} ${selectors.table.cells}:nth-child(1):contains("${deploymentName}")`
     ).click();
-    cy.wait('@getDeploymentWithRisk');
+
+    cy.wait('@deploymentswithrisk/id');
     cy.get(`${riskPageSelectors.sidePanel.panelHeader}:contains("${deploymentName}")`);
 }
 
 export function viewRiskDeploymentInNetworkGraph() {
     // Assume location is risk deployment panel.
-    cy.intercept('GET', api.network.networkGraph).as('getNetworkGraphCluster');
-    cy.intercept('GET', api.network.networkPoliciesGraph).as('getNetworkPoliciesCluster');
+    cy.intercept('GET', api.network.networkGraph).as('networkgraph/cluster/id');
+    cy.intercept('GET', api.network.networkPoliciesGraph).as('networkpolicies/cluster/id');
+
     cy.get(riskPageSelectors.viewDeploymentsInNetworkGraphButton).click();
-    cy.wait(['@getNetworkGraphCluster', '@getNetworkPoliciesCluster']);
+
+    cy.wait(['@networkgraph/cluster/id', '@networkpolicies/cluster/id']);
 }

--- a/ui/apps/platform/cypress/helpers/systemHealth.js
+++ b/ui/apps/platform/cypress/helpers/systemHealth.js
@@ -13,232 +13,49 @@ export function setClock(currentDatetime) {
 
 // visit
 
+const routeMatcherMap = {
+    'integrationhealth/imageintegrations': {
+        method: 'GET',
+        url: api.integrationHealth.imageIntegrations,
+    },
+    imageintegrations: {
+        method: 'GET',
+        url: api.integrations.imageIntegrations,
+    },
+    'integrationhealth/notifiers': {
+        method: 'GET',
+        url: api.integrationHealth.notifiers,
+    },
+    notifiers: {
+        method: 'GET',
+        url: api.integrations.notifiers,
+    },
+    'integrationhealth/externalbackups': {
+        method: 'GET',
+        url: api.integrationHealth.externalBackups,
+    },
+    externalbackups: {
+        method: 'GET',
+        url: api.integrations.externalBackups,
+    },
+    clusters: {
+        method: 'GET',
+        url: api.clusters.list,
+    },
+    'integrationhealth/vulndefinitions': {
+        method: 'GET',
+        url: api.integrationHealth.vulnDefinitions,
+    },
+};
+
 export function visitSystemHealthFromLeftNav() {
-    cy.intercept('GET', api.clusters.list).as('getClusters');
-    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
-    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
-    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
-    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+    visitFromLeftNavExpandable('Platform Configuration', 'System Health', { routeMatcherMap });
 
-    visitFromLeftNavExpandable('Platform Configuration', 'System Health');
-
-    cy.wait([
-        '@getClusters',
-        '@getBackupIntegrations',
-        '@getImageIntegrations',
-        '@getNotifierIntegrations',
-        '@getBackupIntegrationsHealth',
-        '@getImageIntegrationsHealth',
-        '@getNotifierIntegrationsHealth',
-        '@getVulnDefinitionsHealth',
-    ]);
     cy.get('h1:contains("System Health")');
 }
 
-export function visitSystemHealth() {
-    cy.intercept('GET', api.clusters.list).as('getClusters');
-    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
-    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
-    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
-    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
+export function visitSystemHealth(staticResponseMap) {
+    visit(systemHealthUrl, { routeMatcherMap }, staticResponseMap);
 
-    visit(systemHealthUrl);
-
-    cy.wait([
-        '@getClusters',
-        '@getBackupIntegrations',
-        '@getImageIntegrations',
-        '@getNotifierIntegrations',
-        '@getBackupIntegrationsHealth',
-        '@getImageIntegrationsHealth',
-        '@getNotifierIntegrationsHealth',
-        '@getVulnDefinitionsHealth',
-    ]);
-    cy.get('h1:contains("System Health")');
-}
-
-// visit clusters
-
-export function visitSystemHealthWithClustersFixture(fixturePath) {
-    cy.intercept('GET', api.clusters.list, {
-        fixture: fixturePath,
-    }).as('getClusters');
-    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
-    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
-    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
-    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
-
-    visit(systemHealthUrl);
-
-    cy.wait([
-        '@getClusters',
-        '@getBackupIntegrations',
-        '@getImageIntegrations',
-        '@getNotifierIntegrations',
-        '@getBackupIntegrationsHealth',
-        '@getImageIntegrationsHealth',
-        '@getNotifierIntegrationsHealth',
-        '@getVulnDefinitionsHealth',
-    ]);
-    cy.get('h1:contains("System Health")');
-}
-
-export function visitSystemHealthWithClustersFixtureFilteredByNames(fixturePath, clusterNames) {
-    cy.fixture(fixturePath).then(({ clusters }) => {
-        cy.intercept('GET', api.clusters.list, {
-            body: { clusters: clusters.filter(({ name }) => clusterNames.includes(name)) },
-        }).as('getClusters');
-        cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
-        cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
-        cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
-        cy.intercept('GET', api.integrationHealth.externalBackups).as(
-            'getBackupIntegrationsHealth'
-        );
-        cy.intercept('GET', api.integrationHealth.imageIntegrations).as(
-            'getImageIntegrationsHealth'
-        );
-        cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
-        cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
-
-        visit(systemHealthUrl);
-
-        cy.wait([
-            '@getClusters',
-            '@getBackupIntegrations',
-            '@getImageIntegrations',
-            '@getNotifierIntegrations',
-            '@getBackupIntegrationsHealth',
-            '@getImageIntegrationsHealth',
-            '@getNotifierIntegrationsHealth',
-            '@getVulnDefinitionsHealth',
-        ]);
-        cy.get('h1:contains("System Health")');
-    });
-}
-
-// visit integrations
-
-export function visitSystemHealthWithBackupIntegrations(externalBackups, integrationHealth) {
-    cy.intercept('GET', api.clusters.list).as('getClusters');
-    cy.intercept('GET', api.integrations.externalBackups, {
-        body: { externalBackups },
-    }).as('getBackupIntegrations');
-    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
-    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
-    cy.intercept('GET', api.integrationHealth.externalBackups, {
-        body: { integrationHealth },
-    }).as('getBackupIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
-
-    visit(systemHealthUrl);
-
-    cy.wait([
-        '@getClusters',
-        '@getBackupIntegrations',
-        '@getImageIntegrations',
-        '@getNotifierIntegrations',
-        '@getBackupIntegrationsHealth',
-        '@getImageIntegrationsHealth',
-        '@getNotifierIntegrationsHealth',
-        '@getVulnDefinitionsHealth',
-    ]);
-    cy.get('h1:contains("System Health")');
-}
-
-export function visitSystemHealthWithImageIntegrations(integrations, integrationHealth) {
-    cy.intercept('GET', api.clusters.list).as('getClusters');
-    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
-    cy.intercept('GET', api.integrations.imageIntegrations, {
-        body: { integrations },
-    }).as('getImageIntegrations');
-    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
-    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.imageIntegrations, {
-        body: { integrationHealth },
-    }).as('getImageIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
-
-    visit(systemHealthUrl);
-
-    cy.wait([
-        '@getClusters',
-        '@getBackupIntegrations',
-        '@getImageIntegrations',
-        '@getNotifierIntegrations',
-        '@getBackupIntegrationsHealth',
-        '@getImageIntegrationsHealth',
-        '@getNotifierIntegrationsHealth',
-        '@getVulnDefinitionsHealth',
-    ]);
-    cy.get('h1:contains("System Health")');
-}
-
-export function visitSystemHealthWithNotifierIntegrations(notifiers, integrationHealth) {
-    cy.intercept('GET', api.clusters.list).as('getClusters');
-    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
-    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
-    cy.intercept('GET', api.integrations.notifiers, {
-        body: { notifiers },
-    }).as('getNotifierIntegrations');
-    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.notifiers, {
-        body: { integrationHealth },
-    }).as('getNotifierIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.vulnDefinitions).as('getVulnDefinitionsHealth');
-
-    visit(systemHealthUrl);
-
-    cy.wait([
-        '@getClusters',
-        '@getBackupIntegrations',
-        '@getImageIntegrations',
-        '@getNotifierIntegrations',
-        '@getBackupIntegrationsHealth',
-        '@getImageIntegrationsHealth',
-        '@getNotifierIntegrationsHealth',
-        '@getVulnDefinitionsHealth',
-    ]);
-    cy.get('h1:contains("System Health")');
-}
-
-// visit vulnerability definitions
-
-export function visitSystemHealthWithVulnerabilityDefinitionsTimestamp(lastUpdatedTimestamp) {
-    cy.intercept('GET', api.clusters.list).as('getClusters');
-    cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
-    cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
-    cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
-    cy.intercept('GET', api.integrationHealth.externalBackups).as('getBackupIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.imageIntegrations).as('getImageIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.notifiers).as('getNotifierIntegrationsHealth');
-    cy.intercept('GET', api.integrationHealth.vulnDefinitions, {
-        body: { lastUpdatedTimestamp },
-    }).as('getVulnDefinitionsHealth');
-
-    visit(systemHealthUrl);
-
-    cy.wait([
-        '@getClusters',
-        '@getBackupIntegrations',
-        '@getImageIntegrations',
-        '@getNotifierIntegrations',
-        '@getBackupIntegrationsHealth',
-        '@getImageIntegrationsHealth',
-        '@getNotifierIntegrationsHealth',
-        '@getVulnDefinitionsHealth',
-    ]);
     cy.get('h1:contains("System Health")');
 }

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -1,13 +1,33 @@
 import * as api from '../constants/apiEndpoints';
 
+import { interceptRequests, waitForResponses } from './request';
+
 /*
  * Wait for prerequisite requests to render container components.
+ *
+ * Always wait on generic requests for MainPage component.
+ *
+ * Optionally intercept specific requests for container component:
+ * routeMatcherMap: { key: routeMatcher, … }
+ *
+ * Optionally replace responses with stub for routeMatcher alias key:
+ * staticResponseMap: { alias: { body }, … }
+ * staticResponseMap: { alias: { fixture }, … }
+ *
+ * Optionally assign aliases for multiple GraphQL requests with routeMatcher opname key:
+ * graphqlMultiAliasMap: { opname: { aliases, routeHandler }, … }
+ *
+ * Optionally wait for responses with waitOptions: { requestTimeout, responseTimeout }
  */
 // eslint-disable-next-line import/prefer-default-export
-export function visit(url) {
-    cy.intercept('GET', api.featureFlags).as('getFeatureFlags');
-    cy.intercept('GET', api.roles.mypermissions).as('getMyPermissions');
-    cy.intercept('GET', api.system.configPublic).as('getConfigPublic');
-    cy.visit(url);
-    cy.wait(['@getFeatureFlags', '@getMyPermissions', '@getConfigPublic']);
+export function visit(pageUrl, requestConfig, staticResponseMap) {
+    cy.intercept('GET', api.featureFlags).as('featureflags');
+    cy.intercept('GET', api.roles.mypermissions).as('mypermissions');
+    cy.intercept('GET', api.system.configPublic).as('config/public');
+    interceptRequests(requestConfig, staticResponseMap);
+
+    cy.visit(pageUrl);
+
+    cy.wait(['@featureflags', '@mypermissions', '@config/public']);
+    waitForResponses(requestConfig);
 }

--- a/ui/apps/platform/cypress/integration/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/clusters.test.js
@@ -6,7 +6,6 @@ import withAuth from '../helpers/basicAuth';
 import {
     visitClusters,
     visitClustersFromLeftNav,
-    visitClustersWithFixture,
     visitClustersWithFixtureMetadataDatetime,
     visitClusterByNameWithFixture,
     visitClusterByNameWithFixtureMetadataDatetime,
@@ -251,7 +250,9 @@ describe('Cluster management', () => {
 
     it('should indicate which clusters are managed by Helm and the Operator', () => {
         const fixturePath = 'clusters/health.json';
-        visitClustersWithFixture(fixturePath);
+        visitClusters({
+            clusters: { fixture: fixturePath },
+        });
 
         const helmIndicator = '[data-testid="cluster-name"] img[alt="Managed by Helm"]';
         const k8sOperatorIndicator =

--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -51,7 +51,7 @@ describe('Risk page', () => {
                 'eq',
                 '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=true'
             );
-            cy.wait('@getDeploymentsWithProcessInfo'); // assume intercept in visitRiskDeployments
+            cy.wait('@deploymentswithprocessinfo'); // assume intercept in visitRiskDeployments
             cy.get(priorityColumnHeadingSelector).should('have.class', '-sort-desc');
             cy.get(`${RiskPageSelectors.table.dataRows} .rt-td:nth-child(5)`).then(
                 ($priorityCells) => {

--- a/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
@@ -1,12 +1,17 @@
 import { clustersUrl } from '../../constants/ClustersPage';
 import { selectors } from '../../constants/SystemHealth';
 import withAuth from '../../helpers/basicAuth';
-import {
-    setClock,
-    visitSystemHealth,
-    visitSystemHealthWithClustersFixture,
-    visitSystemHealthWithClustersFixtureFilteredByNames,
-} from '../../helpers/systemHealth';
+import { setClock, visitSystemHealth } from '../../helpers/systemHealth';
+
+function visitSystemHealthWithClustersFixtureFilteredByNames(fixturePath, clusterNames) {
+    cy.fixture(fixturePath).then(({ clusters }) => {
+        visitSystemHealth({
+            clusters: {
+                body: { clusters: clusters.filter(({ name }) => clusterNames.includes(name)) },
+            },
+        });
+    });
+}
 
 describe('System Health Clusters without fixture', () => {
     withAuth();
@@ -33,7 +38,9 @@ describe('System Health Clusters with fixture', () => {
 
     it('should have counts in Cluster Overview', () => {
         setClock(currentDatetime); // call before visit
-        visitSystemHealthWithClustersFixture(clustersFixturePath);
+        visitSystemHealth({
+            clusters: { fixture: clustersFixturePath },
+        });
 
         const widgetSelector = selectors.clusters.widgets.clusterOverview;
 
@@ -63,7 +70,9 @@ describe('System Health Clusters with fixture', () => {
 
     it('should have counts in Collector Status', () => {
         setClock(currentDatetime); // call before visit
-        visitSystemHealthWithClustersFixture(clustersFixturePath);
+        visitSystemHealth({
+            clusters: { fixture: clustersFixturePath },
+        });
 
         const widgetSelector = selectors.clusters.widgets.collectorStatus;
         let total = 0;
@@ -91,7 +100,9 @@ describe('System Health Clusters with fixture', () => {
 
     it('should have counts in Sensor Status', () => {
         setClock(currentDatetime); // call before visit
-        visitSystemHealthWithClustersFixture(clustersFixturePath);
+        visitSystemHealth({
+            clusters: { fixture: clustersFixturePath },
+        });
 
         const widgetSelector = selectors.clusters.widgets.sensorStatus;
         let total = 0;
@@ -119,7 +130,9 @@ describe('System Health Clusters with fixture', () => {
 
     it('should have counts in Sensor Updgrade', () => {
         setClock(currentDatetime); // call before visit
-        visitSystemHealthWithClustersFixture(clustersFixturePath);
+        visitSystemHealth({
+            clusters: { fixture: clustersFixturePath },
+        });
 
         const widgetSelector = selectors.clusters.widgets.sensorUpgrade;
         let total = 0;
@@ -143,7 +156,9 @@ describe('System Health Clusters with fixture', () => {
 
     it('should have counts in Credential Expiration', () => {
         setClock(currentDatetime); // call before visit
-        visitSystemHealthWithClustersFixture(clustersFixturePath);
+        visitSystemHealth({
+            clusters: { fixture: clustersFixturePath },
+        });
 
         const widgetSelector = selectors.clusters.widgets.credentialExpiration;
         let total = 0;

--- a/ui/apps/platform/cypress/integration/systemHealth/integrations.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/integrations.test.js
@@ -1,12 +1,7 @@
 import { url as integrationsUrl } from '../../constants/IntegrationsPage';
 import { selectors } from '../../constants/SystemHealth';
 import withAuth from '../../helpers/basicAuth';
-import {
-    visitSystemHealth,
-    visitSystemHealthWithBackupIntegrations,
-    visitSystemHealthWithImageIntegrations,
-    visitSystemHealthWithNotifierIntegrations,
-} from '../../helpers/systemHealth';
+import { visitSystemHealth } from '../../helpers/systemHealth';
 
 describe('System Health Integrations local deployment', () => {
     withAuth();
@@ -51,7 +46,12 @@ describe('System Health Integrations local deployment', () => {
 describe('System Health Integrations fixtures', () => {
     withAuth();
     it('should not have count in healthy text for backup integrations', () => {
-        visitSystemHealthWithBackupIntegrations([], []);
+        const externalBackups = [];
+        const integrationHealth = [];
+        visitSystemHealth({
+            externalbackups: { body: { externalBackups } },
+            'integrationhealth/externalbackups': { body: { integrationHealth } },
+        });
 
         const { healthyText, widgets } = selectors.integrations;
         cy.get(`${widgets.backupIntegrations} ${healthyText}`).should(
@@ -104,7 +104,10 @@ describe('System Health Integrations fixtures', () => {
                 lastTimestamp: '2020-12-09T15:15:38.327627700Z',
             },
         ];
-        visitSystemHealthWithImageIntegrations(integrations, integrationHealth);
+        visitSystemHealth({
+            imageintegrations: { body: { integrations } },
+            'integrationhealth/imageintegrations': { body: { integrationHealth } },
+        });
 
         const { healthyText, widgets } = selectors.integrations;
         cy.get(`${widgets.imageIntegrations} ${healthyText}`).should(
@@ -131,7 +134,10 @@ describe('System Health Integrations fixtures', () => {
                 lastTimestamp: '2020-12-09T17:52:18.743384877Z',
             },
         ];
-        visitSystemHealthWithNotifierIntegrations(notifiers, integrationHealth);
+        visitSystemHealth({
+            notifiers: { body: { notifiers } },
+            'integrationhealth/notifiers': { body: { integrationHealth } },
+        });
 
         const { healthyText, widgets } = selectors.integrations;
         cy.get(`${widgets.notifierIntegrations} ${healthyText}`).should(
@@ -159,7 +165,10 @@ describe('System Health Integrations fixtures', () => {
                 lastTimestamp: '2020-12-04T00:38:17.906318735Z',
             },
         ];
-        visitSystemHealthWithImageIntegrations(integrations, integrationHealth);
+        visitSystemHealth({
+            imageintegrations: { body: { integrations } },
+            'integrationhealth/imageintegrations': { body: { integrationHealth } },
+        });
 
         const { integrationLabel, integrationName, widgets } = selectors.integrations;
 

--- a/ui/apps/platform/cypress/integration/systemHealth/vulnDefinitions.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/vulnDefinitions.test.js
@@ -1,10 +1,6 @@
 import { selectors } from '../../constants/SystemHealth';
 import withAuth from '../../helpers/basicAuth';
-import {
-    setClock,
-    visitSystemHealth,
-    visitSystemHealthWithVulnerabilityDefinitionsTimestamp,
-} from '../../helpers/systemHealth';
+import { setClock, visitSystemHealth } from '../../helpers/systemHealth';
 
 const nbsp = '\u00A0';
 
@@ -31,7 +27,9 @@ describe('System Health Vulnerability Definitions with fixture', () => {
         const lastUpdatedTimestamp = '2020-12-09T03:04:59.377369440Z';
 
         setClock(currentDatetime); // call before visit
-        visitSystemHealthWithVulnerabilityDefinitionsTimestamp(lastUpdatedTimestamp);
+        visitSystemHealth({
+            'integrationhealth/vulndefinitions': { body: { lastUpdatedTimestamp } },
+        });
 
         const { vulnDefinitions } = selectors;
         cy.get(vulnDefinitions.header).should('have.text', 'Vulnerability Definitions');


### PR DESCRIPTION
## Description

Provide a reusable declarative convention for the following cypress features:

1. `requestConfig`
    * `routeMatcherMap` see https://docs.cypress.io/api/commands/intercept#Matching-with-RouteMatcher
    * `opnameAliasesMap` see https://docs.cypress.io/api/commands/intercept#Aliasing-individual-requests
    * `waitOptions` see https://docs.cypress.io/api/commands/wait#Timeouts

2. `staticResponseMap` see https://docs.cypress.io/api/commands/intercept#StaticResponse-objects

### Goals

Keep the current inline `cy.intercept(…)`, `visit(…)` or interact, and `cy.wait(…)` sandwich pattern, unless helpers or tests have any of the following goals:

1. Reduce repeated intercept and wait in helper functions which provide mock responses for **different subsets** of requests
    * For example, 6 `visitSystemHealthWithWhatever` functions in helpers/systemHealth.js
    * PatternFly dashboard widgets was another potential example, but might be even better with unit tests instead of integration tests
2. Reuse intercept and wait from helper functions for initial **visit** and also for subsequent **interaction**
    * For example, reuse `requestConfig` in `visitComplianceDashboard` and also `scanCompliance` for intercept-click-wait sandwich
    * For example, reuse `requestConfig` in container page url `visit` function call and also in `visitFromLeftNav` function call for intercept-click-wait sandwich
3. Reuse `requestConfig` in helper functions or tests which use real responses **and also mock responses** via optional `staticResponseMap` arg

By the way, here is one example each of minus and plus to specify most or all requests for initial visit or subsequent interaction:
* Minus: Tests become coupled to implementation of data fetching
* Plus: Eliminate timing problems as a cause of test failure when a sequence of tests assert of DOM elements which do **not** depend on slow responses: for example,becaise most tests in compliance do **not** depend on 6 slow responses to complianceStandards requests, the debug panel in cypress looks like a chain-reaction fender bender with cancelled requests because next test starts before some responses from previous test (although situation in compliance has not caused failures, prevent potential blocker if cypress 13 changes its behavior in this edge case)

Keep current intercept and wait for subset of requests in tests:
* which do not need to factor out common `routeConfig` for real versus mock responses
* which do not have problem with slow responses

### Limitations

1. The `requestHandler` arg of `intercept` is limited in this abstraction to distinguish aliases by payload for multiple GraphQL requests for the same opname
    * It does not support mock response, which tests do not yet require
    * It does not support other request or response mutation, which tests do not yet require

### Overview

1. Factor out corresponding `cy.intercept(…)` and `cy.wait(aliases)` for example in helpers/violations.js

    * replace

        ```js
        export function visitRiskDeployments() {
            cy.intercept('GET', api.risks.riskyDeployments).as('getDeploymentsWithProcessInfo');
            cy.intercept('GET', api.risks.deploymentsCount).as('getDeploymentsCount');
            cy.intercept('POST', api.graphql('searchOptions')).as('postSearchOptions');
            visit(riskURL);
            cy.wait(['@getDeploymentsWithProcessInfo', '@getDeploymentsCount', '@postSearchOptions']);
            cy.get('h1:contains("Risk")');
        }
        ```

    * with

        ```js
        const routeMatcherMap = {
            deploymentswithprocessinfo: {
                method: 'GET',
                url: api.risks.riskyDeployments,
            },
            deploymentscount: {
                method: 'GET',
                url: api.risks.deploymentsCount,
            },
        };

        export function visitRiskDeployments() {
            visit(riskURL, { routeMatcherMap });

            cy.get('h1:contains("Risk")');
        }
        ```

2. If needed, also add optional `staticResponseMap` arg, for example in helpers/clusters.js

    * replace

        ```js
        export function visitClusters() {
            cy.intercept('GET', api.clusters.list).as('getClusters');
            visit(clustersUrl);
            cy.wait('@getClusters');
            cy.get(selectors.clustersListHeading).contains('Clusters');
        }
        ```

    * with

        ```js
        export function visitClusters(staticResponseMap) {
            visit(clustersUrl, { routeMatcherMap }, staticResponseMap);

            cy.get(selectors.clustersListHeading).contains('Clusters');
        }
        ```

3. See helpers/comliance.js for an example of

    * `opnameAliasesMap`
    * `waitOptions`

### Recommended naming convention for aliases

To investigate intergration test failures during 2022
* I look at screen grab at point of failure on CI
* I look at requests in side panel of cypress UI for local deployment
* I look at requests in network panel of brower for local deployment

From this experience correlating test code to external evidence of UI data fetching, here is a recommended naming convention for aliases:

1. REST GET method
    * `'whatevers'` for `/v1/whatevers` might also have search query string
    * `'whatevers/id'` for `/v1/whatevers/id` apiEndpoints.js might have wildcard
    * `'segment/whatevers'` for `/v1/segment/whatevers` might also have search query string
    * `'hypenated-whatever'` for `/v1/hyphenated-whatever`

2. REST other methods for `/v1/whatevers` but **prefix** is optional if they do **not** contrast with any other method
    What are pro and con with underscore `'PREFIX_whatevers'` versus without underscore `'PREFIXwhatevers'`
    * `'DELETE_whatevers'`
    * `'PATCH_whatevers'`
    * `'POST_whatevers'`
    * `'PUT_whatevers'`

4. GraphQL opname is key in `routeMatcherMap` and alias if single request
    * `'whatever'` for `/api/graphql?opname=whatever` notice **no prefix** in alias for GraphQL request although route matcher must have `method: 'POST'` property
    * In theory, this point could conflict with point 1 above; but because it is only a convention, one or both aliases can be adjusted:
        * `'whateverREST'` for `/v1/whatevers`
        * '`whateverGraphQL'` for `/api/graphql?opname=whatever`

5. GraphQL opname is key in `routeMatcherMap` but not alias if multiple requests
    * see helpers/compliance.js for examples of `getAggregatedResults` and `complianceStandards` which have most relevant strings from payload as aliases

### Changed files for **generic** helpers

1. Edit helpers/main.js
    * Add `requestConfig` and `staticResponseMap` args to `visitMainDashboard` function
    * Edit aliases in helper functions

2. Edit helpers/nav.js
    * Add `requestConfig` arg to helper functions
    * Add `interceptRequests` and `waitForResponses` function calls to make interaction sandwich

3. Add helpers/request.js

4. Edit helpers/visit.js
    * Add `requestConfig` and `staticResponseMap` args to `visit` function
    * Add `interceptRequests` and `waitForResponses` function calls to make `cy.visit` sandwich
    * Edit aliases in helper function

### Changed files for **clusters** 

Most recently edited in #1381

1. Edit constants/apiEndpoints.js
    * Add `sensorUpgradesConfig` to `clusters` endpoints

2. Edit helpers/clusters.js
    * Add `routeMatcherMap` for `visit` function calls
    * Add `staticResponseMap` arg for `visitClusters` and `visitClusterById` helper functions
    * Edit aliases in helper function

3. Edit integration/clusters.test.js
    * Replace `visitClustersWithFixture` function calls with `visitClusters` and argument
    * Leave `skip` for Cluster Health and Cluster Certificate Expiration tests after running locally to verify that the updated helpers work

### Changed files for **compliance**

Most recently edited in #1824

1. Edit helpers/compliance.js
    * Add `routeMatcherMap` for all graphql opnames
    * Add `opnameAliasesMap` with predicates for opnames which have multiple requests
    * Add `waitOptions` for request and especially response
    * Add `interceptRequests` and `waitForResponses` function calls to make scan button-click sandwich

### Changed files for **risk**

Most recently edited in #1555

1. Edit helpers/risk.js
    * Add `routeMatcherMap` for `visit` function calls
    * Edit aliases in helper functions

2. Edit integration/risk/risk.test.js
    * Edit alias that corresponds to intercept in `visitRiskDeployments` function

### Changed files for **systemHealth**

Most recently edited in #1633

1. Edit helpers/systemHealth.js
    * Add `routeMatcherMap` for helper functions
    * Add `staticResponseMap` arg for `visitSystemHealth` helper function

2. Edit integration/systemHealth/clusters.test.js
    * Define `visitSystemHealthWithClustersFixtureFilteredByNames` helper function in test file
    * Replace `visitSystemHealthWithClustersFixture` with `visitSystemHealth` and argument

3. Edit integration/systemHealth/integrations.test.js
    * Replace `visitSystemHealthWith` function calls with `visitSystemHealth` and argument

4. Edit integration/systemHealth/vulnDefinitions.test.js
    * Replace `visitSystemHealthWith` function call with `visitSystemHealth` and argument

### Changed files for **violations**

Most recently edited in #1685

1. helpers/violations.js
    * Add `routeMatcherMap` and `staticResponseMap` for `visitSystemHealth` helper function
    * Edit aliases in helper functions

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Ran tests one at a time in local deployment
1. clusters.test.js
2. compliance
    * complianceDashboard.test.js
    * also affects general.test.js
* risk
    * risk.test.js
    * also affects network.test.js
4. systemHealth
    * bundle.test.js
    * clusters.test.js
    * integrations.test.js
    * systemHealthGeneral.test.js
    * vulnDefinitions.test.js
* violations/violations.test.js