### PR TITLE
ROX-11659: Remove reference of deprecated registry in roxctl

### DIFF
--- a/roxctl/helm/output/output.go
+++ b/roxctl/helm/output/output.go
@@ -151,8 +151,6 @@ func (cfg *helmOutputCommand) getChartMetaValues(release bool) (*charts.MetaValu
 func handleRhacsWarnings(rhacs, imageFlavorProvided bool, logger logger.Logger) {
 	if rhacs {
 		logger.WarnfLn("'--rhacs' is deprecated, please use '--%s=%s' instead", flags.ImageDefaultsFlagName, defaults.ImageFlavorNameRHACSRelease)
-	} else if !imageFlavorProvided {
-		logger.WarnfLn("Default image registries have changed. Images will be taken from 'registry.redhat.io'. Specify '--%s=%s' command line argument to use images from 'stackrox.io' registries.", flags.ImageDefaultsFlagName, defaults.ImageFlavorNameStackRoxIORelease)
 	}
 }
 

--- a/tests/roxctl/bats-tests/helpers.bash
+++ b/tests/roxctl/bats-tests/helpers.bash
@@ -329,16 +329,6 @@ has_deprecation_warning() {
   assert_line --regexp "WARN:[[:space:]]+'--rhacs' is deprecated, please use '--image-defaults=rhacs' instead"
 }
 
-flavor_warning_regexp="WARN:[[:space:]]+Default image registries have changed. Images will be taken from 'registry.redhat.io'. Specify '--image-defaults=stackrox.io' command line argument to use images from 'stackrox.io' registries."
-
-has_default_flavor_warning() {
-  assert_line --regexp "$flavor_warning_regexp"
-}
-
-has_no_default_flavor_warning() {
-  refute_line --regexp "$flavor_warning_regexp"
-}
-
 has_flag_collision_warning() {
   assert_line --partial "flag '--rhacs' is deprecated and must not be used together with '--image-defaults'. Remove '--rhacs' flag and specify only '--image-defaults'"
 }

--- a/tests/roxctl/bats-tests/local/roxctl-helm-output-central-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-helm-output-central-development.bats
@@ -24,13 +24,11 @@ teardown() {
   run roxctl-development helm output central-services --rhacs --output-dir "$out_dir"
   assert_success
   has_deprecation_warning
-  has_no_default_flavor_warning
 }
 
 @test "roxctl-development helm output should support --image-defaults flag" {
   run roxctl-development helm output central-services --image-defaults="stackrox.io" --output-dir "$out_dir"
   assert_success
-  has_no_default_flavor_warning
 }
 
 @test "roxctl-development helm output help-text should state default value for --image-defaults flag" {
@@ -42,7 +40,6 @@ teardown() {
 @test "roxctl-development helm output central-services should use docker.io registry" {
   run roxctl-development helm output central-services --output-dir "$out_dir"
   assert_success
-  has_default_flavor_warning
   assert_output --partial "Written Helm chart central-services to directory"
   assert_helm_template_central_registry "$out_dir" 'quay.io' "$any_version" 'main' 'scanner' 'scanner-db'
 }
@@ -94,7 +91,6 @@ teardown() {
   assert_failure
   has_deprecation_warning
   has_flag_collision_warning
-  has_no_default_flavor_warning
 }
 
 @test "roxctl-development helm output central-services --rhacs --image-defaults=rhacs should return error about --rhacs colliding with --image-defaults" {
@@ -102,7 +98,6 @@ teardown() {
   assert_failure
   has_deprecation_warning
   has_flag_collision_warning
-  has_no_default_flavor_warning
 }
 
 @test "roxctl-development helm output central-services --debug should use the local directory" {

--- a/tests/roxctl/bats-tests/local/roxctl-helm-output-central-release.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-helm-output-central-release.bats
@@ -29,7 +29,6 @@ teardown() {
   run roxctl-release helm output central-services --output-dir "$out_dir"
   assert_success
   assert_output --partial "Written Helm chart central-services to directory"
-  has_default_flavor_warning
   assert_helm_template_central_registry "$out_dir" 'registry.redhat.io' "$any_version" 'main' 'scanner' 'scanner-db'
 }
 
@@ -38,14 +37,12 @@ teardown() {
   assert_success
   assert_output --partial "Written Helm chart central-services to directory"
   has_deprecation_warning
-  has_no_default_flavor_warning
   assert_helm_template_central_registry "$out_dir" 'registry.redhat.io' "$any_version" 'main' 'scanner' 'scanner-db'
 }
 
 @test "roxctl-release helm output central-services --image-defaults=stackrox.io should use stackrox.io registry" {
   run roxctl-release helm output central-services --image-defaults=stackrox.io --output-dir "$out_dir"
   assert_success
-  has_no_default_flavor_warning
   assert_output --partial "Written Helm chart central-services to directory"
   assert_helm_template_central_registry "$out_dir" 'stackrox.io' "$any_version" 'main' 'scanner' 'scanner-db'
 }
@@ -53,7 +50,6 @@ teardown() {
 @test "roxctl-release helm output central-services --image-defaults=rhacs should use registry.redhat.io registry" {
   run roxctl-release helm output central-services --image-defaults=rhacs --output-dir "$out_dir"
   assert_success
-  has_no_default_flavor_warning
   assert_output --partial "Written Helm chart central-services to directory"
   assert_helm_template_central_registry "$out_dir" 'registry.redhat.io' "$any_version" 'main' 'scanner' 'scanner-db'
 }
@@ -74,7 +70,6 @@ teardown() {
   run roxctl-release helm output central-services --rhacs --image-defaults=stackrox.io --output-dir "$out_dir"
   assert_failure
   has_deprecation_warning
-  has_no_default_flavor_warning
   has_flag_collision_warning
 }
 
@@ -82,7 +77,6 @@ teardown() {
   run roxctl-release helm output central-services --rhacs --image-defaults=rhacs --output-dir "$out_dir"
   assert_failure
   has_deprecation_warning
-  has_no_default_flavor_warning
   has_flag_collision_warning
 }
 


### PR DESCRIPTION
## Description

With the removal of `stackrox.io`, the additional warning message that defaults have changed is not required anymore.

We should simply remove the warning message for now.

Note that [ROX-11642](https://issues.redhat.com/browse/ROX-11642) exists to handle removal of the image flavor for `stackrox.io`, which will not be done within this PR.

## Testing Performed

- re-test unit tests + adapted existing E2E tests.
