### PR TITLE
Add link color override rule for PF styles in production builds

### DIFF
--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -8,6 +8,11 @@ body {
     font-family: var(--pf-global--FontFamily--sans-serif) !important;
 }
 
+/* overrides the default link styling in Tailwind (`inherit`) with PF's default blue */
+.pf-c-page__main-section a {
+    color: var(--pf-global--link--Color);
+}
+
 .pf-c-page__sidebar {
     --pf-c-page__sidebar-body--PaddingTop: 0;
 }


### PR DESCRIPTION
## Description

Regular anchor <a> links have a PatternFly/Tailwind style conflict.

PatternFly's default style is to make links blue with `color: var(--pf-global--link--Color);`, while Tailwind reverts links to black with `color: inherit;`. In development links are the correct blue color, but they become black in prod due to our Tailwind style sheet being loaded first in production builds.

This ensures that the PF rule takes precedence with `.pf-c-page__main-section a (0-1-1)` over the Tailwind `a (0-0-1)` on all pages that are within a PatternFly `<PageSection>`. Once Tailwind is removed from the project this rule can be deleted.

Alternatively we could convert all links to use a PatternFly `<Button variant='link' isSmall isInline>`, but that seems a bit more heavyweight.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Visit the Dashboard in a production environment and ensure that the links are blue and not black. (This currently needs a build deployed to test.)
