### PR TITLE
ROX-11632: The “Most Common Vulnerabilities” widget should be renamed to “Most Common Image Vulnerabilities” and scoped to Image CVEs

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabilities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabilities.js
@@ -78,7 +78,7 @@ const MostCommonVulnerabilities = ({ entityContext, search, limit }) => {
 
     const queryObject = { ...entityContextObject, ...search }; // Combine entity context and search
     const query = queryService.objectToWhereClause(queryObject); // get final gql query string
-    const GQL_QUERY = showVMUpdates
+    const queryToUse = showVMUpdates
         ? MOST_COMMON_IMAGE_VULNERABILITIES
         : MOST_COMMON_VULNERABILITIES;
 
@@ -86,7 +86,7 @@ const MostCommonVulnerabilities = ({ entityContext, search, limit }) => {
         loading,
         data = {},
         error,
-    } = useQuery(GQL_QUERY, {
+    } = useQuery(queryToUse, {
         variables: {
             query,
             vulnPagination: queryService.getPagination(


### PR DESCRIPTION
## Description

In accordance with the changes to VM post-splitting the CVEs, we need to update the `Most Common Vulnerabilities` widget to be the `Most Common Image Vulnerabilities`. The links within the widget should now send the user to the `Image CVE` entity page rather than the `CVE` entity page when the `ROX_FRONTEND_VM_UDPATES` feature flag is turned on

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

<img width="1552" alt="Screen Shot 2022-07-05 at 8 25 12 PM" src="https://user-images.githubusercontent.com/4805485/177461685-1184adb8-1bfa-44cb-a64f-77c0ed007c6f.png">
<img width="1552" alt="Screen Shot 2022-07-05 at 8 25 26 PM" src="https://user-images.githubusercontent.com/4805485/177461687-60f7040d-f00e-46af-980a-73cf6c00b8f9.png">

