### PR TITLE
Build OS clusters for RCs in version 4.10 instead of 4.7

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -323,6 +323,7 @@ jobs:
     with:
       flavor: openshift-4-demo
       name: openshift-4-demo-${{needs.variables.outputs.milestone}}
+      args: openshift-version=ocp/stable-4.10
       lifespan: 48h
       wait: true
 


### PR DESCRIPTION
## Description

The default version in infra is `4.7`, so lets try the newest stable release instead.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

- None, I just use this param personally, so I copied it.