### PR TITLE
upgrade-test: use helm for install and upgrade

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -56,8 +56,6 @@ setup_deployment_env() {
     ci_export MAIN_IMAGE_REPO "quay.io/$REPO/main"
     ci_export CENTRAL_DB_IMAGE_REPO "quay.io/$REPO/central-db"
     ci_export COLLECTOR_IMAGE_REPO "quay.io/$REPO/collector"
-    ci_export SCANNER_IMAGE "quay.io/$REPO/scanner:$(cat "$(git rev-parse --show-toplevel)/SCANNER_VERSION")"
-    ci_export SCANNER_DB_IMAGE "quay.io/$REPO/scanner-db:$(cat "$(git rev-parse --show-toplevel)/SCANNER_VERSION")"
 }
 
 install_built_roxctl_in_gopath() {

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -404,8 +404,8 @@ deploy_earlier_central() {
     PATH="bin/$TEST_HOST_OS:$PATH" roxctl version
     PATH="bin/$TEST_HOST_OS:$PATH" \
     MAIN_IMAGE_TAG="$EARLIER_TAG" \
-    SCANNER_IMAGE="quay.io/$REGISTRY/scanner:$(cat SCANNER_VERSION)" \
-    SCANNER_DB_IMAGE="quay.io/$REGISTRY/scanner-db:$(cat SCANNER_VERSION)" \
+    SCANNER_IMAGE="$REGISTRY/scanner:$(cat SCANNER_VERSION)" \
+    SCANNER_DB_IMAGE="$REGISTRY/scanner-db:$(cat SCANNER_VERSION)" \
     ./deploy/k8s/central.sh
 
     get_central_basic_auth_creds

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -465,6 +465,12 @@ set_images_to_current() {
     kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:$(make --quiet tag)"
     kubectl -n stackrox set image deploy/scanner "scanner=$REGISTRY/scanner:$(cat SCANNER_VERSION)"
     kubectl -n stackrox set image deploy/scanner-db "*=$REGISTRY/scanner-db:$(cat SCANNER_VERSION)"
+
+    touch /tmp/hold
+    while [[ -e /tmp/hold ]]; do
+        info "Holding this job for debug"
+        sleep 60
+    done
 }
 
 validate_db_backup_and_restore() {

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -35,6 +35,7 @@ test_upgrade() {
         REGISTRY="stackrox"
     fi
 
+    export OUTPUT_FORMAT="helm"
     export STORAGE="pvc"
     export CLUSTER_TYPE_FOR_TEST=K8S
     require_environment "LONGTERM_LICENSE"

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -462,9 +462,12 @@ force_rollback() {
 set_images_to_current() {
     info "Setting images to the current tag"
 
-    kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:$(make --quiet tag)"
-    kubectl -n stackrox set image deploy/scanner "scanner=$REGISTRY/scanner:$(cat SCANNER_VERSION)"
-    kubectl -n stackrox set image deploy/scanner-db "*=$REGISTRY/scanner-db:$(cat SCANNER_VERSION)"
+    roxctl helm output central-services --image-defaults development_build --output-dir /tmp/stackrox-central-services-chart || true
+    helm upgrade -n stackrox stackrox-central-services /tmp/stackrox-central-services-chart || true
+
+    echo kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:$(make --quiet tag)"
+    echo kubectl -n stackrox set image deploy/scanner "scanner=$REGISTRY/scanner:$(cat SCANNER_VERSION)"
+    echo kubectl -n stackrox set image deploy/scanner-db "*=$REGISTRY/scanner-db:$(cat SCANNER_VERSION)"
 
     touch /tmp/hold
     while [[ -e /tmp/hold ]]; do

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -402,7 +402,11 @@ deploy_earlier_central() {
     chmod +x "bin/$TEST_HOST_OS/roxctl"
     PATH="bin/$TEST_HOST_OS:$PATH" command -v roxctl
     PATH="bin/$TEST_HOST_OS:$PATH" roxctl version
-    PATH="bin/$TEST_HOST_OS:$PATH" MAIN_IMAGE_TAG="$EARLIER_TAG" ./deploy/k8s/central.sh
+    PATH="bin/$TEST_HOST_OS:$PATH" \
+    MAIN_IMAGE_TAG="$EARLIER_TAG" \
+    SCANNER_IMAGE="quay.io/$REGISTRY/scanner:$(cat SCANNER_VERSION)" \
+    SCANNER_DB_IMAGE="quay.io/$REGISTRY/scanner-db:$(cat SCANNER_VERSION)" \
+    ./deploy/k8s/central.sh
 
     get_central_basic_auth_creds
 }


### PR DESCRIPTION
## Description

The upgrade test is [failing](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-upgrade-tests/1544783120299986944) because:
- It deploys the latest scanner with an earlier rox.
- This is due to persisted latest scanner envs in `setup_deployment_env()`.
- The test in general does not care about scanner upgrade and so this might have been fine.
- But the earlier version of the UpgradeTest inherits from a BaseSpec that does a scanImage().
- And the latest scanner is not starting due to an incompatibility with the earlier configuration yaml.

This PR:
- removes the persistent scanner version env settings
- uses helm for the earlier rox deploy
- and uses helm for the upgrade so that scanner (and presumably other components) follow a supported upgrade path.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.

/test openshift-4-qa-e2e-tests
