### PR TITLE
Don't declare GITHUB_TOKEN in workflow_call

### DIFF
--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -5,9 +5,6 @@ on:
       INFRA_TOKEN:
         description: Infra access token
         required: true
-      GITHUB_TOKEN:
-        description: GitHub access token
-        required: true
     inputs:
       flavor:
         description: Flavor (`qa-demo`, `gke-default`, `openshift-4-demo`...)
@@ -81,7 +78,7 @@ jobs:
       - name: Create Cluster
         env:
           INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{github.token}}
         run: |
           set -uo pipefail
           gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \


### PR DESCRIPTION
## Description

`GITHUB_TOKEN` is a reserved name which cannot be used as a workflow_call secret. Use `github.token` as suggested here: https://github.community/t/how-to-pass-github-token-to-reusable-workflows/204905/6