### PR TITLE
Disable medium and low severities by default in violations widget

### DIFF
--- a/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
+++ b/ui/apps/platform/cypress/integration/dashboard/dashboardSecurityMetrics.test.js
@@ -50,7 +50,7 @@ describe('Dashboard security metrics phase one action widgets', () => {
 
         const widgetSelectors = selectors.violationsByCategory;
 
-        // Default sorting should be by severity of Violations, with critical taking priority.
+        // Default sorting should be by severity of critical and high Violations, with critical taking priority.
         cy.get(`${widgetSelectors.axisLabel(0, 4)}:contains('Privileges')`);
         cy.get(`${widgetSelectors.axisLabel(0, 3)}:contains('Vulnerability Management')`);
         cy.get(`${widgetSelectors.axisLabel(0, 2)}:contains('Security Best Practices')`);
@@ -62,11 +62,11 @@ describe('Dashboard security metrics phase one action widgets', () => {
         cy.get(widgetSelectors.volumeOption).click();
         cy.get(widgetSelectors.optionsToggle).click();
 
-        cy.get(`${widgetSelectors.axisLabel(0, 4)}:contains('Anomalous Activity')`);
-        cy.get(`${widgetSelectors.axisLabel(0, 3)}:contains('Docker CIS')`);
-        cy.get(`${widgetSelectors.axisLabel(0, 2)}:contains('Privileges')`);
-        cy.get(`${widgetSelectors.axisLabel(0, 1)}:contains('Network Tools')`);
-        cy.get(`${widgetSelectors.axisLabel(0, 0)}:contains('Vulnerability Management')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 4)}:contains('Network Tools')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 3)}:contains('Privileges')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 2)}:contains('Anomalous Activity')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 1)}:contains('Vulnerability Management')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 0)}:contains('Security Best Practices')`);
     });
 
     it('should allow toggling of severities for a policy violations by category widget', () => {
@@ -79,19 +79,19 @@ describe('Dashboard security metrics phase one action widgets', () => {
 
         const widgetSelectors = selectors.violationsByCategory;
 
-        // Sort by volume, so that disabling lower severity bars changes the order of the chart
+        // Sort by volume, so that enabling lower severity bars changes the order of the chart
         cy.get(widgetSelectors.optionsToggle).click();
         cy.get(widgetSelectors.volumeOption).click();
         cy.get(widgetSelectors.optionsToggle).click();
 
-        // Toggle off low and medium violations
+        // Toggle on low and medium violations, which are disabled by default
         cy.get(widgetSelectors.legendLabel(2)).click();
         cy.get(widgetSelectors.legendLabel(3)).click();
 
-        cy.get(`${widgetSelectors.axisLabel(0, 4)}:contains('Network Tools')`);
-        cy.get(`${widgetSelectors.axisLabel(0, 3)}:contains('Privileges')`);
-        cy.get(`${widgetSelectors.axisLabel(0, 2)}:contains('Anomalous Activity')`);
-        cy.get(`${widgetSelectors.axisLabel(0, 1)}:contains('Vulnerability Management')`);
-        cy.get(`${widgetSelectors.axisLabel(0, 0)}:contains('Security Best Practices')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 4)}:contains('Anomalous Activity')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 3)}:contains('Docker CIS')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 2)}:contains('Privileges')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 1)}:contains('Network Tools')`);
+        cy.get(`${widgetSelectors.axisLabel(0, 0)}:contains('Vulnerability Management')`);
     });
 });

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -152,6 +152,8 @@ function tooltipForCategory(
 const chartTheme = cloneDeep(patternflySeverityTheme);
 chartTheme.legend.colorScale.reverse();
 
+const defaultHiddenSeverities = ['MEDIUM_SEVERITY', 'LOW_SEVERITY'] as const;
+
 function ViolationsByPolicyCategoryChart({
     alertGroups,
     sortType,
@@ -161,7 +163,9 @@ function ViolationsByPolicyCategoryChart({
     const [widgetContainer, setWidgetContainer] = useState<HTMLDivElement | null>(null);
     const widgetContainerResizeEntry = useResizeObserver(widgetContainer);
 
-    const [hiddenSeverities, setHiddenSeverities] = useState<Set<PolicySeverity>>(new Set());
+    const [hiddenSeverities, setHiddenSeverities] = useState<Set<PolicySeverity>>(
+        new Set(defaultHiddenSeverities)
+    );
 
     const labelLinkCallback = useCallback(
         ({ text }: ChartLabelProps) => linkForViolationsCategory(String(text), searchFilter),


### PR DESCRIPTION
## Description

Disabled the "medium" and "low" severity violations by default in the Violations by severity widget.

During the weekly sync there was concern that the users would not intuitively know that the legend items were clickable. This change disables the lower two severities to give the user a better hint that the legend can be interacted with, as well as provide a more useful default view of this data in their system.

Another way to make these more intuitive would be to use the standard `cursor: pointer` style, which is turning out to be trickier than expected (well, at least trickier than I expected). If time, I'd like to add a follow up PR that adds the correct hover style on this legend, as well as the clickable chart bars in other widgets.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Load the new dashboard and scroll to the Violations by severity widget. The medium and low options should be disabled in the legend, and yellow/gray bars should not be present in the chart.
<img width="655" alt="image" src="https://user-images.githubusercontent.com/1292638/176727191-7f1370ca-0017-4510-a126-fdb7378f5078.png">

Clicking on the disabled items should enable/disable them appropriately.
<img width="655" alt="image" src="https://user-images.githubusercontent.com/1292638/176728042-78d7e437-02a1-4fda-9591-440ae8fa33e7.png">

