### PR TITLE
CI: Bump timeout for race-condition-debug tests

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -361,7 +361,7 @@ function launch_central {
     # On some systems there's a race condition when port-forward connects to central but its pod then gets deleted due
     # to ongoing modifications to the central deployment. This port-forward dies and the script hangs "Waiting for
     # Central to respond" until it times out. Waiting for rollout status should help not get into such situation.
-    kubectl -n stackrox rollout status deploy/central --timeout=3m
+    kubectl -n stackrox rollout status deploy/central --timeout=6m
 
     # if we have specified that we want to use a load balancer, then use that endpoint instead of localhost
     if [[ "${LOAD_BALANCER}" == "lb" ]]; then


### PR DESCRIPTION
## Description

It is taking longer then 3 minutes for central to start when main is built with `-race`. A simple bump seems reasonable.

Test times out at 17:35:39: 
```
Waiting for deployment "central" rollout to finish: 0 out of 1 new replicas have been updated...
Waiting for deployment "central" rollout to finish: 0 out of 1 new replicas have been updated...
Waiting for deployment "central" rollout to finish: 0 out of 1 new replicas have been updated...
Waiting for deployment "central" rollout to finish: 0 of 1 updated replicas are available...
error: timed out waiting for the condition
****
**** 17:35:39: ERROR: test failed [QA tests part I]
```

Central shows sign of life at 17:36:11:
```
main: 2022/07/20 17:36:11.769566 main.go:258: Info: Running StackRox Version: 3.71.x-113-g7e2a9000cc
```

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient