### PR TITLE
Add uid and gid to monitoring pod security context

### DIFF
--- a/deploy/charts/monitoring/templates/deployment.yaml
+++ b/deploy/charts/monitoring/templates/deployment.yaml
@@ -53,6 +53,10 @@ spec:
                     operator: DoesNotExist
       {{- end}}
       serviceAccount: monitoring
+      # The uid and gid are set to make `/var/prometheus` writable. See https://github.com/prometheus/prometheus/issues/5976.
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 2000
       containers:
       - name: grafana
         image: {{ required "A Grafana image is required" .Values.grafanaImage }}


### PR DESCRIPTION
This fixes an issue with Prometheus failing to start on GKE clusters with `permission denied` error.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested that monitoring pod comes up successfully on GKE and OpenShift.
