### PR TITLE
Update aging images query to use new date range queries.

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
@@ -12,9 +12,9 @@ const range1 = '90';
 const range2 = '180';
 const range3 = '365';
 
-const result0 = 40;
-const result1 = 32;
-const result2 = 31;
+const result0 = 8;
+const result1 = 1;
+const result2 = 13;
 const result3 = 18;
 
 const mocks = [
@@ -22,9 +22,9 @@ const mocks = [
         request: {
             query: imageCountQuery,
             variables: {
-                query0: `Image Created Time:>${range0}d`,
-                query1: `Image Created Time:>${range1}d`,
-                query2: `Image Created Time:>${range2}d`,
+                query0: `Image Created Time:${range0}d-${range1}d`,
+                query1: `Image Created Time:${range1}d-${range2}d`,
+                query2: `Image Created Time:${range2}d-${range3}d`,
                 query3: `Image Created Time:>${range3}d`,
             },
         },
@@ -56,18 +56,18 @@ describe('AgingImages dashboard widget', () => {
             </MockedProvider>
         );
 
-        // When all items are selected, the total should be equal to the most recent time
-        // range returned by the server
+        // When all items are selected, the total should be equal to the total of all buckets
+        // returned by the server
         const cardHeading = await screen.findByRole('heading', {
-            name: `${result0} Aging images`,
+            name: `${result0 + result1 + result2 + result3} Aging images`,
         });
         expect(cardHeading).toBeInTheDocument();
 
         // Each bar should display text that is specific to that time bucket, not
         // cumulative.
-        expect(await screen.findByText(result0 - result1)).toBeInTheDocument();
-        expect(await screen.findByText(result1 - result2)).toBeInTheDocument();
-        expect(await screen.findByText(result2 - result3)).toBeInTheDocument();
+        expect(await screen.findByText(result0)).toBeInTheDocument();
+        expect(await screen.findByText(result1)).toBeInTheDocument();
+        expect(await screen.findByText(result2)).toBeInTheDocument();
         expect(await screen.findByText(result3)).toBeInTheDocument();
     });
 
@@ -90,14 +90,14 @@ describe('AgingImages dashboard widget', () => {
         // in the chart or the card header
         expect(
             await screen.findByRole('heading', {
-                name: `${result1} Aging images`,
+                name: `${result1 + result2 + result3} Aging images`,
             })
         ).toBeInTheDocument();
 
         // Test values at top of each bar
-        expect(() => screen.getByText(result0 - result1)).toThrow();
-        expect(await screen.findByText(result1 - result2)).toBeInTheDocument();
-        expect(await screen.findByText(result2 - result3)).toBeInTheDocument();
+        expect(() => screen.getByText(result0)).toThrow();
+        expect(await screen.findByText(result1)).toBeInTheDocument();
+        expect(await screen.findByText(result2)).toBeInTheDocument();
         expect(await screen.findByText(result3)).toBeInTheDocument();
 
         // Test display of x-axis
@@ -112,14 +112,14 @@ describe('AgingImages dashboard widget', () => {
         // should revert to the original value.
         expect(
             await screen.findByRole('heading', {
-                name: `${result0} Aging images`,
+                name: `${result0 + result1 + result2 + result3} Aging images`,
             })
         ).toBeInTheDocument();
 
-        expect(await screen.findByText(result0 - result1)).toBeInTheDocument();
+        expect(await screen.findByText(result0)).toBeInTheDocument();
         // The second bar in the chart should now contain values from the second and third buckets
-        expect(await screen.findByText(result1 - result3)).toBeInTheDocument();
-        expect(() => screen.getByText(result2 - result3)).toThrow();
+        expect(await screen.findByText(result1 + result2)).toBeInTheDocument();
+        expect(() => screen.getByText(result2)).toThrow();
         expect(await screen.findByText(result3)).toBeInTheDocument();
 
         // Test display of x-axis


### PR DESCRIPTION
## Description

Updates the Aging Images widget to use new date range query functionality in central.

This allow us to send queries like `Image Updated Time:30d-90d` to group date ranges into buckets. This also enables us to pass these values via URL parameters to the VulnMgmt images page to filter that table to the selected range.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

The test process for the widget itself is unchanged from the original test steps described in this PR:
https://github.com/stackrox/stackrox/pull/2138

The new test procedure for the x-axis links on the chart is as follows.

Load the dashboard and take note of the number of images in the 90-180 column, then click the link below the graph. The link should take you to the VulnMgmt images page with a `90d-180d` filter applied, resulting in the same number of images.
<img width="656" alt="image" src="https://user-images.githubusercontent.com/1292638/176284752-21ca5fac-079d-4f26-bff4-7c97cfe2a57e.png">
<img width="887" alt="image" src="https://user-images.githubusercontent.com/1292638/176285725-fe6adc24-d432-4068-8fac-2076f6b3b51a.png">

Repeat this process, but selecting the >1 year column. You should be taken to the VulnMgmt page with a `>365d` filter applied, resulting in the same number of images.
<img width="656" alt="image" src="https://user-images.githubusercontent.com/1292638/176284752-21ca5fac-079d-4f26-bff4-7c97cfe2a57e.png">
<img width="901" alt="image" src="https://user-images.githubusercontent.com/1292638/176285915-6823074c-120e-4895-bdb8-804596b3e782.png">

On the dashboard, deselect one of the time ranges to collapse the bucket with the one before it. Repeat the process above and ensure the VulnMgmt page displays the correct filter and number of images.
<img width="656" alt="image" src="https://user-images.githubusercontent.com/1292638/176285028-b45002ef-8f8d-4b0d-ab84-a77f2b466bb2.png">
<img width="901" alt="image" src="https://user-images.githubusercontent.com/1292638/176286099-d5ebd518-c8aa-4d0f-9600-4aaa7600dfe3.png">

