### PR TITLE
ROX-7875: Retry connection if Groovy K8s client fails for a networking reason

### DIFF
--- a/qa-tests-backend/README.md
+++ b/qa-tests-backend/README.md
@@ -101,7 +101,7 @@ group.
 
 # Running Bits of Groovy
 
-Developing groovy code in a test specification context has a lot of 
+Developing groovy code in a test specification context has a lot of
 overhead and can often be painful. For more details see [sampleScripts](src/main/groovy/sampleScripts/README.md).
 
 # Common Failure Patterns

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1871,8 +1871,10 @@ class Kubernetes implements OrchestratorMain {
       } catch (io.fabric8.kubernetes.client.KubernetesClientException e) {
         log.warn("Client returned exception when creating k8s deployment: ",  e)
         if (retry >= maxRetries) {
+          log.debug "No more retries. Retried " + maxRetries + " times already"
           return false
         }
+        log.debug "Retrying. Retry " + retry+1 + " out of " + maxRetries
         return  createDeploymentNoWaitRetry(deployment, retry+1, maxRetries)
       } catch (Exception e) {
         log.warn("Error creating k8s deployment: ",  e)

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1854,7 +1854,7 @@ class Kubernetes implements OrchestratorMain {
         )
 
         try {
-            Helpers.withRetry(10,1) {
+            Helpers.withK8sClientRetry(10,1) {
                 client.apps().deployments().inNamespace(deployment.namespace).createOrReplace(d)
                 int att = Helpers.getAttemptCount()
                 log.debug "Told the orchestrator to createOrReplace " + deployment.name + ". Attempt " + att + " of 10"

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -135,9 +135,9 @@ class Kubernetes implements OrchestratorMain {
         // "any namespace" requests to be scoped to the default project.
         this.client.configuration.namespace = null
         this.client.configuration.setRollingTimeout(60 * 60 * 1000)
-        this.client.configuration.setRequestTimeout(30 * 1000)
-        this.client.configuration.setConnectionTimeout(30 * 1000)
-        this.client.configuration.setWebsocketTimeout(30 * 1000)
+        this.client.configuration.setRequestTimeout(20*1000)
+        this.client.configuration.setConnectionTimeout(20*1000)
+        this.client.configuration.setWebsocketTimeout(20*1000)
         this.deployments = this.client.apps().deployments()
         this.daemonsets = this.client.apps().daemonSets()
         this.statefulsets = this.client.apps().statefulSets()
@@ -1857,7 +1857,6 @@ class Kubernetes implements OrchestratorMain {
         )
 
       try {
-        log.debug "Telling the orchestrator to createOrReplace " + deployment.name
         client.apps().deployments().inNamespace(deployment.namespace).createOrReplace(d)
         log.debug "Told the orchestrator to createOrReplace " + deployment.name
         if (deployment.createLoadBalancer) {
@@ -1871,7 +1870,7 @@ class Kubernetes implements OrchestratorMain {
       } catch (io.fabric8.kubernetes.client.KubernetesClientException e) {
         log.warn("Client returned exception when creating k8s deployment: ",  e)
         if (retry >= maxRetries) {
-          log.debug "No more retries. Retried " + maxRetries + " times already"
+          log.debug "No more retries. Retried " + retry + " times out of " + maxRetries + " already"
           return false
         }
         log.debug "Retrying. Retry " + retry+1 + " out of " + maxRetries

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -106,6 +106,7 @@ import objects.Secret
 import objects.SecretKeyRef
 import okhttp3.Response
 import util.Timer
+import util.Helpers
 
 @Slf4j
 class Kubernetes implements OrchestratorMain {
@@ -1853,9 +1854,10 @@ class Kubernetes implements OrchestratorMain {
         )
 
         try {
-            withRetry(10,1) {
+            Helpers.withRetry(10,1) {
                 client.apps().deployments().inNamespace(deployment.namespace).createOrReplace(d)
-                log.debug "Told the orchestrator to createOrReplace " + deployment.name
+                int att = Helpers.getAttemptCount()
+                log.debug "Told the orchestrator to createOrReplace " + deployment.name + ". Attempt " + att + " of 10"
             }
             if (deployment.createLoadBalancer) {
                 waitForLoadBalancer(deployment)

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1822,10 +1822,10 @@ class Kubernetes implements OrchestratorMain {
     */
 
     def createDeploymentNoWait(Deployment deployment) {
-        createDeploymentNoWaitRetry(deployment, 0, 10)
+        createDeploymentNoWaitWithRetry(deployment, 0, 10)
     }
 
-    def createDeploymentNoWaitRetry(Deployment deployment, int retry, int maxRetries) {
+    def createDeploymentNoWaitWithRetry(Deployment deployment, int retry, int maxRetries) {
         deployment.getNamespace() != null ?: deployment.setNamespace(this.namespace)
 
         // Create service if needed
@@ -1874,7 +1874,7 @@ class Kubernetes implements OrchestratorMain {
                 return false
             }
             log.debug "Retrying. Retry " + retry+1 + " out of " + maxRetries
-            return  createDeploymentNoWaitRetry(deployment, retry+1, maxRetries)
+            return createDeploymentNoWaitWithRetry(deployment, retry+1, maxRetries)
         } catch (Exception e) {
             log.warn("Error creating k8s deployment: ",  e)
             return false

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1822,7 +1822,7 @@ class Kubernetes implements OrchestratorMain {
         Private K8S Support functions
     */
 
-    def createDeploymentNoWait(Deployment deployment) {
+    def createDeploymentNoWait(Deployment deployment, int maxNumRetries=0) {
         deployment.getNamespace() != null ?: deployment.setNamespace(this.namespace)
 
         // Create service if needed
@@ -1854,7 +1854,7 @@ class Kubernetes implements OrchestratorMain {
         )
 
         try {
-            Helpers.withK8sClientRetry(10,1) {
+            Helpers.withK8sClientRetry(maxNumRetries,1) {
                 client.apps().deployments().inNamespace(deployment.namespace).createOrReplace(d)
                 int att = Helpers.getAttemptCount()
                 log.debug "Told the orchestrator to createOrReplace " + deployment.name + ". Attempt " + att + " of 10"

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -135,6 +135,9 @@ class Kubernetes implements OrchestratorMain {
         // "any namespace" requests to be scoped to the default project.
         this.client.configuration.namespace = null
         this.client.configuration.setRollingTimeout(60 * 60 * 1000)
+        this.client.configuration.setRequestTimeout(30 * 1000)
+        this.client.configuration.setConnectionTimeout(30 * 1000)
+        this.client.configuration.setWebsocketTimeout(30 * 1000)
         this.deployments = this.client.apps().deployments()
         this.daemonsets = this.client.apps().daemonSets()
         this.statefulsets = this.client.apps().statefulSets()

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1822,10 +1822,6 @@ class Kubernetes implements OrchestratorMain {
     */
 
     def createDeploymentNoWait(Deployment deployment) {
-        createDeploymentNoWaitWithRetry(deployment, 0, 10)
-    }
-
-    def createDeploymentNoWaitWithRetry(Deployment deployment, int retry, int maxRetries) {
         deployment.getNamespace() != null ?: deployment.setNamespace(this.namespace)
 
         // Create service if needed
@@ -1857,8 +1853,10 @@ class Kubernetes implements OrchestratorMain {
         )
 
         try {
-            client.apps().deployments().inNamespace(deployment.namespace).createOrReplace(d)
-            log.debug "Told the orchestrator to createOrReplace " + deployment.name
+            Helpers.withRetry(10,1) {
+                client.apps().deployments().inNamespace(deployment.namespace).createOrReplace(d)
+                log.debug "Told the orchestrator to createOrReplace " + deployment.name
+            }
             if (deployment.createLoadBalancer) {
                 waitForLoadBalancer(deployment)
             }
@@ -1867,14 +1865,6 @@ class Kubernetes implements OrchestratorMain {
                 deployment.routeHost = waitForRouteHost(deployment.name, deployment.namespace)
             }
             return true
-        } catch (io.fabric8.kubernetes.client.KubernetesClientException e) {
-            log.warn("Client returned exception when creating k8s deployment: ",  e)
-            if (retry >= maxRetries) {
-                log.debug "No more retries. Retried " + retry + " times out of " + maxRetries + " already"
-                return false
-            }
-            log.debug "Retrying. Retry " + retry+1 + " out of " + maxRetries
-            return createDeploymentNoWaitWithRetry(deployment, retry+1, maxRetries)
         } catch (Exception e) {
             log.warn("Error creating k8s deployment: ",  e)
             return false

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1853,7 +1853,7 @@ class Kubernetes implements OrchestratorMain {
         )
 
         try {
-            Helpers.withRetry(10,1) {
+            withRetry(10,1) {
                 client.apps().deployments().inNamespace(deployment.namespace).createOrReplace(d)
                 log.debug "Told the orchestrator to createOrReplace " + deployment.name
             }

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -31,6 +31,22 @@ class Helpers {
         evaluateWithRetry(ignored, retries, pauseSecs, closure)
     }
 
+    static <V> V evaluateWithK8sClientRetry(Object ignored, int retries, int pauseSecs, Closure<V> closure) {
+        for (int i = 0; i < retries; i++) {
+            try {
+                return closure()
+            } catch (io.fabric8.kubernetes.client.KubernetesClientException t) {
+                log.debug("Caught k8 client exception. Retrying in ${pauseSecs}s", t)
+            }
+            sleep pauseSecs * 1000
+        }
+        return closure()
+    }
+
+    static <V> void withK8sClientRetry(Object ignored, int retries, int pauseSecs, Closure<V> closure) {
+        evaluateWithK8sClientRetry(ignored, retries, pauseSecs, closure)
+    }
+
     static boolean determineRetry(Throwable failure) {
         if (failure instanceof AssumptionViolatedException) {
             log.debug "Skipping retry for: " + failure

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -406,7 +406,7 @@ class AdmissionControllerTest extends BaseSpecification {
         then:
         "Verify deployment can be created"
         def deployment = MISC_DEPLOYMENT.clone()
-        def created = orchestrator.createDeploymentNoWait(deployment)
+        def created = orchestrator.createDeploymentNoWait(deployment, 10)
         assert created
 
         and:


### PR DESCRIPTION
## Description

### Investigation

The issue is about the k8s client returning connection timeout exceptions.
Default timeouts are set to 10s. Increasing them to 30s did not help.
Decreasing the timeouts to 100ms allowed to reproduce similar problem a bit easier (different timeout, but resulting in the same exception).
In general, this flake is not easy to reproduce - it takes about 30 minutes of constant looping to spot one occurrence.

### How to reproduce & solution with a retry

Deploy local k8s cluster with `./deploy/k8s/deploy-local.sh`

```shell
cd stackrox/qa-tests-backend

export GOOGLE_CREDENTIALS_GCR_SCANNER='<big json object from bitwarden>'
export CLUSTER="K8S"
export ROX_PASSWORD="$(cat ../deploy/k8s/central-deploy/password)"
export ROX_USERNAME='admin'
export REGISTRY_PASSWORD='<take from bitwarden>'
export REGISTRY_USERNAME='rhacs-eng+stackroxciro'

./gradlew runSampleScript -PrunScript=reproAdmissionControllerTestFailure 
```

```
11:13:48.046 [main] DEBUG orchestratormanager.Kubernetes - Telling the orchestrator to createOrReplace random-busybox-repro
11:13:48.091 [main] DEBUG orchestratormanager.Kubernetes - Told the orchestrator to createOrReplace random-busybox-repro
11:13:50.105 [main] DEBUG orchestratormanager.Kubernetes - Deployment random-busybox-repro with version 264437 found in namespace qa. Updating...
11:13:50.105 [main] DEBUG orchestratormanager.Kubernetes - Telling the orchestrator to createOrReplace random-busybox-repro
11:14:00.109 [main] WARN orchestratormanager.Kubernetes - Client returned exception when creating k8s deployment:
io.fabric8.kubernetes.client.KubernetesClientException: An error has occurred.
        at io.fabric8.kubernetes.client.KubernetesClientException.launderThrowable(KubernetesClientException.java:103)
        at io.fabric8.kubernetes.client.KubernetesClientException.launderThrowable(KubernetesClientException.java:97)
        at io.fabric8.kubernetes.client.dsl.base.CreateOnlyResourceOperation.create(CreateOnlyResourceOperation.java:63)
        at io.fabric8.kubernetes.client.utils.CreateOrReplaceHelper.createOrReplace(CreateOrReplaceHelper.java:48)
        at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:318)
        at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:83)
        at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:308)
        at jdk.internal.reflect.GeneratedMethodAccessor365.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoCachedMethodSite.invoke(PojoMetaMethodSite.java:192)
        at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:56)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:128)
        at orchestratormanager.Kubernetes.createDeploymentNoWaitRetry(Kubernetes.groovy:1861)
        at orchestratormanager.Kubernetes$createDeploymentNoWaitRetry.callCurrent(Unknown Source)
        at orchestratormanager.Kubernetes.createDeploymentNoWait(Kubernetes.groovy:1825)
        at orchestratormanager.OrchestratorMain$createDeploymentNoWait$2.callCurrent(Unknown Source)
        at orchestratormanager.Kubernetes.updateDeploymentNoWait(Kubernetes.groovy:191)
        at orchestratormanager.OrchestratorMain$updateDeploymentNoWait$4.call(Unknown Source)
        at sampleScripts.reproAdmissionControllerTestFailure.run(reproAdmissionControllerTestFailure.groovy:58)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:98)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1225)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1034)
        at org.codehaus.groovy.runtime.InvokerHelper.invokePogoMethod(InvokerHelper.java:947)
        at org.codehaus.groovy.runtime.InvokerHelper.invokeMethod(InvokerHelper.java:930)
        at org.codehaus.groovy.runtime.InvokerHelper.runScript(InvokerHelper.java:428)
        at org.codehaus.groovy.runtime.InvokerHelper$runScript.call(Unknown Source)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:116)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:136)
        at sampleScripts.reproAdmissionControllerTestFailure.main(reproAdmissionControllerTestFailure.groovy)
Caused by: java.net.SocketTimeoutException: timeout
        at okhttp3.internal.http2.Http2Stream$StreamTimeout.newTimeoutException(Http2Stream.kt:675)
        at okhttp3.internal.http2.Http2Stream$StreamTimeout.exitAndThrowIfTimedOut(Http2Stream.kt:684)
        at okhttp3.internal.http2.Http2Stream.takeHeaders(Http2Stream.kt:143)
        at okhttp3.internal.http2.Http2ExchangeCodec.readResponseHeaders(Http2ExchangeCodec.kt:96)
        at okhttp3.internal.connection.Exchange.readResponseHeaders(Exchange.kt:106)
        at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.kt:79)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:34)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at io.fabric8.kubernetes.client.okhttp.OkHttpClientBuilderImpl$InteceptorAdapter.intercept(OkHttpClientBuilderImpl.java:62)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at io.fabric8.kubernetes.client.okhttp.OkHttpClientBuilderImpl$InteceptorAdapter.intercept(OkHttpClientBuilderImpl.java:62)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at io.fabric8.kubernetes.client.okhttp.OkHttpClientBuilderImpl$InteceptorAdapter.intercept(OkHttpClientBuilderImpl.java:62)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at io.fabric8.kubernetes.client.okhttp.OkHttpClientBuilderImpl$InteceptorAdapter.intercept(OkHttpClientBuilderImpl.java:62)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
        at okhttp3.internal.connection.RealCall.execute(RealCall.kt:154)
        at io.fabric8.kubernetes.client.okhttp.OkHttpClientImpl.send(OkHttpClientImpl.java:138)
        at io.fabric8.kubernetes.client.dsl.base.OperationSupport.retryWithExponentialBackoff(OperationSupport.java:574)
        at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:553)
        at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:518)
        at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleCreate(OperationSupport.java:305)
        at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleCreate(BaseOperation.java:644)
        at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleCreate(BaseOperation.java:83)
        at io.fabric8.kubernetes.client.dsl.base.CreateOnlyResourceOperation.create(CreateOnlyResourceOperation.java:61)
        ... 33 common frames omitted
11:14:00.110 [main] DEBUG orchestratormanager.Kubernetes - RRR Retrying. Retry 01 out of 10
11:14:00.110 [main] DEBUG orchestratormanager.Kubernetes - Telling the orchestrator to createOrReplace random-busybox-repro
11:14:00.157 [main] DEBUG orchestratormanager.Kubernetes - Told the orchestrator to createOrReplace random-busybox-repro
11:14:02.166 [main] DEBUG orchestratormanager.Kubernetes - Deployment random-busybox-repro with version 264543 found in namespace qa. Updating... 
```

### Proposed Solution

Retrying the connection attempt seems to be working correctly on the first try - see `RRR Retrying. Retry 01 out of 10` in the  output above. 

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

- Locally as described in the sections above
- CI