### PR TITLE
Fix severity show/hide functionality in violations by category widget

### DIFF
--- a/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
+++ b/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
@@ -85,8 +85,8 @@ describe('Dashboard security metrics phase one action widgets', () => {
         cy.get(widgetSelectors.optionsToggle).click();
 
         // Toggle off low and medium violations
-        cy.get(widgetSelectors.legendLabel(0)).click();
-        cy.get(widgetSelectors.legendLabel(1)).click();
+        cy.get(widgetSelectors.legendLabel(2)).click();
+        cy.get(widgetSelectors.legendLabel(3)).click();
 
         cy.get(`${widgetSelectors.axisLabel(0, 4)}:contains('Network Tools')`);
         cy.get(`${widgetSelectors.axisLabel(0, 3)}:contains('Privileges')`);

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -41,7 +41,11 @@ import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import useURLSearch from 'hooks/useURLSearch';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';
-import { LifecycleStage, policySeverities, PolicySeverity } from 'types/policy.proto';
+import {
+    LifecycleStage,
+    policySeverities as severitiesLowToCritical,
+    PolicySeverity,
+} from 'types/policy.proto';
 
 import { SearchFilter } from 'types/search';
 import useAlertGroups from '../hooks/useAlertGroups';
@@ -49,7 +53,7 @@ import WidgetCard from './WidgetCard';
 
 // The ordering of the legend and the hidden severities runs from Critical->Low
 // so we reverse the order of the default Low->Critical in most cases.
-const severitiesCriticalToLow = [...policySeverities].reverse();
+const severitiesCriticalToLow = [...severitiesLowToCritical].reverse();
 
 /**
  * This function iterates an array of AlertGroups and zeros out severities that
@@ -174,7 +178,7 @@ function ViolationsByPolicyCategoryChart({
 
     // The bars run opposite to the severity display in the rest of the widget, so we iterate the original
     // order of Low->Critical
-    const bars = policySeverities.map((severity) => {
+    const bars = severitiesLowToCritical.map((severity) => {
         const counts = countsBySeverity[severity];
         const data = Object.entries(counts).map(([group, count]) => ({
             name: severity,


### PR DESCRIPTION
## Description

Fixes a bug introduced by the reversing of the chart legend. The reversal also required a reversal of the index check when showing/hiding individual severities, otherwise the wrong severity would be hidden.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Click on the "Low" item in the legend. The low violations should be hidden in the chart. (Previously this would hide the critical violations).
<img width="668" alt="image" src="https://user-images.githubusercontent.com/1292638/176034564-3b5c652e-5507-4e09-91e4-0222735007b7.png">

Click the "Medium" item in the legend. The medium violations should be hidden in the chart. (Previously this would hide the high violations).
<img width="668" alt="image" src="https://user-images.githubusercontent.com/1292638/176034663-3ce90ff3-2861-4dc8-9cc7-016eb77e308e.png">

Click both "Low" and "Medium" again. The chart should return to its original state.
<img width="668" alt="image" src="https://user-images.githubusercontent.com/1292638/176034730-f247ffe5-51a5-4efc-b799-2c2b76516cae.png">

