### PR TITLE
Write frontend policyCategory service for UI

### DIFF
--- a/ui/apps/platform/src/services/policyCategoryService.ts
+++ b/ui/apps/platform/src/services/policyCategoryService.ts
@@ -32,14 +32,9 @@ export function postPolicyCategory(policyCategory: PolicyCategory): Promise<Poli
         .then((response) => response.data);
 }
 
-/*
- * Because the response is empty:
- * For success: UI is responsible to update the name property of the renamed policyCategory object.
- * For failure: UI is responsible not to update the name property of the policyCategory object.
- */
-export function renamePolicyCategory(id: string, newCategoryName: string): Promise<Empty> {
+export function renamePolicyCategory(id: string, newCategoryName: string): Promise<PolicyCategory> {
     return axios
-        .put<Empty>(`${policyCategoriesUrl}/${id}`, { newCategoryName })
+        .put<PolicyCategory>(policyCategoriesUrl, { id, newCategoryName })
         .then((response) => response.data);
 }
 

--- a/ui/apps/platform/src/services/policyCategoryService.ts
+++ b/ui/apps/platform/src/services/policyCategoryService.ts
@@ -1,0 +1,50 @@
+import axios from './instance';
+
+const policyCategoriesUrl = '/v1/policycategories';
+
+export type PolicyCategory = {
+    id: string;
+    // central/policycategory/service/service_impl.go
+    // policy category must have a name between 5 and 128 characters long with no new lines or dollar signs
+    name: string;
+    isDefault: boolean;
+};
+
+export function getPolicyCategory(id: string): Promise<PolicyCategory> {
+    return axios
+        .get<PolicyCategory>(`${policyCategoriesUrl}/${id}`)
+        .then((response) => response.data);
+}
+
+export function getPolicyCategories(): Promise<PolicyCategory[]> {
+    return axios
+        .get<{ categories: PolicyCategory[] }>(policyCategoriesUrl)
+        .then((response) => response.data.categories);
+}
+
+/*
+ * The id property of the argument has empty string value.
+ * The id property of the response has unique value assigned by backend.
+ */
+export function postPolicyCategory(policyCategory: PolicyCategory): Promise<PolicyCategory> {
+    return axios
+        .post<PolicyCategory>(policyCategoriesUrl, policyCategory)
+        .then((response) => response.data);
+}
+
+/*
+ * Because the response is empty:
+ * For success: UI is responsible to update the name property of the renamed policyCategory object.
+ * For failure: UI is responsible not to update the name property of the policyCategory object.
+ */
+export function renamePolicyCategory(id: string, newCategoryName: string): Promise<Empty> {
+    return axios
+        .put<Empty>(`${policyCategoriesUrl}/${id}`, { newCategoryName })
+        .then((response) => response.data);
+}
+
+export function deletePolicyCategory(id: string): Promise<Empty> {
+    return axios.delete<Empty>(`${policyCategoriesUrl}/${id}`).then((response) => response.data);
+}
+
+type Empty = Record<string, never>;

--- a/ui/apps/platform/src/services/policyCategoryService.ts
+++ b/ui/apps/platform/src/services/policyCategoryService.ts
@@ -16,6 +16,9 @@ export function getPolicyCategory(id: string): Promise<PolicyCategory> {
         .then((response) => response.data);
 }
 
+/*
+ * Although the request supports a search query string, UI does not need it.
+ */
 export function getPolicyCategories(): Promise<PolicyCategory[]> {
     return axios
         .get<{ categories: PolicyCategory[] }>(policyCategoriesUrl)


### PR DESCRIPTION
## Description

### Goals

* Increase type safety with compile-time checks.
* Simplify maintenance of consistent backend and frontend response types.

### Overview

1. Compare to https://github.com/stackrox/stackrox/blob/master/proto/api/v1/policy_category_service.proto
    * Use naming convention camelCase in TypeScript for underscore case in proto for **file names** and **properties**.
    * Use `getPolicyCategory` instead of change to `fetchPolicyCategory` function name to reduce unneeded barriers for contributions from backend engineers.
2. Compare to https://github.com/stackrox/stackrox/blob/master/proto/storage/group.proto
    * Backend has started to separate response type from storage type, do not create types/policyCategory.proto.ts

### Questions

1. Backend request for `getPolicyCategories` can have a query string. ~If UI needs to filter categories, then it is possible to add it.~ Added comment about unused ability, because UI filters without additional requests.
    * See https://github.com/stackrox/stackrox/blob/master/proto/api/v1/policy_category_service.proto#L49
2. ~Backend request for `renamePolicyCategory` has empty response. What are pro and con from UI viewpoint for response to be updated policy category?~ Rebased with #2370 and replaced `Empty` with `PolicyCategory`
    * See https://github.com/stackrox/stackrox/blob/master/proto/api/v1/policy_category_service.proto#L64

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Added temporary request calls to PoliciesPage.tsx file:

```js
import {
    deletePolicyCategory,
    getPolicyCategory,
    getPolicyCategories,
    postPolicyCategory,
    renamePolicyCategory,
} from 'services/policyCategoryService';
```

```js
    useEffect(() => {
        postPolicyCategory({ id: '', name: 'policy category name', isDefault: false })
            .then(({ id }) => {
                getPolicyCategory(id).catch(() => {});
                getPolicyCategory(id.slice(2)).catch(() => {});
                renamePolicyCategory(id, 'renamed policy category').catch(() => {});
                getPolicyCategories().catch(() => {});
                deletePolicyCategory(id).catch(() => {});
                getPolicyCategories().catch(() => {});
            })
            .catch(() => {});
    });
```

1. `yarn build` in ui
2. `export ROX_NEW_POLICY_CATEGORIES=true` in ui
3. `yarn deploy-local` in ui
4. `yarn start` in ui

    * POST /v1/policycategories 200 when feature flag enabled and 404 when disabled
    * GET /v1/policycategories/correctId 200
    * GET /v1/policycategories/incorrectId 404
    * PUT /v1/policycategories/correctId 200
    * GET /v1/policycategories 200
    * DELETE /v1/policycategories/correctId 200
    * GET /v1/policycategories 200