### PR TITLE
Add empty state edge case handling to all existing widgets

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.tsx
@@ -32,6 +32,7 @@ import AgingImagesChart, {
     getTimeFilterOption,
 } from './AgingImagesChart';
 import isResourceScoped from '../utils';
+import NoDataEmptyState from './NoDataEmptyState';
 
 export const imageCountQuery = gql`
     query agingImagesQuery($query0: String, $query1: String, $query2: String, $query3: String) {
@@ -157,6 +158,11 @@ function AgingImages() {
         variables,
     });
     const timeRangeCounts = data ?? previousData;
+    const isCountsDataEmpty =
+        timeRangeCounts &&
+        Object.values(timeRangeCounts).every(
+            (value, index) => !timeRanges[index].enabled || value === 0
+        );
 
     let inputError: Error | undefined;
     let errorTitle: string | undefined;
@@ -254,12 +260,14 @@ function AgingImages() {
                 </Flex>
             }
         >
-            {timeRangeCounts && (
+            {timeRangeCounts && !isCountsDataEmpty ? (
                 <AgingImagesChart
                     searchFilter={searchFilter}
                     timeRanges={timeRanges}
                     timeRangeCounts={timeRangeCounts}
                 />
+            ) : (
+                <NoDataEmptyState />
             )}
         </WidgetCard>
     );

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
@@ -10,7 +10,12 @@ import {
     ToggleGroupItem,
     Button,
     Form,
+    EmptyState,
+    EmptyStateIcon,
+    EmptyStateVariant,
+    EmptyStateBody,
 } from '@patternfly/react-core';
+import { SyncIcon } from '@patternfly/react-icons';
 import { useQuery } from '@apollo/client';
 import { sortBy } from 'lodash';
 
@@ -33,9 +38,23 @@ import { complianceBasePath, urlEntityListTypes } from 'routePaths';
 import { standardLabels } from 'messages/standards';
 import ComplianceLevelsByStandardChart, { ComplianceData } from './ComplianceLevelsByStandardChart';
 import WidgetCard from './WidgetCard';
-import NoDataEmptyState from './NoDataEmptyState';
 
 const fieldIdPrefix = 'compliance-levels-by-standard';
+
+function ComplianceScanEmptyState() {
+    return (
+        <EmptyState className="pf-u-h-100" variant={EmptyStateVariant.xs}>
+            <EmptyStateIcon className="pf-u-font-size-xl" icon={SyncIcon} />
+            <Title headingLevel="h4" size="md">
+                No Standard results available.
+            </Title>
+            <EmptyStateBody>Run a scan on the Compliance page.</EmptyStateBody>
+            <Button component={LinkShim} href={complianceBasePath}>
+                Go to compliance
+            </Button>
+        </EmptyState>
+    );
+}
 
 // Adapted from `processData` function in the original DashboardCompliance.js code
 function processData(
@@ -176,7 +195,7 @@ function ComplianceLevelsByStandard() {
             {complianceData && complianceData.length > 0 ? (
                 <ComplianceLevelsByStandardChart complianceData={complianceData} />
             ) : (
-                <NoDataEmptyState />
+                <ComplianceScanEmptyState />
             )}
         </WidgetCard>
     );

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
@@ -33,6 +33,7 @@ import { complianceBasePath, urlEntityListTypes } from 'routePaths';
 import { standardLabels } from 'messages/standards';
 import ComplianceLevelsByStandardChart, { ComplianceData } from './ComplianceLevelsByStandardChart';
 import WidgetCard from './WidgetCard';
+import NoDataEmptyState from './NoDataEmptyState';
 
 const fieldIdPrefix = 'compliance-levels-by-standard';
 
@@ -172,7 +173,11 @@ function ComplianceLevelsByStandard() {
                 </Flex>
             }
         >
-            {complianceData && <ComplianceLevelsByStandardChart complianceData={complianceData} />}
+            {complianceData && complianceData.length > 0 ? (
+                <ComplianceLevelsByStandardChart complianceData={complianceData} />
+            ) : (
+                <NoDataEmptyState />
+            )}
         </WidgetCard>
     );
 }

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandardChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandardChart.tsx
@@ -12,7 +12,7 @@ import {
 } from 'utils/chartUtils';
 
 const labelLinkCallback = ({ datum }: ChartLabelProps, data: ComplianceData) => {
-    return typeof datum === 'number' ? data[datum - 1].link : '';
+    return typeof datum === 'number' ? data[datum - 1]?.link ?? '' : '';
 };
 
 export type ComplianceData = {

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRisk.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/DeploymentsAtMostRisk.tsx
@@ -8,6 +8,7 @@ import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
 import DeploymentsAtMostRiskTable from './DeploymentsAtMostRiskTable';
 import WidgetCard from './WidgetCard';
 import useDeploymentsAtRisk from '../hooks/useDeploymentsAtRisk';
+import NoDataEmptyState from './NoDataEmptyState';
 
 function DeploymentsAtMostRisk() {
     const { searchFilter } = useURLSearch();
@@ -34,10 +35,11 @@ function DeploymentsAtMostRisk() {
                 </Flex>
             }
         >
-            <DeploymentsAtMostRiskTable
-                deployments={deployments ?? []}
-                searchFilter={searchFilter}
-            />
+            {deployments && deployments.length > 0 ? (
+                <DeploymentsAtMostRiskTable deployments={deployments} searchFilter={searchFilter} />
+            ) : (
+                <NoDataEmptyState />
+            )}
         </WidgetCard>
     );
 }

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.tsx
@@ -24,6 +24,7 @@ import LinkShim from 'Components/PatternFly/LinkShim';
 import WidgetCard from './WidgetCard';
 import ImagesAtMostRiskTable, { CveStatusOption, ImageData } from './ImagesAtMostRiskTable';
 import isResourceScoped from '../utils';
+import NoDataEmptyState from './NoDataEmptyState';
 
 function getTitle(searchFilter: SearchFilter, imageStatusOption: ImageStatusOption) {
     return imageStatusOption === 'Active' || isResourceScoped(searchFilter)
@@ -176,8 +177,10 @@ function ImagesAtMostRisk() {
                 </Flex>
             }
         >
-            {imageData && (
+            {imageData && imageData.images.length > 0 ? (
                 <ImagesAtMostRiskTable imageData={imageData} cveStatusOption={cveStatusOption} />
+            ) : (
+                <NoDataEmptyState />
             )}
         </WidgetCard>
     );

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/MostRecentViolations.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/MostRecentViolations.tsx
@@ -1,20 +1,14 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import {
-    EmptyState,
-    EmptyStateIcon,
-    EmptyStateVariant,
-    Flex,
-    Title,
-    Truncate,
-} from '@patternfly/react-core';
+import { Flex, Title, Truncate } from '@patternfly/react-core';
 import { TableComposable, Tbody, Tr, Td } from '@patternfly/react-table';
-import { SearchIcon, SecurityIcon } from '@patternfly/react-icons';
+import { SecurityIcon } from '@patternfly/react-icons';
 
 import { DeploymentAlert } from 'types/alert.proto';
 import { violationsBasePath } from 'routePaths';
 import { severityColors } from 'constants/visuals/colors';
 import { getDateTime } from 'utils/dateUtils';
+import NoDataEmptyState from './NoDataEmptyState';
 
 export type MostRecentViolationsProps = {
     alerts: DeploymentAlert[];
@@ -22,14 +16,7 @@ export type MostRecentViolationsProps = {
 
 function MostRecentViolations({ alerts }: MostRecentViolationsProps) {
     if (alerts.length === 0) {
-        return (
-            <EmptyState variant={EmptyStateVariant.xs}>
-                <EmptyStateIcon className="pf-u-font-size-xl" icon={SearchIcon} />
-                <Title headingLevel="h4" size="md">
-                    No critical violations were found in the selected scope
-                </Title>
-            </EmptyState>
-        );
+        return <NoDataEmptyState />;
     }
 
     return (

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/MostRecentViolations.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/MostRecentViolations.tsx
@@ -8,17 +8,12 @@ import { DeploymentAlert } from 'types/alert.proto';
 import { violationsBasePath } from 'routePaths';
 import { severityColors } from 'constants/visuals/colors';
 import { getDateTime } from 'utils/dateUtils';
-import NoDataEmptyState from './NoDataEmptyState';
 
 export type MostRecentViolationsProps = {
     alerts: DeploymentAlert[];
 };
 
 function MostRecentViolations({ alerts }: MostRecentViolationsProps) {
-    if (alerts.length === 0) {
-        return <NoDataEmptyState />;
-    }
-
     return (
         <>
             <Title headingLevel="h5" className="pf-u-mb-sm">

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/NoDataEmptyState.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/NoDataEmptyState.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { EmptyState, EmptyStateVariant, EmptyStateIcon, Title } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+
+function NoDataEmptyState() {
+    return (
+        <EmptyState className="pf-u-h-100" variant={EmptyStateVariant.xs}>
+            <EmptyStateIcon className="pf-u-font-size-xl" icon={SearchIcon} />
+            <Title headingLevel="h4" size="md">
+                No data was found in the selected scope.
+            </Title>
+        </EmptyState>
+    );
+}
+
+export default NoDataEmptyState;

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -50,6 +50,7 @@ import {
 import { SearchFilter } from 'types/search';
 import useAlertGroups from '../hooks/useAlertGroups';
 import WidgetCard from './WidgetCard';
+import NoDataEmptyState from './NoDataEmptyState';
 
 // The ordering of the legend and the hidden severities runs from Critical->Low
 // so we reverse the order of the default Low->Critical in most cases.
@@ -351,11 +352,15 @@ function ViolationsByPolicyCategory() {
                 </Flex>
             }
         >
-            <ViolationsByPolicyCategoryChart
-                alertGroups={alertGroups ?? []}
-                sortType={sortType}
-                searchFilter={searchFilter}
-            />
+            {alertGroups && alertGroups.length > 0 ? (
+                <ViolationsByPolicyCategoryChart
+                    alertGroups={alertGroups}
+                    sortType={sortType}
+                    searchFilter={searchFilter}
+                />
+            ) : (
+                <NoDataEmptyState />
+            )}
         </WidgetCard>
     );
 }

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicySeverity.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicySeverity.tsx
@@ -16,6 +16,7 @@ import WidgetCard from './WidgetCard';
 import MostRecentViolations from './MostRecentViolations';
 import PolicyViolationTiles from './PolicyViolationTiles';
 import useAlertGroups from '../hooks/useAlertGroups';
+import NoDataEmptyState from './NoDataEmptyState';
 
 function getViewAllLink(searchFilter: SearchFilter) {
     const queryString = getQueryString({
@@ -117,7 +118,11 @@ function ViolationsByPolicySeverity() {
                     <PolicyViolationTiles searchFilter={searchFilter} counts={counts} />
                     <Divider component="div" className="pf-u-my-lg" />
                     <StackItem isFilled>
-                        <MostRecentViolations alerts={recentAlertsData.alerts} />
+                        {recentAlertsData.alerts.length > 0 ? (
+                            <MostRecentViolations alerts={recentAlertsData.alerts} />
+                        ) : (
+                            <NoDataEmptyState />
+                        )}
                     </StackItem>
                 </Stack>
             )}


### PR DESCRIPTION
## Description

Adds an empty state display to all widgets. This is for cases when the data request is successful, but the system simply does not have any data for the selected widget. e.g. The selected scope is too narrow, all images are very up to date, etc.

Prior to this change, some widgets displayed an empty table or empty chart that was confusing if there was an error or some other issue.

Additionally, this change adds a more specific empty state for the Compliance widget on fresh installations that is comparable to the empty state on the old dashboard. This is the main blocking change before we [enable the feature flag](https://github.com/stackrox/stackrox/pull/2249), as without it the new dashboard will throw an error on fresh installs. (Thanks @sachaudh for finding this oversight!)

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Visit the new dashboard and adjust search criteria in a way that would lead to zero results. A good way to test this is to select a single cluster and the "default" namespace only for that cluster.

For the Compliance widget, testing the empty state must be done on a system that has not yet been scanned for Compliance data.

Before:
![image](https://user-images.githubusercontent.com/1292638/176726343-45849971-d319-4b77-8f5d-aeb2cde1fa52.png)

After:
![image](https://user-images.githubusercontent.com/1292638/176725285-4771caa5-4e68-4c90-9188-feb0bce37eb8.png)

