### PR TITLE
ROX-7875: Add retry to more places to fix the flake

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -181,7 +181,7 @@ class Kubernetes implements OrchestratorMain {
         waitForDeploymentAndPopulateInfo(deployment)
     }
 
-    boolean updateDeploymentNoWait(Deployment deployment) {
+    boolean updateDeploymentNoWait(Deployment deployment, int maxRetries=0) {
         K8sDeployment k8sdeployment = deployments.inNamespace(deployment.namespace).withName(deployment.name).get()
         if (k8sdeployment) {
             log.debug "Deployment ${deployment.name} with version ${k8sdeployment.metadata.resourceVersion} " +
@@ -189,7 +189,7 @@ class Kubernetes implements OrchestratorMain {
         } else {
             log.debug "Deployment ${deployment.name} NOT found in namespace ${deployment.namespace}. Creating..."
         }
-        return createDeploymentNoWait(deployment)
+        return createDeploymentNoWait(deployment, maxRetries)
     }
 
     def updateDeployment(Deployment deployment) {
@@ -1857,7 +1857,7 @@ class Kubernetes implements OrchestratorMain {
             Helpers.withK8sClientRetry(maxNumRetries,1) {
                 client.apps().deployments().inNamespace(deployment.namespace).createOrReplace(d)
                 int att = Helpers.getAttemptCount()
-                log.debug "Told the orchestrator to createOrReplace " + deployment.name + ". Attempt " + att + " of 10"
+                log.debug "Told the orchestrator to createOrReplace " + deployment.name + ". Attempt " + att + " of " + maxNumRetries
             }
             if (deployment.createLoadBalancer) {
                 waitForLoadBalancer(deployment)

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -414,7 +414,7 @@ class AdmissionControllerTest extends BaseSpecification {
         for (int i = 0; i < 45; i++) {
             Helpers.sleepWithRetryBackoff(1000)
             deployment.addAnnotation("qa.stackrox.io/iteration", "${i}")
-            assert orchestrator.updateDeploymentNoWait(deployment)
+            assert orchestrator.updateDeploymentNoWait(deployment, 10)
         }
 
         cleanup:


### PR DESCRIPTION
## Description

Apparently, I forgot to add retries to `assert orchestrator.updateDeploymentNoWait(deployment, 10)` in the previous PR #2195. Now this is in place.

## Checklist

- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- [ ] CI 5 green runs