### PR TITLE
ROX-11142: Proposal to mitigate Network Baseline Flake

### DIFF
--- a/qa-tests-backend/src/main/groovy/util/NetworkGraphUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/NetworkGraphUtil.groovy
@@ -109,7 +109,7 @@ class NetworkGraphUtil {
         }
     }
 
-    static checkForEdge(String sourceId, String targetId, Timestamp since = null, int timeoutSeconds = 90) {
+    static checkForEdge(String sourceId, String targetId, Timestamp since = null, int timeoutSeconds = 90, String query = null) {
         int intervalSeconds = 1
         int waitTime
         def startTime = System.currentTimeMillis()
@@ -118,7 +118,7 @@ class NetworkGraphUtil {
                 sleep intervalSeconds * 1000
             }
 
-            def graph = NetworkGraphService.getNetworkGraph(since)
+            def graph = NetworkGraphService.getNetworkGraph(since, query)
             def edges = NetworkGraphUtil.findEdges(graph, sourceId, targetId)
             if (edges != null && edges.size() > 0) {
                 log.debug "Found source ${sourceId} -> target ${targetId} " +

--- a/qa-tests-backend/src/main/groovy/util/NetworkGraphUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/NetworkGraphUtil.groovy
@@ -109,7 +109,8 @@ class NetworkGraphUtil {
         }
     }
 
-    static checkForEdge(String sourceId, String targetId, Timestamp since = null, int timeoutSeconds = 90, String query = null) {
+    static checkForEdge(String sourceId, String targetId, Timestamp since = null,
+                        int timeoutSeconds = 90, String query = null) {
         int intervalSeconds = 1
         int waitTime
         def startTime = System.currentTimeMillis()

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -103,7 +103,7 @@ class NetworkBaselineTest extends BaseSpecification {
     }
 
     def validateBaseline(NetworkBaselineOuterClass.NetworkBaseline baseline, long beforeCreate,
-                         long justAfterCreate, List<Tuple2<String, Boolean>> expectedPeers, List<String> notExpectedPeers) {
+                         long justAfterCreate, List<Tuple2<String, Boolean>> expectedPeers, List<String> explicitMissingPeers) {
         assert baseline.getObservationPeriodEnd().getSeconds() > beforeCreate - CLOCK_SKEW_ALLOWANCE_SECONDS
         assert baseline.getObservationPeriodEnd().getSeconds() <
             justAfterCreate + EXPECTED_BASELINE_DURATION_SECONDS + CLOCK_SKEW_ALLOWANCE_SECONDS
@@ -124,7 +124,7 @@ class NetworkBaselineTest extends BaseSpecification {
             assert properties.getProtocol() == NetworkFlowOuterClass.L4Protocol.L4_PROTOCOL_TCP
         }
 
-        for (def checkMissingId : notExpectedPeers) {
+        for (def checkMissingId : explicitMissingPeers) {
             def actualPeer = baseline.getPeersList().find { it.getEntity().getInfo().getId() == checkMissingId }
             assert actualPeer == null
         }

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -134,8 +134,7 @@ class NetworkBaselineTest extends BaseSpecification {
         }
 
         for (def checkMissingId : mustNotBeInBaseline) {
-            def actualPeer = baseline.getPeersList().find { it.getEntity().getInfo().getId() == checkMissingId }
-            assert actualPeer == null
+            assert !baseline.getPeersList().any { it.getEntity().getInfo().getId() == checkMissingId }
         }
         return true
     }

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -111,8 +111,11 @@ class NetworkBaselineTest extends BaseSpecification {
     // from this OpenShift connection in port 9537. To fix the issue, the split between `expectedPeers` and
     // `explicitMissingPeers` was introduced.
     // Check issues ROX-11142 and PR#2459 for more information.
-    def validateBaseline(NetworkBaselineOuterClass.NetworkBaseline baseline, long beforeCreate,
-                         long justAfterCreate, List<Tuple2<String, Boolean>> mustBeInBaseline, List<String> mustNotBeInBaseline) {
+    def validateBaseline(NetworkBaselineOuterClass.NetworkBaseline baseline,
+                         long beforeCreate,
+                         long justAfterCreate,
+                         List<Tuple2<String, Boolean>> mustBeInBaseline,
+                         List<String> mustNotBeInBaseline) {
         assert baseline.getObservationPeriodEnd().getSeconds() > beforeCreate - CLOCK_SKEW_ALLOWANCE_SECONDS
         assert baseline.getObservationPeriodEnd().getSeconds() <
             justAfterCreate + EXPECTED_BASELINE_DURATION_SECONDS + CLOCK_SKEW_ALLOWANCE_SECONDS

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -112,15 +112,15 @@ class NetworkBaselineTest extends BaseSpecification {
     // `explicitMissingPeers` was introduced.
     // Check issues ROX-11142 and PR#2459 for more information.
     def validateBaseline(NetworkBaselineOuterClass.NetworkBaseline baseline, long beforeCreate,
-                         long justAfterCreate, List<Tuple2<String, Boolean>> expectedPeers, List<String> explicitMissingPeers) {
+                         long justAfterCreate, List<Tuple2<String, Boolean>> mustBeInBaseline, List<String> mustNotBeInBaseline) {
         assert baseline.getObservationPeriodEnd().getSeconds() > beforeCreate - CLOCK_SKEW_ALLOWANCE_SECONDS
         assert baseline.getObservationPeriodEnd().getSeconds() <
             justAfterCreate + EXPECTED_BASELINE_DURATION_SECONDS + CLOCK_SKEW_ALLOWANCE_SECONDS
         assert baseline.getForbiddenPeersCount() == 0
 
-        for (def i = 0; i < expectedPeers.size(); i++) {
-            def expectedPeerID = expectedPeers.get(i).getFirst()
-            def expectedPeerIngress = expectedPeers.get(i).getSecond()
+        for (def i = 0; i < mustBeInBaseline.size(); i++) {
+            def expectedPeerID = mustBeInBaseline.get(i).getFirst()
+            def expectedPeerIngress = mustBeInBaseline.get(i).getSecond()
             def actualPeer = baseline.getPeersList().find { it.getEntity().getInfo().getId() == expectedPeerID }
             assert actualPeer
             def entityInfo = actualPeer.getEntity().getInfo()
@@ -133,7 +133,7 @@ class NetworkBaselineTest extends BaseSpecification {
             assert properties.getProtocol() == NetworkFlowOuterClass.L4Protocol.L4_PROTOCOL_TCP
         }
 
-        for (def checkMissingId : explicitMissingPeers) {
+        for (def checkMissingId : mustNotBeInBaseline) {
             def actualPeer = baseline.getPeersList().find { it.getEntity().getInfo().getId() == checkMissingId }
             assert actualPeer == null
         }

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -235,9 +235,9 @@ class NetworkBaselineTest extends BaseSpecification {
         "Validate the updated baselines"
         validateBaseline(serverBaseline, beforeDeploymentCreate, justAfterDeploymentCreate,
             [new Tuple2<String, Boolean>(baselinedClientDeploymentID, true),
-             // Currently, we add conns to the baseline if it's within the observation period
+             // Currently, we add cons to the baseline if it's within the observation period
              // of _at least_ one of the deployments. Therefore, the deferred client->server connection
-             // gets added since it's within the deferred client's obervation period, and
+             // gets added since it's within the deferred client's observation period, and
              // the server's baseline is modified as well since we keep things consistent.
              new Tuple2<String, Boolean>(deferredBaselinedClientDeploymentID, true),
             ], [anomalousClientDeploymentID]


### PR DESCRIPTION
## Description

This problem seems to be related to an external request arriving at the `net-bl-server` pod during the time it's capturing the network baseline. The culprit connects to `net-bl-server` at port `9537` and it gets classified as an `External Connection` in the Network Graph, meaning its not from any resource managed in this cluster. The `External Connection` entity gets added to the baseline, it eventually fails because the tests assert that only one of the two deployments applied will show up in the baseline.

This seems to only happen in OpenShift clusters.

This PR proposes the following change in this test assertion: 
- `baselineClient` **is present** in the baseline
- `anomalousClient` **is not present** in the baseline
- Any additional entries in the baseline are ignored

This PR also adds two additional improvements to the tests. They are not required for the flake fix, they are just improvements to the test harness:
- Network Graph is filtered by namespace `qa`
- Network Graph has an explicit `since` param to `epoch` in order to capture every edge in the graph.
_I've added this because during debugging I had some strange behaviors locally where there were no edges if `null` was provided_

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

- Run qa tests in OpenShift 

**1st Run:** https://app.circleci.com/pipelines/github/stackrox/stackrox/16815/workflows/a82330e0-6461-45d6-99e8-0458d4cdef13

`NetworkBaselineTest` passed in:
- ✅ `openshift-aro-api-e2e-tests` 
- ✅ `openshift-rosa-api-e2e-tests` (step failed on `DefaultPoliciesTest`)
- ✅ `osd-gcp-api-e2e-tests` (step halted after running the tests)
- ⚠️   `osd-aws-api-e2e-tests` (provision failed)

**2nd Run:** https://app.circleci.com/pipelines/github/stackrox/stackrox/16878/workflows/345321a7-f690-4a32-b527-fbd53ccab6a9

`NetworkBaselineTest` passed in (multiple other flakes made all the steps fail though 😞):
- ✅ `openshift-aro-api-e2e-tests` 
- ✅ `openshift-rosa-api-e2e-tests` 
- ✅ `osd-gcp-api-e2e-tests` 
- ✅  `osd-aws-api-e2e-tests` 

**3rd Run:** https://app.circleci.com/pipelines/github/stackrox/stackrox/16924/workflows/0d46c822-656d-4087-b62e-e3bb47311679

`NetworkBaselineTest` passed in:
- ✅ `openshift-aro-api-e2e-tests` 
- ⚠️  `openshift-rosa-api-e2e-tests` (provision failed)
- ✅ `osd-gcp-api-e2e-tests` 
- ⚠️   `osd-aws-api-e2e-tests` (provision failed)

**4th Run:** https://app.circleci.com/pipelines/github/stackrox/stackrox/17157/workflows/b37938df-10fa-4c89-8a37-0679434a93a9

`NetworkBaselineTest` passed in:
- ✅ `openshift-aro-api-e2e-tests` 
- ✅ `openshift-rosa-api-e2e-tests`
- ✅ `osd-gcp-api-e2e-tests` 
- ⚠️   `osd-aws-api-e2e-tests` (provision failed)

