### PR TITLE
Populate new embedded node vulnerability from scan result

### DIFF
--- a/pkg/nodes/enricher/enricher_impl.go
+++ b/pkg/nodes/enricher/enricher_impl.go
@@ -99,13 +99,6 @@ func (e *enricherImpl) enrichNodeWithScanner(node *storage.Node, scanner types.N
 	scanStartTime := time.Now()
 	scan, err := scanner.GetNodeScan(node)
 
-	if features.PostgresDatastore.Enabled() {
-		fillV2NodeVulnerabilities(node)
-		for _, component := range node.GetScan().GetComponents() {
-			component.Vulns = nil
-		}
-	}
-
 	e.metrics.SetScanDurationTime(scanStartTime, scanner.Name(), err)
 	if err != nil {
 		return errors.Wrapf(err, "Error scanning '%s:%s' with scanner %q", node.GetClusterName(), node.GetName(), scanner.Name())
@@ -115,6 +108,12 @@ func (e *enricherImpl) enrichNodeWithScanner(node *storage.Node, scanner types.N
 	}
 
 	node.Scan = scan
+	if features.PostgresDatastore.Enabled() {
+		fillV2NodeVulnerabilities(node)
+		for _, component := range node.GetScan().GetComponents() {
+			component.Vulns = nil
+		}
+	}
 	FillScanStats(node)
 
 	return nil


### PR DESCRIPTION
## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~
If any of these don't apply, please comment below.

## Testing Performed
Unit

```
$ roxcurl /v1/clusters | jq
{
  "clusters": [
    {
      "id": "8c9344df-bd26-43f6-893d-248248db14c4",
      "name": "K8S",
      "type": "KUBERNETES_CLUSTER",
      "labels": {},
      "mainImage": "quay.io/stackrox-io/main",
      "collectorImage": "quay.io/stackrox-io/collector",
      "centralApiEndpoint": "central.stackrox:443",
      "runtimeSupport": true,
      "collectionMethod": "EBPF",
      "admissionController": true,
      "admissionControllerUpdates": false,
      "admissionControllerEvents": true,
      "status": {
        "sensorVersion": "3.70.x-470-g77d2582293",
        "DEPRECATEDLastContact": null,
        "providerMetadata": {
          "region": "us-central1",
          "zone": "us-central1-a",
          "google": {
            "project": "srox-temp-dev-test",
            "clusterName": "md-demo"
          },
          "verified": true
        },
        "orchestratorMetadata": {
          "version": "v1.21.11-gke.1900",
          "buildDate": "2022-04-13T09:36:54Z",
          "apiVersions": [
            "admissionregistration.k8s.io/v1",
            "admissionregistration.k8s.io/v1beta1",
            "apiextensions.k8s.io/v1",
            "apiextensions.k8s.io/v1beta1",
            "apiregistration.k8s.io/v1",
            "apiregistration.k8s.io/v1beta1",
            "apps/v1",
            "authentication.k8s.io/v1",
            "authentication.k8s.io/v1beta1",
            "authorization.k8s.io/v1",
            "authorization.k8s.io/v1beta1",
            "autoscaling/v1",
            "autoscaling/v2beta1",
            "autoscaling/v2beta2",
            "batch/v1",
            "batch/v1beta1",
            "certificates.k8s.io/v1",
            "certificates.k8s.io/v1beta1",
            "cloud.google.com/v1",
            "cloud.google.com/v1beta1",
            "coordination.k8s.io/v1",
            "coordination.k8s.io/v1beta1",
            "crd.projectcalico.org/v1",
            "discovery.k8s.io/v1",
            "discovery.k8s.io/v1beta1",
            "events.k8s.io/v1",
            "extensions/v1beta1",
            "flowcontrol.apiserver.k8s.io/v1beta1",
            "internal.autoscaling.gke.io/v1alpha1",
            "metrics.k8s.io/v1beta1",
            "migration.k8s.io/v1alpha1",
            "networking.gke.io/v1",
            "networking.gke.io/v1beta1",
            "networking.gke.io/v1beta2",
            "networking.k8s.io/v1",
            "networking.k8s.io/v1beta1",
            "node.k8s.io/v1",
            "node.k8s.io/v1beta1",
            "nodemanagement.gke.io/v1alpha1",
            "policy/v1",
            "policy/v1beta1",
            "rbac.authorization.k8s.io/v1",
            "rbac.authorization.k8s.io/v1beta1",
            "scheduling.k8s.io/v1",
            "scheduling.k8s.io/v1beta1",
            "snapshot.storage.k8s.io/v1",
            "snapshot.storage.k8s.io/v1beta1",
            "storage.k8s.io/v1",
            "storage.k8s.io/v1beta1",
            "v1"
          ]
        },
        "upgradeStatus": {
          "upgradability": "UP_TO_DATE",
          "upgradabilityStatusReason": "sensor is running the same version as Central",
          "mostRecentProcess": null
        },
        "certExpiryStatus": {
          "sensorCertExpiry": "2023-06-23T22:17:00Z",
          "sensorCertNotBefore": "2022-06-23T21:17:00Z"
        }
      },
      "dynamicConfig": {
        "admissionControllerConfig": {
          "enabled": false,
          "timeoutSeconds": 20,
          "scanInline": false,
          "disableBypass": false,
          "enforceOnUpdates": false
        },
        "registryOverride": "",
        "disableAuditLogs": true
      },
      "tolerationsConfig": {
        "disabled": false
      },
      "priority": "1",
      "healthStatus": {
        "id": "8c9344df-bd26-43f6-893d-248248db14c4",
        "collectorHealthInfo": {
          "version": "3.8.1",
          "totalDesiredPods": 3,
          "totalReadyPods": 3,
          "totalRegisteredNodes": 3,
          "statusErrors": []
        },
        "admissionControlHealthInfo": {
          "totalDesiredPods": 3,
          "totalReadyPods": 3,
          "statusErrors": []
        },
        "scannerHealthInfo": null,
        "sensorHealthStatus": "HEALTHY",
        "collectorHealthStatus": "HEALTHY",
        "overallHealthStatus": "HEALTHY",
        "admissionControlHealthStatus": "HEALTHY",
        "scannerHealthStatus": "UNINITIALIZED",
        "lastContact": "2022-06-23T22:17:46.399415Z",
        "healthInfoComplete": true
      },
      "slimCollector": true,
      "helmConfig": null,
      "mostRecentSensorId": {
        "systemNamespaceId": "90b0a21f-e4f2-4901-9159-cadbb615340f",
        "defaultNamespaceId": "6af7a1ed-0aef-4fbe-bdc4-5f07da2d1ecc",
        "appNamespace": "stackrox",
        "appNamespaceId": "8eca0e4d-0ab7-4ec3-a155-02438db2ab9b",
        "appServiceaccountId": "",
        "k8sNodeName": "gke-md-demo-default-pool-c4d79a52-7v1z"
      },
      "auditLogState": {},
      "initBundleId": "67ec84aa-96aa-4691-9f58-a1f02966ce85",
      "managedBy": "MANAGER_TYPE_MANUAL"
    }
  ]
}
mandar@MacBook-Pro:~/go/dev1/src/github.com/stackrox/stackrox$ roxcurl /v1/nodes/8c9344df-bd26-43f6-893d-248248db14c4 | jq
{
  "nodes": [
    {
      "id": "63bf69e1-13d7-4b24-9926-a13d2d34da25",
      "name": "gke-md-demo-default-pool-c4d79a52-7v1z",
      "taints": [],
      "clusterId": "8c9344df-bd26-43f6-893d-248248db14c4",
      "clusterName": "K8S",
      "labels": {
        "beta.kubernetes.io/arch": "amd64",
        "beta.kubernetes.io/instance-type": "e2-standard-4",
        "beta.kubernetes.io/os": "linux",
        "cloud.google.com/gke-boot-disk": "pd-standard",
        "cloud.google.com/gke-container-runtime": "docker",
        "cloud.google.com/gke-nodepool": "default-pool",
        "cloud.google.com/gke-os-distribution": "ubuntu",
        "cloud.google.com/machine-family": "e2",
        "failure-domain.beta.kubernetes.io/region": "us-central1",
        "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
        "kubernetes.io/arch": "amd64",
        "kubernetes.io/hostname": "gke-md-demo-default-pool-c4d79a52-7v1z",
        "kubernetes.io/os": "linux",
        "node.kubernetes.io/instance-type": "e2-standard-4",
        "node.kubernetes.io/masq-agent-ds-ready": "true",
        "projectcalico.org/ds-ready": "true",
        "topology.gke.io/zone": "us-central1-a",
        "topology.kubernetes.io/region": "us-central1",
        "topology.kubernetes.io/zone": "us-central1-a"
      },
      "annotations": {
        "container.googleapis.com/instance_id": "4575336815708954620",
        "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/srox-temp-dev-test/zones/us-central1-a/instances/gke-md-demo-default-pool-c4d79a52-7v1z\"}",
        "node.alpha.kubernetes.io/ttl": "0",
        "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-boot-disk=pd-standard,cloud.google.com/gke-container-runtime=docker,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=ubuntu,cloud.google.com/machine-family=e2,node.kubernetes.io/masq-agent-ds-ready=tru...",
        "node.gke.io/last-applied-node-taints": "",
        "projectcalico.org/IPv4Address": "10.33.23.212/32",
        "projectcalico.org/IPv4IPIPTunnelAddr": "10.33.34.1",
        "volumes.kubernetes.io/controller-managed-attach-detach": "true"
      },
      "joinedAt": "2022-06-23T21:56:58Z",
      "internalIpAddresses": [
        "10.33.23.212"
      ],
      "externalIpAddresses": [
        "34.67.213.163"
      ],
      "containerRuntimeVersion": "docker://19.3.8",
      "containerRuntime": {
        "type": "DOCKER_CONTAINER_RUNTIME",
        "version": "19.3.8"
      },
      "kernelVersion": "5.4.0-1067-gke",
      "operatingSystem": "",
      "osImage": "Ubuntu 20.04.4 LTS",
      "kubeletVersion": "v1.21.11-gke.1900",
      "kubeProxyVersion": "v1.21.11-gke.1900",
      "lastUpdated": "2022-06-23T22:17:17.743607907Z",
      "k8sUpdated": "2022-06-23T22:17:17.000065204Z",
      "scan": {
        "scanTime": "2022-06-23T22:17:17.742792561Z",
        "operatingSystem": "ubuntu:20.04",
        "components": [
          {
            "name": "docker",
            "version": "19.3.8",
            "vulns": [],
            "vulnerabilities": [
              {
                "cveBaseInfo": {
                  "cve": "CVE-2020-27534",
                  "summary": "util/binfmt_misc/check.go in Builder in Docker Engine before 19.03.9 calls os.OpenFile with a potentially unsafe qemu-check temporary pathname, constructed with an empty first argument in an ioutil.TempDir call.",
                  "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-27534",
                  "publishedOn": "2020-12-30T23:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
                    "attackVector": "ATTACK_NETWORK",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 10,
                    "impactScore": 2.9,
                    "score": 5,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
                    "exploitabilityScore": 3.9,
                    "impactScore": 1.4,
                    "attackVector": "ATTACK_NETWORK",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_NONE",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_LOW",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "score": 5.3,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.3,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-21284",
                  "summary": "In Docker before versions 9.03.15, 20.10.3 there is a vulnerability involving the --userns-remap option in which access to remapped root allows privilege escalation to real root. When using \"--userns-remap\", if the root user in the remapped namespace has access to the host filesystem they can modify files under \"/var/lib/docker/<remapping>\" that cause writing files with extended privileges. Versions 20.10.3 and 19.03.15 contain patches that prevent privilege escalation from remapped user.",
                  "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21284",
                  "publishedOn": "2021-02-02T18:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:A/AC:L/Au:S/C:N/I:P/A:N",
                    "attackVector": "ATTACK_ADJACENT",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_SINGLE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 5.1,
                    "impactScore": 2.9,
                    "score": 2.7,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:N",
                    "exploitabilityScore": 2.3,
                    "impactScore": 4,
                    "attackVector": "ATTACK_ADJACENT",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "CHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_NONE",
                    "score": 6.8,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 6.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-21285",
                  "summary": "In Docker before versions 9.03.15, 20.10.3 there is a vulnerability in which pulling an intentionally malformed Docker image manifest crashes the dockerd daemon. Versions 20.10.3 and 19.03.15 contain patches that prevent the daemon from crashing.",
                  "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21285",
                  "publishedOn": "2021-02-02T18:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
                    "attackVector": "ATTACK_NETWORK",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 8.6,
                    "impactScore": 2.9,
                    "score": 4.3,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 2.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_NETWORK",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_NONE",
                    "userInteraction": "UI_REQUIRED",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 6.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 6.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              }
            ],
            "priority": "0",
            "topCvss": 6.8,
            "riskScore": 0
          },
          {
            "name": "kube-proxy",
            "version": "v1.21.11-gke.1900",
            "vulns": [],
            "vulnerabilities": [],
            "priority": "0",
            "riskScore": 0
          },
          {
            "name": "kubelet",
            "version": "v1.21.11-gke.1900",
            "vulns": [],
            "vulnerabilities": [],
            "priority": "0",
            "riskScore": 0
          },
          {
            "name": "linux-gke",
            "version": "5.4.0-1067",
            "vulns": [],
            "vulnerabilities": [
              {
                "cveBaseInfo": {
                  "cve": "CVE-2013-7445",
                  "summary": "The Direct Rendering Manager (DRM) subsystem in the Linux kernel through 4.x mishandles requests for Graphics Execution Manager (GEM) objects, which allows context-dependent attackers to cause a denial of service (memory consumption) via an application that processes graphics data, as demonstrated by JavaScript code that creates many CANVAS elements for rendering by Chrome or Firefox.",
                  "link": "https://ubuntu.com/security/CVE-2013-7445",
                  "publishedOn": "2015-10-16T01:59:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V2",
                  "cvssV2": {
                    "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:C",
                    "attackVector": "ATTACK_NETWORK",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 10,
                    "impactScore": 6.9,
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "cvssV3": null,
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2015-8553",
                  "summary": "Xen allows guest OS users to obtain sensitive information from uninitialized locations in host OS kernel memory by not enabling memory and I/O decoding control bits.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2015-0777.",
                  "link": "https://ubuntu.com/security/CVE-2015-8553",
                  "publishedOn": "2016-04-13T15:59:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N",
                    "exploitabilityScore": 2,
                    "impactScore": 4,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "CHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "score": 6.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 6.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2016-8660",
                  "summary": "The XFS subsystem in the Linux kernel through 4.8.2 allows local users to cause a denial of service (fdatasync failure and system hang) by using the vfs syscall group in the trinity program, related to a \"page lock order bug in the XFS seek hole/data implementation.\"",
                  "link": "https://ubuntu.com/security/CVE-2016-8660",
                  "publishedOn": "2016-10-16T21:59:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.9,
                    "score": 4.9,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2017-0537",
                  "summary": "An information disclosure vulnerability in the kernel USB gadget driver could enable a local malicious application to access data outside of its permission levels. This issue is rated as Moderate because it first requires compromising a privileged process. Product: Android. Versions: Kernel-3.18. Android ID: A-31614969.",
                  "link": "https://ubuntu.com/security/CVE-2017-0537",
                  "publishedOn": "2017-03-08T01:59:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:N/AC:H/Au:N/C:P/I:N/A:N",
                    "attackVector": "ATTACK_NETWORK",
                    "accessComplexity": "ACCESS_HIGH",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 4.9,
                    "impactScore": 2.9,
                    "score": 2.6,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:R/S:U/C:H/I:N/A:N",
                    "exploitabilityScore": 1,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_NONE",
                    "userInteraction": "UI_REQUIRED",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "score": 4.7,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 4.7,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2017-13165",
                  "summary": "An elevation of privilege vulnerability in the kernel file system. Product: Android. Versions: Android kernel. Android ID A-31269937.",
                  "link": "https://ubuntu.com/security/CVE-2017-13165",
                  "publishedOn": "2017-12-06T14:29:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.4,
                    "score": 4.6,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2017-13693",
                  "summary": "The acpi_ds_create_operands() function in drivers/acpi/acpica/dsutils.c in the Linux kernel through 4.12.9 does not flush the operand cache and causes a kernel stack dump, which allows local users to obtain sensitive information from kernel memory and bypass the KASLR protection mechanism (in the kernel through 4.9) via a crafted ACPI table.",
                  "link": "https://ubuntu.com/security/CVE-2017-13693",
                  "publishedOn": "2017-08-25T08:29:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:C/I:N/A:N",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_COMPLETE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.9,
                    "score": 4.9,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2018-1121",
                  "summary": "procps-ng, procps is vulnerable to a process hiding through race condition. Since the kernel's proc_pid_readdir() returns PID entries in ascending numeric order, a process occupying a high PID can use inotify events to determine when the process list is being scanned, and fork/exec to obtain a lower PID, thus avoiding enumeration. An unprivileged attacker can hide a process from procps-ng's utilities by exploiting a race condition in reading /proc/PID entries. This vulnerability affects procps and procps-ng up to version 3.3.15, newer versions might be affected also.",
                  "link": "https://ubuntu.com/security/CVE-2018-1121",
                  "publishedOn": "2018-06-13T20:29:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
                    "attackVector": "ATTACK_NETWORK",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 8.6,
                    "impactScore": 2.9,
                    "score": 4.3,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N",
                    "exploitabilityScore": 2.2,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_NETWORK",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_NONE",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_NONE",
                    "score": 5.9,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.9,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2018-12928",
                  "summary": "In the Linux kernel 4.15.0, a NULL pointer dereference was discovered in hfs_ext_read_extent in hfs.ko. This can occur during a mount of a crafted hfs filesystem.",
                  "link": "https://ubuntu.com/security/CVE-2018-12928",
                  "publishedOn": "2018-06-28T14:29:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.9,
                    "score": 4.9,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2018-12929",
                  "summary": "ntfs_read_locked_inode in the ntfs.ko filesystem driver in the Linux kernel 4.15.0 allows attackers to trigger a use-after-free read and possibly cause a denial of service (kernel oops or panic) via a crafted ntfs filesystem.",
                  "link": "https://ubuntu.com/security/CVE-2018-12929",
                  "publishedOn": "2018-06-28T14:29:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.9,
                    "score": 4.9,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2018-12930",
                  "summary": "ntfs_end_buffer_async_read in the ntfs.ko filesystem driver in the Linux kernel 4.15.0 allows attackers to trigger a stack-based out-of-bounds write and cause a denial of service (kernel oops or panic) or possibly have unspecified other impact via a crafted ntfs filesystem.",
                  "link": "https://ubuntu.com/security/CVE-2018-12930",
                  "publishedOn": "2018-06-28T14:29:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_COMPLETE",
                    "integrity": "IMPACT_COMPLETE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 10,
                    "score": 7.2,
                    "severity": "HIGH"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2018-12931",
                  "summary": "ntfs_attr_find in the ntfs.ko filesystem driver in the Linux kernel 4.15.0 allows attackers to trigger a stack-based out-of-bounds write and cause a denial of service (kernel oops or panic) or possibly have unspecified other impact via a crafted ntfs filesystem.",
                  "link": "https://ubuntu.com/security/CVE-2018-12931",
                  "publishedOn": "2018-06-28T14:29:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_COMPLETE",
                    "integrity": "IMPACT_COMPLETE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 10,
                    "score": 7.2,
                    "severity": "HIGH"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2018-17977",
                  "summary": "The Linux kernel 4.14.67 mishandles certain interaction among XFRM Netlink messages, IPPROTO_AH packets, and IPPROTO_IP packets, which allows local users to cause a denial of service (memory consumption and system hang) by leveraging root access to execute crafted applications, as demonstrated on CentOS 7.",
                  "link": "https://ubuntu.com/security/CVE-2018-17977",
                  "publishedOn": "2018-10-08T17:29:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.9,
                    "score": 4.9,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.0/AV:L/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 0.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_HIGH",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 4.4,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 4.4,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2019-14899",
                  "summary": "A vulnerability was discovered in Linux, FreeBSD, OpenBSD, MacOS, iOS, and Android that allows a malicious access point, or an adjacent user, to determine if a connected user is using a VPN, make positive inferences about the websites they are visiting, and determine the correct sequence and acknowledgement numbers in use, allowing the bad actor to inject data into the TCP stream. This provides everything that is needed for an attacker to hijack active connections inside the VPN tunnel.",
                  "link": "https://ubuntu.com/security/CVE-2019-14899",
                  "publishedOn": "2019-12-11T15:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:A/AC:M/Au:S/C:P/I:P/A:P",
                    "attackVector": "ATTACK_ADJACENT",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_SINGLE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 4.4,
                    "impactScore": 6.4,
                    "score": 4.9,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:A/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.5,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_ADJACENT",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_REQUIRED",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.4,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.4,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2019-15213",
                  "summary": "An issue was discovered in the Linux kernel before 5.2.3. There is a use-after-free caused by a malicious USB device in the drivers/media/usb/dvb-usb/dvb-usb-init.c driver.",
                  "link": "https://ubuntu.com/security/CVE-2019-15213",
                  "publishedOn": "2019-08-19T22:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.9,
                    "score": 4.9,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.0/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 0.9,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_PHYSICAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_NONE",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 4.6,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 4.6,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2019-16230",
                  "summary": "** DISPUTED ** drivers/gpu/drm/radeon/radeon_display.c in the Linux kernel 5.2.14 does not check the alloc_workqueue return value, leading to a NULL pointer dereference. NOTE: A third-party software maintainer states that the work queue allocation is happening during device initialization, which for a graphics card occurs during boot. It is not attacker controllable and OOM at that time is highly unlikely.",
                  "link": "https://ubuntu.com/security/CVE-2019-16230",
                  "publishedOn": "2019-09-11T16:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:M/Au:N/C:N/I:N/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.4,
                    "impactScore": 6.9,
                    "score": 4.7,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 4.7,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 4.7,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2019-19378",
                  "summary": "In the Linux kernel 5.0.21, mounting a crafted btrfs filesystem image can lead to slab-out-of-bounds write access in index_rbio_pages in fs/btrfs/raid56.c.",
                  "link": "https://ubuntu.com/security/CVE-2019-19378",
                  "publishedOn": "2019-11-29T17:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_NETWORK",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 8.6,
                    "impactScore": 6.4,
                    "score": 6.8,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_NONE",
                    "userInteraction": "UI_REQUIRED",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2019-19814",
                  "summary": "In the Linux kernel 5.0.21, mounting a crafted f2fs filesystem image can cause __remove_dirty_segment slab-out-of-bounds write access because an array is bounded by the number of dirty types (8) but the array index can exceed this.",
                  "link": "https://ubuntu.com/security/CVE-2019-19814",
                  "publishedOn": "2019-12-17T06:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:N/AC:M/Au:N/C:C/I:C/A:C",
                    "attackVector": "ATTACK_NETWORK",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_COMPLETE",
                    "integrity": "IMPACT_COMPLETE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 8.6,
                    "impactScore": 10,
                    "score": 9.3,
                    "severity": "HIGH"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_NONE",
                    "userInteraction": "UI_REQUIRED",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2020-11725",
                  "summary": "** DISPUTED ** snd_ctl_elem_add in sound/core/control.c in the Linux kernel through 5.6.3 has a count=info->owner line, which later affects a private_size*count multiplication for unspecified \"interesting side effects.\" NOTE: kernel engineers dispute this finding, because it could be relevant only if new callers were added that were unfamiliar with the misuse of the info->owner field to represent data unrelated to the \"owner\" concept. The existing callers, SNDRV_CTL_IOCTL_ELEM_ADD and SNDRV_CTL_IOCTL_ELEM_REPLACE, have been designed to misuse the info->owner field in a safe way.",
                  "link": "https://ubuntu.com/security/CVE-2020-11725",
                  "publishedOn": "2020-04-12T22:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.4,
                    "score": 4.6,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2020-12362",
                  "summary": "Integer overflow in the firmware for some Intel(R) Graphics Drivers for Windows * before version 26.20.100.7212 and before Linux kernel version 5.5 may allow a privileged user to potentially enable an escalation of privilege via local access.",
                  "link": "https://ubuntu.com/security/CVE-2020-12362",
                  "publishedOn": "2021-02-17T14:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.4,
                    "score": 4.6,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2020-12363",
                  "summary": "Improper input validation in some Intel(R) Graphics Drivers for Windows* before version 26.20.100.7212 and before Linux kernel version 5.5 may allow a privileged user to potentially enable a denial of service via local access.",
                  "link": "https://ubuntu.com/security/CVE-2020-12363",
                  "publishedOn": "2021-02-17T14:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2020-12364",
                  "summary": "Null pointer reference in some Intel(R) Graphics Drivers for Windows* before version 26.20.100.7212 and before version Linux kernel version 5.5 may allow a privileged user to potentially enable a denial of service via local access.",
                  "link": "https://ubuntu.com/security/CVE-2020-12364",
                  "publishedOn": "2021-02-17T14:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2020-14304",
                  "summary": "A memory disclosure flaw was found in the Linux kernel's ethernet drivers, in the way it read data from the EEPROM of the device. This flaw allows a local user to read uninitialized values from the kernel memory. The highest threat from this vulnerability is to confidentiality.",
                  "link": "https://ubuntu.com/security/CVE-2020-14304",
                  "publishedOn": "2020-09-15T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N",
                    "exploitabilityScore": 0.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_HIGH",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "score": 4.4,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 4.4,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2020-24504",
                  "summary": "Uncontrolled resource consumption in some Intel(R) Ethernet E810 Adapter drivers for Linux before version 1.0.4 may allow an authenticated user to potentially enable denial of service via local access.",
                  "link": "https://ubuntu.com/security/CVE-2020-24504",
                  "publishedOn": "2021-02-17T14:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2020-27820",
                  "summary": "A vulnerability was found in Linux kernel, where a use-after-frees in nouveau's postclose() handler could happen if removing device (that is not common to remove video card physically without power-off, but same happens if \"unbind\" the driver).",
                  "link": "https://ubuntu.com/security/CVE-2020-27820",
                  "publishedOn": "2021-11-03T00:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:M/Au:N/C:N/I:N/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.4,
                    "impactScore": 6.9,
                    "score": 4.7,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 4.7,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 4.7,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2020-27835",
                  "summary": "A use after free in the Linux kernel infiniband hfi1 driver in versions prior to 5.10-rc6 was found in the way user calls Ioctl after open dev file and fork. A local user could use this flaw to crash the system.",
                  "link": "https://ubuntu.com/security/CVE-2020-27835",
                  "publishedOn": "2021-01-07T18:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.9,
                    "score": 4.9,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 0.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_HIGH",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 4.4,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 4.4,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2020-35501",
                  "summary": "A flaw was found in the Linux kernels implementation of audit rules, where a syscall can unexpectedly not be correctly not be logged by the audit subsystem",
                  "link": "https://ubuntu.com/security/CVE-2020-35501",
                  "publishedOn": "2022-03-30T16:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:N",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 4.9,
                    "score": 3.6,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N",
                    "exploitabilityScore": 0.8,
                    "impactScore": 2.5,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_HIGH",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_LOW",
                    "integrity": "IMPACT_LOW",
                    "availability": "IMPACT_NONE",
                    "score": 3.4,
                    "severity": "LOW"
                  },
                  "references": []
                },
                "cvss": 3.4,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2020-36310",
                  "summary": "An issue was discovered in the Linux kernel before 5.8. arch/x86/kvm/svm/svm.c allows a set_memory_region_test infinite loop for certain nested page faults, aka CID-e72436bc3a52.",
                  "link": "https://ubuntu.com/security/CVE-2020-36310",
                  "publishedOn": "2021-04-07T00:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-20320",
                  "summary": "A flaw was found in s390 eBPF JIT in bpf_jit_insn in arch/s390/net/bpf_jit_comp.c in the Linux kernel. In this flaw, a local attacker with special user privilege can circumvent the verifier and may lead to a confidentiality problem.",
                  "link": "https://ubuntu.com/security/CVE-2021-20320",
                  "publishedOn": "2022-02-18T18:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-26401",
                  "summary": "LFENCE/JMP (mitigation V2-2) may not sufficiently mitigate CVE-2017-5715 on some AMD CPUs.",
                  "link": "https://ubuntu.com/security/CVE-2021-26401",
                  "publishedOn": "2022-03-11T18:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 3.4,
                    "impactScore": 2.9,
                    "score": 1.9,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N",
                    "exploitabilityScore": 1.1,
                    "impactScore": 4,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "CHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "score": 5.6,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.6,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-26934",
                  "summary": "An issue was discovered in the Linux kernel 4.18 through 5.10.16, as used by Xen. The backend allocation (aka be-alloc) mode of the drm_xen_front drivers was not meant to be a supported configuration, but this wasn't stated accordingly in its support status entry.",
                  "link": "https://ubuntu.com/security/CVE-2021-26934",
                  "publishedOn": "2021-02-17T02:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.4,
                    "score": 4.6,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-32078",
                  "summary": "An Out-of-Bounds Read was discovered in arch/arm/mach-footbridge/personal-pci.c in the Linux kernel through 5.12.11 because of the lack of a check for a value that shouldn't be negative, e.g., access to element -2 of an array, aka CID-298a58e165e4.",
                  "link": "https://ubuntu.com/security/CVE-2021-32078",
                  "publishedOn": "2021-06-17T15:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:C/I:N/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_COMPLETE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 9.2,
                    "score": 6.6,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.2,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 7.1,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.1,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-33061",
                  "summary": "Insufficient control flow management for the Intel(R) 82599 Ethernet Controllers and Adapters may allow an authenticated user to potentially enable denial of service via local access.",
                  "link": "https://ubuntu.com/security/CVE-2021-33061",
                  "publishedOn": "2022-02-09T23:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-3772",
                  "summary": "A flaw was found in the Linux SCTP stack. A blind attacker may be able to kill an existing SCTP association through invalid chunks if the attacker knows the IP-addresses and port numbers being used and the attacker can send packets with spoofed IP addresses.",
                  "link": "https://ubuntu.com/security/CVE-2021-3772",
                  "publishedOn": "2022-03-02T23:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:P",
                    "attackVector": "ATTACK_NETWORK",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 8.6,
                    "impactScore": 4.9,
                    "score": 5.8,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:H",
                    "exploitabilityScore": 2.2,
                    "impactScore": 4.2,
                    "attackVector": "ATTACK_NETWORK",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_NONE",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_LOW",
                    "availability": "IMPACT_HIGH",
                    "score": 6.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 6.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-39800",
                  "summary": "In ion_ioctl of ion-ioctl.c, there is a possible way to leak kernel head data due to a use after free. This could lead to local information disclosure with no additional execution privileges needed. User interaction is not needed for exploitation.Product: AndroidVersions: Android kernelAndroid ID: A-208277166References: Upstream kernel",
                  "link": "https://ubuntu.com/security/CVE-2021-39800",
                  "publishedOn": "2022-04-12T17:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-39801",
                  "summary": "In ion_ioctl of ion-ioctl.c, there is a possible use after free due to improper locking. This could lead to local escalation of privilege with no additional execution privileges needed. User interaction is not needed for exploitation.Product: AndroidVersions: Android kernelAndroid ID: A-209791720References: Upstream kernel",
                  "link": "https://ubuntu.com/security/CVE-2021-39801",
                  "publishedOn": "2022-04-12T17:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_COMPLETE",
                    "integrity": "IMPACT_COMPLETE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 10,
                    "score": 7.2,
                    "severity": "HIGH"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-39802",
                  "summary": "In change_pte_range of mprotect.c , there is a possible way to make a shared mmap writable due to a permissions bypass. This could lead to local escalation of privilege with no additional execution privileges needed. User interaction is not needed for exploitation.Product: AndroidVersions: Android kernelAndroid ID: A-213339151References: Upstream kernel",
                  "link": "https://ubuntu.com/security/CVE-2021-39802",
                  "publishedOn": "2022-04-12T17:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_COMPLETE",
                    "integrity": "IMPACT_COMPLETE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 10,
                    "score": 7.2,
                    "severity": "HIGH"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-4001",
                  "summary": "A race condition was found in the Linux kernel's ebpf verifier between bpf_map_update_elem and bpf_map_freeze due to a missing lock in kernel/bpf/syscall.c. In this flaw, a local user with a special privilege (cap_sys_admin or cap_bpf) can modify the frozen mapped address space. This flaw affects kernel versions prior to 5.16 rc2.",
                  "link": "https://ubuntu.com/security/CVE-2021-4001",
                  "publishedOn": "2022-01-21T19:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:M/Au:N/C:N/I:C/A:N",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_COMPLETE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 3.4,
                    "impactScore": 6.9,
                    "score": 4.7,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:U/C:N/I:H/A:N",
                    "exploitabilityScore": 0.5,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_HIGH",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_NONE",
                    "score": 4.1,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 4.1,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-4148",
                  "summary": "A vulnerability was found in the Linux kernel's block_invalidatepage in fs/buffer.c in the filesystem. A missing sanity check may allow a local attacker with user privilege to cause a denial of service (DOS) problem.",
                  "link": "https://ubuntu.com/security/CVE-2021-4148",
                  "publishedOn": "2022-03-23T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.9,
                    "score": 4.9,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-4150",
                  "summary": "A use-after-free flaw was found in the add_partition in block/partitions/core.c in the Linux kernel. A local attacker with user privileges could cause a denial of service on the system. The issue results from the lack of code cleanup when device_add call fails when adding a partition to the disk.",
                  "link": "https://ubuntu.com/security/CVE-2021-4150",
                  "publishedOn": "2022-03-23T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.9,
                    "score": 4.9,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-4197",
                  "summary": "An unprivileged write to the file handler flaw in the Linux kernel's control groups and namespaces subsystem was found in the way users have access to some less privileged process that are controlled by cgroups and have higher privileged parent process. It is actually both for cgroup2 and cgroup1 versions of control groups. A local user could use this flaw to crash the system or escalate their privileges on the system.",
                  "link": "https://ubuntu.com/security/CVE-2021-4197",
                  "publishedOn": "2022-03-23T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_COMPLETE",
                    "integrity": "IMPACT_COMPLETE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 10,
                    "score": 7.2,
                    "severity": "HIGH"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2021-44879",
                  "summary": "In gc_data_segment in fs/f2fs/gc.c in the Linux kernel before 5.16.3, special files are not considered, leading to a move_data_page NULL pointer dereference.",
                  "link": "https://ubuntu.com/security/CVE-2021-44879",
                  "publishedOn": "2022-02-14T12:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
                    "attackVector": "ATTACK_NETWORK",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 8.6,
                    "impactScore": 2.9,
                    "score": 4.3,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_NONE",
                    "userInteraction": "UI_REQUIRED",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-0382",
                  "summary": "An information leak flaw was found due to uninitialized memory in the Linux kernel's TIPC protocol subsystem, in the way a user sends a TIPC datagram to one or more destinations. This flaw allows a local user to read some kernel memory. This issue is limited to no more than 7 bytes, and the user cannot control what is read. This flaw affects the Linux kernel versions prior to 5.17-rc1.",
                  "link": "https://ubuntu.com/security/CVE-2022-0382",
                  "publishedOn": "2022-02-11T18:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-0494",
                  "summary": "A kernel information leak flaw was identified in the scsi_ioctl function in drivers/scsi/scsi_ioctl.c in the Linux kernel. This flaw allows a local attacker with a special user privilege (CAP_SYS_ADMIN or CAP_SYS_RAWIO) to create issues with confidentiality.",
                  "link": "https://ubuntu.com/security/CVE-2022-0494",
                  "publishedOn": "2022-03-25T19:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:C/I:N/A:N",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_COMPLETE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.9,
                    "score": 4.9,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N",
                    "exploitabilityScore": 0.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_HIGH",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "score": 4.4,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 4.4,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-0617",
                  "summary": "A flaw null pointer dereference in the Linux kernel UDF file system functionality was found in the way user triggers udf_file_write_iter function for the malicious UDF image. A local user could use this flaw to crash the system. Actual from Linux kernel 4.2-rc1 till 5.17-rc2.",
                  "link": "https://ubuntu.com/security/CVE-2022-0617",
                  "publishedOn": "2022-02-16T17:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.9,
                    "score": 4.9,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-0854",
                  "summary": "A memory leak flaw was found in the Linux kernel’s DMA subsystem, in the way a user calls DMA_FROM_DEVICE. This flaw allows a local user to read random memory from the kernel space.",
                  "link": "https://ubuntu.com/security/CVE-2022-0854",
                  "publishedOn": "2022-03-23T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-0998",
                  "summary": "An integer overflow flaw was found in the Linux kernel’s virtio device driver code in the way a user triggers the vhost_vdpa_config_validate function. This flaw allows a local user to crash or potentially escalate their privileges on the system.",
                  "link": "https://ubuntu.com/security/CVE-2022-0998",
                  "publishedOn": "2022-03-30T16:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_COMPLETE",
                    "integrity": "IMPACT_COMPLETE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 10,
                    "score": 7.2,
                    "severity": "HIGH"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-1011",
                  "summary": "A use-after-free flaw was found in the Linux kernel’s FUSE filesystem in the way a user triggers write(). This flaw allows a local user to gain unauthorized access to data from the FUSE filesystem, resulting in privilege escalation.",
                  "link": "https://ubuntu.com/security/CVE-2022-1011",
                  "publishedOn": "2022-03-18T18:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.4,
                    "score": 4.6,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-1048",
                  "summary": "A use-after-free flaw was found in the Linux kernel’s sound subsystem in the way a user triggers concurrent calls of PCM hw_params. The hw_free ioctls or similar race condition happens inside ALSA PCM for other ioctls. This flaw allows a local user to crash or potentially escalate their privileges on the system.",
                  "link": "https://ubuntu.com/security/CVE-2022-1048",
                  "publishedOn": "2022-04-29T16:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:M/Au:N/C:C/I:C/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_COMPLETE",
                    "integrity": "IMPACT_COMPLETE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.4,
                    "impactScore": 10,
                    "score": 6.9,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-1116",
                  "summary": "Integer Overflow or Wraparound vulnerability in io_uring of Linux Kernel allows local attacker to cause memory corruption and escalate privileges to root. This issue affects: Linux Kernel versions prior to 5.4.189; version 5.4.24 and later versions.",
                  "link": "https://ubuntu.com/security/CVE-2022-1116",
                  "publishedOn": "2022-05-17T17:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_COMPLETE",
                    "integrity": "IMPACT_COMPLETE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 10,
                    "score": 7.2,
                    "severity": "HIGH"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-1195",
                  "summary": "A use-after-free vulnerability was found in the Linux kernel in drivers/net/hamradio. This flaw allows a local attacker with a user privilege to cause a denial of service (DOS) when the mkiss or sixpack device is detached and reclaim resources early.",
                  "link": "https://ubuntu.com/security/CVE-2022-1195",
                  "publishedOn": "2022-04-29T16:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-1353",
                  "summary": "A vulnerability was found in the pfkey_register function in net/key/af_key.c in the Linux kernel. This flaw allows a local, unprivileged user to gain access to kernel memory, leading to a system crash or a leak of internal kernel information.",
                  "link": "https://ubuntu.com/security/CVE-2022-1353",
                  "publishedOn": "2022-04-29T16:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 4.9,
                    "score": 3.6,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.2,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 7.1,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.1,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-1516",
                  "summary": "A NULL pointer dereference flaw was found in the Linux kernel’s X.25 set of standardized network protocols functionality in the way a user terminates their session using a simulated Ethernet card and continued usage of this connection. This flaw allows a local user to crash the system.",
                  "link": "https://ubuntu.com/security/CVE-2022-1516",
                  "publishedOn": "2022-05-05T15:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.9,
                    "score": 4.9,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-1652",
                  "summary": "Linux Kernel could allow a local attacker to execute arbitrary code on the system, caused by a concurrency use-after-free flaw in the bad_flp_intr function. By executing a specially-crafted program, an attacker could exploit this vulnerability to execute arbitrary code or cause a denial of service condition on the system.",
                  "link": "https://ubuntu.com/security/CVE-2022-1652",
                  "publishedOn": "2022-06-02T14:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_COMPLETE",
                    "integrity": "IMPACT_COMPLETE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 10,
                    "score": 7.2,
                    "severity": "HIGH"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-1734",
                  "summary": "A flaw in Linux Kernel found in nfcmrvl_nci_unregister_dev() in drivers/nfc/nfcmrvl/main.c can lead to use after free both read or write when non synchronized between cleanup routine and firmware download routine.",
                  "link": "https://ubuntu.com/security/CVE-2022-1734",
                  "publishedOn": "2022-05-18T17:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.4,
                    "impactScore": 6.4,
                    "score": 4.4,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-20008",
                  "summary": "In mmc_blk_read_single of block.c, there is a possible way to read kernel heap memory due to uninitialized data. This could lead to local information disclosure if reading from an SD card that triggers errors, with no additional execution privileges needed. User interaction is not needed for exploitation.Product: AndroidVersions: Android kernelAndroid ID: A-216481035References: Upstream kernel",
                  "link": "https://ubuntu.com/security/CVE-2022-20008",
                  "publishedOn": "2022-05-10T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
                    "exploitabilityScore": 0.9,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_PHYSICAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_NONE",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "score": 4.6,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 4.6,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-21499",
                  "summary": "KGDB and KDB allow read and write access to kernel memory, and thus should be restricted during lockdown. An attacker with access to a serial port could trigger the debugger so it is important that the debugger respect the lockdown mode when/if it is triggered. CVSS 3.1 Base Score 6.5 (Confidentiality, Integrity and Availability impacts). CVSS Vector: (CVSS:3.1/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H).",
                  "link": "https://ubuntu.com/security/CVE-2022-21499",
                  "publishedOn": "2022-06-09T21:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.4,
                    "score": 4.6,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 0.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_HIGH",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 6.7,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 6.7,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-23036",
                  "summary": "Linux PV device frontends vulnerable to attacks by backends T[his CNA information record relates to multiple CVEs; the text explains which aspects/vulnerabilities correspond to which CVE.] Several Linux PV device frontends are using the grant table interfaces for removing access rights of the backends in ways being subject to race conditions, resulting in potential data leaks, data corruption by malicious backends, and denial of service triggered by malicious backends: blkfront, netfront, scsifront and the gntalloc driver are testing whether a grant reference is still in use. If this is not the case, they assume that a following removal of the granted access will always succeed, which is not true in case the backend has mapped the granted page between those two operations. As a result the backend can keep access to the memory page of the guest no matter how the page will be used after the frontend I/O has finished. The xenbus driver has a similar problem, as it doesn't check the success of removing the granted access of a shared ring buffer. blkfront: CVE-2022-23036 netfront: CVE-2022-23037 scsifront: CVE-2022-23038 gntalloc: CVE-2022-23039 xenbus: CVE-2022-23040 blkfront, netfront, scsifront, usbfront, dmabuf, xenbus, 9p, kbdfront, and pvcalls are using a functionality to delay freeing a grant reference until it is no longer in use, but the freeing of the related data page is not synchronized with dropping the granted access. As a result the backend can keep access to the memory page even after it has been freed and then re-used for a different purpose. CVE-2022-23041 netfront will fail a BUG_ON() assertion if it fails to revoke access in the rx path. This will result in a Denial of Service (DoS) situation of the guest which can be triggered by the backend. CVE-2022-23042",
                  "link": "https://ubuntu.com/security/CVE-2022-23036",
                  "publishedOn": "2022-03-10T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.4,
                    "impactScore": 6.4,
                    "score": 4.4,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-23037",
                  "summary": "Linux PV device frontends vulnerable to attacks by backends T[his CNA information record relates to multiple CVEs; the text explains which aspects/vulnerabilities correspond to which CVE.] Several Linux PV device frontends are using the grant table interfaces for removing access rights of the backends in ways being subject to race conditions, resulting in potential data leaks, data corruption by malicious backends, and denial of service triggered by malicious backends: blkfront, netfront, scsifront and the gntalloc driver are testing whether a grant reference is still in use. If this is not the case, they assume that a following removal of the granted access will always succeed, which is not true in case the backend has mapped the granted page between those two operations. As a result the backend can keep access to the memory page of the guest no matter how the page will be used after the frontend I/O has finished. The xenbus driver has a similar problem, as it doesn't check the success of removing the granted access of a shared ring buffer. blkfront: CVE-2022-23036 netfront: CVE-2022-23037 scsifront: CVE-2022-23038 gntalloc: CVE-2022-23039 xenbus: CVE-2022-23040 blkfront, netfront, scsifront, usbfront, dmabuf, xenbus, 9p, kbdfront, and pvcalls are using a functionality to delay freeing a grant reference until it is no longer in use, but the freeing of the related data page is not synchronized with dropping the granted access. As a result the backend can keep access to the memory page even after it has been freed and then re-used for a different purpose. CVE-2022-23041 netfront will fail a BUG_ON() assertion if it fails to revoke access in the rx path. This will result in a Denial of Service (DoS) situation of the guest which can be triggered by the backend. CVE-2022-23042",
                  "link": "https://ubuntu.com/security/CVE-2022-23037",
                  "publishedOn": "2022-03-10T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.4,
                    "impactScore": 6.4,
                    "score": 4.4,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-23038",
                  "summary": "Linux PV device frontends vulnerable to attacks by backends T[his CNA information record relates to multiple CVEs; the text explains which aspects/vulnerabilities correspond to which CVE.] Several Linux PV device frontends are using the grant table interfaces for removing access rights of the backends in ways being subject to race conditions, resulting in potential data leaks, data corruption by malicious backends, and denial of service triggered by malicious backends: blkfront, netfront, scsifront and the gntalloc driver are testing whether a grant reference is still in use. If this is not the case, they assume that a following removal of the granted access will always succeed, which is not true in case the backend has mapped the granted page between those two operations. As a result the backend can keep access to the memory page of the guest no matter how the page will be used after the frontend I/O has finished. The xenbus driver has a similar problem, as it doesn't check the success of removing the granted access of a shared ring buffer. blkfront: CVE-2022-23036 netfront: CVE-2022-23037 scsifront: CVE-2022-23038 gntalloc: CVE-2022-23039 xenbus: CVE-2022-23040 blkfront, netfront, scsifront, usbfront, dmabuf, xenbus, 9p, kbdfront, and pvcalls are using a functionality to delay freeing a grant reference until it is no longer in use, but the freeing of the related data page is not synchronized with dropping the granted access. As a result the backend can keep access to the memory page even after it has been freed and then re-used for a different purpose. CVE-2022-23041 netfront will fail a BUG_ON() assertion if it fails to revoke access in the rx path. This will result in a Denial of Service (DoS) situation of the guest which can be triggered by the backend. CVE-2022-23042",
                  "link": "https://ubuntu.com/security/CVE-2022-23038",
                  "publishedOn": "2022-03-10T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.4,
                    "impactScore": 6.4,
                    "score": 4.4,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-23039",
                  "summary": "Linux PV device frontends vulnerable to attacks by backends T[his CNA information record relates to multiple CVEs; the text explains which aspects/vulnerabilities correspond to which CVE.] Several Linux PV device frontends are using the grant table interfaces for removing access rights of the backends in ways being subject to race conditions, resulting in potential data leaks, data corruption by malicious backends, and denial of service triggered by malicious backends: blkfront, netfront, scsifront and the gntalloc driver are testing whether a grant reference is still in use. If this is not the case, they assume that a following removal of the granted access will always succeed, which is not true in case the backend has mapped the granted page between those two operations. As a result the backend can keep access to the memory page of the guest no matter how the page will be used after the frontend I/O has finished. The xenbus driver has a similar problem, as it doesn't check the success of removing the granted access of a shared ring buffer. blkfront: CVE-2022-23036 netfront: CVE-2022-23037 scsifront: CVE-2022-23038 gntalloc: CVE-2022-23039 xenbus: CVE-2022-23040 blkfront, netfront, scsifront, usbfront, dmabuf, xenbus, 9p, kbdfront, and pvcalls are using a functionality to delay freeing a grant reference until it is no longer in use, but the freeing of the related data page is not synchronized with dropping the granted access. As a result the backend can keep access to the memory page even after it has been freed and then re-used for a different purpose. CVE-2022-23041 netfront will fail a BUG_ON() assertion if it fails to revoke access in the rx path. This will result in a Denial of Service (DoS) situation of the guest which can be triggered by the backend. CVE-2022-23042",
                  "link": "https://ubuntu.com/security/CVE-2022-23039",
                  "publishedOn": "2022-03-10T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.4,
                    "impactScore": 6.4,
                    "score": 4.4,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-23040",
                  "summary": "Linux PV device frontends vulnerable to attacks by backends T[his CNA information record relates to multiple CVEs; the text explains which aspects/vulnerabilities correspond to which CVE.] Several Linux PV device frontends are using the grant table interfaces for removing access rights of the backends in ways being subject to race conditions, resulting in potential data leaks, data corruption by malicious backends, and denial of service triggered by malicious backends: blkfront, netfront, scsifront and the gntalloc driver are testing whether a grant reference is still in use. If this is not the case, they assume that a following removal of the granted access will always succeed, which is not true in case the backend has mapped the granted page between those two operations. As a result the backend can keep access to the memory page of the guest no matter how the page will be used after the frontend I/O has finished. The xenbus driver has a similar problem, as it doesn't check the success of removing the granted access of a shared ring buffer. blkfront: CVE-2022-23036 netfront: CVE-2022-23037 scsifront: CVE-2022-23038 gntalloc: CVE-2022-23039 xenbus: CVE-2022-23040 blkfront, netfront, scsifront, usbfront, dmabuf, xenbus, 9p, kbdfront, and pvcalls are using a functionality to delay freeing a grant reference until it is no longer in use, but the freeing of the related data page is not synchronized with dropping the granted access. As a result the backend can keep access to the memory page even after it has been freed and then re-used for a different purpose. CVE-2022-23041 netfront will fail a BUG_ON() assertion if it fails to revoke access in the rx path. This will result in a Denial of Service (DoS) situation of the guest which can be triggered by the backend. CVE-2022-23042",
                  "link": "https://ubuntu.com/security/CVE-2022-23040",
                  "publishedOn": "2022-03-10T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.4,
                    "impactScore": 6.4,
                    "score": 4.4,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-23041",
                  "summary": "Linux PV device frontends vulnerable to attacks by backends T[his CNA information record relates to multiple CVEs; the text explains which aspects/vulnerabilities correspond to which CVE.] Several Linux PV device frontends are using the grant table interfaces for removing access rights of the backends in ways being subject to race conditions, resulting in potential data leaks, data corruption by malicious backends, and denial of service triggered by malicious backends: blkfront, netfront, scsifront and the gntalloc driver are testing whether a grant reference is still in use. If this is not the case, they assume that a following removal of the granted access will always succeed, which is not true in case the backend has mapped the granted page between those two operations. As a result the backend can keep access to the memory page of the guest no matter how the page will be used after the frontend I/O has finished. The xenbus driver has a similar problem, as it doesn't check the success of removing the granted access of a shared ring buffer. blkfront: CVE-2022-23036 netfront: CVE-2022-23037 scsifront: CVE-2022-23038 gntalloc: CVE-2022-23039 xenbus: CVE-2022-23040 blkfront, netfront, scsifront, usbfront, dmabuf, xenbus, 9p, kbdfront, and pvcalls are using a functionality to delay freeing a grant reference until it is no longer in use, but the freeing of the related data page is not synchronized with dropping the granted access. As a result the backend can keep access to the memory page even after it has been freed and then re-used for a different purpose. CVE-2022-23041 netfront will fail a BUG_ON() assertion if it fails to revoke access in the rx path. This will result in a Denial of Service (DoS) situation of the guest which can be triggered by the backend. CVE-2022-23042",
                  "link": "https://ubuntu.com/security/CVE-2022-23041",
                  "publishedOn": "2022-03-10T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.4,
                    "impactScore": 6.4,
                    "score": 4.4,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-23042",
                  "summary": "Linux PV device frontends vulnerable to attacks by backends T[his CNA information record relates to multiple CVEs; the text explains which aspects/vulnerabilities correspond to which CVE.] Several Linux PV device frontends are using the grant table interfaces for removing access rights of the backends in ways being subject to race conditions, resulting in potential data leaks, data corruption by malicious backends, and denial of service triggered by malicious backends: blkfront, netfront, scsifront and the gntalloc driver are testing whether a grant reference is still in use. If this is not the case, they assume that a following removal of the granted access will always succeed, which is not true in case the backend has mapped the granted page between those two operations. As a result the backend can keep access to the memory page of the guest no matter how the page will be used after the frontend I/O has finished. The xenbus driver has a similar problem, as it doesn't check the success of removing the granted access of a shared ring buffer. blkfront: CVE-2022-23036 netfront: CVE-2022-23037 scsifront: CVE-2022-23038 gntalloc: CVE-2022-23039 xenbus: CVE-2022-23040 blkfront, netfront, scsifront, usbfront, dmabuf, xenbus, 9p, kbdfront, and pvcalls are using a functionality to delay freeing a grant reference until it is no longer in use, but the freeing of the related data page is not synchronized with dropping the granted access. As a result the backend can keep access to the memory page even after it has been freed and then re-used for a different purpose. CVE-2022-23041 netfront will fail a BUG_ON() assertion if it fails to revoke access in the rx path. This will result in a Denial of Service (DoS) situation of the guest which can be triggered by the backend. CVE-2022-23042",
                  "link": "https://ubuntu.com/security/CVE-2022-23042",
                  "publishedOn": "2022-03-10T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.4,
                    "impactScore": 6.4,
                    "score": 4.4,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_HIGH",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-24448",
                  "summary": "An issue was discovered in fs/nfs/dir.c in the Linux kernel before 5.16.5. If an application sets the O_DIRECTORY flag, and tries to open a regular file, nfs_atomic_open() performs a regular lookup. If a regular file is found, ENOTDIR should occur, but the server instead returns uninitialized data in the file descriptor.",
                  "link": "https://ubuntu.com/security/CVE-2022-24448",
                  "publishedOn": "2022-02-04T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_MEDIUM",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 3.4,
                    "impactScore": 2.9,
                    "score": 1.9,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
                    "exploitabilityScore": 1.8,
                    "impactScore": 1.4,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_LOW",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "score": 3.3,
                    "severity": "LOW"
                  },
                  "references": []
                },
                "cvss": 3.3,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-24958",
                  "summary": "drivers/usb/gadget/legacy/inode.c in the Linux kernel through 5.16.8 mishandles dev->buf release.",
                  "link": "https://ubuntu.com/security/CVE-2022-24958",
                  "publishedOn": "2022-02-11T06:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.4,
                    "score": 4.6,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-24959",
                  "summary": "An issue was discovered in the Linux kernel before 5.16.5. There is a memory leak in yam_siocdevprivate in drivers/net/hamradio/yam.c.",
                  "link": "https://ubuntu.com/security/CVE-2022-24959",
                  "publishedOn": "2022-02-11T06:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-25258",
                  "summary": "An issue was discovered in drivers/usb/gadget/composite.c in the Linux kernel before 5.16.10. The USB Gadget subsystem lacks certain validation of interface OS descriptor requests (ones with a large array index and ones associated with NULL function pointer retrieval). Memory corruption might occur.",
                  "link": "https://ubuntu.com/security/CVE-2022-25258",
                  "publishedOn": "2022-02-16T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.9,
                    "score": 4.9,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 0.9,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_PHYSICAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_NONE",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 4.6,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 4.6,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-25375",
                  "summary": "An issue was discovered in drivers/usb/gadget/function/rndis.c in the Linux kernel before 5.16.10. The RNDIS USB gadget lacks validation of the size of the RNDIS_MSG_SET command. Attackers can obtain sensitive information from kernel memory.",
                  "link": "https://ubuntu.com/security/CVE-2022-25375",
                  "publishedOn": "2022-02-20T20:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-26490",
                  "summary": "st21nfca_connectivity_event_received in drivers/nfc/st21nfca/se.c in the Linux kernel through 5.16.12 has EVT_TRANSACTION buffer overflows because of untrusted length parameters.",
                  "link": "https://ubuntu.com/security/CVE-2022-26490",
                  "publishedOn": "2022-03-06T04:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.4,
                    "score": 4.6,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-26966",
                  "summary": "An issue was discovered in the Linux kernel before 5.16.12. drivers/net/usb/sr9700.c allows attackers to obtain sensitive information from heap memory via crafted frame lengths from a device.",
                  "link": "https://ubuntu.com/security/CVE-2022-26966",
                  "publishedOn": "2022-03-12T22:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 2.9,
                    "score": 2.1,
                    "severity": "LOW"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
                    "exploitabilityScore": 1.8,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_NONE",
                    "score": 5.5,
                    "severity": "MEDIUM"
                  },
                  "references": []
                },
                "cvss": 5.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-27223",
                  "summary": "In drivers/usb/gadget/udc/udc-xilinx.c in the Linux kernel before 5.16.12, the endpoint index is not validated and might be manipulated by the host for out-of-array access.",
                  "link": "https://ubuntu.com/security/CVE-2022-27223",
                  "publishedOn": "2022-03-16T00:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
                    "attackVector": "ATTACK_NETWORK",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_SINGLE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 8,
                    "impactScore": 6.4,
                    "score": 6.5,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 2.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_NETWORK",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 8.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 8.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-28356",
                  "summary": "In the Linux kernel before 5.17.1, a refcount leak bug was found in net/llc/af_llc.c.",
                  "link": "https://ubuntu.com/security/CVE-2022-28356",
                  "publishedOn": "2022-04-02T21:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
                    "attackVector": "ATTACK_NETWORK",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 10,
                    "impactScore": 2.9,
                    "score": 5,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
                    "exploitabilityScore": 3.9,
                    "impactScore": 3.6,
                    "attackVector": "ATTACK_NETWORK",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_NONE",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_NONE",
                    "integrity": "IMPACT_NONE",
                    "availability": "IMPACT_HIGH",
                    "score": 7.5,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.5,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-28388",
                  "summary": "usb_8dev_start_xmit in drivers/net/can/usb/usb_8dev.c in the Linux kernel through 5.17.1 has a double free.",
                  "link": "https://ubuntu.com/security/CVE-2022-28388",
                  "publishedOn": "2022-04-03T21:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.4,
                    "score": 4.6,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-28389",
                  "summary": "mcba_usb_start_xmit in drivers/net/can/usb/mcba_usb.c in the Linux kernel through 5.17.1 has a double free.",
                  "link": "https://ubuntu.com/security/CVE-2022-28389",
                  "publishedOn": "2022-04-03T21:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.4,
                    "score": 4.6,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-28390",
                  "summary": "ems_usb_start_xmit in drivers/net/can/usb/ems_usb.c in the Linux kernel through 5.17.1 has a double free.",
                  "link": "https://ubuntu.com/security/CVE-2022-28390",
                  "publishedOn": "2022-04-03T21:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.4,
                    "score": 4.6,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-28893",
                  "summary": "The SUNRPC subsystem in the Linux kernel through 5.17.2 can call xs_xprt_free before ensuring that sockets are in the intended state.",
                  "link": "https://ubuntu.com/security/CVE-2022-28893",
                  "publishedOn": "2022-04-11T05:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_COMPLETE",
                    "integrity": "IMPACT_COMPLETE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 10,
                    "score": 7.2,
                    "severity": "HIGH"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-29581",
                  "summary": "Improper Update of Reference Count vulnerability in net/sched of Linux Kernel allows local attacker to cause privilege escalation to root. This issue affects: Linux Kernel versions prior to 5.18; version 4.14 and later versions.",
                  "link": "https://ubuntu.com/security/CVE-2022-29581",
                  "publishedOn": "2022-05-17T17:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_COMPLETE",
                    "integrity": "IMPACT_COMPLETE",
                    "availability": "IMPACT_COMPLETE",
                    "exploitabilityScore": 3.9,
                    "impactScore": 10,
                    "score": 7.2,
                    "severity": "HIGH"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              },
              {
                "cveBaseInfo": {
                  "cve": "CVE-2022-30594",
                  "summary": "The Linux kernel before 5.17.2 mishandles seccomp permissions. The PTRACE_SEIZE code path allows attackers to bypass intended restrictions on setting the PT_SUSPEND_SECCOMP flag.",
                  "link": "https://ubuntu.com/security/CVE-2022-30594",
                  "publishedOn": "2022-05-12T05:15:00Z",
                  "createdAt": "2022-06-23T22:17:17.743607907Z",
                  "lastModified": null,
                  "scoreVersion": "V3",
                  "cvssV2": {
                    "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
                    "attackVector": "ATTACK_LOCAL",
                    "accessComplexity": "ACCESS_LOW",
                    "authentication": "AUTH_NONE",
                    "confidentiality": "IMPACT_PARTIAL",
                    "integrity": "IMPACT_PARTIAL",
                    "availability": "IMPACT_PARTIAL",
                    "exploitabilityScore": 3.9,
                    "impactScore": 6.4,
                    "score": 4.6,
                    "severity": "MEDIUM"
                  },
                  "cvssV3": {
                    "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                    "exploitabilityScore": 1.8,
                    "impactScore": 5.9,
                    "attackVector": "ATTACK_LOCAL",
                    "attackComplexity": "COMPLEXITY_LOW",
                    "privilegesRequired": "PRIVILEGE_LOW",
                    "userInteraction": "UI_NONE",
                    "scope": "UNCHANGED",
                    "confidentiality": "IMPACT_HIGH",
                    "integrity": "IMPACT_HIGH",
                    "availability": "IMPACT_HIGH",
                    "score": 7.8,
                    "severity": "HIGH"
                  },
                  "references": []
                },
                "cvss": 7.8,
                "severity": "UNKNOWN_VULNERABILITY_SEVERITY",
                "snoozed": false,
                "snoozeStart": null,
                "snoozeExpiry": null
              }
            ],
            "priority": "0",
            "topCvss": 8.8,
            "riskScore": 0
          }
        ],
        "notes": []
      },
      "components": 4,
      "cves": 81,
      "priority": "1",
      "riskScore": 0,
      "topCvss": 8.8,
      "notes": []
    }
  ]
}

```