### PR TITLE
CI: Resort to set -x to debug missing messages

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -990,6 +990,9 @@ store_test_results() {
 send_slack_notice_for_failures_on_merge() {
     local exitstatus="${1:-}"
 
+    # TODO(RS-509) - remove this once it is clear why messages are not reaching #test-failures
+    set -x
+
     if ! is_OPENSHIFT_CI || [[ "$exitstatus" == "0" ]] || is_in_PR_context || is_nightly_run; then
         return 0
     fi


### PR DESCRIPTION
## Description

I think a `set -x` is called for in this case as I'm unable to figure out why the notifications are not sent. *And* this is only called in an exit trap at the conclusion of test.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.