### PR TITLE
Fix: Use release branch name as required by openshift-ci

### DIFF
--- a/.github/workflows/variables.yml
+++ b/.github/workflows/variables.yml
@@ -25,7 +25,7 @@ on:
         value: ${{format('{0}.{1}{2}', jobs.parse.outputs.release, jobs.parse.outputs.patch, jobs.parse.outputs.dash-name)}}
       branch:
         description: Release branch name (release/A.B.x[-N])
-        value: ${{format('release/{0}.x{1}', jobs.parse.outputs.release, jobs.parse.outputs.dash-name)}}
+        value: ${{format('release-{0}.x{1}', jobs.parse.outputs.release, jobs.parse.outputs.dash-name)}}
       docs-branch:
         description: Documentation branch name
         value: ${{format('rhacs-docs-{0}.{1}', jobs.parse.outputs.release, jobs.parse.outputs.patch)}}


### PR DESCRIPTION
## Description

Release branch name contains now `-` instead of `/` as required by https://github.com/openshift/release/tree/master/ci-operator/config/stackrox/stackrox

## Checklist

- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))


## Testing Performed

- https://github.com/stackrox/stackrox/runs/7236629659?check_suite_focus=true