### PR TITLE
ROX-11668 fix dashboard visual glitches

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/ClusterSelect.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/ClusterSelect.tsx
@@ -93,6 +93,7 @@ function ClusterSelect({
             selections={currentSelection}
             isDisabled={isDisabled}
             maxHeight="50vh"
+            width={180}
             position="right"
             hasInlineFilter
         >

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import { Divider, Flex, FlexItem, Gallery, PageSection, Text, Title } from '@patternfly/react-core';
 import SummaryCounts from './SummaryCounts';
 import ScopeBar from './ScopeBar';
@@ -41,10 +41,15 @@ function DashboardPage() {
             <Divider component="div" />
             <PageSection>
                 <Gallery
-                    style={{
-                        // Ensure the grid has never grows large enough to show 4 columns
-                        maxWidth: `calc(calc(${minWidgetWidth}px * 4) + calc(var(--pf-l-gallery--m-gutter--GridGap) * 3) - 1px)`,
-                    }}
+                    style={
+                        {
+                            // Ensure the grid has never grows large enough to show 4 columns
+                            maxWidth: `calc(calc(${minWidgetWidth}px * 4) + calc(var(--pf-l-gallery--m-gutter--GridGap) * 3) - 1px)`,
+                            // Ensure the grid gap matches that of the outside padding of the containing PageSection
+                            '--pf-l-gallery--m-gutter--GridGap':
+                                'var(--pf-c-page__main-section--PaddingTop)',
+                        } as CSSProperties
+                    }
                     hasGutter
                     minWidths={{ default: `${minWidgetWidth}px` }}
                 >

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/NamespaceSelect.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/NamespaceSelect.tsx
@@ -106,6 +106,7 @@ function NamespaceSelect({
             isDisabled={isDisabled}
             maxHeight="50vh"
             position="right"
+            width={210}
             isGrouped
             hasInlineFilter
         >

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetCard.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetCard.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { CSSProperties, ReactNode } from 'react';
 import { Skeleton, Card, CardBody, CardHeader } from '@patternfly/react-core';
 
 import { defaultChartHeight } from 'utils/chartUtils';
@@ -43,7 +43,12 @@ function WidgetCard({
             <CardHeader>
                 <div className="pf-u-flex-grow-1">{header}</div>
             </CardHeader>
-            <CardBody>{cardContent}</CardBody>
+            <CardBody
+                className="pf-u-min-height"
+                style={{ '--pf-u-min-height--MinHeight': height } as CSSProperties}
+            >
+                {cardContent}
+            </CardBody>
         </Card>
     );
 }


### PR DESCRIPTION
## Description

Fixes various visual nits with the dashboard.

1. [Adds an explicit width to Cluster/Namespace dropdowns](https://github.com/stackrox/stackrox/commit/87b504bfe27fa9948b3c9010901d2167fa88b475) to prevent layout shift when moving between "all" selection and specific selections.
2. [Adds a minimum height to widget cards](https://github.com/stackrox/stackrox/commit/6d9cedf1a5872f37f992113ef5342f9cd446a6bd) to prevent collapsing layout when no items are selected.
3. [Make spacing around widgets match the padding of the parent](https://github.com/stackrox/stackrox/commit/2f8bddec6c36d02519aeeb71e7863f9ab06c94af) PageSection container.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

1. Select one or more clusters and namespaces and ensure the layout of the dropdowns does not shift. (Note that this is safe up until 100000 selected items in the badge display).
<img width="573" alt="image" src="https://user-images.githubusercontent.com/1292638/179254302-06c89b12-3342-4146-8c11-84c1df2dc6ca.png">
<img width="573" alt="image" src="https://user-images.githubusercontent.com/1292638/179254325-ccc9049e-bd88-4189-b8fe-263f05ae7130.png">

2. Apply resource filters the result in no data and verify that the card size remains consistent with widgets that do contain data.

Before:
<img width="1314" alt="image" src="https://user-images.githubusercontent.com/1292638/179254583-0ea42071-94bd-4acd-8e18-4eb086d0debb.png">
After:
<img width="1316" alt="image" src="https://user-images.githubusercontent.com/1292638/179254690-68b533b8-95e5-46b3-858b-a5d9aefc4bf0.png">


3. Test the layout at various breakpoints and ensure the gap between widgets matches the padding around the main page section.

Breakpoint <= 'md':
<img width="404" alt="image" src="https://user-images.githubusercontent.com/1292638/179254959-e2a49afd-8a87-4cb3-8ea6-6aba2a0cfb39.png">
Breakpoint > 'md':
<img width="404" alt="image" src="https://user-images.githubusercontent.com/1292638/179255023-a1a5f8c5-becc-4322-becb-ea492f283436.png">



