### PR TITLE
Delete obsolete functions from policies service in UI

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/ReviewPolicyForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/ReviewPolicyForm.tsx
@@ -46,11 +46,7 @@ function ReviewPolicyForm({
         setAlertsFromDryRun([]);
 
         startDryRun(getServerPolicy(values))
-            .then(({ data: { jobId } }) => {
-                /*
-                 * TODO after policiesSagas.js has been deleted:
-                 * Replace ({ data: { jobId } }) with (jobId) above.
-                 */
+            .then((jobId) => {
                 setIsValidOnServer(true);
                 setJobIdOfDryRun(jobId);
             })
@@ -67,11 +63,7 @@ function ReviewPolicyForm({
     useEffect(() => {
         if (jobIdOfDryRun) {
             checkDryRun(jobIdOfDryRun)
-                .then(({ data: { pending, result } }) => {
-                    /*
-                     * TODO after policiesSagas.js has been deleted:
-                     * Replace ({ data: { pending, result } }) with ({ pending, result }) above.
-                     */
+                .then(({ pending, result }) => {
                     if (pending) {
                         // To make another request, increment counterToCheckDryRun which is in useEffect dependencies.
                         setCounterToCheckDryRun((counter) => counter + 1);

--- a/ui/apps/platform/src/services/PoliciesService.ts
+++ b/ui/apps/platform/src/services/PoliciesService.ts
@@ -1,4 +1,3 @@
-import { normalize } from 'normalizr';
 import queryString from 'qs';
 import FileSaver from 'file-saver';
 
@@ -7,44 +6,17 @@ import { addBrandedTimestampToString } from 'utils/dateUtils';
 import { transformPolicyCriteriaValuesToStrings } from 'utils/policyUtils';
 
 import axios from './instance';
-import { policy as policySchema } from './schemas';
 
 const baseUrl = '/v1/policies';
 const policyCategoriesUrl = '/v1/policyCategories';
 
-/*
- * Fetch policy summary for a given policy policyId.
- * TODO delete after policiesSagas.js has been deleted, because superseded by getPolicy
- */
-export function fetchPolicy(
-    policyId: string
-): Promise<{ response: { entities: { policy: Record<string, Policy> } } }> {
-    return axios.get<Policy>(`${baseUrl}/${policyId}`).then((response) => ({
-        response: normalize(response.data, policySchema),
-    }));
-}
+type Empty = Record<string, never>;
 
 /*
  * Get a policy. Policy is a superset of ListPolicy.
  */
 export function getPolicy(policyId: string): Promise<Policy> {
     return axios.get<Policy>(`${baseUrl}/${policyId}`).then((response) => response.data);
-}
-
-/*
- * Fetch a list of policies.
- * TODO delete after policiesSagas.js has been deleted, because superseded by getPolicies
- */
-export function fetchPolicies(filters: { query: string }): Promise<{
-    response: {
-        entities: { policy: Record<string, ListPolicy> };
-        result: { policies: ListPolicy[] };
-    };
-}> {
-    const params = queryString.stringify(filters, { arrayFormat: 'repeat' });
-    return axios.get<{ policies: Policy[] }>(`${baseUrl}?${params}`).then((response) => ({
-        response: normalize(response.data, { policies: [policySchema] }),
-    }));
 }
 
 /*
@@ -55,16 +27,6 @@ export function getPolicies(query = ''): Promise<ListPolicy[]> {
     return axios
         .get<{ policies: Policy[] }>(`${baseUrl}?${params}`)
         .then((response) => response?.data?.policies ?? []);
-}
-
-/*
- * Fetch a list of policy categories.
- * TODO delete after policiesSagas.js has been deleted, because superseded by getPolicyCategories
- */
-export function fetchPolicyCategories(): Promise<{ response: { categories: string[] } }> {
-    return axios.get<{ categories: string[] }>(policyCategoriesUrl).then((response) => ({
-        response: response.data,
-    }));
 }
 
 /*
@@ -79,25 +41,21 @@ export function getPolicyCategories(): Promise<string[]> {
 /*
  * Reassess policies.
  */
-export function reassessPolicies(): Promise<Record<string, never>> {
-    return axios
-        .post<Record<string, never>>(`${baseUrl}/reassess`)
-        .then((response) => response.data);
+export function reassessPolicies(): Promise<Empty> {
+    return axios.post<Empty>(`${baseUrl}/reassess`).then((response) => response.data);
 }
 
 /*
  * Delete a policy.
  */
-export function deletePolicy(policyId: string): Promise<Record<string, never>> {
-    return axios
-        .delete<Record<string, never>>(`${baseUrl}/${policyId}`)
-        .then((response) => response.data);
+export function deletePolicy(policyId: string): Promise<Empty> {
+    return axios.delete<Empty>(`${baseUrl}/${policyId}`).then((response) => response.data);
 }
 
 /*
  * Delete policies.
  */
-export function deletePolicies(policyIds: string[] = []): Promise<Record<string, never>[]> {
+export function deletePolicies(policyIds: string[] = []): Promise<Empty[]> {
     return Promise.all(policyIds.map((policyId) => deletePolicy(policyId)));
 }
 
@@ -108,9 +66,9 @@ export function enableDisablePolicyNotifications(
     policyId: string,
     notifierIds: string[],
     disable: boolean
-): Promise<Record<string, never>> {
+): Promise<Empty> {
     return axios
-        .patch<Record<string, never>>(`${baseUrl}/${policyId}/notifiers`, { notifierIds, disable })
+        .patch<Empty>(`${baseUrl}/${policyId}/notifiers`, { notifierIds, disable })
         .then((response) => response.data);
 }
 
@@ -121,7 +79,7 @@ export function enableDisableNotificationsForPolicies(
     policyIds: string[],
     notifierIds: string[],
     disable: boolean
-): Promise<Record<string, never>[]> {
+): Promise<Empty[]> {
     return Promise.all(
         policyIds.map((policyId) =>
             enableDisablePolicyNotifications(policyId, notifierIds, disable)
@@ -132,57 +90,45 @@ export function enableDisableNotificationsForPolicies(
 /*
  * Save a policy.
  */
-export function savePolicy(policy: Policy): Promise<Record<string, never>> {
+export function savePolicy(policy: Policy): Promise<Empty> {
     if (!policy.id) {
         throw new Error('Policy entity must have an id to be saved');
     }
     const transformedPolicy = transformPolicyCriteriaValuesToStrings(policy);
 
     return axios
-        .put<Record<string, never>>(`${baseUrl}/${policy.id}`, transformedPolicy)
+        .put<Empty>(`${baseUrl}/${policy.id}`, transformedPolicy)
         .then((response) => response.data);
 }
 
 /*
  * Create a new policy.
  */
-export function createPolicy(policy: Policy): Promise<{ data: Policy }> {
-    /*
-     * TODO after policiesSagas.js has been deleted:
-     * function return type: Promise<Policy>
-     * add method: then((response) => response.data)
-     */
+export function createPolicy(policy: Policy): Promise<Policy> {
     const transformedPolicy = transformPolicyCriteriaValuesToStrings(policy);
 
-    return axios.post(`${baseUrl}?enableStrictValidation=true`, transformedPolicy); // TODO prop?
+    return axios
+        .post<Policy>(`${baseUrl}?enableStrictValidation=true`, transformedPolicy)
+        .then((response) => response.data);
 }
 
 /*
  * Start a dry run for a policy. Return the jobId.
  */
-export function startDryRun(policy: Policy): Promise<{ data: { jobId: string } }> {
-    /*
-     * TODO after policiesSagas.js has been deleted:
-     * function return type: Promise<string>
-     * add method: then((response) => response?.data?.jobId)
-     */
+export function startDryRun(policy: Policy): Promise<string> {
     const transformedPolicy = transformPolicyCriteriaValuesToStrings(policy);
 
-    return axios.post(`${baseUrl}/dryrunjob`, transformedPolicy);
+    return axios
+        .post<{ jobId: string }>(`${baseUrl}/dryrunjob`, transformedPolicy)
+        .then((response) => response.data.jobId);
 }
-
 /*
  * Get status of a dry run job.
  */
-export function checkDryRun(
-    jobId: string
-): Promise<{ data: { pending: boolean; result: { alerts: DryRunAlert[] } } }> {
-    /*
-     * TODO after policiesSagas.js has been deleted:
-     * function return type: Promise<DryRunJobStatusResponse>
-     * add method: then((response) => response.data)
-     */
-    return axios.get(`${baseUrl}/dryrunjob/${jobId}`);
+export function checkDryRun(jobId: string): Promise<DryRunJobStatusResponse> {
+    return axios
+        .get<DryRunJobStatusResponse>(`${baseUrl}/dryrunjob/${jobId}`)
+        .then((response) => response.data);
 }
 
 export type DryRunJobStatusResponse = {
@@ -200,10 +146,8 @@ export type DryRunAlert = {
 /*
  * Cancel a dry run job.
  */
-export function cancelDryRun(jobId: string): Promise<Record<string, never>> {
-    return axios
-        .delete<Record<string, never>>(`${baseUrl}/dryrunjob/${jobId}`)
-        .then((response) => response.data);
+export function cancelDryRun(jobId: string): Promise<Empty> {
+    return axios.delete<Empty>(`${baseUrl}/dryrunjob/${jobId}`).then((response) => response.data);
 }
 
 /*
@@ -212,7 +156,7 @@ export function cancelDryRun(jobId: string): Promise<Record<string, never>> {
 export async function excludeDeployments(
     policyId: string,
     deploymentNames: string[]
-): Promise<Record<string, never>> {
+): Promise<Empty> {
     const policy = await getPolicy(policyId);
 
     const deploymentEntries = deploymentNames.map((name) => ({
@@ -222,20 +166,15 @@ export async function excludeDeployments(
         expiration: null,
     }));
     policy.exclusions = [...policy.exclusions, ...deploymentEntries];
-    return axios
-        .put<Record<string, never>>(`${baseUrl}/${policy.id}`, policy)
-        .then((response) => response.data);
+    return axios.put<Empty>(`${baseUrl}/${policy.id}`, policy).then((response) => response.data);
 }
 
 /*
  * Enable or disable a policy.
  */
-export function updatePolicyDisabledState(
-    policyId: string,
-    disabled: boolean
-): Promise<Record<string, never>> {
+export function updatePolicyDisabledState(policyId: string, disabled: boolean): Promise<Empty> {
     return axios
-        .patch<Record<string, never>>(`${baseUrl}/${policyId}`, { disabled })
+        .patch<Empty>(`${baseUrl}/${policyId}`, { disabled })
         .then((response) => response.data);
 }
 
@@ -245,7 +184,7 @@ export function updatePolicyDisabledState(
 export function updatePoliciesDisabledState(
     policyIds: string[],
     disabled: boolean
-): Promise<Record<string, never>[]> {
+): Promise<Empty[]> {
     return Promise.all(policyIds.map((policyId) => updatePolicyDisabledState(policyId, disabled)));
 }
 

--- a/ui/apps/platform/src/services/schemas.js
+++ b/ui/apps/platform/src/services/schemas.js
@@ -1,12 +1,5 @@
 import { schema } from 'normalizr';
 
-export const policy = new schema.Entity('policy');
-export const deployment = new schema.Entity('deployment', undefined, {
-    idAttribute: (value) => value.deployment.id,
-});
-
 export const image = new schema.Entity('image');
 
 export const cluster = new schema.Entity('cluster');
-
-export const secret = new schema.Entity('secret');


### PR DESCRIPTION
## Description

Follow up task that was missed after release of policies in PatternFly.

### Changed files

1. Edit Containers/Policies/Wizard/Step5/ReviewPolicyForm.tsx
    * Replace `{ data: { jobId } }` with `jobId` in response of `startDryRun` function
    * Replace `{ data: { pending, result } }` with `{ pending, result }` in response of `checkDryRun` function

2. Edit services/PoliciesService.ts
    * Delete `fetchPolicy` function
    * Delete `fetchPolicies` function
    * Delete `fetchPolicyCategories` function
    * Replace `Record<string, never>` with `Empty` type for similarity with declarations of backend services
        For example, https://github.com/stackrox/stackrox/blob/master/proto/api/v1/policy_service.proto#L171
    * Simplify return type of `createPolicy` function (note that caller does not use it, but instead goes back to policies table which gets policies)
    * Simplify return type of `startDryRun` function (and make corresponding change to ReviewPolicyForm)
    * Simplify return type of `checkDryRun` function (and make corresponding change to ReviewPolicyForm)

3. Edit services/schemas.js
    * Delete `policy`
    * Delete `deployment` because already unused
    * Delete `secret` because already unused

### Residue

1. Investigate whether it is possible to remove `normalizr` from dependencies
    * Does `fetchImages` function still need `image` schema?
    * Do `fetchClusters`, `fetchCluster`, and `saveCluster` functions still need `cluster` schema?

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### manual testing

1. `yarn build` in ui
2. `wc build/static/js/*.chunk.js` in ui
    * branch - master: 154 = 10390361 - 10390207 slight increase because simplifications did not quite pay for additions of `then((response) => response.data)`
3. `yarn start` in ui

    * Visit /main/policy-management/policies: see GET /v1/policies request
    * For an enabled policy, click kabob, and then click **Disable policy**: see PATCH /v1/policies/id request with `{disabled: true}` payload and `{}` response
    * For the disabled policy, click kabob, and then click **Enable policy**: see PATCH /v1/policies/id request with `{disabled: false}` payload and `{}` response
    * Click existing policy name link: see GET /v1/policies/id request
    * Click back button, click **Create policy** button, continue to click **Next** button at step 4:
        see POST /v1/policies/dryrunjob request with `{jobId}` response
        see GET /v1/policies/dryrunjob/jobId request
    * Click **Save** button: see POST /v1/policies?enableStrictValidation=true request for which `id` property has empty string value in payload and non-empty string value in response
    * Click new policy name link: see GET /v1/policies/id request
    * Click **Actions** button, click **Edit policy**, edit name, click **Review policy**, click **Save** button: see PUT /v1/policies/id request and `{}` response
    * Click **Actions** button, click **Delete policy**, and then click **Delete**: see DELETE /v1/policies/id request and `{}` response

### integration testing

1. `yarn cypress-open` in ui/apps/platform
    * policies/exportPolicy.test.js
    * policies/importPolicy.test.js
    * policies/policiesTable.test.js
    * policies/policyWizardStep3.test.js