### PR TITLE
RS-443: Trigger nightly tests in prow also

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4202,7 +4202,7 @@ jobs:
             git commit --allow-empty -m "Nightly build $(date)"
             NIGHTLY_TAG="$(git describe --tags --abbrev=0 --exclude '*-nightly-*')-nightly-$(date '+%Y%m%d')"
             git tag "$NIGHTLY_TAG"
-            git push origin "$NIGHTLY_TAG"
+            git push origin --follow-tags
 
       - run:
           name: Remove tags more than 3 days old


### PR DESCRIPTION
## Description

It is unclear to me why, but this change (`--follow-tags`) is required to get OpenShift CI postsubmit jobs to run for nightly tags. From all the jobs that my test tags kicked off in Circle CI, it looks like it works there also.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient