### PR TITLE
Use roxbot PAT to do git push

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -187,6 +187,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: "${{needs.variables.outputs.branch}}"
+          token: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
       - name: Initialize mandatory git config
         run: |
           git config user.name "${{github.event.sender.login}}"

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -116,6 +116,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{inputs.ref}}
+          token: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
       - name: Check remote branch exists
         id: check-existing
         run: |


### PR DESCRIPTION
## Description

Pushing a branch with workflow files in it requires a GitHub token with `workflows` scope permissions. This PR makes use of the `ROBOT_ROX_GITHUB_TOKEN` which should be good for this job.

## Testing Performed

Manually on `stackrox/test-gh-actions` repository.