### PR TITLE
ROX-11070: Only allow a single default group per auth provider

### DIFF
--- a/central/group/datastore/internal/store/store.go
+++ b/central/group/datastore/internal/store/store.go
@@ -1,11 +1,8 @@
 package store
 
 import (
-	"time"
-
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/bolthelper"
-	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/utils"
 	bolt "go.etcd.io/bbolt"
 )
@@ -39,8 +36,7 @@ func New(db *bolt.DB) Store {
 	bolthelper.RegisterBucketOrPanic(db, groupsBucket)
 
 	store := &storeImpl{
-		db:                db,
-		defaultGroupCache: expiringcache.NewExpiringCache(time.Hour),
+		db: db,
 	}
 	grps, err := store.GetFiltered(isEmptyGroupPropertiesF)
 	utils.Should(err)

--- a/central/group/datastore/internal/store/store.go
+++ b/central/group/datastore/internal/store/store.go
@@ -1,8 +1,11 @@
 package store
 
 import (
+	"time"
+
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/bolthelper"
+	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/utils"
 	bolt "go.etcd.io/bbolt"
 )
@@ -36,7 +39,8 @@ func New(db *bolt.DB) Store {
 	bolthelper.RegisterBucketOrPanic(db, groupsBucket)
 
 	store := &storeImpl{
-		db: db,
+		db:                db,
+		defaultGroupCache: expiringcache.NewExpiringCache(time.Hour),
 	}
 	grps, err := store.GetFiltered(isEmptyGroupPropertiesF)
 	utils.Should(err)

--- a/central/group/datastore/internal/store/store_impl.go
+++ b/central/group/datastore/internal/store/store_impl.go
@@ -159,11 +159,7 @@ func addInTransaction(tx *bolt.Tx, group *storage.Group) error {
 		return errox.InvariantViolation.CausedBy(err)
 	}
 
-	if err := buc.Put([]byte(id), bytes); err != nil {
-		return err
-	}
-
-	return nil
+	return buc.Put([]byte(id), bytes)
 }
 
 func updateInTransaction(tx *bolt.Tx, group *storage.Group) error {
@@ -204,11 +200,7 @@ func updateInTransaction(tx *bolt.Tx, group *storage.Group) error {
 		return errox.InvariantViolation.CausedBy(err)
 	}
 
-	if err := buc.Put([]byte(id), bytes); err != nil {
-		return err
-	}
-
-	return nil
+	return buc.Put([]byte(id), bytes)
 }
 
 func removeInTransaction(tx *bolt.Tx, props *storage.GroupProperties) error {
@@ -233,11 +225,7 @@ func removeInTransaction(tx *bolt.Tx, props *storage.GroupProperties) error {
 		id = grp.GetProps().GetId()
 	}
 
-	if err := buc.Delete([]byte(id)); err != nil {
-		return err
-	}
-
-	return nil
+	return buc.Delete([]byte(id))
 }
 
 func filterInTransaction(tx *bolt.Tx, filter func(*storage.GroupProperties) bool) (grps []*storage.Group, err error) {

--- a/central/group/datastore/internal/store/store_test.go
+++ b/central/group/datastore/internal/store/store_test.go
@@ -542,13 +542,13 @@ func (s *GroupStoreTestSuite) TestDefaultGroup() {
 	s.ErrorIs(err, errox.AlreadyExists)
 
 	// 3. Updating the initially existing group to make it a default group should fail.
-	//		Fetch the group by its properties.
+	// Fetch the group by its properties.
 	initialGroup, err = s.sto.Get(initialGroup.GetProps())
 	s.NoError(err)
-	// 		Unset Key / Value fields, making it a default group.
+	// Unset Key / Value fields, making it a default group.
 	initialGroup.GetProps().Key = ""
 	initialGroup.GetProps().Value = ""
-	//		Ensure a "AlreadyExists" error is yielded when trying to update the group.
+	// Ensure a "AlreadyExists" error is yielded when trying to update the group.
 	err = s.sto.Update(initialGroup)
 	s.Error(err)
 	s.ErrorIs(err, errox.AlreadyExists)

--- a/central/group/datastore/internal/store/store_test.go
+++ b/central/group/datastore/internal/store/store_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/bolthelper"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/suite"
 	bolt "go.etcd.io/bbolt"
@@ -508,4 +509,47 @@ func (s *GroupStoreTestSuite) TestGetFiltered() {
 	}
 	s.NoError(err)
 	s.ElementsMatch(expectedGroups, actualGroups)
+}
+
+func (s *GroupStoreTestSuite) TestDefaultGroup() {
+	defaultGroup := &storage.Group{
+		RoleName: "admin",
+		Props: &storage.GroupProperties{
+			AuthProviderId: "defaultGroup1",
+			Id:             "some-id",
+		},
+	}
+	initialGroup := &storage.Group{
+		RoleName: "Manager",
+		Props: &storage.GroupProperties{
+			AuthProviderId: "defaultGroup1",
+			Key:            "something",
+			Value:          "someone",
+			Id:             "some-id-3",
+		},
+	}
+
+	// 0. Setting up an existing group for the auth provider "defaultGroup1".
+	s.NoError(s.sto.Add(initialGroup))
+
+	// 1. Add the default group.
+	s.NoError(s.sto.Add(defaultGroup))
+
+	// 2. Adding the group a second time should not work and yield a "AlreadyExists" error.
+	defaultGroup.GetProps().Id = "some-id-2"
+	err := s.sto.Add(defaultGroup)
+	s.Error(err)
+	s.ErrorIs(err, errox.AlreadyExists)
+
+	// 3. Updating the initially existing group to make it a default group should fail.
+	//		Fetch the group by its properties.
+	initialGroup, err = s.sto.Get(initialGroup.GetProps())
+	s.NoError(err)
+	// 		Unset Key / Value fields, making it a default group.
+	initialGroup.GetProps().Key = ""
+	initialGroup.GetProps().Value = ""
+	//		Ensure a "AlreadyExists" error is yielded when trying to update the group.
+	err = s.sto.Update(initialGroup)
+	s.Error(err)
+	s.ErrorIs(err, errox.AlreadyExists)
 }


### PR DESCRIPTION
## Description

This PR is a follow-up from the [discussion here](https://github.com/stackrox/stackrox/pull/2075#discussion_r911410235).

The issue is that, with the changes of introducing a unique identifier not based on a composite key of a group's properties, we potentially allow clients to create an arbitrary amount of default groups.

Previously, this was not possible due to the `authProviderID`'s value being used as a key to store the group, uniquely identifying it, creating a 1:1 mapping between default group and auth provider.

This complicates things for the UI, as we would either change the current flow within the UI and allow multiple "default roles" to be assigned, as well as posing a challenge to distinguish between the different default groups.

Since this is not at all intended, we should restrict the datastore and only allow a single default group (with no key / value field set) _per auth provider ID_. This way, we achieve the same behavior related to default groups as 
beforehand and do not add increased complexity to the front end.

## Testing Performed

- Unit tests added.
