### PR TITLE
CI: Fix tagging

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -829,7 +829,7 @@ openshift_ci_mods() {
 
     # Provide Circle CI vars that are commonly used
     export CIRCLE_JOB="${JOB_NAME:-${OPENSHIFT_BUILD_NAME}}"
-    CIRCLE_TAG="$(git tag --contains --sort=creatordate | tail -1)" || echo "Warning: Cannot get tag"
+    CIRCLE_TAG="$(git tag --sort=creatordate --contains | tail -1)" || echo "Warning: Cannot get tag"
     export CIRCLE_TAG
 
     # For gradle


### PR DESCRIPTION
## Description

I must not have looked at CI for #2367 :shame:

```
2022-07-12T05:28:13.832005250Z error: malformed object name --sort=creatordate
```

`--contains` must be the last arg.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Checking CI is sufficient