### PR TITLE
Improve assertion for risk sort priority integration test in UI

### DIFF
--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -42,7 +42,7 @@ describe('Risk page', () => {
                         'eq',
                         '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=false'
                     );
-                    // No request because response is sorted ascending.
+                    // There is no request because response is sorted ascending.
 
                     // Sort descending by priority.
                     cy.get(priorityColumnHeadingSelector).click();
@@ -50,7 +50,7 @@ describe('Risk page', () => {
                         'eq',
                         '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=true'
                     );
-                    cy.wait('@deploymentswithprocessinfo'); // assume intercept in visitRiskDeployments
+                    // There is a request because of change in sorting.
                     cy.get(priorityColumnHeadingSelector).should('have.class', '-sort-desc');
                     cy.get(
                         `.rt-tr-group:first-child .rt-tr .rt-td:nth-child(5):contains("${priorityLast}")`
@@ -65,7 +65,7 @@ describe('Risk page', () => {
                         'eq',
                         '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=false'
                     );
-                    cy.wait('@deploymentswithprocessinfo'); // assume intercept in visitRiskDeployments
+                    // There is a request because of change in sorting.
                     cy.get(priorityColumnHeadingSelector).should('have.class', '-sort-asc');
                     cy.get(
                         `.rt-tr-group:first-child .rt-tr .rt-td:nth-child(5):contains("${priorityFirst}")`

--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -22,44 +22,57 @@ describe('Risk page', () => {
 
             const priorityColumnHeadingSelector = `${RiskPageSelectors.table.columnHeaders}:contains("Priority")`;
 
-            // Default is not sorted by priority.
-            cy.get(priorityColumnHeadingSelector)
-                .should('not.have.class', '-sort-asc')
-                .should('not.have.class', '-sort-desc');
-
-            // Sort ascending by priority.
-            cy.get(priorityColumnHeadingSelector).click();
-            cy.location('search').should(
-                'eq',
-                '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=false'
-            );
-            // Why no request here?
-            cy.get(priorityColumnHeadingSelector).should('have.class', '-sort-asc');
+            /*
+             * Because risk table displays all deployments on only one page in integration testing environment,
+             * sort descending just reverses the rows so first becomes last, and last becomes first.
+             */
             cy.get(`${RiskPageSelectors.table.dataRows} .rt-td:nth-child(5)`).then(
                 ($priorityCells) => {
-                    const firstCellPriority = Number($priorityCells.eq(0).text());
-                    const lastCellPriority = Number(
-                        $priorityCells.eq($priorityCells.length - 1).text()
-                    );
-                    expect(lastCellPriority).to.be.at.least(firstCellPriority);
-                }
-            );
+                    const priorityFirst = $priorityCells.eq(0).text();
+                    const priorityLast = $priorityCells.eq($priorityCells.length - 1).text();
 
-            // Sort descending by priority.
-            cy.get(priorityColumnHeadingSelector).click();
-            cy.location('search').should(
-                'eq',
-                '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=true'
-            );
-            cy.wait('@deploymentswithprocessinfo'); // assume intercept in visitRiskDeployments
-            cy.get(priorityColumnHeadingSelector).should('have.class', '-sort-desc');
-            cy.get(`${RiskPageSelectors.table.dataRows} .rt-td:nth-child(5)`).then(
-                ($priorityCells) => {
-                    const firstCellPriority = Number($priorityCells.eq(0).text());
-                    const lastCellPriority = Number(
-                        $priorityCells.eq($priorityCells.length - 1).text()
+                    // Initial table state is not sorted by priority.
+                    cy.get(priorityColumnHeadingSelector)
+                        .should('not.have.class', '-sort-asc')
+                        .should('not.have.class', '-sort-desc');
+
+                    // Sort ascending by priority.
+                    cy.get(priorityColumnHeadingSelector).click();
+                    cy.location('search').should(
+                        'eq',
+                        '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=false'
                     );
-                    expect(firstCellPriority).to.be.at.least(lastCellPriority);
+                    // No request because response is sorted ascending.
+
+                    // Sort descending by priority.
+                    cy.get(priorityColumnHeadingSelector).click();
+                    cy.location('search').should(
+                        'eq',
+                        '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=true'
+                    );
+                    cy.wait('@deploymentswithprocessinfo'); // assume intercept in visitRiskDeployments
+                    cy.get(priorityColumnHeadingSelector).should('have.class', '-sort-desc');
+                    cy.get(
+                        `.rt-tr-group:first-child .rt-tr .rt-td:nth-child(5):contains("${priorityLast}")`
+                    );
+                    cy.get(
+                        `.rt-tr-group:last-child .rt-tr .rt-td:nth-child(5):contains("${priorityFirst}")`
+                    );
+
+                    // Sort ascending by priority.
+                    cy.get(priorityColumnHeadingSelector).click();
+                    cy.location('search').should(
+                        'eq',
+                        '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=false'
+                    );
+                    cy.wait('@deploymentswithprocessinfo'); // assume intercept in visitRiskDeployments
+                    cy.get(priorityColumnHeadingSelector).should('have.class', '-sort-asc');
+                    cy.get(
+                        `.rt-tr-group:first-child .rt-tr .rt-td:nth-child(5):contains("${priorityFirst}")`
+                    );
+                    cy.get(
+                        `.rt-tr-group:last-child .rt-tr .rt-td:nth-child(5):contains("${priorityLast}")`
+                    );
                 }
             );
         });


### PR DESCRIPTION
## Description

Although I do not have as clear an explanation as I like, there is timing problem between the test and the UI.

Although the screen grab displays the expected state of UI for descending sort when the assertion failed, the test apparently got values during the previous state of ascending sort, just a moment too soon before re-rendering.

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/2341/pull-ci-stackrox-stackrox-master-gke-ui-e2e-tests/1545393241459789824
![cypress-failure](https://user-images.githubusercontent.com/11862657/178514581-b6816ae4-34b9-44f8-b441-81d048338e21.png)

I confused the risk table in which the number of deployments is predictable with the violations table in which the number of rows is not predictable, when I rewrote this test to replace mock response with real response in #1555

Because risk table displays all deployments on only one page in integration testing environment, it is possible to get expected values for descending sort, therefore cypress can retry to overcome timing problems.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed

Ran test in local deployment