### PR TITLE
Quickfix: Change `cd` into a pair of `pushd` and `popd` to fix release failures

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -470,7 +470,7 @@ mark_collector_release() {
     info "Create a branch for the PR"
 
     collector_version="$(cat COLLECTOR_VERSION)"
-    cd /tmp/collector || exit
+    pushd /tmp/collector || exit
     gitbot(){
         git -c "user.name=RoxBot" -c "user.email=roxbot@stackrox.com" \
             -c "url.https://${GITHUB_TOKEN}:x-oauth-basic@github.com/.insteadOf=https://github.com/" \
@@ -502,6 +502,7 @@ mark_collector_release() {
     export CIRCLE_PULL_REQUEST="https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/${JOB_NAME}/${BUILD_ID}"
     export GITHUB_TOKEN_FOR_PRS="${GITHUB_TOKEN}"
     /scripts/create_update_pr.sh "${branch_name}" collector "Update RELEASED_VERSIONS" "Add entry into the RELEASED_VERSIONS file"
+    popd
 }
 
 is_tagged() {


### PR DESCRIPTION
See https://srox.slack.com/archives/CMH5M8MHN/p1658395416730139 for more
info about why this is a bug

## Description

In the release process, before running `release/scripts/scan-images-with-roxctl.sh` we run `mark_collector_release` and this function does `cd /tmp/collector || exit`. This `cd` "stays" after `mark_collector_release` exits (we do not do `cd -` later), so the parent script is in a wrong directory (collector instead of stackrox) and when it tries to call `make collector-tag` it cannot find the target, because collector's makefile doesn’t have it.

This is a strong argument for using `pushd` and `popd` in the scripts instead of `cd`.

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

This is a CI-only change.

## Testing Performed

- None, this code is only used when releasing the final upstream tag, so it is also difficult to test int he field. But the changes int the code are so tiny that it should be easy to test it by looking at the code.
