### PR TITLE
Dashrews/ROX-11660 dedupe process baseline

### DIFF
--- a/central/processbaseline/datastore/datastore_impl.go
+++ b/central/processbaseline/datastore/datastore_impl.go
@@ -399,15 +399,15 @@ func (ds *datastoreImpl) CreateUnlockedProcessBaseline(ctx context.Context, key 
 		return nil, err
 	}
 
-	// Build the elements for the baseline
-	elements := make([]*storage.BaselineItem, 0, len(baselineList))
+	// Build the de-duped elements for the baseline
+	elements := make(map[string]*storage.BaselineItem, len(baselineList))
 
 	for _, indicator := range baselineList {
 		baselineItem := processBaselinePkg.BaselineItemFromProcess(indicator)
 
 		insertableElement := &storage.BaselineItem{Item: &storage.BaselineItem_ProcessName{ProcessName: baselineItem}}
 
-		elements = append(elements, insertableElement)
+		elements[baselineItem] = insertableElement
 	}
 
 	baseElements := make([]*storage.BaselineElement, 0, len(elements))


### PR DESCRIPTION
## Description

When building an on demand process baseline, the process list was duplicated.  used a map to build the process list to ensure that we do not have duplicates in this case going forward.  There was not an issue when the baseline was built organically at the end of the observation window.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested locally with an nginx deployment that I would scale up to multiple replicas.  I set the observation window to 10 minutes.  I requested to look at the nginx baseline before the observation period was over.  Prior to the fix these steps showed the processes duplicated for each replica.  After the fix these steps showed a process list that had no duplicates.

Additionally I added a unit test to drive the condition.
