### PR TITLE
Consistently display policy YAML in Network Graph

### DIFF
--- a/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/NetworkPoliciesDetail/NetworkPoliciesDetail.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/NetworkPoliciesDetail/NetworkPoliciesDetail.tsx
@@ -53,10 +53,11 @@ function NetworkPoliciesDetail({ policyIds }: NetworkPoliciesDetailProps): React
             )}
             {networkPolicies.map((networkPolicy) => {
                 const { id, name, yaml } = networkPolicy;
+                // text-base restores 12px font size which text-sm overrides in div element for overlay ancestor
                 return (
                     <CollapsibleCard title={name} cardClassName="border border-base-400" key={id}>
                         <div className="p-4 bg-primary-100">
-                            <pre className="font-600 font-sans h-full leading-normal p-3">
+                            <pre className="font-600 h-full leading-normal p-3 text-base whitespace-pre-wrap word-break">
                                 {yaml}
                             </pre>
                         </div>

--- a/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/NetworkPoliciesDetail/NetworkPoliciesDetail.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/NetworkPoliciesDetail/NetworkPoliciesDetail.tsx
@@ -57,7 +57,7 @@ function NetworkPoliciesDetail({ policyIds }: NetworkPoliciesDetailProps): React
                 return (
                     <CollapsibleCard title={name} cardClassName="border border-base-400" key={id}>
                         <div className="p-4 bg-primary-100">
-                            <pre className="font-600 h-full leading-normal p-3 text-base whitespace-pre-wrap word-break">
+                            <pre className="font-600 break-all h-full leading-normal p-3 text-base whitespace-pre-wrap">
                                 {yaml}
                             </pre>
                         </div>

--- a/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/SuccessViewTabs.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/SuccessViewTabs.tsx
@@ -42,7 +42,7 @@ function SuccessViewTabs({
         <Tabs headers={tabs}>
             <Tab>
                 <div className="flex flex-col bg-base-100 overflow-auto h-full">
-                    <pre className="p-3 pt-4 whitespace-pre-wrap word-break">{displayYaml}</pre>
+                    <pre className="p-3 pt-4 break-all whitespace-pre-wrap">{displayYaml}</pre>
                 </div>
             </Tab>
         </Tabs>

--- a/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/SuccessViewTabs.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/SuccessViewTabs.tsx
@@ -42,9 +42,7 @@ function SuccessViewTabs({
         <Tabs headers={tabs}>
             <Tab>
                 <div className="flex flex-col bg-base-100 overflow-auto h-full">
-                    <pre className="p-3 pt-4 leading-tight whitespace-pre-wrap word-break">
-                        {displayYaml}
-                    </pre>
+                    <pre className="p-3 pt-4 whitespace-pre-wrap word-break">{displayYaml}</pre>
                 </div>
             </Tab>
         </Tabs>

--- a/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/SuccessViewTabs.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/SuccessViewTabs.tsx
@@ -42,7 +42,9 @@ function SuccessViewTabs({
         <Tabs headers={tabs}>
             <Tab>
                 <div className="flex flex-col bg-base-100 overflow-auto h-full">
-                    <pre className="p-3 pt-4 break-all whitespace-pre-wrap">{displayYaml}</pre>
+                    <pre className="p-3 pt-4 break-all leading-normal whitespace-pre-wrap">
+                        {displayYaml}
+                    </pre>
                 </div>
             </Tab>
         </Tabs>


### PR DESCRIPTION
## Description

Independent of possible future change to PatternFly elements:
* Identify location of the inconsistencies in UI code
* Fix the problems in classic style

### NetworkPoliciesDetail

Computed styles:

font-family "Open Sans", -apple-system, "system-ui", "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif
font-size 11px
font-style normal
font-weight 600
line-height 16.5px
white-space pre
word-break normal

https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/NetworkPoliciesDetail/NetworkPoliciesDetail.tsx

```js
                        <div className="p-4 bg-primary-100">
                            <pre className="font-600 font-sans h-full leading-normal p-3">
                                {yaml}
                            </pre>
                        </div>
```

1. Delete `font-sans` which overrides monospace value of `font-family` for `pre` element
2. Add `text-base` to restore 12px font size which `text-sm` overrides in `div` element for overlay ancestor
3. Add `whitespace-pre-wrap` for consistency with the following component
    * https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
        > Sequences of white space are preserved. Lines are broken at newline characters, at `<br>`, and as necessary to fill line boxes.
4. Add `break-all` in case of long lines which might otherwise overflow
    * https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
        > To prevent overflow, word breaks should be inserted between any two characters (excluding Chinese/Japanese/Korean text).

### SuccessViewTabs

Computed styles:

font-family Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace
font-size 12px
font-style normal
font-weight 600
line-height 15px
white-space pre-wrap
word-break break-word

https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/SuccessViewTabs.tsx

```js
                <div className="flex flex-col bg-base-100 overflow-auto h-full">
                    <pre className="p-3 pt-4 leading-tight whitespace-pre-wrap word-break">
                        {displayYaml}
                    </pre>
                </div>
```

1. Replace `word-break` with `break-all` in case of long lines which might otherwise overflow
2. Replace `leading-tight` with `leading-normal` for consistency with the preceding component

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### NetworkPoliciesDetail

1. Visit /main/network
2. Click a deployment node
3. Click **Network Policies**
4. Click **Download YAML File**

Inconsistent style before changes
![NetworkPoliciesDetail-inconsistent](https://user-images.githubusercontent.com/11862657/178576776-532c7ebd-d764-492e-bd01-f36a3e13047a.png)

Consistent style after changes
![NetworkPoliciesDetail-consistent](https://user-images.githubusercontent.com/11862657/178576797-dcd0b140-f74a-4a9c-8d3f-dc794ad37bdf.png)

### SuccessViewTabs

1. Visit /main/network
2. Click **Network Policy Simulator**
3. Click **Upload and Simulate Network Policy YAML**
4. Select sensor.yaml which had been downloaded in step 4 above

Inconsistent style before changes
![SuccessViewTabs-inconsistent](https://user-images.githubusercontent.com/11862657/178576816-e4b2eb00-b241-4cac-a6c3-4ac22f0510df.png)

Consistent style after changes
![SuccessViewTabs-consistent](https://user-images.githubusercontent.com/11862657/178576860-e0648797-de35-4751-9893-eabed696006f.png)