### PR TITLE
Add PID and args to mock gRPC output

### DIFF
--- a/integration-tests/mock-grpc-server/main.go
+++ b/integration-tests/mock-grpc-server/main.go
@@ -49,7 +49,7 @@ func (s *signalServer) PushSignals(stream sensorAPI.SignalService_PushSignalsSer
 			processSignal = signal.GetSignal().GetProcessSignal()
 		}
 
-		processInfo := fmt.Sprintf("%s:%s:%d:%d", processSignal.GetName(), processSignal.GetExecFilePath(), processSignal.GetUid(), processSignal.GetGid())
+		processInfo := fmt.Sprintf("%s:%s:%d:%d:%d:%s", processSignal.GetName(), processSignal.GetExecFilePath(), processSignal.GetUid(), processSignal.GetGid(), processSignal.GetPid(), processSignal.GetArgs())
 		fmt.Printf("ProcessInfo: %s %s\n", processSignal.GetContainerId(), processInfo)
 		if err := s.UpdateProcessSignals(processSignal.GetName(), processInfo); err != nil {
 			return err

--- a/integration-tests/mock-grpc-server/main.go
+++ b/integration-tests/mock-grpc-server/main.go
@@ -48,15 +48,9 @@ func (s *signalServer) PushSignals(stream sensorAPI.SignalService_PushSignalsSer
 		var processSignal *storage.ProcessSignal
 		if signal != nil && signal.GetSignal() != nil && signal.GetSignal().GetProcessSignal() != nil {
 			processSignal = signal.GetSignal().GetProcessSignal()
+		} else {
+			continue
 		}
-
-		fmt.Printf("Process: ")
-		fmt.Printf("    name: %s\n", processSignal.GetName())
-		fmt.Printf("    file-path: %s\n", processSignal.GetExecFilePath())
-		fmt.Printf("    uid: %d\n", processSignal.GetUid())
-		fmt.Printf("    gid: %d\n", processSignal.GetGid())
-		fmt.Printf("    pid: %d\n", processSignal.GetPid())
-		fmt.Printf("    args: %s\n", processSignal.GetArgs())
 
 		processInfo := fmt.Sprintf("%s:%s:%d:%d:%d:%s", processSignal.GetName(), processSignal.GetExecFilePath(), processSignal.GetUid(), processSignal.GetGid(), processSignal.GetPid(), processSignal.GetArgs())
 		fmt.Printf("ProcessInfo: %s %s\n", processSignal.GetContainerId(), processInfo)

--- a/integration-tests/mock-grpc-server/main.go
+++ b/integration-tests/mock-grpc-server/main.go
@@ -50,6 +50,14 @@ func (s *signalServer) PushSignals(stream sensorAPI.SignalService_PushSignalsSer
 			processSignal = signal.GetSignal().GetProcessSignal()
 		}
 
+		fmt.Printf("Process: ")
+		fmt.Printf("    name: %s\n", processSignal.GetName())
+		fmt.Printf("    file-path: %s\n", processSignal.GetExecFilePath())
+		fmt.Printf("    uid: %s\n", processSignal.GetUid())
+		fmt.Printf("    gid: %s\n", processSignal.GetGid())
+		fmt.Printf("    pid: %s\n", processSignal.GetPid())
+		fmt.Printf("    args: %s\n", processSignal.GetArgs())
+
 		processInfo := fmt.Sprintf("%s:%s:%d:%d:%d:%s", processSignal.GetName(), processSignal.GetExecFilePath(), processSignal.GetUid(), processSignal.GetGid(), processSignal.GetPid(), processSignal.GetArgs())
 		fmt.Printf("ProcessInfo: %s %s\n", processSignal.GetContainerId(), processInfo)
 		if err := s.UpdateProcessSignals(processSignal.GetContainerId(), processSignal.GetName(), processInfo); err != nil {

--- a/integration-tests/mock-grpc-server/main.go
+++ b/integration-tests/mock-grpc-server/main.go
@@ -6,8 +6,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"syscall"
 	"strconv"
+	"syscall"
 
 	sensorAPI "github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"

--- a/integration-tests/mock-grpc-server/main.go
+++ b/integration-tests/mock-grpc-server/main.go
@@ -53,9 +53,9 @@ func (s *signalServer) PushSignals(stream sensorAPI.SignalService_PushSignalsSer
 		fmt.Printf("Process: ")
 		fmt.Printf("    name: %s\n", processSignal.GetName())
 		fmt.Printf("    file-path: %s\n", processSignal.GetExecFilePath())
-		fmt.Printf("    uid: %s\n", processSignal.GetUid())
-		fmt.Printf("    gid: %s\n", processSignal.GetGid())
-		fmt.Printf("    pid: %s\n", processSignal.GetPid())
+		fmt.Printf("    uid: %d\n", processSignal.GetUid())
+		fmt.Printf("    gid: %d\n", processSignal.GetGid())
+		fmt.Printf("    pid: %d\n", processSignal.GetPid())
 		fmt.Printf("    args: %s\n", processSignal.GetArgs())
 
 		processInfo := fmt.Sprintf("%s:%s:%d:%d:%d:%s", processSignal.GetName(), processSignal.GetExecFilePath(), processSignal.GetUid(), processSignal.GetGid(), processSignal.GetPid(), processSignal.GetArgs())


### PR DESCRIPTION
## Description

Adds PID and process args to mock gRPC output to improve test coverage on collector. 

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Tested manually with collector's integration tests specifically, with various versions of collector that have a bug in which process args were not reported. Tested alongside collector as part of https://github.com/stackrox/collector/pull/740
