### PR TITLE
ROX-11633, ROX-11634, ROX-11635: Changing Top Riskiest Images/Nodes widget in VM to Top Riskiest Image/Node Vulns

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
@@ -62,7 +62,7 @@ const TOP_RISKIEST_IMAGES = gql`
 
 const TOP_RISKIEST_IMAGE_VULNERABILITIES = gql`
     query topRiskiestImageVulnerabilities($query: String, $pagination: Pagination) {
-        results: imageVulnerabilities(query: $query, pagination: $pagination) {
+        results: images(query: $query, pagination: $pagination) {
             id
             name {
                 fullName

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
@@ -61,13 +61,13 @@ const TOP_RISKIEST_IMAGES = gql`
 `;
 
 const TOP_RISKIEST_IMAGE_VULNS = gql`
-    query topRiskiestImages($query: String, $pagination: Pagination) {
-        results: imageVulnerabilityCounter(query: $query, pagination: $pagination) {
+    query topRiskiestImageVulns($query: String, $pagination: Pagination) {
+        results: images(query: $query, pagination: $pagination) {
             id
             name {
                 fullName
             }
-            vulnCounter {
+            vulnCounter: imageVulnerabilityCounter {
                 all {
                     total
                     fixable
@@ -168,11 +168,11 @@ const TOP_RISKIEST_NODES = gql`
 `;
 
 const TOP_RISKIEST_NODE_VULNS = gql`
-    query topRiskiestNodes($query: String, $pagination: Pagination) {
-        results: nodeVulnerabilityCounter(query: $query, pagination: $pagination) {
+    query topRiskiestNodeVulns($query: String, $pagination: Pagination) {
+        results: nodes(query: $query, pagination: $pagination) {
             id
             name
-            vulnCounter {
+            vulnCounter: nodeVulnerabilityCounter {
                 all {
                     total
                     fixable

--- a/ui/apps/platform/src/constants/sortFields.js
+++ b/ui/apps/platform/src/constants/sortFields.js
@@ -279,6 +279,8 @@ export const entitySortFieldsMap = {
     [entityTypes.CVE]: cveSortFields,
     [entityTypes.POLICY]: policySortFields,
     [entityTypes.NODE]: nodeSortFields,
-    [entityTypes.IMAGE_CVE]: cveSortFields,
     [entityTypes.NODE_CVE]: cveSortFields,
+    [entityTypes.NODE_COMPONENT]: componentSortFields,
+    [entityTypes.IMAGE_CVE]: cveSortFields,
+    [entityTypes.IMAGE_COMPONENT]: componentSortFields,
 };

--- a/ui/apps/platform/src/constants/sortFields.js
+++ b/ui/apps/platform/src/constants/sortFields.js
@@ -279,4 +279,6 @@ export const entitySortFieldsMap = {
     [entityTypes.CVE]: cveSortFields,
     [entityTypes.POLICY]: policySortFields,
     [entityTypes.NODE]: nodeSortFields,
+    [entityTypes.IMAGE_CVE]: cveSortFields,
+    [entityTypes.NODE_CVE]: cveSortFields,
 };


### PR DESCRIPTION
## Description

I changed:
*  `Top Riskiest Images` widget query to use the `imageVulnerabilityCounter`
* 
<img width="546" alt="image" src="https://user-images.githubusercontent.com/10412893/179110193-5000e979-c7c5-480e-98a5-41f7ed0b2bce.png">

*  `Top Riskiest Nodes` widget query to use the 'nodeVulnerabilityCounter`
* 
<img width="544" alt="image" src="https://user-images.githubusercontent.com/10412893/179110442-22b5d5a9-afaf-45b7-a60e-f957e1e2de85.png">

* added `Top Riskiest Image Components` to the widget behind a feature flag
* 
<img width="548" alt="image" src="https://user-images.githubusercontent.com/10412893/179111018-f6524da2-c14a-4396-bdfb-47addbd76186.png">

* added links from said widget to the image component page
* added links from said widget to the image component/image cves page
* added `Top Riskiest Node Components` to the widget behind a feature flag
* 
<img width="554" alt="image" src="https://user-images.githubusercontent.com/10412893/179110795-e942e2ff-0799-48af-ad10-fd3007e899d6.png">

* added links from said widget to the node component page
* added links from said widget to the node component/node cves page


## Checklist
- [x] Investigated and inspected CI test results (failing tests fixed in Van's current PR)

If any of these don't apply, please comment below.

## Testing Performed

Manual testing