### PR TITLE
Fix alert deduping by moving scoping info to the pipeline

### DIFF
--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -309,34 +309,8 @@ func getNSScopedObjectFromAlert(alert *storage.Alert) sac.NamespaceScopedObject 
 	return nil
 }
 
-func copyScopingInformationToObjectRoot(alert *storage.Alert) {
-	switch alert.GetEntity().(type) {
-	case *storage.Alert_Deployment_:
-		entity := alert.GetDeployment()
-		alert.ClusterId = entity.ClusterId
-		alert.ClusterName = entity.ClusterName
-		alert.Namespace = entity.Namespace
-		alert.NamespaceId = entity.NamespaceId
-	case *storage.Alert_Resource_:
-		entity := alert.GetResource()
-		alert.ClusterId = entity.ClusterId
-		alert.ClusterName = entity.ClusterName
-		alert.Namespace = entity.Namespace
-		alert.NamespaceId = entity.NamespaceId
-	case *storage.Alert_Image:
-		// Image doesn't have a ns/cluster
-		alert.ClusterId = ""
-		alert.ClusterName = ""
-		alert.Namespace = ""
-		alert.NamespaceId = ""
-	default:
-		log.Errorf("UNEXPECTED: Alert Entity %s unknown", alert.GetEntity())
-	}
-}
-
 func (ds *datastoreImpl) updateAlertNoLock(ctx context.Context, alert *storage.Alert) error {
 	// Checks pass then update.
-	copyScopingInformationToObjectRoot(alert)
 	if err := ds.storage.Upsert(ctx, alert); err != nil {
 		return err
 	}

--- a/central/sensor/service/pipeline/alerts/pipeline.go
+++ b/central/sensor/service/pipeline/alerts/pipeline.go
@@ -73,13 +73,19 @@ func (s *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 	}
 
 	for _, a := range alertResults.GetAlerts() {
+		a.ClusterId = clusterID
+		a.ClusterName = clusterName
 		if deployment := a.GetDeployment(); deployment != nil {
 			deployment.ClusterId = clusterID
 			deployment.ClusterName = clusterName
+			a.Namespace = deployment.Namespace
+			a.NamespaceId = deployment.NamespaceId
 		}
 		if resource := a.GetResource(); resource != nil {
 			resource.ClusterId = clusterID
 			resource.ClusterName = clusterName
+			a.Namespace = resource.Namespace
+			a.NamespaceId = resource.NamespaceId
 		}
 	}
 

--- a/pkg/fixtures/alert.go
+++ b/pkg/fixtures/alert.go
@@ -8,9 +8,25 @@ import (
 	"github.com/stackrox/rox/pkg/uuid"
 )
 
+func copyScopingInfo(alert *storage.Alert) *storage.Alert {
+	switch entity := alert.Entity.(type) {
+	case *storage.Alert_Deployment_:
+		alert.ClusterName = entity.Deployment.ClusterName
+		alert.ClusterId = entity.Deployment.ClusterId
+		alert.Namespace = entity.Deployment.Namespace
+		alert.NamespaceId = entity.Deployment.NamespaceId
+	case *storage.Alert_Resource_:
+		alert.ClusterName = entity.Resource.ClusterName
+		alert.ClusterId = entity.Resource.ClusterId
+		alert.Namespace = entity.Resource.Namespace
+		alert.NamespaceId = entity.Resource.NamespaceId
+	}
+	return alert
+}
+
 // GetScopedDeploymentAlert returns a Mock alert attached to a deployment belonging to the input scope
 func GetScopedDeploymentAlert(ID string, clusterID string, namespace string) *storage.Alert {
-	return &storage.Alert{
+	return copyScopingInfo(&storage.Alert{
 		Id: ID,
 		Violations: []*storage.Alert_Violation{
 			{
@@ -57,7 +73,7 @@ func GetScopedDeploymentAlert(ID string, clusterID string, namespace string) *st
 				},
 			},
 		},
-	}
+	})
 }
 
 // GetAlert returns a Mock Alert
@@ -79,7 +95,7 @@ func GetResourceAlert() *storage.Alert {
 
 // GetScopedResourceAlert returns a Mock alert with a resource entity belonging to the input scope
 func GetScopedResourceAlert(ID string, clusterID string, namespace string) *storage.Alert {
-	return &storage.Alert{
+	return copyScopingInfo(&storage.Alert{
 		Id: ID, // "some-resource-alert-on-secret",
 		Violations: []*storage.Alert_Violation{
 			{
@@ -114,7 +130,7 @@ func GetScopedResourceAlert(ID string, clusterID string, namespace string) *stor
 			},
 		},
 		LifecycleStage: storage.LifecycleStage_RUNTIME,
-	}
+	})
 }
 
 // GetImageAlert returns a Mock alert with an image for entity


### PR DESCRIPTION
## Description

Move alert scoping info to the pipeline, since when we add it at the datastore, we are guaranteeing that the alert equality check fails and that we always have to write new alerts.

## Checklist
- [x] Investigated and inspected CI test results
- ~Unit test and regression tests added~
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Manual