### PR TITLE
[ROX-11258] : Add node vulnerability resolver for postgres and wire it in cluster and node graphQL; Update PlottedNodeVulnerabilities resolvers to use Postgres

### DIFF
--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -649,8 +649,9 @@ func (resolver *clusterResolver) NodeVulnerabilityCount(ctx context.Context, arg
 func (resolver *clusterResolver) NodeVulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "NodeVulnerabilityCounter")
 
+	// (ROX-10911) Cluster scoping the context is not able to resolve node vulns when combined with 'Fixable:true/false' query
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
-	return resolver.root.NodeVulnCounter(ctx, RawQuery{Query: &query})
+	return resolver.root.NodeVulnerabilityCounter(ctx, RawQuery{Query: &query})
 }
 
 func (resolver *clusterResolver) withClusterScope(ctx context.Context) context.Context {
@@ -1117,6 +1118,7 @@ func (resolver *clusterResolver) LatestViolation(ctx context.Context, args RawQu
 func (resolver *clusterResolver) PlottedNodeVulnerabilities(ctx context.Context, args RawQuery) (*PlottedNodeVulnerabilitiesResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "PlottedNodeVulnerabilities")
 
+	// (ROX-10911) Cluster scoping the context is not able to resolve node vulns when combined with 'Fixable:true/false' query
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
 	return newPlottedNodeVulnerabilitiesResolver(ctx, resolver.root, RawQuery{Query: &query})
 }

--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -1117,12 +1117,8 @@ func (resolver *clusterResolver) LatestViolation(ctx context.Context, args RawQu
 func (resolver *clusterResolver) PlottedNodeVulnerabilities(ctx context.Context, args RawQuery) (*PlottedNodeVulnerabilitiesResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "PlottedNodeVulnerabilities")
 
-	if !features.PostgresDatastore.Enabled() {
-		query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
-		return newPlottedNodeVulnerabilitiesResolver(ctx, resolver.root, RawQuery{Query: &query})
-	}
-	// TODO : Add postgres support
-	return nil, errors.New("Sub-resolver PlottedNodeVulnerabilities in Cluster does not support postgres yet")
+	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
+	return newPlottedNodeVulnerabilitiesResolver(ctx, resolver.root, RawQuery{Query: &query})
 }
 
 // PlottedImageVulnerabilities returns the data required by top risky entity scatter-plot on vuln mgmt dashboard

--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -631,38 +631,26 @@ func (resolver *clusterResolver) VulnCounter(ctx context.Context, args RawQuery)
 func (resolver *clusterResolver) NodeVulnerabilities(ctx context.Context, args PaginatedQuery) ([]NodeVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "NodeVulnerabilities")
 
-	if !features.PostgresDatastore.Enabled() {
-		// (ROX-10911) Cluster scoping the context is not able to resolve node vulns when combined with 'Fixable:true/false' query
-		query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
-		return resolver.root.NodeVulnerabilities(ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
-	}
-	// TODO : Add postgres support
-	return nil, errors.New("Sub-resolver NodeVulnerabilities in Cluster does not support postgres yet")
+	// (ROX-10911) Cluster scoping the context is not able to resolve node vulns when combined with 'Fixable:true/false' query
+	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
+	return resolver.root.NodeVulnerabilities(ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
 }
 
 // NodeVulnerabilityCount returns the number of node vulnerabilities in the cluster.
 func (resolver *clusterResolver) NodeVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "NodeVulnerabilityCount")
 
-	if !features.PostgresDatastore.Enabled() {
-		// (ROX-10911) Cluster scoping the context is not able to resolve node vulns when combined with 'Fixable:true/false' query
-		query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
-		return resolver.root.NodeVulnerabilityCount(ctx, RawQuery{Query: &query})
-	}
-	// TODO : Add postgres support
-	return 0, errors.New("Sub-resolver NodeVulnerabilityCount in Cluster does not support postgres yet")
+	// (ROX-10911) Cluster scoping the context is not able to resolve node vulns when combined with 'Fixable:true/false' query
+	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
+	return resolver.root.NodeVulnerabilityCount(ctx, RawQuery{Query: &query})
 }
 
 // NodeVulnerabilityCounter resolves the number of different types of node vulnerabilities contained in the cluster.
 func (resolver *clusterResolver) NodeVulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "NodeVulnerabilityCounter")
 
-	if !features.PostgresDatastore.Enabled() {
-		query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
-		return resolver.root.NodeVulnCounter(ctx, RawQuery{Query: &query})
-	}
-	// TODO : Add postgres support
-	return nil, errors.New("Sub-resolver NodeVulnerabilityCounter in Cluster does not support postgres yet")
+	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
+	return resolver.root.NodeVulnCounter(ctx, RawQuery{Query: &query})
 }
 
 func (resolver *clusterResolver) withClusterScope(ctx context.Context) context.Context {

--- a/central/graphql/resolvers/common_vulnerabilities.go
+++ b/central/graphql/resolvers/common_vulnerabilities.go
@@ -33,7 +33,6 @@ var commonVulnerabilitySubResolvers = []string{
 	"suppressed: Boolean!",
 	"unusedVarSink(query: String): Int",
 	"vectors: EmbeddedVulnerabilityVectors",
-	"vulnerabilityState: String!",
 }
 
 // CommonVulnerabilityResolver represents the supported API on all vulnerabilities
@@ -59,5 +58,4 @@ type CommonVulnerabilityResolver interface {
 	Suppressed(ctx context.Context) bool
 	UnusedVarSink(ctx context.Context, args RawQuery) *int32
 	Vectors() *EmbeddedVulnerabilityVectorsResolver
-	VulnerabilityState(ctx context.Context) string
 }

--- a/central/graphql/resolvers/components_v2.go
+++ b/central/graphql/resolvers/components_v2.go
@@ -421,7 +421,7 @@ func (eicr *imageComponentResolver) NodeVulnerabilityCount(_ context.Context, ar
 func (eicr *imageComponentResolver) NodeVulnerabilityCounter(_ context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageComponents, "NodeVulnerabilityCounter")
 	if !features.PostgresDatastore.Enabled() {
-		return eicr.root.NodeVulnCounter(eicr.imageComponentScopeContext(), args)
+		return eicr.root.NodeVulnerabilityCounter(eicr.imageComponentScopeContext(), args)
 	}
 	// TODO : Add postgres support
 	return nil, errors.New("Sub-resolver NodeVulnerabilityCounter in NodeComponent does not support postgres yet")

--- a/central/graphql/resolvers/gen/main.go
+++ b/central/graphql/resolvers/gen/main.go
@@ -20,7 +20,7 @@ var (
 			reflect.TypeOf((*storage.ActiveComponent_ActiveContext)(nil)),
 			reflect.TypeOf((*storage.Alert)(nil)),
 			reflect.TypeOf((*storage.Cluster)(nil)),
-			//reflect.TypeOf((*storage.ClusterCVE)(nil)), TODO rox-11259
+			// reflect.TypeOf((*storage.ClusterCVE)(nil)), TODO rox-11259
 			reflect.TypeOf((*storage.ComplianceAggregation_Response)(nil)),
 			reflect.TypeOf((*storage.ComplianceControlResult)(nil)),
 			reflect.TypeOf((*storage.CVE)(nil)),

--- a/central/graphql/resolvers/gen/main.go
+++ b/central/graphql/resolvers/gen/main.go
@@ -39,6 +39,7 @@ var (
 			reflect.TypeOf((*storage.MitreAttackVector)(nil)),
 			reflect.TypeOf((*storage.NetworkFlow)(nil)),
 			reflect.TypeOf((*storage.Node)(nil)),
+			reflect.TypeOf((*storage.NodeCVE)(nil)),
 			reflect.TypeOf((*storage.Notifier)(nil)),
 			reflect.TypeOf((*storage.PermissionSet)(nil)),
 			reflect.TypeOf((*storage.Pod)(nil)),

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -870,6 +870,17 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"scan: NodeScan",
 		"taints: [Taint]!",
 	}))
+	utils.Must(builder.AddType("NodeCVE", []string{
+		"cveBaseInfo: CVEInfo",
+		"cvss: Float!",
+		"id: ID!",
+		"impactScore: Float!",
+		"operatingSystem: String!",
+		"severity: VulnerabilitySeverity!",
+		"snoozeExpiry: Time",
+		"snoozeStart: Time",
+		"snoozed: Boolean!",
+	}))
 	utils.Must(builder.AddType("NodeScan", []string{
 		"notes: [NodeScan_Note!]!",
 		"operatingSystem: String!",
@@ -7984,6 +7995,75 @@ func (resolver *nodeResolver) Scan(ctx context.Context) (*nodeScanResolver, erro
 func (resolver *nodeResolver) Taints(ctx context.Context) ([]*taintResolver, error) {
 	value := resolver.data.GetTaints()
 	return resolver.root.wrapTaints(value, nil)
+}
+
+type nodeCVEResolver struct {
+	ctx  context.Context
+	root *Resolver
+	data *storage.NodeCVE
+}
+
+func (resolver *Resolver) wrapNodeCVE(value *storage.NodeCVE, ok bool, err error) (*nodeCVEResolver, error) {
+	if !ok || err != nil || value == nil {
+		return nil, err
+	}
+	return &nodeCVEResolver{root: resolver, data: value}, nil
+}
+
+func (resolver *Resolver) wrapNodeCVEs(values []*storage.NodeCVE, err error) ([]*nodeCVEResolver, error) {
+	if err != nil || len(values) == 0 {
+		return nil, err
+	}
+	output := make([]*nodeCVEResolver, len(values))
+	for i, v := range values {
+		output[i] = &nodeCVEResolver{root: resolver, data: v}
+	}
+	return output, nil
+}
+
+func (resolver *nodeCVEResolver) CveBaseInfo(ctx context.Context) (*cVEInfoResolver, error) {
+	value := resolver.data.GetCveBaseInfo()
+	return resolver.root.wrapCVEInfo(value, true, nil)
+}
+
+func (resolver *nodeCVEResolver) Cvss(ctx context.Context) float64 {
+	value := resolver.data.GetCvss()
+	return float64(value)
+}
+
+func (resolver *nodeCVEResolver) Id(ctx context.Context) graphql.ID {
+	value := resolver.data.GetId()
+	return graphql.ID(value)
+}
+
+func (resolver *nodeCVEResolver) ImpactScore(ctx context.Context) float64 {
+	value := resolver.data.GetImpactScore()
+	return float64(value)
+}
+
+func (resolver *nodeCVEResolver) OperatingSystem(ctx context.Context) string {
+	value := resolver.data.GetOperatingSystem()
+	return value
+}
+
+func (resolver *nodeCVEResolver) Severity(ctx context.Context) string {
+	value := resolver.data.GetSeverity()
+	return value.String()
+}
+
+func (resolver *nodeCVEResolver) SnoozeExpiry(ctx context.Context) (*graphql.Time, error) {
+	value := resolver.data.GetSnoozeExpiry()
+	return timestamp(value)
+}
+
+func (resolver *nodeCVEResolver) SnoozeStart(ctx context.Context) (*graphql.Time, error) {
+	value := resolver.data.GetSnoozeStart()
+	return timestamp(value)
+}
+
+func (resolver *nodeCVEResolver) Snoozed(ctx context.Context) bool {
+	value := resolver.data.GetSnoozed()
+	return value
 }
 
 type nodeScanResolver struct {

--- a/central/graphql/resolvers/image_vulnerabilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities.go
@@ -171,9 +171,8 @@ func (resolver *Resolver) ImageVulnerabilityCounter(ctx context.Context, args Ra
 	if err != nil {
 		return nil, err
 	}
-
 	// check for Fixable fields in args
-	ErrorOnQueryContainingField(query, search.Fixable, "Unexpected `Fixable` field in ImageVulnerabilityCounter resolver")
+	logErrorOnQueryContainingField(query, search.Fixable, "ImageVulnerabilityCounter")
 
 	// get loader
 	loader, err := loaders.GetImageCVELoader(ctx)
@@ -276,9 +275,8 @@ func (resolver *imageCVEResolver) IsFixable(ctx context.Context, args RawQuery) 
 	if err != nil {
 		return false, err
 	}
-
 	// check for Fixable fields in args
-	ErrorOnQueryContainingField(query, search.Fixable, "Unexpected `Fixable` field in IsFixable sub resolver")
+	logErrorOnQueryContainingField(query, search.Fixable, "IsFixable")
 
 	conjuncts := []*v1.Query{query, search.NewQueryBuilder().AddBools(search.Fixable, true).ProtoQuery()}
 

--- a/central/graphql/resolvers/image_vulnerabilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities.go
@@ -173,12 +173,7 @@ func (resolver *Resolver) ImageVulnerabilityCounter(ctx context.Context, args Ra
 	}
 
 	// check for Fixable fields in args
-	search.ApplyFnToAllBaseQueries(query, func(bq *v1.BaseQuery) {
-		mfQ, ok := bq.GetQuery().(*v1.BaseQuery_MatchFieldQuery)
-		if ok && mfQ.MatchFieldQuery.GetField() == search.Fixable.String() {
-			log.Errorf("Unexpected `Fixable` field in ImageVulnerabilityCounter resolver")
-		}
-	})
+	ErrorOnQueryContainingField(query, search.Fixable, "Unexpected `Fixable` field in ImageVulnerabilityCounter resolver")
 
 	// get loader
 	loader, err := loaders.GetImageCVELoader(ctx)
@@ -277,18 +272,13 @@ func (resolver *imageCVEResolver) FixedByVersion(ctx context.Context) (string, e
 
 func (resolver *imageCVEResolver) IsFixable(ctx context.Context, args RawQuery) (bool, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "IsFixable")
-	query, err := args.AsV1QueryOrEmpty(search.ExcludeFieldLabel(search.CVEID), search.ExcludeFieldLabel(search.Fixable))
+	query, err := args.AsV1QueryOrEmpty(search.ExcludeFieldLabel(search.CVEID))
 	if err != nil {
 		return false, err
 	}
 
 	// check for Fixable fields in args
-	search.ApplyFnToAllBaseQueries(query, func(bq *v1.BaseQuery) {
-		mfQ, ok := bq.GetQuery().(*v1.BaseQuery_MatchFieldQuery)
-		if ok && mfQ.MatchFieldQuery.GetField() == search.Fixable.String() {
-			log.Errorf("Unexpected `Fixable` field in IsFixable sub resolver")
-		}
-	})
+	ErrorOnQueryContainingField(query, search.Fixable, "Unexpected `Fixable` field in IsFixable sub resolver")
 
 	conjuncts := []*v1.Query{query, search.NewQueryBuilder().AddBools(search.Fixable, true).ProtoQuery()}
 

--- a/central/graphql/resolvers/image_vulnerabilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities.go
@@ -33,6 +33,7 @@ func init() {
 				"imageComponents(query: String, pagination: Pagination): [ImageComponent!]!",
 				"imageCount(query: String): Int!",
 				"images(query: String, pagination: Pagination): [Image!]!",
+				"vulnerabilityState: String!",
 			)),
 		schema.AddQuery("imageVulnerability(id: ID): ImageVulnerability"),
 		schema.AddQuery("imageVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [ImageVulnerability!]!"),
@@ -54,6 +55,7 @@ type ImageVulnerabilityResolver interface {
 	ImageComponentCount(ctx context.Context, args RawQuery) (int32, error)
 	ImageCount(ctx context.Context, args RawQuery) (int32, error)
 	Images(ctx context.Context, args PaginatedQuery) ([]*imageResolver, error)
+	VulnerabilityState(ctx context.Context) string
 }
 
 // ImageVulnerability returns a vulnerability of the given id

--- a/central/graphql/resolvers/loaders/images.go
+++ b/central/graphql/resolvers/loaders/images.go
@@ -135,11 +135,3 @@ func (idl *imageLoaderImpl) readAll(ids []string) (images []*storage.Image, miss
 	}
 	return
 }
-
-func collectMissing(ids []string, missing []int) []string {
-	missingIds := make([]string, 0, len(missing))
-	for _, missingIdx := range missing {
-		missingIds = append(missingIds, ids[missingIdx])
-	}
-	return missingIds
-}

--- a/central/graphql/resolvers/loaders/node_cves.go
+++ b/central/graphql/resolvers/loaders/node_cves.go
@@ -9,7 +9,6 @@ import (
 	nodeCVEDataStore "github.com/stackrox/rox/central/cve/node/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/cvss"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -56,10 +55,6 @@ type nodeCVELoaderImpl struct {
 
 	ds nodeCVEDataStore.DataStore
 }
-
-//func enrichNodeCVESeverity(value *storage.NodeCVE) {
-//	value.Severity = cvss.VulnToSeverity(cvss.NewFromNodeCVE(value))
-//}
 
 // FromIDs loads a set of nodeCVEs from a set of ids.
 func (idl *nodeCVELoaderImpl) FromIDs(ctx context.Context, ids []string) ([]*storage.NodeCVE, error) {
@@ -109,9 +104,6 @@ func (idl *nodeCVELoaderImpl) load(ctx context.Context, ids []string) ([]*storag
 		if err != nil {
 			return nil, err
 		}
-		for _, cve := range nodeCves {
-			cve.Severity = cvss.VulnToSeverity(cvss.NewFromNodeCVE(cve))
-		}
 		idl.setAll(nodeCves)
 		nodeCves, missing = idl.readAll(ids)
 	}
@@ -120,7 +112,7 @@ func (idl *nodeCVELoaderImpl) load(ctx context.Context, ids []string) ([]*storag
 		for _, m := range missing {
 			missingIDs = append(missingIDs, ids[m])
 		}
-		return nil, errors.Errorf("not all cves could be found: %s", strings.Join(missingIDs, ","))
+		return nil, errors.Errorf("not all node cves could be found: %s", strings.Join(missingIDs, ","))
 	}
 	return nodeCves, nil
 }

--- a/central/graphql/resolvers/loaders/node_cves.go
+++ b/central/graphql/resolvers/loaders/node_cves.go
@@ -9,6 +9,7 @@ import (
 	nodeCVEDataStore "github.com/stackrox/rox/central/cve/node/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -16,9 +17,11 @@ import (
 var nodeCveLoaderType = reflect.TypeOf(storage.NodeCVE{})
 
 func init() {
-	RegisterTypeFactory(reflect.TypeOf(storage.NodeCVE{}), func() interface{} {
-		return NewNodeCVELoader(nodeCVEDataStore.Singleton())
-	})
+	if features.PostgresDatastore.Enabled() {
+		RegisterTypeFactory(reflect.TypeOf(storage.NodeCVE{}), func() interface{} {
+			return NewNodeCVELoader(nodeCVEDataStore.Singleton())
+		})
+	}
 }
 
 // NewNodeCVELoader creates a new loader for nodeCVE data.

--- a/central/graphql/resolvers/loaders/node_cves.go
+++ b/central/graphql/resolvers/loaders/node_cves.go
@@ -1,0 +1,150 @@
+package loaders
+
+import (
+	"context"
+	"reflect"
+	"strings"
+
+	"github.com/pkg/errors"
+	nodeCVEDataStore "github.com/stackrox/rox/central/cve/node/datastore"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/cvss"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var nodeCveLoaderType = reflect.TypeOf(storage.NodeCVE{})
+
+func init() {
+	RegisterTypeFactory(reflect.TypeOf(storage.NodeCVE{}), func() interface{} {
+		return NewNodeCVELoader(nodeCVEDataStore.Singleton())
+	})
+}
+
+// NewNodeCVELoader creates a new loader for nodeCVE data.
+func NewNodeCVELoader(ds nodeCVEDataStore.DataStore) NodeCVELoader {
+	return &nodeCVELoaderImpl{
+		loaded: make(map[string]*storage.NodeCVE),
+		ds:     ds,
+	}
+}
+
+// GetNodeCVELoader returns the NodeCVELoader from the context if it exists.
+func GetNodeCVELoader(ctx context.Context) (NodeCVELoader, error) {
+	loader, err := GetLoader(ctx, nodeCveLoaderType)
+	if err != nil {
+		return nil, err
+	}
+	return loader.(NodeCVELoader), nil
+}
+
+// NodeCVELoader loads nodeCVE data, and stores already loaded nodeCVEs for other ops in the same context to use.
+type NodeCVELoader interface {
+	FromIDs(ctx context.Context, ids []string) ([]*storage.NodeCVE, error)
+	FromID(ctx context.Context, id string) (*storage.NodeCVE, error)
+	FromQuery(ctx context.Context, query *v1.Query) ([]*storage.NodeCVE, error)
+
+	CountFromQuery(ctx context.Context, query *v1.Query) (int32, error)
+	CountAll(ctx context.Context) (int32, error)
+}
+
+// nodeCVELoaderImpl implements the NodeCVELoader interface.
+type nodeCVELoaderImpl struct {
+	lock   sync.RWMutex
+	loaded map[string]*storage.NodeCVE
+
+	ds nodeCVEDataStore.DataStore
+}
+
+//func enrichNodeCVESeverity(value *storage.NodeCVE) {
+//	value.Severity = cvss.VulnToSeverity(cvss.NewFromNodeCVE(value))
+//}
+
+// FromIDs loads a set of nodeCVEs from a set of ids.
+func (idl *nodeCVELoaderImpl) FromIDs(ctx context.Context, ids []string) ([]*storage.NodeCVE, error) {
+	nodeCves, err := idl.load(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	return nodeCves, nil
+}
+
+// FromID loads a nodeCVE from an ID.
+func (idl *nodeCVELoaderImpl) FromID(ctx context.Context, id string) (*storage.NodeCVE, error) {
+	nodeCves, err := idl.load(ctx, []string{id})
+	if err != nil {
+		return nil, err
+	}
+	return nodeCves[0], nil
+}
+
+// FromQuery loads a set of nodeCVEs that match a query.
+func (idl *nodeCVELoaderImpl) FromQuery(ctx context.Context, query *v1.Query) ([]*storage.NodeCVE, error) {
+	results, err := idl.ds.Search(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return idl.FromIDs(ctx, search.ResultsToIDs(results))
+}
+
+func (idl *nodeCVELoaderImpl) CountFromQuery(ctx context.Context, query *v1.Query) (int32, error) {
+	count, err := idl.ds.Count(ctx, query)
+	if err != nil {
+		return 0, err
+	}
+	return int32(count), nil
+}
+
+func (idl *nodeCVELoaderImpl) CountAll(ctx context.Context) (int32, error) {
+	count, err := idl.ds.Count(ctx, search.EmptyQuery())
+	return int32(count), err
+}
+
+func (idl *nodeCVELoaderImpl) load(ctx context.Context, ids []string) ([]*storage.NodeCVE, error) {
+	nodeCves, missing := idl.readAll(ids)
+	if len(missing) > 0 {
+		var err error
+		nodeCves, err = idl.ds.GetBatch(ctx, collectMissing(ids, missing))
+		if err != nil {
+			return nil, err
+		}
+		for _, cve := range nodeCves {
+			cve.Severity = cvss.VulnToSeverity(cvss.NewFromNodeCVE(cve))
+		}
+		idl.setAll(nodeCves)
+		nodeCves, missing = idl.readAll(ids)
+	}
+	if len(missing) > 0 {
+		missingIDs := make([]string, 0, len(missing))
+		for _, m := range missing {
+			missingIDs = append(missingIDs, ids[m])
+		}
+		return nil, errors.Errorf("not all cves could be found: %s", strings.Join(missingIDs, ","))
+	}
+	return nodeCves, nil
+}
+
+func (idl *nodeCVELoaderImpl) setAll(nodeCves []*storage.NodeCVE) {
+	idl.lock.Lock()
+	defer idl.lock.Unlock()
+
+	for _, cve := range nodeCves {
+		idl.loaded[cve.GetId()] = cve
+	}
+}
+
+func (idl *nodeCVELoaderImpl) readAll(ids []string) (nodeCves []*storage.NodeCVE, missing []int) {
+	idl.lock.RLock()
+	defer idl.lock.RUnlock()
+
+	for idx, id := range ids {
+		cve, isLoaded := idl.loaded[id]
+		if !isLoaded {
+			missing = append(missing, idx)
+		} else {
+			nodeCves = append(nodeCves, cve)
+		}
+	}
+	return
+}

--- a/central/graphql/resolvers/loaders/node_cves_test.go
+++ b/central/graphql/resolvers/loaders/node_cves_test.go
@@ -1,0 +1,192 @@
+package loaders
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stackrox/rox/central/cve/node/datastore/mocks"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	nodeCve1 = "nodeCve1"
+	nodeCve2 = "nodeCve2"
+	nodeCve3 = "nodeCve3"
+)
+
+func TestNodeCVELoader(t *testing.T) {
+	suite.Run(t, new(CVELoaderTestSuite))
+}
+
+type NodeCVELoaderTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+
+	mockCtrl      *gomock.Controller
+	mockDataStore *mocks.MockDataStore
+}
+
+func (suite *NodeCVELoaderTestSuite) SetupTest() {
+	suite.ctx = context.Background()
+
+	suite.mockCtrl = gomock.NewController(suite.T())
+	suite.mockDataStore = mocks.NewMockDataStore(suite.mockCtrl)
+}
+
+func (suite *NodeCVELoaderTestSuite) TearDownTest() {
+	suite.mockCtrl.Finish()
+}
+
+func (suite *NodeCVELoaderTestSuite) TestFromID() {
+	// Create a loader with some reloaded cves.
+	loader := nodeCVELoaderImpl{
+		loaded: map[string]*storage.NodeCVE{
+			"nodeCve1": {Id: nodeCve1},
+			"nodeCve2": {Id: nodeCve2},
+		},
+		ds: suite.mockDataStore,
+	}
+
+	// Get a preloaded cve from id.
+	cve, err := loader.FromID(suite.ctx, nodeCve1)
+	suite.NoError(err)
+	suite.Equal(loader.loaded[nodeCve1], cve)
+
+	// Get a non-preloaded cve from id.
+	thirdCVE := &storage.NodeCVE{Id: nodeCve3}
+	suite.mockDataStore.EXPECT().GetBatch(suite.ctx, []string{nodeCve3}).
+		Return([]*storage.NodeCVE{thirdCVE}, nil)
+
+	cve, err = loader.FromID(suite.ctx, nodeCve3)
+	suite.NoError(err)
+	suite.Equal(thirdCVE, cve)
+
+	// Above call should now be preloaded.
+	cve, err = loader.FromID(suite.ctx, nodeCve3)
+	suite.NoError(err)
+	suite.Equal(loader.loaded[nodeCve3], cve)
+}
+
+func (suite *NodeCVELoaderTestSuite) TestFromIDs() {
+	// Create a loader with some reloaded cves.
+	loader := nodeCVELoaderImpl{
+		loaded: map[string]*storage.NodeCVE{
+			"nodeCve1": {Id: nodeCve1},
+			"nodeCve2": {Id: nodeCve2},
+		},
+		ds: suite.mockDataStore,
+	}
+
+	// Get a preloaded cve from id.
+	cves, err := loader.FromIDs(suite.ctx, []string{nodeCve1, nodeCve2})
+	suite.NoError(err)
+	suite.Equal([]*storage.NodeCVE{
+		loader.loaded[nodeCve1],
+		loader.loaded[nodeCve2],
+	}, cves)
+
+	// Get a non-preloaded cve from id.
+	thirdCVE := &storage.NodeCVE{Id: "nodeCve3"}
+	suite.mockDataStore.EXPECT().GetBatch(suite.ctx, []string{nodeCve3}).
+		Return([]*storage.NodeCVE{thirdCVE}, nil)
+
+	cves, err = loader.FromIDs(suite.ctx, []string{nodeCve1, nodeCve2, nodeCve3})
+	suite.NoError(err)
+	suite.Equal([]*storage.NodeCVE{
+		loader.loaded[nodeCve1],
+		loader.loaded[nodeCve2],
+		thirdCVE,
+	}, cves)
+
+	// Above call should now be preloaded.
+	cves, err = loader.FromIDs(suite.ctx, []string{nodeCve1, nodeCve2, nodeCve3})
+	suite.NoError(err)
+	suite.Equal([]*storage.NodeCVE{
+		loader.loaded[nodeCve1],
+		loader.loaded[nodeCve2],
+		loader.loaded[nodeCve3],
+	}, cves)
+}
+
+func (suite *NodeCVELoaderTestSuite) TestFromQuery() {
+	// Create a loader with some reloaded cves.
+	loader := nodeCVELoaderImpl{
+		loaded: map[string]*storage.NodeCVE{
+			"nodeCve1": {Id: nodeCve1},
+			"nodeCve2": {Id: nodeCve2},
+		},
+		ds: suite.mockDataStore,
+	}
+	query := &v1.Query{}
+
+	// Get a preloaded cve from id.
+	results := []search.Result{
+		{
+			ID: nodeCve1,
+		},
+		{
+			ID: nodeCve2,
+		},
+	}
+	suite.mockDataStore.EXPECT().Search(suite.ctx, query).Return(results, nil)
+
+	cves, err := loader.FromQuery(suite.ctx, query)
+	suite.NoError(err)
+	suite.Equal([]*storage.NodeCVE{
+		loader.loaded[nodeCve1],
+		loader.loaded[nodeCve2],
+	}, cves)
+
+	// Get a non-preloaded cve from id.
+	results = []search.Result{
+		{
+			ID: nodeCve1,
+		},
+		{
+			ID: nodeCve2,
+		},
+		{
+			ID: nodeCve3,
+		},
+	}
+	suite.mockDataStore.EXPECT().Search(suite.ctx, query).Return(results, nil)
+
+	thirdCVE := &storage.NodeCVE{Id: "nodeCve3"}
+	suite.mockDataStore.EXPECT().GetBatch(suite.ctx, []string{nodeCve3}).
+		Return([]*storage.NodeCVE{thirdCVE}, nil)
+
+	cves, err = loader.FromQuery(suite.ctx, query)
+	suite.NoError(err)
+	suite.Equal([]*storage.NodeCVE{
+		loader.loaded[nodeCve1],
+		loader.loaded[nodeCve2],
+		thirdCVE,
+	}, cves)
+
+	// Above call should now be preloaded.
+	results = []search.Result{
+		{
+			ID: nodeCve1,
+		},
+		{
+			ID: nodeCve2,
+		},
+		{
+			ID: nodeCve3,
+		},
+	}
+	suite.mockDataStore.EXPECT().Search(suite.ctx, query).Return(results, nil)
+
+	cves, err = loader.FromQuery(suite.ctx, query)
+	suite.NoError(err)
+	suite.Equal([]*storage.NodeCVE{
+		loader.loaded[nodeCve1],
+		loader.loaded[nodeCve2],
+		loader.loaded[nodeCve3],
+	}, cves)
+}

--- a/central/graphql/resolvers/loaders/utils.go
+++ b/central/graphql/resolvers/loaders/utils.go
@@ -1,0 +1,9 @@
+package loaders
+
+func collectMissing(ids []string, missing []int) []string {
+	missingIds := make([]string, 0, len(missing))
+	for _, missingIdx := range missing {
+		missingIds = append(missingIds, ids[missingIdx])
+	}
+	return missingIds
+}

--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"time"
 
+	"github.com/graph-gophers/graphql-go"
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/dackbox/edges"
 	"github.com/stackrox/rox/pkg/features"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
@@ -47,8 +52,7 @@ func (resolver *Resolver) NodeVulnerability(ctx context.Context, args IDQuery) (
 	if !features.PostgresDatastore.Enabled() {
 		return resolver.nodeVulnerabilityV2(ctx, args)
 	}
-	// TODO : Add postgres support
-	return nil, errors.New("Resolver NodeVulnerability does not support postgres yet")
+	return resolver.nodeCveV2(ctx, args)
 }
 
 // NodeVulnerabilities resolves a set of vulnerabilities based on a query.
@@ -58,8 +62,7 @@ func (resolver *Resolver) NodeVulnerabilities(ctx context.Context, q PaginatedQu
 		query := withNodeCveTypeFiltering(q.String())
 		return resolver.nodeVulnerabilitiesV2(ctx, PaginatedQuery{Query: &query, Pagination: q.Pagination})
 	}
-	// TODO : Add postgres support
-	return nil, errors.New("Resolver NodeVulnerabilities does not support postgres yet")
+	return resolver.nodeCvesV2(ctx, q)
 }
 
 // NodeVulnerabilityCount returns count of all clusters across infrastructure
@@ -69,8 +72,7 @@ func (resolver *Resolver) NodeVulnerabilityCount(ctx context.Context, args RawQu
 		query := withNodeCveTypeFiltering(args.String())
 		return resolver.vulnerabilityCountV2(ctx, RawQuery{Query: &query})
 	}
-	// TODO : Add postgres support
-	return 0, errors.New("Resolver NodeVulnerabilityCount does not support postgres yet")
+	return resolver.nodeCveCountV2(ctx, args)
 }
 
 // NodeVulnCounter returns a VulnerabilityCounterResolver for the input query.s
@@ -80,8 +82,366 @@ func (resolver *Resolver) NodeVulnCounter(ctx context.Context, args RawQuery) (*
 		query := withNodeCveTypeFiltering(args.String())
 		return resolver.vulnCounterV2(ctx, RawQuery{Query: &query})
 	}
-	// TODO : Add postgres support
-	return nil, errors.New("Resolver NodeVulnCounter does not support postgres yet")
+	return resolver.nodeCveCounterV2(ctx, args)
+}
+
+func (resolver *Resolver) nodeCveV2(ctx context.Context, args IDQuery) (NodeVulnerabilityResolver, error) {
+	if err := readCVEs(ctx); err != nil {
+		return nil, err
+	}
+	vuln, exists, err := resolver.NodeCVEDataStore.Get(ctx, string(*args.ID))
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.Errorf("node cve not found: %s", string(*args.ID))
+	}
+	vulnResolver, err := resolver.wrapNodeCVE(vuln, true, nil)
+	if err != nil {
+		return nil, err
+	}
+	vulnResolver.ctx = ctx
+	return vulnResolver, nil
+}
+
+func (resolver *Resolver) nodeCvesV2(ctx context.Context, args PaginatedQuery) ([]NodeVulnerabilityResolver, error) {
+	if err := readCVEs(ctx); err != nil {
+		return nil, err
+	}
+	query, err := args.AsV1QueryOrEmpty()
+	if err != nil {
+		return nil, err
+	}
+
+	vulnResolvers, err := resolver.nodeCvesV2Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]NodeVulnerabilityResolver, 0, len(vulnResolvers))
+	for _, res := range vulnResolvers {
+		res.ctx = ctx
+		ret = append(ret, res)
+	}
+	return ret, nil
+}
+
+func (resolver *Resolver) nodeCvesV2Query(ctx context.Context, query *v1.Query) ([]*nodeCVEResolver, error) {
+	vulnLoader, err := loaders.GetNodeCVELoader(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	query = tryUnsuppressedQuery(query)
+
+	vulns, err := vulnLoader.FromQuery(ctx, query)
+	vulnResolvers, err := resolver.wrapNodeCVEs(vulns, err)
+	return vulnResolvers, err
+}
+
+func (resolver *Resolver) nodeCveCountV2(ctx context.Context, args RawQuery) (int32, error) {
+	if err := readCVEs(ctx); err != nil {
+		return 0, err
+	}
+	query, err := args.AsV1QueryOrEmpty()
+	if err != nil {
+		return 0, err
+	}
+
+	vulnLoader, err := loaders.GetNodeCVELoader(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	query = tryUnsuppressedQuery(query)
+	return vulnLoader.CountFromQuery(ctx, query)
+}
+
+func (resolver *Resolver) nodeCveCounterV2(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
+	if err := readCVEs(ctx); err != nil {
+		return nil, err
+	}
+	query, err := args.AsV1QueryOrEmpty()
+	if err != nil {
+		return nil, err
+	}
+	return resolver.nodeCveCounterV2Query(ctx, query)
+}
+
+func (resolver *Resolver) nodeCveCounterV2Query(ctx context.Context, query *v1.Query) (*VulnerabilityCounterResolver, error) {
+	vulnLoader, err := loaders.GetNodeCVELoader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	query = tryUnsuppressedQuery(query)
+	fixableVulnsQuery := search.ConjunctionQuery(query, search.NewQueryBuilder().AddBools(search.Fixable, true).ProtoQuery())
+	fixableVulns, err := vulnLoader.FromQuery(ctx, fixableVulnsQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	unFixableVulnsQuery := search.ConjunctionQuery(query, search.NewQueryBuilder().AddBools(search.Fixable, false).ProtoQuery())
+	unFixableCVEs, err := vulnLoader.FromQuery(ctx, unFixableVulnsQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	return mapNodeCVEsToVulnerabilityCounter(fixableVulns, unFixableCVEs), nil
+}
+
+// CreatedAt is the time a node CVE first seen in the system
+func (resolver *nodeCVEResolver) CreatedAt(ctx context.Context) (*graphql.Time, error) {
+	value := resolver.data.GetCveBaseInfo().GetCreatedAt()
+	return timestamp(value)
+}
+
+// CVE name of the node CVE
+func (resolver *nodeCVEResolver) CVE(ctx context.Context) string {
+	return resolver.data.GetCveBaseInfo().GetCve()
+}
+
+// EnvImpact is the fraction of nodes that contain the nodeCVE
+func (resolver *nodeCVEResolver) EnvImpact(ctx context.Context) (float64, error) {
+	n, d, err := resolver.getEnvImpactComponentsForNodeCVE(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if d == 0 {
+		return 0, nil
+	}
+	return float64(n) / float64(d), nil
+}
+
+func (resolver *nodeCVEResolver) getEnvImpactComponentsForNodeCVE(ctx context.Context) (numerator, denominator int, err error) {
+	allNodesCount, err := resolver.root.NodeGlobalDataStore.CountAllNodes(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	if allNodesCount == 0 {
+		return 0, 0, nil
+	}
+	nodeLoader, err := loaders.GetNodeLoader(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	withThisCVECount, err := nodeLoader.CountFromQuery(resolver.withNodeVulnerabilityScope(ctx), search.EmptyQuery())
+	if err != nil {
+		return 0, 0, err
+	}
+	return int(withThisCVECount), allNodesCount, nil
+}
+
+func (resolver *nodeCVEResolver) withNodeVulnerabilityScope(ctx context.Context) context.Context {
+	return scoped.Context(ctx, scoped.Scope{
+		ID:    resolver.data.GetId(),
+		Level: v1.SearchCategory_NODE_VULNERABILITIES,
+	})
+}
+
+// FixedByVersion returns the version of the parent component that removes this CVE
+func (resolver *nodeCVEResolver) FixedByVersion(ctx context.Context) (string, error) {
+	return resolver.getNodeComponentFixedByVersion(ctx)
+}
+
+func (resolver *nodeCVEResolver) getNodeComponentFixedByVersion(_ context.Context) (string, error) {
+	scope, hasScope := scoped.GetScope(resolver.ctx)
+	if !hasScope {
+		return "", nil
+	}
+	if scope.Level != v1.SearchCategory_NODE_COMPONENTS {
+		return "", nil
+	}
+	edgeID := edges.EdgeID{ParentID: scope.ID, ChildID: resolver.data.GetId()}.ToString()
+	edge, found, err := resolver.root.NodeComponentCVEEdgeDataStore.Get(resolver.ctx, edgeID)
+	if err != nil || !found {
+		return "", err
+	}
+	return edge.GetFixedBy(), nil
+}
+
+// ID of the node CVE
+func (resolver *nodeCVEResolver) ID(ctx context.Context) graphql.ID {
+	value := resolver.data.GetId()
+	return graphql.ID(value)
+}
+
+// IsFixable returns whether node CVE is fixable by any component
+func (resolver *nodeCVEResolver) IsFixable(ctx context.Context, args RawQuery) (bool, error) {
+	// TODO : Why do we remove this field query and then add it back again in addScopeContextOrNodeCVEQuery ?
+	q, err := args.AsV1QueryOrEmpty(search.ExcludeFieldLabel(search.CVE))
+	if err != nil {
+		return false, err
+	}
+
+	ctx, query := resolver.addScopeContextOrNodeCVEQuery(q)
+	query = search.ConjunctionQuery(query, search.NewQueryBuilder().AddBools(search.Fixable, true).ProtoQuery())
+	count, err := resolver.root.NodeComponentCVEEdgeDataStore.Count(ctx, query)
+	if err != nil {
+		return false, err
+	}
+	return count != 0, nil
+}
+
+func (resolver *nodeCVEResolver) addScopeContextOrNodeCVEQuery(query *v1.Query) (context.Context, *v1.Query) {
+	ctx := resolver.ctx
+	scope, ok := scoped.GetScope(ctx)
+	if !ok {
+		return resolver.withNodeVulnerabilityScope(ctx), query
+	}
+	// If the scope is not set to node vulnerabilities then
+	// we need to add a query to scope the search to the current nodeCVE
+	if scope.Level != v1.SearchCategory_NODE_VULNERABILITIES {
+		return ctx, search.ConjunctionQuery(query, resolver.getNodeCVEQuery())
+	}
+
+	return ctx, query
+}
+
+func (resolver *nodeCVEResolver) addScopeContextOrNodeCVERawQuery(query string) (context.Context, string) {
+	ctx := resolver.ctx
+	scope, ok := scoped.GetScope(ctx)
+	if !ok {
+		return resolver.withNodeVulnerabilityScope(ctx), query
+	}
+	// If the scope is not set to node vulnerabilities then
+	// we need to add a query to scope the search to the current nodeCVE
+	if scope.Level != v1.SearchCategory_NODE_VULNERABILITIES {
+		return ctx, search.AddRawQueriesAsConjunction(query, resolver.getNodeCVERawQuery())
+	}
+
+	return ctx, query
+}
+
+func (resolver *nodeCVEResolver) getNodeCVEQuery() *v1.Query {
+	return search.NewQueryBuilder().AddExactMatches(search.CVE, resolver.data.GetId()).ProtoQuery()
+}
+
+func (resolver *nodeCVEResolver) getNodeCVERawQuery() string {
+	return search.NewQueryBuilder().AddExactMatches(search.CVE, resolver.data.GetId()).Query()
+}
+
+// LastModified is the time this node CVE was last modified in the system
+func (resolver *nodeCVEResolver) LastModified(ctx context.Context) (*graphql.Time, error) {
+	value := resolver.data.GetCveBaseInfo().GetLastModified()
+	return timestamp(value)
+}
+
+// LastScanned is the last time this node CVE was last scanned in a node
+func (resolver *nodeCVEResolver) LastScanned(ctx context.Context) (*graphql.Time, error) {
+	nodeLoader, err := loaders.GetNodeLoader(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	q := search.EmptyQuery()
+	q.Pagination = &v1.QueryPagination{
+		Limit:  1,
+		Offset: 0,
+		SortOptions: []*v1.QuerySortOption{
+			{
+				Field:    search.NodeScanTime.String(),
+				Reversed: true,
+			},
+		},
+	}
+
+	nodes, err := nodeLoader.FromQuery(resolver.withNodeVulnerabilityScope(ctx), q)
+	if err != nil || len(nodes) == 0 {
+		return nil, err
+	} else if len(nodes) > 1 {
+		return nil, errors.New("multiple nodes matched for last scanned node vulnerability query")
+	}
+
+	return timestamp(nodes[0].GetScan().GetScanTime())
+}
+
+// Link to the node CVE
+func (resolver *nodeCVEResolver) Link(ctx context.Context) string {
+	return resolver.data.GetCveBaseInfo().GetLink()
+}
+
+// PublishedOn is date and time when this node CVE was first published in the cve feeds
+func (resolver *nodeCVEResolver) PublishedOn(ctx context.Context) (*graphql.Time, error) {
+	value := resolver.data.GetCveBaseInfo().GetPublishedOn()
+	return timestamp(value)
+}
+
+// ScoreVersion of the node CVE
+func (resolver *nodeCVEResolver) ScoreVersion(ctx context.Context) string {
+	value := resolver.data.GetCveBaseInfo().GetScoreVersion()
+	return value.String()
+}
+
+// Summary of the node CVE
+func (resolver *nodeCVEResolver) Summary(ctx context.Context) string {
+	return resolver.data.GetCveBaseInfo().GetSummary()
+}
+
+// SuppressActivation returns the snooze start timestamp of the node CVE
+func (resolver *nodeCVEResolver) SuppressActivation(ctx context.Context) (*graphql.Time, error) {
+	value := resolver.data.GetSnoozeStart()
+	return timestamp(value)
+}
+
+// SuppressExpiry returns the snooze expiration timestamp of the node CVE
+func (resolver *nodeCVEResolver) SuppressExpiry(ctx context.Context) (*graphql.Time, error) {
+	value := resolver.data.GetSnoozeExpiry()
+	return timestamp(value)
+}
+
+// Suppressed returns true if the node CVE is snoozed
+func (resolver *nodeCVEResolver) Suppressed(ctx context.Context) bool {
+	return resolver.data.GetSnoozed()
+}
+
+// UnusedVarSink represents a query sink
+func (resolver *nodeCVEResolver) UnusedVarSink(ctx context.Context, args RawQuery) *int32 {
+	return nil
+}
+
+// Vectors returns the CVSSV3 or CVSSV2 associated with the node CVE
+func (resolver *nodeCVEResolver) Vectors() *EmbeddedVulnerabilityVectorsResolver {
+	if val := resolver.data.GetCveBaseInfo().GetCvssV3(); val != nil {
+		return &EmbeddedVulnerabilityVectorsResolver{
+			resolver: &cVSSV3Resolver{resolver.ctx, resolver.root, val},
+		}
+	}
+	if val := resolver.data.GetCveBaseInfo().GetCvssV2(); val != nil {
+		return &EmbeddedVulnerabilityVectorsResolver{
+			resolver: &cVSSV2Resolver{resolver.ctx, resolver.root, val},
+		}
+	}
+	return nil
+}
+
+// VulnerabilityState returns the effective state of the node CVE (observed, deferred or marked as false positive).
+func (resolver *nodeCVEResolver) VulnerabilityState(ctx context.Context) string {
+	//TODO Should this be removed from nodeVulnerabilities graphQL ?
+	return ""
+}
+
+// NodeComponentCount is the number of node components that contain the node CVE.
+func (resolver *nodeCVEResolver) NodeComponentCount(ctx context.Context, args RawQuery) (int32, error) {
+	//TODO implement me (ROX-11299)
+	panic("implement me")
+}
+
+// NodeComponents are the node components that contain the node CVE.
+func (resolver *nodeCVEResolver) NodeComponents(ctx context.Context, args PaginatedQuery) ([]NodeComponentResolver, error) {
+	//TODO implement me (ROX-11299)
+	panic("implement me")
+}
+
+// NodeCount is the number of nodes that contain the node CVE
+func (resolver *nodeCVEResolver) NodeCount(ctx context.Context, args RawQuery) (int32, error) {
+	ctx, query := resolver.addScopeContextOrNodeCVERawQuery(args.String())
+	return resolver.root.NodeCount(ctx, RawQuery{Query: &query})
+}
+
+// Nodes are the nodes that contain the node CVE
+func (resolver *nodeCVEResolver) Nodes(ctx context.Context, args PaginatedQuery) ([]*nodeResolver, error) {
+	ctx, query := resolver.addScopeContextOrNodeCVERawQuery(args.String())
+	return resolver.root.Nodes(ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
 }
 
 // withNodeCveTypeFiltering adds a conjunction as a raw query to filter vulns by CVEType Node

--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stackrox/rox/central/metrics"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/dackbox/edges"
 	"github.com/stackrox/rox/pkg/features"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres"
 	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -208,7 +208,7 @@ func (resolver *nodeCVEResolver) FixedByVersion(_ context.Context) (string, erro
 	if scope.Level != v1.SearchCategory_NODE_COMPONENTS {
 		return "", nil
 	}
-	edgeID := edges.EdgeID{ParentID: scope.ID, ChildID: resolver.data.GetId()}.ToString()
+	edgeID := postgres.IDFromPks([]string{scope.ID, resolver.data.GetId()})
 	edge, _, err := resolver.root.NodeComponentCVEEdgeDataStore.Get(resolver.ctx, edgeID)
 	if err != nil {
 		return "", err
@@ -235,7 +235,7 @@ func (resolver *nodeCVEResolver) IsFixable(ctx context.Context, args RawQuery) (
 	}
 
 	query = search.ConjunctionQuery(query, search.NewQueryBuilder().AddBools(search.Fixable, true).ProtoQuery())
-	count, err := resolver.root.NodeComponentCVEEdgeDataStore.Count(ctx, query)
+	count, err := resolver.root.NodeCVEDataStore.Count(ctx, query)
 	if err != nil {
 		return false, err
 	}

--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -346,13 +346,13 @@ func (resolver *nodeCVEResolver) Vectors() *EmbeddedVulnerabilityVectorsResolver
 
 // NodeComponentCount is the number of node components that contain the node CVE.
 func (resolver *nodeCVEResolver) NodeComponentCount(ctx context.Context, args RawQuery) (int32, error) {
-	//TODO implement me (ROX-11299)
+	// TODO implement me (ROX-11299)
 	panic("implement me")
 }
 
 // NodeComponents are the node components that contain the node CVE.
 func (resolver *nodeCVEResolver) NodeComponents(ctx context.Context, args PaginatedQuery) ([]NodeComponentResolver, error) {
-	//TODO implement me (ROX-11299)
+	// TODO implement me (ROX-11299)
 	panic("implement me")
 }
 

--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -243,11 +243,11 @@ func (resolver *nodeCVEResolver) IsFixable(ctx context.Context, args RawQuery) (
 }
 
 func (resolver *nodeCVEResolver) getNodeCVEQuery() *v1.Query {
-	return search.NewQueryBuilder().AddExactMatches(search.CVE, resolver.data.GetId()).ProtoQuery()
+	return search.NewQueryBuilder().AddExactMatches(search.CVEID, resolver.data.GetId()).ProtoQuery()
 }
 
 func (resolver *nodeCVEResolver) getNodeCVERawQuery() string {
-	return search.NewQueryBuilder().AddExactMatches(search.CVE, resolver.data.GetId()).Query()
+	return search.NewQueryBuilder().AddExactMatches(search.CVEID, resolver.data.GetId()).Query()
 }
 
 // LastModified is the time this node CVE was last modified in the system

--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -209,8 +209,8 @@ func (resolver *nodeCVEResolver) FixedByVersion(_ context.Context) (string, erro
 		return "", nil
 	}
 	edgeID := edges.EdgeID{ParentID: scope.ID, ChildID: resolver.data.GetId()}.ToString()
-	edge, found, err := resolver.root.NodeComponentCVEEdgeDataStore.Get(resolver.ctx, edgeID)
-	if err != nil || !found {
+	edge, _, err := resolver.root.NodeComponentCVEEdgeDataStore.Get(resolver.ctx, edgeID)
+	if err != nil {
 		return "", err
 	}
 	return edge.GetFixedBy(), nil

--- a/central/graphql/resolvers/nodes.go
+++ b/central/graphql/resolvers/nodes.go
@@ -524,7 +524,7 @@ func (resolver *nodeResolver) NodeVulnerabilityCounter(ctx context.Context, args
 	if err := readNodes(ctx); err != nil {
 		return nil, err
 	}
-	return resolver.root.NodeVulnCounter(resolver.withNodeScopeContext(ctx), args)
+	return resolver.root.NodeVulnerabilityCounter(resolver.withNodeScopeContext(ctx), args)
 }
 
 // PlottedVulns returns the data required by top risky entity scatter-plot on vuln mgmt dashboard

--- a/central/graphql/resolvers/nodes.go
+++ b/central/graphql/resolvers/nodes.go
@@ -405,9 +405,7 @@ func (resolver *nodeResolver) TopNodeVulnerability(ctx context.Context, args Raw
 		return nil, err
 	}
 	vulns, err := vulnLoader.FromQuery(ctx, query)
-	if err != nil {
-		return nil, err
-	} else if len(vulns) == 0 {
+	if err != nil || len(vulns) == 0 {
 		return nil, err
 	} else if len(vulns) > 1 {
 		return nil, errors.New("multiple vulnerabilities matched for top node vulnerability")

--- a/central/graphql/resolvers/nodes.go
+++ b/central/graphql/resolvers/nodes.go
@@ -109,11 +109,11 @@ func (resolver *Resolver) NodeCount(ctx context.Context, args RawQuery) (int32, 
 	if err != nil {
 		return 0, err
 	}
-	results, err := resolver.NodeGlobalDataStore.Search(ctx, query)
+	nodeLoader, err := loaders.GetNodeLoader(ctx)
 	if err != nil {
 		return 0, err
 	}
-	return int32(len(results)), nil
+	return nodeLoader.CountFromQuery(ctx, query)
 }
 
 func (resolver *nodeResolver) Cluster(ctx context.Context) (*clusterResolver, error) {

--- a/central/graphql/resolvers/nodes.go
+++ b/central/graphql/resolvers/nodes.go
@@ -369,7 +369,7 @@ func (resolver *nodeResolver) TopVuln(ctx context.Context, args RawQuery) (Vulne
 		return nil, err
 	}
 
-	query, err := resolver.getTopVulnV1Query(args)
+	query, err := resolver.getTopNodeCVEV1Query(args)
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +387,7 @@ func (resolver *nodeResolver) TopNodeVulnerability(ctx context.Context, args Raw
 		return nil, err
 	}
 
-	query, err := resolver.getTopVulnV1Query(args)
+	query, err := resolver.getTopNodeCVEV1Query(args)
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +405,7 @@ func (resolver *nodeResolver) TopNodeVulnerability(ctx context.Context, args Raw
 	return vulnResolver, nil
 }
 
-func (resolver *nodeResolver) getTopVulnV1Query(args RawQuery) (*v1.Query, error) {
+func (resolver *nodeResolver) getTopNodeCVEV1Query(args RawQuery) (*v1.Query, error) {
 	query, err := args.AsV1QueryOrEmpty()
 	if err != nil {
 		return nil, err

--- a/central/graphql/resolvers/nodes.go
+++ b/central/graphql/resolvers/nodes.go
@@ -317,7 +317,7 @@ func (resolver *nodeResolver) Components(ctx context.Context, args PaginatedQuer
 	}
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getNodeRawQuery())
 
-	return resolver.root.componentsV2(resolver.nodeScopeContext(ctx), PaginatedQuery{Query: &query, Pagination: args.Pagination})
+	return resolver.root.componentsV2(resolver.withNodeScopeContext(ctx), PaginatedQuery{Query: &query, Pagination: args.Pagination})
 }
 
 // ComponentCount returns the number of components in the node
@@ -329,7 +329,7 @@ func (resolver *nodeResolver) ComponentCount(ctx context.Context, args RawQuery)
 
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getNodeRawQuery())
 
-	return resolver.root.componentCountV2(resolver.nodeScopeContext(ctx), RawQuery{Query: &query})
+	return resolver.root.componentCountV2(resolver.withNodeScopeContext(ctx), RawQuery{Query: &query})
 }
 
 // NodeComponents returns the components in the node.
@@ -341,7 +341,7 @@ func (resolver *nodeResolver) NodeComponents(ctx context.Context, args Paginated
 
 	if !features.PostgresDatastore.Enabled() {
 		query := search.AddRawQueriesAsConjunction(args.String(), resolver.getNodeRawQuery())
-		return resolver.root.NodeComponents(resolver.nodeScopeContext(ctx), PaginatedQuery{Query: &query, Pagination: args.Pagination})
+		return resolver.root.NodeComponents(resolver.withNodeScopeContext(ctx), PaginatedQuery{Query: &query, Pagination: args.Pagination})
 	}
 	// TODO : Add postgres support
 	return nil, errors.New("Sub-resolver NodeComponents in Node does not support postgres yet")
@@ -356,7 +356,7 @@ func (resolver *nodeResolver) NodeComponentCount(ctx context.Context, args RawQu
 
 	if !features.PostgresDatastore.Enabled() {
 		query := search.AddRawQueriesAsConjunction(args.String(), resolver.getNodeRawQuery())
-		return resolver.root.NodeComponentCount(resolver.nodeScopeContext(ctx), RawQuery{Query: &query})
+		return resolver.root.NodeComponentCount(resolver.withNodeScopeContext(ctx), RawQuery{Query: &query})
 	}
 	// TODO : Add postgres support
 	return 0, errors.New("Sub-resolver NodeComponentCount in Node does not support postgres yet")
@@ -475,7 +475,7 @@ func (resolver *nodeResolver) Vulns(ctx context.Context, args PaginatedQuery) ([
 	}
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getNodeRawQuery())
 
-	return resolver.root.vulnerabilitiesV2(resolver.nodeScopeContext(ctx), PaginatedQuery{Query: &query, Pagination: args.Pagination})
+	return resolver.root.vulnerabilitiesV2(resolver.withNodeScopeContext(ctx), PaginatedQuery{Query: &query, Pagination: args.Pagination})
 }
 
 // VulnCount returns the number of vulnerabilities the node has.
@@ -486,7 +486,7 @@ func (resolver *nodeResolver) VulnCount(ctx context.Context, args RawQuery) (int
 	}
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getNodeRawQuery())
 
-	return resolver.root.vulnerabilityCountV2(resolver.nodeScopeContext(ctx), RawQuery{Query: &query})
+	return resolver.root.vulnerabilityCountV2(resolver.withNodeScopeContext(ctx), RawQuery{Query: &query})
 }
 
 // VulnCounter resolves the number of different types of vulnerabilities contained in a node.
@@ -497,7 +497,7 @@ func (resolver *nodeResolver) VulnCounter(ctx context.Context, args RawQuery) (*
 	}
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getNodeRawQuery())
 
-	return resolver.root.vulnCounterV2(resolver.nodeScopeContext(ctx), RawQuery{Query: &query})
+	return resolver.root.vulnCounterV2(resolver.withNodeScopeContext(ctx), RawQuery{Query: &query})
 }
 
 // NodeVulnerabilities returns the vulnerabilities in the node.
@@ -506,7 +506,7 @@ func (resolver *nodeResolver) NodeVulnerabilities(ctx context.Context, args Pagi
 	if err := readNodes(ctx); err != nil {
 		return nil, err
 	}
-	return resolver.root.NodeVulnerabilities(resolver.nodeScopeContext(ctx), args)
+	return resolver.root.NodeVulnerabilities(resolver.withNodeScopeContext(ctx), args)
 }
 
 // NodeVulnerabilityCount returns the number of vulnerabilities the node has.
@@ -515,7 +515,7 @@ func (resolver *nodeResolver) NodeVulnerabilityCount(ctx context.Context, args R
 	if err := readNodes(ctx); err != nil {
 		return 0, err
 	}
-	return resolver.root.NodeVulnerabilityCount(resolver.nodeScopeContext(ctx), args)
+	return resolver.root.NodeVulnerabilityCount(resolver.withNodeScopeContext(ctx), args)
 }
 
 // NodeVulnerabilityCounter resolves the number of different types of vulnerabilities contained in a node.
@@ -524,7 +524,7 @@ func (resolver *nodeResolver) NodeVulnerabilityCounter(ctx context.Context, args
 	if err := readNodes(ctx); err != nil {
 		return nil, err
 	}
-	return resolver.root.NodeVulnCounter(resolver.nodeScopeContext(ctx), args)
+	return resolver.root.NodeVulnCounter(resolver.withNodeScopeContext(ctx), args)
 }
 
 // PlottedVulns returns the data required by top risky entity scatter-plot on vuln mgmt dashboard
@@ -540,14 +540,14 @@ func (resolver *nodeResolver) PlottedVulns(ctx context.Context, args RawQuery) (
 // PlottedNodeVulnerabilities returns the data required by top risky entity scatter-plot on vuln mgmt dashboard
 func (resolver *nodeResolver) PlottedNodeVulnerabilities(ctx context.Context, args RawQuery) (*PlottedNodeVulnerabilitiesResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Nodes, "PlottedNodeVulnerabilities")
-	return newPlottedNodeVulnerabilitiesResolver(resolver.nodeScopeContext(ctx), resolver.root, args)
+	return newPlottedNodeVulnerabilitiesResolver(resolver.withNodeScopeContext(ctx), resolver.root, args)
 }
 
 func (resolver *nodeResolver) UnusedVarSink(ctx context.Context, args RawQuery) *int32 {
 	return nil
 }
 
-func (resolver *nodeResolver) nodeScopeContext(ctx context.Context) context.Context {
+func (resolver *nodeResolver) withNodeScopeContext(ctx context.Context) context.Context {
 	return scoped.Context(ctx, scoped.Scope{
 		Level: v1.SearchCategory_NODES,
 		ID:    resolver.data.GetId(),

--- a/central/graphql/resolvers/plotted_node_vulnerabilities.go
+++ b/central/graphql/resolvers/plotted_node_vulnerabilities.go
@@ -3,7 +3,6 @@ package resolvers
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/graphql/resolvers/inputtypes"
 	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/search"
@@ -84,9 +83,9 @@ func (pvr *PlottedNodeVulnerabilitiesResolver) BasicNodeVulnerabilityCounter(_ c
 }
 
 // NodeVulnerabilities returns the node vulnerabilities for top risky nodes scatter-plot
-func (pvr *PlottedNodeVulnerabilitiesResolver) NodeVulnerabilities(ctx context.Context, args *inputtypes.Pagination) ([]NodeVulnerabilityResolver, error) {
+func (pvr *PlottedNodeVulnerabilitiesResolver) NodeVulnerabilities(ctx context.Context, args PaginatedQuery) ([]NodeVulnerabilityResolver, error) {
 	if !features.PostgresDatastore.Enabled() {
-		vulnResolvers, err := unwrappedPlottedVulnerabilities(ctx, pvr.root, pvr.all, PaginatedQuery{Pagination: args})
+		vulnResolvers, err := unwrappedPlottedVulnerabilities(ctx, pvr.root, pvr.all, PaginatedQuery{Pagination: args.Pagination})
 		if err != nil {
 			return nil, err
 		}
@@ -102,5 +101,5 @@ func (pvr *PlottedNodeVulnerabilitiesResolver) NodeVulnerabilities(ctx context.C
 		return nil, nil
 	}
 	q := search.NewQueryBuilder().AddExactMatches(search.CVEID, pvr.all...).Query()
-	return pvr.root.NodeVulnerabilities(ctx, PaginatedQuery{Query: &q, Pagination: args})
+	return pvr.root.NodeVulnerabilities(ctx, PaginatedQuery{Query: &q, Pagination: args.Pagination})
 }

--- a/central/graphql/resolvers/plotted_node_vulnerabilities.go
+++ b/central/graphql/resolvers/plotted_node_vulnerabilities.go
@@ -58,7 +58,9 @@ func newPlottedNodeVulnerabilitiesResolver(ctx context.Context, root *Resolver, 
 		allCveIds = append(allCveIds, cve.GetId())
 	}
 
-	fixableQuery, err := getPlottedVulnsV1Query(args, search.ExcludeFieldLabel(search.Fixable))
+	ErrorOnQueryContainingField(query, search.Fixable, "Unexpected `Fixable` field in PlottedNodeVulnerabilities resolver")
+
+	fixableQuery, err := getPlottedVulnsV1Query(args)
 	fixableCount, err := vulnLoader.CountFromQuery(ctx,
 		search.ConjunctionQuery(fixableQuery, search.NewQueryBuilder().AddBools(search.Fixable, true).ProtoQuery()))
 	if err != nil {
@@ -83,7 +85,7 @@ func (pvr *PlottedNodeVulnerabilitiesResolver) BasicNodeVulnerabilityCounter(_ c
 }
 
 // NodeVulnerabilities returns the node vulnerabilities for top risky nodes scatter-plot
-func (pvr *PlottedNodeVulnerabilitiesResolver) NodeVulnerabilities(ctx context.Context, args PaginatedQuery) ([]NodeVulnerabilityResolver, error) {
+func (pvr *PlottedNodeVulnerabilitiesResolver) NodeVulnerabilities(ctx context.Context, args PaginationWrapper) ([]NodeVulnerabilityResolver, error) {
 	if !features.PostgresDatastore.Enabled() {
 		vulnResolvers, err := unwrappedPlottedVulnerabilities(ctx, pvr.root, pvr.all, PaginatedQuery{Pagination: args.Pagination})
 		if err != nil {

--- a/central/graphql/resolvers/plotted_vulnerabilities_common.go
+++ b/central/graphql/resolvers/plotted_vulnerabilities_common.go
@@ -11,7 +11,7 @@ import (
 
 func getPlottedVulnsIdsAndFixableCount(ctx context.Context, root *Resolver, args RawQuery) ([]string, int, error) {
 	if features.PostgresDatastore.Enabled() {
-		return nil, 0, errors.New("Unexpected access to legacy CVE datastore")
+		return nil, 0, errors.New("unexpected access to legacy CVE datastore")
 	}
 	query, err := getPlottedVulnsV1Query(args)
 	if err != nil {

--- a/central/graphql/resolvers/plotted_vulnerabilities_common.go
+++ b/central/graphql/resolvers/plotted_vulnerabilities_common.go
@@ -31,8 +31,8 @@ func getPlottedVulnsIdsAndFixableCount(ctx context.Context, root *Resolver, args
 	return search.ResultsToIDs(all), fixable, nil
 }
 
-func getPlottedVulnsV1Query(args RawQuery, opts ...search.ParseQueryOption) (*v1.Query, error) {
-	q, err := args.AsV1QueryOrEmpty(opts...)
+func getPlottedVulnsV1Query(args RawQuery) (*v1.Query, error) {
+	q, err := args.AsV1QueryOrEmpty()
 	if err != nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/plotted_vulnerabilities_common.go
+++ b/central/graphql/resolvers/plotted_vulnerabilities_common.go
@@ -2,12 +2,17 @@ package resolvers
 
 import (
 	"context"
+	"errors"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/search"
 )
 
 func getPlottedVulnsIdsAndFixableCount(ctx context.Context, root *Resolver, args RawQuery) ([]string, int, error) {
+	if features.PostgresDatastore.Enabled() {
+		return nil, 0, errors.New("Unexpected access to legacy CVE datastore")
+	}
 	query, err := getPlottedVulnsV1Query(args)
 	if err != nil {
 		return nil, 0, err

--- a/central/graphql/resolvers/plotted_vulnerabilities_common.go
+++ b/central/graphql/resolvers/plotted_vulnerabilities_common.go
@@ -31,8 +31,8 @@ func getPlottedVulnsIdsAndFixableCount(ctx context.Context, root *Resolver, args
 	return search.ResultsToIDs(all), fixable, nil
 }
 
-func getPlottedVulnsV1Query(args RawQuery) (*v1.Query, error) {
-	q, err := args.AsV1QueryOrEmpty()
+func getPlottedVulnsV1Query(args RawQuery, opts ...search.ParseQueryOption) (*v1.Query, error) {
+	q, err := args.AsV1QueryOrEmpty(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/resolver.go
+++ b/central/graphql/resolvers/resolver.go
@@ -39,6 +39,7 @@ import (
 	npDS "github.com/stackrox/rox/central/networkpolicies/datastore"
 	nodeDataStore "github.com/stackrox/rox/central/node/globaldatastore"
 	nodeComponentDataStore "github.com/stackrox/rox/central/nodecomponent/datastore"
+	nodeComponentCVEEdgeDataStore "github.com/stackrox/rox/central/nodecomponentcveedge/datastore"
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/notifier/processor"
 	podDatastore "github.com/stackrox/rox/central/pod/datastore"
@@ -67,53 +68,54 @@ import (
 
 // Resolver is the root GraphQL resolver
 type Resolver struct {
-	ActiveComponent             activeComponent.DataStore
-	ComplianceAggregator        aggregation.Aggregator
-	APITokenBackend             backend.Backend
-	ClusterDataStore            clusterDatastore.DataStore
-	ClusterCVEDataStore         clusterCVEDataStore.DataStore
-	ComplianceDataStore         complianceDS.DataStore
-	ComplianceStandardStore     complianceStandards.Repository
-	ComplianceService           v1.ComplianceServiceServer
-	ComplianceManagementService v1.ComplianceManagementServiceServer
-	ComplianceManager           complianceManager.ComplianceManager
-	clusterCVEEdgeDataStore     clusterCVEEdgeDataStore.DataStore
-	ComponentCVEEdgeDataStore   componentCVEEdgeDataStore.DataStore
-	CVEDataStore                legacyImageCVEDataStore.DataStore
-	ImageCVEDataStore           imageCVEDataStore.DataStore
-	NodeCVEDataStore            nodeCVEDataStore.DataStore
-	DeploymentDataStore         deploymentDatastore.DataStore
-	PodDataStore                podDatastore.DataStore
-	ImageDataStore              imageDatastore.DataStore
-	ImageComponentDataStore     imageComponentDataStore.DataStore
-	NodeComponentDataStore      nodeComponentDataStore.DataStore
-	ImageComponentEdgeDataStore imageComponentEdgeDataStore.DataStore
-	ImageCVEEdgeDataStore       imageCVEEdgeDataStore.DataStore
-	GroupDataStore              groupDataStore.DataStore
-	NamespaceDataStore          namespaceDataStore.DataStore
-	NetworkFlowDataStore        nfDS.ClusterDataStore
-	NetworkPoliciesStore        npDS.DataStore
-	NodeGlobalDataStore         nodeDataStore.GlobalDataStore
-	NotifierStore               notifierDataStore.DataStore
-	PolicyDataStore             policyDatastore.DataStore
-	ProcessIndicatorStore       processIndicatorStore.DataStore
-	K8sRoleStore                k8sroleStore.DataStore
-	K8sRoleBindingStore         k8srolebindingStore.DataStore
-	RoleDataStore               roleDataStore.DataStore
-	RiskDataStore               riskDataStore.DataStore
-	SecretsDataStore            secretDataStore.DataStore
-	ServiceAccountsDataStore    serviceAccountDataStore.DataStore
-	ViolationsDataStore         violationsDatastore.DataStore
-	BaselineDataStore           baselineStore.DataStore
-	WatchedImageDataStore       watchedImageDataStore.DataStore
-	orchestratorIstioCVEManager fetcher.OrchestratorIstioCVEManager
-	cveMatcher                  *cveMatcher.CVEMatcher
-	manager                     complianceOperatorManager.Manager
-	mitreStore                  mitreDataStore.MitreAttackReadOnlyDataStore
-	vulnReqMgr                  requestmgr.Manager
-	vulnReqQueryMgr             querymgr.VulnReqQueryManager
-	vulnReqStore                vulnReqDataStore.DataStore
-	AuditLogger                 auditPkg.Auditor
+	ActiveComponent               activeComponent.DataStore
+	ComplianceAggregator          aggregation.Aggregator
+	APITokenBackend               backend.Backend
+	ClusterDataStore              clusterDatastore.DataStore
+	ClusterCVEDataStore           clusterCVEDataStore.DataStore
+	ComplianceDataStore           complianceDS.DataStore
+	ComplianceStandardStore       complianceStandards.Repository
+	ComplianceService             v1.ComplianceServiceServer
+	ComplianceManagementService   v1.ComplianceManagementServiceServer
+	ComplianceManager             complianceManager.ComplianceManager
+	clusterCVEEdgeDataStore       clusterCVEEdgeDataStore.DataStore
+	ComponentCVEEdgeDataStore     componentCVEEdgeDataStore.DataStore
+	CVEDataStore                  legacyImageCVEDataStore.DataStore
+	ImageCVEDataStore             imageCVEDataStore.DataStore
+	NodeCVEDataStore              nodeCVEDataStore.DataStore
+	DeploymentDataStore           deploymentDatastore.DataStore
+	PodDataStore                  podDatastore.DataStore
+	ImageDataStore                imageDatastore.DataStore
+	ImageComponentDataStore       imageComponentDataStore.DataStore
+	NodeComponentDataStore        nodeComponentDataStore.DataStore
+	NodeComponentCVEEdgeDataStore nodeComponentCVEEdgeDataStore.DataStore
+	ImageComponentEdgeDataStore   imageComponentEdgeDataStore.DataStore
+	ImageCVEEdgeDataStore         imageCVEEdgeDataStore.DataStore
+	GroupDataStore                groupDataStore.DataStore
+	NamespaceDataStore            namespaceDataStore.DataStore
+	NetworkFlowDataStore          nfDS.ClusterDataStore
+	NetworkPoliciesStore          npDS.DataStore
+	NodeGlobalDataStore           nodeDataStore.GlobalDataStore
+	NotifierStore                 notifierDataStore.DataStore
+	PolicyDataStore               policyDatastore.DataStore
+	ProcessIndicatorStore         processIndicatorStore.DataStore
+	K8sRoleStore                  k8sroleStore.DataStore
+	K8sRoleBindingStore           k8srolebindingStore.DataStore
+	RoleDataStore                 roleDataStore.DataStore
+	RiskDataStore                 riskDataStore.DataStore
+	SecretsDataStore              secretDataStore.DataStore
+	ServiceAccountsDataStore      serviceAccountDataStore.DataStore
+	ViolationsDataStore           violationsDatastore.DataStore
+	BaselineDataStore             baselineStore.DataStore
+	WatchedImageDataStore         watchedImageDataStore.DataStore
+	orchestratorIstioCVEManager   fetcher.OrchestratorIstioCVEManager
+	cveMatcher                    *cveMatcher.CVEMatcher
+	manager                       complianceOperatorManager.Manager
+	mitreStore                    mitreDataStore.MitreAttackReadOnlyDataStore
+	vulnReqMgr                    requestmgr.Manager
+	vulnReqQueryMgr               querymgr.VulnReqQueryManager
+	vulnReqStore                  vulnReqDataStore.DataStore
+	AuditLogger                   auditPkg.Auditor
 }
 
 // New returns a Resolver wired into the relevant data stores
@@ -166,6 +168,7 @@ func New() *Resolver {
 		resolver.ClusterCVEDataStore = clusterCVEDataStore.Singleton()
 		resolver.ImageCVEDataStore = imageCVEDataStore.Singleton()
 		resolver.NodeCVEDataStore = nodeCVEDataStore.Singleton()
+		resolver.NodeComponentCVEEdgeDataStore = nodeComponentCVEEdgeDataStore.Singleton()
 		resolver.NodeComponentDataStore = nodeComponentDataStore.Singleton()
 	} else {
 		resolver.CVEDataStore = legacyImageCVEDataStore.Singleton()

--- a/central/graphql/resolvers/search.go
+++ b/central/graphql/resolvers/search.go
@@ -30,6 +30,11 @@ type PaginatedQuery struct {
 	Pagination *inputtypes.Pagination
 }
 
+// PaginationWrapper represents pagination without any query
+type PaginationWrapper struct {
+	Pagination *inputtypes.Pagination
+}
+
 // AsV1QueryOrEmpty returns a proto query or empty proto query if pagination query is empty
 func (r *PaginatedQuery) AsV1QueryOrEmpty() (*v1.Query, error) {
 	var q *v1.Query

--- a/central/graphql/resolvers/utils.go
+++ b/central/graphql/resolvers/utils.go
@@ -358,12 +358,12 @@ func V1RawQueryAsResolverQuery(rQ *v1.RawQuery) (RawQuery, PaginatedQuery) {
 	}
 }
 
-// ErrorOnQueryContainingField logs error if the query contains the given field label
-func ErrorOnQueryContainingField(query *v1.Query, label search.FieldLabel, errMsg string) {
+// logErrorOnQueryContainingField logs error if the query contains the given field label.
+func logErrorOnQueryContainingField(query *v1.Query, label search.FieldLabel, resolver string) {
 	search.ApplyFnToAllBaseQueries(query, func(bq *v1.BaseQuery) {
 		mfQ, ok := bq.GetQuery().(*v1.BaseQuery_MatchFieldQuery)
 		if ok && mfQ.MatchFieldQuery.GetField() == label.String() {
-			log.Errorf(errMsg)
+			log.Errorf("Unexpected field (%s) found in query to resolver (%s). Response maybe unexpected.", label.String(), resolver)
 		}
 	})
 }

--- a/central/graphql/resolvers/utils.go
+++ b/central/graphql/resolvers/utils.go
@@ -357,3 +357,13 @@ func V1RawQueryAsResolverQuery(rQ *v1.RawQuery) (RawQuery, PaginatedQuery) {
 		},
 	}
 }
+
+// ErrorOnQueryContainingField logs error if the query contains the given field label
+func ErrorOnQueryContainingField(query *v1.Query, label search.FieldLabel, errMsg string) {
+	search.ApplyFnToAllBaseQueries(query, func(bq *v1.BaseQuery) {
+		mfQ, ok := bq.GetQuery().(*v1.BaseQuery_MatchFieldQuery)
+		if ok && mfQ.MatchFieldQuery.GetField() == label.String() {
+			log.Errorf(errMsg)
+		}
+	})
+}

--- a/central/graphql/resolvers/vulnerability_counter.go
+++ b/central/graphql/resolvers/vulnerability_counter.go
@@ -128,25 +128,6 @@ func mapCVEsToVulnerabilityCounter(fixable, unFixable []VulnerabilityWithSeverit
 	return counter
 }
 
-func mapNodeCVEsToVulnerabilityCounter(fixable, unFixable []*storage.NodeCVE) *VulnerabilityCounterResolver {
-	counter := emptyVulnerabilityCounter()
-	seenVulns := set.NewStringSet()
-	for _, vuln := range fixable {
-		counter.all.total++
-		counter.all.fixable++
-		seenVulns.Add(vuln.GetId())
-		incCounterBySev(counter, vuln.GetSeverity(), true)
-	}
-
-	for _, vuln := range unFixable {
-		if !seenVulns.Contains(vuln.GetId()) {
-			counter.all.total++
-			incCounterBySev(counter, vuln.GetSeverity(), false)
-		}
-	}
-	return counter
-}
-
 func incCounterBySev(counter *VulnerabilityCounterResolver, sev storage.VulnerabilitySeverity, fixable bool) {
 	switch sev {
 	case storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY, storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY:

--- a/central/graphql/resolvers/vulnerability_counter.go
+++ b/central/graphql/resolvers/vulnerability_counter.go
@@ -75,6 +75,7 @@ func (evr *VulnerabilityFixableCounterResolver) Fixable(_ context.Context) int32
 	return evr.fixable
 }
 
+// VulnerabilityWithSeverity provides functionality to fetch vulnerability severity.
 type VulnerabilityWithSeverity interface {
 	GetId() string
 	GetSeverity() storage.VulnerabilitySeverity

--- a/central/graphql/resolvers/vulnerability_counter.go
+++ b/central/graphql/resolvers/vulnerability_counter.go
@@ -128,6 +128,25 @@ func mapCVEsToVulnerabilityCounter(fixable, unFixable []VulnerabilityWithSeverit
 	return counter
 }
 
+func mapNodeCVEsToVulnerabilityCounter(fixable, unFixable []*storage.NodeCVE) *VulnerabilityCounterResolver {
+	counter := emptyVulnerabilityCounter()
+	seenVulns := set.NewStringSet()
+	for _, vuln := range fixable {
+		counter.all.total++
+		counter.all.fixable++
+		seenVulns.Add(vuln.GetId())
+		incCounterBySev(counter, vuln.GetSeverity(), true)
+	}
+
+	for _, vuln := range unFixable {
+		if !seenVulns.Contains(vuln.GetId()) {
+			counter.all.total++
+			incCounterBySev(counter, vuln.GetSeverity(), false)
+		}
+	}
+	return counter
+}
+
 func incCounterBySev(counter *VulnerabilityCounterResolver, sev storage.VulnerabilitySeverity, fixable bool) {
 	switch sev {
 	case storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY, storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY:

--- a/central/node/datastore/internal/search/searcher_impl_v2.go
+++ b/central/node/datastore/internal/search/searcher_impl_v2.go
@@ -7,9 +7,11 @@ import (
 	"github.com/stackrox/rox/central/node/index"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
-	"github.com/stackrox/rox/pkg/search/scoped/postgres"
+	"github.com/stackrox/rox/pkg/search/paginated"
+	"github.com/stackrox/rox/pkg/search/sortfields"
 )
 
 // NewV2 returns a new instance of Searcher for the given storage and indexer.
@@ -17,8 +19,14 @@ func NewV2(storage store.Store, indexer index.Indexer) Searcher {
 	return &searcherImplV2{
 		storage:  storage,
 		indexer:  indexer,
-		searcher: postgres.WithScoping(blevesearch.WrapUnsafeSearcherAsSearcher(indexer)),
+		searcher: formatSearcherV2(indexer),
 	}
+}
+
+func formatSearcherV2(unsafeSearcher blevesearch.UnsafeSearcher) search.Searcher {
+	safeSearcher := blevesearch.WrapUnsafeSearcherAsSearcher(unsafeSearcher)
+	transformedSortFieldSearcher := sortfields.TransformSortFields(safeSearcher, schema.NodesSchema.OptionsMap)
+	return paginated.WithDefaultSortOption(transformedSortFieldSearcher, defaultSortOption)
 }
 
 type searcherImplV2 struct {

--- a/central/node/datastore/internal/search/searcher_impl_v2.go
+++ b/central/node/datastore/internal/search/searcher_impl_v2.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/paginated"
+	"github.com/stackrox/rox/pkg/search/scoped/postgres"
 	"github.com/stackrox/rox/pkg/search/sortfields"
 )
 
@@ -25,7 +26,8 @@ func NewV2(storage store.Store, indexer index.Indexer) Searcher {
 
 func formatSearcherV2(unsafeSearcher blevesearch.UnsafeSearcher) search.Searcher {
 	safeSearcher := blevesearch.WrapUnsafeSearcherAsSearcher(unsafeSearcher)
-	transformedSortFieldSearcher := sortfields.TransformSortFields(safeSearcher, schema.NodesSchema.OptionsMap)
+	scopedSafeSearcher := postgres.WithScoping(safeSearcher)
+	transformedSortFieldSearcher := sortfields.TransformSortFields(scopedSafeSearcher, schema.NodesSchema.OptionsMap)
 	return paginated.WithDefaultSortOption(transformedSortFieldSearcher, defaultSortOption)
 }
 

--- a/pkg/cvss/severity.go
+++ b/pkg/cvss/severity.go
@@ -44,6 +44,15 @@ func NewFromNodeVulnerability(vuln *storage.NodeVulnerability) VulnI {
 	}
 }
 
+func NewFromNodeCVE(vuln *storage.NodeCVE) VulnI {
+	return &vulnScoreInfo{
+		severity:     vuln.GetSeverity(),
+		cvssV3:       vuln.GetCveBaseInfo().GetCvssV3(),
+		cvssv2:       vuln.GetCveBaseInfo().GetCvssV2(),
+		scoreVersion: vuln.GetCveBaseInfo().GetScoreVersion(),
+	}
+}
+
 type vulnScoreInfo struct {
 	severity     storage.VulnerabilitySeverity
 	cvssv2       *storage.CVSSV2

--- a/pkg/cvss/severity.go
+++ b/pkg/cvss/severity.go
@@ -44,15 +44,6 @@ func NewFromNodeVulnerability(vuln *storage.NodeVulnerability) VulnI {
 	}
 }
 
-func NewFromNodeCVE(vuln *storage.NodeCVE) VulnI {
-	return &vulnScoreInfo{
-		severity:     vuln.GetSeverity(),
-		cvssV3:       vuln.GetCveBaseInfo().GetCvssV3(),
-		cvssv2:       vuln.GetCveBaseInfo().GetCvssV2(),
-		scoreVersion: vuln.GetCveBaseInfo().GetScoreVersion(),
-	}
-}
-
 type vulnScoreInfo struct {
 	severity     storage.VulnerabilitySeverity
 	cvssv2       *storage.CVSSV2


### PR DESCRIPTION
## Description

- Added NodeVulnerabilitiesResolver implementation that uses Postgres
- Wired up node vulnerability sub resolvers in cluster and node to use the new implementation when Postgres is enabled
- Added NodeCVELoader
- Updated plotted node vulnerabilities resolvers to use NodeCVEDatastore when Postgres is enabled 

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- Manually tested by querying the resolvers to see if they return node vulnerabilities (and no other vulns) and that they contain expected fields, when Postgres is enabled.
- e2e/unit tests will be added in a separate task.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
