### PR TITLE
ROX-10821: Don't alias ID from CVE name

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
@@ -49,7 +49,7 @@ const CveBulkActionDialogue = ({ closeAction, bulkActionCveIds }) => {
     const CVES_QUERY = gql`
         query getCves($query: String) {
             results: vulnerabilities(query: $query) {
-                id: cve
+                id
                 cve
                 summary
                 vulnerabilityTypes

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
@@ -60,7 +60,7 @@ export const VULN_CVE_ONLY_FRAGMENT = gql`
 // TODO: remove this fragment after switch to Image/Node/Cluster vuln types
 export const VULN_CVE_DETAIL_FRAGMENT = gql`
     fragment cveFields on EmbeddedVulnerability {
-        id: cve
+        id
         cve
         vulnerabilityTypes
         envImpact
@@ -216,7 +216,7 @@ export const CLUSTER_CVE_DETAIL_FRAGMENT = gql`
 
 export const VULN_CVE_LIST_FRAGMENT = gql`
     fragment cveFields on EmbeddedVulnerability {
-        id: cve
+        id
         cve
         cvss
         vulnerabilityTypes

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabiltiesInDeployment.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabiltiesInDeployment.js
@@ -22,7 +22,7 @@ const MOST_COMMON_VULNERABILITIES = gql`
         $vulnPagination: Pagination
     ) {
         results: vulnerabilities(query: $query, pagination: $vulnPagination) {
-            id: cve
+            id
             cve
             cvss
             scoreVersion

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/RecentlyDetectedVulnerabilities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/RecentlyDetectedVulnerabilities.js
@@ -22,7 +22,7 @@ export const RECENTLY_DETECTED_VULNERABILITIES = gql`
         $pagination: Pagination
     ) {
         results: vulnerabilities(query: $query, pagination: $pagination) {
-            id: cve
+            id
             cve
             cvss
             scoreVersion

--- a/ui/apps/platform/src/queries/cve.js
+++ b/ui/apps/platform/src/queries/cve.js
@@ -3,7 +3,7 @@ import { gql } from '@apollo/client';
 export const CVE_NAME = gql`
     query getCveName($id: ID!) {
         vulnerability(id: $id) {
-            id: cve
+            id
             name: cve
             cve
         }


### PR DESCRIPTION
## Description

As the title suggests, this is removing the aliasing of `cve` -> `id`, since the `id` field does exist on the proto object now

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

