### PR TITLE
RS-443: Handle nightly runs

### DIFF
--- a/.openshift-ci/build/build-central-db-bundle.sh
+++ b/.openshift-ci/build/build-central-db-bundle.sh
@@ -24,6 +24,10 @@ build_central-db-bundle() {
     "$ROOT/status.sh" || true
 
     openshift_ci_mods
+    handle_nightly_runs
+
+    info "Status after mods:"
+    "$ROOT/status.sh" || true
 
     info "Make the central-db image Dockerfile"
     make "$ROOT/image/postgres/Dockerfile.gen"

--- a/.openshift-ci/build/build-main-and-bundle.sh
+++ b/.openshift-ci/build/build-main-and-bundle.sh
@@ -116,6 +116,10 @@ build_main_and_bundles() {
     "$ROOT/status.sh" || true
 
     openshift_ci_mods
+    handle_nightly_runs
+
+    info "Status after mods:"
+    "$ROOT/status.sh" || true
 
     info "Make the main image Dockerfile"
     make "$ROOT/image/rhel/Dockerfile.gen"

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -11,6 +11,7 @@ for cred in /tmp/secret/**/[A-Z]*; do
 done
 
 openshift_ci_mods
+handle_nightly_runs
 
 function hold() {
     while [[ -e /tmp/hold ]]; do

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -10,8 +10,14 @@ for cred in /tmp/secret/**/[A-Z]*; do
     export "$(basename "$cred")"="$(cat "$cred")"
 done
 
+info "Current Status:"
+"$ROOT/status.sh" || true
+
 openshift_ci_mods
 handle_nightly_runs
+
+info "Status after mods:"
+"$ROOT/status.sh" || true
 
 function hold() {
     while [[ -e /tmp/hold ]]; do

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -78,7 +78,7 @@ class Helpers {
         }
 
         if (exception && (exception instanceof AssumptionViolatedException ||
-                exception.getMessage().contains("org.junit.AssumptionViolatedException"))) {
+                exception.getMessage()?.contains("org.junit.AssumptionViolatedException"))) {
             log.info("Won't collect logs for: ${exception.getMessage()}", exception)
             return
         }

--- a/scripts/ci/bats/lib_is_in_PR_context.bats
+++ b/scripts/ci/bats/lib_is_in_PR_context.bats
@@ -5,6 +5,9 @@ load "../../test_helpers.bats"
 
 function setup() {
     export CI=true
+    unset OPENSHIFT_CI
+    unset PULL_NUMBER
+    unset CLONEREFS_OPTIONS
     source "${BATS_TEST_DIRNAME}/../lib.sh"
 }
 

--- a/scripts/ci/bats/lib_is_in_PR_context.bats
+++ b/scripts/ci/bats/lib_is_in_PR_context.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC1091
+
+load "../../test_helpers.bats"
+
+function setup() {
+    export CI=true
+    source "${BATS_TEST_DIRNAME}/../lib.sh"
+}
+
+@test "is_in_PR_context() is not by default" {
+    run is_in_PR_context
+    assert_failure 1
+    assert_output ''
+}
+
+@test "is_in_PR_context() is not for OpenShift CI" {
+    export OPENSHIFT_CI=true
+    run is_in_PR_context
+    assert_failure 1
+    assert_output ''
+}
+
+@test "is_in_PR_context() is for OpenShift CI pulls" {
+    export OPENSHIFT_CI=true
+    export PULL_NUMBER=99
+    run is_in_PR_context
+    assert_success
+    assert_output ''
+}
+
+@test "is_in_PR_context() is for OpenShift CI test-bin" {
+    export OPENSHIFT_CI=true
+    export CLONEREFS_OPTIONS='{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"stackrox","repo":"stackrox","repo_link":"https://github.com/stackrox/stackrox","base_ref":"master","base_sha":"9827e744730820045fa14935f3cd1858c9a1afad","base_link":"https://github.com/stackrox/stackrox/commit/9827e744730820045fa14935f3cd1858c9a1afad","pulls":[{"number":2224,"author":"gavin-stackrox","sha":"3bfd0d09eb2bf5e8be74e87724512ca714a1f516","link":"https://github.com/stackrox/stackrox/pull/2224","commit_link":"https://github.com/stackrox/stackrox/pull/2224/commits/3bfd0d09eb2bf5e8be74e87724512ca714a1f516","author_link":"https://github.com/gavin-stackrox"}]}],"fail":true}'
+    run is_in_PR_context
+    assert_success
+    assert_output ''
+}
+
+@test "is_in_PR_context() is not for OpenShift CI unexpected env" {
+    export OPENSHIFT_CI=true
+    export CLONEREFS_OPTIONS='{"bad":"ness"}'
+    run is_in_PR_context
+    assert_failure 1
+    assert_output ''
+}
+
+@test "is_in_PR_context() is not for OpenShift CI unexpected env II" {
+    export OPENSHIFT_CI=true
+    export CLONEREFS_OPTIONS='real badness'
+    run is_in_PR_context
+    assert_failure 1
+    assert_output ''
+}

--- a/scripts/ci/jobs/test-binary-build-commands.sh
+++ b/scripts/ci/jobs/test-binary-build-commands.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 make_test_bin() {
     info "Making test-bin"
 
+    info "Current Status:"
+    "$ROOT/status.sh" || true
+
     make cli upgrader
     install_built_roxctl_in_gopath
 }

--- a/scripts/ci/jobs/test-binary-build-commands.sh
+++ b/scripts/ci/jobs/test-binary-build-commands.sh
@@ -8,9 +8,6 @@ set -euo pipefail
 make_test_bin() {
     info "Making test-bin"
 
-    info "Current Status:"
-    "$ROOT/status.sh" || true
-
     make cli upgrader
     install_built_roxctl_in_gopath
 }

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -490,7 +490,7 @@ is_in_PR_context() {
         return 0
     elif is_OPENSHIFT_CI; then
         # bin, test-bin, images
-        get_pr_details > /dev/null 2>&1 || return "$?"
+        get_pr_details > /dev/null 2>&1 && return 0
     fi
 
     return 1

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -484,7 +484,16 @@ is_nightly_run() {
 }
 
 is_in_PR_context() {
-    (is_CIRCLECI && [[ -n "${CIRCLE_PULL_REQUEST:-}" ]]) || (is_OPENSHIFT_CI && [[ -n "${PULL_NUMBER:-}" ]])
+    if is_CIRCLECI && [[ -n "${CIRCLE_PULL_REQUEST:-}" ]]; then
+        return 0
+    elif is_OPENSHIFT_CI && [[ -n "${PULL_NUMBER:-}" ]]; then
+        return 0
+    elif is_OPENSHIFT_CI; then
+        # bin, test-bin, images
+        get_pr_details > /dev/null 2>&1 || return "$?"
+    fi
+
+    return 1
 }
 
 is_openshift_CI_rehearse_PR() {

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -837,7 +837,7 @@ handle_nightly_runs() {
     if ! is_in_PR_context && [[ "${JOB_NAME_SAFE:-}" =~ ^nightly- ]]; then
         ci_export CIRCLE_TAG "${nightly_tag_prefix}$(date '+%Y%m%d')"
     elif is_in_PR_context && pr_has_label "simulate-nightly-run"; then
-        ci_export CIRCLE_TAG "${nightly_tag_prefix}${BUILD_ID: -8}"
+        ci_export CIRCLE_TAG "${nightly_tag_prefix}${PULL_PULL_SHA:0:8}"
     fi
 }
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -832,6 +832,10 @@ handle_nightly_runs() {
         die "Only for OpenShift CI"
     fi
 
+    info "Debug:"
+    env | sort || true
+    info "PR: $(is_in_PR_context)" || true
+
     local nightly_tag_prefix
     nightly_tag_prefix="$(git describe --tags --abbrev=0 --exclude '*-nightly-*')-nightly-"
     if ! is_in_PR_context && [[ "${JOB_NAME_SAFE:-}" =~ ^nightly- ]]; then

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -841,10 +841,6 @@ handle_nightly_runs() {
         die "Only for OpenShift CI"
     fi
 
-    info "Debug:"
-    env | sort || true
-    info "PR: $(is_in_PR_context)" || true
-
     local nightly_tag_prefix
     nightly_tag_prefix="$(git describe --tags --abbrev=0 --exclude '*-nightly-*')-nightly-"
     if ! is_in_PR_context && [[ "${JOB_NAME_SAFE:-}" =~ ^nightly- ]]; then

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -850,7 +850,13 @@ handle_nightly_runs() {
     if ! is_in_PR_context && [[ "${JOB_NAME_SAFE:-}" =~ ^nightly- ]]; then
         ci_export CIRCLE_TAG "${nightly_tag_prefix}$(date '+%Y%m%d')"
     elif is_in_PR_context && pr_has_label "simulate-nightly-run"; then
-        ci_export CIRCLE_TAG "${nightly_tag_prefix}${PULL_PULL_SHA:0:8}"
+        local sha
+        if [[ -n "${PULL_PULL_SHA:-}" ]]; then
+            sha="${PULL_PULL_SHA}"
+        else
+            sha=$(jq -r <<<"$CLONEREFS_OPTIONS" '.refs[0].pulls[0].sha')
+        fi
+        ci_export CIRCLE_TAG "${nightly_tag_prefix}${sha:0:8}"
     fi
 }
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -832,12 +832,12 @@ handle_nightly_runs() {
         die "Only for OpenShift CI"
     fi
 
-    local nightly_tag
-    nightly_tag="$(git describe --tags --abbrev=0 --exclude '*-nightly-*')-nightly-$(date '+%Y%m%d')"
+    local nightly_tag_prefix
+    nightly_tag_prefix="$(git describe --tags --abbrev=0 --exclude '*-nightly-*')-nightly-"
     if ! is_in_PR_context && [[ "${JOB_NAME_SAFE:-}" =~ ^nightly- ]]; then
-        ci_export CIRCLE_TAG "${nightly_tag}"
+        ci_export CIRCLE_TAG "${nightly_tag_prefix}$(date '+%Y%m%d')"
     elif is_in_PR_context && pr_has_label "simulate-nightly-run"; then
-        ci_export CIRCLE_TAG "${nightly_tag}"
+        ci_export CIRCLE_TAG "${nightly_tag_prefix}${BUILD_ID: -8}"
     fi
 }
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -53,7 +53,7 @@ deploy_central() {
 
     # If we're running a nightly build or race condition check, then set CGO_CHECKS=true so that central is
     # deployed with strict checks
-    if is_nightly_tag || pr_has_label ci-race-tests; then
+    if is_nightly_run || pr_has_label ci-race-tests; then
         ci_export CGO_CHECKS "true"
     fi
 


### PR DESCRIPTION
## Description

Sets CIRCLE_TAG for nightly test runs. This relies on makes use of CIRCLE_TAG to indicate that this is a release build.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

With `simulate-nightly-run` label:
- [x] builds are tagged in the nightly manner: `1.2.x-nightly-12345678` (simulation does not use -date to avoid clash with real nightlies) - [3.70.x-nightly-8ebd9fee](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/stackrox_stackrox/2224/pull-ci-stackrox-stackrox-master-push-images/1541650021340942336/artifacts/push-images/push/build-log.txt)
- [x] builds are release:
```
[1;30m06:04:23[0;39m | [34mINFO [0;39m | BaseSpecification         | version: "3.70.x-nightly-8ebd9fee"
    build_flavor: "release"
    release_build: true
    license_status: VALID
```
- [x] ~qa tests test 'all'~ will check the actual nightly run
