### PR TITLE
Don't send more events once deletion timestamp has been set

### DIFF
--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -55,6 +55,10 @@ func (d *deploymentDispatcherImpl) ProcessEvent(obj, oldObj interface{}, action 
 		return nil
 	}
 
+	// If GetDeletionTimestamp is set, then
+	if metaObj.GetDeletionTimestamp() != nil {
+		action = central.ResourceAction_REMOVE_RESOURCE
+	}
 	if action == central.ResourceAction_REMOVE_RESOURCE {
 		d.handler.hierarchy.Remove(string(metaObj.GetUID()))
 		return d.handler.processWithType(obj, oldObj, action, d.deploymentType)


### PR DESCRIPTION
## Description

Pod deletion workflow is as follows

UPDATE
```
6c6
<     "resourceVersion": "28821",
---
>     "resourceVersion": "28866",
7a8,9
>     "deletionTimestamp": "2022-07-12T23:56:13Z",
>     "deletionGracePeriodSeconds": 30,
```

UPDATE

```
6c6
<     "resourceVersion": "28866",
---
>     "resourceVersion": "28868",
15,16c15,16
<       "cni.projectcalico.org/podIP": "10.37.162.18/32",
<       "cni.projectcalico.org/podIPs": "10.37.162.18/32"
---
>       "cni.projectcalico.org/podIP": "",
>       "cni.projectcalico.org/podIPs": ""
```

UPDATE
```
6c6
<     "resourceVersion": "28868",
---
>     "resourceVersion": "28873",
74c74
<         "time": "2022-07-12T23:55:36Z",
---
>         "time": "2022-07-12T23:55:44Z",
82a83,84
>                 "f:message": {},
>                 "f:reason": {},
96a99,100
>                 "f:message": {},
>                 "f:reason": {},
104,111d107
<             "f:podIP": {},
<             "f:podIPs": {
<               ".": {},
<               "k:{\"ip\":\"10.37.162.18\"}": {
<                 ".": {},
<                 "f:ip": {}
<               }
<             },
213c209
<         "status": "True",
---
>         "status": "False",
215c211,213
<         "lastTransitionTime": "2022-07-12T23:55:36Z"
---
>         "lastTransitionTime": "2022-07-12T23:55:44Z",
>         "reason": "ContainersNotReady",
>         "message": "containers with unready status: [nginx]"
219c217
<         "status": "True",
---
>         "status": "False",
221c219,221
<         "lastTransitionTime": "2022-07-12T23:55:36Z"
---
>         "lastTransitionTime": "2022-07-12T23:55:44Z",
>         "reason": "ContainersNotReady",
>         "message": "containers with unready status: [nginx]"
231,236d230
<     "podIP": "10.37.162.18",
<     "podIPs": [
<       {
<         "ip": "10.37.162.18"
<       }
<     ],
242,243c236,237
<           "running": {
<             "startedAt": "2022-07-12T23:55:35Z"
---
>           "waiting": {
>             "reason": "ContainerCreating"
246,247c240,249
<         "lastState": {},
<         "ready": true,
---
>         "lastState": {
>           "terminated": {
>             "exitCode": 137,
>             "reason": "ContainerStatusUnknown",
>             "message": "The container could not be located when the pod was deleted.  The container used to be Running",
>             "startedAt": null,
>             "finishedAt": null
>           }
>         },
>         "ready": false,
249,252c251,253
<         "image": "nginx:latest",
<         "imageID": "docker-pullable://nginx@sha256:dbe677093f569cc0afe2a149c529645f255aac959490ef11fb19ac6418b815d3",
<         "containerID": "docker://c547faec934393e8ec2e9450f8c49ae53ea75bf45bb763aa54594d9fd49887b5",
<         "started": true
---
>         "image": "nginx",
>         "imageID": "",
>         "started": false
```

UPDATE
```
6c6
<     "resourceVersion": "28873",
---
>     "resourceVersion": "28919",
8,9c8,9
<     "deletionTimestamp": "2022-07-12T23:56:13Z",
<     "deletionGracePeriodSeconds": 30,
---
>     "deletionTimestamp": "2022-07-12T23:55:43Z",
>     "deletionGracePeriodSeconds": 0,
```

REMOVE EVENT

This ends up making its way to Central because we are modifying running containers which we track. This will reduce the number of update events to pods

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI and metrics check