### PR TITLE
ROX-9350 Use fine-grained host paths for compliance mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-13500: Previously, deployment YAML check on V1 CronJob workload would cause Central to panic. This is now fixed.
 - `cves.ids` field of `storage.VulnerabilityRequest` object, which is in the response of `VulnerabilityRequestService` (`/v1/cve/requests/`) endpoints, has been renamed to `cves.cves`.
 - ROX-13347: Vulnerability reporting scopes specifying cluster and/or namespace names now perform exact matches on those entities, as opposed to the erroneous prefix match.
+- ROX-9350: The compliance container no longer mounts the entire host root to prevent a recursive mount of other pods' persistent volumes.
 
 ## [3.72.0]
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -116,8 +116,41 @@ spec:
           name: etc-ssl
         - mountPath: /etc/pki/ca-trust/
           name: etc-pki-volume
-        - mountPath: /host
-          name: host-root-ro
+        - mountPath: /host/etc
+          name: etc-ro
+          readOnly: true
+        - mountPath: /host/proc
+          name: proc-ro
+          readOnly: true
+        - mountPath: /host/opt
+          name: opt-ro
+          readOnly: true
+        - mountPath: /host/run
+          name: run-ro
+          readOnly: true
+        - mountPath: /host/srv
+          name: srv-ro
+          readOnly: true
+        - mountPath: /host/sys
+          name: sys-ro
+          readOnly: true
+        - mountPath: /host/usr
+          name: usr-ro
+          readOnly: true
+        - mountPath: /host/var/lib/kubelet/kubeconfig
+          name: var-lib-kubelet-kubeconfig
+          readOnly: true
+        - mountPath: /host/var/lib/docker
+          name: var-lib-docker
+          readOnly: true
+        - mountPath: /host/var/lib/containers
+          name: var-lib-containers
+          readOnly: true
+        - mountPath: /host/var/log
+          name: var-log
+          readOnly: true
+        - mountPath: /host/var/run
+          name: var-run
           readOnly: true
         - mountPath: /run/secrets/stackrox.io/certs/
           name: certs
@@ -144,6 +177,33 @@ spec:
       - hostPath:
           path: /dev
         name: dev-ro
+      - hostPath:
+          path: /opt
+        name: opt-ro
+      - hostPath:
+          path: /run
+        name: run-ro
+      - hostPath:
+          path: /srv
+        name: srv-ro
+      - hostPath:
+          path: /usr
+        name: usr-ro
+      - hostPath:
+          path: /var/lib/kubelet/kubeconfig
+        name: var-lib-kubelet-kubeconfig
+      - hostPath:
+          path: /var/lib/docker
+        name: var-lib-docker
+      - hostPath:
+          path: /var/lib/containers
+        name: var-lib-containers
+      - hostPath:
+          path: /var/log
+        name: var-log
+      - hostPath:
+          path: /var/run
+        name: var-run
       - name: certs
         secret:
           secretName: collector-tls
@@ -154,9 +214,6 @@ spec:
             path: key.pem
           - key: ca.pem
             path: ca.pem
-      - hostPath:
-          path: /
-        name: host-root-ro
       - name: etc-ssl
         emptyDir: {}
       - name: etc-pki-volume

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -65,7 +65,8 @@ spec:
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /host/var/run/docker.sock
-          name: var-run-docker-sock
+          name: var-run
+          subPath: /var/run/docker.sock
           readOnly: true
         - mountPath: /host/proc
           name: proc-ro
@@ -76,7 +77,8 @@ spec:
           name: etc-ro
           readOnly: true
         - mountPath: /host/usr/lib
-          name: usr-lib-ro
+          name: usr-ro
+          subPath: /usr/lib
           readOnly: true
         - mountPath: /host/sys
           name: sys-ro
@@ -157,9 +159,6 @@ spec:
           readOnly: true
       volumes:
       - hostPath:
-          path: /var/run/docker.sock
-        name: var-run-docker-sock
-      - hostPath:
           path: /proc
         name: proc-ro
       - emptyDir:
@@ -168,9 +167,6 @@ spec:
       - hostPath:
           path: /etc
         name: etc-ro
-      - hostPath:
-          path: /usr/lib
-        name: usr-lib-ro
       - hostPath:
           path: /sys/
         name: sys-ro

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -66,7 +66,7 @@ spec:
         volumeMounts:
         - mountPath: /host/var/run/docker.sock
           name: var-run
-          subPath: /var/run/docker.sock
+          subPath: var/run/docker.sock
           readOnly: true
         - mountPath: /host/proc
           name: proc-ro
@@ -78,7 +78,7 @@ spec:
           readOnly: true
         - mountPath: /host/usr/lib
           name: usr-ro
-          subPath: /usr/lib
+          subPath: usr/lib
           readOnly: true
         - mountPath: /host/sys
           name: sys-ro

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -139,6 +139,9 @@ spec:
         - mountPath: /host/usr
           name: usr-ro
           readOnly: true
+        - mountPath: /host/lib
+          name: lib-ro
+          readOnly: true
         - mountPath: /host/var/lib/kubelet/kubeconfig
           name: var-lib-kubelet-kubeconfig
           readOnly: true
@@ -168,7 +171,7 @@ spec:
           path: /etc
         name: etc-ro
       - hostPath:
-          path: /sys/
+          path: /sys
         name: sys-ro
       - hostPath:
           path: /dev
@@ -185,6 +188,9 @@ spec:
       - hostPath:
           path: /usr
         name: usr-ro
+      - hostPath:
+          path: /lib
+        name: lib-ro
       - hostPath:
           path: /var/lib/kubelet/kubeconfig
         name: var-lib-kubelet-kubeconfig


### PR DESCRIPTION
## Description

The compliance container Is mounting the whole host filesystem, including any PV mounts that the node might be mounted which can prevent the unmounting of PV mounts, as the `compliance` binary will keep the mount points busy. This has been noticed on an OpenShift node when a Pod was mounting a 1TB volume with thousands of files. The compliance container started to scan these files and prevented the unmounting of the PV.

The problem of this behavior has been discussed in detail in https://bugzilla.redhat.com/show_bug.cgi?id=2036055


## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed


