### PR TITLE
Test out mocking PF react-charts to disable animation.

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
@@ -39,6 +39,15 @@ const mocks = [
     },
 ];
 
+jest.mock('@patternfly/react-charts', () => {
+    const { Chart, ...rest } = jest.requireActual('@patternfly/react-charts');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return {
+        ...rest,
+        Chart: (props) => <Chart {...props} animate={undefined} />,
+    };
+});
+
 jest.mock('hooks/useResizeObserver', () => ({
     __esModule: true,
     default: jest.fn().mockImplementation(jest.fn),

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
@@ -80,6 +80,15 @@ const mocks = [
     },
 ];
 
+jest.mock('@patternfly/react-charts', () => {
+    const { Chart, ...rest } = jest.requireActual('@patternfly/react-charts');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return {
+        ...rest,
+        Chart: (props) => <Chart {...props} animate={undefined} />,
+    };
+});
+
 jest.mock('hooks/useResizeObserver', () => ({
     __esModule: true,
     default: jest.fn().mockImplementation(jest.fn),

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
@@ -6,6 +6,15 @@ import '@testing-library/jest-dom/extend-expect';
 import renderWithRouter from 'test-utils/renderWithRouter';
 import ViolationsByPolicyCategory from 'Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory';
 
+jest.mock('@patternfly/react-charts', () => {
+    const { Chart, ...rest } = jest.requireActual('@patternfly/react-charts');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return {
+        ...rest,
+        Chart: (props) => <Chart {...props} animate={undefined} />,
+    };
+});
+
 jest.mock('hooks/useResizeObserver', () => ({
     __esModule: true,
     default: jest.fn().mockImplementation(jest.fn),

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
@@ -92,9 +92,9 @@ describe('Violations by policy category widget', () => {
         ]);
 
         // Switch to sort-by-volume, which orders the chart by total violations per category
-        await user.click(screen.getByRole('button', { name: 'Options' }));
-        await user.click(screen.getByRole('button', { name: 'Volume' }));
-        await user.click(screen.getByRole('button', { name: 'Options' }));
+        await user.click(await screen.findByRole('button', { name: 'Options' }));
+        await user.click(await screen.findByRole('button', { name: 'Volume' }));
+        await user.click(await screen.findByRole('button', { name: 'Options' }));
 
         await waitForAxisLinksToBe([
             'Security Best Practices',
@@ -113,13 +113,13 @@ describe('Violations by policy category widget', () => {
         ).toBeInTheDocument();
 
         // Sort by volume, so that enabling lower severity bars changes the order of the chart
-        await user.click(screen.getByRole('button', { name: 'Options' }));
-        await user.click(screen.getByRole('button', { name: 'Volume' }));
-        await user.click(screen.getByRole('button', { name: 'Options' }));
+        await user.click(await screen.findByRole('button', { name: 'Options' }));
+        await user.click(await screen.findByRole('button', { name: 'Volume' }));
+        await user.click(await screen.findByRole('button', { name: 'Options' }));
 
         // Toggle on low and medium violations, which are disabled by default
-        await user.click(screen.getByText('Low'));
-        await user.click(screen.getByText('Medium'));
+        await user.click(await screen.findByText('Low'));
+        await user.click(await screen.findByText('Medium'));
 
         await waitForAxisLinksToBe([
             'Vulnerability Management',


### PR DESCRIPTION
## Description

Potential fix for ui-unit-test flakes.

The error from these seems to originate from animation in the charts. Whenever there is one or more `act` errors thrown in prow at least one stack trace ends at `at VictoryChart (/go/src/github.com/stackrox/stackrox/ui/node_modules/victory-chart/lib/victory-chart.js:47:50)`, which contains the line that calls a `useAnimation` hook in the Victory library. This hook sets React state, and it looks like it does so async after a period of time outside of RTL's `act` call, which causes the error. Thanks @pedrottimark for the insight on this!

This is a hypothesis so far, since the tests never fail locally and only seem to fail intermittently in CI.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Automated