### PR TITLE
Add transformed sorts field searcher

### DIFF
--- a/central/cve/node/datastore/internal/search/searcher.go
+++ b/central/cve/node/datastore/internal/search/searcher.go
@@ -8,9 +8,12 @@ import (
 	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/blevesearch"
 	pkgPostgres "github.com/stackrox/rox/pkg/search/scoped/postgres"
+	"github.com/stackrox/rox/pkg/search/sortfields"
 )
 
 var (
@@ -31,6 +34,11 @@ func New(storage postgres.Store, indexer index.Indexer) Searcher {
 	return &searcherImpl{
 		storage:  storage,
 		indexer:  indexer,
-		searcher: pkgPostgres.WithScoping(sacHelper.FilteredSearcher(indexer)),
+		searcher: formatSearcherV2(indexer),
 	}
+}
+
+func formatSearcherV2(unsafeSearcher blevesearch.UnsafeSearcher) search.Searcher {
+	scopedSafeSearcher := pkgPostgres.WithScoping(sacHelper.FilteredSearcher(unsafeSearcher))
+	return sortfields.TransformSortFields(scopedSafeSearcher, schema.NodesSchema.OptionsMap)
 }

--- a/central/nodecomponent/datastore/datastore.go
+++ b/central/nodecomponent/datastore/datastore.go
@@ -29,7 +29,7 @@ type DataStore interface {
 }
 
 // New returns a new instance of a DataStore.
-func New(storage postgres.Store, indexer index.Indexer, searcher search.Searcher, risks riskDataStore.DataStore, ranker *ranking.Ranker) (DataStore, error) {
+func New(storage postgres.Store, indexer index.Indexer, searcher search.Searcher, risks riskDataStore.DataStore, ranker *ranking.Ranker) DataStore {
 	ds := &datastoreImpl{
 		storage:             storage,
 		indexer:             indexer,
@@ -39,7 +39,7 @@ func New(storage postgres.Store, indexer index.Indexer, searcher search.Searcher
 	}
 
 	ds.initializeRankers()
-	return ds, nil
+	return ds
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
@@ -51,5 +51,5 @@ func GetTestPostgresDataStore(t *testing.T, pool *pgxpool.Pool) (DataStore, erro
 	if err != nil {
 		return nil, err
 	}
-	return New(dbstore, indexer, searcher, riskStore, ranking.NodeComponentRanker())
+	return New(dbstore, indexer, searcher, riskStore, ranking.NodeComponentRanker()), nil
 }

--- a/central/nodecomponent/datastore/search/searcher.go
+++ b/central/nodecomponent/datastore/search/searcher.go
@@ -8,9 +8,12 @@ import (
 	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/blevesearch"
 	pkgPostgres "github.com/stackrox/rox/pkg/search/scoped/postgres"
+	"github.com/stackrox/rox/pkg/search/sortfields"
 )
 
 var (
@@ -31,6 +34,11 @@ func New(storage postgres.Store, indexer index.Indexer) Searcher {
 	return &searcherImpl{
 		storage:  storage,
 		indexer:  indexer,
-		searcher: pkgPostgres.WithScoping(sacHelper.FilteredSearcher(indexer)),
+		searcher: formatSearcherV2(indexer),
 	}
+}
+
+func formatSearcherV2(unsafeSearcher blevesearch.UnsafeSearcher) search.Searcher {
+	scopedSafeSearcher := pkgPostgres.WithScoping(sacHelper.FilteredSearcher(unsafeSearcher))
+	return sortfields.TransformSortFields(scopedSafeSearcher, schema.NodesSchema.OptionsMap)
 }

--- a/central/nodecomponent/datastore/singleton.go
+++ b/central/nodecomponent/datastore/singleton.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stackrox/rox/central/ranking"
 	riskDataStore "github.com/stackrox/rox/central/risk/datastore"
 	"github.com/stackrox/rox/pkg/sync"
-	"github.com/stackrox/rox/pkg/utils"
 )
 
 var (
@@ -19,10 +18,7 @@ var (
 func initialize() {
 	storage := postgres.New(globaldb.GetPostgres())
 	indexer := postgres.NewIndexer(globaldb.GetPostgres())
-
-	var err error
-	ds, err = New(storage, indexer, search.New(storage, indexer), riskDataStore.Singleton(), ranking.NodeComponentRanker())
-	utils.CrashOnError(err)
+	ds = New(storage, indexer, search.New(storage, indexer), riskDataStore.Singleton(), ranking.NodeComponentRanker())
 }
 
 // Singleton returns a singleton instance of cve datastore

--- a/central/nodecomponentcveedge/datastore/search/searcher.go
+++ b/central/nodecomponentcveedge/datastore/search/searcher.go
@@ -8,9 +8,12 @@ import (
 	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/blevesearch"
 	pkgPostgres "github.com/stackrox/rox/pkg/search/scoped/postgres"
+	"github.com/stackrox/rox/pkg/search/sortfields"
 )
 
 var (
@@ -31,6 +34,11 @@ func New(storage postgres.Store, indexer index.Indexer) Searcher {
 	return &searcherImpl{
 		storage:  storage,
 		indexer:  indexer,
-		searcher: pkgPostgres.WithScoping(sacHelper.FilteredSearcher(indexer)),
+		searcher: formatSearcherV2(indexer),
 	}
+}
+
+func formatSearcherV2(unsafeSearcher blevesearch.UnsafeSearcher) search.Searcher {
+	scopedSafeSearcher := pkgPostgres.WithScoping(sacHelper.FilteredSearcher(unsafeSearcher))
+	return sortfields.TransformSortFields(scopedSafeSearcher, schema.NodesSchema.OptionsMap)
 }

--- a/pkg/fixtures/node.go
+++ b/pkg/fixtures/node.go
@@ -23,7 +23,7 @@ func GetNode() *storage.Node {
 
 // GetNodeWithUniqueComponents returns a mock Node where each component is unique
 func GetNodeWithUniqueComponents() *storage.Node {
-	componentCount := 2
+	componentCount := 5
 	components := make([]*storage.EmbeddedNodeScanComponent, 0, componentCount)
 	for i := 0; i < componentCount; i++ {
 		components = append(components, &storage.EmbeddedNodeScanComponent{


### PR DESCRIPTION
## Checklist

Transformed searcher for nodes needs to be carried over for the short-term since FE cannot accommodate the change, to send full and correct sort fields (component+version), in MVP. Once FE removes the dependency on BE to transform `Component` to `Component+Version` sort, we can remove this wrapper.

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
CI