### PR TITLE
CI: handle ci-operator teardown

### DIFF
--- a/.openshift-ci/README.md
+++ b/.openshift-ci/README.md
@@ -16,4 +16,3 @@ alias osci-format='osci; ack -f --python | entr black .'
 alias osci-lint='osci; ack -f --python | entr pylint --rcfile .pylintrc *.py tests'
 alias osci-test='osci; ack -f --python --shell | entr python -m unittest discover'
 ```
-

--- a/.openshift-ci/README.md
+++ b/.openshift-ci/README.md
@@ -16,3 +16,4 @@ alias osci-format='osci; ack -f --python | entr black .'
 alias osci-lint='osci; ack -f --python | entr pylint --rcfile .pylintrc *.py tests'
 alias osci-test='osci; ack -f --python --shell | entr python -m unittest discover'
 ```
+

--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -44,10 +44,7 @@ class GKECluster:
                 raise err
 
         # OpenShift CI sends a SIGINT when tests are canceled
-        def handler():
-            print("Tearing down the cluster due to SIGINT")
-            self.teardown()
-        signal.signal(signal.SIGINT, handler)
+        signal.signal(signal.SIGINT, self.sigint_handler)
 
         subprocess.run(
             [GKECluster.GKE_SCRIPT, "wait_for_cluster"],
@@ -80,3 +77,7 @@ class GKECluster:
         )
 
         return self
+
+    def sigint_handler(self, signum, frame):
+        print("Tearing down the cluster due to SIGINT", signum, frame)
+        self.teardown()

--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -39,15 +39,15 @@ class GKECluster:
                 exitstatus = cmd.wait(GKECluster.PROVISION_TIMEOUT)
                 if exitstatus != 0:
                     raise RuntimeError(f"Cluster provision failed: exit {exitstatus}")
-                # OpenShift CI sends a SIGINT when tests are canceled
-                def handler():
-                    print("Tearing down the cluster due to SIGINT")
-                    self.teardown()
-
-                signal.signal(signal.SIGINT, handler)
             except subprocess.TimeoutExpired as err:
                 popen_graceful_kill(cmd)
                 raise err
+
+        # OpenShift CI sends a SIGINT when tests are canceled
+        def handler():
+            print("Tearing down the cluster due to SIGINT")
+            self.teardown()
+        signal.signal(signal.SIGINT, handler)
 
         subprocess.run(
             [GKECluster.GKE_SCRIPT, "wait_for_cluster"],

--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -5,6 +5,7 @@ Clusters used in test
 """
 
 import os
+import signal
 import subprocess
 import time
 
@@ -23,10 +24,7 @@ class GKECluster:
     PROVISION_TIMEOUT = 20 * 60
     WAIT_TIMEOUT = 20 * 60
     TEARDOWN_TIMEOUT = 5 * 60
-    PROVISION_PATH = "scripts/ci/gke.sh"
-    WAIT_PATH = "scripts/ci/gke.sh"
-    REFRESH_PATH = "scripts/ci/gke.sh"
-    TEARDOWN_PATH = "scripts/ci/gke.sh"
+    GKE_SCRIPT = "scripts/ci/gke.sh"
 
     def __init__(self, cluster_id):
         self.cluster_id = cluster_id
@@ -34,26 +32,32 @@ class GKECluster:
 
     def provision(self):
         with subprocess.Popen(
-            [GKECluster.PROVISION_PATH, "provision_gke_cluster", self.cluster_id]
+            [GKECluster.GKE_SCRIPT, "provision_gke_cluster", self.cluster_id]
         ) as cmd:
 
             try:
                 exitstatus = cmd.wait(GKECluster.PROVISION_TIMEOUT)
                 if exitstatus != 0:
                     raise RuntimeError(f"Cluster provision failed: exit {exitstatus}")
+                # OpenShift CI sends a SIGINT when tests are canceled
+                def handler():
+                    print("Tearing down the cluster due to SIGINT")
+                    self.teardown()
+
+                signal.signal(signal.SIGINT, handler)
             except subprocess.TimeoutExpired as err:
                 popen_graceful_kill(cmd)
                 raise err
 
         subprocess.run(
-            [GKECluster.WAIT_PATH, "wait_for_cluster"],
+            [GKECluster.GKE_SCRIPT, "wait_for_cluster"],
             check=True,
             timeout=GKECluster.WAIT_TIMEOUT,
         )
 
         # pylint: disable=consider-using-with
         self.refresh_token_cmd = subprocess.Popen(
-            [GKECluster.REFRESH_PATH, "refresh_gke_token"]
+            [GKECluster.GKE_SCRIPT, "refresh_gke_token"]
         )
 
         return self
@@ -63,13 +67,14 @@ class GKECluster:
             print("Pausing teardown because /tmp/hold-cluster exists")
             time.sleep(60)
 
-        try:
-            popen_graceful_kill(self.refresh_token_cmd)
-        except Exception as err:
-            print(f"Could not terminate the token refresh: {err}")
+        if self.refresh_token_cmd is not None:
+            try:
+                popen_graceful_kill(self.refresh_token_cmd)
+            except Exception as err:
+                print(f"Could not terminate the token refresh: {err}")
 
         subprocess.run(
-            [GKECluster.TEARDOWN_PATH, "teardown_gke_cluster"],
+            [GKECluster.GKE_SCRIPT, "teardown_gke_cluster"],
             check=True,
             timeout=GKECluster.TEARDOWN_TIMEOUT,
         )

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -69,4 +69,13 @@ else
     exit 0
 fi
 
-"${job_script}" "$@"
+"${job_script}" "$@" &
+job_pid="$!"
+
+forward_sigint() {
+    echo "Dispatch is forwarding SIGINT to job"
+    kill -SIGINT "${job_pid}"
+}
+trap forward_sigint SIGTINT
+
+wait "${job_pid}"

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -76,6 +76,6 @@ forward_sigint() {
     echo "Dispatch is forwarding SIGINT to job"
     kill -SIGINT "${job_pid}"
 }
-trap forward_sigint SIGTINT
+trap forward_sigint SIGINT
 
 wait "${job_pid}"


### PR DESCRIPTION
## Description

Per title. This PR will teardown GKE clusters if ci-operator terminates tests due to, for example, a new commit.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient:
- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/2295/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/1543695509569409024
- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/2295/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1543695509607157760