### PR TITLE
ROX-11281: Update pruning to remove clusters that have been unhealthy for a configurable period of time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Entries in this file should be limited to:
 Please avoid adding duplicate information across this changelog and JIRA/doc input pages.
 
 ## [NEXT RELEASE]
+- ROX-11181: Any clusters that have been unhealthy (defined as central being unable to reach sensor running on those clusters) for a period of time will be automatically removed. By default, it will remove if it's been unhealthy for 90 days, however that can be configured in the System Configuration page or using the cluster API.
+  - Any cluster that is expected to be unavailable for a period of time (e.g. clusters used in disaster recovery), can be tagged with a customizable label. Clusters with those labels will never be removed automatically.
 
 ## [3.71.0]
 

--- a/central/cluster/service/service_impl.go
+++ b/central/cluster/service/service_impl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/images/defaults"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/timeutil"
 	"google.golang.org/grpc"
 )
@@ -140,7 +141,7 @@ func (s *serviceImpl) getClusterRetentionInfo(ctx context.Context, cluster *stor
 		return nil, nil
 	}
 
-	if mapsIntersect(clusterRetentionConfig.GetIgnoreClusterLabels(), cluster.GetLabels()) {
+	if sliceutils.MapsIntersect(clusterRetentionConfig.GetIgnoreClusterLabels(), cluster.GetLabels()) {
 		return &v1.DecommissionedClusterRetentionInfo{
 			RetentionInfo: &v1.DecommissionedClusterRetentionInfo_IsExcluded{
 				IsExcluded: true,
@@ -258,15 +259,4 @@ func (s *serviceImpl) GetClusterDefaultValues(ctx context.Context, _ *v1.Empty) 
 		KernelSupportAvailable:   kernelSupport,
 	}
 	return defaults, nil
-}
-
-func mapsIntersect(m1 map[string]string, m2 map[string]string) bool {
-	for k, v := range m1 {
-		if val, exists := m2[k]; exists {
-			if val == v {
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/central/cluster/service/service_impl_test.go
+++ b/central/cluster/service/service_impl_test.go
@@ -82,9 +82,15 @@ func (suite *ClusterServiceTestSuite) TestGetClusterDefaults() {
 }
 
 func (suite *ClusterServiceTestSuite) TestGetClusterWithRetentionInfo() {
+	isolator := envisolator.NewEnvIsolator(suite.T())
+	defer isolator.RestoreAll()
+
+	isolator.Setenv(features.DecommissionedClusterRetention.EnvVar(), "true")
 	if !features.DecommissionedClusterRetention.Enabled() {
-		suite.T().Skip("Skipping GetCluster with RetentionInfo tests because decommissioned cluster retention feature is turned off")
+		// if it's still not enabled, we're probably in release tests so skip
+		suite.T().Skip("Skipping because ROX_DECOMMISSIONED_CLUSTER_RETENTION feature flag isn't set.")
 	}
+
 	config := suite.getTestSystemConfig()
 
 	cases := map[string]struct {
@@ -152,8 +158,13 @@ func (suite *ClusterServiceTestSuite) TestGetClusterWithRetentionInfo() {
 }
 
 func (suite *ClusterServiceTestSuite) TestGetClustersWithRetentionInfoMap() {
+	isolator := envisolator.NewEnvIsolator(suite.T())
+	defer isolator.RestoreAll()
+
+	isolator.Setenv(features.DecommissionedClusterRetention.EnvVar(), "true")
 	if !features.DecommissionedClusterRetention.Enabled() {
-		suite.T().Skip("Skipping GetClusters with RetentionInfo map tests because decommissioned cluster retention feature is turned off")
+		// if it's still not enabled, we're probably in release tests so skip
+		suite.T().Skip("Skipping because ROX_DECOMMISSIONED_CLUSTER_RETENTION feature flag isn't set.")
 	}
 
 	config := suite.getTestSystemConfig()

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -495,10 +495,6 @@ func (g *garbageCollectorImpl) collectImages(config *storage.PrivateConfig) {
 }
 
 func (g *garbageCollectorImpl) collectClusters(config *storage.PrivateConfig) {
-	if !features.DecommissionedClusterRetention.Enabled() {
-		return
-	}
-
 	// Check to see if pruning is enabled
 	clusterRetention := config.GetDecommissionedClusterRetention()
 	retentionDays := int64(clusterRetention.GetRetentionDurationDays())
@@ -535,7 +531,7 @@ func (g *garbageCollectorImpl) collectClusters(config *storage.PrivateConfig) {
 		return
 	}
 	if timeutil.TimeDiffDays(time.Now(), configCreationTime) < int(retentionDays) {
-		// In this case, the deployments that became unhealthy after config creation would also be unhealthy for fewer than retention days
+		// In this case, the clusters that became unhealthy after config creation would also be unhealthy for fewer than retention days
 		// and pruning can be skipped
 		log.Info("[Cluster Pruning] skipping pruning as retention period only starts after upgrade to version 3.71.0.")
 		return
@@ -590,7 +586,7 @@ func (g *garbageCollectorImpl) collectClusters(config *storage.PrivateConfig) {
 
 	if len(clustersToPrune) == 0 {
 		// Debug log as it's be noisy, but is helpful if debugging
-		log.Debug("[Cluster Pruning] no inactive clusters found.")
+		log.Debug("[Cluster Pruning] no inactive, non excluded clusters found.")
 		return
 	}
 

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -533,7 +533,7 @@ func (g *garbageCollectorImpl) collectClusters(config *storage.PrivateConfig) {
 	if timeutil.TimeDiffDays(time.Now(), configCreationTime) < int(retentionDays) {
 		// In this case, the deployments that became unhealthy after config creation would also be unhealthy for fewer than retention days
 		// and pruning can be skipped
-		log.Info("[Cluster Pruning] skipping pruning to as retention period only starts after upgrade to version 3.71.0.")
+		log.Info("[Cluster Pruning] skipping pruning as retention period only starts after upgrade to version 3.71.0.")
 		return
 	}
 
@@ -591,7 +591,7 @@ func (g *garbageCollectorImpl) collectClusters(config *storage.PrivateConfig) {
 }
 
 func (g *garbageCollectorImpl) checkIfClusterContainsCentral(cluster *storage.Cluster) (bool, error) {
-	//This query could be expensive, but it's an extremely rare occurrence. It only happens if there is a cluster that has been unhealthy for a long time (configurable)
+	//This query could be expensive, but it's a rare occurrence. It only happens if there is a cluster that has been unhealthy for a long time (configurable)
 	query := search.NewQueryBuilder().
 		AddStrings(search.ClusterID, cluster.GetId()).
 		AddExactMatches(search.DeploymentName, "central")

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -508,10 +508,20 @@ func TestImagePruning(t *testing.T) {
 		},
 	}
 
-	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
-		sac.AllowFixedScopes(
-			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
-			sac.ResourceScopeKeys(resources.Cluster)))
+	scc := sac.TestScopeCheckerCoreFromAccessResourceMap(t,
+		[]permissions.ResourceWithAccess{
+			resourceWithAccess(storage.Access_READ_ACCESS, resources.Alert),
+			resourceWithAccess(storage.Access_READ_ACCESS, resources.Config),
+			resourceWithAccess(storage.Access_READ_ACCESS, resources.Deployment),
+			resourceWithAccess(storage.Access_READ_ACCESS, resources.Image),
+			resourceWithAccess(storage.Access_READ_ACCESS, resources.Risk),
+			resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Alert),
+			resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Deployment),
+			resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Image),
+			resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Risk),
+		})
+
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), scc)
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -561,6 +571,9 @@ func TestImagePruning(t *testing.T) {
 }
 
 func TestClusterPruning(t *testing.T) {
+	if !features.DecommissionedClusterRetention.Enabled() {
+		t.Skip("Skipping cluster pruning tests because decommissioned cluster retention feature is turned off")
+	}
 	var cases = []struct {
 		name        string
 		config 	    *storage.Config
@@ -610,17 +623,22 @@ func TestClusterPruning(t *testing.T) {
 		},
 	}
 
-	scc := sac.TestScopeCheckerCoreFromAccessResourceMap(t,
-		[]permissions.ResourceWithAccess{
-			resourceWithAccess(storage.Access_READ_ACCESS, resources.Alert),
-			resourceWithAccess(storage.Access_READ_ACCESS, resources.Config),
-			resourceWithAccess(storage.Access_READ_ACCESS, resources.Deployment),
-			resourceWithAccess(storage.Access_READ_ACCESS, resources.Image),
-			resourceWithAccess(storage.Access_READ_ACCESS, resources.Risk),
-			resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Cluster),
-		})
+	//scc := sac.TestScopeCheckerCoreFromAccessResourceMap(t,
+	//	[]permissions.ResourceWithAccess{
+	//		resourceWithAccess(storage.Access_READ_ACCESS, resources.Alert),
+	//		resourceWithAccess(storage.Access_READ_ACCESS, resources.Config),
+	//		resourceWithAccess(storage.Access_READ_ACCESS, resources.Deployment),
+	//		resourceWithAccess(storage.Access_READ_ACCESS, resources.Image),
+	//		resourceWithAccess(storage.Access_READ_ACCESS, resources.Risk),
+	//		resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Cluster),
+	//	})
+	//
+	//ctx := sac.WithGlobalAccessScopeChecker(context.Background(), scc)
 
-	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), scc)
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Cluster)))
 
 
 

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -597,34 +597,34 @@ func TestClusterPruning(t *testing.T) {
 					HealthStatus: &storage.ClusterHealthStatus{SensorHealthStatus: storage.ClusterHealthStatus_HEALTHY},
 				},
 				{
-					Name:         "UNHEALTHY cluster with last contact time before config creation time",
+					Name:         "UNHEALTHY cluster last contacted more than retention days ago",
 					Labels:       map[string]string{"k1": "v2"},
 					HealthStatus: unhealthyClusterStatus(80),
 				},
 			},
 			expectedNames: []string{
 				"HEALTHY cluster",
-				"UNHEALTHY cluster with last contact time before config creation time",
+				"UNHEALTHY cluster last contacted more than retention days ago",
 			},
 		},
 		{
 			name:        "No pruning if it hasn't been 24hrs since last run",
 			recentlyRun: true,
-			config:      getCluserRetentionConfig(0, 90, 72),
+			config:      getCluserRetentionConfig(60, 90, 72),
 			clusters: []*storage.Cluster{
 				{
 					Name:         "HEALTHY cluster",
 					HealthStatus: &storage.ClusterHealthStatus{SensorHealthStatus: storage.ClusterHealthStatus_HEALTHY},
 				},
 				{
-					Name:         "UNHEALTHY cluster with last contact time before config creation time",
+					Name:         "UNHEALTHY cluster last contacted more than retention days ago",
 					Labels:       map[string]string{"k1": "v2"},
 					HealthStatus: unhealthyClusterStatus(80),
 				},
 			},
 			expectedNames: []string{
 				"HEALTHY cluster",
-				"UNHEALTHY cluster with last contact time before config creation time",
+				"UNHEALTHY cluster last contacted more than retention days ago",
 			},
 		},
 		{
@@ -636,14 +636,14 @@ func TestClusterPruning(t *testing.T) {
 					HealthStatus: &storage.ClusterHealthStatus{SensorHealthStatus: storage.ClusterHealthStatus_HEALTHY},
 				},
 				{
-					Name:         "UNHEALTHY cluster with last contact time before config creation time",
+					Name:         "UNHEALTHY cluster last contacted more than retention days ago",
 					Labels:       map[string]string{"k1": "v2"},
 					HealthStatus: unhealthyClusterStatus(80),
 				},
 			},
 			expectedNames: []string{
 				"HEALTHY cluster",
-				"UNHEALTHY cluster with last contact time before config creation time",
+				"UNHEALTHY cluster last contacted more than retention days ago",
 			},
 		},
 		{
@@ -670,13 +670,13 @@ func TestClusterPruning(t *testing.T) {
 			config: getCluserRetentionConfig(60, 90, 72),
 			clusters: []*storage.Cluster{
 				{
-					Name:         "UNHEALTHY cluster with last contact time before config creation time",
+					Name:         "UNHEALTHY cluster last contacted more than retention days ago",
 					Labels:       map[string]string{"k1": "v2"},
 					HealthStatus: unhealthyClusterStatus(80),
 				},
 			},
 			expectedNames: []string{
-				"UNHEALTHY cluster with last contact time before config creation time",
+				"UNHEALTHY cluster last contacted more than retention days ago",
 			},
 		},
 		{
@@ -684,19 +684,19 @@ func TestClusterPruning(t *testing.T) {
 			config: getCluserRetentionConfig(60, 90, 72),
 			clusters: []*storage.Cluster{
 				{
-					Name:         "UNHEALTHY cluster with last contact time before config creation time",
+					Name:         "UNHEALTHY cluster last contacted more than retention days ago",
 					Labels:       map[string]string{"k1": "v2"},
 					HealthStatus: unhealthyClusterStatus(80),
 				},
 				{
-					Name:         "Another UNHEALTHY cluster with last contact time before config creation time",
+					Name:         "Another UNHEALTHY cluster last contacted more than retention days ago",
 					Labels:       map[string]string{"k1": "v2"},
 					HealthStatus: unhealthyClusterStatus(80),
 				},
 			},
 			expectedNames: []string{
-				"UNHEALTHY cluster with last contact time before config creation time",
-				"Another UNHEALTHY cluster with last contact time before config creation time",
+				"UNHEALTHY cluster last contacted more than retention days ago",
+				"Another UNHEALTHY cluster last contacted more than retention days ago",
 			},
 		},
 		{
@@ -708,7 +708,7 @@ func TestClusterPruning(t *testing.T) {
 					HealthStatus: &storage.ClusterHealthStatus{SensorHealthStatus: storage.ClusterHealthStatus_HEALTHY},
 				},
 				{
-					Name:         "UNHEALTHY cluster with last contact time before config creation time",
+					Name:         "UNHEALTHY cluster last contacted more than retention days ago",
 					HealthStatus: unhealthyClusterStatus(80),
 				},
 			},
@@ -735,7 +735,7 @@ func TestClusterPruning(t *testing.T) {
 					HealthStatus: unhealthyClusterStatus(10),
 				},
 				{
-					Name:         "UNHEALTHY cluster with last contact time more than retention",
+					Name:         "UNHEALTHY cluster last contacted more than retention days ago",
 					Labels:       map[string]string{"k1": "v2"},
 					HealthStatus: unhealthyClusterStatus(80),
 				},
@@ -755,12 +755,12 @@ func TestClusterPruning(t *testing.T) {
 					HealthStatus: &storage.ClusterHealthStatus{SensorHealthStatus: storage.ClusterHealthStatus_HEALTHY},
 				},
 				{
-					Name:         "UNHEALTHY cluster with last contact time more than retention",
+					Name:         "UNHEALTHY cluster last contacted more than retention days ago",
 					Labels:       map[string]string{"k1": "v2"},
 					HealthStatus: unhealthyClusterStatus(80),
 				},
 				{
-					Name:         "Another UNHEALTHY cluster with last contact time more than retention",
+					Name:         "Another UNHEALTHY cluster last contacted more than retention days ago",
 					Labels:       map[string]string{"k1": "v2"},
 					HealthStatus: unhealthyClusterStatus(100),
 				},

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -571,6 +571,11 @@ func TestClusterPruning(t *testing.T) {
 	defer isolator.RestoreAll()
 
 	isolator.Setenv(features.DecommissionedClusterRetention.EnvVar(), "true")
+	if !features.DecommissionedClusterRetention.Enabled() {
+		// if it's still not enabled, we're probably in release tests so skip
+		t.Skip("Skipping because ROX_DECOMMISSIONED_CLUSTER_RETENTION feature flag isn't set.")
+	}
+
 	isolator.Setenv("ROX_IMAGE_FLAVOR", "rhacs")
 
 	testbuildinfo.SetForTest(t)
@@ -802,6 +807,11 @@ func TestClusterPruningCentralCheck(t *testing.T) {
 	defer isolator.RestoreAll()
 
 	isolator.Setenv(features.DecommissionedClusterRetention.EnvVar(), "true")
+	if !features.DecommissionedClusterRetention.Enabled() {
+		// if it's still not enabled, we're probably in release tests so skip
+		t.Skip("Skipping because ROX_DECOMMISSIONED_CLUSTER_RETENTION feature flag isn't set.")
+	}
+
 	isolator.Setenv("ROX_IMAGE_FLAVOR", "rhacs")
 
 	testbuildinfo.SetForTest(t)

--- a/pkg/sliceutils/map.go
+++ b/pkg/sliceutils/map.go
@@ -54,7 +54,7 @@ func Map(slice, mapFunc interface{}) interface{} {
 
 // MapsIntersect returns true there is at least one key-value pair that is present in both maps
 // If both, or either maps are empty, it returns false
-// TODO : Implement this so that it can take map[interface{}]interface{}
+// TODO : Convert to generics after upgrade to go 1.18
 func MapsIntersect(m1 map[string]string, m2 map[string]string) bool {
 	for k, v := range m1 {
 		if val, exists := m2[k]; exists {

--- a/pkg/sliceutils/map.go
+++ b/pkg/sliceutils/map.go
@@ -51,3 +51,17 @@ func Map(slice, mapFunc interface{}) interface{} {
 	}
 	return outSlice.Interface()
 }
+
+// MapsIntersect returns true there is at least one key-value pair that is present in both maps
+// If both, or either maps are empty, it returns false
+// TODO : Implement this so that it can take map[interface{}]interface{}
+func MapsIntersect(m1 map[string]string, m2 map[string]string) bool {
+	for k, v := range m1 {
+		if val, exists := m2[k]; exists {
+			if reflect.DeepEqual(v, val) {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Description

- Adds a new garbage collection task to auto remove decommissioned clusters (for a configurable period of time)
- The task should run every 24 hours
- Retention value of 0 days should mean that auto remove is disabled
- Do not delete a cluster if it's the last one around
- If all clusters are unhealthy, do not delete; warn the user instead. There's something seriously wrong with their setup.

For the last item, there are a caveat:
- Finding out if a cluster has central in it, is apparently not easy. There is a todo to tag such clusters in the future. But for now, we will search for clusters with a deployment in it called "central" and then we'll validate using a label (app=central) and annotation (owner=stackrox). This may have some FPs and catch other clusters, but that's ok. We'd rather err on not deleting something than to delete cluster with central in it. 


## Checklist
- [] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
~[ ] Determined and documented upgrade steps~
~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
