### PR TITLE
ROX-11228: Centralize CRUD SAC test case definitions

### DIFF
--- a/central/alert/datastore/datastore_sac_test.go
+++ b/central/alert/datastore/datastore_sac_test.go
@@ -117,8 +117,7 @@ func (s *alertDatastoreSACTestSuite) TestUpsertAlert() {
 	s.testAlertIDs = append(s.testAlertIDs, alert1.Id)
 	s.testAlertIDs = append(s.testAlertIDs, alert2.Id)
 
-	testedVerb := "upsert"
-	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testedVerb)
+	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testutils.VerbUpsert)
 
 	for name, c := range cases {
 		s.Run(name, func() {

--- a/central/alert/datastore/datastore_sac_test.go
+++ b/central/alert/datastore/datastore_sac_test.go
@@ -141,71 +141,26 @@ func (s *alertDatastoreSACTestSuite) TestUpsertAlert() {
 	s.testAlertIDs = append(s.testAlertIDs, alert1.Id)
 	s.testAlertIDs = append(s.testAlertIDs, alert2.Id)
 
-	cases := map[string]crudTest{
-		"(full) read-only cannot upsert": {
-			scopeKey:      testutils.UnrestrictedReadCtx,
-			expectError:   true,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"full read-write can upsert": {
-			scopeKey:      testutils.UnrestrictedReadWriteCtx,
-			expectError:   false,
-			expectedError: nil,
-		},
-		"full read-write on wrong cluster cannot upsert": {
-			scopeKey:      testutils.Cluster1ReadWriteCtx,
-			expectError:   true,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on wrong cluster and wrong namespace name cannot upsert": {
-			scopeKey:      testutils.Cluster1NamespaceAReadWriteCtx,
-			expectError:   true,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on wrong cluster and matching namespace name cannot upsert": {
-			scopeKey:      testutils.Cluster1NamespaceBReadWriteCtx,
-			expectError:   true,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on right cluster but wrong namespaces cannot upsert": {
-			scopeKey:      testutils.Cluster2NamespacesACReadWriteCtx,
-			expectError:   true,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"full read-write on right cluster can upsert": {
-			scopeKey:      testutils.Cluster2ReadWriteCtx,
-			expectError:   false,
-			expectedError: nil,
-		},
-		"read-write on the right cluster and namespace can upsert": {
-			scopeKey:      testutils.Cluster2NamespaceBReadWriteCtx,
-			expectError:   false,
-			expectedError: nil,
-		},
-		"read-write on the right cluster and at least the right namespace can upsert": {
-			scopeKey:      testutils.Cluster2NamespacesABReadWriteCtx,
-			expectError:   false,
-			expectedError: nil,
-		},
-	}
+	testedVerb := "upsert"
+	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testedVerb)
 
 	for name, c := range cases {
 		s.Run(name, func() {
-			ctx := s.testContexts[c.scopeKey]
+			ctx := s.testContexts[c.ScopeKey]
 			var err error
 			err = s.datastore.UpsertAlert(ctx, alert1)
 			defer s.cleanupAlert(alert1.Id)
-			if !c.expectError {
+			if !c.ExpectError {
 				s.NoError(err)
 			} else {
-				s.Equal(c.expectedError, err)
+				s.Equal(c.ExpectedError, err)
 			}
 			err = s.datastore.UpsertAlert(ctx, alert2)
 			defer s.cleanupAlert(alert2.Id)
-			if !c.expectError {
+			if !c.ExpectError {
 				s.NoError(err)
 			} else {
-				s.Equal(c.expectedError, err)
+				s.Equal(c.ExpectedError, err)
 			}
 		})
 	}
@@ -306,51 +261,14 @@ func (s *alertDatastoreSACTestSuite) TestGetAlert() {
 	s.testAlertIDs = append(s.testAlertIDs, alert2.Id)
 	s.NoError(err)
 
-	cases := map[string]crudTest{
-		"(full) read-only can read": {
-			scopeKey:      testutils.UnrestrictedReadCtx,
-			expectedFound: true,
-		},
-		"full read-write can read": {
-			scopeKey:      testutils.UnrestrictedReadWriteCtx,
-			expectedFound: true,
-		},
-		"full read-write on wrong cluster cannot read": {
-			scopeKey:      testutils.Cluster1ReadWriteCtx,
-			expectedFound: false,
-		},
-		"read-write on wrong cluster and wrong namespace name cannot read": {
-			scopeKey:      testutils.Cluster1NamespaceAReadWriteCtx,
-			expectedFound: false,
-		},
-		"read-write on wrong cluster and matching namespace name cannot read": {
-			scopeKey:      testutils.Cluster1NamespaceBReadWriteCtx,
-			expectedFound: false,
-		},
-		"read-write on right cluster but wrong namespaces cannot read": {
-			scopeKey:      testutils.Cluster2NamespacesACReadWriteCtx,
-			expectedFound: false,
-		},
-		"full read-write on right cluster can read": {
-			scopeKey:      testutils.Cluster2ReadWriteCtx,
-			expectedFound: true,
-		},
-		"read-write on the right cluster and namespace can read": {
-			scopeKey:      testutils.Cluster2NamespaceBReadWriteCtx,
-			expectedFound: true,
-		},
-		"read-write on the right cluster and at least the right namespace can read": {
-			scopeKey:      testutils.Cluster2NamespacesABReadWriteCtx,
-			expectedFound: true,
-		},
-	}
+	cases := testutils.GenericNamespaceSACGetTestCases(s.T())
 
 	for name, c := range cases {
 		s.Run(name, func() {
-			ctx := s.testContexts[c.scopeKey]
+			ctx := s.testContexts[c.ScopeKey]
 			readAlert1, found1, err1 := s.datastore.GetAlert(ctx, alert1.GetId())
 			s.NoError(err1)
-			if c.expectedFound {
+			if c.ExpectedFound {
 				s.True(found1)
 				s.Equal(*alert1, *readAlert1)
 			} else {
@@ -359,7 +277,7 @@ func (s *alertDatastoreSACTestSuite) TestGetAlert() {
 			}
 			readAlert2, found2, err2 := s.datastore.GetAlert(ctx, alert2.GetId())
 			s.NoError(err2)
-			if c.expectedFound {
+			if c.ExpectedFound {
 				s.True(found2)
 				s.Equal(*alert2, *readAlert2)
 			} else {
@@ -377,52 +295,7 @@ func (s *alertDatastoreSACTestSuite) TestGetAlert() {
 // full access scope on the alert resource are allowed to delete alerts
 
 func (s *alertDatastoreSACTestSuite) TestDeleteAlert() {
-
-	cases := map[string]crudTest{
-		"(full) read-only cannot delete": {
-			scopeKey:      testutils.UnrestrictedReadCtx,
-			expectError:   true,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"full read-write can delete": {
-			scopeKey: testutils.UnrestrictedReadWriteCtx,
-		},
-		"full read-write on wrong cluster cannot delete": {
-			scopeKey:      testutils.Cluster1ReadWriteCtx,
-			expectError:   true,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on wrong cluster and wrong namespace name cannot delete": {
-			scopeKey:      testutils.Cluster1NamespaceAReadWriteCtx,
-			expectError:   true,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on wrong cluster and matching namespace name cannot delete": {
-			scopeKey:      testutils.Cluster1NamespaceBReadWriteCtx,
-			expectError:   true,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on right cluster but wrong namespaces cannot delete": {
-			scopeKey:      testutils.Cluster2NamespacesACReadWriteCtx,
-			expectError:   true,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"full read-write on right cluster cannot delete": {
-			scopeKey:      testutils.Cluster2ReadWriteCtx,
-			expectError:   true,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on the right cluster and namespace cannot delete": {
-			scopeKey:      testutils.Cluster2NamespaceBReadWriteCtx,
-			expectError:   true,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on the right cluster and at least the right namespace cannot delete": {
-			scopeKey:      testutils.Cluster2NamespacesABReadWriteCtx,
-			expectError:   true,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-	}
+	cases := testutils.GenericGlobalSACDeleteTestCases(s.T())
 
 	for name, c := range cases {
 		s.Run(name, func() {
@@ -438,18 +311,18 @@ func (s *alertDatastoreSACTestSuite) TestDeleteAlert() {
 			err = s.datastore.UpsertAlert(s.testContexts[testutils.UnrestrictedReadWriteCtx], alert2)
 			s.testAlertIDs = append(s.testAlertIDs, alert2.Id)
 			s.NoError(err)
-			ctx := s.testContexts[c.scopeKey]
+			ctx := s.testContexts[c.ScopeKey]
 			err1 := s.datastore.DeleteAlerts(ctx, alert1.GetId())
-			if c.expectError {
+			if c.ExpectError {
 				s.Error(err1)
-				s.ErrorIs(c.expectedError, err1)
+				s.ErrorIs(c.ExpectedError, err1)
 			} else {
 				s.NoError(err1)
 			}
 			err2 := s.datastore.DeleteAlerts(ctx, alert1.GetId(), alert2.GetId())
-			if c.expectError {
+			if c.ExpectError {
 				s.Error(err2)
-				s.ErrorIs(c.expectedError, err2)
+				s.ErrorIs(c.ExpectedError, err2)
 			} else {
 				s.NoError(err2)
 			}

--- a/central/networkbaseline/datastore/datastore_impl.go
+++ b/central/networkbaseline/datastore/datastore_impl.go
@@ -2,11 +2,16 @@ package datastore
 
 import (
 	"context"
+	"testing"
 
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/networkbaseline/store"
+	"github.com/stackrox/rox/central/networkbaseline/store/postgres"
+	"github.com/stackrox/rox/central/networkbaseline/store/rocksdb"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
+	rocksdbBase "github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/sac"
 )
 
@@ -24,6 +29,18 @@ func newNetworkBaselineDataStore(storage store.Store) DataStore {
 		storage: storage,
 	}
 	return ds
+}
+
+// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetTestPostgresDataStore(_ *testing.T, pool *pgxpool.Pool) (DataStore, error) {
+	dbstore := postgres.New(pool)
+	return newNetworkBaselineDataStore(dbstore), nil
+}
+
+// GetTestRocksBleveDataStore provides a datastore connected to rocksdb and bleve for testing purposes.
+func GetTestRocksBleveDataStore(_ *testing.T, rocksengine *rocksdbBase.RocksDB) (DataStore, error) {
+	dbstore := rocksdb.New(rocksengine)
+	return newNetworkBaselineDataStore(dbstore), nil
 }
 
 func (ds *dataStoreImpl) GetNetworkBaseline(

--- a/central/networkbaseline/datastore/datastore_sac_test.go
+++ b/central/networkbaseline/datastore/datastore_sac_test.go
@@ -110,52 +110,15 @@ func (s *networkBaselineDatastoreSACTestSuite) TestGetNetworkBaseline() {
 	s.testNBIDs = append(s.testNBIDs, testNB.GetDeploymentId())
 	s.NoError(err)
 
-	cases := map[string]crudTest{
-		"(full) read-only can read": {
-			scopeKey:    testutils.UnrestrictedReadCtx,
-			expectFound: true,
-		},
-		"full read-write can read": {
-			scopeKey:    testutils.UnrestrictedReadCtx,
-			expectFound: true,
-		},
-		"full read-write on wrong cluster cannot read": {
-			scopeKey:    testutils.Cluster1ReadWriteCtx,
-			expectFound: false,
-		},
-		"read-write on wrong cluster and wrong namespace cannot read": {
-			scopeKey:    testutils.Cluster1NamespaceAReadWriteCtx,
-			expectFound: false,
-		},
-		"read-write on wrong cluster and matching namespace cannot read": {
-			scopeKey:    testutils.Cluster1NamespaceBReadWriteCtx,
-			expectFound: false,
-		},
-		"read-write on right cluster but wrong namespaces cannot read": {
-			scopeKey:    testutils.Cluster2NamespacesACReadWriteCtx,
-			expectFound: false,
-		},
-		"full read-write on right cluster can read": {
-			scopeKey:    testutils.Cluster2ReadWriteCtx,
-			expectFound: true,
-		},
-		"read-write on the right cluster and namespace can read": {
-			scopeKey:    testutils.Cluster2NamespaceBReadWriteCtx,
-			expectFound: true,
-		},
-		"read-write on the right cluster and at least the right namespace can read": {
-			scopeKey:    testutils.Cluster2NamespacesABReadWriteCtx,
-			expectFound: true,
-		},
-	}
+	cases := testutils.GenericNamespaceSACGetTestCases(s.T())
 
 	for name, c := range cases {
 		s.Run(name, func() {
-			ctx := s.testContexts[c.scopeKey]
+			ctx := s.testContexts[c.ScopeKey]
 			readNetworkBaseline, found, getErr := s.datastore.GetNetworkBaseline(ctx, testNB.GetDeploymentId())
 			s.NoError(getErr)
-			s.Equal(c.expectFound, found)
-			if c.expectFound {
+			s.Equal(c.ExpectedFound, found)
+			if c.ExpectedFound {
 				s.Equal(testNB, readNetworkBaseline)
 			} else {
 				s.Nil(readNetworkBaseline)
@@ -232,162 +195,56 @@ func (s *networkBaselineDatastoreSACTestSuite) TestWalkNetworkBaseline() {
 }
 
 func (s *networkBaselineDatastoreSACTestSuite) TestUpsertNetworkBaselines() {
-	cases := map[string]crudTest{
-		"(full) read-only cannot upsert": {
-			scopeKey:      testutils.UnrestrictedReadCtx,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"full read-write can upsert": {
-			scopeKey:      testutils.UnrestrictedReadWriteCtx,
-			expectedError: nil,
-		},
-		"full read-write on wrong cluster cannot upsert": {
-			scopeKey:      testutils.Cluster1ReadWriteCtx,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on wrong cluster and wrong namespace cannot upsert": {
-			scopeKey:      testutils.Cluster1NamespaceAReadWriteCtx,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on wrong cluster and matching namespace cannot upsert": {
-			scopeKey:      testutils.Cluster1NamespaceBReadWriteCtx,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on right cluster but wrong namespaces cannot upsert": {
-			scopeKey:      testutils.Cluster2NamespacesACReadWriteCtx,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"full read-write on right cluster can upsert": {
-			scopeKey:      testutils.Cluster2ReadWriteCtx,
-			expectedError: nil,
-		},
-		"read-write on the right cluster and namespace can upsert": {
-			scopeKey:      testutils.Cluster2NamespaceBReadWriteCtx,
-			expectedError: nil,
-		},
-		"read-write on the right cluster and at least the right namespace can upsert": {
-			scopeKey:      testutils.Cluster2NamespacesABReadWriteCtx,
-			expectedError: nil,
-		},
-	}
+	testedVerb := "upsert"
+	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testedVerb)
 
 	for name, c := range cases {
 		s.Run(name, func() {
 			testNB := fixtures.GetScopedNetworkBaseline(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
 			s.testNBIDs = append(s.testNBIDs, testNB.GetDeploymentId())
-			ctx := s.testContexts[c.scopeKey]
+			ctx := s.testContexts[c.ScopeKey]
 			err := s.datastore.UpsertNetworkBaselines(ctx, []*storage.NetworkBaseline{testNB})
-			s.Equal(c.expectedError, err)
+			s.Equal(c.ExpectedError, err)
 
 			_, ok, err := s.datastore.GetNetworkBaseline(ctx, testNB.GetDeploymentId())
 			s.NoError(err)
-			s.Equal(c.expectedError == nil, ok, "The resource must exist if Upsert succeeded, or not otherwise")
+			s.Equal(c.ExpectedError == nil, ok, "The resource must exist if Upsert succeeded, or not otherwise")
 		})
 	}
 }
 
 func (s *networkBaselineDatastoreSACTestSuite) TestDeleteNetworkBaseline() {
-	cases := map[string]crudTest{
-		"(full) read-only cannot remove": {
-			scopeKey:      testutils.UnrestrictedReadCtx,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"full read-write can remove": {
-			scopeKey:      testutils.UnrestrictedReadWriteCtx,
-			expectedError: nil,
-		},
-		"full read-write on wrong cluster cannot remove": {
-			scopeKey:      testutils.Cluster1ReadWriteCtx,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on wrong cluster and wrong namespace cannot remove": {
-			scopeKey:      testutils.Cluster1NamespaceAReadWriteCtx,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on wrong cluster and matching namespace cannot remove": {
-			scopeKey:      testutils.Cluster1NamespaceBReadWriteCtx,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on right cluster but wrong namespaces cannot remove": {
-			scopeKey:      testutils.Cluster2NamespacesACReadWriteCtx,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"full read-write on right cluster can remove": {
-			scopeKey:      testutils.Cluster2ReadWriteCtx,
-			expectedError: nil,
-		},
-		"read-write on the right cluster and namespace can remove": {
-			scopeKey:      testutils.Cluster2NamespaceBReadWriteCtx,
-			expectedError: nil,
-		},
-		"read-write on the right cluster and at least the right namespace can remove": {
-			scopeKey:      testutils.Cluster2NamespacesABReadWriteCtx,
-			expectedError: nil,
-		},
-	}
+	cases := testutils.GenericNamespaceSACDeleteTestCases(s.T())
 
 	for name, c := range cases {
 		s.Run(name, func() {
 			testNB := fixtures.GetScopedNetworkBaseline(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
 			s.testNBIDs = append(s.testNBIDs, testNB.GetDeploymentId())
 			s.NoError(s.datastore.UpsertNetworkBaselines(s.testContexts[testutils.UnrestrictedReadWriteCtx], []*storage.NetworkBaseline{testNB}))
-			ctx := s.testContexts[c.scopeKey]
+			ctx := s.testContexts[c.ScopeKey]
 			err := s.datastore.DeleteNetworkBaseline(ctx, testNB.GetDeploymentId())
-			s.Equal(c.expectedError, err)
+			s.Equal(c.ExpectedError, err)
 			_, ok, err := s.datastore.GetNetworkBaseline(s.testContexts[testutils.UnrestrictedReadWriteCtx], testNB.GetDeploymentId())
 			s.NoError(err)
-			s.Equal(c.expectedError != nil, ok, "The resource must still exist if Delete failed, or not otherwise")
+			s.Equal(c.ExpectedError != nil, ok, "The resource must still exist if Delete failed, or not otherwise")
 		})
 	}
 }
 
 func (s *networkBaselineDatastoreSACTestSuite) TestDeleteNetworkBaselines() {
-	cases := map[string]crudTest{
-		"(full) read-only cannot remove": {
-			scopeKey:      testutils.UnrestrictedReadCtx,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"full read-write can remove": {
-			scopeKey: testutils.UnrestrictedReadWriteCtx,
-		},
-		"full read-write on wrong cluster cannot remove": {
-			scopeKey:      testutils.Cluster1ReadWriteCtx,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on wrong cluster and wrong namespace cannot remove": {
-			scopeKey:      testutils.Cluster1NamespaceAReadWriteCtx,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on wrong cluster and matching namespace cannot remove": {
-			scopeKey:      testutils.Cluster1NamespaceBReadWriteCtx,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"read-write on right cluster but wrong namespaces cannot remove": {
-			scopeKey:      testutils.Cluster2NamespacesACReadWriteCtx,
-			expectedError: sac.ErrResourceAccessDenied,
-		},
-		"full read-write on right cluster can remove": {
-			scopeKey: testutils.Cluster2ReadWriteCtx,
-		},
-		"read-write on the right cluster and namespace can remove": {
-			scopeKey: testutils.Cluster2NamespaceBReadWriteCtx,
-		},
-		"read-write on the right cluster and at least the right namespace can remove": {
-			scopeKey: testutils.Cluster2NamespacesABReadWriteCtx,
-		},
-	}
+	cases := testutils.GenericNamespaceSACDeleteTestCases(s.T())
 
 	for name, c := range cases {
 		s.Run(name, func() {
 			testNB := fixtures.GetScopedNetworkBaseline(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
 			s.testNBIDs = append(s.testNBIDs, testNB.GetDeploymentId())
-			ctx := s.testContexts[c.scopeKey]
+			ctx := s.testContexts[c.ScopeKey]
 			var err error
 			err = s.datastore.UpsertNetworkBaselines(s.testContexts[testutils.UnrestrictedReadWriteCtx], []*storage.NetworkBaseline{testNB})
 			defer s.cleanupNetworkBaseline(testNB.GetDeploymentId())
 			s.NoError(err)
 			err = s.datastore.DeleteNetworkBaselines(ctx, []string{testNB.GetDeploymentId()})
-			s.Equal(c.expectedError, err)
+			s.Equal(c.ExpectedError, err)
 		})
 	}
 

--- a/central/networkbaseline/datastore/datastore_sac_test.go
+++ b/central/networkbaseline/datastore/datastore_sac_test.go
@@ -186,8 +186,7 @@ func (s *networkBaselineDatastoreSACTestSuite) TestWalkNetworkBaseline() {
 }
 
 func (s *networkBaselineDatastoreSACTestSuite) TestUpsertNetworkBaselines() {
-	testedVerb := "upsert"
-	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testedVerb)
+	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testutils.VerbUpsert)
 
 	for name, c := range cases {
 		s.Run(name, func() {

--- a/central/networkpolicies/datastore/datastore_sac_test.go
+++ b/central/networkpolicies/datastore/datastore_sac_test.go
@@ -201,8 +201,7 @@ func (s *networkPolicySACSuite) TestCountMatchingNetworkPolicies() {
 }
 
 func (s *networkPolicySACSuite) TestUpsertNetworkPolicy() {
-	testedVerb := "upsert"
-	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testedVerb)
+	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testutils.VerbUpsert)
 
 	for name, c := range cases {
 		s.Run(name, func() {

--- a/central/networkpolicies/datastore/datastore_sac_test.go
+++ b/central/networkpolicies/datastore/datastore_sac_test.go
@@ -98,50 +98,14 @@ func (s *networkPolicySACSuite) TestGetNetworkPolicy() {
 	err := s.datastore.UpsertNetworkPolicy(s.testContexts[testutils.UnrestrictedReadWriteCtx], networkPolicy)
 	s.Require().NoError(err)
 	s.testNetworkPolicyIDs = append(s.testNetworkPolicyIDs, networkPolicy.GetId())
-	cases := map[string]struct {
-		scopeKey string
-		found    bool
-	}{
-		"global read-only can get": {
-			scopeKey: testutils.UnrestrictedReadCtx,
-			found:    true,
-		},
-		"global read-write can get": {
-			scopeKey: testutils.UnrestrictedReadWriteCtx,
-			found:    true,
-		},
-		"read-write on wrong cluster cannot get": {
-			scopeKey: testutils.Cluster1ReadWriteCtx,
-		},
-		"read-write on wrong cluster and namespace cannot get": {
-			scopeKey: testutils.Cluster1NamespaceAReadWriteCtx,
-		},
-		"read-write on wrong cluster and matching namespace cannot get": {
-			scopeKey: testutils.Cluster1NamespaceBReadWriteCtx,
-		},
-		"read-write on matching cluster can get": {
-			scopeKey: testutils.Cluster2ReadWriteCtx,
-			found:    true,
-		},
-		"read-write on matching cluster but wrong namespace cannot get": {
-			scopeKey: testutils.Cluster2NamespaceAReadWriteCtx,
-		},
-		"read-write on matching cluster and namespace can get": {
-			scopeKey: testutils.Cluster2NamespaceBReadWriteCtx,
-			found:    true,
-		},
-		"read-write on matching cluster and at least one matching namespace can get": {
-			scopeKey: testutils.Cluster2NamespacesABReadWriteCtx,
-			found:    true,
-		},
-	}
+	cases := testutils.GenericNamespaceSACGetTestCases(s.T())
 
 	for name, c := range cases {
 		s.Run(name, func() {
-			ctx := s.testContexts[c.scopeKey]
+			ctx := s.testContexts[c.ScopeKey]
 			policy, found, err := s.datastore.GetNetworkPolicy(ctx, networkPolicy.GetId())
 			s.NoError(err)
-			if c.found {
+			if c.ExpectedFound {
 				s.True(found)
 				s.Equal(networkPolicy, policy)
 			} else {
@@ -162,50 +126,18 @@ func (s *networkPolicySACSuite) TestGetNetworkPolicies() {
 	err = s.datastore.UpsertNetworkPolicy(s.testContexts[testutils.UnrestrictedReadWriteCtx], networkPolicy2)
 	s.Require().NoError(err)
 	s.testNetworkPolicyIDs = append(s.testNetworkPolicyIDs, networkPolicy2.GetId())
-	cases := map[string]struct {
-		scopeKey      string
-		expectedFound []*storage.NetworkPolicy
-	}{
-		"global read-only can get": {
-			scopeKey:      testutils.UnrestrictedReadCtx,
-			expectedFound: []*storage.NetworkPolicy{networkPolicy1},
-		},
-		"global read-write can get": {
-			scopeKey:      testutils.UnrestrictedReadWriteCtx,
-			expectedFound: []*storage.NetworkPolicy{networkPolicy1},
-		},
-		"read-write on wrong cluster cannot get": {
-			scopeKey: testutils.Cluster1ReadWriteCtx,
-		},
-		"read-write on wrong cluster and namespace cannot get": {
-			scopeKey: testutils.Cluster1NamespaceAReadWriteCtx,
-		},
-		"read-write on wrong cluster and matching namespace cannot get": {
-			scopeKey: testutils.Cluster1NamespaceBReadWriteCtx,
-		},
-		"read-write on matching cluster can get": {
-			scopeKey:      testutils.Cluster2ReadWriteCtx,
-			expectedFound: []*storage.NetworkPolicy{networkPolicy1},
-		},
-		"read-write on matching cluster but wrong namespace cannot get": {
-			scopeKey: testutils.Cluster2NamespaceAReadWriteCtx,
-		},
-		"read-write on matching cluster and namespace can get": {
-			scopeKey:      testutils.Cluster2NamespaceBReadWriteCtx,
-			expectedFound: []*storage.NetworkPolicy{networkPolicy1},
-		},
-		"read-write on matching cluster and at least one matching namespace can get": {
-			scopeKey:      testutils.Cluster2NamespacesABReadWriteCtx,
-			expectedFound: []*storage.NetworkPolicy{networkPolicy1},
-		},
-	}
+	cases := testutils.GenericNamespaceSACGetTestCases(s.T())
 
 	for name, c := range cases {
 		s.Run(name, func() {
-			ctx := s.testContexts[c.scopeKey]
+			ctx := s.testContexts[c.ScopeKey]
 			policies, err := s.datastore.GetNetworkPolicies(ctx, testconsts.Cluster2, testconsts.NamespaceB)
 			s.NoError(err)
-			s.ElementsMatch(c.expectedFound, policies)
+			if c.ExpectedFound {
+				s.ElementsMatch([]*storage.NetworkPolicy{networkPolicy1}, policies)
+			} else {
+				s.ElementsMatch([]*storage.NetworkPolicy{}, policies)
+			}
 		})
 	}
 }
@@ -269,52 +201,17 @@ func (s *networkPolicySACSuite) TestCountMatchingNetworkPolicies() {
 }
 
 func (s *networkPolicySACSuite) TestUpsertNetworkPolicy() {
-	cases := map[string]struct {
-		scopeKey      string
-		expectedError bool
-	}{
-		"global read-only cannot upsert": {
-			scopeKey:      testutils.UnrestrictedReadCtx,
-			expectedError: true,
-		},
-		"global read-write can upsert": {
-			scopeKey: testutils.UnrestrictedReadWriteCtx,
-		},
-		"read-write on wrong cluster cannot upsert": {
-			scopeKey:      testutils.Cluster1ReadWriteCtx,
-			expectedError: true,
-		},
-		"read-write on wrong cluster and namespace cannot upsert": {
-			scopeKey:      testutils.Cluster1NamespaceAReadWriteCtx,
-			expectedError: true,
-		},
-		"read-write on wrong cluster and matching namespace cannot upsert": {
-			scopeKey:      testutils.Cluster1NamespaceBReadWriteCtx,
-			expectedError: true,
-		},
-		"read-write on matching cluster can upsert": {
-			scopeKey: testutils.Cluster2ReadWriteCtx,
-		},
-		"read-write on matching cluster but wrong namespace cannot upsert": {
-			scopeKey:      testutils.Cluster2NamespaceAReadWriteCtx,
-			expectedError: true,
-		},
-		"read-write on matching cluster and namespace can upsert": {
-			scopeKey: testutils.Cluster2NamespaceBReadWriteCtx,
-		},
-		"read-write on matching cluster and at least one matching namespace can upsert": {
-			scopeKey: testutils.Cluster2NamespacesABReadWriteCtx,
-		},
-	}
+	testedVerb := "upsert"
+	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testedVerb)
 
 	for name, c := range cases {
 		s.Run(name, func() {
 			unrestrictedCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
-			ctx := s.testContexts[c.scopeKey]
+			ctx := s.testContexts[c.ScopeKey]
 			policy := fixtures.GetScopedNetworkPolicy(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
 			err := s.datastore.UpsertNetworkPolicy(ctx, policy)
 			defer s.deleteNetworkPolicy(policy.GetId())
-			if c.expectedError {
+			if c.ExpectError {
 				s.ErrorIs(err, sac.ErrResourceAccessDenied)
 			} else {
 				s.NoError(err)
@@ -327,54 +224,18 @@ func (s *networkPolicySACSuite) TestUpsertNetworkPolicy() {
 }
 
 func (s *networkPolicySACSuite) TestRemoveNetworkPolicy() {
-	cases := map[string]struct {
-		scopeKey      string
-		expectedError bool
-	}{
-		"global read-only cannot remove": {
-			scopeKey:      testutils.UnrestrictedReadCtx,
-			expectedError: true,
-		},
-		"global read-write can remove": {
-			scopeKey: testutils.UnrestrictedReadWriteCtx,
-		},
-		"read-write on wrong cluster cannot remove": {
-			scopeKey:      testutils.Cluster1ReadWriteCtx,
-			expectedError: true,
-		},
-		"read-write on wrong cluster and namespace cannot remove": {
-			scopeKey:      testutils.Cluster1NamespaceAReadWriteCtx,
-			expectedError: true,
-		},
-		"read-write on wrong cluster and matching namespace cannot remove": {
-			scopeKey:      testutils.Cluster1NamespaceBReadWriteCtx,
-			expectedError: true,
-		},
-		"read-write on matching cluster can remove": {
-			scopeKey: testutils.Cluster2ReadWriteCtx,
-		},
-		"read-write on matching cluster but wrong namespace cannot remove": {
-			scopeKey:      testutils.Cluster2NamespaceAReadWriteCtx,
-			expectedError: true,
-		},
-		"read-write on matching cluster and namespace can remove": {
-			scopeKey: testutils.Cluster2NamespaceBReadWriteCtx,
-		},
-		"read-write on matching cluster and at least one matching namespace can remove": {
-			scopeKey: testutils.Cluster2NamespacesABReadWriteCtx,
-		},
-	}
+	cases := testutils.GenericNamespaceSACDeleteTestCases(s.T())
 
 	for name, c := range cases {
 		s.Run(name, func() {
 			unrestrictedCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
-			ctx := s.testContexts[c.scopeKey]
+			ctx := s.testContexts[c.ScopeKey]
 			policy := fixtures.GetScopedNetworkPolicy(uuid.NewV4().String(), testconsts.Cluster2, testconsts.NamespaceB)
 			err := s.datastore.UpsertNetworkPolicy(unrestrictedCtx, policy)
 			s.Require().NoError(err)
 			deleteErr := s.datastore.RemoveNetworkPolicy(ctx, policy.GetId())
 			defer s.deleteNetworkPolicy(policy.GetId())
-			if c.expectedError {
+			if c.ExpectError {
 				s.ErrorIs(deleteErr, sac.ErrResourceAccessDenied)
 				count, countErr := s.datastore.CountMatchingNetworkPolicies(unrestrictedCtx, testconsts.Cluster2, testconsts.NamespaceB)
 				s.NoError(countErr)

--- a/central/pod/datastore/datastore_sac_test.go
+++ b/central/pod/datastore/datastore_sac_test.go
@@ -94,8 +94,7 @@ func (s *podDatastoreSACSuite) deletePod(id string) {
 }
 
 func (s *podDatastoreSACSuite) TestUpsertPod() {
-	testedVerb := "upsert"
-	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testedVerb)
+	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testutils.VerbUpsert)
 
 	for name, c := range cases {
 		s.Run(name, func() {

--- a/central/processbaseline/datastore/datastore_sac_test.go
+++ b/central/processbaseline/datastore/datastore_sac_test.go
@@ -105,8 +105,7 @@ func (s *processBaselineSACTestSuite) deleteProcessBaseline(id string) {
 }
 
 func (s *processBaselineSACTestSuite) TestAddProcessBaseline() {
-	testedVerb := "add"
-	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testedVerb)
+	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testutils.VerbAdd)
 
 	for name, c := range cases {
 		s.Run(name, func() {
@@ -126,8 +125,7 @@ func (s *processBaselineSACTestSuite) TestAddProcessBaseline() {
 }
 
 func (s *processBaselineSACTestSuite) TestUpsertProcessBaseline() {
-	testedVerb := "upsert"
-	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testedVerb)
+	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testutils.VerbUpsert)
 
 	for name, c := range cases {
 		s.Run(name, func() {
@@ -153,8 +151,7 @@ func (s *processBaselineSACTestSuite) TestUpdateProcessBaselineElements() {
 	s.Require().NoError(err)
 	s.testProcessBaselineIDs = append(s.testProcessBaselineIDs, processBaseline.GetId())
 
-	testedVerb := "update"
-	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testedVerb)
+	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testutils.VerbUpdate)
 
 	for name, c := range cases {
 		s.Run(name, func() {

--- a/central/processbaselineresults/datastore/datastore_sac_test.go
+++ b/central/processbaselineresults/datastore/datastore_sac_test.go
@@ -87,8 +87,7 @@ func (s *processBaselineResultsDatastoreSACSuite) deleteProcessBaselineResult(id
 }
 
 func (s *processBaselineResultsDatastoreSACSuite) TestUpsertBaselineResults() {
-	testedVerb := "upsert"
-	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testedVerb)
+	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), testutils.VerbUpsert)
 
 	for name, c := range cases {
 		s.Run(name, func() {

--- a/central/processindicator/datastore/datastore_sac_test.go
+++ b/central/processindicator/datastore/datastore_sac_test.go
@@ -103,8 +103,7 @@ func (s *processIndicatorDatastoreSACSuite) deleteProcessIndicator(id string) {
 }
 
 func (s *processIndicatorDatastoreSACSuite) TestAddProcessIndicators() {
-	testedVerb := "add"
-	cases := sacTestUtils.GenericGlobalSACUpsertTestCases(s.T(), testedVerb)
+	cases := sacTestUtils.GenericGlobalSACUpsertTestCases(s.T(), sacTestUtils.VerbAdd)
 
 	for name, c := range cases {
 		s.Run(name, func() {

--- a/central/rbac/k8srole/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srole/datastore/datastore_sac_test.go
@@ -101,8 +101,7 @@ func (s *k8sRoleSACSuite) deleteK8sRole(id string) {
 }
 
 func (s *k8sRoleSACSuite) TestUpsertRole() {
-	testedVerb := "upsert"
-	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testedVerb)
+	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testutils.VerbUpsert)
 
 	for name, c := range cases {
 		s.Run(name, func() {

--- a/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
@@ -102,8 +102,7 @@ func (s *k8sRoleBindingSACSuite) deleteK8sRoleBinding(id string) {
 }
 
 func (s *k8sRoleBindingSACSuite) TestUpsertRoleBinding() {
-	testedVerb := "upsert"
-	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testedVerb)
+	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testutils.VerbUpsert)
 
 	for name, c := range cases {
 		s.Run(name, func() {

--- a/central/risk/datastore/datastore_sac_test.go
+++ b/central/risk/datastore/datastore_sac_test.go
@@ -103,8 +103,7 @@ func (s *riskDatastoreSACSuite) deleteRisk(id string) {
 }
 
 func (s *riskDatastoreSACSuite) TestUpsertRisk() {
-	testedVerb := "upsert"
-	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testedVerb)
+	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testutils.VerbUpsert)
 
 	for name, c := range cases {
 		s.Run(name, func() {

--- a/central/risk/datastore/datastore_sac_test.go
+++ b/central/risk/datastore/datastore_sac_test.go
@@ -123,57 +123,20 @@ func (s *riskDatastoreSACSuite) deleteRisk(id string) {
 }
 
 func (s *riskDatastoreSACSuite) TestUpsertRisk() {
-	cases := map[string]struct {
-		scopeKey    string
-		expectFail  bool
-		expectedErr error
-	}{
-		"global read-only should not be able to add": {
-			scopeKey:    testutils.UnrestrictedReadCtx,
-			expectFail:  true,
-			expectedErr: sac.ErrResourceAccessDenied,
-		},
-		"global read-write should be able to add": {
-			scopeKey: testutils.UnrestrictedReadWriteCtx,
-		},
-		"read-write on wrong cluster should not be able to add": {
-			scopeKey:    testutils.Cluster1ReadWriteCtx,
-			expectFail:  true,
-			expectedErr: sac.ErrResourceAccessDenied,
-		},
-		"read-write on wrong cluster and namespace should not be able to add": {
-			scopeKey:    testutils.Cluster1NamespaceAReadWriteCtx,
-			expectFail:  true,
-			expectedErr: sac.ErrResourceAccessDenied,
-		},
-		"read-write on wrong cluster and matching namespace should not be able to add": {
-			scopeKey:    testutils.Cluster1NamespaceBReadWriteCtx,
-			expectFail:  true,
-			expectedErr: sac.ErrResourceAccessDenied,
-		},
-		"read-write on matching cluster and wrong namespace should not be able to add": {
-			scopeKey:    testutils.Cluster2NamespaceAReadWriteCtx,
-			expectFail:  true,
-			expectedErr: sac.ErrResourceAccessDenied,
-		},
-		"read-write on matching cluster and no namespace should not be able to add": {
-			scopeKey:    testutils.Cluster2ReadWriteCtx,
-			expectFail:  true,
-			expectedErr: sac.ErrResourceAccessDenied,
-		},
-	}
+	testedVerb := "upsert"
+	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testedVerb)
 
 	for name, c := range cases {
 		s.Run(name, func() {
 			risk := fixtures.GetScopedRisk(uuid.NewV4().String(), testconsts.Cluster2,
 				testconsts.NamespaceB)
 			s.testRiskIDs = append(s.testRiskIDs, risk.GetSubject().GetId())
-			ctx := s.testContexts[c.scopeKey]
+			ctx := s.testContexts[c.ScopeKey]
 			err := s.datastore.UpsertRisk(ctx, risk)
 			defer s.deleteRisk(risk.GetSubject().GetId())
-			if c.expectFail {
+			if c.ExpectError {
 				s.Require().Error(err)
-				s.ErrorIs(err, c.expectedErr)
+				s.ErrorIs(err, c.ExpectedError)
 			} else {
 				s.NoError(err)
 			}
@@ -188,47 +151,14 @@ func (s *riskDatastoreSACSuite) TestGetRisk() {
 	s.Require().NoError(err)
 	s.testRiskIDs = append(s.testRiskIDs, risk.GetSubject().GetId())
 
-	cases := map[string]struct {
-		scopeKey string
-		found    bool
-	}{
-		"global read-only can get": {
-			scopeKey: testutils.UnrestrictedReadCtx,
-			found:    true,
-		},
-		"global read-write can get": {
-			scopeKey: testutils.UnrestrictedReadWriteCtx,
-			found:    true,
-		},
-		"read-write on wrong cluster cannot get": {
-			scopeKey: testutils.Cluster1ReadWriteCtx,
-		},
-		"read-write on wrong cluster and wrong namespace cannot get": {
-			scopeKey: testutils.Cluster1NamespaceAReadWriteCtx,
-		},
-		"read-write on wrong cluster and matching namespace cannot get": {
-			scopeKey: testutils.Cluster1NamespaceBReadWriteCtx,
-		},
-		"read-write on matching cluster but wrong namespaces cannot get": {
-			scopeKey: testutils.Cluster2NamespacesACReadWriteCtx,
-		},
-		"read-write on matching cluster cannot read": {
-			scopeKey: testutils.Cluster2ReadWriteCtx,
-		},
-		"read-write on the matching cluster and namespace cannot get": {
-			scopeKey: testutils.Cluster2NamespaceBReadWriteCtx,
-		},
-		"read-write on the matching cluster and at least one matching namespace cannot get": {
-			scopeKey: testutils.Cluster2NamespacesABReadWriteCtx,
-		},
-	}
+	cases := testutils.GenericGlobalSACGetTestCases(s.T())
 
 	for name, c := range cases {
 		s.Run(name, func() {
-			ctx := s.testContexts[c.scopeKey]
+			ctx := s.testContexts[c.ScopeKey]
 			res, found, err := s.datastore.GetRisk(ctx, risk.GetSubject().GetId(), storage.RiskSubjectType_DEPLOYMENT)
 			s.Require().NoError(err)
-			if c.found {
+			if c.ExpectedFound {
 				s.Require().True(found)
 				s.Equal(*risk, *res)
 			} else {
@@ -252,50 +182,14 @@ func (s *riskDatastoreSACSuite) TestGetRiskForDeployment() {
 		Namespace: testconsts.NamespaceB,
 	}
 
-	cases := map[string]struct {
-		scopeKey string
-		found    bool
-	}{
-		"global read-only can get": {
-			scopeKey: testutils.UnrestrictedReadCtx,
-			found:    true,
-		},
-		"global read-write can get": {
-			scopeKey: testutils.UnrestrictedReadWriteCtx,
-			found:    true,
-		},
-		"read-write on wrong cluster cannot get": {
-			scopeKey: testutils.Cluster1ReadWriteCtx,
-		},
-		"read-write on wrong cluster and wrong namespace cannot get": {
-			scopeKey: testutils.Cluster1NamespaceAReadWriteCtx,
-		},
-		"read-write on wrong cluster and matching namespace cannot get": {
-			scopeKey: testutils.Cluster1NamespaceBReadWriteCtx,
-		},
-		"read-write on matching cluster but wrong namespaces cannot get": {
-			scopeKey: testutils.Cluster2NamespacesACReadWriteCtx,
-		},
-		"read-write on matching cluster can read": {
-			scopeKey: testutils.Cluster2ReadWriteCtx,
-			found:    true,
-		},
-		"read-write on the matching cluster and namespace can get": {
-			scopeKey: testutils.Cluster2NamespaceBReadWriteCtx,
-			found:    true,
-		},
-		"read-write on the matching cluster and at least one matching namespace can get": {
-			scopeKey: testutils.Cluster2NamespacesABReadWriteCtx,
-			found:    true,
-		},
-	}
+	cases := testutils.GenericNamespaceSACGetTestCases(s.T())
 
 	for name, c := range cases {
 		s.Run(name, func() {
-			ctx := s.testContexts[c.scopeKey]
+			ctx := s.testContexts[c.ScopeKey]
 			res, found, err := s.datastore.GetRiskForDeployment(ctx, d)
 			s.Require().NoError(err)
-			if c.found {
+			if c.ExpectedFound {
 				s.Require().True(found)
 				s.Equal(*risk, *res)
 			} else {
@@ -307,56 +201,7 @@ func (s *riskDatastoreSACSuite) TestGetRiskForDeployment() {
 }
 
 func (s *riskDatastoreSACSuite) TestRemoveRisk() {
-	cases := map[string]struct {
-		scopeKey    string
-		expectFail  bool
-		expectedErr error
-	}{
-		"global read-only cannot remove": {
-			scopeKey:    testutils.UnrestrictedReadCtx,
-			expectFail:  true,
-			expectedErr: sac.ErrResourceAccessDenied,
-		},
-		"global read-write can remove": {
-			scopeKey:    testutils.UnrestrictedReadWriteCtx,
-			expectedErr: nil,
-		},
-		"read-write on wrong cluster cannot remove": {
-			scopeKey:    testutils.Cluster1ReadWriteCtx,
-			expectFail:  true,
-			expectedErr: sac.ErrResourceAccessDenied,
-		},
-		"read-write on wrong cluster and wrong namespace cannot remove": {
-			scopeKey:    testutils.Cluster1NamespaceAReadWriteCtx,
-			expectFail:  true,
-			expectedErr: sac.ErrResourceAccessDenied,
-		},
-		"read-write on wrong cluster and matching namespace cannot remove": {
-			scopeKey:    testutils.Cluster1NamespaceBReadWriteCtx,
-			expectFail:  true,
-			expectedErr: sac.ErrResourceAccessDenied,
-		},
-		"read-write on matching cluster but wrong namespaces cannot remove": {
-			scopeKey:    testutils.Cluster2NamespacesACReadWriteCtx,
-			expectFail:  true,
-			expectedErr: sac.ErrResourceAccessDenied,
-		},
-		"full read-write on matching cluster cannot remove": {
-			scopeKey:    testutils.Cluster2ReadWriteCtx,
-			expectFail:  true,
-			expectedErr: sac.ErrResourceAccessDenied,
-		},
-		"read-write on the matching cluster and namespace cannot remove": {
-			scopeKey:    testutils.Cluster2NamespaceBReadWriteCtx,
-			expectFail:  true,
-			expectedErr: sac.ErrResourceAccessDenied,
-		},
-		"read-write on the matching cluster and at least the right namespace cannot remove": {
-			scopeKey:    testutils.Cluster2NamespacesABReadWriteCtx,
-			expectFail:  true,
-			expectedErr: sac.ErrResourceAccessDenied,
-		},
-	}
+	cases := testutils.GenericGlobalSACDeleteTestCases(s.T())
 
 	for name, c := range cases {
 		s.Run(name, func() {
@@ -364,15 +209,15 @@ func (s *riskDatastoreSACSuite) TestRemoveRisk() {
 				testconsts.NamespaceB)
 			s.testRiskIDs = append(s.testRiskIDs, risk.GetSubject().GetId())
 
-			ctx := s.testContexts[c.scopeKey]
+			ctx := s.testContexts[c.ScopeKey]
 			err := s.datastore.UpsertRisk(s.testContexts[testutils.UnrestrictedReadWriteCtx], risk)
 			s.Require().NoError(err)
 			defer s.deleteRisk(risk.GetId())
 
 			err = s.datastore.RemoveRisk(ctx, risk.GetSubject().GetId(), storage.RiskSubjectType_DEPLOYMENT)
-			if c.expectFail {
+			if c.ExpectError {
 				s.Require().Error(err)
-				s.ErrorIs(err, c.expectedErr)
+				s.ErrorIs(err, c.ExpectedError)
 			} else {
 				s.NoError(err)
 			}

--- a/central/risk/datastore/datastore_sac_test.go
+++ b/central/risk/datastore/datastore_sac_test.go
@@ -7,11 +7,6 @@ import (
 	"github.com/blevesearch/bleve"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/central/globalindex"
-	"github.com/stackrox/rox/central/risk/datastore/internal/index"
-	"github.com/stackrox/rox/central/risk/datastore/internal/search"
-	"github.com/stackrox/rox/central/risk/datastore/internal/store"
-	pgStore "github.com/stackrox/rox/central/risk/datastore/internal/store/postgres"
-	rdbStore "github.com/stackrox/rox/central/risk/datastore/internal/store/rocksdb"
 	"github.com/stackrox/rox/central/risk/mappings"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
@@ -40,10 +35,6 @@ type riskDatastoreSACSuite struct {
 
 	pool *pgxpool.Pool
 
-	storage store.Store
-	indexer index.Indexer
-	search  search.Searcher
-
 	datastore DataStore
 
 	optionsMap searchPkg.OptionsMap
@@ -55,33 +46,22 @@ type riskDatastoreSACSuite struct {
 func (s *riskDatastoreSACSuite) SetupSuite() {
 	var err error
 	if features.PostgresDatastore.Enabled() {
-		ctx := context.Background()
-		src := pgtest.GetConnectionString(s.T())
-		cfg, err := pgxpool.ParseConfig(src)
+		pgtestbase := pgtest.ForT(s.T())
+		s.Require().NotNil(pgtestbase)
+		s.pool = pgtestbase.Pool
+		s.datastore, err = GetTestPostgresDataStore(s.T(), s.pool)
 		s.Require().NoError(err)
-		s.pool, err = pgxpool.ConnectConfig(ctx, cfg)
-		s.Require().NoError(err)
-		pgStore.Destroy(ctx, s.pool)
-		gormDB := pgtest.OpenGormDB(s.T(), src)
-		defer pgtest.CloseGormDB(s.T(), gormDB)
-		s.storage = pgStore.CreateTableAndNewStore(ctx, s.pool, gormDB)
-		s.indexer = pgStore.NewIndexer(s.pool)
 		s.optionsMap = schema.RisksSchema.OptionsMap
 	} else {
 		s.engine, err = rocksdb.NewTemp("riskSACTest")
 		s.Require().NoError(err)
-		bleveIndex, err := globalindex.MemOnlyIndex()
+		s.index, err = globalindex.MemOnlyIndex()
 		s.Require().NoError(err)
-		s.index = bleveIndex
 
-		s.storage = rdbStore.New(s.engine)
-		s.indexer = index.New(s.index)
+		s.datastore, err = GetTestRocksBleveDataStore(s.T(), s.engine, s.index)
+		s.Require().NoError(err)
 		s.optionsMap = mappings.OptionsMap
 	}
-
-	s.search = search.New(s.storage, s.indexer)
-	s.datastore, err = New(s.storage, s.indexer, s.search)
-	s.Require().NoError(err)
 
 	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(),
 		resources.Risk)

--- a/central/secret/datastore/datastore_sac_test.go
+++ b/central/secret/datastore/datastore_sac_test.go
@@ -100,8 +100,7 @@ func (s *secretDatastoreSACTestSuite) cleanupSecret(ID string) {
 }
 
 func (s *secretDatastoreSACTestSuite) TestUpsertSecret() {
-	testedVerb := "upsert"
-	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testedVerb)
+	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testutils.VerbUpsert)
 
 	for name, c := range cases {
 		s.Run(name, func() {

--- a/central/serviceaccount/datastore/datastore.go
+++ b/central/serviceaccount/datastore/datastore.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 
 	"github.com/blevesearch/bleve"
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/central/serviceaccount/internal/index"
 	"github.com/stackrox/rox/central/serviceaccount/internal/store"
+	"github.com/stackrox/rox/central/serviceaccount/internal/store/postgres"
 	"github.com/stackrox/rox/central/serviceaccount/internal/store/rocksdb"
 	"github.com/stackrox/rox/central/serviceaccount/search"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -56,15 +58,20 @@ func NewForTestOnly(t *testing.T, db *pkgRocksDB.RocksDB, bleveIndex bleve.Index
 	testutils.MustBeInTest(t)
 	saStore := rocksdb.New(db)
 	indexer := index.New(bleveIndex)
+	searcher := search.New(saStore, indexer)
 
-	d := &datastoreImpl{
-		storage:  saStore,
-		indexer:  indexer,
-		searcher: search.New(saStore, indexer),
-	}
+	return New(saStore, indexer, searcher)
+}
 
-	if err := d.buildIndex(context.TODO()); err != nil {
-		return nil, errors.Wrap(err, "failed to build index from existing store")
-	}
-	return d, nil
+// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetTestPostgresDataStore(_ *testing.T, pool *pgxpool.Pool) (DataStore, error) {
+	dbstore := postgres.New(pool)
+	indexer := postgres.NewIndexer(pool)
+	searcher := search.New(dbstore, indexer)
+	return New(dbstore, indexer, searcher)
+}
+
+// GetTestRocksBleveDataStore provides a datastore connected to rocksdb and bleve for testing purposes.
+func GetTestRocksBleveDataStore(t *testing.T, rocksengine *pkgRocksDB.RocksDB, bleveIndex bleve.Index) (DataStore, error) {
+	return NewForTestOnly(t, rocksengine, bleveIndex)
 }

--- a/central/serviceaccount/datastore/datastore_sac_test.go
+++ b/central/serviceaccount/datastore/datastore_sac_test.go
@@ -8,12 +8,7 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/central/globalindex"
 	"github.com/stackrox/rox/central/role/resources"
-	"github.com/stackrox/rox/central/serviceaccount/internal/index"
-	"github.com/stackrox/rox/central/serviceaccount/internal/store"
-	pgStore "github.com/stackrox/rox/central/serviceaccount/internal/store/postgres"
-	rdbStore "github.com/stackrox/rox/central/serviceaccount/internal/store/rocksdb"
 	"github.com/stackrox/rox/central/serviceaccount/mappings"
-	"github.com/stackrox/rox/central/serviceaccount/search"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
@@ -41,9 +36,6 @@ type serviceAccountSACSuite struct {
 	engine *rocksdb.RocksDB
 	index  bleve.Index
 
-	storage    store.Store
-	indexer    index.Indexer
-	search     search.Searcher
 	optionsMap searchPkg.OptionsMap
 
 	testContexts          map[string]context.Context
@@ -54,33 +46,21 @@ func (s *serviceAccountSACSuite) SetupSuite() {
 	var err error
 
 	if features.PostgresDatastore.Enabled() {
-		ctx := context.Background()
-		src := pgtest.GetConnectionString(s.T())
-		cfg, err := pgxpool.ParseConfig(src)
+		pgtestbase := pgtest.ForT(s.T())
+		s.Require().NotNil(pgtestbase)
+		s.pool = pgtestbase.Pool
+		s.datastore, err = GetTestPostgresDataStore(s.T(), s.pool)
 		s.Require().NoError(err)
-		s.pool, err = pgxpool.ConnectConfig(ctx, cfg)
-		s.Require().NoError(err)
-		pgStore.Destroy(ctx, s.pool)
-		gormDB := pgtest.OpenGormDB(s.T(), src)
-		defer pgtest.CloseGormDB(s.T(), gormDB)
-		s.storage = pgStore.CreateTableAndNewStore(ctx, s.pool, gormDB)
-		s.indexer = pgStore.NewIndexer(s.pool)
 		s.optionsMap = schema.ServiceAccountsSchema.OptionsMap
 	} else {
 		s.engine, err = rocksdb.NewTemp("serviceAccountSACTest")
 		s.Require().NoError(err)
-		bleveIndex, err := globalindex.MemOnlyIndex()
+		s.index, err = globalindex.MemOnlyIndex()
 		s.Require().NoError(err)
-		s.index = bleveIndex
-
-		s.storage = rdbStore.New(s.engine)
-		s.indexer = index.New(s.index)
+		s.datastore, err = GetTestRocksBleveDataStore(s.T(), s.engine, s.index)
+		s.Require().NoError(err)
 		s.optionsMap = mappings.OptionsMap
 	}
-
-	s.search = search.New(s.storage, s.indexer)
-	s.datastore, err = New(s.storage, s.indexer, s.search)
-	s.Require().NoError(err)
 
 	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(),
 		resources.ServiceAccount)

--- a/central/serviceaccount/datastore/datastore_sac_test.go
+++ b/central/serviceaccount/datastore/datastore_sac_test.go
@@ -101,8 +101,7 @@ func (s *serviceAccountSACSuite) deleteServiceAccount(id string) {
 }
 
 func (s *serviceAccountSACSuite) TestUpsertServiceAccount() {
-	testedVerb := "upsert"
-	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testedVerb)
+	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testutils.VerbUpsert)
 
 	for name, c := range cases {
 		s.Run(name, func() {

--- a/pkg/sac/testutils/crud_test_cases.go
+++ b/pkg/sac/testutils/crud_test_cases.go
@@ -6,6 +6,13 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 )
 
+// Verbs for the Generic*SACUpsertTestCases functions.
+const (
+	VerbAdd    = "add"
+	VerbUpdate = "update"
+	VerbUpsert = "upsert"
+)
+
 // SACCrudTestCase is used within SAC tests. It describes the expected behaviour of a datastore CRUD function for
 // a given scoped context. The contexts are defined in the current package in the test_contexts.go file and
 // are referred to by their key in test cases.

--- a/pkg/sac/testutils/crud_test_cases.go
+++ b/pkg/sac/testutils/crud_test_cases.go
@@ -1,0 +1,346 @@
+package testutils
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/sac"
+)
+
+// SACCrudTestCase is used within SAC tests. It describes the expected behaviour of a datastore CRUD function for
+// a given scoped context. The contexts are defined in the current package in the test_contexts.go file and
+// are referred to by their key in test cases.
+type SACCrudTestCase struct {
+	ScopeKey      string
+	ExpectedError error
+	ExpectError   bool
+	ExpectedFound bool
+}
+
+// GenericNamespaceSACUpsertTestCases returns a generic set of SACCrudTestCase.
+// It is appropriate for use in the context of testing Upsert function on namespace scoped resources
+// when the scope checks are expected to assess whether the object to upsert belongs to a namespace
+// in scope. These test cases assume the inserted test object belongs to Cluster2 and NamespaceB.
+func GenericNamespaceSACUpsertTestCases(_ *testing.T, verb string) map[string]SACCrudTestCase {
+	return map[string]SACCrudTestCase{
+		"(full) read-only cannot " + verb: {
+			ScopeKey:      UnrestrictedReadCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write can " + verb: {
+			ScopeKey:      UnrestrictedReadWriteCtx,
+			ExpectError:   false,
+			ExpectedError: nil,
+		},
+		"full read-write on wrong cluster cannot " + verb: {
+			ScopeKey:      Cluster1ReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and wrong namespace name cannot " + verb: {
+			ScopeKey:      Cluster1NamespaceAReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and matching namespace name cannot " + verb: {
+			ScopeKey:      Cluster1NamespaceBReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write on right cluster can " + verb: {
+			ScopeKey:      Cluster2ReadWriteCtx,
+			ExpectError:   false,
+			ExpectedError: nil,
+		},
+		"read-write on right cluster but wrong namespace cannot " + verb: {
+			ScopeKey:      Cluster2NamespaceAReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on right cluster but wrong namespaces cannot " + verb: {
+			ScopeKey:      Cluster2NamespacesACReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on the right cluster and namespace can " + verb: {
+			ScopeKey:      Cluster2NamespaceBReadWriteCtx,
+			ExpectError:   false,
+			ExpectedError: nil,
+		},
+		"read-write on the right cluster and at least the right namespace can " + verb: {
+			ScopeKey:      Cluster2NamespacesABReadWriteCtx,
+			ExpectError:   false,
+			ExpectedError: nil,
+		},
+	}
+}
+
+// GenericNamespaceSACGetTestCases returns a generic set of SACCrudTestCase.
+// It is appropriate for use in the context of testing Get function on namespace scoped resources
+// when the scope checks are expected to assess whether the retrieved object belongs to a namespace
+// in scope. These test cases assume the tested object belongs to Cluster2 and NamespaceB.
+func GenericNamespaceSACGetTestCases(_ *testing.T) map[string]SACCrudTestCase {
+	return map[string]SACCrudTestCase{
+		"(full) read-only can get": {
+			ScopeKey:      UnrestrictedReadCtx,
+			ExpectedFound: true,
+		},
+		"full read-write can get": {
+			ScopeKey:      UnrestrictedReadWriteCtx,
+			ExpectedFound: true,
+		},
+		"full read-write on wrong cluster cannot get": {
+			ScopeKey:      Cluster1ReadWriteCtx,
+			ExpectedFound: false,
+		},
+		"read-write on wrong cluster and wrong namespace name cannot get": {
+			ScopeKey:      Cluster1NamespaceAReadWriteCtx,
+			ExpectedFound: false,
+		},
+		"read-write on wrong cluster and matching namespace name cannot get": {
+			ScopeKey:      Cluster1NamespaceBReadWriteCtx,
+			ExpectedFound: false,
+		},
+		"full read-write on right cluster can get": {
+			ScopeKey:      Cluster2ReadWriteCtx,
+			ExpectedFound: true,
+		},
+		"read-write on right cluster but wrong namespace cannot get": {
+			ScopeKey:      Cluster2NamespaceAReadWriteCtx,
+			ExpectedFound: false,
+		},
+		"read-write on right cluster but wrong namespaces cannot get": {
+			ScopeKey:      Cluster2NamespacesACReadWriteCtx,
+			ExpectedFound: false,
+		},
+		"read-write on the right cluster and namespace can get": {
+			ScopeKey:      Cluster2NamespaceBReadWriteCtx,
+			ExpectedFound: true,
+		},
+		"read-write on the right cluster and at least the right namespace can get": {
+			ScopeKey:      Cluster2NamespacesABReadWriteCtx,
+			ExpectedFound: true,
+		},
+	}
+}
+
+// GenericNamespaceSACDeleteTestCases returns a generic set of SACCrudTestCase.
+// It is appropriate for use in the context of testing Delete or Remove function on resources when the scope checks
+// are expected to assess whether the retrieved object belongs to a namespace
+// in scope. These test cases assume the removed test object belongs to Cluster2 and NamespaceB.
+func GenericNamespaceSACDeleteTestCases(_ *testing.T) map[string]SACCrudTestCase {
+	return map[string]SACCrudTestCase{
+		"global read-only should not be able to delete": {
+			ScopeKey:      UnrestrictedReadCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"global read-write should be able to delete": {
+			ScopeKey:      UnrestrictedReadWriteCtx,
+			ExpectError:   false,
+			ExpectedError: nil,
+		},
+		"read-write on wrong cluster should not be able to delete": {
+			ScopeKey:      Cluster1ReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and namespace should not be able to delete": {
+			ScopeKey:      Cluster1NamespaceAReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and matching namespace should not be able to delete": {
+			ScopeKey:      Cluster1NamespaceBReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster should be able to delete": {
+			ScopeKey:      Cluster2ReadWriteCtx,
+			ExpectError:   false,
+			ExpectedError: nil,
+		},
+		"read-write on matching cluster and wrong namespace should not be able to delete": {
+			ScopeKey:      Cluster2NamespaceAReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and wrong namespaces should not be able to delete": {
+			ScopeKey:      Cluster2NamespacesACReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and matching namespace should be able to delete": {
+			ScopeKey:      Cluster2NamespaceBReadWriteCtx,
+			ExpectError:   false,
+			ExpectedError: nil,
+		},
+		"read-write on matching cluster and at least one matching namespace should be able to delete": {
+			ScopeKey:      Cluster2NamespacesABReadWriteCtx,
+			ExpectError:   false,
+			ExpectedError: nil,
+		},
+	}
+}
+
+// GenericGlobalSACUpsertTestCases returns a generic set of SACCrudTestCase.
+// It is appropriate for use in the context of testing Upsert function on resources when the scope checks
+// are expected to check global resource access only. These test cases assume the inserted test object
+// belongs to Cluster2 and NamespaceB.
+func GenericGlobalSACUpsertTestCases(_ *testing.T, verb string) map[string]SACCrudTestCase {
+	return map[string]SACCrudTestCase{
+		"global read-only should not be able to " + verb: {
+			ScopeKey:      UnrestrictedReadCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"global read-write should be able to " + verb: {
+			ScopeKey:      UnrestrictedReadWriteCtx,
+			ExpectError:   false,
+			ExpectedError: nil,
+		},
+		"read-write on wrong cluster should not be able to " + verb: {
+			ScopeKey:      Cluster1ReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and namespace should not be able to " + verb: {
+			ScopeKey:      Cluster1NamespaceAReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and matching namespace should not be able to " + verb: {
+			ScopeKey:      Cluster1NamespaceBReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and wrong namespace should not be able to " + verb: {
+			ScopeKey:      Cluster2NamespaceAReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and wrong namespaces should not be able to " + verb: {
+			ScopeKey:      Cluster2NamespacesACReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and matching namespace should be able to " + verb: {
+			ScopeKey:      Cluster2NamespaceBReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and at least one matching namespace should be able to " + verb: {
+			ScopeKey:      Cluster2NamespacesABReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+	}
+}
+
+// GenericGlobalSACGetTestCases returns a generic set of SACCrudTestCase.
+// It is appropriate for use in the context of testing Get function on namespace scoped resources
+// when the scope checks are expected to check global resource access only.
+// These test cases assume the tested object belongs to Cluster2 and NamespaceB.
+func GenericGlobalSACGetTestCases(_ *testing.T) map[string]SACCrudTestCase {
+	return map[string]SACCrudTestCase{
+		"(full) read-only can get": {
+			ScopeKey:      UnrestrictedReadCtx,
+			ExpectedFound: true,
+		},
+		"full read-write can get": {
+			ScopeKey:      UnrestrictedReadWriteCtx,
+			ExpectedFound: true,
+		},
+		"full read-write on wrong cluster cannot get": {
+			ScopeKey:      Cluster1ReadWriteCtx,
+			ExpectedFound: false,
+		},
+		"read-write on wrong cluster and wrong namespace name cannot get": {
+			ScopeKey:      Cluster1NamespaceAReadWriteCtx,
+			ExpectedFound: false,
+		},
+		"read-write on wrong cluster and matching namespace name cannot get": {
+			ScopeKey:      Cluster1NamespaceBReadWriteCtx,
+			ExpectedFound: false,
+		},
+		"full read-write on right cluster cannot get": {
+			ScopeKey:      Cluster2ReadWriteCtx,
+			ExpectedFound: false,
+		},
+		"read-write on right cluster but wrong namespace cannot get": {
+			ScopeKey:      Cluster2NamespaceAReadWriteCtx,
+			ExpectedFound: false,
+		},
+		"read-write on right cluster but wrong namespaces cannot get": {
+			ScopeKey:      Cluster2NamespacesACReadWriteCtx,
+			ExpectedFound: false,
+		},
+		"read-write on the right cluster and namespace cannot get": {
+			ScopeKey:      Cluster2NamespaceBReadWriteCtx,
+			ExpectedFound: false,
+		},
+		"read-write on the right cluster and at least the right namespace cannot get": {
+			ScopeKey:      Cluster2NamespacesABReadWriteCtx,
+			ExpectedFound: false,
+		},
+	}
+}
+
+// GenericGlobalSACDeleteTestCases returns a generic set of SACCrudTestCase.
+// It is appropriate for use in the context of testing Delete or Remove function on resources when the scope checks
+// are expected to check global resource access only. These test cases assume the removed test object
+// belongs to Cluster2 and NamespaceB.
+func GenericGlobalSACDeleteTestCases(_ *testing.T) map[string]SACCrudTestCase {
+	return map[string]SACCrudTestCase{
+		"global read-only should not be able to delete": {
+			ScopeKey:      UnrestrictedReadCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"global read-write should be able to delete": {
+			ScopeKey:      UnrestrictedReadWriteCtx,
+			ExpectError:   false,
+			ExpectedError: nil,
+		},
+		"read-write on wrong cluster should not be able to delete": {
+			ScopeKey:      Cluster1ReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and namespace should not be able to delete": {
+			ScopeKey:      Cluster1NamespaceAReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and matching namespace should not be able to delete": {
+			ScopeKey:      Cluster1NamespaceBReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster should not be able to delete": {
+			ScopeKey:      Cluster2ReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and wrong namespace should not be able to delete": {
+			ScopeKey:      Cluster2NamespaceAReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and wrong namespaces should not be able to delete": {
+			ScopeKey:      Cluster2NamespacesACReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and matching namespace not should be able to delete": {
+			ScopeKey:      Cluster2NamespaceBReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on matching cluster and at least one matching namespace should not be able to delete": {
+			ScopeKey:      Cluster2NamespacesABReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+	}
+}


### PR DESCRIPTION
## Description

Test cases were added for the datastores of directly scoped object types in parallel. Most of the test cases for the Add, Delete, Get, Update, Upsert functions are very similar or identical. Centralizing the test cases in a common location helps defining a single set of pre-defined behaviour patterns and the associated tests.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Manual run of the go integration tests in the impacted datastore directories.

CI run should be enough for this test re-structuration change.
