### PR TITLE
Clean up heading hierarchy for empty states

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
@@ -45,7 +45,7 @@ function ComplianceScanEmptyState() {
     return (
         <EmptyState className="pf-u-h-100" variant={EmptyStateVariant.xs}>
             <EmptyStateIcon className="pf-u-font-size-xl" icon={SyncIcon} />
-            <Title headingLevel="h4" size="md">
+            <Title headingLevel="h3" size="md">
                 No Standard results available.
             </Title>
             <EmptyStateBody>Run a scan on the Compliance page.</EmptyStateBody>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/NoDataEmptyState.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/NoDataEmptyState.tsx
@@ -6,7 +6,7 @@ function NoDataEmptyState() {
     return (
         <EmptyState className="pf-u-h-100" variant={EmptyStateVariant.xs}>
             <EmptyStateIcon className="pf-u-font-size-xl" icon={SearchIcon} />
-            <Title headingLevel="h4" size="md">
+            <Title headingLevel="h3" size="md">
                 No data was found in the selected scope.
             </Title>
         </EmptyState>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/NoDataEmptyState.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/NoDataEmptyState.tsx
@@ -7,7 +7,7 @@ function NoDataEmptyState() {
         <EmptyState className="pf-u-h-100" variant={EmptyStateVariant.xs}>
             <EmptyStateIcon className="pf-u-font-size-xl" icon={SearchIcon} />
             <Title headingLevel="h3" size="md">
-                No data was found in the selected scope.
+                No data was found in the selected resources.
             </Title>
         </EmptyState>
     );


### PR DESCRIPTION
## Description

These empty states appear on the widget card where the smallest decendent heading is an `h2`, so these are changed from `h4` to `h3`.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

"No testable changes" - this does not have a visual or functional impact on the page.
