### PR TITLE
ROX-11747 Increase default timeout for waitForDeployment in Groovy tests to prevent flakes

### DIFF
--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -423,7 +423,7 @@ class Services extends BaseService {
         return disappearedFromStackRox
     }
 
-    static waitForDeployment(objects.Deployment deployment, int retries = 30, int interval = 2) {
+    static waitForDeployment(objects.Deployment deployment, int retries = 60, int interval = 2) {
         if (deployment.deploymentUid == null) {
             LOG.info "deploymentID for [${deployment.name}] is null, checking orchestrator directly for deployment ID"
             deployment.deploymentUid = OrchestratorType.orchestrator.getDeploymentId(deployment)


### PR DESCRIPTION
## Description

Increase the timeout to 2 minutes from the current 1 minute to prevent flakes similar to those in the ticket. This won't make tests slower in the passing case since we still poll every 2 seconds.

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~



## Testing Performed

CI