### PR TITLE
Fix version header in the changelog: `3.71.0-rc.1` -> `3.71.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Entries in this file should be limited to:
 -  Obscure side-effects that are not obviously apparent based on the JIRA associated with the changes.
 Please avoid adding duplicate information across this changelog and JIRA/doc input pages.
 
-## [3.71.0-rc.1]
+## [3.71.0]
 
 - ROX-8051: The default collection method is changed from KernelModule to eBPF, following improved eBPF performance in collector.
 - ROX-11070: There have been changes made to the `v1/groups` API, including a deprecation:


### PR DESCRIPTION
## Description

Our automation has a tiny bug regarding the version number in the changelog section. Let's fix it manually to prevent potential issues with cherry-picking later.

This PR should be merged into the release branch. Here is the other PR for master: #2334

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

- None, just looking at the diff.
