### PR TITLE
Setup `main_branch` env var in `create-cluster.yml`

### DIFF
--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -62,6 +62,7 @@ on:
 env:
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
   script_url: /repos/${{github.repository}}/contents/.github/workflows/scripts/common.sh?ref=${{github.event.repository.default_branch}}
+  main_branch: ${{github.event.repository.default_branch}}
 
 jobs:
   infra:


### PR DESCRIPTION
## Description

The scripts from `.github/workflows/scripts` require `main_branch` variable set, so they could be called.

The PR adds the missing variable to `create-cluster.yml`.