### PR TITLE
Dashrews rox 11771 turnoff migrations when postgres for now

### DIFF
--- a/central/version/ensure_test.go
+++ b/central/version/ensure_test.go
@@ -39,9 +39,12 @@ func (suite *EnsurerTestSuite) SetupTest() {
 		source := pgtest.GetConnectionString(suite.T())
 		config, err := pgxpool.ParseConfig(source)
 		suite.Require().NoError(err)
-		pool, err := pgxpool.ConnectConfig(sac.WithAllAccess(context.Background()), config)
+		ctx := sac.WithAllAccess(context.Background())
+		pool, err := pgxpool.ConnectConfig(ctx, config)
 		suite.pool = pool
 
+		// Ensure we are starting fresh
+		postgres.Destroy(ctx, pool)
 		suite.versionStore = store.NewPostgres(pool)
 	} else {
 		boltDB, err := bolthelper.NewTemp(testutils.DBFileName(suite))

--- a/central/version/ensure_test.go
+++ b/central/version/ensure_test.go
@@ -1,13 +1,19 @@
 package version
 
 import (
+	"context"
 	"testing"
 
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/central/version/store"
+	"github.com/stackrox/rox/central/version/store/postgres"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/bolthelper"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/migrations"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
 	"github.com/stretchr/testify/suite"
@@ -23,28 +29,50 @@ type EnsurerTestSuite struct {
 
 	boltDB       *bolt.DB
 	rocksDB      *rocksdb.RocksDB
+	pgStore      postgres.Store
+	pool         *pgxpool.Pool
 	versionStore store.Store
 }
 
 func (suite *EnsurerTestSuite) SetupTest() {
-	boltDB, err := bolthelper.NewTemp(testutils.DBFileName(suite))
-	suite.Require().NoError(err, "Failed to make BoltDB")
+	if features.PostgresDatastore.Enabled() {
+		source := pgtest.GetConnectionString(suite.T())
+		config, err := pgxpool.ParseConfig(source)
+		suite.Require().NoError(err)
+		pool, err := pgxpool.ConnectConfig(sac.WithAllAccess(context.Background()), config)
+		suite.pool = pool
 
-	rocksDB := rocksdbtest.RocksDBForT(suite.T())
-	suite.Require().NoError(err, "Failed to create RocksDB")
+		suite.versionStore = store.NewPostgres(pool)
+	} else {
+		boltDB, err := bolthelper.NewTemp(testutils.DBFileName(suite))
+		suite.Require().NoError(err, "Failed to make BoltDB")
 
-	suite.boltDB = boltDB
-	suite.rocksDB = rocksDB
-	suite.versionStore = store.New(boltDB, rocksDB)
+		rocksDB := rocksdbtest.RocksDBForT(suite.T())
+		suite.Require().NoError(err, "Failed to create RocksDB")
+
+		suite.boltDB = boltDB
+		suite.rocksDB = rocksDB
+
+		suite.versionStore = store.New(boltDB, rocksDB)
+	}
 }
 
 func (suite *EnsurerTestSuite) TearDownTest() {
-	suite.NoError(suite.boltDB.Close())
+	if features.PostgresDatastore.Enabled() {
+		if suite.pool != nil {
+			suite.pool.Close()
+		}
+	} else {
+		suite.NoError(suite.boltDB.Close())
+	}
 }
 
 func (suite *EnsurerTestSuite) TestWithEmptyDB() {
-
-	suite.NoError(Ensure(store.New(suite.boltDB, suite.rocksDB)))
+	if features.PostgresDatastore.Enabled() {
+		suite.NoError(Ensure(store.NewPostgres(suite.pool)))
+	} else {
+		suite.NoError(Ensure(store.New(suite.boltDB, suite.rocksDB)))
+	}
 	version, err := suite.versionStore.GetVersion()
 	suite.NoError(err)
 	suite.Equal(migrations.CurrentDBVersionSeqNum(), int(version.GetSeqNum()))
@@ -52,7 +80,11 @@ func (suite *EnsurerTestSuite) TestWithEmptyDB() {
 
 func (suite *EnsurerTestSuite) TestWithCurrentVersion() {
 	suite.NoError(suite.versionStore.UpdateVersion(&storage.Version{SeqNum: int32(migrations.CurrentDBVersionSeqNum())}))
-	suite.NoError(Ensure(store.New(suite.boltDB, suite.rocksDB)))
+	if features.PostgresDatastore.Enabled() {
+		suite.NoError(Ensure(store.NewPostgres(suite.pool)))
+	} else {
+		suite.NoError(Ensure(store.New(suite.boltDB, suite.rocksDB)))
+	}
 
 	version, err := suite.versionStore.GetVersion()
 	suite.NoError(err)
@@ -61,5 +93,9 @@ func (suite *EnsurerTestSuite) TestWithCurrentVersion() {
 
 func (suite *EnsurerTestSuite) TestWithIncorrectVersion() {
 	suite.NoError(suite.versionStore.UpdateVersion(&storage.Version{SeqNum: int32(migrations.CurrentDBVersionSeqNum()) - 2}))
-	suite.Error(Ensure(store.New(suite.boltDB, suite.rocksDB)))
+	if features.PostgresDatastore.Enabled() {
+		suite.Error(Ensure(store.NewPostgres(suite.pool)))
+	} else {
+		suite.Error(Ensure(store.New(suite.boltDB, suite.rocksDB)))
+	}
 }

--- a/central/version/store/store_impl_test.go
+++ b/central/version/store/store_impl_test.go
@@ -1,12 +1,18 @@
 package store
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/central/version/store/postgres"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/bolthelper"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
 	"github.com/stretchr/testify/suite"
 	"github.com/tecbot/gorocksdb"
@@ -22,23 +28,44 @@ type VersionStoreTestSuite struct {
 
 	boltDB  *bolt.DB
 	rocksDB *rocksdb.RocksDB
+	pgStore postgres.Store
+	pool    *pgxpool.Pool
+	ctx     context.Context
 	store   Store
 }
 
 func (suite *VersionStoreTestSuite) SetupTest() {
-	boltDB, err := bolthelper.NewTemp(suite.T().Name() + ".db")
-	suite.Require().NoError(err, "Failed to make BoltDB")
+	if features.PostgresDatastore.Enabled() {
+		source := pgtest.GetConnectionString(suite.T())
+		config, err := pgxpool.ParseConfig(source)
+		suite.Require().NoError(err)
+		suite.ctx = sac.WithAllAccess(context.Background())
+		pool, err := pgxpool.ConnectConfig(suite.ctx, config)
+		suite.pool = pool
 
-	rocksDB := rocksdbtest.RocksDBForT(suite.T())
+		suite.store = NewPostgres(pool)
+	} else {
+		boltDB, err := bolthelper.NewTemp(suite.T().Name() + ".db")
+		suite.Require().NoError(err, "Failed to make BoltDB")
 
-	suite.boltDB = boltDB
-	suite.rocksDB = rocksDB
-	suite.store = New(boltDB, rocksDB)
+		rocksDB := rocksdbtest.RocksDBForT(suite.T())
+
+		suite.boltDB = boltDB
+		suite.rocksDB = rocksDB
+		suite.store = New(boltDB, rocksDB)
+	}
 }
 
 func (suite *VersionStoreTestSuite) TearDownTest() {
-	suite.NoError(suite.boltDB.Close())
-	suite.rocksDB.Close()
+	if features.PostgresDatastore.Enabled() {
+		postgres.Destroy(suite.ctx, suite.pool)
+		if suite.pool != nil {
+			suite.pool.Close()
+		}
+	} else {
+		suite.NoError(suite.boltDB.Close())
+		suite.rocksDB.Close()
+	}
 }
 
 func (suite *VersionStoreTestSuite) TestVersionStore() {
@@ -56,6 +83,10 @@ func (suite *VersionStoreTestSuite) TestVersionStore() {
 }
 
 func (suite *VersionStoreTestSuite) TestVersionMismatch() {
+	if features.PostgresDatastore.Enabled() {
+		suite.T().Skip("Skip TestVersionMismatch as it does not apply to Postgres")
+		suite.T().SkipNow()
+	}
 	boltVersion := &storage.Version{SeqNum: 2, Version: "Version 2"}
 	boltVersionBytes, err := boltVersion.Marshal()
 	suite.Require().NoError(err)

--- a/migrator/main.go
+++ b/migrator/main.go
@@ -81,7 +81,7 @@ func run() error {
 			return errors.Wrap(err, "failed to connect to postgres DB")
 		}
 		pkgSchema.ApplyAllSchemas(context.Background(), gormDB)
-		log.WriteToStderr("Used gorm to apply schemas")
+		log.WriteToStderr("Applied all table schemas.")
 	}
 
 	return nil

--- a/migrator/main.go
+++ b/migrator/main.go
@@ -56,32 +56,34 @@ func run() error {
 		return nil
 	}
 
-	dbm, err := replica.Scan(migrations.DBMountPath(), conf.Maintenance.ForceRollbackVersion)
-	if err != nil {
-		return errors.Wrap(err, "fail to scan replicas")
-	}
+	// TODO: ROX-9884, ROX-10700 -- turn off replicas and migrations until Postgres updates complete.
+	if !features.PostgresDatastore.Enabled() {
+		dbm, err := replica.Scan(migrations.DBMountPath(), conf.Maintenance.ForceRollbackVersion)
+		if err != nil {
+			return errors.Wrap(err, "fail to scan replicas")
+		}
 
-	replica, replicaPath, err := dbm.GetReplicaToMigrate()
-	if err != nil {
-		return err
-	}
-	option.MigratorOptions.DBPathBase = replicaPath
-	if err = upgrade(conf); err != nil {
-		return err
-	}
-
-	if features.PostgresDatastore.Enabled() {
+		replicaName, replicaPath, err := dbm.GetReplicaToMigrate()
+		if err != nil {
+			return err
+		}
+		option.MigratorOptions.DBPathBase = replicaPath
+		if err = upgrade(conf); err != nil {
+			return err
+		}
+		if err = dbm.Persist(replicaName); err != nil {
+			return err
+		}
+	} else {
 		var gormDB *gorm.DB
-		gormDB, err = postgreshelper.Load(conf)
+		gormDB, err := postgreshelper.Load(conf)
 		if err != nil {
 			return errors.Wrap(err, "failed to connect to postgres DB")
 		}
 		pkgSchema.ApplyAllSchemas(context.Background(), gormDB)
+		log.WriteToStderr("Used gorm to apply schemas")
 	}
 
-	if err = dbm.Persist(replica); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/migrator/postgreshelper/load.go
+++ b/migrator/postgreshelper/load.go
@@ -55,6 +55,8 @@ func Load(conf *config.Config) (*gorm.DB, error) {
 
 		if err != nil {
 			log.WriteToStderrf("timed out connecting to database: %v", err)
+		} else {
+			log.WriteToStderr("Eventually got the connection with gorm")
 		}
 	})
 	return gormDB, err

--- a/migrator/postgreshelper/load.go
+++ b/migrator/postgreshelper/load.go
@@ -56,7 +56,7 @@ func Load(conf *config.Config) (*gorm.DB, error) {
 		if err != nil {
 			log.WriteToStderrf("timed out connecting to database: %v", err)
 		} else {
-			log.WriteToStderr("Eventually got the connection with gorm")
+			log.WriteToStderr("Successfully connected to central database.")
 		}
 	})
 	return gormDB, err


### PR DESCRIPTION
## Description

With the Version store now implemented we should probably bypass migrations and upgrades when in postgres mode until those features are implemented (ROX-9884, ROX-10700).  Additionally, I stumbled across a couple of tests dealing with version that would not work with Postgres and adjusted them to use the postgres store when running with postgres.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
