### PR TITLE
Upstream release automation: use DRY_RUN when possible (dry-run bugfix)

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -23,10 +23,26 @@ env:
   jira_projects: ROX, RS, RTOOLS
   slack_channel: C03KSV3N6N8 #test-release-automation
   script_url: /repos/${{github.repository}}/contents/.github/workflows/scripts/common.sh?ref=${{github.event.repository.default_branch}}
-  DRY_RUN: ${{ fromJSON('["true", "false"]')[inputs.dry-run != 'true'] }}
+  DRY_RUN: ${{ fromJSON('["true", "false"]')[github.event.inputs.dry-run != 'true'] }}
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
+  run-parameters:
+    name: Run parameters
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          [ "$DRY_RUN" = "true" ] && echo "::warning::This is a dry run"
+          echo "Event: ${{github.event_name}}" >>"$GITHUB_STEP_SUMMARY"
+          if [ "${{github.event_name}}" = "workflow_dispatch" ]; then
+            cat <<EOF >>"$GITHUB_STEP_SUMMARY"
+          \`\`\`
+          ${{toJSON(inputs)}}
+          \`\`\`
+          EOF
+          fi
+
   variables:
     name: Setup variables
     uses: ./.github/workflows/variables.yml
@@ -41,7 +57,6 @@ jobs:
       - name: Query JIRA
         env:
           JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
           gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
@@ -55,8 +70,6 @@ jobs:
     name: Postpone open PRs
     needs: variables
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check open PRs
         id: check
@@ -102,7 +115,7 @@ jobs:
           echo "The following PRs are still open: $PRS"
 
           for PR in $PRS; do
-            [ "${{inputs.dry-run}}" != "true" ] && \
+            [ "$DRY_RUN" != "true" ] && \
             gh pr edit $PR \
               --milestone "${{needs.variables.outputs.next-milestone}}" \
               --repo "${{github.repository}}"
@@ -126,9 +139,7 @@ jobs:
       - run: |
           # Could be optimized: done only if there are closed PRs to cherry-pick
           git fetch origin ${{env.main_branch}}:${{env.main_branch}} --unshallow
-      - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        name: Cherry-pick commits from the main branch
+      - name: Cherry-pick commits from the main branch
         id: cherry-pick
         run: |
           set -uo pipefail
@@ -203,8 +214,6 @@ jobs:
     needs: [variables, cut-rc]
     if: failure() && inputs.dry-run != 'true'
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Reopen milestone ${{needs.variables.outputs.milestone}}
         if: inputs.dry-run != 'true'
@@ -218,8 +227,6 @@ jobs:
     name: Publish a GitHub pre-release
     needs: [variables, cut-rc]
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Create GitHub Pre-release
         id: pre-release

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -85,7 +85,7 @@ jobs:
           fi
 
       - name: Create next milestone
-        if: inputs.dry-run != 'true' && steps.check.outputs.open-issues != ''
+        if: env.DRY_RUN == 'false' && steps.check.outputs.open-issues != ''
         run: |
           set -u
           if ! http_code=$(gh api --silent -X POST \
@@ -203,7 +203,7 @@ jobs:
         run: |
           git tag --annotate "${{needs.variables.outputs.milestone}}" --message ""
       - name: Push
-        if: inputs.dry-run != 'true'
+        if: env.DRY_RUN == 'false'
         run: |
           git push --follow-tags
       - run: |
@@ -212,11 +212,11 @@ jobs:
   reopen-milestone:
     name: Reopen milestone ${{needs.variables.outputs.milestone}}
     needs: [variables, cut-rc]
-    if: failure() && inputs.dry-run != 'true'
+    if: failure()
     runs-on: ubuntu-latest
     steps:
       - name: Reopen milestone ${{needs.variables.outputs.milestone}}
-        if: inputs.dry-run != 'true'
+        if: env.DRY_RUN == 'false'
         run: |
           gh api "repos/${{github.repository}}/milestones/${{github.event.milestone.number}}" \
             -X PATCH -f state=open
@@ -230,7 +230,7 @@ jobs:
     steps:
       - name: Create GitHub Pre-release
         id: pre-release
-        if: inputs.dry-run != 'true'
+        if: env.DRY_RUN == 'false'
         run: |
           URL=$(gh release create "${{needs.variables.outputs.milestone}}" \
             --prerelease \
@@ -268,7 +268,8 @@ jobs:
   create-k8s-cluster:
     name: Create k8s cluster
     needs: [variables, cut-rc]
-    if: inputs.dry-run != 'true'
+    # Cannot use env.DRY_RUN here. `dry-run` can be 'true', 'false' or empty.
+    if: github.event.inputs.dry-run != 'true'
     uses: ./.github/workflows/create-cluster.yml
     secrets: inherit
     with:
@@ -280,7 +281,8 @@ jobs:
   create-os4-cluster:
     name: Create OS4 cluster
     needs: [variables, cut-rc]
-    if: inputs.dry-run != 'true'
+    # Cannot use env.DRY_RUN here. `dry-run` can be 'true', 'false' or empty.
+    if: github.event.inputs.dry-run != 'true'
     uses: ./.github/workflows/create-cluster.yml
     secrets: inherit
     with:
@@ -367,8 +369,9 @@ jobs:
   create-long-running-cluster:
     name: Create GKE long-running cluster
     needs: [variables, cut-rc]
+    # Cannot use env.DRY_RUN here. `dry-run` can be 'true', 'false' or empty.
     if: >-
-      inputs.dry-run != 'true' &&
+      github.event.inputs.dry-run != 'true' &&
       needs.variables.outputs.rc == '1'
     uses: ./.github/workflows/create-cluster.yml
     secrets: inherit

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -115,7 +115,7 @@ jobs:
           echo "The following PRs are still open: $PRS"
 
           for PR in $PRS; do
-            [ "$DRY_RUN" != "true" ] && \
+            [ "$DRY_RUN" = "false" ] && \
             gh pr edit $PR \
               --milestone "${{needs.variables.outputs.next-milestone}}" \
               --repo "${{github.repository}}"

--- a/.github/workflows/scripts/check-jira-issues.sh
+++ b/.github/workflows/scripts/check-jira-issues.sh
@@ -80,7 +80,7 @@ OPEN_ISSUES=$(get_open_issues)
 echo "Open issues:"
 echo "$OPEN_ISSUES"
 
-if [ "$DRY_RUN" != "true" ]; then
+if [ "$DRY_RUN" = "false" ]; then
     while read -r KEY; do
         comment_issue "$KEY"
     done <<<"$OPEN_ISSUES"

--- a/.github/workflows/scripts/cherry-pick.sh
+++ b/.github/workflows/scripts/cherry-pick.sh
@@ -44,14 +44,14 @@ cherry_pick() {
     if git cherry-pick -x "$COMMIT"; then
         gh_summary "Cherry-picked $COMMIT from PR $PR"
 
-        [ "$DRY_RUN" != "true" ] &&
+        [ "$DRY_RUN" = "false" ] &&
             gh pr comment "$PR" --body "Merge commit has been cherry-picked to branch \`$BRANCH\`."
 
         PICKED=$((PICKED+1))
     else
         git cherry-pick --abort
 
-        [ "$DRY_RUN" != "true" ] &&
+        [ "$DRY_RUN" = "false" ] &&
             gh pr comment "$PR" --body "Please merge the changes to branch \`$BRANCH\`."
 
         gh_summary "* [PR $PR]($URL) by **${AUTHOR}** (_${TITLE}_) could not be cherry-picked. Merge commit: \`$COMMIT\`."
@@ -94,7 +94,7 @@ if [ -n "$PR_COMMITS" ]; then
     done <<<"$PR_COMMITS"
 
     if [ "$PICKED" -gt 0 ]; then
-        [ "$DRY_RUN" != "true" ] &&
+        [ "$DRY_RUN" = "false" ] &&
             git push
 
         gh_summary "Cherry-picked commits have been pushed to the release branch."

--- a/.github/workflows/scripts/patch-changelog.sh
+++ b/.github/workflows/scripts/patch-changelog.sh
@@ -59,7 +59,7 @@ if ! git diff-index --quiet HEAD; then
     git commit --message "Next version in changelog after $VERSION"
 
     PR_URL=""
-    if [ "$DRY_RUN" != "true" ]; then
+    if [ "$DRY_RUN" = "false" ]; then
         git push --set-upstream origin "$CHANGELOG_BRANCH"
         PR_URL=$(create_pr)
     fi

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -24,36 +24,47 @@ env:
   main_branch: ${{github.event.repository.default_branch}}
   jira_project: ROX
   script_url: /repos/${{github.repository}}/contents/.github/workflows/scripts/common.sh?ref=${{github.event.repository.default_branch}}
-  DRY_RUN: ${{ fromJSON('["true", "false"]')[inputs.dry-run != 'true'] }}
+  DRY_RUN: ${{ fromJSON('["true", "false"]')[github.event.inputs.dry-run != 'true'] }}
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  check-jira:
-    name: Check Jira release
+  run-parameters:
+    name: Run parameters
     runs-on: ubuntu-latest
-    env:
-      JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    outputs:
-      release-date: ${{steps.check-jira-release.outputs.date}}
     steps:
-      - name: Check that Jira release ${{inputs.version}} is not released
-        id: check-jira-release
-        env:
-          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -uo pipefail
-          gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
-            check-jira-release \
-            "${{inputs.version}}" \
-            "${{env.jira_project}}"
+      - run: |
+          [ "$DRY_RUN" = "true" ] && echo "::warning::This is a dry run"
+          echo "Event: ${{github.event_name}}" >>"$GITHUB_STEP_SUMMARY"
+          cat <<EOF >>"$GITHUB_STEP_SUMMARY"
+          \`\`\`
+          ${{toJSON(inputs)}}
+          \`\`\`
+          EOF
 
   variables:
     name: Setup variables
     uses: ./.github/workflows/variables.yml
     with:
       version: ${{github.event.inputs.version}}
+
+  check-jira:
+    name: Check Jira release
+    needs: variables
+    runs-on: ubuntu-latest
+    outputs:
+      release-date: ${{steps.check-jira-release.outputs.date}}
+    steps:
+      - name: Check that Jira release ${{needs.variables.outputs.release}}.${{needs.variables.outputs.patch}} is not released
+        id: check-jira-release
+        env:
+          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+        run: |
+          set -uo pipefail
+          gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
+            check-jira-release \
+            "${{needs.variables.outputs.release}}.${{needs.variables.outputs.patch}}" \
+            "${{env.jira_project}}"
 
   check-docs-branch:
     name: Check documentation branch
@@ -62,8 +73,6 @@ jobs:
     steps:
       - name: Test if branch ${{needs.variables.outputs.docs-branch}} exists
         id: check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh api "repos/${{env.docs_repository}}/git/refs/heads/${{needs.variables.outputs.docs-branch}}"
       - name: Post to Slack
@@ -164,8 +173,6 @@ jobs:
           git config user.name "${{github.event.sender.login}}"
           git config user.email noreply@github.com
       - name: Patch CHANGELOG.md on ${{inputs.ref}}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
           gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
@@ -178,8 +185,6 @@ jobs:
     name: Create milestone
     needs: [variables]
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Create ${{needs.variables.outputs.milestone}} milestone
         if: inputs.dry-run != 'true'
@@ -191,13 +196,15 @@ jobs:
             2>&1); then
 
             if grep "HTTP 422" <<< "$http_code"; then
-              echo "::notice::Milestone ${{needs.variables.outputs.milestone}} already exists. Close it once it's finished."
+              echo ":arrow_right: Milestone ${{needs.variables.outputs.milestone}} already exists." \
+                "**Close it once it's finished.**" >>"$GITHUB_STEP_SUMMARY"
             else
               echo "::error::Couldn't create milestone ${{needs.variables.outputs.milestone}}: $http_code"
               exit 1
             fi
           else
-            echo "::notice::Milestone ${{needs.variables.outputs.milestone}} has been created. Close it once it's finished."
+            echo ":arrow_right: Milestone ${{needs.variables.outputs.milestone}} has been created." \
+              "**Close it once it's finished.**" >>"$GITHUB_STEP_SUMMARY"
           fi
 
   notify:

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -153,7 +153,7 @@ jobs:
             echo "\`CHANGELOG.md\` has been updated on the release branch." >> $GITHUB_STEP_SUMMARY
           fi
       - name: Push changes
-        if: inputs.dry-run != 'true' && steps.check-existing.outputs.branch-exists == 'false'
+        if: env.DRY_RUN == 'false' && steps.check-existing.outputs.branch-exists == 'false'
         run: |
           git push --set-upstream origin ${{needs.variables.outputs.branch}}
 
@@ -187,7 +187,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create ${{needs.variables.outputs.milestone}} milestone
-        if: inputs.dry-run != 'true'
+        if: env.DRY_RUN == 'false'
         run: |
           set -u
           if ! http_code=$(gh api --silent -X POST \

--- a/.github/workflows/variables.yml
+++ b/.github/workflows/variables.yml
@@ -61,11 +61,14 @@ jobs:
                 exit(1)
 
             rc = int(m.group('rc') or 1)
+            name = m.group('name') or ''
+            dash_name = f'-{name}' if name else ''
 
             print(f'''
             ::set-output name=release::{m.group('release')}
             ::set-output name=patch::{m.group('patch')}
-            ::set-output name=name::{m.group('name') or ''}
+            ::set-output name=name::{name}
+            ::set-output name=dash-name::{dash_name}
             ::set-output name=rc::{rc}
             ::set-output name=next-rc::{rc+1}
             ''')


### PR DESCRIPTION
## Description

This PR fixes an issue with the `inputs` context not being _always_ available (not sure why). Using `github.event.inputs` instead seems to fix the issue.

The problem has been discovered during a "Start Release" dry run on `stackrox/stackrox`: the RC1 milestone [was created](https://github.com/stackrox/stackrox/runs/7140127856?check_suite_focus=true) despite the dry-run option being set.

Due to another GitHub context issue, the DRY_RUN environment variable cannot be used at the `job.<job_id>.if` level, so reverting back the use of `github.event.input` for those cases.

A little out-of-scope fix in `variables.yml`: bringing back the forgotten `dash-name` variable, which stores the release name following a dash (or empty if no name). This variable simplifies output formatting.

## Testing Performed

Manual testing on `stackrox/test-gh-actions` repository.