### PR TITLE
VM Demo Bug Fixes

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
@@ -64,14 +64,13 @@ describe('Vuln Management Dashboard Page', () => {
 
     it('should show same number of images between the tile and the images list', () => {
         visitVulnerabilityManagementDashboard();
-        cy.get(selectors.tileLinks)
-            .eq(2)
-
+        cy.get(selectors.tileLinks, { timeout: 8000 })
+            .eq(3)
             .find(selectors.tileLinkValue)
             .invoke('text')
             .then((value) => {
                 const numImages = value;
-                cy.get(selectors.tileLinks).eq(2).click();
+                cy.get(selectors.tileLinks).eq(3).click();
                 cy.get(`[data-testid="panel"] [data-testid="panel-header"]`)
                     .invoke('text')
                     .then((panelHeaderText) => {

--- a/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
@@ -2,16 +2,25 @@ import * as api from '../../constants/apiEndpoints';
 import { selectors } from '../../constants/VulnManagementPage';
 import withAuth from '../../helpers/basicAuth';
 import { visitVulnerabilityManagementEntities } from '../../helpers/vulnmanagement/entities';
+import { hasFeatureFlag } from '../../helpers/features';
 
 describe('Entities single views', () => {
     withAuth();
 
     it('related entities tile links should unset search params upon navigation', () => {
+        const usingVMUpdates = hasFeatureFlag('ROX_FRONTEND_VM_UDPATES');
+
         visitVulnerabilityManagementEntities('clusters');
 
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('clusters', 'IMAGE_CVE')).as(
-            'clustersCVE'
-        );
+        if (usingVMUpdates) {
+            cy.intercept('POST', api.vulnMgmt.graphqlEntities2('clusters', 'IMAGE_CVE')).as(
+                'clustersCVE'
+            );
+        } else {
+            cy.intercept('POST', api.vulnMgmt.graphqlEntities2('clusters', 'CVE')).as(
+                'clustersCVE'
+            );
+        }
         cy.get(`${selectors.tableBodyRows} ${selectors.fixableCvesLink}:eq(0)`).click();
         cy.wait('@clustersCVE');
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtEntityCve.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtEntityCve.js
@@ -81,17 +81,17 @@ const VulmMgmtCve = ({ entityId, entityListType, search, entityContext, sort, pa
 
     function getListQuery(listFieldName, fragmentName, fragment) {
         return gql`
-        query getCve${entityListType}($id: ID!, $pagination: Pagination, $query: String, $policyQuery: String, $scopeQuery: String) {
-            result: ${vulnQuery}(id: $id) {
-                id
-                ${defaultCountKeyMap[entityListType]}(query: $query)
-                ${listFieldName}(query: $query, pagination: $pagination) { ...${fragmentName} }
-                unusedVarSink(query: $policyQuery)
-                unusedVarSink(query: $scopeQuery)
+            query getCve${entityListType}($id: ID!, $pagination: Pagination, $query: String, $policyQuery: String, $scopeQuery: String) {
+                result: ${vulnQuery}(id: $id) {
+                    id
+                    ${defaultCountKeyMap[entityListType]}(query: $query)
+                    ${listFieldName}(query: $query, pagination: $pagination) { ...${fragmentName} }
+                    unusedVarSink(query: $policyQuery)
+                    unusedVarSink(query: $scopeQuery)
+                }
             }
-        }
-        ${fragment}
-    `;
+            ${fragment}
+        `;
     }
 
     const fullEntityContext = workflowState.getEntityContext();

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/RelatedEntitiesSideList.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/RelatedEntitiesSideList.js
@@ -46,11 +46,21 @@ const RelatedEntitiesSideList = ({ entityType, data, altCountKeyMap, entityConte
                 newMatchEntity = 'IMAGE_COMPONENT';
             }
 
-            const countKeyToUse =
+            let countKeyToUse = countKeyMap[newMatchEntity];
+            if (
                 countKeyMap[newMatchEntity].includes('imageComponentCount') ||
                 countKeyMap[newMatchEntity].includes('nodeComponentCount')
-                    ? 'componentCount'
-                    : countKeyMap[newMatchEntity];
+            ) {
+                countKeyToUse = 'componentCount';
+            }
+            if (
+                countKeyMap[newMatchEntity].includes('imageVulnerabilityCount') ||
+                countKeyMap[newMatchEntity].includes('nodeVulnerabilityCount') ||
+                countKeyMap[newMatchEntity].includes('clusterVulnerabilityCount') ||
+                countKeyMap[newMatchEntity].includes('k8sVulnCount')
+            ) {
+                countKeyToUse = 'vulnCount';
+            }
             const count = data[countKeyToUse];
 
             return {
@@ -85,7 +95,23 @@ const RelatedEntitiesSideList = ({ entityType, data, altCountKeyMap, entityConte
                 newContainEntity = 'IMAGE_COMPONENT';
             }
 
-            const count = data[countKeyMap[newContainEntity]];
+            let countKeyToUse = countKeyMap[newContainEntity];
+            if (
+                countKeyMap[newContainEntity].includes('imageComponentCount') ||
+                countKeyMap[newContainEntity].includes('nodeComponentCount')
+            ) {
+                countKeyToUse = 'componentCount';
+            }
+            if (
+                countKeyMap[newContainEntity].includes('imageVulnerabilityCount') ||
+                countKeyMap[newContainEntity].includes('nodeVulnerabilityCount') ||
+                countKeyMap[newContainEntity].includes('clusterVulnerabilityCount') ||
+                countKeyMap[newContainEntity].includes('k8sVulnCount')
+            ) {
+                countKeyToUse = 'vulnCount';
+            }
+            const count = data[countKeyToUse];
+
             const entityLabel = entityLabels[newContainEntity].toUpperCase();
             return {
                 count,

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.js
@@ -76,7 +76,6 @@ const TableWidgetFixableCves = ({
             $id: ID!
             ${
                 entityType !== entityTypes.NODE_COMPONENT &&
-                entityType !== entityTypes.IMAGE_COMPONENT &&
                 vulnType !== entityTypes.NODE_CVE &&
                 vulnType !== entityTypes.CLUSTER_CVE
                     ? '$query: String'

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.js
@@ -50,7 +50,7 @@ export function getComponentTableColumns(workflowState) {
             sortField: componentSortFields.COMPONENT,
         },
         {
-            Header: `CVEs`,
+            Header: `Image CVEs`,
             entityType: entityTypes.CVE,
             headerClassName: `w-1/8 ${defaultHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.js
@@ -20,6 +20,7 @@ import removeEntityContextColumns from 'utils/tableUtils';
 import { componentSortFields } from 'constants/sortFields';
 
 import TableCountLink from 'Components/workflow/TableCountLink';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import { getFilteredComponentColumns } from './ListImageComponents.utils';
 
 export const defaultComponentSort = [
@@ -29,181 +30,192 @@ export const defaultComponentSort = [
     },
 ];
 
-export function getComponentTableColumns(workflowState) {
-    const tableColumns = [
-        {
-            Header: 'Id',
-            headerClassName: 'hidden',
-            className: 'hidden',
-            accessor: 'id',
-        },
-        {
-            Header: `Component`,
-            headerClassName: `w-1/4 ${defaultHeaderClassName}`,
-            className: `w-1/4 ${defaultColumnClassName}`,
-            Cell: ({ original }) => {
-                const { version, name } = original;
-                return `${name} ${version}`;
+export function getComponentTableColumns(showVMUpdates) {
+    return function getTableColumns(workflowState) {
+        const tableColumns = [
+            {
+                Header: 'Id',
+                headerClassName: 'hidden',
+                className: 'hidden',
+                accessor: 'id',
             },
-            id: componentSortFields.COMPONENT,
-            accessor: 'name',
-            sortField: componentSortFields.COMPONENT,
-        },
-        {
-            Header: `Image CVEs`,
-            entityType: entityTypes.CVE,
-            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
-            className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
-                const { vulnCounter, id } = original;
-                if (!vulnCounter || vulnCounter.all.total === 0) {
-                    return 'No CVEs';
-                }
-
-                const newState = workflowState.pushListItem(id).pushList(entityTypes.IMAGE_CVE);
-                const url = newState.toUrl();
-                const fixableUrl = newState.setSearch({ Fixable: true }).toUrl();
-
-                return (
-                    <CVEStackedPill
-                        vulnCounter={vulnCounter}
-                        url={url}
-                        fixableUrl={fixableUrl}
-                        hideLink={pdf}
-                    />
-                );
+            {
+                Header: `Component`,
+                headerClassName: `w-1/4 ${defaultHeaderClassName}`,
+                className: `w-1/4 ${defaultColumnClassName}`,
+                Cell: ({ original }) => {
+                    const { version, name } = original;
+                    return `${name} ${version}`;
+                },
+                id: componentSortFields.COMPONENT,
+                accessor: 'name',
+                sortField: componentSortFields.COMPONENT,
             },
-            id: componentSortFields.CVE_COUNT,
-            accessor: 'vulnCounter.all.total',
-            sortField: componentSortFields.CVE_COUNT,
-        },
-        {
-            Header: `Active`,
-            headerClassName: `w-1/10 text-center ${nonSortableHeaderClassName}`,
-            className: `w-1/10 ${defaultColumnClassName}`,
-            // eslint-disable-next-line
-            Cell: ({ original }) => {
-                const activeStatus = original.activeState?.state || 'Undetermined';
-                switch (activeStatus) {
-                    case 'Active': {
+            {
+                Header: showVMUpdates ? `Image CVEs` : 'CVEs',
+                entityType: entityTypes.CVE,
+                headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+                className: `w-1/8 ${defaultColumnClassName}`,
+                Cell: ({ original, pdf }) => {
+                    const { vulnCounter, id } = original;
+                    if (!vulnCounter || vulnCounter.all.total === 0) {
+                        return 'No CVEs';
+                    }
+
+                    const newState = workflowState
+                        .pushListItem(id)
+                        .pushList(showVMUpdates ? entityTypes.IMAGE_CVE : entityTypes.CVE);
+                    const url = newState.toUrl();
+                    const fixableUrl = newState.setSearch({ Fixable: true }).toUrl();
+
+                    return (
+                        <CVEStackedPill
+                            vulnCounter={vulnCounter}
+                            url={url}
+                            fixableUrl={fixableUrl}
+                            hideLink={pdf}
+                        />
+                    );
+                },
+                id: componentSortFields.CVE_COUNT,
+                accessor: 'vulnCounter.all.total',
+                sortField: componentSortFields.CVE_COUNT,
+            },
+            {
+                Header: `Active`,
+                headerClassName: `w-1/10 text-center ${nonSortableHeaderClassName}`,
+                className: `w-1/10 ${defaultColumnClassName}`,
+                // eslint-disable-next-line
+                Cell: ({ original }) => {
+                    const activeStatus = original.activeState?.state || 'Undetermined';
+                    switch (activeStatus) {
+                        case 'Active': {
+                            return (
+                                <div className="mx-auto">
+                                    <LabelChip text={activeStatus} type="alert" size="large" />
+                                </div>
+                            );
+                        }
+                        case 'Inactive': {
+                            return <div className="mx-auto">{activeStatus}</div>;
+                        }
+                        case 'Undetermined':
+                        default: {
+                            return <div className="mx-auto">Undetermined</div>;
+                        }
+                    }
+                },
+                id: componentSortFields.ACTIVE,
+                accessor: 'isActive',
+                sortField: componentSortFields.ACTIVE,
+                sortable: false,
+            },
+            {
+                Header: `Fixed In`,
+                headerClassName: `w-1/12 ${defaultHeaderClassName}`,
+                className: `w-1/12 word-break-all ${defaultColumnClassName}`,
+                Cell: ({ original }) =>
+                    original.fixedIn ||
+                    (original.vulnCounter.all.total === 0 ? 'N/A' : 'Not Fixable'),
+                id: componentSortFields.FIXEDIN,
+                accessor: 'fixedIn',
+                sortField: componentSortFields.FIXEDIN,
+                sortable: false,
+            },
+            {
+                Header: `Top CVSS`,
+                headerClassName: `w-1/10 text-center ${defaultHeaderClassName}`,
+                className: `w-1/10 ${defaultColumnClassName}`,
+                Cell: ({ original }) => {
+                    const { topVuln } = original;
+                    if (!topVuln) {
                         return (
-                            <div className="mx-auto">
-                                <LabelChip text={activeStatus} type="alert" size="large" />
+                            <div className="mx-auto flex flex-col">
+                                <span>–</span>
                             </div>
                         );
                     }
-                    case 'Inactive': {
-                        return <div className="mx-auto">{activeStatus}</div>;
-                    }
-                    case 'Undetermined':
-                    default: {
-                        return <div className="mx-auto">Undetermined</div>;
-                    }
-                }
+                    const { cvss, scoreVersion } = topVuln;
+                    return <TopCvssLabel cvss={cvss} version={scoreVersion} />;
+                },
+                id: componentSortFields.TOP_CVSS,
+                accessor: 'topVuln.cvss',
+                sortField: componentSortFields.TOP_CVSS,
             },
-            id: componentSortFields.ACTIVE,
-            accessor: 'isActive',
-            sortField: componentSortFields.ACTIVE,
-            sortable: false,
-        },
-        {
-            Header: `Fixed In`,
-            headerClassName: `w-1/12 ${defaultHeaderClassName}`,
-            className: `w-1/12 word-break-all ${defaultColumnClassName}`,
-            Cell: ({ original }) =>
-                original.fixedIn || (original.vulnCounter.all.total === 0 ? 'N/A' : 'Not Fixable'),
-            id: componentSortFields.FIXEDIN,
-            accessor: 'fixedIn',
-            sortField: componentSortFields.FIXEDIN,
-            sortable: false,
-        },
-        {
-            Header: `Top CVSS`,
-            headerClassName: `w-1/10 text-center ${defaultHeaderClassName}`,
-            className: `w-1/10 ${defaultColumnClassName}`,
-            Cell: ({ original }) => {
-                const { topVuln } = original;
-                if (!topVuln) {
-                    return (
-                        <div className="mx-auto flex flex-col">
-                            <span>–</span>
-                        </div>
-                    );
-                }
-                const { cvss, scoreVersion } = topVuln;
-                return <TopCvssLabel cvss={cvss} version={scoreVersion} />;
+            {
+                Header: `Source`,
+                headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+                className: `w-1/8 ${defaultColumnClassName}`,
+                id: componentSortFields.SOURCE,
+                accessor: 'source',
+                sortField: componentSortFields.SOURCE,
             },
-            id: componentSortFields.TOP_CVSS,
-            accessor: 'topVuln.cvss',
-            sortField: componentSortFields.TOP_CVSS,
-        },
-        {
-            Header: `Source`,
-            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
-            className: `w-1/8 ${defaultColumnClassName}`,
-            id: componentSortFields.SOURCE,
-            accessor: 'source',
-            sortField: componentSortFields.SOURCE,
-        },
-        {
-            Header: `Location`,
-            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
-            className: `w-1/8 word-break-all ${defaultColumnClassName}`,
-            Cell: ({ original }) => original.location || 'N/A',
-            id: componentSortFields.LOCATION,
-            accessor: 'location',
-            sortField: componentSortFields.LOCATION,
-        },
-        {
-            Header: `Images`,
-            entityType: entityTypes.IMAGE,
-            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
-            className: `w-1/8 ${defaultColumnClassName}`,
-            id: componentSortFields.IMAGE_COUNT,
-            accessor: 'imageCount',
-            Cell: ({ original, pdf }) => (
-                <TableCountLink
-                    entityType={entityTypes.IMAGE}
-                    count={original.imageCount}
-                    textOnly={pdf}
-                    selectedRowId={original.id}
-                />
-            ),
-            sortField: componentSortFields.IMAGE_COUNT,
-        },
-        {
-            Header: `Deployments`,
-            entityType: entityTypes.DEPLOYMENT,
-            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
-            className: `w-1/8 ${defaultColumnClassName}`,
-            id: componentSortFields.DEPLOYMENT_COUNT,
-            accessor: 'deploymentCount',
-            Cell: ({ original, pdf }) => (
-                <TableCountLink
-                    entityType={entityTypes.DEPLOYMENT}
-                    count={original.deploymentCount}
-                    textOnly={pdf}
-                    selectedRowId={original.id}
-                />
-            ),
-            sortField: componentSortFields.DEPLOYMENT_COUNT,
-        },
-        {
-            Header: `Risk Priority`,
-            headerClassName: `w-1/10 ${defaultHeaderClassName}`,
-            className: `w-1/10 ${defaultColumnClassName}`,
-            id: componentSortFields.PRIORITY,
-            accessor: 'priority',
-            sortField: componentSortFields.PRIORITY,
-        },
-    ];
+            {
+                Header: `Location`,
+                headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+                className: `w-1/8 word-break-all ${defaultColumnClassName}`,
+                Cell: ({ original }) => original.location || 'N/A',
+                id: componentSortFields.LOCATION,
+                accessor: 'location',
+                sortField: componentSortFields.LOCATION,
+            },
+            {
+                Header: `Images`,
+                entityType: entityTypes.IMAGE,
+                headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+                className: `w-1/8 ${defaultColumnClassName}`,
+                id: componentSortFields.IMAGE_COUNT,
+                accessor: 'imageCount',
+                Cell: ({ original, pdf }) => (
+                    <TableCountLink
+                        entityType={entityTypes.IMAGE}
+                        count={original.imageCount}
+                        textOnly={pdf}
+                        selectedRowId={original.id}
+                    />
+                ),
+                sortField: componentSortFields.IMAGE_COUNT,
+            },
+            {
+                Header: `Deployments`,
+                entityType: entityTypes.DEPLOYMENT,
+                headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+                className: `w-1/8 ${defaultColumnClassName}`,
+                id: componentSortFields.DEPLOYMENT_COUNT,
+                accessor: 'deploymentCount',
+                Cell: ({ original, pdf }) => (
+                    <TableCountLink
+                        entityType={entityTypes.DEPLOYMENT}
+                        count={original.deploymentCount}
+                        textOnly={pdf}
+                        selectedRowId={original.id}
+                    />
+                ),
+                sortField: componentSortFields.DEPLOYMENT_COUNT,
+            },
+            {
+                Header: `Risk Priority`,
+                headerClassName: `w-1/10 ${defaultHeaderClassName}`,
+                className: `w-1/10 ${defaultColumnClassName}`,
+                id: componentSortFields.PRIORITY,
+                accessor: 'priority',
+                sortField: componentSortFields.PRIORITY,
+            },
+        ];
 
-    const componentColumnsBasedOnContext = getFilteredComponentColumns(tableColumns, workflowState);
+        const componentColumnsBasedOnContext = getFilteredComponentColumns(
+            tableColumns,
+            workflowState
+        );
 
-    return removeEntityContextColumns(componentColumnsBasedOnContext, workflowState);
+        return removeEntityContextColumns(componentColumnsBasedOnContext, workflowState);
+    };
 }
 
 const VulnMgmtNodeComponents = ({ selectedRowId, search, sort, page, data, totalResults }) => {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const showVMUpdates = isFeatureFlagEnabled('ROX_FRONTEND_VM_UDPATES');
+
     const query = gql`
         query getComponents($query: String, $pagination: Pagination) {
             results: imageComponents(query: $query, pagination: $pagination) {
@@ -222,6 +234,8 @@ const VulnMgmtNodeComponents = ({ selectedRowId, search, sort, page, data, total
         },
     };
 
+    const getTableColumns = getComponentTableColumns(showVMUpdates);
+
     return (
         <WorkflowListPage
             data={data}
@@ -230,7 +244,7 @@ const VulnMgmtNodeComponents = ({ selectedRowId, search, sort, page, data, total
             queryOptions={queryOptions}
             idAttribute="id"
             entityListType={entityTypes.COMPONENT}
-            getTableColumns={getComponentTableColumns}
+            getTableColumns={getTableColumns}
             selectedRowId={selectedRowId}
             search={search}
             sort={tableSort}

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.js
@@ -20,6 +20,7 @@ import { workflowListPropTypes, workflowListDefaultProps } from 'constants/entit
 import removeEntityContextColumns from 'utils/tableUtils';
 import { componentSortFields } from 'constants/sortFields';
 
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import { getFilteredComponentColumns } from './ListNodeComponents.utils';
 
 export const defaultComponentSort = [
@@ -29,164 +30,175 @@ export const defaultComponentSort = [
     },
 ];
 
-export function getComponentTableColumns(workflowState) {
-    const tableColumns = [
-        {
-            Header: 'Id',
-            headerClassName: 'hidden',
-            className: 'hidden',
-            accessor: 'id',
-        },
-        {
-            Header: `Component`,
-            headerClassName: `w-1/4 ${defaultHeaderClassName}`,
-            className: `w-1/4 ${defaultColumnClassName}`,
-            Cell: ({ original }) => {
-                const { version, name } = original;
-                return `${name} ${version}`;
+export function getComponentTableColumns(showVMUpdates) {
+    return function getTableColumns(workflowState) {
+        const tableColumns = [
+            {
+                Header: 'Id',
+                headerClassName: 'hidden',
+                className: 'hidden',
+                accessor: 'id',
             },
-            id: componentSortFields.COMPONENT,
-            accessor: 'name',
-            sortField: componentSortFields.COMPONENT,
-        },
-        {
-            Header: `Node CVEs`,
-            entityType: entityTypes.CVE,
-            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
-            className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
-                const { vulnCounter, id } = original;
-                if (!vulnCounter || vulnCounter.all.total === 0) {
-                    return 'No CVEs';
-                }
-
-                const newState = workflowState.pushListItem(id).pushList(entityTypes.NODE_CVE);
-                const url = newState.toUrl();
-                const fixableUrl = newState.setSearch({ Fixable: true }).toUrl();
-
-                return (
-                    <CVEStackedPill
-                        vulnCounter={vulnCounter}
-                        url={url}
-                        fixableUrl={fixableUrl}
-                        hideLink={pdf}
-                    />
-                );
+            {
+                Header: `Component`,
+                headerClassName: `w-1/4 ${defaultHeaderClassName}`,
+                className: `w-1/4 ${defaultColumnClassName}`,
+                Cell: ({ original }) => {
+                    const { version, name } = original;
+                    return `${name} ${version}`;
+                },
+                id: componentSortFields.COMPONENT,
+                accessor: 'name',
+                sortField: componentSortFields.COMPONENT,
             },
-            id: componentSortFields.CVE_COUNT,
-            accessor: 'vulnCounter.all.total',
-            sortField: componentSortFields.CVE_COUNT,
-        },
-        {
-            Header: `Active`,
-            headerClassName: `w-1/10 text-center ${nonSortableHeaderClassName}`,
-            className: `w-1/10 ${defaultColumnClassName}`,
-            // eslint-disable-next-line
-            Cell: ({ original }) => {
-                const activeStatus = original.activeState?.state || 'Undetermined';
-                switch (activeStatus) {
-                    case 'Active': {
+            {
+                Header: showVMUpdates ? `Node CVEs` : 'CVEs',
+                entityType: entityTypes.CVE,
+                headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+                className: `w-1/8 ${defaultColumnClassName}`,
+                Cell: ({ original, pdf }) => {
+                    const { vulnCounter, id } = original;
+                    if (!vulnCounter || vulnCounter.all.total === 0) {
+                        return 'No CVEs';
+                    }
+
+                    const newState = workflowState
+                        .pushListItem(id)
+                        .pushList(showVMUpdates ? entityTypes.NODE_CVE : entityTypes.CVE);
+                    const url = newState.toUrl();
+                    const fixableUrl = newState.setSearch({ Fixable: true }).toUrl();
+
+                    return (
+                        <CVEStackedPill
+                            vulnCounter={vulnCounter}
+                            url={url}
+                            fixableUrl={fixableUrl}
+                            hideLink={pdf}
+                        />
+                    );
+                },
+                id: componentSortFields.CVE_COUNT,
+                accessor: 'vulnCounter.all.total',
+                sortField: componentSortFields.CVE_COUNT,
+            },
+            {
+                Header: `Active`,
+                headerClassName: `w-1/10 text-center ${nonSortableHeaderClassName}`,
+                className: `w-1/10 ${defaultColumnClassName}`,
+                // eslint-disable-next-line
+                Cell: ({ original }) => {
+                    const activeStatus = original.activeState?.state || 'Undetermined';
+                    switch (activeStatus) {
+                        case 'Active': {
+                            return (
+                                <div className="mx-auto">
+                                    <LabelChip text={activeStatus} type="alert" size="large" />
+                                </div>
+                            );
+                        }
+                        case 'Inactive': {
+                            return <div className="mx-auto">{activeStatus}</div>;
+                        }
+                        case 'Undetermined':
+                        default: {
+                            return <div className="mx-auto">Undetermined</div>;
+                        }
+                    }
+                },
+                id: componentSortFields.ACTIVE,
+                accessor: 'isActive',
+                sortField: componentSortFields.ACTIVE,
+                sortable: false,
+            },
+            {
+                Header: `Fixed In`,
+                headerClassName: `w-1/12 ${defaultHeaderClassName}`,
+                className: `w-1/12 word-break-all ${defaultColumnClassName}`,
+                Cell: ({ original }) =>
+                    original.fixedIn ||
+                    (original.vulnCounter.all.total === 0 ? 'N/A' : 'Not Fixable'),
+                id: componentSortFields.FIXEDIN,
+                accessor: 'fixedIn',
+                sortField: componentSortFields.FIXEDIN,
+                sortable: false,
+            },
+            {
+                Header: `Top CVSS`,
+                headerClassName: `w-1/10 text-center ${defaultHeaderClassName}`,
+                className: `w-1/10 ${defaultColumnClassName}`,
+                Cell: ({ original }) => {
+                    const { topVuln } = original;
+                    if (!topVuln) {
                         return (
-                            <div className="mx-auto">
-                                <LabelChip text={activeStatus} type="alert" size="large" />
+                            <div className="mx-auto flex flex-col">
+                                <span>–</span>
                             </div>
                         );
                     }
-                    case 'Inactive': {
-                        return <div className="mx-auto">{activeStatus}</div>;
-                    }
-                    case 'Undetermined':
-                    default: {
-                        return <div className="mx-auto">Undetermined</div>;
-                    }
-                }
+                    const { cvss, scoreVersion } = topVuln;
+                    return <TopCvssLabel cvss={cvss} version={scoreVersion} />;
+                },
+                id: componentSortFields.TOP_CVSS,
+                accessor: 'topVuln.cvss',
+                sortField: componentSortFields.TOP_CVSS,
             },
-            id: componentSortFields.ACTIVE,
-            accessor: 'isActive',
-            sortField: componentSortFields.ACTIVE,
-            sortable: false,
-        },
-        {
-            Header: `Fixed In`,
-            headerClassName: `w-1/12 ${defaultHeaderClassName}`,
-            className: `w-1/12 word-break-all ${defaultColumnClassName}`,
-            Cell: ({ original }) =>
-                original.fixedIn || (original.vulnCounter.all.total === 0 ? 'N/A' : 'Not Fixable'),
-            id: componentSortFields.FIXEDIN,
-            accessor: 'fixedIn',
-            sortField: componentSortFields.FIXEDIN,
-            sortable: false,
-        },
-        {
-            Header: `Top CVSS`,
-            headerClassName: `w-1/10 text-center ${defaultHeaderClassName}`,
-            className: `w-1/10 ${defaultColumnClassName}`,
-            Cell: ({ original }) => {
-                const { topVuln } = original;
-                if (!topVuln) {
-                    return (
-                        <div className="mx-auto flex flex-col">
-                            <span>–</span>
-                        </div>
-                    );
-                }
-                const { cvss, scoreVersion } = topVuln;
-                return <TopCvssLabel cvss={cvss} version={scoreVersion} />;
+            {
+                Header: `Source`,
+                headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+                className: `w-1/8 ${defaultColumnClassName}`,
+                id: componentSortFields.SOURCE,
+                accessor: 'source',
+                sortField: componentSortFields.SOURCE,
             },
-            id: componentSortFields.TOP_CVSS,
-            accessor: 'topVuln.cvss',
-            sortField: componentSortFields.TOP_CVSS,
-        },
-        {
-            Header: `Source`,
-            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
-            className: `w-1/8 ${defaultColumnClassName}`,
-            id: componentSortFields.SOURCE,
-            accessor: 'source',
-            sortField: componentSortFields.SOURCE,
-        },
-        {
-            Header: `Location`,
-            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
-            className: `w-1/8 word-break-all ${defaultColumnClassName}`,
-            Cell: ({ original }) => original.location || 'N/A',
-            id: componentSortFields.LOCATION,
-            accessor: 'location',
-            sortField: componentSortFields.LOCATION,
-        },
-        {
-            Header: `Nodes`,
-            entityType: entityTypes.NODE,
-            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
-            className: `w-1/8 ${defaultColumnClassName}`,
-            id: componentSortFields.NODE_COUNT,
-            accessor: 'nodeCount',
-            Cell: ({ original, pdf }) => (
-                <TableCountLink
-                    entityType={entityTypes.NODE}
-                    count={original.nodeCount}
-                    textOnly={pdf}
-                    selectedRowId={original.id}
-                />
-            ),
-            sortField: componentSortFields.NODE_COUNT,
-        },
-        {
-            Header: `Risk Priority`,
-            headerClassName: `w-1/10 ${defaultHeaderClassName}`,
-            className: `w-1/10 ${defaultColumnClassName}`,
-            id: componentSortFields.PRIORITY,
-            accessor: 'priority',
-            sortField: componentSortFields.PRIORITY,
-        },
-    ];
+            {
+                Header: `Location`,
+                headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+                className: `w-1/8 word-break-all ${defaultColumnClassName}`,
+                Cell: ({ original }) => original.location || 'N/A',
+                id: componentSortFields.LOCATION,
+                accessor: 'location',
+                sortField: componentSortFields.LOCATION,
+            },
+            {
+                Header: `Nodes`,
+                entityType: entityTypes.NODE,
+                headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+                className: `w-1/8 ${defaultColumnClassName}`,
+                id: componentSortFields.NODE_COUNT,
+                accessor: 'nodeCount',
+                Cell: ({ original, pdf }) => (
+                    <TableCountLink
+                        entityType={entityTypes.NODE}
+                        count={original.nodeCount}
+                        textOnly={pdf}
+                        selectedRowId={original.id}
+                    />
+                ),
+                sortField: componentSortFields.NODE_COUNT,
+            },
+            {
+                Header: `Risk Priority`,
+                headerClassName: `w-1/10 ${defaultHeaderClassName}`,
+                className: `w-1/10 ${defaultColumnClassName}`,
+                id: componentSortFields.PRIORITY,
+                accessor: 'priority',
+                sortField: componentSortFields.PRIORITY,
+            },
+        ];
 
-    const componentColumnsBasedOnContext = getFilteredComponentColumns(tableColumns, workflowState);
+        const componentColumnsBasedOnContext = getFilteredComponentColumns(
+            tableColumns,
+            workflowState
+        );
 
-    return removeEntityContextColumns(componentColumnsBasedOnContext, workflowState);
+        return removeEntityContextColumns(componentColumnsBasedOnContext, workflowState);
+    };
 }
 
 const VulnMgmtNodeComponents = ({ selectedRowId, search, sort, page, data, totalResults }) => {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const showVMUpdates = isFeatureFlagEnabled('ROX_FRONTEND_VM_UDPATES');
+
     const query = gql`
         query getComponents($query: String, $pagination: Pagination) {
             results: nodeComponents(query: $query, pagination: $pagination) {
@@ -205,6 +217,8 @@ const VulnMgmtNodeComponents = ({ selectedRowId, search, sort, page, data, total
         },
     };
 
+    const getTableColumns = getComponentTableColumns(showVMUpdates);
+
     return (
         <WorkflowListPage
             data={data}
@@ -213,7 +227,7 @@ const VulnMgmtNodeComponents = ({ selectedRowId, search, sort, page, data, total
             queryOptions={queryOptions}
             idAttribute="id"
             entityListType={entityTypes.COMPONENT}
-            getTableColumns={getComponentTableColumns}
+            getTableColumns={getTableColumns}
             selectedRowId={selectedRowId}
             search={search}
             sort={tableSort}

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.js
@@ -50,7 +50,7 @@ export function getComponentTableColumns(workflowState) {
             sortField: componentSortFields.COMPONENT,
         },
         {
-            Header: `CVEs`,
+            Header: `Node CVEs`,
             entityType: entityTypes.CVE,
             headerClassName: `w-1/8 ${defaultHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Nodes/VulnMgmtListNodes.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Nodes/VulnMgmtListNodes.js
@@ -68,7 +68,7 @@ export function getNodeTableColumns(showVMUpdates) {
                 sortField: nodeSortFields.NODE,
             },
             {
-                Header: `Node CVEs`,
+                Header: showVMUpdates ? `Node CVEs` : 'CVEs',
                 entityType: entityTypes.CVE,
                 headerClassName: `w-1/6 ${defaultHeaderClassName}`,
                 className: `w-1/6 ${defaultColumnClassName}`,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Nodes/VulnMgmtListNodes.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Nodes/VulnMgmtListNodes.js
@@ -68,7 +68,7 @@ export function getNodeTableColumns(showVMUpdates) {
                 sortField: nodeSortFields.NODE,
             },
             {
-                Header: `CVEs`,
+                Header: `Node CVEs`,
                 entityType: entityTypes.CVE,
                 headerClassName: `w-1/6 ${defaultHeaderClassName}`,
                 className: `w-1/6 ${defaultColumnClassName}`,

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
@@ -357,8 +357,10 @@ function getCVEListType(entityType, showVmUpdates) {
         return entityType.CVE;
     }
     switch (entityType) {
+        case entityTypes.NODE:
         case entityTypes.NODE_COMPONENT:
             return entityTypes.NODE_CVE;
+        case entityTypes.IMAGE:
         case entityTypes.IMAGE_COMPONENT:
             return entityTypes.IMAGE_CVE;
         default:

--- a/ui/apps/platform/src/Containers/Workflow/WorkflowEntityPageLayout.js
+++ b/ui/apps/platform/src/Containers/Workflow/WorkflowEntityPageLayout.js
@@ -34,8 +34,6 @@ const WorkflowEntityPageLayout = ({ location }) => {
         const newTypes = useCaseEntityMap['vulnerability-management'].filter(
             (entityType) => entityType !== entityTypes.COMPONENT
         );
-        newTypes.push(entityTypes.NODE_COMPONENT);
-        newTypes.push(entityTypes.IMAGE_COMPONENT);
         useCaseEntityMap['vulnerability-management'] = newTypes;
     }
 

--- a/ui/apps/platform/src/Containers/Workflow/WorkflowListPageLayout.js
+++ b/ui/apps/platform/src/Containers/Workflow/WorkflowListPageLayout.js
@@ -28,8 +28,6 @@ const WorkflowListPageLayout = ({ location }) => {
         const newTypes = useCaseEntityMap['vulnerability-management'].filter(
             (entityType) => entityType !== entityTypes.COMPONENT
         );
-        newTypes.push(entityTypes.NODE_COMPONENT);
-        newTypes.push(entityTypes.IMAGE_COMPONENT);
         useCaseEntityMap['vulnerability-management'] = newTypes;
     }
 

--- a/ui/apps/platform/src/constants/workflowPages.constants.js
+++ b/ui/apps/platform/src/constants/workflowPages.constants.js
@@ -10,8 +10,8 @@ export const LIST_PAGE_SIZE = 25;
 
 export const defaultCountKeyMap = {
     [entityTypes.COMPONENT]: 'componentCount',
-    [entityTypes.NODE_COMPONENT]: 'componentCount',
-    [entityTypes.IMAGE_COMPONENT]: 'componentCount',
+    [entityTypes.NODE_COMPONENT]: 'componentCount: nodeComponentCount',
+    [entityTypes.IMAGE_COMPONENT]: 'componentCount: imageComponentCount',
     [entityTypes.CVE]: 'vulnCount',
     [entityTypes.IMAGE_CVE]: 'vulnCount: imageVulnerabilityCount',
     [entityTypes.NODE_CVE]: 'vulnCount: nodeVulnerabilityCount',

--- a/ui/apps/platform/src/constants/workflowPages.constants.js
+++ b/ui/apps/platform/src/constants/workflowPages.constants.js
@@ -17,6 +17,7 @@ export const defaultCountKeyMap = {
     [entityTypes.NODE_CVE]: 'vulnCount: nodeVulnerabilityCount',
     [entityTypes.CLUSTER_CVE]: 'vulnCount: clusterVulnerabilityCount',
     [entityTypes.K8S_CVE]: 'vulnCount: k8sVulnCount',
+    [entityTypes.CLUSTER]: 'clusterCount',
     [entityTypes.DEPLOYMENT]: 'deploymentCount',
     [entityTypes.NAMESPACE]: 'namespaceCount',
     [entityTypes.NODE]: 'nodeCount',


### PR DESCRIPTION
## Description

Fixes the following issues from [this Doc](https://docs.google.com/document/d/1G6r3wD9IkDgSyekx60CMmlFGMvhA6wH5cUsu4K-HLZs/edit):

* The “All Entities” dropdown has duplicates for “Node Components” and “Image Components”
* The columns in the tables should specify what CVE type it is
* The Top Riskiest Images+Nodes Widget’s links still take you to the non-split CVEs table
* Image CVEs page - click image components for a row -> fails - calling component count and not imageComponentCount
* Node CVEs -> click a Node CVE -> click on Node Component related entity -> Breaks
* Platform CVEs -> click on a Platform CVE -> Breaks UI
* Image Components -> click an Image Component -> The Component Findings breaks
* Images -> click an Image -> click an Image CVE in Image Findings -> Click on Image Components related entities -> Breaks
 
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

The “All Entities” dropdown has duplicates for “Node Components” and “Image Components”

<img width="1552" alt="Screen Shot 2022-07-15 at 12 22 54 PM" src="https://user-images.githubusercontent.com/4805485/179296753-dbceaf99-80a8-4ac7-a1da-46d54887155b.png">

The columns in the tables should specify what CVE type it is

<img width="1552" alt="Screen Shot 2022-07-15 at 12 23 32 PM" src="https://user-images.githubusercontent.com/4805485/179296929-6005b6d4-b292-40a9-94da-c71f899b745f.png">
<img width="1552" alt="Screen Shot 2022-07-15 at 12 23 49 PM" src="https://user-images.githubusercontent.com/4805485/179296932-dff28092-a76a-48c4-a767-218181537e44.png">
<img width="1552" alt="Screen Shot 2022-07-15 at 12 23 57 PM" src="https://user-images.githubusercontent.com/4805485/179296935-31ab70a3-ec02-44c7-a5ff-feb510f0d9da.png">

The Top Riskiest Images+Nodes Widget’s links still take you to the non-split CVEs table

<img width="1552" alt="Screen Shot 2022-07-15 at 12 24 24 PM" src="https://user-images.githubusercontent.com/4805485/179297028-d50d900c-6aaa-40a7-a295-801e146823dc.png">
<img width="1552" alt="Screen Shot 2022-07-15 at 12 24 33 PM" src="https://user-images.githubusercontent.com/4805485/179297050-04185504-9c8c-46b8-95ef-1bc59567b365.png">
<img width="1552" alt="Screen Shot 2022-07-15 at 12 25 01 PM" src="https://user-images.githubusercontent.com/4805485/179297121-c411e8f0-14cd-4b6e-974a-0b2e02581bd7.png">
<img width="1552" alt="Screen Shot 2022-07-15 at 12 25 11 PM" src="https://user-images.githubusercontent.com/4805485/179297133-e0e5b0de-1c2c-409e-a836-c6e7235e02f3.png">

Image CVEs page - click image components for a row -> fails - calling component count and not imageComponentCount

<img width="1552" alt="Screen Shot 2022-07-15 at 12 25 49 PM" src="https://user-images.githubusercontent.com/4805485/179297239-9a45e013-6bdd-428b-816b-3859ef498787.png">

Node CVEs -> click a Node CVE -> click on Node Component related entity -> Breaks

<img width="1552" alt="Screen Shot 2022-07-15 at 12 26 28 PM" src="https://user-images.githubusercontent.com/4805485/179297299-375d700c-4867-4307-995d-7a29d448ce70.png">

Platform CVEs -> click on a Platform CVE -> Breaks UI

<img width="1552" alt="Screen Shot 2022-07-15 at 5 11 26 PM" src="https://user-images.githubusercontent.com/4805485/179326396-fd494a72-53b2-4efa-964d-68b1fe3bc81a.png">

Image Components -> click an Image Component -> The Component Findings breaks

<img width="1552" alt="Screen Shot 2022-07-15 at 5 12 07 PM" src="https://user-images.githubusercontent.com/4805485/179326433-fc83e4ea-1498-4779-867c-019c51c52df8.png">

Images -> click an Image -> click an Image CVE in Image Findings -> Click on Image Components related entities -> Breaks

<img width="1552" alt="Screen Shot 2022-07-15 at 5 13 04 PM" src="https://user-images.githubusercontent.com/4805485/179326471-d6e6e554-0a5f-4ec0-b256-3a0bef0296b9.png">
