### PR TITLE
Display Imminent instead of zero or negative days for Cluster Deletion in UI

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/clusterDeletion.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clusterDeletion.test.js
@@ -92,17 +92,24 @@ describe('Cluster page clusterRetentionInfo', () => {
         cy.get('div:contains("Cluster Deletion"):contains("in 1 day")'); // FYI red color
     });
 
+    it('should display Imminent for 0 days in Cluster Deletion widget for mock request', () => {
+        const clusterRetentionInfo = { daysUntilDeletion: 0 };
+        visitClusterWithRetentionInfo(clusterRetentionInfo);
+
+        cy.get('div:contains("Cluster Deletion"):contains("Imminent")'); // FYI red color
+    });
+
+    it('should display Imminent for -1 days in Cluster Deletion widget for mock request', () => {
+        const clusterRetentionInfo = { daysUntilDeletion: -1 };
+        visitClusterWithRetentionInfo(clusterRetentionInfo);
+
+        cy.get('div:contains("Cluster Deletion"):contains("Imminent")'); // FYI red color
+    });
+
     it('should display Excuded from deletion in Cluster Deletion widget for mock request', () => {
         const clusterRetentionInfo = { isExcluded: true };
         visitClusterWithRetentionInfo(clusterRetentionInfo);
 
         cy.get('div:contains("Cluster Deletion"):contains("Excluded from deletion")');
-    });
-
-    it('should display Deletion is turned off in Cluster Deletion widget for mock request', () => {
-        const clusterRetentionInfo = { isExcluded: false };
-        visitClusterWithRetentionInfo(clusterRetentionInfo);
-
-        cy.get('div:contains("Cluster Deletion"):contains("Deletion is turned off")');
     });
 });

--- a/ui/apps/platform/cypress/integration/clusters/clusterDeletion.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clusterDeletion.test.js
@@ -106,7 +106,7 @@ describe('Cluster page clusterRetentionInfo', () => {
         cy.get('div:contains("Cluster Deletion"):contains("Imminent")'); // FYI red color
     });
 
-    it('should display Excuded from deletion in Cluster Deletion widget for mock request', () => {
+    it('should display Excluded from deletion in Cluster Deletion widget for mock request', () => {
         const clusterRetentionInfo = { isExcluded: true };
         visitClusterWithRetentionInfo(clusterRetentionInfo);
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterDeletion.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterDeletion.tsx
@@ -13,7 +13,7 @@ type ClusterDeletionProps = {
 
 function ClusterDeletion({ clusterRetentionInfo }: ClusterDeletionProps): ReactElement {
     if (clusterRetentionInfo === null) {
-        // Cluster does not have sensor status UNHEALTHY.
+        // Cluster does not have sensor status UNHEALTHY or cluster deletion is turned off.
         return <HealthStatusNotApplicable testId={testId} />;
     }
 
@@ -24,19 +24,23 @@ function ClusterDeletion({ clusterRetentionInfo }: ClusterDeletionProps): ReactE
         const { daysUntilDeletion } = clusterRetentionInfo;
         const healthStatus = getClusterDeletionStatus(daysUntilDeletion);
         const { bgColor, fgColor } = healthStatusStyles[healthStatus];
-        const text = daysUntilDeletion === 1 ? 'in 1 day' : `in ${daysUntilDeletion} days`;
+        /* eslint-disable no-nested-ternary */
+        const text =
+            daysUntilDeletion < 1
+                ? 'Imminent'
+                : daysUntilDeletion === 1
+                ? 'in 1 day'
+                : `in ${daysUntilDeletion} days`;
+        /* eslint-enable no-nested-ternary */
 
         return <span className={`${bgColor} ${fgColor} whitespace-nowrap`}>{text}</span>;
     }
 
-    // Cluster will not be deleted even if sensor status remains UNHEALTHY:
-    // because it has an ignore label, if true
-    // because system configuration is never delete, if false
+    // Cluster will not be deleted even if sensor status remains UNHEALTHY, because it has an ignore label.
     const { bgColor, fgColor } = healthStatusStyles.HEALTHY;
-    const { isExcluded } = clusterRetentionInfo;
-    const text = isExcluded ? 'Excluded from deletion' : 'Deletion is turned off';
-
-    return <span className={`${bgColor} ${fgColor} whitespace-nowrap`}>{text}</span>;
+    return (
+        <span className={`${bgColor} ${fgColor} whitespace-nowrap`}>Excluded from deletion</span>
+    );
 }
 
 export default ClusterDeletion;

--- a/ui/apps/platform/src/types/clusterService.proto.ts
+++ b/ui/apps/platform/src/types/clusterService.proto.ts
@@ -6,16 +6,15 @@ export type LoadBalancerType = 'NONE' | 'LOAD_BALANCER' | 'NODE_PORT' | 'ROUTE';
 
 export type DecommissionedClusterRetentionInfo =
     | {
-          // Cluster will not be deleted even if sensor status remains UNHEALTHY:
-          // because it has an ignore label, if true
-          // because system configuration is never delete, if false
+          // Cluster will not be deleted even if sensor status remains UNHEALTHY, because it has an ignore label.
+          // Therefore, if isExcluded property is present, then it has value true.
           isExcluded: boolean;
       }
     | {
           // Cluster will be deleted if sensor status remains UNHEALTHY for the number of days.
           daysUntilDeletion: number; // int32
       }
-    | null; // Cluster does not have sensor status UNHEALTHY.
+    | null; // Cluster does not have sensor status UNHEALTHY or cluster deletion is turned off.
 
 export type ClusterResponse = {
     cluster: Cluster;


### PR DESCRIPTION
## Description

Here is a screen grab with temporary code change to replace `null` with `{ daysUntilDeletion: 0 }` for `clusterRetentionInfo` prop of `ClusterDeletion` element:
![Imminent](https://user-images.githubusercontent.com/11862657/179286403-2569cc3d-c796-4bf2-ae24-daf753a1abb0.png)

Also I corrected my misunderstanding about `isExcluded` property.

### Changed files

1. Edit cypress/integration/clusters/clusterDeletion.test.js
    * Add 2 tests for zero and negative days
    * Delete test for `isExcluded: false` which is not a valid case

2. Edit src/Containers/Clusters/Components/ClusterDeletion.tsx
    * Correct the comments
    * Add **Imminent** for `daysUntilDeletion < 1`
    * Delete **Deletion is turned off** for `isExcluded: false` which is not a valid case

3. Edit src/types/clusterService.proto.ts
    * Correct the comments

### Residue

1. Improve integration tests to mock response in clusters table instead of cluster panel, because **Cluster Deletion** is below the fold on the panel. If the test fails, the snapshot displays the incorrectly rendered result. Also possible to use test to take pictures of UI for different scenarios.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

1. `export ROX_DECOMMISSIONED_CLUSTER_RETENTION=true` in ui
2. `yarn deploy-local` in ui
3. `yarn start` in ui
4. `export CYPRESS_ROX_DECOMMISSIONED_CLUSTER_RETENTION=true` in ui/apps/platform
5. `yarn cypress-open` in ui/apps/platform
    * clusters/clusterDeletion.test.js see that existing and new tests pass