### PR TITLE
ROX-10847: Add decommissioned cluster retention to System Configuration in UI

### DIFF
--- a/ui/apps/platform/cypress/constants/SystemConfigPage.js
+++ b/ui/apps/platform/cypress/constants/SystemConfigPage.js
@@ -56,12 +56,11 @@ const selectors = {
     },
     dataRetention: {
         widget: '[data-testid="data-retention-config"]',
-        allRuntimeViolationsBox: '[data-testid="number-box"]:contains("All runtime violations")',
+        allRuntimeViolationsBox: '.pf-c-card:contains("All runtime violations")',
         deletedRuntimeViolationsBox:
-            '[data-testid="number-box"]:contains("Runtime violations for deleted deployments")',
-        resolvedDeployViolationsBox:
-            '[data-testid="number-box"]:contains("Resolved deploy-phase violations")',
-        imagesBox: '[data-testid="number-box"]:contains("Images no longer deployed")',
+            '.pf-c-card:contains("Runtime violations for deleted deployments")',
+        resolvedDeployViolationsBox: '.pf-c-card:contains("Resolved deploy-phase violations")',
+        imagesBox: '.pf-c-card:contains("Images no longer deployed")',
     },
 };
 

--- a/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
@@ -10,6 +10,7 @@ export type ClusterLabelsTableProps = {
     labels: ClusterLabels;
     hasAction: boolean;
     handleChangeLabels: (labels: ClusterLabels) => void;
+    isValueRequired?: boolean;
 };
 
 /*
@@ -23,13 +24,14 @@ function ClusterLabelsTable({
     labels,
     hasAction,
     handleChangeLabels,
+    isValueRequired,
 }: ClusterLabelsTableProps): ReactElement {
     const refKeyInput = useRef<null | HTMLInputElement>(null); // for focus after adding a label
     const [keyInput, setKeyInput] = useState('');
     const [valueInput, setValueInput] = useState('');
 
     const isValidKey = getIsValidLabelKey(keyInput);
-    const isValidValue = getIsValidLabelValue(valueInput);
+    const isValidValue = getIsValidLabelValue(valueInput, isValueRequired);
     const isValid = isValidKey && isValidValue;
 
     const isReplace = Object.prototype.hasOwnProperty.call(labels, keyInput); // no-prototype-builtins
@@ -142,7 +144,9 @@ function ClusterLabelsTable({
                             />
                             {validatedValue === ValidatedOptions.error && (
                                 <p className="pf-u-font-size-sm pf-u-danger-color-100">
-                                    Invalid label value
+                                    {valueInput.length === 0
+                                        ? 'Label value is required'
+                                        : 'Invalid label value'}
                                 </p>
                             )}
                         </Td>

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigDataRetentionDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigDataRetentionDetails.tsx
@@ -1,105 +1,181 @@
 import React, { ReactElement } from 'react';
 import pluralize from 'pluralize';
-import {
-    Card,
-    CardBody,
-    CardTitle,
-    Divider,
-    Gallery,
-    GalleryItem,
-    Hint,
-    HintTitle,
-    HintBody,
-} from '@patternfly/react-core';
+import { Button, Card, CardBody, CardTitle, Grid, GridItem, Title } from '@patternfly/react-core';
 
+import LinkShim from 'Components/PatternFly/LinkShim';
+import ClusterLabelsTable from 'Containers/Clusters/ClusterLabelsTable';
 import { PrivateConfig } from 'types/config.proto';
+import { clustersBasePath } from 'routePaths';
 
-const UNKNOWN_FLAG = -1;
-
-type NumberBoxProps = {
-    label: string;
-    value?: number;
-    suffix?: string;
+type DataRetentionValueProps = {
+    value: number | undefined;
+    suffix: string;
 };
 
-const NumberBox = ({ label, value = UNKNOWN_FLAG, suffix = '' }: NumberBoxProps): ReactElement => (
-    <Hint data-testid="number-box" className="pf-u-h-100">
-        <HintTitle className="pf-u-font-size-sm">{label}</HintTitle>
-        <HintBody className="pf-u-font-size-xl pf-u-font-weight-bold">
-            {value === UNKNOWN_FLAG && `Unknown`}
-            {!value && `Never deleted`}
-            {value > 0 && `${value} ${pluralize(suffix, value)}`}
-        </HintBody>
-    </Hint>
-);
+function DataRetentionValue({ value, suffix }: DataRetentionValueProps): ReactElement {
+    let content = 'Unknown';
+
+    if (typeof value === 'number') {
+        if (value === 0) {
+            content = 'Never deleted';
+        } else if (value > 0) {
+            content = `${value} ${pluralize(suffix, value)}`;
+        }
+    }
+
+    return <span className="pf-u-font-size-xl pf-u-font-weight-bold">{content}</span>;
+}
 
 export type PrivateConfigDataRetentionDetailsProps = {
+    isClustersRoutePathRendered: boolean;
+    isDecommissionedClusterRetentionEnabled: boolean;
     privateConfig: PrivateConfig;
 };
 
 const PrivateConfigDataRetentionDetails = ({
+    isClustersRoutePathRendered,
+    isDecommissionedClusterRetentionEnabled,
     privateConfig,
 }: PrivateConfigDataRetentionDetailsProps): ReactElement => {
     return (
-        <Card data-testid="data-retention-config">
-            <CardTitle>Data retention configuration</CardTitle>
-            <Divider component="div" />
-            <CardBody>
-                <Gallery hasGutter>
-                    <GalleryItem>
-                        <NumberBox
-                            label="All runtime violations"
+        <Grid hasGutter md={6}>
+            <GridItem>
+                <Card isFlat className="pf-u-h-100">
+                    <CardTitle>All runtime violations</CardTitle>
+                    <CardBody>
+                        <DataRetentionValue
                             value={privateConfig?.alertConfig?.allRuntimeRetentionDurationDays}
                             suffix="day"
                         />
-                    </GalleryItem>
-                    <GalleryItem>
-                        <NumberBox
-                            label="Runtime violations for deleted deployments"
+                    </CardBody>
+                </Card>
+            </GridItem>
+            <GridItem>
+                <Card isFlat className="pf-u-h-100">
+                    <CardTitle>Runtime violations for deleted deployments</CardTitle>
+                    <CardBody>
+                        <DataRetentionValue
                             value={privateConfig?.alertConfig?.deletedRuntimeRetentionDurationDays}
                             suffix="day"
                         />
-                    </GalleryItem>
-                    <GalleryItem>
-                        <NumberBox
-                            label="Resolved deploy-phase violations"
+                    </CardBody>
+                </Card>
+            </GridItem>
+            <GridItem>
+                <Card isFlat className="pf-u-h-100">
+                    <CardTitle>Resolved deploy-phase violations</CardTitle>
+                    <CardBody>
+                        <DataRetentionValue
                             value={privateConfig?.alertConfig?.resolvedDeployRetentionDurationDays}
                             suffix="day"
                         />
-                    </GalleryItem>
-                    <GalleryItem>
-                        <NumberBox
-                            label="Attempted deploy-phase violations"
+                    </CardBody>
+                </Card>
+            </GridItem>
+            <GridItem>
+                <Card isFlat className="pf-u-h-100">
+                    <CardTitle>Attempted deploy-phase violations</CardTitle>
+                    <CardBody>
+                        <DataRetentionValue
                             value={privateConfig?.alertConfig?.attemptedDeployRetentionDurationDays}
                             suffix="day"
                         />
-                    </GalleryItem>
-                    <GalleryItem>
-                        <NumberBox
-                            label="Attempted runtime violations"
+                    </CardBody>
+                </Card>
+            </GridItem>
+            <GridItem>
+                <Card isFlat className="pf-u-h-100">
+                    <CardTitle>Attempted runtime violations</CardTitle>
+                    <CardBody>
+                        <DataRetentionValue
                             value={
                                 privateConfig?.alertConfig?.attemptedRuntimeRetentionDurationDays
                             }
                             suffix="day"
                         />
-                    </GalleryItem>
-                    <GalleryItem>
-                        <NumberBox
-                            label="Images no longer deployed"
+                    </CardBody>
+                </Card>
+            </GridItem>
+            <GridItem>
+                <Card isFlat className="pf-u-h-100">
+                    <CardTitle>Images no longer deployed</CardTitle>
+                    <CardBody>
+                        <DataRetentionValue
                             value={privateConfig?.imageRetentionDurationDays}
                             suffix="day"
                         />
-                    </GalleryItem>
-                    <GalleryItem>
-                        <NumberBox
-                            label="Expired vulnerability requests"
+                    </CardBody>
+                </Card>
+            </GridItem>
+            <GridItem>
+                <Card isFlat>
+                    <CardTitle>Expired vulnerability requests</CardTitle>
+                    <CardBody>
+                        <DataRetentionValue
                             value={privateConfig?.expiredVulnReqRetentionDurationDays}
                             suffix="day"
                         />
-                    </GalleryItem>
-                </Gallery>
-            </CardBody>
-        </Card>
+                    </CardBody>
+                </Card>
+            </GridItem>
+            {isDecommissionedClusterRetentionEnabled && (
+                <>
+                    <GridItem sm={12}>
+                        <Title headingLevel="h3" id="cluster-deletion">
+                            Cluster deletion
+                        </Title>
+                    </GridItem>
+                    <GridItem>
+                        <Card isFlat>
+                            <CardTitle>Decommissioned cluster age</CardTitle>
+                            <CardBody>
+                                <DataRetentionValue
+                                    value={
+                                        privateConfig?.decommissionedClusterRetention
+                                            ?.retentionDurationDays
+                                    }
+                                    suffix="day"
+                                />
+                            </CardBody>
+                        </Card>
+                    </GridItem>
+                    <GridItem>
+                        <Card isFlat>
+                            <CardTitle>Ignore clusters which have labels</CardTitle>
+                            <CardBody>
+                                {Object.keys(
+                                    privateConfig?.decommissionedClusterRetention
+                                        ?.ignoreClusterLabels ?? {}
+                                ).length === 0 ? (
+                                    'No labels'
+                                ) : (
+                                    <ClusterLabelsTable
+                                        labels={
+                                            privateConfig.decommissionedClusterRetention
+                                                .ignoreClusterLabels
+                                        }
+                                        hasAction={false}
+                                        handleChangeLabels={() => {}}
+                                    />
+                                )}
+                            </CardBody>
+                            {isClustersRoutePathRendered && (
+                                <CardBody>
+                                    <Button
+                                        variant="link"
+                                        isInline
+                                        component={LinkShim}
+                                        href={`${clustersBasePath}?s[Sensor Status]=UNHEALTHY`}
+                                    >
+                                        Clusters which have Sensor Status: Unhealthy
+                                    </Button>
+                                </CardBody>
+                            )}
+                        </Card>
+                    </GridItem>
+                </>
+            )}
+        </Grid>
     );
 };
 

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigBannerDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigBannerDetails.tsx
@@ -40,10 +40,10 @@ const PublicConfigBannerDetails = ({
     const title = `${capitalize(type)} configuration`;
 
     return (
-        <Card data-testid={`${type}-config`}>
+        <Card isFlat data-testid={`${type}-config`}>
             <CardHeader>
                 <CardHeaderMain>
-                    <CardTitle>{title}</CardTitle>
+                    <CardTitle component="h3">{title}</CardTitle>
                 </CardHeaderMain>
                 <CardActions data-testid={`${type}-state`}>
                     {enabled ? <Label color="green">Enabled</Label> : <Label>Disabled</Label>}

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigLoginDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigLoginDetails.tsx
@@ -27,10 +27,10 @@ const PublicConfigLoginDetails = ({
     const loginNoticeText = publicConfig?.loginNotice?.text || 'None';
 
     return (
-        <Card data-testid="login-notice-config">
+        <Card isFlat data-testid="login-notice-config">
             <CardHeader>
                 <CardHeaderMain>
-                    <CardTitle>Login configuration</CardTitle>
+                    <CardTitle component="h3">Login configuration</CardTitle>
                 </CardHeaderMain>
                 <CardActions data-testid="login-notice-state">
                     {isEnabled ? <Label color="green">Enabled</Label> : <Label>Disabled</Label>}

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/SystemConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/SystemConfigDetails.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Grid, GridItem } from '@patternfly/react-core';
+import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
 
 import { SystemConfig } from 'types/config.proto';
 
@@ -7,33 +7,55 @@ import PrivateConfigDataRetentionDetails from './PrivateConfigDataRetentionDetai
 import PublicConfigBannerDetails from './PublicConfigBannerDetails';
 import PublicConfigLoginDetails from './PublicConfigLoginDetails';
 
-export type SystemConfigDetailProps = {
+export type SystemConfigDetailsProps = {
+    isClustersRoutePathRendered: boolean;
+    isDecommissionedClusterRetentionEnabled: boolean;
     systemConfig: SystemConfig;
 };
 
-function SystemConfigDetail({ systemConfig }: SystemConfigDetailProps): ReactElement {
+function SystemConfigDetails({
+    isClustersRoutePathRendered,
+    isDecommissionedClusterRetentionEnabled,
+    systemConfig,
+}: SystemConfigDetailsProps): ReactElement {
     return (
-        <Grid hasGutter>
-            <GridItem span={12}>
-                <PrivateConfigDataRetentionDetails privateConfig={systemConfig?.privateConfig} />
-            </GridItem>
-            <GridItem sm={12} md={6}>
-                <PublicConfigBannerDetails
-                    type="header"
-                    publicConfig={systemConfig?.publicConfig}
+        <>
+            <PageSection data-testid="data-retention-config">
+                <Title headingLevel="h2" className="pf-u-mb-md">
+                    Private data retention configuration
+                </Title>
+                <PrivateConfigDataRetentionDetails
+                    isClustersRoutePathRendered={isClustersRoutePathRendered}
+                    isDecommissionedClusterRetentionEnabled={
+                        isDecommissionedClusterRetentionEnabled
+                    }
+                    privateConfig={systemConfig?.privateConfig}
                 />
-            </GridItem>
-            <GridItem sm={12} md={6}>
-                <PublicConfigBannerDetails
-                    type="footer"
-                    publicConfig={systemConfig?.publicConfig}
-                />
-            </GridItem>
-            <GridItem sm={12} md={6}>
-                <PublicConfigLoginDetails publicConfig={systemConfig?.publicConfig} />
-            </GridItem>
-        </Grid>
+            </PageSection>
+            <PageSection>
+                <Title headingLevel="h2" className="pf-u-mb-md">
+                    Public configuration
+                </Title>
+                <Grid hasGutter>
+                    <GridItem sm={12} md={6}>
+                        <PublicConfigBannerDetails
+                            type="header"
+                            publicConfig={systemConfig?.publicConfig}
+                        />
+                    </GridItem>
+                    <GridItem sm={12} md={6}>
+                        <PublicConfigBannerDetails
+                            type="footer"
+                            publicConfig={systemConfig?.publicConfig}
+                        />
+                    </GridItem>
+                    <GridItem sm={12} md={6}>
+                        <PublicConfigLoginDetails publicConfig={systemConfig?.publicConfig} />
+                    </GridItem>
+                </Grid>
+            </PageSection>
+        </>
     );
 }
 
-export default SystemConfigDetail;
+export default SystemConfigDetails;

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
@@ -4,26 +4,28 @@ import {
     ActionGroup,
     Alert,
     Button,
-    TextArea,
-    Form,
-    FormSection,
-    FormGroup,
-    TextInput,
     Card,
-    CardHeader,
-    CardTitle,
+    CardActions,
     CardBody,
+    CardHeader,
     CardHeaderMain,
+    CardTitle,
     Divider,
-    SelectOption,
+    Form,
+    FormGroup,
+    FormSection,
     Grid,
     GridItem,
-    CardActions,
+    SelectOption,
     Switch,
+    TextArea,
+    TextInput,
+    Title,
 } from '@patternfly/react-core';
 import { useFormik } from 'formik';
 
 import ColorPicker from 'Components/ColorPicker';
+import ClusterLabelsTable from 'Containers/Clusters/ClusterLabelsTable';
 import { types } from 'reducers/systemConfig';
 import { saveSystemConfig } from 'services/SystemConfigService';
 import { PrivateConfig, PublicConfig, SystemConfig } from 'types/config.proto';
@@ -60,12 +62,14 @@ type Values = {
 };
 
 export type SystemConfigFormProps = {
+    isDecommissionedClusterRetentionEnabled: boolean;
     systemConfig: SystemConfig;
     setSystemConfig: (systemConfig: SystemConfig) => void;
     setIsNotEditing: () => void;
 };
 
 const SystemConfigForm = ({
+    isDecommissionedClusterRetentionEnabled,
     systemConfig,
     setSystemConfig,
     setIsNotEditing,
@@ -104,175 +108,200 @@ const SystemConfigForm = ({
         });
 
     function onChange(value, event) {
-        return setFieldValue(event.target.id, value, false);
+        return setFieldValue(event.target.id, value);
     }
 
     function onCustomChange(value, id) {
-        return setFieldValue(id, value, false);
+        return setFieldValue(id, value);
     }
 
-    function onSubmitForm(event) {
-        event.preventDefault();
-        return submitForm();
+    function handleChangeLabels(labels) {
+        return onCustomChange(
+            labels,
+            'privateConfig.decommissionedClusterRetention.ignoreClusterLabels'
+        );
     }
 
     return (
-        <Form onSubmit={onSubmitForm}>
-            <Grid hasGutter md={12}>
-                <GridItem md={12}>
-                    <Card>
-                        <CardHeader>
-                            <CardHeaderMain>
-                                <CardTitle>Data retention configuration</CardTitle>
-                            </CardHeaderMain>
-                        </CardHeader>
-                        <Divider component="div" />
-                        <CardBody>
-                            <FormSection>
-                                <Grid hasGutter md={6}>
-                                    <GridItem>
-                                        <FormGroup
-                                            label="All runtime violations"
-                                            isRequired
-                                            fieldId="privateConfig.alertConfig.allRuntimeRetentionDurationDays"
-                                        >
-                                            <TextInput
-                                                isRequired
-                                                type="number"
-                                                id="privateConfig.alertConfig.allRuntimeRetentionDurationDays"
-                                                name="privateConfig.alertConfig.allRuntimeRetentionDurationDays"
-                                                value={
-                                                    values?.privateConfig?.alertConfig
-                                                        ?.allRuntimeRetentionDurationDays
-                                                }
-                                                onChange={onChange}
-                                            />
-                                        </FormGroup>
-                                    </GridItem>
-                                    <GridItem>
-                                        <FormGroup
-                                            label="Runtime violations for deleted deployments"
-                                            isRequired
-                                            fieldId="privateConfig.alertConfig.deletedRuntimeRetentionDurationDays"
-                                        >
-                                            <TextInput
-                                                isRequired
-                                                type="number"
-                                                id="privateConfig.alertConfig.deletedRuntimeRetentionDurationDays"
-                                                name="privateConfig.alertConfig.deletedRuntimeRetentionDurationDays"
-                                                value={
-                                                    values?.privateConfig?.alertConfig
-                                                        ?.deletedRuntimeRetentionDurationDays
-                                                }
-                                                onChange={onChange}
-                                            />
-                                        </FormGroup>
-                                    </GridItem>
-                                    <GridItem>
-                                        <FormGroup
-                                            label="Resolved deploy-phase violations"
-                                            isRequired
-                                            fieldId="privateConfig.alertConfig.resolvedDeployRetentionDurationDays"
-                                        >
-                                            <TextInput
-                                                isRequired
-                                                type="number"
-                                                id="privateConfig.alertConfig.resolvedDeployRetentionDurationDays"
-                                                name="privateConfig.alertConfig.resolvedDeployRetentionDurationDays"
-                                                value={
-                                                    values?.privateConfig?.alertConfig
-                                                        ?.resolvedDeployRetentionDurationDays
-                                                }
-                                                onChange={onChange}
-                                            />
-                                        </FormGroup>
-                                    </GridItem>
-                                    <GridItem>
-                                        <FormGroup
-                                            label="Attempted deploy-phase violations"
-                                            isRequired
-                                            fieldId="privateConfig.alertConfig.attemptedDeployRetentionDurationDays"
-                                        >
-                                            <TextInput
-                                                isRequired
-                                                type="number"
-                                                id="privateConfig.alertConfig.attemptedDeployRetentionDurationDays"
-                                                name="privateConfig.alertConfig.attemptedDeployRetentionDurationDays"
-                                                value={
-                                                    values?.privateConfig?.alertConfig
-                                                        ?.attemptedDeployRetentionDurationDays
-                                                }
-                                                onChange={onChange}
-                                            />
-                                        </FormGroup>
-                                    </GridItem>
-                                    <GridItem>
-                                        <FormGroup
-                                            label="Attempted runtime violations"
-                                            isRequired
-                                            fieldId="privateConfig.alertConfig.attemptedRuntimeRetentionDurationDays"
-                                        >
-                                            <TextInput
-                                                isRequired
-                                                type="number"
-                                                id="privateConfig.alertConfig.attemptedRuntimeRetentionDurationDays"
-                                                name="privateConfig.alertConfig.attemptedRuntimeRetentionDurationDays"
-                                                value={
-                                                    values?.privateConfig?.alertConfig
-                                                        ?.attemptedRuntimeRetentionDurationDays
-                                                }
-                                                onChange={onChange}
-                                            />
-                                        </FormGroup>
-                                    </GridItem>
-                                    <GridItem>
-                                        <FormGroup
-                                            label="Images no longer deployed"
-                                            isRequired
-                                            fieldId="privateConfig.imageRetentionDurationDays"
-                                        >
-                                            <TextInput
-                                                isRequired
-                                                type="number"
-                                                id="privateConfig.imageRetentionDurationDays"
-                                                name="privateConfig.imageRetentionDurationDays"
-                                                value={
-                                                    values?.privateConfig
-                                                        ?.imageRetentionDurationDays
-                                                }
-                                                onChange={onChange}
-                                            />
-                                        </FormGroup>
-                                    </GridItem>
-                                    <GridItem>
-                                        <FormGroup
-                                            label="Expired vulnerability requests"
-                                            isRequired
-                                            fieldId="privateConfig.expiredVulnReqRetentionDurationDays"
-                                        >
-                                            <TextInput
-                                                isRequired
-                                                type="number"
-                                                id="privateConfig.expiredVulnReqRetentionDurationDays"
-                                                name="privateConfig.expiredVulnReqRetentionDurationDays"
-                                                value={
-                                                    values?.privateConfig
-                                                        ?.expiredVulnReqRetentionDurationDays
-                                                }
-                                                onChange={onChange}
-                                            />
-                                        </FormGroup>
-                                    </GridItem>
-                                </Grid>
-                            </FormSection>
-                        </CardBody>
-                    </Card>
+        <Form>
+            <Title headingLevel="h2">Private data retention configuration</Title>
+            <Grid hasGutter md={6}>
+                <GridItem>
+                    <FormGroup
+                        label="All runtime violations"
+                        isRequired
+                        fieldId="privateConfig.alertConfig.allRuntimeRetentionDurationDays"
+                    >
+                        <TextInput
+                            isRequired
+                            type="number"
+                            id="privateConfig.alertConfig.allRuntimeRetentionDurationDays"
+                            name="privateConfig.alertConfig.allRuntimeRetentionDurationDays"
+                            value={
+                                values?.privateConfig?.alertConfig?.allRuntimeRetentionDurationDays
+                            }
+                            onChange={onChange}
+                        />
+                    </FormGroup>
                 </GridItem>
+                <GridItem>
+                    <FormGroup
+                        label="Runtime violations for deleted deployments"
+                        isRequired
+                        fieldId="privateConfig.alertConfig.deletedRuntimeRetentionDurationDays"
+                    >
+                        <TextInput
+                            isRequired
+                            type="number"
+                            id="privateConfig.alertConfig.deletedRuntimeRetentionDurationDays"
+                            name="privateConfig.alertConfig.deletedRuntimeRetentionDurationDays"
+                            value={
+                                values?.privateConfig?.alertConfig
+                                    ?.deletedRuntimeRetentionDurationDays
+                            }
+                            onChange={onChange}
+                        />
+                    </FormGroup>
+                </GridItem>
+                <GridItem>
+                    <FormGroup
+                        label="Resolved deploy-phase violations"
+                        isRequired
+                        fieldId="privateConfig.alertConfig.resolvedDeployRetentionDurationDays"
+                    >
+                        <TextInput
+                            isRequired
+                            type="number"
+                            id="privateConfig.alertConfig.resolvedDeployRetentionDurationDays"
+                            name="privateConfig.alertConfig.resolvedDeployRetentionDurationDays"
+                            value={
+                                values?.privateConfig?.alertConfig
+                                    ?.resolvedDeployRetentionDurationDays
+                            }
+                            onChange={onChange}
+                        />
+                    </FormGroup>
+                </GridItem>
+                <GridItem>
+                    <FormGroup
+                        label="Attempted deploy-phase violations"
+                        isRequired
+                        fieldId="privateConfig.alertConfig.attemptedDeployRetentionDurationDays"
+                    >
+                        <TextInput
+                            isRequired
+                            type="number"
+                            id="privateConfig.alertConfig.attemptedDeployRetentionDurationDays"
+                            name="privateConfig.alertConfig.attemptedDeployRetentionDurationDays"
+                            value={
+                                values?.privateConfig?.alertConfig
+                                    ?.attemptedDeployRetentionDurationDays
+                            }
+                            onChange={onChange}
+                        />
+                    </FormGroup>
+                </GridItem>
+                <GridItem>
+                    <FormGroup
+                        label="Attempted runtime violations"
+                        isRequired
+                        fieldId="privateConfig.alertConfig.attemptedRuntimeRetentionDurationDays"
+                    >
+                        <TextInput
+                            isRequired
+                            type="number"
+                            id="privateConfig.alertConfig.attemptedRuntimeRetentionDurationDays"
+                            name="privateConfig.alertConfig.attemptedRuntimeRetentionDurationDays"
+                            value={
+                                values?.privateConfig?.alertConfig
+                                    ?.attemptedRuntimeRetentionDurationDays
+                            }
+                            onChange={onChange}
+                        />
+                    </FormGroup>
+                </GridItem>
+                <GridItem>
+                    <FormGroup
+                        label="Images no longer deployed"
+                        isRequired
+                        fieldId="privateConfig.imageRetentionDurationDays"
+                    >
+                        <TextInput
+                            isRequired
+                            type="number"
+                            id="privateConfig.imageRetentionDurationDays"
+                            name="privateConfig.imageRetentionDurationDays"
+                            value={values?.privateConfig?.imageRetentionDurationDays}
+                            onChange={onChange}
+                        />
+                    </FormGroup>
+                </GridItem>
+                <GridItem>
+                    <FormGroup
+                        label="Expired vulnerability requests"
+                        isRequired
+                        fieldId="privateConfig.expiredVulnReqRetentionDurationDays"
+                    >
+                        <TextInput
+                            isRequired
+                            type="number"
+                            id="privateConfig.expiredVulnReqRetentionDurationDays"
+                            name="privateConfig.expiredVulnReqRetentionDurationDays"
+                            value={values?.privateConfig?.expiredVulnReqRetentionDurationDays}
+                            onChange={onChange}
+                        />
+                    </FormGroup>
+                </GridItem>
+            </Grid>
+            {isDecommissionedClusterRetentionEnabled && (
+                <>
+                    <Title headingLevel="h3">Cluster deletion</Title>
+                    <Grid hasGutter md={6}>
+                        <GridItem>
+                            <FormGroup
+                                label="Decommissioned cluster age"
+                                isRequired
+                                fieldId="privateConfig.decommissionedClusterRetention.retentionDurationDays"
+                            >
+                                <TextInput
+                                    isRequired
+                                    type="number"
+                                    id="privateConfig.decommissionedClusterRetention.retentionDurationDays"
+                                    name="privateConfig.decommissionedClusterRetention.retentionDurationDays"
+                                    value={
+                                        values?.privateConfig?.decommissionedClusterRetention
+                                            ?.retentionDurationDays
+                                    }
+                                    onChange={onChange}
+                                />
+                            </FormGroup>
+                        </GridItem>
+                        <GridItem>
+                            <FormGroup
+                                label="Ignore clusters which have labels"
+                                fieldId="privateConfig.decommissionedClusterRetention.ignoreClusterLabels"
+                            >
+                                <ClusterLabelsTable
+                                    labels={
+                                        values.privateConfig.decommissionedClusterRetention
+                                            .ignoreClusterLabels
+                                    }
+                                    hasAction
+                                    handleChangeLabels={handleChangeLabels}
+                                    isValueRequired
+                                />
+                            </FormGroup>
+                        </GridItem>
+                    </Grid>
+                </>
+            )}
+            <Title headingLevel="h2">Public configuration</Title>
+            <Grid hasGutter>
                 <GridItem sm={12} md={6}>
-                    <Card data-testid="header-config">
+                    <Card isFlat data-testid="header-config">
                         <CardHeader>
                             <CardHeaderMain>
-                                <CardTitle>Header configuration</CardTitle>
+                                <CardTitle component="h3">Header configuration</CardTitle>
                             </CardHeaderMain>
                             <CardActions>
                                 <Switch
@@ -356,10 +385,10 @@ const SystemConfigForm = ({
                     </Card>
                 </GridItem>
                 <GridItem sm={12} md={6}>
-                    <Card data-testid="footer-config">
+                    <Card isFlat data-testid="footer-config">
                         <CardHeader>
                             <CardHeaderMain>
-                                <CardTitle>Footer configuration</CardTitle>
+                                <CardTitle component="h3">Footer configuration</CardTitle>
                             </CardHeaderMain>
                             <CardActions>
                                 <Switch
@@ -443,10 +472,10 @@ const SystemConfigForm = ({
                     </Card>
                 </GridItem>
                 <GridItem md={6}>
-                    <Card data-testid="login-notice-config">
+                    <Card isFlat data-testid="login-notice-config">
                         <CardHeader>
                             <CardHeaderMain>
-                                <CardTitle>Login configuration</CardTitle>
+                                <CardTitle component="h3">Login configuration</CardTitle>
                             </CardHeaderMain>
                             <CardActions>
                                 <Switch
@@ -487,9 +516,10 @@ const SystemConfigForm = ({
             <ActionGroup>
                 <Button
                     variant="primary"
-                    type="submit"
+                    type="button"
                     isDisabled={!dirty || !isValid || isSubmitting}
                     isLoading={isSubmitting}
+                    onClick={submitForm}
                 >
                     Save
                 </Button>

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
@@ -278,7 +278,7 @@ const SystemConfigForm = ({
                         </GridItem>
                         <GridItem>
                             <FormGroup
-                                label="Ignore clusters which have labels"
+                                label="Ignore clusters which have the following labels"
                                 fieldId="privateConfig.decommissionedClusterRetention.ignoreClusterLabels"
                             >
                                 <ClusterLabelsTable

--- a/ui/apps/platform/src/types/config.proto.ts
+++ b/ui/apps/platform/src/types/config.proto.ts
@@ -30,10 +30,18 @@ export type AlertRetentionConfig = {
     attemptedRuntimeRetentionDurationDays: number; // int32
 };
 
+export type DecommissionedClusterRetentionConfig = {
+    retentionDurationDays: number; // int32
+    ignoreClusterLabels: Record<string, string>;
+    lastUpdated: string; // ISO 8601 date string
+    createdAt: string; // ISO 8601 date string
+};
+
 export type PrivateConfig = {
     alertConfig: AlertRetentionConfig;
     imageRetentionDurationDays: number; // int32
     expiredVulnReqRetentionDurationDays: number; // int32
+    decommissionedClusterRetention: DecommissionedClusterRetentionConfig;
 };
 
 export type SystemConfig = {

--- a/ui/apps/platform/src/utils/labels.ts
+++ b/ui/apps/platform/src/utils/labels.ts
@@ -40,9 +40,9 @@ export function getIsValidLabelKey(key: string): boolean {
     return prefix.split('.').every((subdomain) => subdomainRegExp.test(subdomain));
 }
 
-export function getIsValidLabelValue(value: string): boolean {
+export function getIsValidLabelValue(value: string, isLabelRequired?: boolean): boolean {
     if (value.length === 0) {
-        return true; // value can be empty
+        return !isLabelRequired; // value can be empty
     }
 
     if (value.length > 63) {


### PR DESCRIPTION
## Description

Follow up #2092 and #2182

### Overview

Refactor details and form following `IntegrationTilesPage` as an example, except not nested sections

Differences from mocks are to maximize consistency between details and form. Also to reuse grid layout for correct responsive behavior

1. Consistent accessible heading hierarchy in details and form
    * h2 Private data retention configuration
        * h3 Cluster deletion
    * h2 Public configuration
        * h3 Header configuration
        * h3 Footer configuration
        * h3 Login configuration
2. Consistent responsive layout in details and form
    * Replace `Gallery` with `<Grid hasGutter md={6}>` element
    * Replace `Hint` with `Card` element
    * Ensure same height for side-by-side cards in detail with `className="pf-u-h-100"` prop

### Changed files

1. Edit cypress/constants/SystemConfigPage.js
    * Replace `[data-testid="number-box"]` with `.pf-c-card` to remove prop from `PrivateConfigDataRetentionDetailsProps` component

2. Edit src/Containers/Clusters/ClusterLabelsTable.tsx
    * Add `isValueRequired` prop

3. Edit src/Containers/SystemConfig/Details/PrivateConfigDataRetentionDetails.tsx
    * Replace `Gallery` with `Grid` and `Hint` with `Card` elements
    * Replace `NumberBox` with `DataRetentionValue` to compose with labels and link for new config
    * Add `isClustersRoutePathRendered` and `isDecommissionedClusterRetentionEnabled` props
    * Move heading to `SystemConfigDetails` component to be parallel with sibling heading for public configuration
    * Add conditional rendering for decommissioned cluster retention config
    * Add heading with `id` prop for possible hash link from cluster side panel

4. Edit src/Containers/SystemConfig/Details/PublicConfigBannerDetails.tsx
    * Add `isFlat` prop to `Card` element and `component="h3"` prop to `CardTitle` element

5. Edit src/Containers/SystemConfig/Details/PublicConfigLoginDetails.tsx
    * Add `isFlat` prop to `Card` element and `component="h3"` prop to `CardTitle` element

6. Edit src/Containers/SystemConfig/Details/SystemConfigDetails.tsx
    * Make component name consistent with file name
    * Add `isClustersRoutePathRendered` and `isDecommissionedClusterRetentionEnabled` props
    * Add `PageSection` elements with `Title` elements to distinguish private and public configuration

7. Edit src/Containers/SystemConfig/Form/SystemConfigForm.tsx
    * Alphabetize PatternFly element names in `import` statement
    * Add `isDecommissionedClusterRetentionEnabled` prop
    * Delete optional `false` arg from `setFieldValue` function calls to prepare for possible future validation
    * Add `handleChangeLabels` function
    * Replace `onSubmit={onSubmitForm}` prop of `Form` element with `onClick={submitForm}` prop of `Button` element
    * Add conditional rendering for decommissioned cluster retention config
    * Add `Title` elements to distinguish private and public configuration
    * Add `isFlat` prop to `Card` elements and `component="h3"` prop to `CardTitle` elements
    * Replace `type="submit"` with `type="button"` prop of **Save** button because enter key is alternative to add label button

8. Edit src/Containers/SystemConfig/SystemConfigPage.tsx
    * Add `useFeatureFlags` and `usePermissions` hooks
    * Move `PageSection` element so `SystemConfigDetails` can render multiple `PageSection` elements
    * Add conditional rendering for **Edit** button

9. Edit src/types/config.proto.ts
    * Add `decommissionedClusterRetention` to `privateConfig`

10. Edit src/utils/labels.ts
    * Add optional `isValueRequired` arg to `getIsValidLabelValue` function

### Residue

1. Investigate why **Delete value** instead of **Delete label** for screen tip, even though it does delete the label?
2. Add integration tests.
3. Add validation for data retention days. By the way, label table encapsulates validation so add is disabled until a label is valid
4. Add commented-out code for future computation of `isClustersRoutePathRendered` after #2105 has been merged

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

## Testing Performed

### manual testing

1. `export ROX_DECOMMISSIONED_CLUSTER_RETENTION=true` in ui
2. `yarn deploy-local` in ui
3. `yarn build` in ui
4. `yarn start` in ui

    * Visit /main/systemconfig: see GET /v1/config

        ```json
        {
            "publicConfig": null,
            "privateConfig": {
                "alertConfig": {
                    "resolvedDeployRetentionDurationDays": 7,
                    "deletedRuntimeRetentionDurationDays": 7,
                    "allRuntimeRetentionDurationDays": 30,
                    "attemptedDeployRetentionDurationDays": 7,
                    "attemptedRuntimeRetentionDurationDays": 7
                },
                "imageRetentionDurationDays": 7,
                "expiredVulnReqRetentionDurationDays": 90,
                "decommissionedClusterRetention": {
                    "retentionDurationDays": 90,
                    "ignoreClusterLabels": {},
                    "lastUpdated": "2022-06-28T14:10:11.103607300Z"
                }
            }
        }
        ```

        Details **without** feature flag: does **not** have **Cluster deletion**
        ![details-without-feature-flag](https://user-images.githubusercontent.com/11862657/176768887-b0126df2-cee7-472e-a6d5-ec67fcb032fb.png)

        Details **with** feature flag: does have **Cluster deletion**
        ![details-with-feature-flag](https://user-images.githubusercontent.com/11862657/176768919-cff25192-b555-4f70-8b3e-533264ed601d.png)

        Form **without** feature flag: does **not** have **Cluster deletion**
        ![form-without-feature-flag](https://user-images.githubusercontent.com/11862657/176768968-e0d79a08-041b-46f8-86e4-3d8b95de9c1a.png)

        Form **with** feature flag: does have **Cluster deletion**
        ![form-with-feature-flag](https://user-images.githubusercontent.com/11862657/176769000-ba1070cc-d8c9-450a-bf9b-085fa7a44b6d.png)

    * Change **Expired vulnerability requests** and **Decommissioned cluster age** values
        ![form-change-values](https://user-images.githubusercontent.com/11862657/176769102-1b42130a-b5d5-4950-9f4b-aa5860bcbb92.png)

        Click **Save**: see changed values PUT /v1/config response and in details
        ![save-values-response-details](https://user-images.githubusercontent.com/11862657/176769185-867f999c-a0e0-4810-80d7-088d993b7001.png)

    * See message for empty value when you add a label
        ![form-label-empty-value](https://user-images.githubusercontent.com/11862657/176769321-0f629af4-f18a-46e1-9301-0e90a0e8a396.png)

        Click **Save**: see changed values PUT /v1/config response and in details
        ![save-add-label](https://user-images.githubusercontent.com/11862657/176769525-b5e76823-9529-4131-98c0-2de714c2a226.png)

    * Interlude: see no message for empty value when you add a label to a cluster
        ![value-optional-cluster](https://user-images.githubusercontent.com/11862657/176770851-b64c2a1d-f55d-4758-8ecc-5de5f02591da.png)

    * Interlude: see no message for empty value when you add a label to an access scope
        ![value-optional-access-scope](https://user-images.githubusercontent.com/11862657/176770880-bb3cb58c-492a-4580-a1e7-838e1c686416.png)

    * Delete a label (see Residue why **Delete value** instead of **Delete label** for screen tip)
        ![form-label-delete](https://user-images.githubusercontent.com/11862657/176769869-992b5f88-1ddf-4107-ae3c-583139346ce5.png)

        Click **Save**: see changed values PUT /v1/config response and in details
        ![save-delete-label](https://user-images.githubusercontent.com/11862657/176770282-059b59bd-fe8c-44ef-aab5-94b5776b3093.png)

    * Reduce width from 1280px to 760px: see grid change from 2 columns to 1 column

        Details
        ![detail-one-column](https://user-images.githubusercontent.com/11862657/176770345-89b0f3d9-7768-4785-9298-a36b75164ba6.png)

        Form
        ![form-one-column](https://user-images.githubusercontent.com/11862657/176770428-2d4e9e28-7b85-4cbd-b7e5-3c85b57e4dd5.png)

### integration testing

1. `yarn cypress-open` in ui/apps/platform
    * systemconfig.test.js
