### PR TITLE
CI: handle test-bin issue with nightlies

### DIFF
--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -47,6 +47,10 @@ case "$ci_job" in
         ;;
 esac
 
+if [[ "$ci_job" =~ e2e|upgrade ]]; then
+    handle_nightly_roxctl_mismatch
+fi
+
 export PYTHONPATH="${PYTHONPATH:-}:.openshift-ci"
 
 if ! [[ "$ci_job" =~ [a-z-]+ ]]; then

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -480,7 +480,7 @@ is_tagged() {
 }
 
 is_nightly_run() {
-    [[ "${CIRCLE_TAG:-}" =~ ^nightly- ]]
+    [[ "${CIRCLE_TAG:-}" =~ nightly ]]
 }
 
 is_in_PR_context() {

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -859,6 +859,27 @@ handle_nightly_runs() {
     fi
 }
 
+handle_nightly_roxctl_mismatch() {
+    if ! is_OPENSHIFT_CI; then
+        die "Only for OpenShift CI"
+    fi
+
+    if is_in_PR_context || ! [[ "${JOB_NAME_SAFE:-}" =~ ^nightly- ]]; then
+        return 0
+    fi
+
+    # JOB_NAME_SAFE is not set in test_binary_build_commands context for
+    # periodics, so the roxctl produced in that step will cause deploy.sh to
+    # fail.
+
+    info "Correcting roxctl version for nightly e2e tests"
+
+    roxctl version
+    make cli
+    install_built_roxctl_in_gopath
+    roxctl version
+}
+
 validate_expected_go_version() {
     info "Validating the expected go version against what was used to build roxctl"
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -480,7 +480,7 @@ is_tagged() {
 }
 
 is_nightly_run() {
-    [[ "${CIRCLE_TAG:-}" =~ nightly ]]
+    [[ "${CIRCLE_TAG:-}" =~ -nightly- ]]
 }
 
 is_in_PR_context() {


### PR DESCRIPTION
## Description

OpenShift CI periodics do not set a JOB_NAME_SAFE env in the test_binary_build_commands context and so the roxctl build for stackrox nightlies is not built with the nightly tag. And so the test-bin provided to e2e and system tests has an incorrectly versioned roxctl and deploy.sh will try to docker run a matching one which is not supported in OpenShift CI. 

This PR is a workaround that recompiles roxctl for e2e and system tests to fix the version for nightly test runs.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient
