### PR TITLE
ROX-11767: Client side crash when viewing Image -> CVE (#2404)

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtEntityCve.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtEntityCve.js
@@ -3,7 +3,7 @@ import { gql } from '@apollo/client';
 
 import { workflowEntityPropTypes, workflowEntityDefaultProps } from 'constants/entityPageProps';
 import useCases from 'constants/useCaseTypes';
-import entityTypes from 'constants/entityTypes';
+import entityTypes, { resourceTypes } from 'constants/entityTypes';
 import { defaultCountKeyMap } from 'constants/workflowPages.constants';
 import workflowStateContext from 'Containers/workflowStateContext';
 import {
@@ -22,6 +22,13 @@ import {
     getScopeQuery,
 } from '../VulnMgmtPolicyQueryUtil';
 
+const validCVETypes = [
+    resourceTypes.CVE,
+    resourceTypes.IMAGE_CVE,
+    resourceTypes.NODE_CVE,
+    resourceTypes.CLUSTER_CVE,
+];
+
 const vulnQueryMap = {
     CVE: 'vulnerability',
     IMAGE_CVE: 'imageVulnerability',
@@ -35,9 +42,20 @@ const vulnFieldMap = {
     CLUSTER_CVE: CLUSTER_CVE_DETAIL_FRAGMENT,
 };
 
+function getCVETypeFromStack(worklowStateStack) {
+    const cveTypes = worklowStateStack.filter((state) => {
+        return validCVETypes.includes(state.t);
+    });
+    if (cveTypes.length) {
+        return cveTypes[0].t;
+    }
+    return undefined;
+}
+
 const VulmMgmtCve = ({ entityId, entityListType, search, entityContext, sort, page }) => {
     const workflowState = useContext(workflowStateContext);
-    const cveType = workflowState.getBaseEntityType() || entityTypes.IMAGE_CVE;
+    const worklowStateStack = workflowState.getStateStack();
+    const cveType = getCVETypeFromStack(worklowStateStack) || entityTypes.IMAGE_CVE;
     const vulnQuery = vulnQueryMap[cveType];
     const vulnFields = vulnFieldMap[cveType];
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
@@ -44,7 +44,7 @@ function DeferredCVEs({ imageId }: DeferredCVEsProps): ReactElement {
     });
 
     const itemCount = data?.image?.vulnCount || 0;
-    const rows = data?.image?.imageVulnerabilities || [];
+    const rows = data?.image?.vulns || [];
 
     return (
         <DeferredCVEsTable

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
@@ -238,9 +238,7 @@ function DeferredCVEsTable({
                                         )}
                                     </Td>
                                     <Td dataLabel="Affected components">
-                                        <AffectedComponentsButton
-                                            components={row.imageComponents}
-                                        />
+                                        <AffectedComponentsButton components={row.components} />
                                     </Td>
                                     <Td dataLabel="Comments">
                                         {row.vulnerabilityRequest ? (

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
@@ -44,7 +44,7 @@ function FalsePositiveCVEs({ imageId }: FalsePositiveCVEsProps): ReactElement {
     });
 
     const itemCount = data?.image?.vulnCount || 0;
-    const rows = data?.image?.imageVulnerabilities || [];
+    const rows = data?.image?.vulns || [];
 
     return (
         <FalsePositiveCVEsTable

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
@@ -223,9 +223,7 @@ function FalsePositiveCVEsTable({
                                         />
                                     </Td>
                                     <Td dataLabel="Affected components">
-                                        <AffectedComponentsButton
-                                            components={row.imageComponents}
-                                        />
+                                        <AffectedComponentsButton components={row.components} />
                                     </Td>
                                     <Td dataLabel="Comments">
                                         <RequestCommentsButton

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
@@ -44,7 +44,7 @@ function ObservedCVEs({ imageId }: ObservedCVEsProps): ReactElement {
     });
 
     const itemCount = data?.image?.vulnCount || 0;
-    const rows = data?.image?.imageVulnerabilities || [];
+    const rows = data?.image?.vulns || [];
     const registry = data?.image?.name?.registry || '';
     const remote = data?.image?.name?.remote || '';
     const tag = data?.image?.name?.tag || '';

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
@@ -279,9 +279,7 @@ function ObservedCVEsTable({
                                         <CVSSScoreLabel cvss={row.cvss} />
                                     </Td>
                                     <Td dataLabel="Affected components">
-                                        <AffectedComponentsButton
-                                            components={row.imageComponents}
-                                        />
+                                        <AffectedComponentsButton components={row.components} />
                                     </Td>
                                     <Td dataLabel="Discovered">
                                         <DateTimeFormat time={row.discoveredAtImage} />

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/imageVulnerabilities.graphql.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/imageVulnerabilities.graphql.ts
@@ -29,7 +29,7 @@ export type Vulnerability = {
     cvss: string;
     scoreVersion: string;
     discoveredAtImage: string;
-    imageComponents: EmbeddedImageScanComponent[];
+    components: EmbeddedImageScanComponent[];
     vulnerabilityRequest: VulnerabilityRequest;
 };
 
@@ -49,7 +49,7 @@ export type GetImageVulnerabilitiesData = {
             tag: string;
         };
         vulnCount: number;
-        imageVulnerabilities: Vulnerability[];
+        vulns: Vulnerability[];
     };
 };
 
@@ -76,7 +76,7 @@ export const GET_IMAGE_VULNERABILITIES = gql`
                 tag
             }
             vulnCount(query: $vulnsQuery)
-            imageVulnerabilities(query: $vulnsQuery, pagination: $pagination) {
+            vulns(query: $vulnsQuery, pagination: $pagination) {
                 id
                 cve
                 isFixable
@@ -84,7 +84,7 @@ export const GET_IMAGE_VULNERABILITIES = gql`
                 scoreVersion
                 cvss
                 discoveredAtImage
-                imageComponents {
+                components {
                     id
                     name
                     version

--- a/ui/apps/platform/src/utils/WorkflowState.js
+++ b/ui/apps/platform/src/utils/WorkflowState.js
@@ -248,6 +248,10 @@ export class WorkflowState {
         return new WorkflowState(useCase, newStateStack, newSearch, newSort, newPaging);
     }
 
+    getStateStack() {
+        return this.stateStack;
+    }
+
     // Resets the current state based on minimal parameters
     reset(useCase, entityType, entityId, search, sort, paging) {
         const newUseCase = useCase || this.useCase;


### PR DESCRIPTION
## Description

We ended up using some of the new fields for the Image Findings section without the feature flag on and it was causing some issues. This PR fixes that and also a few other fixes to get it all working again.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

1. Navigate to Vuln Mgmt Dashboard -> Images -> a single image -> Click CVE name

https://user-images.githubusercontent.com/4805485/178845679-399711c8-8ed3-4a38-ad8a-903270ac8612.mov


