### PR TITLE
Fix table row duplication bug in risky deployments widget

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRiskTable.tsx
@@ -43,7 +43,7 @@ function DeploymentsAtMostRiskTable({
             </Thead>
             <Tbody>
                 {deployments.map(({ id, name, cluster, namespace, priority }) => (
-                    <Tr key={name}>
+                    <Tr key={id}>
                         <Td className="pf-u-pl-0" dataLabel={columnNames.deployment}>
                             <Link to={riskPageLinkToDeployment(id, name, searchFilter)}>
                                 {name}


### PR DESCRIPTION
## Description

Fixes a bug that resulted in duplicate table rows if deployments across clusters had the same name. This change uses a more sensible field (id) as the React element key...


## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Against a demo with multiple clusters, this change was easily reproducible by filtering the display to one cluster at a time. Each time a duplicate namespace appeared in the list it would be duplicated in the table.

Testing this now always results in 6 or less deployments in the table.
