### PR TITLE
[ROX-11629] : Hide any cluster retention config updates behind its feature flag

### DIFF
--- a/central/config/datastore/datastore.go
+++ b/central/config/datastore/datastore.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/central/config/store"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sac"
 )
 
@@ -53,23 +54,26 @@ func (d *datastoreImpl) UpsertConfig(ctx context.Context, config *storage.Config
 		return sac.ErrResourceAccessDenied
 	}
 
-	if clusterRetentionConf := config.GetPrivateConfig().GetDecommissionedClusterRetention(); clusterRetentionConf != nil {
-		oldConf, err := d.getClusterRetentionConfig(ctx)
-		if err != nil {
-			return err
-		}
-		if oldConf != nil {
-			clusterRetentionConf.CreatedAt = oldConf.GetCreatedAt()
-		} else {
-			clusterRetentionConf.CreatedAt = types.TimestampNow()
-		}
+	if features.DecommissionedClusterRetention.Enabled() {
+		if clusterRetentionConf := config.GetPrivateConfig().GetDecommissionedClusterRetention(); clusterRetentionConf != nil {
+			oldConf, err := d.getClusterRetentionConfig(ctx)
+			if err != nil {
+				return err
+			}
+			if oldConf != nil {
+				clusterRetentionConf.CreatedAt = oldConf.GetCreatedAt()
+			} else {
+				clusterRetentionConf.CreatedAt = types.TimestampNow()
+			}
 
-		hasUpdate := !clusterRetentionConfigsEqual(oldConf, clusterRetentionConf)
+			hasUpdate := !clusterRetentionConfigsEqual(oldConf, clusterRetentionConf)
 
-		if hasUpdate {
-			clusterRetentionConf.LastUpdated = types.TimestampNow()
+			if hasUpdate {
+				clusterRetentionConf.LastUpdated = types.TimestampNow()
+			}
 		}
 	}
+
 	return d.store.Upsert(ctx, config)
 }
 

--- a/central/config/datastore/singleton.go
+++ b/central/config/datastore/singleton.go
@@ -51,9 +51,6 @@ var (
 			},
 		},
 		ExpiredVulnReqRetentionDurationDays: DefaultExpiredVulnReqRetention,
-		DecommissionedClusterRetention: &storage.DecommissionedClusterRetentionConfig{
-			RetentionDurationDays: DefaultDecommissionedClusterRetentionDays,
-		},
 	}
 )
 
@@ -81,8 +78,12 @@ func initialize() {
 	if privateConfig == nil {
 		privateConfig = &defaultPrivateConfig
 		needsUpsert = true
-	} else if config.GetPrivateConfig().GetDecommissionedClusterRetention() == nil {
-		privateConfig.DecommissionedClusterRetention = defaultPrivateConfig.GetDecommissionedClusterRetention()
+	}
+
+	if features.DecommissionedClusterRetention.Enabled() && privateConfig.GetDecommissionedClusterRetention() == nil {
+		privateConfig.DecommissionedClusterRetention = &storage.DecommissionedClusterRetentionConfig{
+			RetentionDurationDays: DefaultDecommissionedClusterRetentionDays,
+		}
 		needsUpsert = true
 	}
 


### PR DESCRIPTION
## Description

Hide updates to `DecommissionedClusterRetention` system config behind its feature flag.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Manual testing to check if `DecommissionedClusterRetention` is null when the feature flag is disabled.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
