### PR TITLE
Wrap exact query values individually in dbl quotes instead of as a single string

### DIFF
--- a/ui/apps/platform/src/utils/queryService.js
+++ b/ui/apps/platform/src/utils/queryService.js
@@ -42,10 +42,14 @@ function objectToWhereClause(query, delimiter = '+') {
             if (typeof value === 'undefined' || value === '') {
                 return acc;
             }
-            const flatValue = Array.isArray(value) ? value.join() : value;
-            const needsExactMatch =
-                key.toLowerCase().indexOf(' id') !== -1 && value.indexOf(',') === -1;
-            const queryValue = needsExactMatch ? `"${flatValue}"` : flatValue;
+            const valueArray = Array.isArray(value) ? value : [value];
+            const queryValue = valueArray
+                .map((val) => {
+                    const needsExactMatch =
+                        key.toLowerCase().indexOf(' id') !== -1 && val.indexOf(',') === -1;
+                    return needsExactMatch ? `"${val}"` : val;
+                })
+                .join();
             return `${acc}${key}:${queryValue}${delimiter}`;
         }, '')
         .slice(0, -delimiter.length);

--- a/ui/apps/platform/src/utils/queryService.test.js
+++ b/ui/apps/platform/src/utils/queryService.test.js
@@ -20,6 +20,32 @@ describe('queryService.', () => {
 
             expect(queryStr).toEqual('cve:CVE-2005-2541,CVE-2017-12424,CVE-2018-16402');
         });
+
+        it('correctly quote wraps exact search term values', () => {
+            const singleValueQueryObject = {
+                'Cluster ID': '8afe70aa-0092-4c3f-a744-d259e863e262',
+            };
+
+            const singleValueQueryString = queryService.objectToWhereClause(singleValueQueryObject);
+
+            expect(singleValueQueryString).toEqual(
+                'Cluster ID:"8afe70aa-0092-4c3f-a744-d259e863e262"'
+            );
+
+            const multiValueQueryObject = {
+                'Cluster ID': [
+                    '8afe70aa-0092-4c3f-a744-d259e863e262',
+                    '7c9786b3-d436-40f2-aff5-6ea758d15830',
+                    '395b243e-bd99-404b-96d1-493768f54ca3',
+                ],
+            };
+
+            const multiValueQueryString = queryService.objectToWhereClause(multiValueQueryObject);
+
+            expect(multiValueQueryString).toEqual(
+                'Cluster ID:"8afe70aa-0092-4c3f-a744-d259e863e262","7c9786b3-d436-40f2-aff5-6ea758d15830","395b243e-bd99-404b-96d1-493768f54ca3"'
+            );
+        });
     });
 
     describe('entityContextToQueryObject', () => {


### PR DESCRIPTION
## Description

The function used to create query strings in VulnMgmt will wrap queries for any search key that ends in ` id` with double quotes. However if the search query is an array, instead of wrapping each individual term in quotes it will create a single comma delimited string and wrap the entire thing in a single set of double quotes. This was introduced [quite a while ago](https://github.com/stackrox/rox/pull/3192/commits/678091d14f0b7a2052947cfd088337896fca0fb2#diff-6e11ac39ca0f153e15b0e72560c6bd563c7a3889fca060d5c059415316384c52R9) but I can't really tell what the context is. Most of the UI in the [screenshots on that PR](https://github.com/stackrox/rox/pull/3192) is long gone. This PR changes the behavior to wrap the array of items individually in double quotes:

```
Namespace:"payments,frontend,stackrox"
> becomes
Namespace:"payments","frontend","stackrox"
```

My hunch is that this was just an oversight that didn't account for queries with multiple "ID" values, as there was a test case added (also gone in current code) that only [checked for the single case](https://github.com/stackrox/rox/pull/3192/files#diff-a9de3a6e284d727d68acc071ae38fc935cb2d596e79077ca81fc13a6ffa87552).

This should fix https://issues.redhat.com/browse/ROX-11510 and the links on the new dashboard that end up on VulnMgmt pages.

The weird thing is that this quoted query string does appear to return results. It gives results as if it is checking each item in the array _except_ for the first and last item in quotes. e.g. It would give query results for `"frontend"` only using the examples above. Background discussion on Slack https://srox.slack.com/archives/C01DQH7UP8C/p1656702347490589.

I think this is a bug on the frontend and a ~separate bug on the backend~ that are rare enough that no-one has noticed until this specific use case. _Not a backend bug, this is intended behavior as per the Slack convo above._

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Visit the dashboard and apply multiple namespace filters:

<img width="538" alt="image" src="https://user-images.githubusercontent.com/1292638/176958423-b2cd629c-d66f-408b-b17e-3c069df7946f.png">
<img width="661" alt="image" src="https://user-images.githubusercontent.com/1292638/176958401-c8d6485d-6d0d-4242-8f56-af85998b8d21.png">

Click the `>1 year` link and go to the VulnMgmt images page. This page should contain the same number of images as the bar in the chart.
<img width="894" alt="image" src="https://user-images.githubusercontent.com/1292638/176958609-caee4e45-eb0a-483b-afaa-ff04aa628a57.png">

The old behavior would not display 73 images, and show a reduced number (47 images):
<img width="894" alt="image" src="https://user-images.githubusercontent.com/1292638/176959109-9465f6a2-13bc-4378-a410-1e6857be67e8.png">

If we go back to the dashboard on this branch, and deselect the first and last namespaces we picked in the dropdown:
<img width="538" alt="image" src="https://user-images.githubusercontent.com/1292638/176959236-e6b0f182-e66f-47be-bd37-d56b5426531b.png">
<img width="659" alt="image" src="https://user-images.githubusercontent.com/1292638/176959203-0f91c64d-5c38-45ed-baf8-a444a99beea9.png">




