### PR TITLE
Add force to click because network zoom buttons can cover Navigate button in UI

### DIFF
--- a/ui/apps/platform/cypress/integration/networkGraph/networkFlows.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkFlows.test.js
@@ -37,7 +37,7 @@ describe('Network Baseline Flows', () => {
                 cy.get(tabbedOverlayHeader).contains('central');
 
                 cy.get(sensorTableRow).trigger('mouseover');
-                cy.get(navigateButton).click();
+                cy.get(navigateButton).click({ force: true }); // because network-zoom-buttons can cover it
 
                 cy.get(tabbedOverlayHeader).contains('sensor');
             });


### PR DESCRIPTION
## Description

Work around UI bug: invisible padding of network-zoom-buttons can cover the Navigate button (compare other picture).
![network-zoom-buttons](https://user-images.githubusercontent.com/11862657/179550874-d4d0be77-ee99-443e-9598-9961f976b0b1.png)

Too bad, so sad, if a customer sees this edge case.

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-ui-e2e-tests/1548128506360107008

networkGraph/networkFlows.test.js

should navigate to a different deployment when clicking the "Navigate" button

`<button class="border-2 font-600 inline-flex items-center justify-center rounded-sm uppercase text-sm border-base-400 bg-base-100 hover:bg-base-200 hover:text-base-700 text-base-800 px-2" type="button">...</button>`

is being covered by another element:

`<div class="flex absolute bottom-0 pin-network-zoom-buttons-left">...</div>`

Fix this problem, or use {force: true} to disable error checking.
![click-Navigate](https://user-images.githubusercontent.com/11862657/179550932-12cb7c15-6335-45d1-91f6-0f2846ba1ae3.png)

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed