### PR TITLE
CI: restore Circle slack notice for RCs/releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2190,6 +2190,8 @@ jobs:
             # Cannot use .circleci/is-nightly-tag.sh because this job doesn't have access to git
             if [[ "$CIRCLE_TAG" =~ .*-nightly-.* ]]; then
               webhook_url="$NIGHTLY_WORKFLOW_NOTIFY_WEBHOOK"
+            elif [[ "$CIRCLE_TAG" =~ << pipeline.parameters.release_rc_tag_bash_regex >> ]]; then
+              webhook_url="$RELEASE_WORKFLOW_NOTIFY_WEBHOOK"
             else
               exit 0
             fi


### PR DESCRIPTION
## Description

Per title. Circle CI will run some CI for 3.71.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

n/a this change reverts to the previous state and will be added to the next 3.71 milestone after merge.