### PR TITLE
ROX-11605: Display clusterIdToRetentionInfo in clusters list and cluster panel

### DIFF
--- a/ui/apps/platform/cypress/fixtures/clusters/health.json
+++ b/ui/apps/platform/cypress/fixtures/clusters/health.json
@@ -679,5 +679,10 @@
             "helmConfig": null,
             "managedBy": "MANAGER_TYPE_MANUAL"
         }
-    ]
+    ],
+    "clusterIdToRetentionInfo": {
+        "f342ca31-9271-081c-c40d-4e4cd442707a": {
+            "daysUntilDeletion": 90
+        }
+    }
 }

--- a/ui/apps/platform/cypress/helpers/clusters.js
+++ b/ui/apps/platform/cypress/helpers/clusters.js
@@ -35,7 +35,10 @@ export function visitClusters(staticResponseMap) {
 
 export function visitClusterById(clusterId, staticResponseMap) {
     const routeMatcherMapClusterById = {
-        ...routeMatcherMap,
+        'cluster-defaults': {
+            method: 'GET',
+            url: api.clusters.clusterDefaults,
+        },
         cluster: {
             method: 'GET',
             url: `${api.clusters.list}/${clusterId}`,
@@ -67,12 +70,12 @@ export function visitClustersWithFixtureMetadataDatetime(fixturePath, metadata, 
 }
 
 export function visitClusterByNameWithFixture(clusterName, fixturePath) {
-    cy.fixture(fixturePath).then(({ clusters }) => {
+    cy.fixture(fixturePath).then(({ clusters, clusterIdToRetentionInfo }) => {
         const cluster = clusters.find(({ name }) => name === clusterName);
+        const clusterRetentionInfo = clusterIdToRetentionInfo[cluster.id] ?? null;
 
         visitClusterById(cluster.id, {
-            clusters: { body: { clusters } },
-            cluster: { body: { cluster } },
+            cluster: { body: { cluster, clusterRetentionInfo } },
         });
 
         cy.get(selectors.clusterSidePanelHeading).contains(clusterName);
@@ -85,20 +88,20 @@ export function visitClusterByNameWithFixtureMetadataDatetime(
     metadata,
     datetimeISOString
 ) {
-    cy.fixture(fixturePath).then(({ clusters }) => {
+    cy.fixture(fixturePath).then(({ clusters, clusterIdToRetentionInfo }) => {
         cy.intercept('GET', api.metadata, {
             body: metadata,
         }).as('metadata');
 
         const cluster = clusters.find(({ name }) => name === clusterName);
+        const clusterRetentionInfo = clusterIdToRetentionInfo[cluster.id] ?? null;
 
         // For comparison to `lastContact` and `sensorCertExpiry` in clusters fixture.
         const currentDatetime = new Date(datetimeISOString);
         cy.clock(currentDatetime.getTime(), ['Date', 'setInterval']);
 
         visitClusterById(cluster.id, {
-            clusters: { body: { clusters } },
-            cluster: { body: { cluster } },
+            cluster: { body: { cluster, clusterRetentionInfo } },
         });
 
         cy.wait(['@metadata']);

--- a/ui/apps/platform/cypress/helpers/clusters.js
+++ b/ui/apps/platform/cypress/helpers/clusters.js
@@ -33,6 +33,12 @@ export function visitClusters(staticResponseMap) {
     cy.get(selectors.clustersListHeading).contains('Clusters');
 }
 
+export function visitClustersWithFixture(fixturePath) {
+    visitClusters({
+        clusters: { fixture: fixturePath },
+    });
+}
+
 export function visitClusterById(clusterId, staticResponseMap) {
     const routeMatcherMapClusterById = {
         'cluster-defaults': {
@@ -62,9 +68,7 @@ export function visitClustersWithFixtureMetadataDatetime(fixturePath, metadata, 
     const currentDatetime = new Date(datetimeISOString);
     cy.clock(currentDatetime.getTime(), ['Date', 'setInterval']);
 
-    visitClusters({
-        clusters: { fixture: fixturePath },
-    });
+    visitClustersWithFixture(fixturePath);
 
     cy.wait('@metadata');
 }

--- a/ui/apps/platform/cypress/integration/clusters/clusterDeletion.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clusterDeletion.test.js
@@ -1,0 +1,108 @@
+import { selectors } from '../../constants/ClustersPage';
+import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
+import { visitClusterById, visitClusters, visitClustersWithFixture } from '../../helpers/clusters';
+
+describe('Clusters list clusterIdToRetentionInfo', () => {
+    withAuth();
+
+    before(function beforeHook() {
+        if (!hasFeatureFlag('ROX_DECOMMISSIONED_CLUSTER_RETENTION')) {
+            this.skip();
+        }
+    });
+
+    const fixturePath = 'clusters/health.json';
+
+    it('should display Cluster Deletion column', () => {
+        visitClusters();
+
+        cy.get(`${selectors.clusters.tableHeadingCell}:contains("Cluster Deletion")`);
+    });
+
+    // .rt-td:nth(6) because [data-testid="clusterDeletion"] fails for unknown reason :(
+
+    it('should display Not applicable in Cluster Deletion cell for actual request', () => {
+        visitClusters();
+
+        cy.get('.rt-tr:contains("remote") .rt-td:nth(6):contains("Not applicable")');
+    });
+
+    it('should display alternatives in Cluster Deletion cell for mock request', () => {
+        visitClustersWithFixture(fixturePath);
+
+        cy.get('.rt-tr:contains("alpha-amsterdam-1") .rt-td:nth(6):contains("Not applicable")');
+        cy.get('.rt-tr:contains("epsilon-edison-5") .rt-td:nth(6):contains("in 90 days")');
+    });
+});
+
+describe('Cluster page clusterRetentionInfo', () => {
+    withAuth();
+
+    before(function beforeHook() {
+        if (!hasFeatureFlag('ROX_DECOMMISSIONED_CLUSTER_RETENTION')) {
+            this.skip();
+        }
+    });
+
+    // div:contains("Cluster Deletion") because [data-testid="clusterDeletion"] fails for unknown reason :(
+
+    it('should display Not applicable in Cluster Deletion widget for actual request', () => {
+        visitClusters();
+
+        const clusterName = 'remote';
+        cy.get(`[data-testid="cluster-name"]:contains("${clusterName}")`).click();
+        cy.get(`${selectors.clusterSidePanelHeading}:contains("${clusterName}")`);
+        cy.get('div:contains("Cluster Deletion"):contains("Not applicable")');
+    });
+
+    const fixturePath = 'clusters/health.json';
+    const clusterName = 'epsilon-edison-5'; // has sensorHealthStatus UNHEALTHY
+
+    function visitClusterWithRetentionInfo(clusterRetentionInfo) {
+        cy.fixture(fixturePath).then(({ clusters }) => {
+            const cluster = clusters.find(({ name }) => name === clusterName);
+
+            visitClusterById(cluster.id, {
+                cluster: { body: { cluster, clusterRetentionInfo } },
+            });
+
+            cy.get(selectors.clusterSidePanelHeading).contains(clusterName);
+        });
+    }
+
+    it('should display in 30 days in Cluster Deletion widget for mock request', () => {
+        const clusterRetentionInfo = { daysUntilDeletion: 30 };
+        visitClusterWithRetentionInfo(clusterRetentionInfo);
+
+        cy.get('div:contains("Cluster Deletion"):contains("Not applicable")');
+    });
+
+    it('should display in 7 days in Cluster Deletion widget for mock request', () => {
+        const clusterRetentionInfo = { daysUntilDeletion: 7 };
+        visitClusterWithRetentionInfo(clusterRetentionInfo);
+
+        cy.get('div:contains("Cluster Deletion"):contains("in 7 days")'); // FYI yellow color
+    });
+
+    it('should display in 1 day in Cluster Deletion widget for mock request', () => {
+        const clusterRetentionInfo = { daysUntilDeletion: 1 };
+        visitClusterWithRetentionInfo(clusterRetentionInfo);
+
+        cy.get('div:contains("Cluster Deletion"):contains("in 1 day")'); // FYI red color
+    });
+
+    it('should display Excuded from deletion in Cluster Deletion widget for mock request', () => {
+        const clusterRetentionInfo = { isExcluded: true };
+        visitClusterWithRetentionInfo(clusterRetentionInfo);
+
+        cy.get('div:contains("Cluster Deletion"):contains("Excluded from deletion")');
+    });
+
+    it('should display Deletion is turned off in Cluster Deletion widget for mock request', () => {
+        const clusterRetentionInfo = { isExcluded: false };
+        visitClusterWithRetentionInfo(clusterRetentionInfo);
+
+        cy.get('div:contains("Cluster Deletion"):contains("Deletion is turned off")');
+    });
+});

--- a/ui/apps/platform/cypress/integration/clusters/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clusters.test.js
@@ -1,15 +1,15 @@
 import cloneDeep from 'lodash/cloneDeep';
 
-import { selectors } from '../constants/ClustersPage';
-import { clusters as clustersApi } from '../constants/apiEndpoints';
-import withAuth from '../helpers/basicAuth';
+import { selectors } from '../../constants/ClustersPage';
+import { clusters as clustersApi } from '../../constants/apiEndpoints';
+import withAuth from '../../helpers/basicAuth';
 import {
     visitClusters,
     visitClustersFromLeftNav,
     visitClustersWithFixtureMetadataDatetime,
     visitClusterByNameWithFixture,
     visitClusterByNameWithFixtureMetadataDatetime,
-} from '../helpers/clusters';
+} from '../../helpers/clusters';
 
 describe('Clusters page', () => {
     withAuth();
@@ -34,6 +34,7 @@ describe('Clusters page', () => {
                 'Cluster Status',
                 'Sensor Upgrade',
                 'Credential Expiration',
+                // Cluster Deletion: see clusterDeletion.test.js
             ].forEach((heading, index) => {
                 /*
                  * Important: nth is pseudo selector for zero-based index of matching cells.
@@ -502,6 +503,7 @@ describe.skip('Cluster Health', () => {
          * Some cells have no internal markup (for example, Name or Cloud Provider).
          * Other cells have div and spans for status color versus default color.
          */
+        // TODO add assertion for Cluster Deletion column after ROX_DECOMMISSIONED_CLUSTER_RETENTION feature flag is deleted.
         cy.get(selectors.clusters.tableDataCell).should(($tds) => {
             let n = 0;
             expectedClusters.forEach(({ expectedInListAndSide }) => {

--- a/ui/apps/platform/src/Containers/Clusters/ClusterEditForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterEditForm.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 
 import Loader from 'Components/Loader';
 import { labelClassName } from 'constants/form.constants';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
 
 import ClusterSummary from './Components/ClusterSummary';
@@ -31,6 +32,11 @@ function ClusterEditForm({
     handleChangeLabels,
     isLoading,
 }: ClusterEditFormProps): ReactElement {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isDecommissionedClusterRetentionEnabled = isFeatureFlagEnabled(
+        'ROX_DECOMMISSIONED_CLUSTER_RETENTION'
+    );
+
     if (isLoading) {
         return <Loader />;
     }
@@ -47,6 +53,9 @@ function ClusterEditForm({
                     centralVersion={centralVersion}
                     clusterId={selectedCluster.id}
                     clusterRetentionInfo={clusterRetentionInfo}
+                    isDecommissionedClusterRetentionEnabled={
+                        isDecommissionedClusterRetentionEnabled
+                    }
                 />
             )}
             <form

--- a/ui/apps/platform/src/Containers/Clusters/ClusterEditForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterEditForm.tsx
@@ -2,6 +2,8 @@ import React, { ReactElement } from 'react';
 
 import Loader from 'Components/Loader';
 import { labelClassName } from 'constants/form.constants';
+import { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
+
 import ClusterSummary from './Components/ClusterSummary';
 import StaticConfigurationSection from './StaticConfigurationSection';
 import DynamicConfigurationSection from './DynamicConfigurationSection';
@@ -11,6 +13,7 @@ import { CentralEnv, Cluster, ClusterManagerType } from './clusterTypes';
 type ClusterEditFormProps = {
     centralEnv: CentralEnv;
     centralVersion: string;
+    clusterRetentionInfo: DecommissionedClusterRetentionInfo;
     selectedCluster: Cluster;
     managerType: ClusterManagerType;
     handleChange: (any) => void;
@@ -21,6 +24,7 @@ type ClusterEditFormProps = {
 function ClusterEditForm({
     centralEnv,
     centralVersion,
+    clusterRetentionInfo,
     selectedCluster,
     managerType,
     handleChange,
@@ -42,6 +46,7 @@ function ClusterEditForm({
                     status={selectedCluster.status}
                     centralVersion={centralVersion}
                     clusterId={selectedCluster.id}
+                    clusterRetentionInfo={clusterRetentionInfo}
                 />
             )}
             <form

--- a/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
@@ -14,7 +14,7 @@ import { useTheme } from 'Containers/ThemeProvider';
 import useInterval from 'hooks/useInterval';
 import useMetadata from 'hooks/useMetadata';
 import {
-    fetchClusterWithRetentionInformationById,
+    fetchClusterWithRetentionInformation,
     saveCluster,
     downloadClusterYaml,
     getClusterDefaults,
@@ -125,7 +125,7 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
                 setMessageState(null);
                 setIsBlocked(false);
                 // don't want to cache or memoize, because we always want the latest real-time data
-                fetchClusterWithRetentionInformationById(clusterIdToRetrieve)
+                fetchClusterWithRetentionInformation(clusterIdToRetrieve)
                     .then((clusterResponse) => {
                         const { cluster } = clusterResponse;
                         // eslint-disable-next-line no-param-reassign

--- a/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
@@ -248,6 +248,12 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
             setSubmissionError('');
             saveCluster(selectedCluster)
                 .then((response) => {
+                    /*
+                    setSelectedCluster(response.cluster);
+                    setClusterRetentionInfo(clusterResponse.clusterRetentionInfo);
+                    */
+                    // TODO After saveCluster returns response without normalize,
+                    // something like the preceding commented lines should replace the following:
                     const newId = response.response.result.cluster; // really is nested like this
                     const clusterWithId = { ...selectedCluster, id: newId };
                     setSelectedCluster(clusterWithId);

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
@@ -11,8 +11,10 @@ import PanelButton from 'Components/PanelButton';
 import { DEFAULT_PAGE_SIZE } from 'Components/Table';
 import TableHeader from 'Components/TableHeader';
 import { PanelNew, PanelBody, PanelHead, PanelHeadEnd } from 'Components/Panel';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useInterval from 'hooks/useInterval';
 import useMetadata from 'hooks/useMetadata';
+import usePermissions from 'hooks/usePermissions';
 import useURLSearch from 'hooks/useURLSearch';
 import {
     fetchClustersWithRetentionInfo,
@@ -28,6 +30,13 @@ import { clusterTablePollingInterval, getUpgradeableClusters } from './cluster.h
 import { getColumnsForClusters } from './clustersTableColumnDescriptors';
 
 function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOptions }) {
+    const { hasReadWriteAccess } = usePermissions();
+    const hasReadWriteAccessForCluster = hasReadWriteAccess('Cluster');
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isDecommissionedClusterRetentionEnabled = isFeatureFlagEnabled(
+        'ROX_DECOMMISSIONED_CLUSTER_RETENTION'
+    );
+
     const metadata = useMetadata();
 
     const { searchFilter: pageSearch } = useURLSearch();
@@ -227,6 +236,8 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
 
     const columnOptions = {
         clusterIdToRetentionInfo,
+        hasReadWriteAccessForCluster,
+        isDecommissionedClusterRetentionEnabled,
         metadata,
         rowActions: {
             onDeleteHandler,

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
@@ -15,7 +15,7 @@ import useInterval from 'hooks/useInterval';
 import useMetadata from 'hooks/useMetadata';
 import useURLSearch from 'hooks/useURLSearch';
 import {
-    fetchClustersAsArray,
+    fetchClustersWithRetentionInfo,
     deleteClusters,
     upgradeClusters,
     upgradeCluster,
@@ -42,6 +42,7 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
     const [isViewFiltered, setIsViewFiltered] = useState(false);
 
     const [currentClusters, setCurrentClusters] = useState([]);
+    const [clusterIdToRetentionInfo, setClusterIdToRetentionInfo] = useState({});
 
     function notificationsReducer(state, action) {
         switch (action.type) {
@@ -74,8 +75,9 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
     ));
 
     function refreshClusterList(restSearch) {
-        return fetchClustersAsArray(restSearch).then((clusters) => {
-            setCurrentClusters(clusters);
+        return fetchClustersWithRetentionInfo(restSearch).then((clustersResponse) => {
+            setCurrentClusters(clustersResponse.clusters);
+            setClusterIdToRetentionInfo(clustersResponse.clusterIdToRetentionInfo);
         });
     }
 
@@ -140,8 +142,9 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
             .then(() => {
                 setCheckedClusters([]);
 
-                fetchClustersAsArray().then((clusters) => {
-                    setCurrentClusters(clusters);
+                fetchClustersWithRetentionInfo().then((clustersResponse) => {
+                    setCurrentClusters(clustersResponse.clusters);
+                    setClusterIdToRetentionInfo(clustersResponse.clusterIdToRetentionInfo);
                 });
             })
             .finally(() => {
@@ -223,6 +226,7 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
     }
 
     const columnOptions = {
+        clusterIdToRetentionInfo,
         metadata,
         rowActions: {
             onDeleteHandler,

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterDeletion.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterDeletion.tsx
@@ -13,12 +13,14 @@ type ClusterDeletionProps = {
 
 function ClusterDeletion({ clusterRetentionInfo }: ClusterDeletionProps): ReactElement {
     if (clusterRetentionInfo === null) {
+        // Cluster does not have sensor status UNHEALTHY.
         return <HealthStatusNotApplicable testId={testId} />;
     }
 
     // Adapt health status categories to cluster deletion.
 
     if ('daysUntilDeletion' in clusterRetentionInfo) {
+        // Cluster will be deleted if sensor status remains UNHEALTHY for the number of days.
         const { daysUntilDeletion } = clusterRetentionInfo;
         const healthStatus = getClusterDeletionStatus(daysUntilDeletion);
         const { bgColor, fgColor } = healthStatusStyles[healthStatus];
@@ -27,9 +29,12 @@ function ClusterDeletion({ clusterRetentionInfo }: ClusterDeletionProps): ReactE
         return <span className={`${bgColor} ${fgColor} whitespace-nowrap`}>{text}</span>;
     }
 
+    // Cluster will not be deleted even if sensor status remains UNHEALTHY:
+    // because it has an ignore label, if true
+    // because system configuration is never delete, if false
     const { bgColor, fgColor } = healthStatusStyles.HEALTHY;
     const { isExcluded } = clusterRetentionInfo;
-    const text = isExcluded ? 'Excluded from deletion' : 'Never delete';
+    const text = isExcluded ? 'Excluded from deletion' : 'Deletion is turned off';
 
     return <span className={`${bgColor} ${fgColor} whitespace-nowrap`}>{text}</span>;
 }

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterDeletion.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterDeletion.tsx
@@ -1,0 +1,37 @@
+import React, { ReactElement } from 'react';
+
+import { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
+
+import HealthStatusNotApplicable from './HealthStatusNotApplicable';
+import { getClusterDeletionStatus, healthStatusStyles } from '../cluster.helpers';
+
+const testId = 'clusterDeletion';
+
+type ClusterDeletionProps = {
+    clusterRetentionInfo: DecommissionedClusterRetentionInfo;
+};
+
+function ClusterDeletion({ clusterRetentionInfo }: ClusterDeletionProps): ReactElement {
+    if (clusterRetentionInfo === null) {
+        return <HealthStatusNotApplicable testId={testId} />;
+    }
+
+    // Adapt health status categories to cluster deletion.
+
+    if ('daysUntilDeletion' in clusterRetentionInfo) {
+        const { daysUntilDeletion } = clusterRetentionInfo;
+        const healthStatus = getClusterDeletionStatus(daysUntilDeletion);
+        const { bgColor, fgColor } = healthStatusStyles[healthStatus];
+        const text = daysUntilDeletion === 1 ? 'in 1 day' : `in ${daysUntilDeletion} days`;
+
+        return <span className={`${bgColor} ${fgColor} whitespace-nowrap`}>{text}</span>;
+    }
+
+    const { bgColor, fgColor } = healthStatusStyles.HEALTHY;
+    const { isExcluded } = clusterRetentionInfo;
+    const text = isExcluded ? 'Excluded from deletion' : 'Never delete';
+
+    return <span className={`${bgColor} ${fgColor} whitespace-nowrap`}>{text}</span>;
+}
+
+export default ClusterDeletion;

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterSummary.js
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterSummary.js
@@ -5,6 +5,7 @@ import CollapsibleSection from 'Components/CollapsibleSection';
 import Metadata from 'Components/Metadata';
 import Widget from 'Components/Widget';
 
+import ClusterDeletion from './ClusterDeletion';
 import ClusterStatus from './ClusterStatus';
 import CollectorStatus from './Collector/CollectorStatus';
 import AdmissionControlStatus from './AdmissionControl/AdmissionControlStatus';
@@ -30,7 +31,13 @@ const tdClass = 'px-0 py-1';
  *
  * Metadata renders a special purpose Widget whose body has built-in p-3 (too bad, so sad)
  */
-const ClusterSummary = ({ healthStatus, status, centralVersion, clusterId }) => (
+const ClusterSummary = ({
+    healthStatus,
+    status,
+    centralVersion,
+    clusterId,
+    clusterRetentionInfo,
+}) => (
     <CollapsibleSection title="Cluster Summary" titleClassName="text-xl">
         <div className="grid grid-columns-1 md:grid-columns-2 xl:grid-columns-4 grid-gap-4 xl:grid-gap-6 mb-4 w-full">
             <div className="s-1">
@@ -125,6 +132,11 @@ const ClusterSummary = ({ healthStatus, status, centralVersion, clusterId }) => 
                     )}
                 </Widget>
             </div>
+            <div className="s-1">
+                <Widget header="Cluster Deletion" bodyClassName="p-2">
+                    <ClusterDeletion clusterRetentionInfo={clusterRetentionInfo} />
+                </Widget>
+            </div>
         </div>
     </CollapsibleSection>
 );
@@ -173,6 +185,7 @@ ClusterSummary.propTypes = {
     }).isRequired,
     centralVersion: PropTypes.string.isRequired,
     clusterId: PropTypes.string.isRequired,
+    clusterRetentionInfo: PropTypes.oneOf([PropTypes.shape({}), PropTypes.null]).isRequired,
 };
 
 export default ClusterSummary;

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterSummary.js
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterSummary.js
@@ -37,6 +37,7 @@ const ClusterSummary = ({
     centralVersion,
     clusterId,
     clusterRetentionInfo,
+    isDecommissionedClusterRetentionEnabled,
 }) => (
     <CollapsibleSection title="Cluster Summary" titleClassName="text-xl">
         <div className="grid grid-columns-1 md:grid-columns-2 xl:grid-columns-4 grid-gap-4 xl:grid-gap-6 mb-4 w-full">
@@ -132,11 +133,13 @@ const ClusterSummary = ({
                     )}
                 </Widget>
             </div>
-            <div className="s-1">
-                <Widget header="Cluster Deletion" bodyClassName="p-2">
-                    <ClusterDeletion clusterRetentionInfo={clusterRetentionInfo} />
-                </Widget>
-            </div>
+            {isDecommissionedClusterRetentionEnabled && (
+                <div className="s-1">
+                    <Widget header="Cluster Deletion" bodyClassName="p-2">
+                        <ClusterDeletion clusterRetentionInfo={clusterRetentionInfo} />
+                    </Widget>
+                </div>
+            )}
         </div>
     </CollapsibleSection>
 );
@@ -186,6 +189,7 @@ ClusterSummary.propTypes = {
     centralVersion: PropTypes.string.isRequired,
     clusterId: PropTypes.string.isRequired,
     clusterRetentionInfo: PropTypes.oneOf([PropTypes.shape({}), PropTypes.null]).isRequired,
+    isDecommissionedClusterRetentionEnabled: PropTypes.bool.isRequired,
 };
 
 export default ClusterSummary;

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -354,6 +354,19 @@ const resolveThresholds = (expiryStatus: CertExpiryStatus) => {
 /*
  * Adapt health status categories to certificate expiration.
  */
+export const getClusterDeletionStatus = (daysUntilDeletion: number) => {
+    if (daysUntilDeletion < 7) {
+        return 'UNHEALTHY';
+    }
+    if (daysUntilDeletion < 30) {
+        return 'DEGRADED';
+    }
+    return 'UNINITIALIZED';
+};
+
+/*
+ * Adapt health status categories to certificate expiration.
+ */
 export const getCredentialExpirationStatus = (
     sensorCertExpiryStatus: CertExpiryStatus,
     currentDatetime

--- a/ui/apps/platform/src/Containers/Clusters/clusterTypes.ts
+++ b/ui/apps/platform/src/Containers/Clusters/clusterTypes.ts
@@ -1,4 +1,6 @@
-import { ClusterLabels } from 'services/ClustersService';
+import { Cluster } from 'types/cluster.proto';
+
+export type { Cluster }; // TODO replace all imports from this file with imports from types/cluster.proto file
 
 export type SensorHealthStatus = 'HEALTHY' | 'UNHEALTHY' | 'DEGRADED' | 'UNINITIALIZED';
 
@@ -96,25 +98,3 @@ export type ClusterManagerType =
     | 'MANAGER_TYPE_MANUAL'
     | 'MANAGER_TYPE_HELM_CHART'
     | 'MANAGER_TYPE_KUBERNETES_OPERATOR';
-
-export type Cluster = {
-    id: string;
-    name: string;
-    type: string;
-    mainImage: string;
-    centralApiEndpoint: string;
-    collectionMethod: string;
-    collectorImage: string;
-    admissionController: boolean;
-    admissionControllerUpdates: boolean;
-    tolerationsConfig: {
-        disabled: boolean;
-    };
-    status: ClusterStatus;
-    dynamicConfig: DynamicConfig;
-    helmConfig?: HelmConfig;
-    slimCollector: boolean;
-    healthStatus: ClusterHealthStatus;
-    labels: ClusterLabels;
-    managedBy: ClusterManagerType;
-};

--- a/ui/apps/platform/src/Containers/Clusters/clustersTableColumnDescriptors.js
+++ b/ui/apps/platform/src/Containers/Clusters/clustersTableColumnDescriptors.js
@@ -10,13 +10,14 @@ import {
 } from 'Components/Table';
 
 import { formatCloudProvider } from './cluster.helpers';
+import ClusterDeletion from './Components/ClusterDeletion';
 import ClusterStatus from './Components/ClusterStatus';
 import CredentialExpiration from './Components/CredentialExpiration';
 import SensorUpgrade from './Components/SensorUpgrade';
 import HelmIndicator from './Components/HelmIndicator';
 import OperatorIndicator from './Components/OperatorIndicator';
 
-export function getColumnsForClusters({ metadata, rowActions }) {
+export function getColumnsForClusters({ clusterIdToRetentionInfo, metadata, rowActions }) {
     function renderRowActionButtons(cluster) {
         return (
             <div className="border-2 border-r-2 border-base-400 bg-base-100">
@@ -31,13 +32,13 @@ export function getColumnsForClusters({ metadata, rowActions }) {
     }
 
     // Because of fixed checkbox width, total of column ratios must be less than 1
-    // 6/8 + 1/9 + 1/10 = 0.961
+    // 5/7 + 1/4 = 0.964
     const clusterColumnsWithHealth = [
         {
             accessor: 'name',
             Header: 'Name',
-            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
-            className: `w-1/8 ${wrapClassName} ${defaultColumnClassName}`,
+            headerClassName: `w-1/7 ${defaultHeaderClassName}`,
+            className: `w-1/7 ${wrapClassName} ${defaultColumnClassName}`,
             Cell: ({ original }) => (
                 <span className="flex items-center" data-testid="cluster-name">
                     {original.name}
@@ -59,8 +60,8 @@ export function getColumnsForClusters({ metadata, rowActions }) {
         {
             Header: 'Cloud Provider',
             Cell: ({ original }) => formatCloudProvider(original.status?.providerMetadata),
-            headerClassName: `w-1/9 ${defaultHeaderClassName}`,
-            className: `w-1/9 ${wrapClassName} ${defaultColumnClassName}`,
+            headerClassName: `w-1/7 ${defaultHeaderClassName}`,
+            className: `w-1/7 ${wrapClassName} ${defaultColumnClassName}`,
         },
         {
             Header: 'Cluster Status',
@@ -87,8 +88,8 @@ export function getColumnsForClusters({ metadata, rowActions }) {
                     }}
                 />
             ),
-            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
-            className: `w-1/8 ${wrapClassName} ${defaultColumnClassName}`,
+            headerClassName: `w-1/7 ${defaultHeaderClassName}`,
+            className: `w-1/7 ${wrapClassName} ${defaultColumnClassName}`,
         },
         {
             Header: 'Credential Expiration',
@@ -99,8 +100,18 @@ export function getColumnsForClusters({ metadata, rowActions }) {
                     isList
                 />
             ),
-            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
-            className: `w-1/8 ${wrapClassName} ${defaultColumnClassName}`,
+            headerClassName: `w-1/7 ${defaultHeaderClassName}`,
+            className: `w-1/7 ${wrapClassName} ${defaultColumnClassName}`,
+        },
+        {
+            Header: 'Cluster Deletion',
+            Cell: ({ original }) => (
+                <ClusterDeletion
+                    clusterIdToRetentionInfo={clusterIdToRetentionInfo[original.id] ?? null}
+                />
+            ),
+            headerClassName: `w-1/7 ${defaultHeaderClassName}`,
+            className: `w-1/7 ${wrapClassName} ${defaultColumnClassName}`,
         },
         {
             Header: '',

--- a/ui/apps/platform/src/Containers/Clusters/clustersTableColumnDescriptors.js
+++ b/ui/apps/platform/src/Containers/Clusters/clustersTableColumnDescriptors.js
@@ -116,7 +116,7 @@ export function getColumnsForClusters({
             Header: 'Cluster Deletion',
             Cell: ({ original }) => (
                 <ClusterDeletion
-                    clusterIdToRetentionInfo={clusterIdToRetentionInfo[original.id] ?? null}
+                    clusterRetentionInfo={clusterIdToRetentionInfo[original.id] ?? null}
                 />
             ),
             headerClassName: `w-1/7 ${defaultHeaderClassName}`,

--- a/ui/apps/platform/src/Containers/Clusters/clustersTableColumnDescriptors.js
+++ b/ui/apps/platform/src/Containers/Clusters/clustersTableColumnDescriptors.js
@@ -17,7 +17,13 @@ import SensorUpgrade from './Components/SensorUpgrade';
 import HelmIndicator from './Components/HelmIndicator';
 import OperatorIndicator from './Components/OperatorIndicator';
 
-export function getColumnsForClusters({ clusterIdToRetentionInfo, metadata, rowActions }) {
+export function getColumnsForClusters({
+    clusterIdToRetentionInfo,
+    hasReadWriteAccessForCluster,
+    isDecommissionedClusterRetentionEnabled,
+    metadata,
+    rowActions,
+}) {
     function renderRowActionButtons(cluster) {
         return (
             <div className="border-2 border-r-2 border-base-400 bg-base-100">
@@ -33,7 +39,7 @@ export function getColumnsForClusters({ clusterIdToRetentionInfo, metadata, rowA
 
     // Because of fixed checkbox width, total of column ratios must be less than 1
     // 5/7 + 1/4 = 0.964
-    const clusterColumnsWithHealth = [
+    const clusterColumns = [
         {
             accessor: 'name',
             Header: 'Name',
@@ -103,7 +109,10 @@ export function getColumnsForClusters({ clusterIdToRetentionInfo, metadata, rowA
             headerClassName: `w-1/7 ${defaultHeaderClassName}`,
             className: `w-1/7 ${wrapClassName} ${defaultColumnClassName}`,
         },
-        {
+    ];
+
+    if (isDecommissionedClusterRetentionEnabled) {
+        clusterColumns.push({
             Header: 'Cluster Deletion',
             Cell: ({ original }) => (
                 <ClusterDeletion
@@ -112,17 +121,20 @@ export function getColumnsForClusters({ clusterIdToRetentionInfo, metadata, rowA
             ),
             headerClassName: `w-1/7 ${defaultHeaderClassName}`,
             className: `w-1/7 ${wrapClassName} ${defaultColumnClassName}`,
-        },
-        {
+        });
+    }
+
+    if (hasReadWriteAccessForCluster) {
+        clusterColumns.push({
             Header: '',
             accessor: '',
             headerClassName: 'hidden',
             className: rtTrActionsClassName,
             Cell: ({ original }) => renderRowActionButtons(original),
-        },
-    ];
+        });
+    }
 
-    return clusterColumnsWithHealth;
+    return clusterColumns;
 }
 
 export default {

--- a/ui/apps/platform/src/services/ClustersService.ts
+++ b/ui/apps/platform/src/services/ClustersService.ts
@@ -3,7 +3,11 @@ import qs from 'qs';
 
 import searchOptionsToQuery, { RestSearchOption } from 'services/searchOptionsToQuery';
 import { saveFile } from 'services/DownloadService';
-import { ClusterDefaultsResponse } from 'types/clusterService.proto';
+import {
+    ClusterDefaultsResponse,
+    ClusterResponse,
+    ClustersResponse,
+} from 'types/clusterService.proto';
 import axios from './instance';
 import { cluster as clusterSchema } from './schemas';
 
@@ -58,12 +62,37 @@ export function fetchClustersAsArray(options?: RestSearchOption[]): Promise<Clus
     });
 }
 
-/**
- * Fetches unwrapped cluster object by ID.
+/*
+ * Fetch secured clusters and retention information.
  */
-export function getClusterById(id: string): Promise<Cluster | null> {
-    return axios.get<{ cluster: Cluster }>(`${clustersUrl}/${id}`).then((response) => {
-        return response?.data?.cluster ?? null;
+export function fetchClustersWithRetentionInfo(
+    options?: RestSearchOption[]
+): Promise<ClustersResponse> {
+    let queryString = '';
+    if (options && options.length !== 0) {
+        const query = searchOptionsToQuery(options);
+        queryString = qs.stringify(
+            {
+                query,
+            },
+            {
+                addQueryPrefix: true,
+                arrayFormat: 'repeat',
+                allowDots: true,
+            }
+        );
+    }
+    return axios.get<ClustersResponse>(`${clustersUrl}${queryString}`).then((response) => {
+        return response?.data;
+    });
+}
+
+/*
+ * Fetch secured cluster and its retention information by ID.
+ */
+export function fetchClusterWithRetentionInformationById(id: string): Promise<ClusterResponse> {
+    return axios.get<ClusterResponse>(`${clustersUrl}/${id}`).then((response) => {
+        return response?.data;
     });
 }
 

--- a/ui/apps/platform/src/services/ClustersService.ts
+++ b/ui/apps/platform/src/services/ClustersService.ts
@@ -83,16 +83,16 @@ export function fetchClustersWithRetentionInfo(
         );
     }
     return axios.get<ClustersResponse>(`${clustersUrl}${queryString}`).then((response) => {
-        return response?.data;
+        return response.data;
     });
 }
 
 /*
- * Fetch secured cluster and its retention information by ID.
+ * Fetch secured cluster and its retention information.
  */
-export function fetchClusterWithRetentionInformationById(id: string): Promise<ClusterResponse> {
+export function fetchClusterWithRetentionInformation(id: string): Promise<ClusterResponse> {
     return axios.get<ClusterResponse>(`${clustersUrl}/${id}`).then((response) => {
-        return response?.data;
+        return response.data;
     });
 }
 

--- a/ui/apps/platform/src/types/cluster.proto.ts
+++ b/ui/apps/platform/src/types/cluster.proto.ts
@@ -4,6 +4,8 @@ export type ClusterType =
     | 'OPENSHIFT_CLUSTER'
     | 'OPENSHIFT4_CLUSTER';
 
+export type ClusterLabels = Record<string, string>;
+
 export type ClusterProviderMetadata =
     | ClusterGoogleProviderMetadata
     | ClusterAWSProviderMetadata
@@ -105,7 +107,7 @@ export type Cluster = {
     id: string;
     name: string;
     type: ClusterType;
-    labels: Record<string, string>;
+    labels: ClusterLabels;
     mainImage: string;
     collectorImage: string;
     centralApiEndpoint: string;
@@ -131,10 +133,10 @@ export type Cluster = {
     auditLogState: Record<string, AuditLogFileState>;
 
     initBundleId: string;
-    managedBy: ManagerType;
+    managedBy: ClusterManagerType;
 };
 
-export type ManagerType =
+export type ClusterManagerType =
     | 'MANAGER_TYPE_UNKNOWN'
     | 'MANAGER_TYPE_MANUAL'
     | 'MANAGER_TYPE_HELM_CHART'

--- a/ui/apps/platform/src/types/clusterService.proto.ts
+++ b/ui/apps/platform/src/types/clusterService.proto.ts
@@ -26,7 +26,7 @@ export type ClusterIdToRetentionInfo = Record<string, DecommissionedClusterReten
 
 export type ClustersResponse = {
     clusters: Cluster[];
-    // Map secured clusters whose sensort have 'UNHEALTHY' status by clusterId to retention info
+    // Map secured clusters whose sensors have 'UNHEALTHY' status by clusterId to retention info.
     clusterIdToRetentionInfo: ClusterIdToRetentionInfo;
 };
 

--- a/ui/apps/platform/src/types/clusterService.proto.ts
+++ b/ui/apps/platform/src/types/clusterService.proto.ts
@@ -1,3 +1,35 @@
+import { Cluster } from './cluster.proto';
+
+export type DeploymentFormat = 'KUBECTL' | 'HELM' | 'HELM_VALUES';
+
+export type LoadBalancerType = 'NONE' | 'LOAD_BALANCER' | 'NODE_PORT' | 'ROUTE';
+
+export type DecommissionedClusterRetentionInfo =
+    | {
+          // Cluster will not be deleted even if sensor status remains UNHEALTHY:
+          // because it has an ignore label, if true
+          // because system configuration is never delete, if false
+          isExcluded: boolean;
+      }
+    | {
+          // Cluster will be deleted if sensor status remains UNHEALTHY for the number of days.
+          daysUntilDeletion: number; // int32
+      }
+    | null; // Cluster does not have sensor status UNHEALTHY.
+
+export type ClusterResponse = {
+    cluster: Cluster;
+    clusterRetentionInfo: DecommissionedClusterRetentionInfo;
+};
+
+export type ClusterIdToRetentionInfo = Record<string, DecommissionedClusterRetentionInfo>;
+
+export type ClustersResponse = {
+    clusters: Cluster[];
+    // Map secured clusters whose sensort have 'UNHEALTHY' status by clusterId to retention info
+    clusterIdToRetentionInfo: ClusterIdToRetentionInfo;
+};
+
 export type ClusterDefaultsResponse = {
     mainImageRepository: string;
     collectorImageRepository: string;


### PR DESCRIPTION
## Description

Follow up #2182

1. Adapt `ClusterDeletion` component from `CertificateExpiration` but without icon
    * **Not applicable** if `clusterRetentionInfo === null`
    * **in D days** if `'daysUntilDeletion' in clusterRetentionInfo`
    * **Excluded from deletion** if `isExcluded` 
    * **Deletion is turned off** if `!isExcluded`
2. Clusters table
    * Render **Cluster Deletion** column if feature flag is enabled
    * Omit row actions unless role has READ_WRITE_ACCESS for Cluster resource
3. Cluster side panel
    * Render **Cluster Deletion** column if feature flag is enabled

### Changed files

1. Edit cypress/fixtures/clusters/health.json
    * Add `clusterIdToRetentionInfo` property

2. Edit cypress/helpers/clusters.js
    * Factor out `visitClustersWithFixture` helper function
    * Remove clusters request from route matcher map for `visitClusterById` function for forward compatibility with cluster page
    * Add `clusterRetentionInfo` prop in `visitClusterByNameWithFixture` and `visitClusterByNameWithFixtureMetadataDatetime` functions

3. Add cypress/integration/clusters subfolder and move clusters.test.js into it

4. Add cypress/integration/clusters/clusterDeletion.test.js

5. Edit src/Containers/Clusters/ClusterEditForm.tsx
    * Add `clusterRetentionInfo` prop

6. Edit src/Containers/Clusters/ClustersSidePanel.tsx
    * Import `Cluster` from frontend proto type and add `as unknown as Cluster` cast to get rid of `Partial<Cluster> | null` type
    * Replace `getClusterById` with `fetchClusterWithRetentionInformation` function call
    * Destructure `clusterRetentionInfo` property from cluster response
    * Add comment about future code to prevent possible edge case from not updating retention info after save

7. Edit src/Containers/Clusters/ClustersTablePanel.js
    * Replace `fetchClustersAsArray` with `fetchClustersWithRetentionInfo` function call
    * Add `clusterIdToRetentionInfo`,  `hasReadWriteAccessForCluster` and `isDecommissionedClusterRetentionEnabled` properties to arg of `getColumnsForClusters` function call

8. Add src/Containers/Clusters/Components/ClusterDeletion.tsx

9. Edit src/Containers/Clusters/Components/ClusterSummary.tsx
    * Add `ClusterRetentionInfo` and `isDecommissionedClusterRetentionEnabled` props

10. Edit src/Containers/Clusters/cluster.helpers.tsx
    * Add `getClusterDeletionStatus` function

11. Edit src/Containers/Clusters/clusterTypes.ts
    * Re-export `Cluster` type from frontend cluster proto, as first step to supersede this container types file

12. Edit src/Containers/Clusters/clustersTableColumnDescriptors.js
    * Add `clusterIdToRetentionInfo`,  `hasReadWriteAccessForCluster` and `isDecommissionedClusterRetentionEnabled` properties
    * Update column width classes
    * Push **Cluster Deletion** column if feature flag is enabled
    * Push row actions if role has READ_WRITE_ACCESS for `'Cluster'` resource

13. Edit src/services/ClustersService.ts
    * Add `fetchClustersWithRetentionInfo` function
    * Rename `getClusterById` with `getClusterWithRetentionInforation` function

14. Edit src/types/cluster.proto.ts
    * Factor out `ClusterLabels`
    * Rename `ManagerType` as `ClusterManagerType`

15. Edit src/types/clusterService.proto.ts
    * Add `ClusterResponse`, `ClustersResponse`, `DecommissionedClusterRetentionInfo` types

### Residue

1. Replace imports from clusterTypes.ts with imports from frontend cluster proto
2. Rewrite files in TypeScript
3. Conditionally render other actions only if READ_WRITE_ACCESS for 'Cluster' resource

## Checklist
- [x] Investigated and inspected CI test results
- [x] Added integration tests

## Testing Performed

### manual testing

1. `export ROX_DECOMMISSIONED_CLUSTER_RETENTION=true` in ui also verified does not render if false
2. `yarn deploy-local` in ui
3. `yarn build` in ui
4. `yarn start` in ui

    * Visit /main/clusters: see GET /v1/clusters has new property

        ```js
        {
            clusterIdToRetentionInfo: {},
            clusters: […]
        }
        ```

    * Click cluster: see GET /v1/clusters/id has new property

        ```js
        {
            cluster: {…},
            clusterRetentionInfo: null
        }
        ```

### integration testing

1. `export CYPRESS_ROX_DECOMMISSIONED_CLUSTER_RETENTION=true` in ui/apps/platform
2. `yarn cypress-open` in ui/apps/platform
    * clusters.test.js
    * clusters/clusterDeletion.test.js see it skip tests without above feature flag export
