### PR TITLE
ROX-9565: support building, pushing and testing operator on prow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2327,6 +2327,13 @@ jobs:
     steps:
       - checkout
       - poll-for-builds-from-other-ci
+      - setup_remote_docker:
+          # Default docker server version isn't new enough therefore we're asking for more recent one to enjoy Buildkit.
+          version: << pipeline.parameters.docker_version >>
+      - run:
+          name: Login to Docker Hub and Quay.io
+          command: |
+            docker login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin \<<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
       - run:
           name: Check that Operator image is runnable - quay.io/rhacs-eng
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2326,26 +2326,7 @@ jobs:
     resource_class: large
     steps:
       - checkout
-
-      - setup_remote_docker:
-          # Default docker server version isn't new enough therefore we're asking for more recent one to enjoy Buildkit.
-          version: << pipeline.parameters.docker_version >>
-      - run:
-          name: Login to Docker Hub and Quay.io
-          command: |
-            docker login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin \<<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
-
-      - attach_workspace:
-          at: /go/src/github.com/stackrox/rox
-
-      - restore-go-mod-cache
-      - setup-go-build-env
-
-      - run:
-          name: Build and push images for quay.io/rhacs-eng
-          command: |
-            ROX_PRODUCT_BRANDING=RHACS_BRANDING make -C operator/ everything
-
+      - poll-for-builds-from-other-ci
       - run:
           name: Check that Operator image is runnable - quay.io/rhacs-eng
           command: |

--- a/.openshift-ci/build/Dockerfile.build-central-db-bundle
+++ b/.openshift-ci/build/Dockerfile.build-central-db-bundle
@@ -1,4 +1,5 @@
 FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.35
+# note the above FROM line is ignored and OpenShift CI uses build_root image instead
 
 ARG ROX_PRODUCT_BRANDING
 ENV ROX_PRODUCT_BRANDING=${ROX_PRODUCT_BRANDING}

--- a/.openshift-ci/build/Dockerfile.build-main-and-bundle
+++ b/.openshift-ci/build/Dockerfile.build-main-and-bundle
@@ -1,4 +1,5 @@
 FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.35
+# note the above FROM line is ignored and OpenShift CI uses build_root image instead
 
 ARG ROX_PRODUCT_BRANDING
 ENV ROX_PRODUCT_BRANDING=${ROX_PRODUCT_BRANDING}

--- a/.openshift-ci/build/Dockerfile.build-operator-artifacts
+++ b/.openshift-ci/build/Dockerfile.build-operator-artifacts
@@ -1,0 +1,10 @@
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.35
+# note the above FROM line is ignored and OpenShift CI uses build_root image instead
+
+ARG ROX_PRODUCT_BRANDING
+ENV ROX_PRODUCT_BRANDING=${ROX_PRODUCT_BRANDING}
+
+COPY . /go/src/github.com/stackrox/stackrox
+WORKDIR /go/src/github.com/stackrox/stackrox
+
+RUN ./.openshift-ci/build/build-operator-artifacts.sh

--- a/.openshift-ci/build/build-operator-artifacts.sh
+++ b/.openshift-ci/build/build-operator-artifacts.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Execute all build steps required to create the operator bundle.tar.gz and
+# scripts used in image/rhel/Dockerfile
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+source "$ROOT/scripts/ci/lib.sh"
+
+set -euo pipefail
+
+build_operator_bundle_and_binary() {
+    # avoid a -dirty tag
+    info "Reset to remove Dockerfile modification by OpenShift CI"
+    git restore .
+    git status
+
+    info "Current Status:"
+    "$ROOT/status.sh" || true
+
+    openshift_ci_mods
+
+    info "Downloading go modules"
+    # We need to download dependencies before invoking the `manifests` target (depended on by `bundle`).
+    # Otherwise we get the cryptic "Missing value for flag: -I" error when running protoc.
+    go mod download
+
+    info "Preparing bundle sources and smuggled status.sh file"
+    # TODO(ROX-11889): get rid of the SILENT= once we gain some confidence (after release 3.72?)
+    make -C operator bundle bundle-post-process smuggled-status-sh SILENT=
+
+    info "Making a copy of the built bundle sources in a magically named directory that will be used instead of the bundle image."
+    # The hacked opm tool will first see if a directory named as the reference exists, and if so, use its content as if it's an unpacked image of that name.
+    # TODO(ROX-11889): get rid of or upstream this hack in a nicer way
+    # Because the hack needs the directory to be named exactly the same as the image specification, this cannot be placed
+    # in the "build/" directory.
+    bundle_source_parent="operator/$(make --quiet default-image-registry)"
+    mkdir -p "${bundle_source_parent}"
+    cp -a operator/build/bundle "${bundle_source_parent}/stackrox-operator-bundle:v$(make --quiet --no-print-directory -C operator tag)"
+
+    info "Preparing bundle index sources"
+    # TODO(ROX-11889): get rid of the SILENT= once we gain some confidence (after release 3.72?)
+    make -C operator index-build SKIP_INDEX_DOCKER_BUILD=--skip-build SILENT=
+}
+
+build_operator_bundle_and_binary

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -49,6 +49,35 @@ class UpgradeTest(BaseTest):
         )
 
 
+class OperatorE2eTest(BaseTest):
+    # TODO(ROX-11889): adjust these timeouts once we know average run times
+    DEPLOY_TIMEOUT_SEC = 40 * 60
+    UPGRADE_TEST_TIMEOUT_SEC = 50 * 60
+    E2E_TEST_TIMEOUT_SEC = 50 * 60
+    SCORECARD_TEST_TIMEOUT_SEC = 20 * 60
+
+    def run(self):
+        print("Deploying operator")
+        self.run_with_graceful_kill(
+            ["make", "-C", "operator", "kuttl", "deploy-previous-via-olm"], OperatorE2eTest.DEPLOY_TIMEOUT_SEC
+        )
+
+        print("Executing operator upgrade test")
+        self.run_with_graceful_kill(
+            ["make", "-C", "operator", "test-upgrade"], OperatorE2eTest.UPGRADE_TEST_TIMEOUT_SEC
+        )
+
+        print("Executing operator e2e tests")
+        self.run_with_graceful_kill(
+            ["make", "-C", "operator", "test-e2e-deployed"], OperatorE2eTest.E2E_TEST_TIMEOUT_SEC
+        )
+
+        print("Executing Operator Bundle Scorecard tests")
+        self.run_with_graceful_kill(
+            ["./operator/scripts/retry.sh", "4", "2", "make", "-C", "operator", "bundle-test-image"], OperatorE2eTest.SCORECARD_TEST_TIMEOUT_SEC
+        )
+
+
 class QaE2eTestPart1(BaseTest):
     TEST_TIMEOUT = 240 * 60
 

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -31,7 +31,7 @@ case "$ci_job" in
         registry_ro_login "quay.io/rhacs-eng"
         # NAMESPACE is injected by OpenShift CI for the cluster that is running the
         # tests but this can have side effects for operator tests due to its use as
-        # the default namespace e.g. in opertor-sdk scorecard.
+        # the default namespace e.g. in operator-sdk scorecard.
         # Cannot use `openshift_ci_e2e_mods` for the following, since it also nukes KUBECONFIG,
         # which we need.
         if [[ -n "${NAMESPACE:-}" ]]; then

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -27,6 +27,18 @@ case "$ci_job" in
     gke-qa-e2e-tests|gke-nongroovy-e2e-tests|gke-upgrade-tests|gke-ui-e2e-tests)
         openshift_ci_e2e_mods
         ;;
+    openshift-*-operator-e2e-tests)
+        registry_ro_login "quay.io/rhacs-eng"
+        # NAMESPACE is injected by OpenShift CI for the cluster that is running the
+        # tests but this can have side effects for operator tests due to its use as
+        # the default namespace e.g. in opertor-sdk scorecard.
+        # Cannot use `openshift_ci_e2e_mods` for the following, since it also nukes KUBECONFIG,
+        # which we need.
+        if [[ -n "${NAMESPACE:-}" ]]; then
+            export OPENSHIFT_CI_NAMESPACE="$NAMESPACE"
+            unset NAMESPACE
+        fi
+        ;;
 esac
 
 if [[ "$ci_job" =~ e2e|upgrade ]]; then

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -28,16 +28,7 @@ case "$ci_job" in
         openshift_ci_e2e_mods
         ;;
     openshift-*-operator-e2e-tests)
-        registry_ro_login "quay.io/rhacs-eng"
-        # NAMESPACE is injected by OpenShift CI for the cluster that is running the
-        # tests but this can have side effects for operator tests due to its use as
-        # the default namespace e.g. in operator-sdk scorecard.
-        # Cannot use `openshift_ci_e2e_mods` for the following, since it also nukes KUBECONFIG,
-        # which we need.
-        if [[ -n "${NAMESPACE:-}" ]]; then
-            export OPENSHIFT_CI_NAMESPACE="$NAMESPACE"
-            unset NAMESPACE
-        fi
+        operator_e2e_test_setup
         ;;
 esac
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -67,7 +67,11 @@ SCORECARD_STORAGE_IMAGE ?= $(SCORECARD_STORAGE_IMAGE_BASE):$(SCORECARD_STORAGE_I
 SCORECARD_WAIT_TIME_DURATION ?= 5m
 
 # SCORECARD_ARGS should be passed to any invocation of "$(OPERATOR_SDK) scorecard".
-SCORECARD_ARGS ?= --storage-image="$(SCORECARD_STORAGE_IMAGE)" --wait-time="$(SCORECARD_WAIT_TIME_DURATION)" --verbose
+# TODO(ROX-11889): The `--namespace default` is a workaround for failures such as the following when running in a pod:
+# TODO(ROX-11889):   Error: error running tests error creating ConfigMap namespaces "ci-op-05qx07r3" not found
+# TODO(ROX-11889): These seem to happen despite unsetting the $NAMESPACE environment variable.
+# TODO(ROX-11889): Figure out where scorecard gets the namespace name from, elliminate this source, and remove the flag here.
+SCORECARD_ARGS ?= --storage-image="$(SCORECARD_STORAGE_IMAGE)" --wait-time="$(SCORECARD_WAIT_TIME_DURATION)" --verbose --namespace default
 
 # TEST_NAMESPACE is where the operator is installed for e2e tests by CI.
 TEST_NAMESPACE ?= stackrox-operator

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -430,7 +430,7 @@ bundle-test-image: operator-sdk ## Run scorecard tests against bundle image in t
 	$(OPERATOR_SDK) scorecard $(SCORECARD_ARGS) $(BUNDLE_IMG)
 
 .PHONY: index-build
-index-build: bundle-post-process ## Build Index (a.k.a. Catalog) image with the bundle. Bundle image must be pushed beforehand.
+index-build: bundle-post-process ## Build Index (a.k.a. Catalog) image with the bundles. Bundle image must be pushed beforehand.
 # If the bundle has `replaces:` attribute in CSV, then the one it replaces has to already be in the index. Otherwise,
 # validation of the index fails because more than one version is identified as the head of the channel. An example of an
 # error: `multiple channel heads found in graph: rhacs-operator.v3.67.0, rhacs-operator.v3.69.0`

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -237,13 +237,13 @@ test-e2e: build install validate-crs kuttl ensure-rox-main-image-exists ## Run e
 
 test-e2e-deployed: validate-crs kuttl ## Run e2e tests with manager deployed on cluster.
 	mkdir -p $(PROJECT_DIR)/build/kuttl-test-artifacts
-	KUTTL=$(KUTTL) SKIP_MANAGER_START=1 $(KUTTL) test
+	KUTTL=$(KUTTL) REAL_KUBECONFIG=$${KUBECONFIG} SKIP_MANAGER_START=1 $(KUTTL) test
 
 test-upgrade: kuttl bundle-post-process ## Run OLM-based operator upgrade tests.
 	mkdir -p $(PROJECT_DIR)/build/kuttl-test-artifacts
 	SKIP_MANAGER_START=1 \
 	NEW_PRODUCT_VERSION=$$(make --quiet --no-print-directory -C .. tag) \
-	KUTTL=$(KUTTL) $(KUTTL) test --config kuttl-test.yaml tests/upgrade
+	KUTTL=$(KUTTL) REAL_KUBECONFIG=$${KUBECONFIG} $(KUTTL) test --config kuttl-test.yaml tests/upgrade
 
 stackrox-image-pull-secret: ## Create default image pull secret for StackRox images on Quay.io. Used by Helm chart.
 # Create stackrox namespace if not exists.

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -33,6 +33,9 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
+# Set to "--skip-build" to avoid the "docker build" part in index-build target.
+SKIP_INDEX_DOCKER_BUILD ?=
+
 # IMAGE_REPO is the repository (server and namespace) into which the operator images will get pushed.
 IMAGE_REPO ?= $(shell $(MAKE) --quiet --no-print-directory -C .. default-image-registry)
 # IMAGE_TAG_BASE defines the quay.io namespace and part of the image name for remote images.
@@ -441,7 +444,8 @@ index-build: bundle-post-process ## Build Index (a.k.a. Catalog) image with the 
 		--index-tag "$(INDEX_IMG)" \
 		--bundle-tag "$(BUNDLE_IMG)" \
 		--replaced-version "$${replaced_version}" \
-		--clean-output-dir
+		--clean-output-dir \
+		$(SKIP_INDEX_DOCKER_BUILD)
 
 ##@ Push images
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -268,7 +268,8 @@ ensure-rox-main-image-exists:
 build: generate fmt vet ## Build operator local binary.
 	../scripts/go-build-file.sh ./main.go bin/manager
 
-docker-build: test ## Build docker image with the operator.
+.PHONY: smuggled-status-sh
+smuggled-status-sh:
 	$(SILENT)( \
 		`# status.sh file is used by scripts/go-build.sh which we try to run in the docker container.` \
 		`# status.sh needs git repo, make and Makefile and who knows what else but its actual output is simple.` \
@@ -284,6 +285,8 @@ docker-build: test ## Build docker image with the operator.
 		`# Verify that the resulting status.sh is actually runnable` \
 		"$${smuggled_status_sh}" ;\
 	)
+
+docker-build: test smuggled-status-sh ## Build docker image with the operator.
 	DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain docker build \
 		--build-arg "GO_VERSION=${GO_VERSION}" \
 		-t ${IMG} \

--- a/operator/tests/central/basic/20-verify-password.yaml
+++ b/operator/tests/central/basic/20-verify-password.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-- command: kubectl exec -n $NAMESPACE deployment/central -- roxctl central whoami --insecure-skip-tls-verify -p letmein
+- script: KUBECONFIG="${REAL_KUBECONFIG}" kubectl exec -n $NAMESPACE deployment/central -- roxctl central whoami --insecure-skip-tls-verify -p letmein

--- a/operator/tests/central/basic/60-use-new-password.yaml
+++ b/operator/tests/central/basic/60-use-new-password.yaml
@@ -5,7 +5,7 @@ commands:
     # Updating the password may take some time, so retry until it works.
     set +e
     for i in `seq 60`; do
-      kubectl exec -n $NAMESPACE deployment/central -- roxctl central whoami --insecure-skip-tls-verify -p opensesame && exit 0
+      KUBECONFIG="${REAL_KUBECONFIG}" kubectl exec -n $NAMESPACE deployment/central -- roxctl central whoami --insecure-skip-tls-verify -p opensesame && exit 0
       sleep 1
     done
     exit 1

--- a/operator/tests/common/delete-central-assert.yaml
+++ b/operator/tests/common/delete-central-assert.yaml
@@ -12,5 +12,5 @@ commands:
     # With 6 objects in the assert file, each attempt typically takes ~22 seconds (including the 1s sleep between attempts),
     # although it can occasionally take significantly longer, see https://github.com/kudobuilder/kuttl/issues/321
     # So we specify a timeout value of 13, aiming for under 5 minutes.
-    ${KUTTL:-kubectl-kuttl} errors --timeout 13 $errors_file
+    KUBECONFIG="${REAL_KUBECONFIG}" ${KUTTL:-kubectl-kuttl} errors --timeout 13 $errors_file
     rm $errors_file

--- a/operator/tests/common/fetch-bundle.yaml
+++ b/operator/tests/common/fetch-bundle.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-- script: kubectl exec -n $NAMESPACE deployment/central -- roxctl central --insecure-skip-tls-verify init-bundles generate testing-cluster -p letmein --output-secrets - > init-bundle.yaml
-- command: kubectl apply -n $NAMESPACE -f init-bundle.yaml
+- script: KUBECONFIG="${REAL_KUBECONFIG}" kubectl exec -n $NAMESPACE deployment/central -- roxctl central --insecure-skip-tls-verify init-bundles generate testing-cluster -p letmein --output-secrets - > init-bundle.yaml
+- script: KUBECONFIG="${REAL_KUBECONFIG}" kubectl apply -n $NAMESPACE -f init-bundle.yaml

--- a/operator/tests/common/image-pull-secrets.yaml
+++ b/operator/tests/common/image-pull-secrets.yaml
@@ -7,6 +7,6 @@ commands:
     secret=$(mktemp)
     registry_hostname=quay.io
     ../../../../deploy/common/pull-secret.sh stackrox ${registry_hostname} > $secret
-    kubectl -n $NAMESPACE create -f $secret
+    KUBECONFIG="${REAL_KUBECONFIG}" kubectl -n $NAMESPACE create -f $secret
     echo "Created pull secret for ${registry_hostname} in $NAMESPACE"
     rm $secret

--- a/operator/tests/upgrade/upgrade/20-assert.yaml
+++ b/operator/tests/upgrade/upgrade/20-assert.yaml
@@ -13,7 +13,7 @@ commands:
     # With 5 objects in the assert file, each attempt typically takes ~18 seconds (including the 1s sleep between attempts),
     # although it can occasionally take significantly longer, see https://github.com/kudobuilder/kuttl/issues/321
     # So we specify a timeout value of 16, aiming for under 5 minutes.
-    ${KUTTL:-kubectl-kuttl} assert --namespace $NAMESPACE --timeout 16 $assert_file
+    KUBECONFIG="${REAL_KUBECONFIG}" ${KUTTL:-kubectl-kuttl} assert --namespace $NAMESPACE --timeout 16 $assert_file
     rm $assert_file
 collectors:
 - type: pod

--- a/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
+++ b/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
@@ -3,5 +3,5 @@ kind: TestStep
 commands:
 # We invoke the upgrade script via make such that we do not need to redefine here or plumb through
 # from the parent make: the namespace and operator version string (which are arguments to upgrade script).
-- command: make -C ../../.. upgrade-via-olm
+- script: KUBECONFIG="${REAL_KUBECONFIG}" make -C ../../.. upgrade-via-olm
   timeout: 600

--- a/scripts/ci/jobs/openshift_4_operator_e2e_tests.py
+++ b/scripts/ci/jobs/openshift_4_operator_e2e_tests.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run operator e2e tests in a openshift 4 cluster provided via a hive cluster_claim.
+"""
+from runners import ClusterTestRunner
+from ci_tests import OperatorE2eTest
+from pre_tests import PreSystemTests
+
+
+ClusterTestRunner(
+    pre_test=PreSystemTests(),
+    test=OperatorE2eTest()
+).run()

--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -44,7 +44,10 @@ push_images() {
         push_context="merge-to-master"
     fi
 
-    push_operator_image_set "$push_context" "$brand"
+    # TODO(ROX-11889): make this unconditional once the openshift/release side is ready
+    if [[ -n "${OPERATOR_IMAGE:-}" ]]; then
+      push_operator_image_set "$push_context" "$brand"
+    fi
     push_main_image_set "$push_context" "$brand"
     push_matching_collector_scanner_images "$brand"
     if [[ -n "${PIPELINE_DOCS_IMAGE:-}" ]]; then

--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -44,6 +44,7 @@ push_images() {
         push_context="merge-to-master"
     fi
 
+    push_operator_image_set "$push_context" "$brand"
     push_main_image_set "$push_context" "$brand"
     push_matching_collector_scanner_images "$brand"
     if [[ -n "${PIPELINE_DOCS_IMAGE:-}" ]]; then

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1023,7 +1023,9 @@ openshift_ci_e2e_mods() {
 }
 
 operator_e2e_test_setup() {
+    # TODO(ROX-11901): pass the brand explicitly from the CI config file rather than hardcode here
     registry_ro_login "quay.io/rhacs-eng"
+    export ROX_PRODUCT_BRANDING="RHACS_BRANDING"
 
     # $NAMESPACE is set by OpenShift CI, but confuses `operator-sdk scorecard` which runs against
     # a completely different cluster, where this namespace does not even exist.


### PR DESCRIPTION
## Description

Please look at individual commits' descriptions.

These changes should not change anything in the CircleCI-based operator tests.
At the same time, this is the complete set of changes (on the `stackrox/stackrox` repo side) for running operator CI on OpenShift CI.

The [release branch is here](https://github.com/porridge/release/pull/new/ROX-9565-operator-on-prow) and a PR will be created once this part is merged.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Roughly the same changes (module some debug output and comments) were tested in https://github.com/openshift/release/pull/30630
