### PR TITLE
Adjust padding on policy violations by category to ensure axis is not cut off

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -246,6 +246,7 @@ function ViolationsByPolicyCategoryChart({
                     // TODO Auto-adjust padding based on screen size and/or max text length, if possible
                     left: 180, // left padding is dependent on the length of the text on the left axis
                     bottom: 55, // Adjusted to accommodate legend
+                    right: 35,
                 }}
                 theme={chartTheme}
             >


### PR DESCRIPTION
## Description

The default padding cuts of the text on the chart axis when the last tick marker is directly next to the edge of the widget. This adds some additional padding that fixes the issue, and should hold for policy violations that stay under 4 digits or so. We may want to adjust the axis display in this and other charts if systems have a much larger volume of data.

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Load the dashboard and scroll to the Policy violations by category widget.

Padding before change:
<img width="668" alt="image" src="https://user-images.githubusercontent.com/1292638/176331821-2d93d9ad-5c22-45d1-93bb-9b64e432cf1c.png">


Padding after change:
<img width="668" alt="image" src="https://user-images.githubusercontent.com/1292638/176331803-219f9cc1-e217-4aa5-a14e-79dbbe8bcac3.png">



