### PR TITLE
ROX-11296: set redirect_uri for the OAuth exchange

### DIFF
--- a/pkg/auth/authproviders/openshift/backend_impl.go
+++ b/pkg/auth/authproviders/openshift/backend_impl.go
@@ -103,9 +103,9 @@ func (b *backend) LoginURL(clientState string, ri *requestinfo.RequestInfo) (str
 	state := idputil.MakeState(b.id, clientState)
 
 	// Augment baseRedirectURLPath to a redirect URL with hostname, etc set.
-	redirectURL := dexconnector.MakeRedirectURI(ri, b.baseRedirectURLPath)
+	redirectURI := dexconnector.MakeRedirectURI(ri, b.baseRedirectURLPath)
 
-	return b.openshiftConnector.LoginURL(defaultScopes, redirectURL.String(), state)
+	return b.openshiftConnector.LoginURL(defaultScopes, redirectURI.String(), state)
 }
 
 func (b *backend) RefreshURL() string {

--- a/pkg/auth/authproviders/openshift/backend_impl.go
+++ b/pkg/auth/authproviders/openshift/backend_impl.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"net/http"
-	"net/url"
 	"os"
 	"time"
 
@@ -17,7 +16,6 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
 	"github.com/stackrox/rox/pkg/httputil"
-	"github.com/stackrox/rox/pkg/netutil"
 	"github.com/stackrox/rox/pkg/satoken"
 )
 
@@ -56,9 +54,9 @@ type callbackAndRefreshConnector interface {
 }
 
 type backend struct {
-	id                 string
-	baseRedirectURL    url.URL
-	openshiftConnector callbackAndRefreshConnector
+	id                  string
+	baseRedirectURLPath string
+	openshiftConnector  callbackAndRefreshConnector
 }
 
 type openShiftSettings struct {
@@ -75,11 +73,6 @@ func newBackend(id string, callbackURLPath string, _ map[string]string) (authpro
 		return nil, err
 	}
 
-	baseRedirectURL := url.URL{
-		Scheme: "https",
-		Path:   callbackURLPath,
-	}
-
 	dexCfg := dexconnector.Config{
 		Issuer:          openshiftAPIUrl,
 		ClientID:        settings.clientID,
@@ -93,9 +86,9 @@ func newBackend(id string, callbackURLPath string, _ map[string]string) (authpro
 	}
 
 	b := &backend{
-		id:                 id,
-		baseRedirectURL:    baseRedirectURL,
-		openshiftConnector: openshiftConnector,
+		id:                  id,
+		baseRedirectURLPath: callbackURLPath,
+		openshiftConnector:  openshiftConnector,
 	}
 
 	return b, nil
@@ -109,13 +102,9 @@ func (b *backend) Config() map[string]string {
 func (b *backend) LoginURL(clientState string, ri *requestinfo.RequestInfo) (string, error) {
 	state := idputil.MakeState(b.id, clientState)
 
-	// baseRedirectURL does not include the hostname, take it from the request.
-	// Allow HTTP only if the client did not use TLS and the host is localhost.
-	redirectURL := b.baseRedirectURL
-	redirectURL.Host = ri.Hostname
-	if !ri.ClientUsedTLS && netutil.IsLocalEndpoint(redirectURL.Host) {
-		redirectURL.Scheme = "http"
-	}
+	// baseRedirectURLPath does not include the hostname, take it from the
+	// request.
+	redirectURL := dexconnector.MakeRedirectURI(ri, b.baseRedirectURLPath)
 
 	return b.openshiftConnector.LoginURL(defaultScopes, redirectURL.String(), state)
 }
@@ -129,12 +118,13 @@ func (b *backend) OnEnable(_ authproviders.Provider) {}
 func (b *backend) OnDisable(_ authproviders.Provider) {}
 
 func (b *backend) ProcessHTTPRequest(_ http.ResponseWriter, r *http.Request) (*authproviders.AuthResponse, error) {
-	if r.URL.Path != b.baseRedirectURL.Path {
+	if r.URL.Path != b.baseRedirectURLPath {
 		return nil, httputil.Errorf(http.StatusNotFound, "path %q not found", r.URL.Path)
 	}
 	if r.Method != http.MethodGet {
 		return nil, httputil.Errorf(http.StatusMethodNotAllowed, "unsupported method %q, only GET requests are allowed to this URL", r.Method)
 	}
+
 	id, err := b.openshiftConnector.HandleCallback(defaultScopes, r)
 	if err != nil {
 		return nil, errors.Wrap(err, "retrieving user identity")

--- a/pkg/auth/authproviders/openshift/backend_impl.go
+++ b/pkg/auth/authproviders/openshift/backend_impl.go
@@ -102,8 +102,7 @@ func (b *backend) Config() map[string]string {
 func (b *backend) LoginURL(clientState string, ri *requestinfo.RequestInfo) (string, error) {
 	state := idputil.MakeState(b.id, clientState)
 
-	// baseRedirectURLPath does not include the hostname, take it from the
-	// request.
+	// Augment baseRedirectURLPath to a redirect URL with hostname, etc set.
 	redirectURL := dexconnector.MakeRedirectURI(ri, b.baseRedirectURLPath)
 
 	return b.openshiftConnector.LoginURL(defaultScopes, redirectURL.String(), state)

--- a/pkg/auth/authproviders/openshift/internal/dexconnector/openshift.go
+++ b/pkg/auth/authproviders/openshift/internal/dexconnector/openshift.go
@@ -238,7 +238,13 @@ func (c *openshiftConnector) HandleCallback(s connector.Scopes, r *http.Request)
 	ri := requestinfo.FromContext(ctx)
 	redirect_uri := MakeRedirectURI(&ri, ri.HTTPRequest.URL.Path)
 
-	// redirect_uri is set here to support the mulitple redirect URI case.
+	// Our service might be accessible via different routes and hence specify
+	// different redirect URIs in the login URL to authorization server. The
+	// latter must check that the redirect URI passed with the initial request
+	// equals the one passed during the code exchange. Hence we dynamically
+	// adjust the redirect URI in the oauth2 config here to the URL deduced
+	// from the request to us, which we expect to match the redirect URL we
+	// included in login URL earlier in the flow.
 	token, err := c.oauth2Config.Exchange(ctx, q.Get("code"),
 		oauth2.SetAuthURLParam("redirect_uri", redirect_uri.String()))
 

--- a/pkg/auth/authproviders/openshift/internal/dexconnector/openshift.go
+++ b/pkg/auth/authproviders/openshift/internal/dexconnector/openshift.go
@@ -40,6 +40,7 @@ import (
 //     verification                                                           //
 //   * add validation for connectivity to OAuth2 endpoints                    //
 //   * extract fetching user info into identity() function                    //
+//   * deduce redirect URI's host and scheme via MakeRedirectURI() function   //
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -236,7 +237,7 @@ func (c *openshiftConnector) HandleCallback(s connector.Scopes, r *http.Request)
 	}
 
 	ri := requestinfo.FromContext(ctx)
-	redirect_uri := MakeRedirectURI(&ri, ri.HTTPRequest.URL.Path)
+	redirectURI := MakeRedirectURI(&ri, ri.HTTPRequest.URL.Path)
 
 	// Our service might be accessible via different routes and hence specify
 	// different redirect URIs in the login URL to authorization server. The
@@ -246,7 +247,7 @@ func (c *openshiftConnector) HandleCallback(s connector.Scopes, r *http.Request)
 	// from the request to us, which we expect to match the redirect URL we
 	// included in login URL earlier in the flow.
 	token, err := c.oauth2Config.Exchange(ctx, q.Get("code"),
-		oauth2.SetAuthURLParam("redirect_uri", redirect_uri.String()))
+		oauth2.SetAuthURLParam("redirect_uri", redirectURI.String()))
 
 	if err != nil {
 		return identity, errors.Wrap(err, "failed to get token")


### PR DESCRIPTION
## Description

In the case of multiple routes created for the same service account OAuth client, Openshift needs the `redirect_uri` parameter set for the code exchange call.

The suggested fix makes use of the fact that the backend `callback` is called on the `redirect_uri` passed to the `/authorize`, so the value is available in the request.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* Created an instance of Openshift OAuth provider;
* Created 2 additional routes: `alt-central` and `alt2-central`;
* Altered `central` service account to add redirect URIs and routes references;
* Tried to log in via the created provider using the 3 routes;
* Observed successful login and the use of the correct route in the URI.
