### PR TITLE
CI: slack notify on merge test failures

### DIFF
--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -10,12 +10,8 @@ source "$ROOT/scripts/ci/lib.sh"
 set -euo pipefail
 
 openshift_ci_mods
-handle_nightly_runs
-
-info "Status after mods:"
-"$ROOT/status.sh" || true
-
-trap ci_exit_trap EXIT
+openshift_ci_import_creds
+create_exit_trap
 
 if [[ "$#" -lt 1 ]]; then
     die "usage: dispatch <ci-job> [<...other parameters...>]"

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -10,8 +10,12 @@ source "$ROOT/scripts/ci/lib.sh"
 set -euo pipefail
 
 openshift_ci_mods
-openshift_ci_import_creds
-create_hold_trap
+handle_nightly_runs
+
+info "Status after mods:"
+"$ROOT/status.sh" || true
+
+trap ci_exit_trap EXIT
 
 if [[ "$#" -lt 1 ]]; then
     die "usage: dispatch <ci-job> [<...other parameters...>]"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -40,6 +40,10 @@ ci_exit_trap() {
     done
 }
 
+create_exit_trap() {
+    trap ci_exit_trap EXIT
+}
+
 setup_deployment_env() {
     info "Setting up the deployment environment"
 
@@ -847,16 +851,6 @@ openshift_ci_import_creds() {
     done
 }
 
-create_hold_trap() {
-    function hold() {
-        while [[ -e /tmp/hold ]]; do
-            info "Holding this job for debug"
-            sleep 60
-        done
-    }
-    trap hold EXIT
-}
-
 openshift_ci_e2e_mods() {
     # NAMESPACE is injected by OpenShift CI for the cluster that is running the
     # tests but this can have side effects for stackrox tests due to its use as
@@ -998,17 +992,17 @@ store_test_results() {
 }
 
 send_slack_notice_for_failures_on_merge() {
-    # local exitstatus="${1:-}"
+    local exitstatus="${1:-}"
 
-    # if ! is_OPENSHIFT_CI || [[ "$exitstatus" == "0" ]] || is_in_PR_context || is_nightly_run; then
-    #     return
-    # fi
+    if ! is_OPENSHIFT_CI || [[ "$exitstatus" == "0" ]] || is_in_PR_context || is_nightly_run; then
+        return
+    fi
 
-    # local tag
-    # tag="$(make --quiet tag)"
-    # [[ "$tag" =~ $RELEASE_RC_TAG_BASH_REGEX ]] || {
-    #     return
-    # }
+    local tag
+    tag="$(make --quiet tag)"
+    [[ "$tag" =~ $RELEASE_RC_TAG_BASH_REGEX ]] || {
+        return
+    }
 
     local webhook_url="${TEST_FAILURES_NOTIFY_WEBHOOK}"
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -826,10 +826,7 @@ openshift_ci_mods() {
     export OPENSHIFT_CI=true
 
     # Provide Circle CI vars that are commonly used
-    CIRCLE_JOB="${JOB_NAME_SAFE:-${OPENSHIFT_BUILD_NAME:-unknown}}"
-    CIRCLE_JOB="${CIRCLE_JOB#merge-}"
-    CIRCLE_JOB="${CIRCLE_JOB#nightly-}"
-    export CIRCLE_JOB
+    export CIRCLE_JOB="${JOB_NAME:-${OPENSHIFT_BUILD_NAME}}"
     CIRCLE_TAG="$(git tag --contains | head -1)"
     export CIRCLE_TAG
 


### PR DESCRIPTION
## Description

Per title. This notice is more limited than the one from circle-notifier a future PR could address pulling test failures from JUNIT files for example.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Tested manually as this will only take effect for test failures in a merge context.