### PR TITLE
CI: Fix the upgrader version in nightlies

### DIFF
--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -30,7 +30,7 @@ case "$ci_job" in
 esac
 
 if [[ "$ci_job" =~ e2e|upgrade ]]; then
-    handle_nightly_roxctl_mismatch
+    handle_nightly_binary_version_mismatch
 fi
 
 export PYTHONPATH="${PYTHONPATH:-}:.openshift-ci"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -915,7 +915,7 @@ handle_nightly_runs() {
     fi
 }
 
-handle_nightly_roxctl_mismatch() {
+handle_nightly_binary_version_mismatch() {
     if ! is_OPENSHIFT_CI; then
         die "Only for OpenShift CI"
     fi
@@ -934,11 +934,11 @@ handle_nightly_roxctl_mismatch() {
         echo "JOB_NAME_SAFE: ${JOB_NAME_SAFE:-}"
     fi
 
-    info "Correcting roxctl version for nightly e2e tests"
+    info "Correcting binary versions for nightly e2e tests"
     echo "Current roxctl is: $(command -v roxctl || true), version: $(roxctl version || true)"
 
     if ! [[ "$(roxctl version || true)" =~ nightly-$(date '+%Y%m%d') ]]; then
-        make cli-build
+        make cli-build upgrader
         install_built_roxctl_in_gopath
         echo "Replacement roxctl is: $(command -v roxctl || true), version: $(roxctl version || true)"
     fi


### PR DESCRIPTION
## Description

Similar to the reason for rebuilding roxctl in nightlies we also need to rebuild upgrader to get the nightly tag.

Note: there is a lot of whack-a-mole around getting 'nightlies' to function in OpenShift CI in the same manner as Circle CI. We may need to revisit the mechanism.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient to ensure there is no regression with PR/merge CI. 