### PR TITLE
CI: Fix slack notice II

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1026,6 +1026,7 @@ send_slack_notice_for_failures_on_merge() {
 
     local commit_msg
     commit_msg=$(jq -r <<<"$commit_details" '.commit.message') || return 1
+    commit_msg="${commit_msg%%$'\n'*}" # use first line of commit msg
     local commit_url
     commit_url=$(jq -r <<<"$commit_details" '.html_url') || return 1
     local author

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1061,10 +1061,10 @@ send_slack_notice_for_failures_on_merge() {
 '
 
     echo "About to post:"
-    jq --arg job_name "$job_name" --arg commit_url "$commit_url" --arg commit_msg "$commit_msg" \
+    jq --null-input --arg job_name "$job_name" --arg commit_url "$commit_url" --arg commit_msg "$commit_msg" \
        --arg repo "$repo" --arg author "$author" --arg log_url "$log_url" "$body"
 
-    jq --arg job_name "$job_name" --arg commit_url "$commit_url" --arg commit_msg "$commit_msg" \
+    jq --null-input --arg job_name "$job_name" --arg commit_url "$commit_url" --arg commit_msg "$commit_msg" \
        --arg repo "$repo" --arg author "$author" --arg log_url "$log_url" "$body" | \
     curl -XPOST -d @- -H 'Content-Type: application/json' "$webhook_url"
 }

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1049,7 +1049,7 @@ send_slack_notice_for_failures_on_merge() {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "*Commit:* <$commit_url|$commit_msg>\n*Author:* $author\n*Log:* $log_url"
+                "text": "*Commit:* <$commit_url|$commit_msg>\n*Repo:* $repo\n*Author:* $author\n*Log:* $log_url"
             }
         },
 		{

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1060,9 +1060,8 @@ send_slack_notice_for_failures_on_merge() {
 }
 '
 
-    echo "$body" | \
     jq --arg job_name "$job_name" --arg commit_url "$commit_url" --arg commit_msg "$commit_msg" \
-       --arg repo "$repo" --arg author "$author" --arg log_url "$log_url" | \
+       --arg repo "$repo" --arg author "$author" --arg log_url "$log_url" "$body" | \
     curl -XPOST -d @- -H 'Content-Type: application/json' "$webhook_url"
 }
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1037,20 +1037,20 @@ send_slack_notice_for_failures_on_merge() {
     # shellcheck disable=SC2016
     local body='
 {
-    "text": "*Job Name:* $job_name",
+    "text": "*Job Name:* \($job_name)",
     "blocks": [
 		{
 			"type": "header",
 			"text": {
 				"type": "plain_text",
-				"text": "Prow job failure: $job_name"
+				"text": "Prow job failure: \($job_name)"
 			}
 		},
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "*Commit:* <$commit_url|$commit_msg>\n*Repo:* $repo\n*Author:* $author\n*Log:* $log_url"
+                "text": "*Commit:* <\($commit_url)|\($commit_msg)>\n*Repo:* \($repo)\n*Author:* \($author)\n*Log:* \($log_url)"
             }
         },
 		{

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1060,6 +1060,10 @@ send_slack_notice_for_failures_on_merge() {
 }
 '
 
+    echo "About to post:"
+    jq --arg job_name "$job_name" --arg commit_url "$commit_url" --arg commit_msg "$commit_msg" \
+       --arg repo "$repo" --arg author "$author" --arg log_url "$log_url" "$body"
+
     jq --arg job_name "$job_name" --arg commit_url "$commit_url" --arg commit_msg "$commit_msg" \
        --arg repo "$repo" --arg author "$author" --arg log_url "$log_url" "$body" | \
     curl -XPOST -d @- -H 'Content-Type: application/json' "$webhook_url"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1002,18 +1002,17 @@ store_test_results() {
 send_slack_notice_for_failures_on_merge() {
     local exitstatus="${1:-}"
 
-    # if ! is_OPENSHIFT_CI || [[ "$exitstatus" == "0" ]] || is_in_PR_context || is_nightly_run; then
-    #     return 0
-    # fi
+    if ! is_OPENSHIFT_CI || [[ "$exitstatus" == "0" ]] || is_in_PR_context || is_nightly_run; then
+        return 0
+    fi
 
-    # local tag
-    # tag="$(make --quiet tag)"
-    # if [[ "$tag" =~ $RELEASE_RC_TAG_BASH_REGEX ]]; then
-    #     return 0
-    # fi
+    local tag
+    tag="$(make --quiet tag)"
+    if [[ "$tag" =~ $RELEASE_RC_TAG_BASH_REGEX ]]; then
+        return 0
+    fi
 
-    # local webhook_url="${TEST_FAILURES_NOTIFY_WEBHOOK}"
-    local webhook_url="${SLACK_MAIN_WEBHOOK}"
+    local webhook_url="${TEST_FAILURES_NOTIFY_WEBHOOK}"
 
     local commit_details
     org=$(jq -r <<<"$CLONEREFS_OPTIONS" '.refs[0].org') || return 1

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1034,16 +1034,16 @@ send_slack_notice_for_failures_on_merge() {
 
     local log_url="https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/${JOB_NAME}/${BUILD_ID}"
 
-    local body
-    body=$(cat <<_EOB_
+    # shellcheck disable=SC2016
+    local body='
 {
-    "text": "*Job Name:* \$job_name",
+    "text": "*Job Name:* $job_name",
     "blocks": [
 		{
 			"type": "header",
 			"text": {
 				"type": "plain_text",
-				"text": "Prow job failure: \$job_name"
+				"text": "Prow job failure: $job_name"
 			}
 		},
         {
@@ -1058,11 +1058,11 @@ send_slack_notice_for_failures_on_merge() {
 		}
     ]
 }
-_EOB_
-    )
+'
 
     echo "$body" | \
-    jq --arg job_name "$job_name" | \
+    jq --arg job_name "$job_name" --arg commit_url "$commit_url" --arg commit_msg "$commit_msg" \
+       --arg repo "$repo" --arg author "$author" --arg log_url "$log_url" | \
     curl -XPOST -d @- -H 'Content-Type: application/json' "$webhook_url"
 }
 


### PR DESCRIPTION
## Description

It fails due to some multi-line commit messages:
`parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 17, column 217`

This PR only uses the first line of a commit message in the slack notice, uses `--arg` for other escaping, and adds the repo to the notice to disambiguate rox -v- scanner.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] - Force failure with prior state: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/stackrox_stackrox/2403/pull-ci-stackrox-stackrox-master-integration-unit-tests/1547647449772855296/artifacts/integration-unit-tests/stackrox-initial/build-log.txt
