### PR TITLE
ROX-10920: Fix ComplianceTest aggregation

### DIFF
--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -265,7 +265,7 @@ class ComplianceTest extends BaseSpecification {
             def countPassing = (counts.get(ComplianceState.COMPLIANCE_STATE_SUCCESS) ?: []).size()
             assert result.numPassing == countPassing
 
-            def countFailing == (counts.get(ComplianceState.COMPLIANCE_STATE_FAILURE) ?: []).size() +
+            def countFailing = (counts.get(ComplianceState.COMPLIANCE_STATE_FAILURE) ?: []).size() +
                     (counts.get(ComplianceState.COMPLIANCE_STATE_ERROR) ?: []).size()
             assert result.numFailing == countFailing
         }

--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -261,9 +261,13 @@ class ComplianceTest extends BaseSpecification {
                     .removeAll(counts.get(ComplianceState.COMPLIANCE_STATE_FAILURE) ?: [])
             counts.get(ComplianceState.COMPLIANCE_STATE_SUCCESS)
                     .removeAll(counts.get(ComplianceState.COMPLIANCE_STATE_ERROR) ?: [])
-            assert result.numPassing == counts.get(ComplianceState.COMPLIANCE_STATE_SUCCESS)?.size() ?: 0
-            assert result.numFailing == counts.get(ComplianceState.COMPLIANCE_STATE_FAILURE)?.size() ?: 0 +
-                    counts.get(ComplianceState.COMPLIANCE_STATE_ERROR)?.size() ?: 0
+
+            def countPassing = (counts.get(ComplianceState.COMPLIANCE_STATE_SUCCESS) ?: []).size()
+            assert result.numPassing == countPassing
+
+            def countFailing == (counts.get(ComplianceState.COMPLIANCE_STATE_FAILURE) ?: []).size() +
+                    (counts.get(ComplianceState.COMPLIANCE_STATE_ERROR) ?: []).size()
+            assert result.numFailing == countFailing
         }
     }
 


### PR DESCRIPTION
## Description

Let's do this again. Fix the groovy. This would fail on select orchestrators because most of the checks for docker are skipped and then if its passes for ssh, then there are no failed and no errored

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
