### PR TITLE
Ensure `REACT_APP_ROX_PRODUCT_BRANDING` is set for UI in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -814,6 +814,10 @@ commands:
       - fetch-ui-deps
 
       - run:
+          name: Set branding environment variable
+          command: cci-export ROX_PRODUCT_BRANDING << parameters.branding >>
+
+      - run:
           name: Prepare UI tree state file
           command: |
             git log -n 1 --pretty=format:%H -- ui/ >/tmp/ui-tree-state
@@ -2287,7 +2291,6 @@ jobs:
     resource_class: large
     environment:
       EKS_AUTOMATION_VERSION: 0.2.17
-      REACT_APP_ROX_PRODUCT_BRANDING: RHACS_BRANDING
     steps:
       - pre-build-ui:
           branding: RHACS_BRANDING

--- a/Makefile
+++ b/Makefile
@@ -681,6 +681,10 @@ image-flavor:
 default-image-registry:
 	@echo $(DEFAULT_IMAGE_REGISTRY)
 
+.PHONY: product-branding
+product-branding:
+	@echo $(ROX_PRODUCT_BRANDING)
+
 .PHONY: ossls-audit
 ossls-audit: deps
 	ossls version

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -10,6 +10,8 @@ SOURCES += $(shell find apps -type d \( -name node_modules \) -prune -o -print)
 # tracking package.json files of monorepo packages is the easiest way to discover such situations
 PACKAGE_JSON_FILES := $(shell find . -type d \( -name node_modules \) -prune -false -o -name package.json)
 
+export REACT_APP_ROX_PRODUCT_BRANDING := $(shell $(MAKE) --quiet --no-print-directory -C .. product-branding)
+
 deps: yarn.lock $(PACKAGE_JSON_FILES)
 	yarn install --frozen-lockfile
 	@touch deps


### PR DESCRIPTION
## Description

Ensure `REACT_APP_ROX_PRODUCT_BRANDING` is set for UI build in CI from `ROX_PRODUCT_BRANDING`.

The idea is to use the `ROX_PRODUCT_BRANDING` as the primary one and set `REACT_APP_ROX_PRODUCT_BRANDING` to the equal value. The former is used for the back-end while the latter for UI.

We already use `ROX_PRODUCT_BRANDING` as primary in other places like deriving image flavor in CI.

This should address the issue reported here https://srox.slack.com/archives/CELUQKESC/p1657585769140049 with follow-on conversation here https://srox.slack.com/archives/CELUQKESC/p1657586625489199

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~ not this time.
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ not needed.
- ~~[ ] Determined and documented upgrade steps~~ not needed.
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~ not needed.

## Testing Performed

Local testing:
1. Deploy StackRox on the cluster (doesn't matter which flavor or branding).
2. Start UI as `ROX_PRODUCT_BRANDING=RHACS_BRANDING make start`. See the RHACS branding.
3. Start UI as `make start`. See StackRox branding.

CI:
- ~~[ ] CircleCI produces StackRox-branded image.~~ - it doesn't produce any images.
- ~~[ ] CircleCI produces ACS-branded image.~~ - it doesn't produce any images.
- [x] OSCI produces StackRox-branded image.
- [x] OSCI produces ACS-branded image.