### PR TITLE
Scan collector-full, scanner-slim and scanner-db-slim in quay

### DIFF
--- a/release/scripts/vuln_check.sh
+++ b/release/scripts/vuln_check.sh
@@ -104,12 +104,15 @@ compare_fixable_vulns "docs" "$DOCS_PRERELEASE_TAG"
 
 # check collector images
 compare_fixable_vulns "collector" "${COLLECTOR_TAG}-slim"
+compare_fixable_vulns "collector" "${COLLECTOR_TAG}"
 
 # check scanner images
 compare_fixable_vulns "scanner" "$SCANNER_TAG"
+compare_fixable_vulns "scanner-slim" "$SCANNER_TAG"
 
 # check scanner-db images
 compare_fixable_vulns "scanner-db" "$SCANNER_TAG"
+compare_fixable_vulns "scanner-db-slim" "$SCANNER_TAG"
 
 # if fixable vulns found, return 1 so CI can fail the job
 [ "$FAIL_SCRIPT" = true ] && exit 1 || exit 0


### PR DESCRIPTION
## Description

We build and push these images. Why don't we scan them?

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~ no tests for config.
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ not user-facing.
- ~~[ ] Determined and documented upgrade steps~~ not user-facing.
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~ not needed.

## Testing Performed

* Ran check script via a change that temporarily enabled it on PR. Results here https://app.circleci.com/pipelines/github/stackrox/stackrox/15224/workflows/72b08585-6554-4a39-a7a1-fea4906673c4/jobs/708617/parallel-runs/0/steps/0-103