### PR TITLE
Revert "RS-443: Trigger nightly tests in prow also"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4202,7 +4202,7 @@ jobs:
             git commit --allow-empty -m "Nightly build $(date)"
             NIGHTLY_TAG="$(git describe --tags --abbrev=0 --exclude '*-nightly-*')-nightly-$(date '+%Y%m%d')"
             git tag "$NIGHTLY_TAG"
-            git push origin --follow-tags
+            git push origin "$NIGHTLY_TAG"
 
       - run:
           name: Remove tags more than 3 days old


### PR DESCRIPTION
Reverts stackrox/stackrox#2183

This change broke the nightly trigger (cannot commit directly to master (even an empty commit))
https://app.circleci.com/pipelines/github/stackrox/stackrox/15079/workflows/75347c78-25b4-45ed-bda2-acc1287ca263/jobs/703126
