### PR TITLE
Force chart axis format to string to avoid floating point interpolation

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImagesChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImagesChart.tsx
@@ -142,6 +142,7 @@ function AgingImagesChart({ searchFilter, timeRanges, timeRangeCounts }: AgingIm
                 />
                 <ChartAxis
                     label={yAxisTitle(searchFilter)}
+                    tickFormat={String}
                     padding={{ bottom: 10 }}
                     dependentAxis
                     showGrid

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -253,7 +253,7 @@ function ViolationsByPolicyCategoryChart({
                 <ChartAxis
                     tickLabelComponent={<LinkableChartLabel linkWith={labelLinkCallback} />}
                 />
-                <ChartAxis dependentAxis />
+                <ChartAxis dependentAxis tickFormat={String} />
                 <ChartStack horizontal>{bars}</ChartStack>
             </Chart>
         </div>


### PR DESCRIPTION
## Description

This forces the `tickFormat` axis on charts that expect an integer to be a string. Allowing a JS `number` type to be passed causes the tick label to display as a float due to the chart library's interpolation method (but only when the axis contains certain values).

This does not impact the Compliance widget as those tick values are statically defined.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

This was difficult to pinpoint, but the only way I could reliably get the incorrect format to appear is when the maximum tick value on the axis was 6 or 7. (Hypothesis is that this only happens when the tick range is small enough that every tick value is one more than the last.) Notice the axis on the 2nd and 3rd widgets below.

Before:
<img width="1315" alt="image" src="https://user-images.githubusercontent.com/1292638/176733718-d667da52-209e-44d7-a29a-2d4371ecc27c.png">


After:
<img width="1315" alt="image" src="https://user-images.githubusercontent.com/1292638/176733742-2c8b2019-47b0-43c7-a4e3-61d352765cb9.png">


