### PR TITLE
Move legacy cve datastore usages in graphQL behind feature flag

### DIFF
--- a/central/graphql/resolvers/components_v2.go
+++ b/central/graphql/resolvers/components_v2.go
@@ -639,6 +639,9 @@ func (eicr *imageComponentResolver) LayerIndex() *int32 {
 
 // PlottedVulns returns the data required by top risky component scatter-plot on vuln mgmt dashboard
 func (eicr *imageComponentResolver) PlottedVulns(ctx context.Context, args RawQuery) (*PlottedVulnerabilitiesResolver, error) {
+	if features.PostgresDatastore.Enabled() {
+		return nil, errors.New("PlottedVulns resolver is not support on postgres. Use PlottedImageVulnerabilities.")
+	}
 	query := search.AddRawQueriesAsConjunction(args.String(), eicr.componentRawQuery())
 	return newPlottedVulnerabilitiesResolver(ctx, eicr.root, RawQuery{Query: &query})
 }

--- a/central/graphql/resolvers/deployments.go
+++ b/central/graphql/resolvers/deployments.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/graphql/resolvers/deploymentctx"
 	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
 	"github.com/stackrox/rox/central/metrics"
@@ -12,6 +13,7 @@ import (
 	"github.com/stackrox/rox/central/processindicator/service"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/scoped"
@@ -787,6 +789,9 @@ func (resolver *deploymentResolver) LatestViolation(ctx context.Context, args Ra
 }
 
 func (resolver *deploymentResolver) PlottedVulns(ctx context.Context, args RawQuery) (*PlottedVulnerabilitiesResolver, error) {
+	if features.PostgresDatastore.Enabled() {
+		return nil, errors.New("PlottedVulns resolver is not support on postgres. Use PlottedImageVulnerabilities.")
+	}
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getDeploymentRawQuery())
 	return newPlottedVulnerabilitiesResolver(ctx, resolver.root, RawQuery{Query: &query})
 }

--- a/central/graphql/resolvers/images.go
+++ b/central/graphql/resolvers/images.go
@@ -380,6 +380,9 @@ func (resolver *imageResolver) getImageQuery() *v1.Query {
 }
 
 func (resolver *imageResolver) PlottedVulns(ctx context.Context, args RawQuery) (*PlottedVulnerabilitiesResolver, error) {
+	if features.PostgresDatastore.Enabled() {
+		return nil, errors.New("PlottedVulns resolver is not support on postgres. Use PlottedImageVulnerabilities.")
+	}
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getImageRawQuery())
 	return newPlottedVulnerabilitiesResolver(ctx, resolver.root, RawQuery{Query: &query})
 }

--- a/central/graphql/resolvers/loaders/cves.go
+++ b/central/graphql/resolvers/loaders/cves.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cvss"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -18,6 +19,9 @@ import (
 var cveLoaderType = reflect.TypeOf(storage.CVE{})
 
 func init() {
+	if features.PostgresDatastore.Enabled() {
+		return
+	}
 	// TODO: [ROX-11257, ROX-11258, ROX-11259] Replace this cve loader.
 	RegisterTypeFactory(reflect.TypeOf(storage.CVE{}), func() interface{} {
 		return NewCVELoader(legacyImageCVEDataStore.Singleton())

--- a/central/graphql/resolvers/namespaces.go
+++ b/central/graphql/resolvers/namespaces.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
 	"github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/namespace"
@@ -12,6 +13,7 @@ import (
 	riskDS "github.com/stackrox/rox/central/risk/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/scoped"
@@ -709,6 +711,9 @@ func (resolver *namespaceResolver) LatestViolation(ctx context.Context, args Raw
 }
 
 func (resolver *namespaceResolver) PlottedVulns(ctx context.Context, args PaginatedQuery) (*PlottedVulnerabilitiesResolver, error) {
+	if features.PostgresDatastore.Enabled() {
+		return nil, errors.New("PlottedVulns resolver is not support on postgres. Use PlottedImageVulnerabilities.")
+	}
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterNamespaceRawQuery())
 	return newPlottedVulnerabilitiesResolver(ctx, resolver.root, RawQuery{Query: &query})
 }

--- a/central/graphql/resolvers/nodes.go
+++ b/central/graphql/resolvers/nodes.go
@@ -520,6 +520,9 @@ func (resolver *nodeResolver) NodeVulnerabilityCounter(ctx context.Context, args
 
 // PlottedVulns returns the data required by top risky entity scatter-plot on vuln mgmt dashboard
 func (resolver *nodeResolver) PlottedVulns(ctx context.Context, args RawQuery) (*PlottedVulnerabilitiesResolver, error) {
+	if features.PostgresDatastore.Enabled() {
+		return nil, errors.New("PlottedVulns resolver is not support on postgres. Use PlottedNodeVulnerabilities.")
+	}
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getNodeRawQuery())
 	return newPlottedVulnerabilitiesResolver(ctx, resolver.root, RawQuery{Query: &query})
 }

--- a/central/graphql/resolvers/resolver.go
+++ b/central/graphql/resolvers/resolver.go
@@ -164,9 +164,6 @@ func New() *Resolver {
 		resolver.ImageCVEDataStore = imageCVEDataStore.Singleton()
 		resolver.NodeCVEDataStore = nodeCVEDataStore.Singleton()
 		resolver.NodeComponentDataStore = nodeComponentDataStore.Singleton()
-
-		// TODO: [ROX-11432] All usages of vuln datastore are not gated behind feature flag.
-		resolver.CVEDataStore = legacyImageCVEDataStore.Singleton()
 	} else {
 		resolver.CVEDataStore = legacyImageCVEDataStore.Singleton()
 	}

--- a/central/graphql/resolvers/search.go
+++ b/central/graphql/resolvers/search.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/central/rbac/service"
 	searchService "github.com/stackrox/rox/central/search/service"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/utils"
@@ -129,8 +130,10 @@ func (resolver *Resolver) getAutoCompleteSearchers() map[v1.SearchCategory]searc
 		v1.SearchCategory_ROLES:            resolver.K8sRoleStore,
 		v1.SearchCategory_ROLEBINDINGS:     resolver.K8sRoleBindingStore,
 		v1.SearchCategory_IMAGE_COMPONENTS: resolver.ImageComponentDataStore,
-		v1.SearchCategory_VULNERABILITIES:  resolver.CVEDataStore,
 		v1.SearchCategory_SUBJECTS:         service.NewSubjectSearcher(resolver.K8sRoleBindingStore),
+	}
+	if !features.PostgresDatastore.Enabled() {
+		searchers[v1.SearchCategory_VULNERABILITIES] = resolver.CVEDataStore
 	}
 
 	return searchers
@@ -151,10 +154,11 @@ func (resolver *Resolver) getSearchFuncs() map[v1.SearchCategory]searchService.S
 		v1.SearchCategory_ROLES:            resolver.K8sRoleStore.SearchRoles,
 		v1.SearchCategory_ROLEBINDINGS:     resolver.K8sRoleBindingStore.SearchRoleBindings,
 		v1.SearchCategory_IMAGE_COMPONENTS: resolver.ImageComponentDataStore.SearchImageComponents,
-		v1.SearchCategory_VULNERABILITIES:  resolver.CVEDataStore.SearchCVEs,
 		v1.SearchCategory_SUBJECTS:         service.NewSubjectSearcher(resolver.K8sRoleBindingStore).SearchSubjects,
 	}
-
+	if !features.PostgresDatastore.Enabled() {
+		searchfuncs[v1.SearchCategory_VULNERABILITIES] = resolver.CVEDataStore.SearchCVEs
+	}
 	return searchfuncs
 }
 

--- a/central/graphql/resolvers/search_test.go
+++ b/central/graphql/resolvers/search_test.go
@@ -20,6 +20,7 @@ import (
 	secretMocks "github.com/stackrox/rox/central/secret/datastore/mocks"
 	serviceAccountMocks "github.com/stackrox/rox/central/serviceaccount/datastore/mocks"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -54,7 +55,10 @@ func TestSearchCategories(t *testing.T) {
 		K8sRoleBindingStore:      rolebindings,
 		K8sRoleStore:             roles,
 		ImageComponentDataStore:  components,
-		CVEDataStore:             cves,
+	}
+
+	if !features.PostgresDatastore.Enabled() {
+		resolver.CVEDataStore = cves
 	}
 
 	searchCategories := resolver.getAutoCompleteSearchers()

--- a/central/graphql/resolvers/vulnerabilities.go
+++ b/central/graphql/resolvers/vulnerabilities.go
@@ -5,8 +5,10 @@ import (
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/metrics"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/features"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/utils"
@@ -118,24 +120,36 @@ type VulnerabilityResolver interface {
 // Vulnerability resolves a single vulnerability based on an id (the CVE value).
 func (resolver *Resolver) Vulnerability(ctx context.Context, args IDQuery) (VulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "Vulnerability")
+	if features.PostgresDatastore.Enabled() {
+		return nil, errors.New("Vulnerability graphQL resolver is not support on postgres. Use Image/Node/ClusterVulnerability resolver.")
+	}
 	return resolver.vulnerabilityV2(ctx, args)
 }
 
 // Vulnerabilities resolves a set of vulnerabilities based on a query.
 func (resolver *Resolver) Vulnerabilities(ctx context.Context, q PaginatedQuery) ([]VulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "Vulnerabilities")
+	if features.PostgresDatastore.Enabled() {
+		return nil, errors.New("Vulnerabilities graphQL resolver is not support on postgres. Use Image/Node/ClusterVulnerabilities resolver.")
+	}
 	return resolver.vulnerabilitiesV2(ctx, q)
 }
 
 // VulnerabilityCount returns count of all clusters across infrastructure
 func (resolver *Resolver) VulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "VulnerabilityCount")
+	if features.PostgresDatastore.Enabled() {
+		return 0, errors.New("VulnerabilityCount graphQL resolver is not support on postgres. Use Image/Node/ClusterVulnerabilityCount resolver.")
+	}
 	return resolver.vulnerabilityCountV2(ctx, args)
 }
 
 // VulnCounter returns a VulnerabilityCounterResolver for the input query.s
 func (resolver *Resolver) VulnCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "VulnCounter")
+	if features.PostgresDatastore.Enabled() {
+		return nil, errors.New("VulnCounter graphQL resolver is not support on postgres. Use Image/Node/ClusterVulnerabilityCounter resolver.")
+	}
 	return resolver.vulnCounterV2(ctx, args)
 }
 

--- a/central/graphql/resolvers/vulnerabilities_v2.go
+++ b/central/graphql/resolvers/vulnerabilities_v2.go
@@ -193,6 +193,9 @@ func (resolver *cVEResolver) CvssV3(ctx context.Context) (*cVSSV3Resolver, error
 }
 
 func (resolver *Resolver) vulnerabilityV2(ctx context.Context, args IDQuery) (VulnerabilityResolver, error) {
+	if features.PostgresDatastore.Enabled() {
+		return nil, errors.New("vulnerabilityV2 not supported on postgres.")
+	}
 	vulnResolver, err := resolver.unwrappedVulnerabilityV2(ctx, args)
 	if err != nil {
 		return nil, err
@@ -201,6 +204,9 @@ func (resolver *Resolver) vulnerabilityV2(ctx context.Context, args IDQuery) (Vu
 }
 
 func (resolver *Resolver) vulnerabilitiesV2(ctx context.Context, args PaginatedQuery) ([]VulnerabilityResolver, error) {
+	if features.PostgresDatastore.Enabled() {
+		return nil, errors.New("vulnerabilitiesV2 not supported on postgres.")
+	}
 	vulnResolvers, err := resolver.unwrappedVulnerabilitiesV2(ctx, args)
 	if err != nil {
 		return nil, err
@@ -376,6 +382,9 @@ func (resolver *Resolver) unwrappedVulnerabilitiesV2Query(ctx context.Context, q
 }
 
 func (resolver *Resolver) vulnerabilityCountV2(ctx context.Context, args RawQuery) (int32, error) {
+	if features.PostgresDatastore.Enabled() {
+		return 0, errors.New("vulnerabilityCountV2 not supported on postgres.")
+	}
 	if err := readCVEs(ctx); err != nil {
 		return 0, err
 	}
@@ -409,6 +418,9 @@ func (resolver *Resolver) vulnerabilityCountV2Query(ctx context.Context, query *
 }
 
 func (resolver *Resolver) vulnCounterV2(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
+	if features.PostgresDatastore.Enabled() {
+		return nil, errors.New("vulnerabilityCountV2 not supported on postgres.")
+	}
 	if err := readCVEs(ctx); err != nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/vulnerability_requests_test.go
+++ b/central/graphql/resolvers/vulnerability_requests_test.go
@@ -20,10 +20,7 @@ import (
 	componentCVEEdgeSearcher "github.com/stackrox/rox/central/componentcveedge/search"
 	componentCVEEdgeStore "github.com/stackrox/rox/central/componentcveedge/store/dackbox"
 	cveDackBox "github.com/stackrox/rox/central/cve/dackbox"
-	cveDS "github.com/stackrox/rox/central/cve/datastore"
 	cveIndex "github.com/stackrox/rox/central/cve/index"
-	cveSearcher "github.com/stackrox/rox/central/cve/search"
-	cveStore "github.com/stackrox/rox/central/cve/store/dackbox"
 	deploymentMockDS "github.com/stackrox/rox/central/deployment/datastore/mocks"
 	deploymentIndex "github.com/stackrox/rox/central/deployment/index"
 	"github.com/stackrox/rox/central/globalindex"
@@ -155,7 +152,6 @@ type VulnRequestResolverTestSuite struct {
 	bleveIndex            bleve.Index
 	vulnReqDataStore      vulnReqDS.DataStore
 	deployments           *deploymentMockDS.MockDataStore
-	cveDataStore          cveDS.DataStore
 	imageDataStore        imageDS.DataStore
 	componentCVEDataStore componentCVEEdgeDS.DataStore
 	sensorConnMgrMocks    *sensorConnMgrMocks.MockManager
@@ -197,7 +193,6 @@ func (s *VulnRequestResolverTestSuite) SetupTest() {
 
 	pendingReqCache, activeReqCache := vulnReqCache.New(), vulnReqCache.New()
 	s.createImageDataStore(dacky)
-	s.createCVEDataStore(dacky, s.indexQ)
 	s.createComponentCVEDataStore(dacky)
 	s.createVulnRequestDataStore(pendingReqCache, activeReqCache)
 	s.deployments = deploymentMockDS.NewMockDataStore(s.mockCtrl)
@@ -235,7 +230,6 @@ func (s *VulnRequestResolverTestSuite) SetupTest() {
 	notifierMock.EXPECT().HasEnabledAuditNotifiers().Return(false).AnyTimes()
 	s.resolver = &Resolver{
 		ImageDataStore: s.imageDataStore,
-		CVEDataStore:   s.cveDataStore,
 		vulnReqMgr:     s.vulnReqManager,
 		vulnReqStore:   s.vulnReqDataStore,
 		AuditLogger:    audit.New(notifierMock),
@@ -248,19 +242,6 @@ func (s *VulnRequestResolverTestSuite) SetupTest() {
 func (s *VulnRequestResolverTestSuite) createImageDataStore(dacky *dackbox.DackBox) {
 	imageDataStore := imageDS.New(dacky, concurrency.NewKeyFence(), s.bleveIndex, s.bleveIndex, true, nil, ranking.ImageRanker(), ranking.ComponentRanker())
 	s.imageDataStore = imageDataStore
-}
-
-func (s *VulnRequestResolverTestSuite) createCVEDataStore(dacky *dackbox.DackBox, indexQ queue.WaitableQueue) {
-	cveStore := cveStore.New(dacky, concurrency.NewKeyFence())
-	cveIndexer := cveIndex.New(s.bleveIndex)
-	cveDataStore, err := cveDS.New(dacky,
-		indexQ,
-		cveStore,
-		cveIndexer,
-		cveSearcher.New(cveStore, dacky, cveIndexer, nil, nil, nil, nil, imageCVEEdgeIndex.New(s.bleveIndex), nil, nil, nil, nil, nil),
-	)
-	s.Require().NoError(err)
-	s.cveDataStore = cveDataStore
 }
 
 func (s *VulnRequestResolverTestSuite) createComponentCVEDataStore(dacky *dackbox.DackBox) {


### PR DESCRIPTION
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
CI
