### PR TITLE
ROX-11546: Fix prometheus monitoring on OCP

### DIFF
--- a/deploy/charts/monitoring/templates/deployment.yaml
+++ b/deploy/charts/monitoring/templates/deployment.yaml
@@ -84,6 +84,14 @@ spec:
             mountPath: /var/lib/grafana
       - name: prometheus
         image: {{ required "A Prometheus image is required" .Values.prometheusImage }}
+        command: ["/bin/prometheus"]
+        # The arguments are set explicitly such that the data path is `/var/prometheus`,
+        # because it allows write access under read only root file systems.
+        args:
+          - "--config.file=/etc/prometheus/prometheus.yml"
+          - "--storage.tsdb.path=/var/prometheus"
+          - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+          - "--web.console.templates=/usr/share/prometheus/consoles"
         securityContext:
           capabilities:
             drop: ["NET_RAW"]
@@ -95,16 +103,7 @@ spec:
             mountPath: /etc/prometheus
             readOnly: true
           - name: prometheus-data-volume
-            mountPath: /prometheus
-      # This is a workaround for Prometheus not being able to write logs on persisted
-      # volumes when running on gke in combination with `readOnlyRootFilesystem: true`.
-      initContainers:
-        - name: changemod
-          image: busybox:1.35.0
-          command: ["/bin/chmod", "-R", "777", "/prometheus"]
-          volumeMounts:
-          - name: prometheus-data-volume
-            mountPath: /prometheus
+            mountPath: /var/prometheus
       volumes:
       - name: monitoring-ui-volume
         secret:


### PR DESCRIPTION
The default data path Prometheus is `/prometheus` - this path is read
only when using a security context contraint with
`readOnlyRootFilesystem: true`. To allow Prometheus write access, we
need to move the data directory under a writable path like `/var/`.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Connected to fresh OCP cluster and ran
 
```
export MONITORING_SUPPORT=true
export STORAGE=pvc
./deploy/openshift/deploy.sh
```

The monitoring pods are started successfully.

```
monitoring-5d8b78c959-jr4xl          2/2     Running   0          2m35s
```