### PR TITLE
ROX-11799: Combine entities into one column in VM Images list

### DIFF
--- a/ui/apps/platform/src/Components/workflow/ClusterTableCountLinks/ClusterTableCountLinks.tsx
+++ b/ui/apps/platform/src/Components/workflow/ClusterTableCountLinks/ClusterTableCountLinks.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement } from 'react';
 import { resourceTypes } from 'constants/entityTypes';
 import TableCountLink from 'Components/workflow/TableCountLink';
 
-type TableCountLinksProps = {
+type ClusterTableCountLinksProps = {
     row: {
         namespaceCount: number;
         deploymentCount: number;
@@ -13,7 +13,7 @@ type TableCountLinksProps = {
     textOnly: boolean;
 };
 
-function TableCountLinks({ row, textOnly }: TableCountLinksProps): ReactElement {
+function ClusterTableCountLinks({ row, textOnly }: ClusterTableCountLinksProps): ReactElement {
     const { deploymentCount, namespaceCount, nodeCount, id } = row;
 
     // Only show entity counts on relevant pages. Node count is not currently supported.
@@ -41,4 +41,4 @@ function TableCountLinks({ row, textOnly }: TableCountLinksProps): ReactElement 
     );
 }
 
-export default TableCountLinks;
+export default ClusterTableCountLinks;

--- a/ui/apps/platform/src/Components/workflow/ImageTableCountLinks/ImageTableCountLinks.tsx
+++ b/ui/apps/platform/src/Components/workflow/ImageTableCountLinks/ImageTableCountLinks.tsx
@@ -1,0 +1,56 @@
+import React, { ReactElement, useContext } from 'react';
+
+import { ResourceType, resourceTypes } from 'constants/entityTypes';
+import TableCountLink from 'Components/workflow/TableCountLink';
+import workflowStateContext from 'Containers/workflowStateContext';
+
+type ImageTableCountLinksProps = {
+    row: {
+        deploymentCount: number;
+        componentCount: number;
+        id: string;
+    };
+    textOnly: boolean;
+    isFrontendVMUpdatesEnabled: boolean;
+};
+
+function ImageTableCountLinks({
+    row,
+    textOnly,
+    isFrontendVMUpdatesEnabled = false,
+}: ImageTableCountLinksProps): ReactElement {
+    // const { isFeatureFlagEnabled } = useFeatureFlags();
+    // const isFrontendVMUpdatesEnabled = isFeatureFlagEnabled('ROX_FRONTEND_VM_UDPATES');
+
+    const workflowState = useContext(workflowStateContext);
+    const entityContext = workflowState.getEntityContext() as Record<ResourceType, string>;
+
+    const { deploymentCount, componentCount, id } = row;
+
+    const componentTypeToUse = isFrontendVMUpdatesEnabled
+        ? resourceTypes.IMAGE_COMPONENT
+        : resourceTypes.COMPONENT;
+
+    // Only show entity counts on relevant pages.
+    return (
+        <div className="flex-col">
+            <TableCountLink
+                entityType={resourceTypes.DEPLOYMENT}
+                count={deploymentCount}
+                textOnly={textOnly}
+                selectedRowId={id}
+            />
+            {!entityContext[resourceTypes.COMPONENT] &&
+                !entityContext[resourceTypes.IMAGE_COMPONENT] && (
+                    <TableCountLink
+                        entityType={componentTypeToUse}
+                        count={componentCount}
+                        textOnly={textOnly}
+                        selectedRowId={id}
+                    />
+                )}
+        </div>
+    );
+}
+
+export default ImageTableCountLinks;

--- a/ui/apps/platform/src/Components/workflow/ImageTableCountLinks/index.ts
+++ b/ui/apps/platform/src/Components/workflow/ImageTableCountLinks/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ImageTableCountLinks';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.js
@@ -5,7 +5,7 @@ import { List } from 'react-feather';
 
 import PanelButton from 'Components/PanelButton';
 import TopCvssLabel from 'Components/TopCvssLabel';
-import TableCountLink from 'Components/workflow/TableCountLink';
+import ImageTableCountLinks from 'Components/workflow/ImageTableCountLinks';
 import StatusChip from 'Components/StatusChip';
 import CVEStackedPill from 'Components/CVEStackedPill';
 import DateTimeField from 'Components/DateTimeField';
@@ -180,44 +180,19 @@ export function getCurriedImageTableColumns(watchedImagesTrigger, isFeatureFlagE
                 sortable: false,
             },
             {
-                Header: `Deployments`,
+                Header: `Entities`,
                 entityType: entityTypes.DEPLOYMENT,
                 headerClassName: `w-1/12 ${defaultHeaderClassName}`,
                 className: `w-1/12 ${defaultColumnClassName}`,
                 Cell: ({ original, pdf }) => (
-                    <TableCountLink
-                        entityType={entityTypes.DEPLOYMENT}
-                        count={original.deploymentCount}
+                    <ImageTableCountLinks
+                        row={original}
                         textOnly={pdf}
-                        selectedRowId={original.id}
+                        isFrontendVMUpdatesEnabled={isFrontendVMUpdatesEnabled}
                     />
                 ),
-                id: imageSortFields.DEPLOYMENT_COUNT,
-                accessor: 'deploymentCount',
-                sortField: imageSortFields.DEPLOYMENT_COUNT,
-            },
-            {
-                Header: `Components`,
-                entityType: isFrontendVMUpdatesEnabled
-                    ? entityTypes.IMAGE_COMPONENT
-                    : entityTypes.COMPONENT,
-                headerClassName: `w-1/12 ${defaultHeaderClassName}`,
-                className: `w-1/12 ${defaultColumnClassName}`,
-                Cell: ({ original, pdf }) => (
-                    <TableCountLink
-                        entityType={
-                            isFrontendVMUpdatesEnabled
-                                ? entityTypes.IMAGE_COMPONENT
-                                : entityTypes.COMPONENT
-                        }
-                        count={original.componentCount}
-                        textOnly={pdf}
-                        selectedRowId={original.id}
-                    />
-                ),
-                id: imageSortFields.COMPONENT_COUNT,
-                accessor: 'componentCount',
-                sortField: imageSortFields.COMPONENT_COUNT,
+                accessor: 'entities',
+                sortable: false,
             },
             {
                 Header: `Risk Priority`,


### PR DESCRIPTION
## Description

This combines the Deployments and Components (soon-to-be Image Components) columns into one Entities column on the Images list page.

Notes:
1. I tried reusing the existing multi-entities TableLinksCount component, but would have required making the conditional logic even more serpentine than it already is, so I "forked" it into a new component for this use case.
2. I still had to pass the feature flag into my new component, so that it can show plain "Components" when the flag is off, and "Image Components" when the flag is on.
3. Saif has a fix for the broken link for the Image Components count. I will test this change again, once Saif's fix is merged. However, that doesn't affect this actual change.

## Checklist
- [x] Investigated and inspected CI test results (failures are unrelated and are being fixed in another PR)


## Testing Performed

Manual testing
![Screen Shot 2022-07-18 at 5 17 51 PM](https://user-images.githubusercontent.com/715729/179619768-d3a4885f-44e4-4bb4-924b-49e76b0df344.png)
