### PR TITLE
Update pf charts to use 'cursor: pointer' by default for bars and legends.

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandardChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandardChart.tsx
@@ -9,6 +9,7 @@ import {
     defaultChartBarWidth,
     navigateOnClickEvent,
     solidBlueChartColor,
+    patternflySeverityTheme,
 } from 'utils/chartUtils';
 
 const labelLinkCallback = ({ datum }: ChartLabelProps, data: ComplianceData) => {
@@ -45,6 +46,7 @@ function ComplianceLevelsByStandardChart({ complianceData }: ComplianceLevelsByS
                     right: 50,
                     bottom: 30,
                 }}
+                theme={patternflySeverityTheme}
             >
                 <ChartAxis
                     tickLabelComponent={

--- a/ui/apps/platform/src/utils/chartUtils.ts
+++ b/ui/apps/platform/src/utils/chartUtils.ts
@@ -1,6 +1,7 @@
 import { History } from 'react-router-dom';
 import { getTheme, ChartThemeColor } from '@patternfly/react-charts';
 import { EventCallbackInterface, EventPropTypeInterface } from 'victory-core';
+import merge from 'lodash/merge';
 
 import { severityColors } from 'constants/visuals/colors';
 
@@ -15,9 +16,17 @@ export const defaultChartHeight = 260;
 
 export const defaultChartBarWidth = 18;
 
+const pointerStyles = {
+    data: { cursor: 'pointer' },
+    labels: { cursor: 'pointer' },
+};
+
 /** A Victory chart theme based on grey/yellow/orange/red colors to indicate severity */
 export const patternflySeverityTheme = {
     ...defaultTheme,
+    bar: {
+        style: merge(defaultTheme?.bar?.style ?? {}, pointerStyles),
+    },
     stack: {
         ...defaultTheme.stack,
         colorScale: [...severityColorScale],
@@ -25,6 +34,7 @@ export const patternflySeverityTheme = {
     legend: {
         ...defaultTheme.legend,
         colorScale: [...severityColorScale],
+        style: merge(defaultTheme?.legend?.style ?? {}, pointerStyles),
     },
     tooltip: {
         style: {


### PR DESCRIPTION
## Description

Sets the default styles for PatternFly charts to show a pointer on hover for bars and legends. Since all instances of the charts currently have linkable bars and clickable legends this style was made the default, but can be overridden on a case-by-case basis if necessary.

## Checklist
- [ ] Investigated and inspected CI test results

If any of these don't apply, please comment below.

## Testing Performed

Load the new dashboard and hover over the chart bars for the following widgets and ensure that the cursor style changes to a pointer, indicating a clickable object:
- Aging images
- Policy Violations by Category
- Compliance by standard

Additionally, hover over the legend items in the Policy Violations by Category widget and ensure the cursor style changes to a pointer.

