### PR TITLE
CI: Fix nightlies III

### DIFF
--- a/scripts/ci/jobs/test-binary-build-commands.sh
+++ b/scripts/ci/jobs/test-binary-build-commands.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 make_test_bin() {
     info "Making test-bin"
 
-    make cli upgrader
+    make cli-build upgrader
     install_built_roxctl_in_gopath
 }
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -843,11 +843,11 @@ handle_nightly_runs() {
         die "Only for OpenShift CI"
     fi
 
-    if ! is_in_PR_context; then
+    # if ! is_in_PR_context; then
         info "Debug:"
         echo "JOB_NAME: ${JOB_NAME:-}"
         echo "JOB_NAME_SAFE: ${JOB_NAME_SAFE:-}"
-    fi
+    # fi
 
     local nightly_tag_prefix
     nightly_tag_prefix="$(git describe --tags --abbrev=0 --exclude '*-nightly-*')-nightly-"
@@ -870,28 +870,28 @@ handle_nightly_roxctl_mismatch() {
         die "Only for OpenShift CI"
     fi
 
-    if is_in_PR_context || ! [[ "${JOB_NAME_SAFE:-}" =~ ^nightly- ]]; then
-        return 0
-    fi
+    # if is_in_PR_context || ! [[ "${JOB_NAME_SAFE:-}" =~ ^nightly- ]]; then
+    #     return 0
+    # fi
 
     # JOB_NAME_SAFE is not set in test_binary_build_commands context for
     # periodics, so the roxctl produced in that step will cause deploy.sh to
     # fail.
 
-    if ! is_in_PR_context; then
+    # if ! is_in_PR_context; then
         info "Debug:"
         echo "JOB_NAME: ${JOB_NAME:-}"
         echo "JOB_NAME_SAFE: ${JOB_NAME_SAFE:-}"
-    fi
+    # fi
 
     info "Correcting roxctl version for nightly e2e tests"
     echo "Current roxctl is: $(command -v roxctl || true), version: $(roxctl version || true)"
 
-    if ! [[ "$(roxctl version || true)" =~ nightly ]]; then
+    # if ! [[ "$(roxctl version || true)" =~ nightly ]]; then
         make cli-build
         install_built_roxctl_in_gopath
         echo "Replacement roxctl is: $(command -v roxctl || true), version: $(roxctl version || true)"
-    fi
+    # fi
 }
 
 validate_expected_go_version() {

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -843,11 +843,11 @@ handle_nightly_runs() {
         die "Only for OpenShift CI"
     fi
 
-    # if ! is_in_PR_context; then
+    if ! is_in_PR_context; then
         info "Debug:"
         echo "JOB_NAME: ${JOB_NAME:-}"
         echo "JOB_NAME_SAFE: ${JOB_NAME_SAFE:-}"
-    # fi
+    fi
 
     local nightly_tag_prefix
     nightly_tag_prefix="$(git describe --tags --abbrev=0 --exclude '*-nightly-*')-nightly-"
@@ -870,28 +870,28 @@ handle_nightly_roxctl_mismatch() {
         die "Only for OpenShift CI"
     fi
 
-    # if is_in_PR_context || ! [[ "${JOB_NAME_SAFE:-}" =~ ^nightly- ]]; then
-    #     return 0
-    # fi
+    if is_in_PR_context || ! [[ "${JOB_NAME_SAFE:-}" =~ ^nightly- ]]; then
+        return 0
+    fi
 
     # JOB_NAME_SAFE is not set in test_binary_build_commands context for
     # periodics, so the roxctl produced in that step will cause deploy.sh to
     # fail.
 
-    # if ! is_in_PR_context; then
+    if ! is_in_PR_context; then
         info "Debug:"
         echo "JOB_NAME: ${JOB_NAME:-}"
         echo "JOB_NAME_SAFE: ${JOB_NAME_SAFE:-}"
-    # fi
+    fi
 
     info "Correcting roxctl version for nightly e2e tests"
     echo "Current roxctl is: $(command -v roxctl || true), version: $(roxctl version || true)"
 
-    # if ! [[ "$(roxctl version || true)" =~ nightly ]]; then
+    if ! [[ "$(roxctl version || true)" =~ nightly ]]; then
         make cli-build
         install_built_roxctl_in_gopath
         echo "Replacement roxctl is: $(command -v roxctl || true), version: $(roxctl version || true)"
-    # fi
+    fi
 }
 
 validate_expected_go_version() {


### PR DESCRIPTION
## Description

Yesterdays fix did not take because `make cli` attempts to `chmod u+w $(GOPATH)/bin/roxctl` which is [not permitted](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-stackrox-stackrox-master-nightly-gke-qa-e2e-tests/1542372629149650944) in the test context (though it is permitted in the image context and `cp bin/$(HOST_OS)/roxctl $(GOPATH)/bin/roxctl` is fine so /shrug).

Also noted in last nights CI runs is that the roxctl generated in `test-bin` does in fact have the proper nightly tag. My working theory is that the CCI trigger has created the tag before OSCI runs and that when they run that tag is at HEAD. (It would be tempting to rely on this and avoid the hacking in prior fixes but relying on different cron jobs to behave in any sort of order notwithstanding external changes is a 💩 IMHO). And it appears as if JOB_NAME_SPEC is defined in the `test-bin` context. So this PR also adds a bunch of defensive checks when building roxctl and some general debug.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient - Forced the code path with commit 0f381d6. Ideally I would also trigger a nightly run but there is no sane way to do that with prow. 