### PR TITLE
Dv/jest mock implementation explicit

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 
 import renderWithRouter from 'test-utils/renderWithRouter';
+import { mockChartsWithoutAnimation } from 'test-utils/mocks/@patternfly/react-charts';
 import AgingImages, { imageCountQuery } from './AgingImages';
 
 const range0 = '30';
@@ -39,19 +40,8 @@ const mocks = [
     },
 ];
 
-jest.mock('@patternfly/react-charts', () => {
-    const { Chart, ...rest } = jest.requireActual('@patternfly/react-charts');
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return {
-        ...rest,
-        Chart: (props) => <Chart {...props} animate={undefined} />,
-    };
-});
-
-jest.mock('hooks/useResizeObserver', () => ({
-    __esModule: true,
-    default: jest.fn().mockImplementation(jest.fn),
-}));
+jest.mock('@patternfly/react-charts', () => mockChartsWithoutAnimation);
+jest.mock('hooks/useResizeObserver');
 
 beforeEach(() => {
     localStorage.clear();

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { MockedProvider } from '@apollo/client/testing';
-import { screen, within, waitFor, act } from '@testing-library/react';
+import { screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 
 import renderWithRouter from 'test-utils/renderWithRouter';
+import { mockChartsWithoutAnimation } from 'test-utils/mocks/@patternfly/react-charts';
 import { AGGREGATED_RESULTS_ACROSS_ENTITIES } from 'queries/controls';
 import entityTypes, { standardEntityTypes } from 'constants/entityTypes';
 import { complianceBasePath, urlEntityListTypes } from 'routePaths';
@@ -80,19 +81,8 @@ const mocks = [
     },
 ];
 
-jest.mock('@patternfly/react-charts', () => {
-    const { Chart, ...rest } = jest.requireActual('@patternfly/react-charts');
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return {
-        ...rest,
-        Chart: (props) => <Chart {...props} animate={undefined} />,
-    };
-});
-
-jest.mock('hooks/useResizeObserver', () => ({
-    __esModule: true,
-    default: jest.fn().mockImplementation(jest.fn),
-}));
+jest.mock('@patternfly/react-charts', () => mockChartsWithoutAnimation);
+jest.mock('hooks/useResizeObserver');
 
 beforeEach(() => {
     localStorage.clear();
@@ -137,10 +127,8 @@ describe('Compliance levels by standard dashboard widget', () => {
         });
 
         // Sort by descending
-        await act(async () => {
-            await user.click(screen.getByText('Options'));
-            await user.click(screen.getByText('Descending'));
-        });
+        await user.click(screen.getByText('Options'));
+        await user.click(screen.getByText('Descending'));
 
         await waitFor(async () => {
             const descendingPercentages = await getBarPercentages();
@@ -163,9 +151,7 @@ describe('Compliance levels by standard dashboard widget', () => {
         expect(history.location.pathname).toBe(complianceBasePath);
 
         const standard = 'CIS Docker v1.2.0';
-        await act(async () => {
-            await user.click(await screen.findByText(standard));
-        });
+        await user.click(await screen.findByText(standard));
         expect(history.location.pathname).toBe(
             `${complianceBasePath}/${urlEntityListTypes[standardEntityTypes.CONTROL]}`
         );

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
@@ -61,10 +61,7 @@ const mocks = [
     },
 ];
 
-jest.mock('hooks/useResizeObserver', () => ({
-    __esModule: true,
-    default: jest.fn().mockImplementation(jest.fn),
-}));
+jest.mock('hooks/useResizeObserver');
 
 beforeEach(() => {
     localStorage.clear();

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
@@ -4,21 +4,11 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 
 import renderWithRouter from 'test-utils/renderWithRouter';
+import { mockChartsWithoutAnimation } from 'test-utils/mocks/@patternfly/react-charts';
 import ViolationsByPolicyCategory from 'Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory';
 
-jest.mock('@patternfly/react-charts', () => {
-    const { Chart, ...rest } = jest.requireActual('@patternfly/react-charts');
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return {
-        ...rest,
-        Chart: (props) => <Chart {...props} animate={undefined} />,
-    };
-});
-
-jest.mock('hooks/useResizeObserver', () => ({
-    __esModule: true,
-    default: jest.fn().mockImplementation(jest.fn),
-}));
+jest.mock('@patternfly/react-charts', () => mockChartsWithoutAnimation);
+jest.mock('hooks/useResizeObserver');
 
 // Mock the hook that handles the data fetching of alert counts
 jest.mock('Containers/Dashboard/PatternFly/hooks/useAlertGroups', () => {

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicySeverity.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicySeverity.test.tsx
@@ -34,10 +34,7 @@ const mocks = [
     },
 ];
 
-jest.mock('hooks/useResizeObserver', () => ({
-    __esModule: true,
-    default: jest.fn().mockImplementation(jest.fn),
-}));
+jest.mock('hooks/useResizeObserver');
 
 // Mock the hook that handles the data fetching of alert counts
 jest.mock('Containers/Dashboard/PatternFly/hooks/useAlertGroups', () => ({

--- a/ui/apps/platform/src/test-utils/mocks/@patternfly/react-charts.tsx
+++ b/ui/apps/platform/src/test-utils/mocks/@patternfly/react-charts.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import * as PFReactCharts from '@patternfly/react-charts';
+
+const { Chart, ...rest } = jest.requireActual('@patternfly/react-charts');
+
+/**
+ * Overrides props to the `Chart` component and globally disables animation. This is to avoid asynchronous
+ * state updates that result in `act()` errors, as well as for a performance boost.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const mockChartsWithoutAnimation = {
+    ...rest,
+    Chart: (props) => <Chart {...props} animate={undefined} />,
+} as jest.Mock<typeof PFReactCharts>;


### PR DESCRIPTION
## Description

This is an alternative implementation to https://github.com/stackrox/stackrox/pull/2354 with the same core functionality. The difference in this case is that the mocking of `@patternfly/react-charts` is handled explicitly via an export instead of automagically through Jest's "Manual Mocks" feature. 

The goal here is to provide contrast to the other approach and potentially clearer and more discoverable code after feedback from the last UI meeting.

Note: We should only merge one of the two PRs.

## Checklist
- [ ] Investigated and inspected CI test results

If any of these don't apply, please comment below.

## Testing Performed

Automated tests pass
