### PR TITLE
ROX-10935: Bump helm dep to fix a loopclosure mistake

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -206,4 +206,4 @@ exclude k8s.io/client-go v12.0.0+incompatible
 
 exclude github.com/openshift/client-go v3.9.0+incompatible
 
-replace helm.sh/helm/v3 => github.com/porridge/helm/v3 v3.7.3-0.20220712081439-a4d429d11bd9
+replace helm.sh/helm/v3 => github.com/porridge/helm/v3 v3.7.3-0.20220719213745-59a08440474d

--- a/go.sum
+++ b/go.sum
@@ -2423,8 +2423,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v0.0.0-20201006195004-351e25ade6e3/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
 github.com/polyfloyd/go-errorlint v0.0.0-20210722154253-910bb7978349/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
-github.com/porridge/helm/v3 v3.7.3-0.20220712081439-a4d429d11bd9 h1:OGXycrprY9q8o2QHBTWpCZK6BjAE23JN53dHYSGN+Lw=
-github.com/porridge/helm/v3 v3.7.3-0.20220712081439-a4d429d11bd9/go.mod h1:UXuiAn0+FfBpqbiMuwWt8/aAKkfJvnWLBJ6f4HcFs0M=
+github.com/porridge/helm/v3 v3.7.3-0.20220719213745-59a08440474d h1:dT/XU5CUFFkLtmSn5IYvhiSCRsjTteDzYB8MddzgUOo=
+github.com/porridge/helm/v3 v3.7.3-0.20220719213745-59a08440474d/go.mod h1:UXuiAn0+FfBpqbiMuwWt8/aAKkfJvnWLBJ6f4HcFs0M=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1/go.mod h1:nSbFQvMj97ZyhFRSJYtut+msi4sOY6zJDGCdSc+/rZU=


### PR DESCRIPTION
## Description

It is likely the bug referred to in the subject is caused by a [classic loopclosure bug](https://go.dev/doc/faq#closures_and_goroutines) that I attempt to [fix here](https://github.com/porridge/helm/commit/59a08440474d707a25b44977e044f17c058840dc).

If this helps with the flake I'll take care of upstreaming it.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Relying on CI