### PR TITLE
Rox-11667 jest mock implementation cleanup

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
@@ -39,15 +39,6 @@ const mocks = [
     },
 ];
 
-jest.mock('@patternfly/react-charts', () => {
-    const { Chart, ...rest } = jest.requireActual('@patternfly/react-charts');
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return {
-        ...rest,
-        Chart: (props) => <Chart {...props} animate={undefined} />,
-    };
-});
-
 jest.mock('hooks/useResizeObserver');
 
 beforeEach(() => {

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
@@ -48,10 +48,7 @@ jest.mock('@patternfly/react-charts', () => {
     };
 });
 
-jest.mock('hooks/useResizeObserver', () => ({
-    __esModule: true,
-    default: jest.fn().mockImplementation(jest.fn),
-}));
+jest.mock('hooks/useResizeObserver');
 
 beforeEach(() => {
     localStorage.clear();

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
@@ -80,15 +80,6 @@ const mocks = [
     },
 ];
 
-jest.mock('@patternfly/react-charts', () => {
-    const { Chart, ...rest } = jest.requireActual('@patternfly/react-charts');
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return {
-        ...rest,
-        Chart: (props) => <Chart {...props} animate={undefined} />,
-    };
-});
-
 jest.mock('hooks/useResizeObserver');
 
 beforeEach(() => {

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MockedProvider } from '@apollo/client/testing';
-import { screen, within, waitFor, act } from '@testing-library/react';
+import { screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 
@@ -125,10 +125,8 @@ describe('Compliance levels by standard dashboard widget', () => {
         });
 
         // Sort by descending
-        await act(async () => {
-            await user.click(screen.getByText('Options'));
-            await user.click(screen.getByText('Descending'));
-        });
+        await user.click(screen.getByText('Options'));
+        await user.click(screen.getByText('Descending'));
 
         await waitFor(async () => {
             const descendingPercentages = await getBarPercentages();
@@ -151,9 +149,7 @@ describe('Compliance levels by standard dashboard widget', () => {
         expect(history.location.pathname).toBe(complianceBasePath);
 
         const standard = 'CIS Docker v1.2.0';
-        await act(async () => {
-            await user.click(await screen.findByText(standard));
-        });
+        await user.click(await screen.findByText(standard));
         expect(history.location.pathname).toBe(
             `${complianceBasePath}/${urlEntityListTypes[standardEntityTypes.CONTROL]}`
         );

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
@@ -89,10 +89,7 @@ jest.mock('@patternfly/react-charts', () => {
     };
 });
 
-jest.mock('hooks/useResizeObserver', () => ({
-    __esModule: true,
-    default: jest.fn().mockImplementation(jest.fn),
-}));
+jest.mock('hooks/useResizeObserver');
 
 beforeEach(() => {
     localStorage.clear();

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
@@ -61,10 +61,7 @@ const mocks = [
     },
 ];
 
-jest.mock('hooks/useResizeObserver', () => ({
-    __esModule: true,
-    default: jest.fn().mockImplementation(jest.fn),
-}));
+jest.mock('hooks/useResizeObserver');
 
 beforeEach(() => {
     localStorage.clear();

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
@@ -15,10 +15,7 @@ jest.mock('@patternfly/react-charts', () => {
     };
 });
 
-jest.mock('hooks/useResizeObserver', () => ({
-    __esModule: true,
-    default: jest.fn().mockImplementation(jest.fn),
-}));
+jest.mock('hooks/useResizeObserver');
 
 // Mock the hook that handles the data fetching of alert counts
 jest.mock('Containers/Dashboard/PatternFly/hooks/useAlertGroups', () => {

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
@@ -6,15 +6,6 @@ import '@testing-library/jest-dom/extend-expect';
 import renderWithRouter from 'test-utils/renderWithRouter';
 import ViolationsByPolicyCategory from 'Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory';
 
-jest.mock('@patternfly/react-charts', () => {
-    const { Chart, ...rest } = jest.requireActual('@patternfly/react-charts');
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return {
-        ...rest,
-        Chart: (props) => <Chart {...props} animate={undefined} />,
-    };
-});
-
 jest.mock('hooks/useResizeObserver');
 
 // Mock the hook that handles the data fetching of alert counts

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicySeverity.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicySeverity.test.tsx
@@ -34,10 +34,7 @@ const mocks = [
     },
 ];
 
-jest.mock('hooks/useResizeObserver', () => ({
-    __esModule: true,
-    default: jest.fn().mockImplementation(jest.fn),
-}));
+jest.mock('hooks/useResizeObserver');
 
 // Mock the hook that handles the data fetching of alert counts
 jest.mock('Containers/Dashboard/PatternFly/hooks/useAlertGroups', () => ({

--- a/ui/apps/platform/src/__mocks__/@patternfly/react-charts.tsx
+++ b/ui/apps/platform/src/__mocks__/@patternfly/react-charts.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const { Chart, ...rest } = jest.requireActual('@patternfly/react-charts');
+
+module.exports = {
+    ...rest,
+    // Disables animation on Charts during testing. Enabling animation on charts causes React.setState calls
+    // to fire asynchronously while the animation updates, often causing a `setState` call to happen outside
+    // of React's `act()` call, which causes intermittent errors during testing.
+    Chart: (props) => <Chart {...props} animate={undefined} />,
+};

--- a/ui/apps/platform/src/__mocks__/README.md
+++ b/ui/apps/platform/src/__mocks__/README.md
@@ -1,0 +1,15 @@
+This directory holds mocks used for Jest [manual mocking](https://jestjs.io/docs/manual-mocks#using-with-es-module-imports) in order to 
+mock `node_module` dependencies in a central location.
+
+Note that the Jest docs specify that this directory [should be placed adjacent](https://jestjs.io/docs/manual-mocks#mocking-node-modules) to 
+the `node_modules` directory, but this is not correct when using CRA/react-scripts. Based on discussion in [this issue](https://github.com/facebook/create-react-app/issues/7539) 
+the documented behavior was broken, and mocks will only automatically be picked up if they reside under the `src` directory. This breakage still appears to exist in 
+the latest version of [CRA](https://github.com/facebook/create-react-app/blob/main/packages/react-scripts/scripts/utils/createJestConfig.js#L26).
+
+Also of note is that ESM `export` does not appear to work in these manual mocks. e.g.
+```typescript
+// works
+module.exports = myMockedModule;
+// does not work, resulting in all imports in dependent modules being `undefined`
+export default myMockedModule;
+```


### PR DESCRIPTION
## Description

This cleans up the duplication of Jest mocked modules from the recent dashboard work.

There are two main changes here:
- Remove the explicit mocking for the `hooks/useResizeObserver` module. In the case of these tests, we don't care about the return value since without a valid width the widgets will use the Victory default of 450px.
- Move the module mocks for `@patternfly/react-charts` to a single location instead of duplicating it in every test file.

**TLDR**, globally disables chart animation during tests. This PR is lower priority so we can discuss the tradeoffs more during the UI sync.

### Why the `react-charts` mocks are needed

The mocks for this module intercept the `Chart` export of the PF chart library and discard any information passed to the `animation` prop for this component. This is needed to prevent intermittent errors that looks like the following:

```
Warning: An update to %s inside a test was not wrapped in act(...).·
When testing, code that causes React state updates should be wrapped into act(...):·
act(() => {
    /* fire events that update state */
});
```
Even though user events fired by React Testing Library wrap the event in `act()` internally, these errors were still popping up. They are caused by the animation prop that uses a hook that calls `setState` asynchronously sometime outside of the RTL `act()` call. This can be approximately reproduced by placing the below code in an event callback in a component under test.
```typescript
setTimeout(() => {
    someSetStateCall(value);
}, 80);
```
Interestingly enough, the calls would only fail reliably if the value passed to setTimeout was between 65 and 85. Any higher or lower and the act errors would disappear. (My theory is that lower time values are fast enough to be flushed by React internally, and higher time values are long enough that the test has moved beyond the trouble section, but I don't know for sure!)

### Use of the `__mocks__` directory

Placing mocked modules in this directory will allow us to globally and automatically mock `node_modules` that we use in tests. In this case, any component that uses `Chart` internally will automatically have animation disabled during tests. There are some caveats to the placement of the directory that go against Jest documentation due to a breakage caused by `react-scripts` that I've documented [here](https://github.com/stackrox/stackrox/pull/2354/files#diff-2ff8bc33d826908ee73eaec047a5e703c90f1d9f79d61c4e9422b69d6d24ba05).

The main downside to using these mocked modules are that are automatically used everywhere throughout the tests, which might not be immediately obvious when debugging tests. We would still have the ability to _unmock_ these modules in specific tests if needed.

Mark also suggested moving the duplication to a test utils location and writing the minimal, inline mock in individual tests like `jest.mock('@patternfly/react-charts', pfChartsNoAnimationMocks);`. This is something I will take a look at to be sure that it works with how jest reorders mock calls. _(edit: this does appear to work)_ If we want to go with this approach instead, the main question is where we want to put these test utils?

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Test running `yarn test` from the apps/platform folder as well as the root to ensure mocks are picked up correctly.
