### PR TITLE
Pass OS to all usages of scancomponent

### DIFF
--- a/central/graphql/resolvers/components_v1.go
+++ b/central/graphql/resolvers/components_v1.go
@@ -50,6 +50,7 @@ func (resolver *imageScanResolver) ComponentCount(ctx context.Context, args RawQ
 
 // EmbeddedImageScanComponentResolver resolves data about an image scan component.
 type EmbeddedImageScanComponentResolver struct {
+	os          string
 	root        *Resolver
 	lastScanned *protoTypes.Timestamp
 	data        *storage.EmbeddedImageScanComponent
@@ -73,7 +74,7 @@ func (eicr *EmbeddedImageScanComponentResolver) License(ctx context.Context) (*l
 
 // ID returns a unique identifier for the component.
 func (eicr *EmbeddedImageScanComponentResolver) ID(ctx context.Context) graphql.ID {
-	return graphql.ID(scancomponent.ComponentID(eicr.data.GetName(), eicr.data.GetVersion(), ""))
+	return graphql.ID(scancomponent.ComponentID(eicr.data.GetName(), eicr.data.GetVersion(), eicr.os))
 }
 
 // Name returns the name of the component.
@@ -264,7 +265,7 @@ func (eicr *EmbeddedImageScanComponentResolver) ActiveState(ctx context.Context,
 		return &activeStateResolver{root: eicr.root, state: Undetermined}, nil
 	}
 
-	acID := acConverter.ComposeID(deploymentID, scancomponent.ComponentID(eicr.data.GetName(), eicr.data.GetVersion(), ""))
+	acID := acConverter.ComposeID(deploymentID, scancomponent.ComponentID(eicr.data.GetName(), eicr.data.GetVersion(), eicr.os))
 	found, err := eicr.root.ActiveComponent.Exists(ctx, acID)
 	if err != nil {
 		return nil, err
@@ -403,9 +404,10 @@ func mapImagesToComponentResolvers(root *Resolver, images []*storage.Image, quer
 			if !componentPred.Matches(component) {
 				continue
 			}
-			thisComponentID := scancomponent.ComponentID(component.GetName(), component.GetVersion(), "")
+			thisComponentID := scancomponent.ComponentID(component.GetName(), component.GetVersion(), image.GetScan().GetOperatingSystem())
 			if _, exists := idToComponent[thisComponentID]; !exists {
 				idToComponent[thisComponentID] = &EmbeddedImageScanComponentResolver{
+					os:   image.GetScan().GetOperatingSystem(),
 					root: root,
 					data: component,
 				}

--- a/central/graphql/resolvers/node_components_v1.go
+++ b/central/graphql/resolvers/node_components_v1.go
@@ -70,6 +70,7 @@ func (resolver *nodeScanResolver) ComponentCount(ctx context.Context, args RawQu
 
 // EmbeddedNodeScanComponentResolver resolves data about an node scan component.
 type EmbeddedNodeScanComponentResolver struct {
+	os          string
 	root        *Resolver
 	lastScanned *protoTypes.Timestamp
 	data        *storage.EmbeddedNodeScanComponent
@@ -87,7 +88,7 @@ func (encr *EmbeddedNodeScanComponentResolver) UnusedVarSink(ctx context.Context
 
 // ID returns a unique identifier for the component.
 func (encr *EmbeddedNodeScanComponentResolver) ID(ctx context.Context) graphql.ID {
-	return graphql.ID(scancomponent.ComponentID(encr.data.GetName(), encr.data.GetVersion(), ""))
+	return graphql.ID(scancomponent.ComponentID(encr.data.GetName(), encr.data.GetVersion(), encr.os))
 }
 
 // Name returns the name of the component.
@@ -198,9 +199,10 @@ func mapNodesToComponentResolvers(root *Resolver, nodes []*storage.Node, query *
 			if !componentPred.Matches(component) {
 				continue
 			}
-			thisComponentID := scancomponent.ComponentID(component.GetName(), component.GetVersion(), "")
+			thisComponentID := scancomponent.ComponentID(component.GetName(), component.GetVersion(), node.GetScan().GetOperatingSystem())
 			if _, exists := idToComponent[thisComponentID]; !exists {
 				idToComponent[thisComponentID] = &EmbeddedNodeScanComponentResolver{
+					os:   node.GetScan().GetOperatingSystem(),
 					root: root,
 					data: component,
 				}

--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -317,6 +317,6 @@ func (ds *datastoreImpl) updateImagePriority(images ...*storage.Image) {
 
 func (ds *datastoreImpl) updateComponentRisk(image *storage.Image) {
 	for _, component := range image.GetScan().GetComponents() {
-		component.RiskScore = ds.imageComponentRanker.GetScoreForID(scancomponent.ComponentID(component.GetName(), component.GetVersion(), ""))
+		component.RiskScore = ds.imageComponentRanker.GetScoreForID(scancomponent.ComponentID(component.GetName(), component.GetVersion(), image.GetScan().GetOperatingSystem()))
 	}
 }

--- a/central/risk/scorer/component/image/scorer_test.go
+++ b/central/risk/scorer/component/image/scorer_test.go
@@ -35,7 +35,7 @@ func TestScore(t *testing.T) {
 		},
 	}
 
-	actualRisk := scorer.Score(ctx, scancomponent.NewFromImageComponent(imageComponent))
+	actualRisk := scorer.Score(ctx, scancomponent.NewFromImageComponent(imageComponent), "")
 	assert.Equal(t, expectedRiskResults, actualRisk.GetResults())
 	assert.InDelta(t, expectedRiskScore, actualRisk.GetScore(), 0.0001)
 

--- a/central/risk/scorer/component/node/scorer_test.go
+++ b/central/risk/scorer/component/node/scorer_test.go
@@ -35,7 +35,7 @@ func TestScore(t *testing.T) {
 		},
 	}
 
-	actualRisk := nodeScorer.Score(ctx, scancomponent.NewFromNodeComponent(nodeComponent))
+	actualRisk := nodeScorer.Score(ctx, scancomponent.NewFromNodeComponent(nodeComponent), "")
 	assert.Equal(t, expectedRiskResults, actualRisk.GetResults())
 	assert.InDelta(t, expectedRiskScore, actualRisk.GetScore(), 0.0001)
 

--- a/central/risk/scorer/component/scorer.go
+++ b/central/risk/scorer/component/scorer.go
@@ -16,7 +16,7 @@ var (
 
 // Scorer is the object that encompasses the multipliers for evaluating component risk
 type Scorer interface {
-	Score(ctx context.Context, component scancomponent.ScanComponent) *storage.Risk
+	Score(ctx context.Context, component scancomponent.ScanComponent, os string) *storage.Risk
 }
 
 // NewComponentScorer returns a new scorer that encompasses multipliers for evaluating component risk
@@ -35,7 +35,7 @@ type componentScorerImpl struct {
 }
 
 // Score takes a component and evaluates its risk
-func (s *componentScorerImpl) Score(ctx context.Context, scanComponent scancomponent.ScanComponent) *storage.Risk {
+func (s *componentScorerImpl) Score(ctx context.Context, scanComponent scancomponent.ScanComponent, os string) *storage.Risk {
 	riskResults := make([]*storage.Risk_Result, 0, len(s.ConfiguredMultipliers))
 	overallScore := float32(1.0)
 	for _, mult := range s.ConfiguredMultipliers {
@@ -52,7 +52,7 @@ func (s *componentScorerImpl) Score(ctx context.Context, scanComponent scancompo
 		Score:   overallScore,
 		Results: riskResults,
 		Subject: &storage.RiskSubject{
-			Id:   scancomponent.ComponentID(scanComponent.GetName(), scanComponent.GetVersion(), ""),
+			Id:   scancomponent.ComponentID(scanComponent.GetName(), scanComponent.GetVersion(), os),
 			Type: s.riskSubjectType,
 		},
 	}

--- a/pkg/clair/convert.go
+++ b/pkg/clair/convert.go
@@ -138,7 +138,7 @@ func ConvertVulnerability(v clairV1.Vulnerability) *storage.EmbeddedVulnerabilit
 	return vul
 }
 
-func convertFeature(feature clairV1.Feature) *storage.EmbeddedImageScanComponent {
+func convertFeature(feature clairV1.Feature, os string) *storage.EmbeddedImageScanComponent {
 	component := &storage.EmbeddedImageScanComponent{
 		Name:     feature.Name,
 		Version:  feature.Version,
@@ -159,7 +159,7 @@ func convertFeature(feature clairV1.Feature) *storage.EmbeddedImageScanComponent
 	for _, executable := range feature.Executables {
 		imageComponentIds := make([]string, 0, len(executable.RequiredFeatures))
 		for _, f := range executable.RequiredFeatures {
-			imageComponentIds = append(imageComponentIds, scancomponent.ComponentID(f.GetName(), f.GetVersion(), ""))
+			imageComponentIds = append(imageComponentIds, scancomponent.ComponentID(f.GetName(), f.GetVersion(), os))
 		}
 		exec := &storage.EmbeddedImageScanComponent_Executable{Path: executable.Path, Dependencies: imageComponentIds}
 		executables = append(executables, exec)
@@ -200,12 +200,12 @@ func BuildSHAToIndexMap(metadata *storage.ImageMetadata) map[string]int32 {
 }
 
 // ConvertFeatures converts clair features to proto components
-func ConvertFeatures(image *storage.Image, features []clairV1.Feature) (components []*storage.EmbeddedImageScanComponent) {
+func ConvertFeatures(image *storage.Image, features []clairV1.Feature, os string) (components []*storage.EmbeddedImageScanComponent) {
 	layerSHAToIndex := BuildSHAToIndexMap(image.GetMetadata())
 
 	components = make([]*storage.EmbeddedImageScanComponent, 0, len(features))
 	for _, feature := range features {
-		convertedComponent := convertFeature(feature)
+		convertedComponent := convertFeature(feature, os)
 		if val, ok := layerSHAToIndex[feature.AddedBy]; ok {
 			convertedComponent.HasLayerIndex = &storage.EmbeddedImageScanComponent_LayerIndex{
 				LayerIndex: val,

--- a/pkg/clair/convert_test.go
+++ b/pkg/clair/convert_test.go
@@ -21,7 +21,7 @@ func TestConvertVulnerability(t *testing.T) {
 
 func TestConvertFeatures(t *testing.T) {
 	clairFeatures, protoComponents := mock.GetTestFeatures()
-	assert.Equal(t, protoComponents, ConvertFeatures(nil, clairFeatures))
+	assert.Equal(t, protoComponents, ConvertFeatures(nil, clairFeatures, ""))
 }
 
 func TestVersionFormatCompleteness(t *testing.T) {
@@ -143,7 +143,7 @@ func TestConvertFeaturesWithLayerIndexes(t *testing.T) {
 			img := &storage.Image{
 				Metadata: c.metadata,
 			}
-			convertedComponents := ConvertFeatures(img, c.features)
+			convertedComponents := ConvertFeatures(img, c.features, "")
 			require.Equal(t, len(c.expectedComponents), len(convertedComponents))
 			for i := range convertedComponents {
 				assert.Equal(t, c.expectedComponents[i], convertedComponents[i])

--- a/pkg/scanners/clair/convert.go
+++ b/pkg/scanners/clair/convert.go
@@ -8,8 +8,9 @@ import (
 )
 
 func convertLayerToImageScan(image *storage.Image, layerEnvelope *clairV1.LayerEnvelope) *storage.ImageScan {
+	os := stringutils.OrDefault(layerEnvelope.Layer.NamespaceName, "unknown")
 	return &storage.ImageScan{
 		OperatingSystem: stringutils.OrDefault(layerEnvelope.Layer.NamespaceName, "unknown"),
-		Components:      clairConv.ConvertFeatures(image, layerEnvelope.Layer.Features),
+		Components:      clairConv.ConvertFeatures(image, layerEnvelope.Layer.Features, os),
 	}
 }

--- a/pkg/scanners/clairify/clairify.go
+++ b/pkg/scanners/clairify/clairify.go
@@ -233,11 +233,12 @@ func convertLayerToImageScan(image *storage.Image, layerEnvelope *clairV1.LayerE
 		notes = append(notes, storage.ImageScan_PARTIAL_SCAN_DATA)
 	}
 
+	os := stringutils.OrDefault(layerEnvelope.Layer.NamespaceName, "unknown")
 	return &storage.ImageScan{
-		OperatingSystem: stringutils.OrDefault(layerEnvelope.Layer.NamespaceName, "unknown"),
+		OperatingSystem: os,
 		ScanTime:        gogoProto.TimestampNow(),
 		ScannerVersion:  layerEnvelope.ScannerVersion,
-		Components:      clairConv.ConvertFeatures(image, layerEnvelope.Layer.Features),
+		Components:      clairConv.ConvertFeatures(image, layerEnvelope.Layer.Features, os),
 		Notes:           notes,
 	}
 }

--- a/pkg/scanners/clairify/convert_test.go
+++ b/pkg/scanners/clairify/convert_test.go
@@ -346,5 +346,6 @@ func TestConvertFeatures(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, expectedFeatures, convertFeatures(metadata, features))
+	converted := convertFeatures(metadata, features, "")
+	assert.Equal(t, expectedFeatures, converted)
 }

--- a/pkg/scanners/quay/convert.go
+++ b/pkg/scanners/quay/convert.go
@@ -8,9 +8,10 @@ import (
 )
 
 func convertScanToImageScan(image *storage.Image, s *scanResult) *storage.ImageScan {
+	os := stringutils.OrDefault(s.Data.Layer.NamespaceName, "unknown")
 	return &storage.ImageScan{
-		OperatingSystem: stringutils.OrDefault(s.Data.Layer.NamespaceName, "unknown"),
+		OperatingSystem: os,
 		ScanTime:        types.TimestampNow(),
-		Components:      clair.ConvertFeatures(image, s.Data.Layer.Features),
+		Components:      clair.ConvertFeatures(image, s.Data.Layer.Features, os),
 	}
 }


### PR DESCRIPTION
## Description

OS needs to be passed to scancomponent to align the ids with the values in the database

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Should have no impact
