### PR TITLE
ROX-11666 build out dashboard test cases

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/ClusterSelect.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/ClusterSelect.tsx
@@ -83,6 +83,7 @@ function ClusterSelect({
 
     return (
         <Select
+            toggleAriaLabel="Select clusters"
             variant={SelectVariant.checkbox}
             isOpen={isOpen}
             onToggle={onToggle}

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/NamespaceSelect.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/NamespaceSelect.tsx
@@ -94,6 +94,7 @@ function NamespaceSelect({
 
     return (
         <Select
+            toggleAriaLabel="Select namespaces"
             className="namespace-select"
             variant={SelectVariant.checkbox}
             isOpen={isOpen}

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/ScopeBar.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/ScopeBar.test.tsx
@@ -54,13 +54,13 @@ describe('Resource scope bar', () => {
     it('should default to all clusters and namespaces selected', async () => {
         const { user } = await setup();
 
-        const clusterDropdownToggle = screen.getByRole('button', { name: 'Select clusters' });
-        const namespaceDropdownToggle = screen.getByRole('button', { name: 'Select namespaces' });
+        const clusterDropdownToggle = screen.getByLabelText('Select clusters');
+        const namespaceDropdownToggle = screen.getByLabelText('Select namespaces');
         await waitFor(() => expect(clusterDropdownToggle).not.toBeDisabled());
 
         // The default state is all clusters selected, with the ns dropdown disabled
         await user.click(clusterDropdownToggle);
-        expect(await screen.findByRole('checkbox', { name: 'All clusters' })).toBeChecked();
+        expect(await screen.findByLabelText('All clusters', { selector: 'input' })).toBeChecked();
         expect(namespaceDropdownToggle).toBeDisabled();
         await user.click(clusterDropdownToggle);
     });
@@ -68,43 +68,43 @@ describe('Resource scope bar', () => {
     it('allows selection of multiple clusters and namespaces', async () => {
         const { user } = await setup();
 
-        const clusterDropdownToggle = screen.getByRole('button', { name: 'Select clusters' });
-        const namespaceDropdownToggle = screen.getByRole('button', { name: 'Select namespaces' });
+        const clusterDropdownToggle = screen.getByLabelText('Select clusters');
+        const namespaceDropdownToggle = screen.getByLabelText('Select namespaces');
         await waitFor(() => expect(clusterDropdownToggle).not.toBeDisabled());
 
         // Selecting one or more clusters enables the ns dropdown
         await user.click(clusterDropdownToggle);
-        await user.click(screen.getByRole('checkbox', { name: 'production' }));
+        await user.click(screen.getByLabelText('production'));
         await user.click(clusterDropdownToggle);
         expect(namespaceDropdownToggle).not.toBeDisabled();
         expect(clusterDropdownToggle).toHaveTextContent('Clusters1');
 
         // Enable some namespaces and check that the select badge updates
         await user.click(namespaceDropdownToggle);
-        await user.click(screen.getByRole('checkbox', { name: 'frontend' }));
-        await user.click(screen.getByRole('checkbox', { name: 'backend' }));
-        await user.click(screen.getByRole('checkbox', { name: 'payments' }));
+        await user.click(screen.getByLabelText('frontend'));
+        await user.click(screen.getByLabelText('backend'));
+        await user.click(screen.getByLabelText('payments'));
         await user.click(namespaceDropdownToggle);
         expect(namespaceDropdownToggle).toHaveTextContent('Namespaces3');
 
         // Selecting another cluster when other namespaces are selected will explicitly select
         // all namespaces in that cluster
         await user.click(clusterDropdownToggle);
-        await user.click(screen.getByRole('checkbox', { name: 'security' }));
+        await user.click(screen.getByLabelText('security'));
         await user.click(clusterDropdownToggle);
         expect(namespaceDropdownToggle).toHaveTextContent('Namespaces6');
 
         // Selecting "All Namespaces" and then a single namespaces will result in a single
         // namespace being selected
         await user.click(namespaceDropdownToggle);
-        await user.click(screen.getByRole('checkbox', { name: 'All namespaces' }));
-        await user.click(screen.getByRole('checkbox', { name: 'frontend' }));
+        await user.click(screen.getByLabelText('All namespaces'));
+        await user.click(screen.getByLabelText('frontend'));
         await user.click(namespaceDropdownToggle);
         expect(namespaceDropdownToggle).toHaveTextContent('Namespaces1');
 
         // Selecting "All Clusters" will clear the namespace selection and disable the dropdown
         await user.click(clusterDropdownToggle);
-        await user.click(screen.getByRole('checkbox', { name: 'All clusters' }));
+        await user.click(screen.getByLabelText('All clusters'));
         await user.click(clusterDropdownToggle);
         expect(clusterDropdownToggle).toHaveTextContent('All clusters');
         expect(namespaceDropdownToggle).toHaveTextContent('All namespaces');
@@ -118,14 +118,14 @@ describe('Resource scope bar', () => {
         } = await setup();
 
         // Check that the default state of "select all" results in empty URL search parameters
-        const clusterDropdownToggle = screen.getByRole('button', { name: 'Select clusters' });
-        const namespaceDropdownToggle = screen.getByRole('button', { name: 'Select namespaces' });
+        const clusterDropdownToggle = screen.getByLabelText('Select clusters');
+        const namespaceDropdownToggle = screen.getByLabelText('Select namespaces');
         await waitFor(() => expect(clusterDropdownToggle).not.toBeDisabled());
         expect(history.location.search).toBe('');
 
         // Select a cluster and verify it has been added to the URL
         await user.click(clusterDropdownToggle);
-        await user.click(screen.getByRole('checkbox', { name: 'production' }));
+        await user.click(screen.getByLabelText('production'));
         await user.click(clusterDropdownToggle);
         expect(history.location.search).toMatch(new RegExp(`s\\[Cluster\\]\\[\\d\\]=production`));
 
@@ -141,8 +141,8 @@ describe('Resource scope bar', () => {
         const backend = productionNamespaces.find(findNsWithName('backend')) as Namespace;
         const payments = productionNamespaces.find(findNsWithName('payments')) as Namespace;
         await user.click(namespaceDropdownToggle);
-        await user.click(screen.getByRole('checkbox', { name: frontend.metadata.name }));
-        await user.click(screen.getByRole('checkbox', { name: backend.metadata.name }));
+        await user.click(screen.getByLabelText(frontend.metadata.name));
+        await user.click(screen.getByLabelText(backend.metadata.name));
         await user.click(namespaceDropdownToggle);
         expect(history.location.search).toMatch(new RegExp(`s\\[Cluster\\]\\[\\d\\]=production`));
         // Namespaces are tracked _by id_ in the URL, not name

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/ScopeBar.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/ScopeBar.test.tsx
@@ -42,11 +42,6 @@ const setup = async () => {
             <ScopeBar />
         </MockedProvider>
     );
-    // Allows the Apollo MockedProvider to transition from the 'loading' state to a state
-    // where data is available. This prevents `act()` errors that occur due to the ScopeBar
-    // component being rendered during `loading` and click events being dispatched before
-    // the data is ready.
-    await waitFor(() => new Promise((res) => setTimeout(res, 0)));
     return { user, utils };
 };
 

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/ScopeBar.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/ScopeBar.test.tsx
@@ -35,26 +35,27 @@ beforeEach(() => {
     jest.resetModules();
 });
 
-const setup = () => {
+const setup = async () => {
     const user = userEvent.setup();
     const utils = renderWithRouter(
         <MockedProvider mocks={mocks} addTypename={false}>
             <ScopeBar />
         </MockedProvider>
     );
+    // Allows the Apollo MockedProvider to transition from the 'loading' state to a state
+    // where data is available. This prevents `act()` errors that occur due to the ScopeBar
+    // component being rendered during `loading` and click events being dispatched before
+    // the data is ready.
+    await waitFor(() => new Promise((res) => setTimeout(res, 0)));
     return { user, utils };
 };
 
 describe('Resource scope bar', () => {
     it('should default to all clusters and namespaces selected', async () => {
-        const { user } = setup();
+        const { user } = await setup();
 
-        const clusterDropdownToggle = await screen.findByRole('button', {
-            name: 'Select clusters',
-        });
-        const namespaceDropdownToggle = await screen.findByRole('button', {
-            name: 'Select namespaces',
-        });
+        const clusterDropdownToggle = screen.getByRole('button', { name: 'Select clusters' });
+        const namespaceDropdownToggle = screen.getByRole('button', { name: 'Select namespaces' });
         await waitFor(() => expect(clusterDropdownToggle).not.toBeDisabled());
 
         // The default state is all clusters selected, with the ns dropdown disabled
@@ -65,14 +66,10 @@ describe('Resource scope bar', () => {
     });
 
     it('allows selection of multiple clusters and namespaces', async () => {
-        const { user } = setup();
+        const { user } = await setup();
 
-        const clusterDropdownToggle = await screen.findByRole('button', {
-            name: 'Select clusters',
-        });
-        const namespaceDropdownToggle = await screen.findByRole('button', {
-            name: 'Select namespaces',
-        });
+        const clusterDropdownToggle = screen.getByRole('button', { name: 'Select clusters' });
+        const namespaceDropdownToggle = screen.getByRole('button', { name: 'Select namespaces' });
         await waitFor(() => expect(clusterDropdownToggle).not.toBeDisabled());
 
         // Selecting one or more clusters enables the ns dropdown
@@ -118,15 +115,11 @@ describe('Resource scope bar', () => {
         const {
             user,
             utils: { history },
-        } = setup();
+        } = await setup();
 
         // Check that the default state of "select all" results in empty URL search parameters
-        const clusterDropdownToggle = await screen.findByRole('button', {
-            name: 'Select clusters',
-        });
-        const namespaceDropdownToggle = await screen.findByRole('button', {
-            name: 'Select namespaces',
-        });
+        const clusterDropdownToggle = screen.getByRole('button', { name: 'Select clusters' });
+        const namespaceDropdownToggle = screen.getByRole('button', { name: 'Select namespaces' });
         await waitFor(() => expect(clusterDropdownToggle).not.toBeDisabled());
         expect(history.location.search).toBe('');
 

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/ScopeBar.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/ScopeBar.test.tsx
@@ -35,7 +35,7 @@ beforeEach(() => {
     jest.resetModules();
 });
 
-const setup = async () => {
+const setup = () => {
     const user = userEvent.setup();
     const utils = renderWithRouter(
         <MockedProvider mocks={mocks} addTypename={false}>
@@ -47,7 +47,7 @@ const setup = async () => {
 
 describe('Resource scope bar', () => {
     it('should default to all clusters and namespaces selected', async () => {
-        const { user } = await setup();
+        const { user } = setup();
 
         const clusterDropdownToggle = screen.getByLabelText('Select clusters');
         const namespaceDropdownToggle = screen.getByLabelText('Select namespaces');
@@ -61,7 +61,7 @@ describe('Resource scope bar', () => {
     });
 
     it('allows selection of multiple clusters and namespaces', async () => {
-        const { user } = await setup();
+        const { user } = setup();
 
         const clusterDropdownToggle = screen.getByLabelText('Select clusters');
         const namespaceDropdownToggle = screen.getByLabelText('Select namespaces');
@@ -110,7 +110,7 @@ describe('Resource scope bar', () => {
         const {
             user,
             utils: { history },
-        } = await setup();
+        } = setup();
 
         // Check that the default state of "select all" results in empty URL search parameters
         const clusterDropdownToggle = screen.getByLabelText('Select clusters');

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/ScopeBar.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/ScopeBar.test.tsx
@@ -49,8 +49,12 @@ describe('Resource scope bar', () => {
     it('should default to all clusters and namespaces selected', async () => {
         const { user } = setup();
 
-        const clusterDropdownToggle = screen.getByRole('button', { name: 'Select clusters' });
-        const namespaceDropdownToggle = screen.getByRole('button', { name: 'Select namespaces' });
+        const clusterDropdownToggle = await screen.findByRole('button', {
+            name: 'Select clusters',
+        });
+        const namespaceDropdownToggle = await screen.findByRole('button', {
+            name: 'Select namespaces',
+        });
         await waitFor(() => expect(clusterDropdownToggle).not.toBeDisabled());
 
         // The default state is all clusters selected, with the ns dropdown disabled
@@ -63,8 +67,12 @@ describe('Resource scope bar', () => {
     it('allows selection of multiple clusters and namespaces', async () => {
         const { user } = setup();
 
-        const clusterDropdownToggle = screen.getByRole('button', { name: 'Select clusters' });
-        const namespaceDropdownToggle = screen.getByRole('button', { name: 'Select namespaces' });
+        const clusterDropdownToggle = await screen.findByRole('button', {
+            name: 'Select clusters',
+        });
+        const namespaceDropdownToggle = await screen.findByRole('button', {
+            name: 'Select namespaces',
+        });
         await waitFor(() => expect(clusterDropdownToggle).not.toBeDisabled());
 
         // Selecting one or more clusters enables the ns dropdown
@@ -113,8 +121,12 @@ describe('Resource scope bar', () => {
         } = setup();
 
         // Check that the default state of "select all" results in empty URL search parameters
-        const clusterDropdownToggle = screen.getByRole('button', { name: 'Select clusters' });
-        const namespaceDropdownToggle = screen.getByRole('button', { name: 'Select namespaces' });
+        const clusterDropdownToggle = await screen.findByRole('button', {
+            name: 'Select clusters',
+        });
+        const namespaceDropdownToggle = await screen.findByRole('button', {
+            name: 'Select namespaces',
+        });
         await waitFor(() => expect(clusterDropdownToggle).not.toBeDisabled());
         expect(history.location.search).toBe('');
 

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/ScopeBar.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/ScopeBar.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { MockedProvider } from '@apollo/client/testing';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+
+import renderWithRouter from 'test-utils/renderWithRouter';
+import ScopeBar, { namespacesQuery } from './ScopeBar';
+import { Cluster, Namespace } from './types';
+
+const clusterNamespaces = {
+    production: ['backend', 'default', 'frontend', 'kube-system', 'medical', 'payments'],
+    security: ['default', ' kube-system', 'stackrox'],
+};
+
+const mockData: {
+    clusters: Cluster[];
+} = { clusters: [] };
+
+Object.entries(clusterNamespaces).forEach(([mockCluster, mockNamespaces], clusterIndex) => {
+    const namespaces = mockNamespaces.map((ns, nsIndex) => ({
+        metadata: { id: `ns-${nsIndex}`, name: ns },
+    }));
+    mockData.clusters.push({ id: `cluster-${clusterIndex}`, name: mockCluster, namespaces });
+});
+
+const mocks = [
+    {
+        request: { query: namespacesQuery, variables: { query: '' } },
+        result: { data: mockData },
+    },
+];
+
+beforeEach(() => {
+    jest.resetModules();
+});
+
+const setup = () => {
+    const user = userEvent.setup();
+    const utils = renderWithRouter(
+        <MockedProvider mocks={mocks} addTypename={false}>
+            <ScopeBar />
+        </MockedProvider>
+    );
+    return { user, utils };
+};
+
+describe('Resource scope bar', () => {
+    it('should default to all clusters and namespaces selected', async () => {
+        const { user } = setup();
+
+        const clusterDropdownToggle = screen.getByRole('button', { name: 'Select clusters' });
+        const namespaceDropdownToggle = screen.getByRole('button', { name: 'Select namespaces' });
+        await waitFor(() => expect(clusterDropdownToggle).not.toBeDisabled());
+
+        // The default state is all clusters selected, with the ns dropdown disabled
+        await user.click(clusterDropdownToggle);
+        expect(await screen.findByRole('checkbox', { name: 'All clusters' })).toBeChecked();
+        expect(namespaceDropdownToggle).toBeDisabled();
+        await user.click(clusterDropdownToggle);
+    });
+
+    it('allows selection of multiple clusters and namespaces', async () => {
+        const { user } = setup();
+
+        const clusterDropdownToggle = screen.getByRole('button', { name: 'Select clusters' });
+        const namespaceDropdownToggle = screen.getByRole('button', { name: 'Select namespaces' });
+        await waitFor(() => expect(clusterDropdownToggle).not.toBeDisabled());
+
+        // Selecting one or more clusters enables the ns dropdown
+        await user.click(clusterDropdownToggle);
+        await user.click(screen.getByRole('checkbox', { name: 'production' }));
+        await user.click(clusterDropdownToggle);
+        expect(namespaceDropdownToggle).not.toBeDisabled();
+        expect(clusterDropdownToggle).toHaveTextContent('Clusters1');
+
+        // Enable some namespaces and check that the select badge updates
+        await user.click(namespaceDropdownToggle);
+        await user.click(screen.getByRole('checkbox', { name: 'frontend' }));
+        await user.click(screen.getByRole('checkbox', { name: 'backend' }));
+        await user.click(screen.getByRole('checkbox', { name: 'payments' }));
+        await user.click(namespaceDropdownToggle);
+        expect(namespaceDropdownToggle).toHaveTextContent('Namespaces3');
+
+        // Selecting another cluster when other namespaces are selected will explicitly select
+        // all namespaces in that cluster
+        await user.click(clusterDropdownToggle);
+        await user.click(screen.getByRole('checkbox', { name: 'security' }));
+        await user.click(clusterDropdownToggle);
+        expect(namespaceDropdownToggle).toHaveTextContent('Namespaces6');
+
+        // Selecting "All Namespaces" and then a single namespaces will result in a single
+        // namespace being selected
+        await user.click(namespaceDropdownToggle);
+        await user.click(screen.getByRole('checkbox', { name: 'All namespaces' }));
+        await user.click(screen.getByRole('checkbox', { name: 'frontend' }));
+        await user.click(namespaceDropdownToggle);
+        expect(namespaceDropdownToggle).toHaveTextContent('Namespaces1');
+
+        // Selecting "All Clusters" will clear the namespace selection and disable the dropdown
+        await user.click(clusterDropdownToggle);
+        await user.click(screen.getByRole('checkbox', { name: 'All clusters' }));
+        await user.click(clusterDropdownToggle);
+        expect(clusterDropdownToggle).toHaveTextContent('All clusters');
+        expect(namespaceDropdownToggle).toHaveTextContent('All namespaces');
+        expect(namespaceDropdownToggle).toBeDisabled();
+    });
+
+    it('will track selected clusters and namespaces in the page URL', async () => {
+        const {
+            user,
+            utils: { history },
+        } = setup();
+
+        // Check that the default state of "select all" results in empty URL search parameters
+        const clusterDropdownToggle = screen.getByRole('button', { name: 'Select clusters' });
+        const namespaceDropdownToggle = screen.getByRole('button', { name: 'Select namespaces' });
+        await waitFor(() => expect(clusterDropdownToggle).not.toBeDisabled());
+        expect(history.location.search).toBe('');
+
+        // Select a cluster and verify it has been added to the URL
+        await user.click(clusterDropdownToggle);
+        await user.click(screen.getByRole('checkbox', { name: 'production' }));
+        await user.click(clusterDropdownToggle);
+        expect(history.location.search).toMatch(new RegExp(`s\\[Cluster\\]\\[\\d\\]=production`));
+
+        // Select multiple namespaces and verify they have been added to the URL
+        const productionNamespaces =
+            mockData.clusters.find((cs) => cs.name === 'production')?.namespaces ?? [];
+        function findNsWithName(name) {
+            return ({ metadata }) => metadata.name === name;
+        }
+
+        // Get a reference to the mock data object for each namespace so we can compare names against ids
+        const frontend = productionNamespaces.find(findNsWithName('frontend')) as Namespace;
+        const backend = productionNamespaces.find(findNsWithName('backend')) as Namespace;
+        const payments = productionNamespaces.find(findNsWithName('payments')) as Namespace;
+        await user.click(namespaceDropdownToggle);
+        await user.click(screen.getByRole('checkbox', { name: frontend.metadata.name }));
+        await user.click(screen.getByRole('checkbox', { name: backend.metadata.name }));
+        await user.click(namespaceDropdownToggle);
+        expect(history.location.search).toMatch(new RegExp(`s\\[Cluster\\]\\[\\d\\]=production`));
+        // Namespaces are tracked _by id_ in the URL, not name
+        expect(history.location.search).toMatch(
+            new RegExp(`s\\[Namespace ID\\]\\[\\d\\]=${frontend.metadata.id}`)
+        );
+        expect(history.location.search).toMatch(
+            new RegExp(`s\\[Namespace ID\\]\\[\\d\\]=${backend.metadata.id}`)
+        );
+        expect(history.location.search).not.toMatch(
+            new RegExp(`s\\[Namespace ID\\]\\[\\d\\]=${payments.metadata.id}`)
+        );
+    });
+});

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/ScopeBar.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/ScopeBar.tsx
@@ -14,7 +14,7 @@ type NamespacesResponse = {
     clusters: Cluster[];
 };
 
-const namespacesQuery = gql`
+export const namespacesQuery = gql`
     query getAllNamespacesByCluster($query: String) {
         clusters(query: $query) {
             id

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MockedProvider } from '@apollo/client/testing';
-import { act, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MockedProvider } from '@apollo/client/testing';
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 
@@ -57,13 +57,19 @@ beforeEach(() => {
     jest.resetModules();
 });
 
+const setup = () => {
+    const user = userEvent.setup();
+    const utils = renderWithRouter(
+        <MockedProvider mocks={mocks} addTypename={false}>
+            <AgingImages />
+        </MockedProvider>
+    );
+    return { user, utils };
+};
+
 describe('AgingImages dashboard widget', () => {
     it('should render the correct number of images with default settings', async () => {
-        renderWithRouter(
-            <MockedProvider mocks={mocks} addTypename={false}>
-                <AgingImages />
-            </MockedProvider>
-        );
+        setup();
 
         // When all items are selected, the total should be equal to the total of all buckets
         // returned by the server
@@ -81,12 +87,7 @@ describe('AgingImages dashboard widget', () => {
     });
 
     it('should render graph bars with the correct image counts when time buckets are toggled', async () => {
-        const user = userEvent.setup();
-        renderWithRouter(
-            <MockedProvider mocks={mocks} addTypename={false}>
-                <AgingImages />
-            </MockedProvider>
-        );
+        const { user } = setup();
 
         await user.click(await screen.findByRole('button', { name: `Options` }));
         const checkboxes = await screen.findAllByRole('checkbox');
@@ -135,5 +136,31 @@ describe('AgingImages dashboard widget', () => {
         expect(await screen.findByText(`${range0}-${range1} days`)).toBeInTheDocument();
         expect(await screen.findByText(`${range1}-${range3} days`)).toBeInTheDocument();
         expect(await screen.findByText(`>1 year`)).toBeInTheDocument();
+    });
+
+    it('links users to the correct filtered image list', async () => {
+        const {
+            user,
+            utils: { history },
+        } = setup();
+
+        // Check default links
+        await user.click(await screen.findByRole('link', { name: `30-90 days` }));
+        expect(history.location.search).toContain('s[Image Created Time]=30d-90d');
+
+        await user.click(await screen.findByRole('link', { name: '90-180 days' }));
+        expect(history.location.search).toContain('s[Image Created Time]=90d-180d');
+
+        await user.click(await screen.findByRole('link', { name: '>1 year' }));
+        expect(history.location.search).toContain('s[Image Created Time]=>365d');
+
+        // Deselect the second time range, merging the first and second time buckets
+        await user.click(await screen.findByRole('button', { name: `Options` }));
+        const checkboxes = await screen.findAllByRole('checkbox');
+        await user.click(checkboxes[1]);
+        await user.click(await screen.findByRole('button', { name: `Options` }));
+
+        await user.click(await screen.findByRole('link', { name: '30-180 days' }));
+        expect(history.location.search).toContain('s[Image Created Time]=30d-180d');
     });
 });

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicySeverity.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicySeverity.test.tsx
@@ -77,8 +77,9 @@ describe('Violations by policy severity widget', () => {
     it('should display total violations in the title that match the sum of the individual tiles', async () => {
         setup();
 
-        // Find items on the screen that with text that contains -only- an integer
-        const tiles = await screen.findAllByText(/^\d+$/);
+        const tiles = await screen.findAllByRole('link', {
+            name: /^\d+ (Low|Medium|High|Critical)$/,
+        });
         expect(tiles).toHaveLength(4);
 
         let alertCount = 0;


### PR DESCRIPTION
## Description

Adds tests for some missing relevant areas of the dashboard.

- Test that aging images outbound links correctly apply date range filters
- Updates the Violations tile test to include the severity as well as the count in the query
- Adds tests for the ScopeBar Cluster and Namespace dropdown interactions

Of note: initially I was favoring the `findByRole` queries due to the additional accessibility semantics as [recommended by testing-library docs](https://testing-library.com/docs/queries/about#priority) but have recently switched to other queries due to [performance issues](https://github.com/testing-library/dom-testing-library/issues/698). Locally the difference wasn't noticeable, although still significant (950ms -> 150ms for a single test). However running in Prow CI the same test would take upwards of 30 **seconds**, and the change from `findByRole` to `findByLabelText` brought the tests down to around 1 second. These lengthy tests were throwing constant `act()` errors in CI that were never reproducible locally. Given that the errors have now disappeared with no logic change to the tests other than the query methods it seems likely that the errors were misdirection due to the length of the tests.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Automated tests
