### PR TITLE
ROX-11537 - Fix test falke TestExecIntoPodNameEventPolicy

### DIFF
--- a/sensor/admission-control/manager/testing/manager_testing_impl.go
+++ b/sensor/admission-control/manager/testing/manager_testing_impl.go
@@ -26,7 +26,6 @@ func ProcessPodEvent(t *testing.T, mgr manager.Manager, pod *storage.Pod) {
 		Resource: &sensor.AdmCtrlUpdateResourceRequest_Pod{Pod: pod},
 		Action:   central.ResourceAction_CREATE_RESOURCE,
 	}
-
 }
 
 // ProcessDeploymentEvent adds deployment to the admission controller deployment storage. In a production system

--- a/sensor/admission-control/service/service_test.go
+++ b/sensor/admission-control/service/service_test.go
@@ -39,8 +39,9 @@ func TestExecIntoPodNameEventPolicy(t *testing.T) {
 	require.NoError(t, err)
 	defer mgr.Stop()
 
+	const deploymentID = "f3237faf-8350-4c39-b045-ff4c493ddb71"
 	managerTesting.ProcessDeploymentEvent(t, mgr, &storage.Deployment{
-		Id:        "f3237faf-8350-4c39-b045-ff4c493ddb71",
+		Id:        deploymentID,
 		Name:      "sensor",
 		Type:      "Deployment",
 		Namespace: "stackrox",
@@ -48,7 +49,7 @@ func TestExecIntoPodNameEventPolicy(t *testing.T) {
 	managerTesting.ProcessPodEvent(t, mgr, &storage.Pod{
 		Id:           "64a1d6ee-2425-5f19-990e-a2d8b18c1e4c",
 		Name:         "sensor-74f6965874-qckz6",
-		DeploymentId: "f3237faf-8350-4c39-b045-ff4c493ddb71",
+		DeploymentId: deploymentID,
 		Namespace:    "stackrox",
 	})
 
@@ -183,7 +184,7 @@ func (r serviceTestRun) execute() {
 	assert.Equal(r.t, http.StatusOK, resp.Code)
 
 	select {
-	case <-time.After(1 * time.Second):
+	case <-time.After(30 * time.Second):
 		assert.Fail(r.t, "Did not receive any alerts before timeout expired, but expected some")
 	case alerts := <-r.mgr.Alerts():
 		r.assertionFunc(r.t, resp.Result(), alerts)


### PR DESCRIPTION
## Description

The test `TestExecIntoPodNameEventPolicy` failed sometimes in openshift-ci.
I tested the test locally and run the complete go-unit-test suite but never saw the failure. It is likely that the timeout of 1 second was too short in a resource limited environment.
Also it was reported that openshift-ci is slower compared to our previous CI solution.

If the test still fails the timeout must be increased even further or more investigations are necessary.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

 - Run test multiple times locally
 - Run CI pipeline