### PR TITLE
Add compliance levels by standard widget

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
@@ -17,6 +17,7 @@ import ViolationsByPolicyCategory from './Widgets/ViolationsByPolicyCategory';
 import DeploymentsAtMostRisk from './Widgets/DeploymentsAtMostRisk';
 import AgingImages from './Widgets/AgingImages';
 import ViolationsByPolicySeverity from './Widgets/ViolationsByPolicySeverity';
+import ComplianceLevelsByStandard from './Widgets/ComplianceLevelsByStandard';
 
 function DashboardPage() {
     return (
@@ -59,6 +60,9 @@ function DashboardPage() {
                     </GridItem>
                     <GridItem lg={6}>
                         <AgingImages />
+                    </GridItem>
+                    <GridItem lg={6}>
+                        <ComplianceLevelsByStandard />
                     </GridItem>
                 </Grid>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { MockedProvider } from '@apollo/client/testing';
+import { screen, within, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+
+import renderWithRouter from 'test-utils/renderWithRouter';
+import { AGGREGATED_RESULTS_ACROSS_ENTITIES } from 'queries/controls';
+import entityTypes, { standardEntityTypes } from 'constants/entityTypes';
+import { complianceBasePath, urlEntityListTypes } from 'routePaths';
+import ComplianceLevelsByStandard from './ComplianceLevelsByStandard';
+
+const mocks = [
+    {
+        request: {
+            query: AGGREGATED_RESULTS_ACROSS_ENTITIES,
+            variables: {
+                groupBy: [entityTypes.STANDARD],
+                where: 'Cluster:*',
+            },
+        },
+        result: {
+            data: {
+                controls: {
+                    results: [
+                        {
+                            aggregationKeys: [{ id: 'CIS_Docker_v1_2_0', scope: 'STANDARD' }],
+                            numFailing: 0,
+                            numPassing: 1,
+                            numSkipped: 0,
+                            unit: 'CONTROL',
+                        },
+                        {
+                            aggregationKeys: [{ id: 'CIS_Kubernetes_v1_5', scope: 'STANDARD' }],
+                            numFailing: 0,
+                            numPassing: 0,
+                            numSkipped: 40,
+                            unit: 'CONTROL',
+                        },
+                        {
+                            aggregationKeys: [{ id: 'HIPAA_164', scope: 'STANDARD' }],
+                            numFailing: 8,
+                            numPassing: 10,
+                            numSkipped: 0,
+                            unit: 'CONTROL',
+                        },
+                        {
+                            aggregationKeys: [{ id: 'NIST_800_190', scope: 'STANDARD' }],
+                            numFailing: 9,
+                            numPassing: 4,
+                            numSkipped: 0,
+                            unit: 'CONTROL',
+                        },
+                        {
+                            aggregationKeys: [{ id: 'NIST_SP_800_53_Rev_4', scope: 'STANDARD' }],
+                            numFailing: 10,
+                            numPassing: 10,
+                            numSkipped: 2,
+                            unit: 'CONTROL',
+                        },
+                        {
+                            aggregationKeys: [{ id: 'PCI_DSS_3_2', scope: 'STANDARD' }],
+                            numFailing: 15,
+                            numPassing: 8,
+                            numSkipped: 1,
+                            unit: 'CONTROL',
+                        },
+                    ],
+                },
+                complianceStandards: [
+                    { id: 'CIS_Docker_v1_2_0', name: 'CIS Docker v1.2.0' },
+                    { id: 'CIS_Kubernetes_v1_5', name: 'CIS Kubernetes v1.5' },
+                    { id: 'HIPAA_164', name: 'HIPAA 164' },
+                    { id: 'NIST_800_190', name: 'NIST SP 800-190' },
+                    { id: 'NIST_SP_800_53_Rev_4', name: 'NIST SP 800-53' },
+                    { id: 'PCI_DSS_3_2', name: 'PCI DSS 3.2.1' },
+                ],
+            },
+        },
+    },
+];
+
+jest.mock('hooks/useResizeObserver', () => ({
+    __esModule: true,
+    default: jest.fn().mockImplementation(jest.fn),
+}));
+
+beforeEach(() => {
+    jest.resetModules();
+});
+
+const setup = () => {
+    const user = userEvent.setup();
+    const utils = renderWithRouter(
+        <MockedProvider mocks={mocks} addTypename={false}>
+            <ComplianceLevelsByStandard />
+        </MockedProvider>
+    );
+
+    return { user, utils };
+};
+
+describe('Compliance levels by standard dashboard widget', () => {
+    it('should render graph bars correctly order by compliance percentage', async () => {
+        const { user } = setup();
+
+        // Allow graph to load
+        await screen.findAllByRole('presentation');
+
+        async function getBarPercentages() {
+            // eslint-disable-next-line testing-library/no-node-access
+            const svgBarsElement = document.querySelector('svg > g:nth-of-type(3)');
+            const barPercentages = await within(svgBarsElement as HTMLElement).findAllByText(
+                /\d+%/
+            );
+            expect(barPercentages).toHaveLength(6);
+            // Note that we reverse here because the order in the DOM (bottom->top) is the opposite from
+            // how that chart is displayed to the user (top->bottom)
+            return barPercentages.map((elem) => parseInt(elem.innerHTML, 10)).reverse();
+        }
+
+        // Default is ascending
+        await waitFor(async () => {
+            const ascendingPercentages = await getBarPercentages();
+            for (let i = 0; i < ascendingPercentages.length - 1; i += 1) {
+                expect(ascendingPercentages[i]).toBeLessThan(ascendingPercentages[i + 1]);
+            }
+        });
+
+        // Sort by descending
+        await user.click(screen.getByRole('button', { name: 'Options' }));
+        await user.click(screen.getByRole('button', { name: 'Descending' }));
+
+        await waitFor(async () => {
+            const descendingPercentages = await getBarPercentages();
+            for (let i = 0; i < descendingPercentages.length - 1; i += 1) {
+                expect(descendingPercentages[i]).toBeGreaterThan(descendingPercentages[i + 1]);
+            }
+        });
+    });
+
+    it('should visit the correct pages when widget links are clicked', async () => {
+        const {
+            user,
+            utils: { history },
+        } = setup();
+
+        await user.click(await screen.findByRole('link', { name: 'View all' }));
+        expect(history.location.pathname).toBe(complianceBasePath);
+
+        const standard = 'CIS Docker v1.2.0';
+        await act(async () => {
+            await user.click(await screen.findByRole('link', { name: standard }));
+        });
+        expect(history.location.pathname).toBe(
+            `${complianceBasePath}/${urlEntityListTypes[standardEntityTypes.CONTROL]}`
+        );
+        expect(history.location.search).toBe(
+            `?s[Cluster]=%2A&s[standard]=${encodeURIComponent(standard)}`
+        );
+    });
+});

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
@@ -128,8 +128,10 @@ describe('Compliance levels by standard dashboard widget', () => {
         });
 
         // Sort by descending
-        await user.click(screen.getByRole('button', { name: 'Options' }));
-        await user.click(screen.getByRole('button', { name: 'Descending' }));
+        await act(async () => {
+            await user.click(screen.getByRole('button', { name: 'Options' }));
+            await user.click(screen.getByRole('button', { name: 'Descending' }));
+        });
 
         await waitFor(async () => {
             const descendingPercentages = await getBarPercentages();

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
@@ -36,10 +36,6 @@ import WidgetCard from './WidgetCard';
 
 const fieldIdPrefix = 'compliance-levels-by-standard';
 
-function getViewAllLink(searchFilter: SearchFilter) {
-    return `${complianceBasePath}?${getUrlQueryStringForSearchFilter(searchFilter)}`;
-}
-
 // Adapted from `processData` function in the original DashboardCompliance.js code
 function processData(
     searchFilter: SearchFilter,
@@ -169,11 +165,7 @@ function ComplianceLevelsByStandard() {
                                 </FormGroup>
                             </Form>
                         </Dropdown>
-                        <Button
-                            variant="secondary"
-                            component={LinkShim}
-                            href={getViewAllLink(searchFilter)}
-                        >
+                        <Button variant="secondary" component={LinkShim} href={complianceBasePath}>
                             View all
                         </Button>
                     </FlexItem>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
@@ -1,0 +1,188 @@
+import React, { useMemo, useState } from 'react';
+import {
+    Flex,
+    FlexItem,
+    Title,
+    Dropdown,
+    DropdownToggle,
+    FormGroup,
+    ToggleGroup,
+    ToggleGroupItem,
+    Button,
+    Form,
+} from '@patternfly/react-core';
+import { useQuery } from '@apollo/client';
+import { sortBy } from 'lodash';
+
+import LinkShim from 'Components/PatternFly/LinkShim';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import useURLSearch from 'hooks/useURLSearch';
+import { SearchFilter } from 'types/search';
+
+import {
+    getRequestQueryStringForSearchFilter,
+    getUrlQueryStringForSearchFilter,
+} from 'utils/searchUtils';
+import entityTypes, {
+    StandardEntityType,
+    standardTypes,
+    standardEntityTypes,
+} from 'constants/entityTypes';
+import { AGGREGATED_RESULTS_ACROSS_ENTITIES } from 'queries/controls';
+import { complianceBasePath, urlEntityListTypes } from 'routePaths';
+import { standardLabels } from 'messages/standards';
+import ComplianceLevelsByStandardChart, { ComplianceData } from './ComplianceLevelsByStandardChart';
+import WidgetCard from './WidgetCard';
+
+const fieldIdPrefix = 'compliance-levels-by-standard';
+
+function getViewAllLink(searchFilter: SearchFilter) {
+    return `${complianceBasePath}?${getUrlQueryStringForSearchFilter(searchFilter)}`;
+}
+
+// Adapted from `processData` function in the original DashboardCompliance.js code
+function processData(
+    searchFilter: SearchFilter,
+    sortDirection: SortBy,
+    data?: AggregationResult
+): ComplianceData | undefined {
+    if (!data) {
+        return undefined;
+    }
+    const { complianceStandards } = data;
+    const modifiedData = data.controls.results.map((result) => {
+        const aggregationName = result?.aggregationKeys[0]?.id;
+        const standard = complianceStandards.find((cs) => cs.id === aggregationName);
+        const { numPassing, numFailing } = result;
+        const standardQueryValue =
+            standardLabels[standard?.id] || aggregationName || 'Unrecognized standard';
+        const query = getUrlQueryStringForSearchFilter({
+            ...searchFilter,
+            Cluster: searchFilter.Cluster || '*',
+            standard: standardQueryValue,
+        });
+        const link = `${complianceBasePath}/${
+            urlEntityListTypes[standardEntityTypes.CONTROL]
+        }?${query}`;
+        const modifiedResult = {
+            name: standard?.name || aggregationName || 'Unrecognized standard',
+            passing: Math.round((numPassing / (numFailing + numPassing)) * 100) || 0,
+            link,
+        };
+        return modifiedResult;
+    });
+
+    const sorted = sortBy(modifiedData, [(datum) => datum.passing]);
+
+    if (sortDirection === 'asc') {
+        sorted.reverse();
+    }
+
+    return sorted;
+}
+
+type AggregationResult = {
+    controls: {
+        results: {
+            aggregationKeys: {
+                id: keyof typeof standardTypes;
+                scope: StandardEntityType;
+            }[];
+            numFailing: number;
+            numPassing: number;
+            numSkipped: number;
+            unit: StandardEntityType;
+        }[];
+    };
+    complianceStandards: {
+        id: string;
+        name: string;
+    }[];
+};
+
+type SortBy = 'asc' | 'desc';
+
+function ComplianceLevelsByStandard() {
+    const { isOpen: isOptionsOpen, onToggle: toggleOptionsOpen } = useSelectToggle();
+    const { searchFilter } = useURLSearch();
+    const [sortDataBy, setSortDataBy] = useState<SortBy>('asc');
+
+    const where = getRequestQueryStringForSearchFilter({
+        // We always need to include some value for Cluster, otherwise aggregation will be performed at the namespace level
+        ...searchFilter,
+        Cluster: searchFilter.Cluster || '*',
+    });
+    const variables = {
+        groupBy: [entityTypes.STANDARD],
+        where,
+    };
+    const { loading, error, data, previousData } = useQuery<AggregationResult>(
+        AGGREGATED_RESULTS_ACROSS_ENTITIES,
+        { variables }
+    );
+
+    const complianceData = useMemo(
+        () => processData(searchFilter, sortDataBy, data || previousData)?.slice(0, 6),
+        [searchFilter, sortDataBy, data, previousData]
+    );
+
+    return (
+        <WidgetCard
+            isLoading={loading && !complianceData}
+            error={error}
+            header={
+                <Flex direction={{ default: 'row' }}>
+                    <FlexItem grow={{ default: 'grow' }}>
+                        <Title headingLevel="h2">Compliance coverage by standard</Title>
+                    </FlexItem>
+                    <FlexItem>
+                        <Dropdown
+                            className="pf-u-mr-sm"
+                            toggle={
+                                <DropdownToggle
+                                    id={`${fieldIdPrefix}-options-toggle`}
+                                    toggleVariant="secondary"
+                                    onToggle={toggleOptionsOpen}
+                                >
+                                    Options
+                                </DropdownToggle>
+                            }
+                            position="right"
+                            isOpen={isOptionsOpen}
+                        >
+                            <Form className="pf-u-px-md pf-u-py-sm">
+                                <FormGroup fieldId={`${fieldIdPrefix}-sort-by`} label="Sort by">
+                                    <ToggleGroup aria-label="Sort coverage by ascending or descending percentage">
+                                        <ToggleGroupItem
+                                            text="Ascending"
+                                            buttonId={`${fieldIdPrefix}-sort-by-asc`}
+                                            isSelected={sortDataBy === 'asc'}
+                                            onChange={() => setSortDataBy('asc')}
+                                        />
+                                        <ToggleGroupItem
+                                            text="Descending"
+                                            buttonId={`${fieldIdPrefix}-sort-by-desc`}
+                                            isSelected={sortDataBy === 'desc'}
+                                            onChange={() => setSortDataBy('desc')}
+                                        />
+                                    </ToggleGroup>
+                                </FormGroup>
+                            </Form>
+                        </Dropdown>
+                        <Button
+                            variant="secondary"
+                            component={LinkShim}
+                            href={getViewAllLink(searchFilter)}
+                        >
+                            View all
+                        </Button>
+                    </FlexItem>
+                </Flex>
+            }
+        >
+            {complianceData && <ComplianceLevelsByStandardChart complianceData={complianceData} />}
+        </WidgetCard>
+    );
+}
+
+export default ComplianceLevelsByStandard;

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandardChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandardChart.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { Chart, ChartAxis, ChartBar, ChartGroup, ChartLabelProps } from '@patternfly/react-charts';
+
+import { LinkableChartLabel } from 'Components/PatternFly/Charts/LinkableChartLabel';
+import useResizeObserver from 'hooks/useResizeObserver';
+import {
+    defaultChartHeight,
+    defaultChartBarWidth,
+    navigateOnClickEvent,
+    solidBlueChartColor,
+} from 'utils/chartUtils';
+
+const labelLinkCallback = ({ datum }: ChartLabelProps, data: ComplianceData) => {
+    return typeof datum === 'number' ? data[datum - 1].link : '';
+};
+
+export type ComplianceData = {
+    name: string;
+    passing: number;
+    link: string;
+}[];
+
+type ComplianceLevelsByStandardChartProps = {
+    complianceData: ComplianceData;
+};
+
+function ComplianceLevelsByStandardChart({ complianceData }: ComplianceLevelsByStandardChartProps) {
+    const history = useHistory();
+    const [widgetContainer, setWidgetContainer] = useState<HTMLDivElement | null>(null);
+    const widgetContainerResizeEntry = useResizeObserver(widgetContainer);
+
+    return (
+        <div ref={setWidgetContainer}>
+            <Chart
+                ariaDesc="Compliance coverage percentages by standard across the selected resource scope"
+                ariaTitle="Compliance coverage by standard"
+                animate={{ duration: 300 }}
+                domainPadding={{ x: [20, 20] }}
+                height={defaultChartHeight}
+                width={widgetContainerResizeEntry?.contentRect.width}
+                padding={{
+                    top: 0,
+                    left: 150,
+                    right: 50,
+                    bottom: 30,
+                }}
+            >
+                <ChartAxis
+                    tickLabelComponent={
+                        <LinkableChartLabel
+                            linkWith={(props) => labelLinkCallback(props, complianceData)}
+                        />
+                    }
+                />
+                <ChartAxis
+                    tickValues={[0, 50, 100]}
+                    tickFormat={['0', '50%', '100%']}
+                    padding={{ bottom: 10 }}
+                    dependentAxis
+                />
+                <ChartGroup horizontal>
+                    {complianceData.map(({ name, passing, link }) => (
+                        <ChartBar
+                            key={name}
+                            style={{ data: { fill: solidBlueChartColor } }}
+                            barWidth={defaultChartBarWidth}
+                            data={[{ x: name, y: passing, link }]}
+                            labels={({ datum }) => `${Math.round(parseInt(datum.y, 10))}%`}
+                            events={[navigateOnClickEvent(history, () => link)]}
+                        />
+                    ))}
+                </ChartGroup>
+            </Chart>
+        </div>
+    );
+}
+
+export default ComplianceLevelsByStandardChart;

--- a/ui/apps/platform/src/utils/chartUtils.ts
+++ b/ui/apps/platform/src/utils/chartUtils.ts
@@ -4,6 +4,8 @@ import { EventCallbackInterface, EventPropTypeInterface } from 'victory-core';
 
 import { severityColors } from 'constants/visuals/colors';
 
+export const solidBlueChartColor = 'var(--pf-global--palette--blue-400)';
+
 export const severityColorScale = Object.values(severityColors);
 
 // Clone default PatternFly chart themes


### PR DESCRIPTION
## Description

Adds a Compliance levels by standard widget. This displays the total compliance percentage across standards at the _cluster_ aggregation level. This is very similar to the existing dashboard widget, with the exception that the data can now be filtered by Cluster and Namespace.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added


## Testing Performed

Test that compliance percentages are displayed in ascending order by default:
<img width="1662" alt="image" src="https://user-images.githubusercontent.com/1292638/175967207-6ebe466e-5fc9-4d6e-a366-af7844d0167e.png">

Test that the ascending sort option reverses the display of the chart:
<img width="1662" alt="image" src="https://user-images.githubusercontent.com/1292638/175967303-f5113057-c9eb-4e60-bfff-f3c5ed6fd54c.png">

Test that Cluster and Namespace filters adjust the data in the chart. Note that as the size of the selected scope decreases, the compliance percentages should always _increase_ or stay the same. This is because aggregation counts a failing standard in one resource (cluster/ns) as a failure for that standard in the entire scope.
<img width="1662" alt="image" src="https://user-images.githubusercontent.com/1292638/175967670-c8a19bf7-ceb5-451b-8123-1ecdfe6be1d3.png">

Test the links from the axis labels and bars take the user to the compliance page to that specific standard:
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/1292638/175968335-7bd96f03-a673-4f0e-8741-52e24127f957.png">

Test that the 'View all' button takes the user to the main compliance page:
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/1292638/175968724-3e4e1ffe-f2b6-4a0b-a18c-816ecb595a06.png">

