### PR TITLE
Optimize dashboard tests and avoid querying that may cause act errors

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
@@ -73,9 +73,9 @@ describe('AgingImages dashboard widget', () => {
 
         // When all items are selected, the total should be equal to the total of all buckets
         // returned by the server
-        const cardHeading = await screen.findByRole('heading', {
-            name: `${result0 + result1 + result2 + result3} Aging images`,
-        });
+        const cardHeading = await screen.findByText(
+            `${result0 + result1 + result2 + result3} Aging images`
+        );
         expect(cardHeading).toBeInTheDocument();
 
         // Each bar should display text that is specific to that time bucket, not
@@ -89,8 +89,12 @@ describe('AgingImages dashboard widget', () => {
     it('should render graph bars with the correct image counts when time buckets are toggled', async () => {
         const { user } = setup();
 
-        await user.click(await screen.findByRole('button', { name: `Options` }));
-        const checkboxes = await screen.findAllByRole('checkbox');
+        expect(
+            await screen.findByText(`${result0 + result1 + result2 + result3} Aging images`)
+        ).toBeInTheDocument();
+
+        await user.click(await screen.findByText(`Options`));
+        const checkboxes = await screen.findAllByLabelText('Toggle image time range');
         expect(checkboxes).toHaveLength(4);
 
         // Disable the first bucket
@@ -99,9 +103,7 @@ describe('AgingImages dashboard widget', () => {
         // With the first item deselected, aging images < 90 days should no longer be present
         // in the chart or the card header
         expect(
-            await screen.findByRole('heading', {
-                name: `${result1 + result2 + result3} Aging images`,
-            })
+            await screen.findByText(`${result1 + result2 + result3} Aging images`)
         ).toBeInTheDocument();
 
         // Test values at top of each bar
@@ -121,9 +123,7 @@ describe('AgingImages dashboard widget', () => {
         // With the first item re-selected (regardless of the other selected items), the heading total
         // should revert to the original value.
         expect(
-            await screen.findByRole('heading', {
-                name: `${result0 + result1 + result2 + result3} Aging images`,
-            })
+            await screen.findByText(`${result0 + result1 + result2 + result3} Aging images`)
         ).toBeInTheDocument();
 
         expect(await screen.findByText(result0)).toBeInTheDocument();
@@ -145,22 +145,22 @@ describe('AgingImages dashboard widget', () => {
         } = setup();
 
         // Check default links
-        await user.click(await screen.findByRole('link', { name: `30-90 days` }));
+        await user.click(await screen.findByText(`30-90 days`));
         expect(history.location.search).toContain('s[Image Created Time]=30d-90d');
 
-        await user.click(await screen.findByRole('link', { name: '90-180 days' }));
+        await user.click(await screen.findByText('90-180 days'));
         expect(history.location.search).toContain('s[Image Created Time]=90d-180d');
 
-        await user.click(await screen.findByRole('link', { name: '>1 year' }));
+        await user.click(await screen.findByText('>1 year'));
         expect(history.location.search).toContain('s[Image Created Time]=>365d');
 
         // Deselect the second time range, merging the first and second time buckets
-        await user.click(await screen.findByRole('button', { name: `Options` }));
-        const checkboxes = await screen.findAllByRole('checkbox');
+        await user.click(await screen.findByText(`Options`));
+        const checkboxes = await screen.findAllByLabelText('Toggle image time range');
         await user.click(checkboxes[1]);
-        await user.click(await screen.findByRole('button', { name: `Options` }));
+        await user.click(await screen.findByText(`Options`));
 
-        await user.click(await screen.findByRole('link', { name: '30-180 days' }));
+        await user.click(await screen.findByText('30-180 days'));
         expect(history.location.search).toContain('s[Image Created Time]=30d-180d');
     });
 });

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
@@ -114,7 +114,7 @@ describe('Compliance levels by standard dashboard widget', () => {
         const { user } = setup();
 
         // Allow graph to load
-        await screen.findAllByRole('presentation');
+        await screen.findByLabelText('Compliance coverage by standard');
 
         async function getBarPercentages() {
             // eslint-disable-next-line testing-library/no-node-access
@@ -138,8 +138,8 @@ describe('Compliance levels by standard dashboard widget', () => {
 
         // Sort by descending
         await act(async () => {
-            await user.click(screen.getByRole('button', { name: 'Options' }));
-            await user.click(screen.getByRole('button', { name: 'Descending' }));
+            await user.click(screen.getByText('Options'));
+            await user.click(screen.getByText('Descending'));
         });
 
         await waitFor(async () => {
@@ -156,12 +156,15 @@ describe('Compliance levels by standard dashboard widget', () => {
             utils: { history },
         } = setup();
 
-        await user.click(await screen.findByRole('link', { name: 'View all' }));
+        // Allow graph to load
+        await screen.findByLabelText('Compliance coverage by standard');
+
+        await user.click(await screen.findByText('View all'));
         expect(history.location.pathname).toBe(complianceBasePath);
 
         const standard = 'CIS Docker v1.2.0';
         await act(async () => {
-            await user.click(await screen.findByRole('link', { name: standard }));
+            await user.click(await screen.findByText(standard));
         });
         expect(history.location.pathname).toBe(
             `${complianceBasePath}/${urlEntityListTypes[standardEntityTypes.CONTROL]}`

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
@@ -86,21 +86,13 @@ describe('Images at most risk dashboard widget', () => {
         const { user } = setup();
 
         // Default is display all images
-        expect(
-            await screen.findByRole('heading', {
-                name: 'Images at most risk',
-            })
-        ).toBeInTheDocument();
+        expect(await screen.findByText('Images at most risk')).toBeInTheDocument();
 
         // Change to display only active images
-        await user.click(await screen.findByRole('button', { name: `Options` }));
-        await user.click(await screen.findByRole('button', { name: `Active images` }));
+        await user.click(await screen.findByText('Options'));
+        await user.click(await screen.findByText('Active images'));
 
-        expect(
-            await screen.findByRole('heading', {
-                name: 'Active images at most risk',
-            })
-        ).toBeInTheDocument();
+        expect(await screen.findByText('Active images at most risk')).toBeInTheDocument();
     });
 
     it('should render the correct text and number of CVEs under each column', async () => {
@@ -118,8 +110,8 @@ describe('Images at most risk dashboard widget', () => {
         );
 
         // Switch to show total CVEs
-        await user.click(await screen.findByRole('button', { name: `Options` }));
-        await user.click(await screen.findByRole('button', { name: `All CVEs` }));
+        await user.click(await screen.findByText('Options'));
+        await user.click(await screen.findByText('All CVEs'));
 
         expect(await screen.findAllByText(`${totalCritical} CVEs`)).toHaveLength(mockImages.length);
         expect(await screen.findAllByText(`${totalImportant} CVEs`)).toHaveLength(
@@ -133,10 +125,10 @@ describe('Images at most risk dashboard widget', () => {
             utils: { history },
         } = setup();
 
-        await screen.findByRole('heading', { name: 'Images at most risk' });
+        await screen.findByText('Images at most risk');
         // Click on the link matching the second image
         const secondImageInList = mockImages[1];
-        await user.click(screen.getByRole('link', { name: secondImageInList.name?.remote }));
+        await user.click(await screen.findByText(secondImageInList.name?.remote));
         expect(history.location.pathname).toBe(
             `${vulnManagementPath}/image/${secondImageInList.id}`
         );
@@ -144,7 +136,7 @@ describe('Images at most risk dashboard widget', () => {
 
         await history.goBack();
 
-        await user.click(screen.getByRole('link', { name: 'View all' }));
+        await user.click(screen.getByText('View all'));
         expect(history.location.pathname).toBe(`${vulnManagementImagesPath}`);
     });
 });

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
@@ -78,9 +78,7 @@ describe('Violations by policy category widget', () => {
     it('should sort a policy violations by category widget by severity and volume of violations', async () => {
         const { user } = setup();
 
-        expect(
-            await screen.findByRole('heading', { name: /Policy violations by category/g })
-        ).toBeInTheDocument();
+        expect(await screen.findByText('Anomalous Activity')).toBeInTheDocument();
 
         // Default sorting should be by severity of critical and high Violations, with critical taking priority.
         await waitForAxisLinksToBe([
@@ -92,9 +90,9 @@ describe('Violations by policy category widget', () => {
         ]);
 
         // Switch to sort-by-volume, which orders the chart by total violations per category
-        await user.click(await screen.findByRole('button', { name: 'Options' }));
-        await user.click(await screen.findByRole('button', { name: 'Total' }));
-        await user.click(await screen.findByRole('button', { name: 'Options' }));
+        await user.click(await screen.findByText('Options'));
+        await user.click(await screen.findByText('Total'));
+        await user.click(await screen.findByText('Options'));
 
         await waitForAxisLinksToBe([
             'Security Best Practices',
@@ -108,14 +106,12 @@ describe('Violations by policy category widget', () => {
     it('should allow toggling of severities for a policy violations by category widget', async () => {
         const { user } = setup();
 
-        expect(
-            await screen.findByRole('heading', { name: /Policy violations by category/g })
-        ).toBeInTheDocument();
+        expect(await screen.findByText('Anomalous Activity')).toBeInTheDocument();
 
         // Sort by volume, so that enabling lower severity bars changes the order of the chart
-        await user.click(await screen.findByRole('button', { name: 'Options' }));
-        await user.click(await screen.findByRole('button', { name: 'Total' }));
-        await user.click(await screen.findByRole('button', { name: 'Options' }));
+        await user.click(await screen.findByText('Options'));
+        await user.click(await screen.findByText('Total'));
+        await user.click(await screen.findByText('Options'));
 
         // Toggle on low and medium violations, which are disabled by default
         await user.click(await screen.findByText('Low'));

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -233,7 +233,7 @@ function ViolationsByPolicyCategoryChart({
     return (
         <div ref={setWidgetContainer}>
             <Chart
-                ariaDesc="Number of violation by policy category, grouped by severity"
+                ariaDesc="Number of violations by policy category, grouped by severity"
                 animate={{ duration: 300 }}
                 domainPadding={{ x: [20, 20] }}
                 events={getInteractiveLegendEvents({

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicySeverity.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicySeverity.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 
 import renderWithRouter from 'test-utils/renderWithRouter';
+import { withTextContent } from 'test-utils/queryUtils';
 import { violationsBasePath } from 'routePaths';
 import ViolationsByPolicySeverity, { mostRecentAlertsQuery } from './ViolationsByPolicySeverity';
 
@@ -77,9 +78,12 @@ describe('Violations by policy severity widget', () => {
     it('should display total violations in the title that match the sum of the individual tiles', async () => {
         setup();
 
-        const tiles = await screen.findAllByRole('link', {
-            name: /^\d+ (Low|Medium|High|Critical)$/,
-        });
+        // Ensure the data has loaded
+        expect(await screen.findByText(withTextContent(/220 ?Low/))).toBeInTheDocument();
+
+        const tiles = await screen.findAllByText(
+            withTextContent(/^\d+ ?(Low|Medium|High|Critical)$/)
+        );
         expect(tiles).toHaveLength(4);
 
         let alertCount = 0;
@@ -88,9 +92,7 @@ describe('Violations by policy severity widget', () => {
         });
 
         expect(
-            await screen.findByRole('heading', {
-                name: `${alertCount} policy violations by severity`,
-            })
+            await screen.findByText(`${alertCount} policy violations by severity`)
         ).toBeInTheDocument();
     });
 
@@ -100,25 +102,24 @@ describe('Violations by policy severity widget', () => {
             utils: { history },
         } = setup();
 
-        expect(
-            await screen.findByRole('heading', { name: /policy violations by severity/g })
-        ).toBeInTheDocument();
+        // Ensure the data has loaded
+        expect(await screen.findByText(withTextContent(/220 ?Low/))).toBeInTheDocument();
 
         // Test the 'View all' violations link button
-        await user.click(await screen.findByRole('link', { name: 'View all' }));
+        await user.click(await screen.findByText('View all'));
         expect(history.location.pathname).toBe(`${violationsBasePath}`);
         expect(history.location.search).toContain('sortOption[field]=Severity');
 
         // Test links from the violation count tiles
-        await user.click(await screen.findByRole('link', { name: '220 Low' }));
+        await user.click(await screen.findByText('Low'));
         expect(history.location.pathname).toBe(`${violationsBasePath}`);
         expect(history.location.search).toContain('[Severity]=LOW_SEVERITY');
-        await user.click(await screen.findByRole('link', { name: '3 Critical' }));
+        await user.click(await screen.findByText('Critical'));
         expect(history.location.pathname).toBe(`${violationsBasePath}`);
         expect(history.location.search).toContain('[Severity]=CRITICAL_SEVERITY');
 
         // Test links from the 'most recent violations' section
-        await user.click(await screen.findByRole('link', { name: /ubuntu package manager/gi }));
+        await user.click(await screen.findByText(/ubuntu package manager/gi));
         expect(history.location.pathname).toBe(`${violationsBasePath}/${mockAlerts[0].id}`);
     });
 });

--- a/ui/apps/platform/src/test-utils/queryUtils.ts
+++ b/ui/apps/platform/src/test-utils/queryUtils.ts
@@ -1,0 +1,41 @@
+import { MatcherFunction } from '@testing-library/react';
+
+/**
+ * Checks that the provided element matches the provided term and that it _does not_ contain
+ * a child element that matches the provided term. This allows querying for the `textContent`
+ * of an element without also returning every descendent element of the match.
+ */
+function isDeepestElementMatch<TermType>(
+    element: Element | null,
+    term: TermType,
+    matcher: (element: Element, term: TermType) => boolean
+) {
+    if (!element || !matcher(element, term)) {
+        return false;
+    }
+    const children = Array.from(element.children);
+    for (let i = 0; i < children.length; i += 1) {
+        if (matcher(children[i], term)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+const stringMatcher = (element: Element, term: string) => !!element?.textContent?.includes(term);
+const regexMatcher = (element: Element, term: RegExp) => term.test(element?.textContent ?? '');
+
+/**
+ * Creates a MatcherFunction https://testing-library.com/docs/queries/about#textmatch that searches
+ * for the deepest element with a `textContent` that matches the provided term. Useful to match
+ * text that may be separated by multiple HTML elements.
+ *
+ * @param term The search term to match
+ * @return A MatcherFunction to run against the document tree
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function withTextContent(term: string | RegExp): MatcherFunction {
+    return typeof term === 'string'
+        ? (_content, element) => isDeepestElementMatch(element, term, stringMatcher)
+        : (_content, element) => isDeepestElementMatch(element, term, regexMatcher);
+}


### PR DESCRIPTION
## Description

This PR optimizes the dashboard tests that use RTL in two main ways:

1. It replaces `*ByRole` queries with a more performant query (`*ByLabelText`, `*ByText`) when possible. I've found that for tests running against components of this size, a `*ByText` query can be used as a replacement easily about 95% of the time. The remaining 5% can usually be targeted by label or by title, with a couple remaining as `*ByRole` when the extra semantic information really makes sense. ([This](https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx#L71) is one case where it was difficult to replace `ByRole` without really changing what was being tested.)

With many test runs and some unscientific napkin math, I've found that changing the queries in the above way sped up test execution from anywhere between 20%-70%, even in the case of a single `*ByRole` call in a test.

2. It also ensures that components under test that render data asynchronously (e.g. via the Apollo `MockedProvider`) run at least one query against an element that _does not exist until the data is returned_. I believe this is the other missing piece that is causing occasional `act()` errors in CI.

From what I understand, Apollo's `MockedProvider` is initialized with a state of `loading=true` and then immediately sets state to the provided mocked data, and then rerenders. The place that the tests run into problems is when a user event immediately follows the initial render, causing this state change and the click event overlap `act` calls. (Both `userEvent.click()` and `render()` from RTL call `act` under the hood.) By awaiting a query that looks for an element that only exists when the data is available we can ensure these two calls do not overlap.

I was able to reproduce these failures locally every 1 out of ~15 times before the change, but after implementing this change I have not seen the error a single time.


## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Many, many local unit test runs.
