### PR TITLE
Namespace GraphQL resolvers should not return deployment, secrets or net pol count

### DIFF
--- a/central/graphql/handler/namespace_test.go
+++ b/central/graphql/handler/namespace_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,17 +19,6 @@ func TestGetNamespaces(t *testing.T) {
 			ClusterName: fakeClusterName,
 		},
 	}, nil)
-	mocks.deployment.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{
-		{
-			ID: fakeDeploymentID,
-		},
-	}, nil)
-	mocks.secret.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{
-		{
-			ID: fakeSecretID,
-		},
-	}, nil)
-	mocks.nps.EXPECT().CountMatchingNetworkPolicies(gomock.Any(), fakeClusterID, fakeNamespaceName).Return(1, nil)
 	response := executeTestQuery(t, mocks, "{namespaces { metadata { id name clusterId clusterName } } }")
 	assert.Equal(t, 200, response.Code)
 	assertJSONMatches(t, response.Body, ".data.namespaces[0].metadata.id", fakeNamespaceID)
@@ -47,17 +35,6 @@ func TestGetNamespace(t *testing.T) {
 		ClusterId:   fakeClusterID,
 		ClusterName: fakeClusterName,
 	}, true, nil)
-	mocks.deployment.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{
-		{
-			ID: fakeDeploymentID,
-		},
-	}, nil)
-	mocks.secret.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{
-		{
-			ID: fakeSecretID,
-		},
-	}, nil)
-	mocks.nps.EXPECT().CountMatchingNetworkPolicies(gomock.Any(), fakeClusterID, fakeNamespaceName).Return(1, nil)
 	response := executeTestQuery(t, mocks, fmt.Sprintf(`{namespace(id:"%s") {metadata{id name clusterId clusterName} }}`, fakeNamespaceID))
 	assert.Equal(t, 200, response.Code)
 	assertJSONMatches(t, response.Body, ".data.namespace.metadata.id", fakeNamespaceID)

--- a/central/graphql/resolvers/namespaces.go
+++ b/central/graphql/resolvers/namespaces.go
@@ -656,7 +656,7 @@ func (resolver *namespaceResolver) DeploymentCount(ctx context.Context, args Raw
 
 func (resolver *namespaceResolver) NetworkPolicyCount(ctx context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Namespaces, "NetworkPolicyCount")
-	if err := readSecrets(ctx); err != nil {
+	if err := readNetPolicies(ctx); err != nil {
 		return 0, err
 	}
 

--- a/central/graphql/resolvers/namespaces.go
+++ b/central/graphql/resolvers/namespaces.go
@@ -134,7 +134,7 @@ func (resolver *Resolver) Namespaces(ctx context.Context, args PaginatedQuery) (
 		return nil, err
 	}
 
-	return resolver.wrapNamespaces(namespace.ResolveMetadataOnlyByQuery(ctx, query, resolver.NamespaceDataStore, resolver.DeploymentDataStore, resolver.SecretsDataStore, resolver.NetworkPoliciesStore))
+	return resolver.wrapNamespaces(namespace.ResolveMetadataOnlyByQuery(ctx, query, resolver.NamespaceDataStore))
 }
 
 type clusterIDAndNameQuery struct {

--- a/central/graphql/resolvers/resolver.go
+++ b/central/graphql/resolvers/resolver.go
@@ -187,6 +187,7 @@ var (
 	readImages                           = readAuth(resources.Image)
 	readIndicators                       = readAuth(resources.Indicator)
 	readNamespaces                       = readAuth(resources.Namespace)
+	readNetPolicies                      = readAuth(resources.NetworkPolicy)
 	readNodes                            = readAuth(resources.Node)
 	readNotifiers                        = readAuth(resources.Notifier)
 	readPolicies                         = readAuth(resources.Policy)

--- a/central/namespace/resolver.go
+++ b/central/namespace/resolver.go
@@ -25,8 +25,7 @@ func ResolveAll(ctx context.Context, dataStore datastore.DataStore, deploymentDa
 }
 
 // ResolveMetadataOnlyByQuery resolves all namespaces based on a query. This will _not_ populate volatile runtime data and that must be requested separately.
-func ResolveMetadataOnlyByQuery(ctx context.Context, q *v1.Query, dataStore datastore.DataStore, _ deploymentDataStore.DataStore,
-	_ secretDataStore.DataStore, _ npDS.DataStore) ([]*v1.Namespace, error) {
+func ResolveMetadataOnlyByQuery(ctx context.Context, q *v1.Query, dataStore datastore.DataStore) ([]*v1.Namespace, error) {
 	metadataSlice, err := dataStore.SearchNamespaces(ctx, q)
 	if err != nil {
 		return nil, errors.Wrap(err, "retrieving namespaces")
@@ -89,7 +88,7 @@ func ResolveByClusterIDAndName(ctx context.Context, clusterID string, name strin
 func ResolveMetadataOnlyByID(ctx context.Context, id string, dataStore datastore.DataStore) (*v1.Namespace, bool, error) {
 	ns, exists, err := dataStore.GetNamespace(ctx, id)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "retrieving from store")
+		return nil, false, errors.Wrap(err, "retrieving namespace from store")
 	}
 	if !exists {
 		return nil, false, nil

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtEntityNamespace.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtEntityNamespace.js
@@ -61,7 +61,7 @@ const VulnMgmtNamespace = ({
                 }
                 policyCount(query: $policyQuery)
                 vulnCount
-                deploymentCount: numDeployments # numDeployments is pre-calculated in namespace resolver
+                deploymentCount
                 imageCount
                 componentCount
             }

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
@@ -694,7 +694,7 @@ export const NAMESPACE_LIST_FRAGMENT = gql`
                 total
             }
         }
-        deploymentCount: numDeployments # numDeployments is pre-calculated in namespace resolver
+        deploymentCount
         imageCount(query: $query)
         # policyCount(query: $policyQuery) # see https://stack-rox.atlassian.net/browse/ROX-4080
         policyStatusOnly(query: $policyQuery)

--- a/ui/apps/platform/src/queries/namespace.js
+++ b/ui/apps/platform/src/queries/namespace.js
@@ -12,7 +12,7 @@ export const NAMESPACE_FRAGMENT = gql`
                 value
             }
         }
-        numSecrets
+        numSecrets: secretCount
         imageCount
         policyCount
         k8sRoleCount
@@ -49,7 +49,7 @@ export const NAMESPACE_NO_POLICIES_FRAGMENT = gql`
                 value
             }
         }
-        numSecrets
+        numSecrets: secretCount
         k8sRoleCount
         serviceAccountCount
         subjectCount
@@ -81,7 +81,7 @@ export const ALL_NAMESPACES = gql`
                     value
                 }
             }
-            numSecrets
+            numSecrets: secretCount
         }
     }
 `;
@@ -98,7 +98,7 @@ export const NAMESPACES = gql`
                     value
                 }
             }
-            numSecrets
+            numSecrets: secretCount
         }
     }
 `;
@@ -117,9 +117,9 @@ export const NAMESPACE_QUERY = gql`
                 }
                 creationTime
             }
-            numDeployments
-            numNetworkPolicies
-            numSecrets
+            numDeployments: deploymentCount
+            numNetworkPolicies: networkPolicyCount
+            numSecrets: secretCount
             imageCount
             policyCount
         }


### PR DESCRIPTION
## Description

It currently returns all the counts that can be fetched using distinct sub-resolvers instead. This leads to poor performance when you actually don't need all of these counts. This comes up in the new dashboard

## Checklist
- [ ] Investigated and inspected CI test results
~[ ] Unit test and regression tests added~
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~
~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Manual

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
