### PR TITLE
CI: Ensure race condition debug catches race conditions

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -239,16 +239,6 @@ func main() {
 
 	devmode.StartOnDevBuilds("central")
 
-	done := make(chan bool)
-	m := make(map[string]string)
-	m["name"] = "world"
-	go func() {
-		m["name"] = "data race"
-		done <- true
-	}()
-	log.Infof("Hello %s", m["name"])
-	<-done
-
 	if features.PostgresDatastore.Enabled() {
 		sourceMap, config, err := globaldb.GetPostgresConfig()
 		if err != nil {

--- a/central/main.go
+++ b/central/main.go
@@ -239,6 +239,16 @@ func main() {
 
 	devmode.StartOnDevBuilds("central")
 
+	done := make(chan bool)
+	m := make(map[string]string)
+	m["name"] = "world"
+	go func() {
+		m["name"] = "data race"
+		done <- true
+	}()
+	log.Infof("Hello %s", m["name"])
+	<-done
+
 	if features.PostgresDatastore.Enabled() {
 		sourceMap, config, err := globaldb.GetPostgresConfig()
 		if err != nil {

--- a/scripts/ci/gate-jobs-config.json
+++ b/scripts/ci/gate-jobs-config.json
@@ -82,7 +82,7 @@
     "gke-race-condition-qa-e2e-tests": {
         "run_with_labels": ["ci-race-condition-tests"],
         "skip_with_label": "",
-        "run_with_changed_path": "^.*$",
+        "run_with_changed_path": "",
         "changed_path_to_ignore": "^ui/",
         "run_on_master": "true",
         "run_on_tags": "true"

--- a/scripts/ci/gate-jobs-config.json
+++ b/scripts/ci/gate-jobs-config.json
@@ -83,7 +83,7 @@
         "run_with_labels": ["ci-race-condition-tests"],
         "skip_with_label": "",
         "run_with_changed_path": "",
-        "changed_path_to_ignore": "^ui/",
+        "changed_path_to_ignore": "",
         "run_on_master": "true",
         "run_on_tags": "true"
     }

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -54,11 +54,11 @@ deploy_central() {
 
     # If we're running a nightly build or race condition check, then set CGO_CHECKS=true so that central is
     # deployed with strict checks
-    if is_nightly_run || pr_has_label ci-race-tests; then
+    if is_nightly_run || pr_has_label ci-race-tests || [[ "${CI_JOB_NAME:-}" =~ race-condition ]]; then
         ci_export CGO_CHECKS "true"
     fi
 
-    if pr_has_label ci-race-tests; then
+    if pr_has_label ci-race-tests || [[ "${CI_JOB_NAME:-}" =~ race-condition ]]; then
         ci_export IS_RACE_BUILD "true"
     fi
 


### PR DESCRIPTION
## Description

Updated the gating definition so this test properly respects the label and fixed required env sets for `-race` tests.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] `ci-race-tests` + forced race condition: all clusters fail with appropriate log message flagged. `gke-race-condition-qa-e2e-tests` cluster flavor does not run.
- [x] `ci-race-condition-tests` + forced race condition: `gke-race-condition-qa-e2e-tests` cluster flavor runs and fails with appropriate log message flagged. Other cluster flavors do not notice the race condition.
- [x] no `-race` labels + forced race condition: `gke-race-condition-qa-e2e-tests` cluster flavor does not run. Other cluster flavors do not notice the race condition.
