### PR TITLE
Reverse chart legend in policy violations by category chart

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
     Dropdown,
@@ -139,6 +139,11 @@ function tooltipForCategory(
         .join('\n');
 }
 
+// This widget uses a theme with the legend order in the opposite direction
+// of the PatternFly defaults
+const chartTheme = cloneDeep(patternflySeverityTheme);
+chartTheme.legend.colorScale.reverse();
+
 function ViolationsByPolicyCategoryChart({
     alertGroups,
     sortType,
@@ -154,14 +159,6 @@ function ViolationsByPolicyCategoryChart({
         ({ text }: ChartLabelProps) => linkForViolationsCategory(String(text), searchFilter),
         [searchFilter]
     );
-
-    // This widget uses a theme with the legend order in the opposite direction
-    // of the PatternFly defaults
-    const chartTheme = useMemo(() => {
-        const theme = cloneDeep(patternflySeverityTheme);
-        theme.legend.colorScale.reverse();
-        return theme;
-    }, []);
 
     const filteredAlertGroups = zeroOutFilteredSeverities(alertGroups, hiddenSeverities);
     const sortedAlertGroups =

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
     Dropdown,
@@ -23,6 +23,7 @@ import {
     getInteractiveLegendItemStyles,
 } from '@patternfly/react-charts';
 import sortBy from 'lodash/sortBy';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { LinkableChartLabel } from 'Components/PatternFly/Charts/LinkableChartLabel';
 import { AlertGroup } from 'services/AlertsService';
@@ -154,6 +155,14 @@ function ViolationsByPolicyCategoryChart({
         [searchFilter]
     );
 
+    // This widget uses a theme with the legend order in the opposite direction
+    // of the PatternFly defaults
+    const chartTheme = useMemo(() => {
+        const theme = cloneDeep(patternflySeverityTheme);
+        theme.legend.colorScale.reverse();
+        return theme;
+    }, []);
+
     const filteredAlertGroups = zeroOutFilteredSeverities(alertGroups, hiddenSeverities);
     const sortedAlertGroups =
         sortType === 'Severity'
@@ -189,12 +198,14 @@ function ViolationsByPolicyCategoryChart({
     });
 
     function getLegendData() {
-        return policySeverities.map((severity) => {
+        const legendData = policySeverities.map((severity) => {
             return {
                 name: severityLabels[severity],
                 ...getInteractiveLegendItemStyles(hiddenSeverities.has(severity)),
             };
         });
+        legendData.reverse();
+        return legendData;
     }
 
     function onLegendClick({ index }: { index: number }) {
@@ -231,7 +242,7 @@ function ViolationsByPolicyCategoryChart({
                     left: 180, // left padding is dependent on the length of the text on the left axis
                     bottom: 55, // Adjusted to accommodate legend
                 }}
-                theme={patternflySeverityTheme}
+                theme={chartTheme}
             >
                 <ChartAxis
                     tickLabelComponent={<LinkableChartLabel linkWith={labelLinkCallback} />}

--- a/ui/apps/platform/src/utils/chartUtils.ts
+++ b/ui/apps/platform/src/utils/chartUtils.ts
@@ -18,11 +18,11 @@ export const patternflySeverityTheme = {
     ...defaultTheme,
     stack: {
         ...defaultTheme.stack,
-        colorScale: severityColorScale,
+        colorScale: [...severityColorScale],
     },
     legend: {
         ...defaultTheme.legend,
-        colorScale: severityColorScale,
+        colorScale: [...severityColorScale],
     },
     tooltip: {
         style: {


### PR DESCRIPTION
## Description

Reverses the order of the legend in the "Violations by policy category" chart to be in line with the mocks.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed
Load the dashboard and see that the legend now goes from Critical->Low, and Red->Gray.
The bars in the chart continue in the original default direction, Gray->Red.
<img width="656" alt="image" src="https://user-images.githubusercontent.com/1292638/175666333-eeaa655a-04dd-403e-ba1b-8c24eb88d342.png">

