### PR TITLE
Fix minor issue with certificate validation error display

### DIFF
--- a/roxctl/common/tls.go
+++ b/roxctl/common/tls.go
@@ -41,7 +41,7 @@ func (v *insecureVerifierWithWarning) VerifyPeerCertificate(leaf *x509.Certifica
 	if err != nil {
 		v.printWarningOnce.Do(func() {
 			v.logger.WarnfLn(warningMsg)
-			v.logger.ErrfLn("Certificate validation error:", err.Error())
+			v.logger.ErrfLn("Certificate validation error: %v", err)
 		})
 	}
 	return nil


### PR DESCRIPTION
## Description

Right now, it displays like this:
```
ERROR:	Certificate validation error:
%!(EXTRA string=x509: certificate signed by unknown authority)
```

([example build](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/2434/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/1548036503966322688#1:build-log.txt%3A840))

This PR fixes that.

## Checklist
- [ ] Investigated and inspected CI test results
- ~Unit test and regression tests added~
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~


## Testing Performed

CI.