### PR TITLE
ROX-11919: Get rid of the GO_VERSION operator build arg.

### DIFF
--- a/EXPECTED_GO_VERSION
+++ b/EXPECTED_GO_VERSION
@@ -1,1 +1,2 @@
 go1.17.2
+# When changing the above, please update operator/Dockerfile accordingly.

--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,7 @@ main-builder-image: build-volumes
 	@echo "+ $@"
 	$(SILENT)# Ensure that the go version in the image matches the expected version
 	# If the next line fails, you need to update the go version in rox-ci-image/images/stackrox-build.Dockerfile
-	grep -q "$(shell cat EXPECTED_GO_VERSION)" <(docker run --rm "$(BUILD_IMAGE)" go version)
+	grep -q "$(shell head -n 1 EXPECTED_GO_VERSION)" <(docker run --rm "$(BUILD_IMAGE)" go version)
 
 .PHONY: main-build
 main-build: build-prep main-build-dockerized

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,8 +1,8 @@
 # We have to emulate directory layout as in the repo so that imports in go files work fine.
 ARG roxpath=/workspace/src/github.com/stackrox/rox
-ARG GO_VERSION
 
-FROM golang:${GO_VERSION} as builder
+# Note: the following version needs to be in sync with the ../EXPECTED_GO_VERSION file.
+FROM golang:1.17.2 as builder
 
 # Build the manager binary
 ARG roxpath

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -7,8 +7,6 @@
 # dropped (e.g. 3.0.61.1 -> 3.61.1) and development version ".x" is changed to ".0" (e.g. 3.0.61.x-123 -> 3.0.61.0-123).
 VERSION ?= $(shell $(MAKE) --quiet --no-print-directory -C .. tag | sed -E 's@^(([[:digit:]]+\.)+)x(-)?@\10\3@g' | sed -E 's@^3.0.([[:digit:]]+\.[[:digit:]]+)(-)?@3.\1\2@g')
 
-GO_VERSION ?= $(shell cat ../EXPECTED_GO_VERSION | sed 's/go//')
-
 # Set to empty string to echo some command lines which are hidden by default.
 SILENT ?= @
 
@@ -293,9 +291,14 @@ smuggled-status-sh:
 		"$${smuggled_status_sh}" ;\
 	)
 
-docker-build: test smuggled-status-sh ## Build docker image with the operator.
+.PHONY: check-expected-go-version
+check-expected-go-version:
+	$(SILENT)expected=$$(head -n 1 ../EXPECTED_GO_VERSION | sed 's/go//'); \
+	actual=$$(grep '^FROM golang' Dockerfile | awk '{print $$2}' | cut -d: -f2); \
+	[ "$${expected}" = "$${actual}" ] || { echo "../EXPECTED_GO_VERSION $${expected}, Dockerfile $${actual}; please update to match"; exit 1; }
+
+docker-build: check-expected-go-version test smuggled-status-sh ## Build docker image with the operator.
 	DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain docker build \
-		--build-arg "GO_VERSION=${GO_VERSION}" \
 		-t ${IMG} \
 		--ssh default=${SSH_AUTH_SOCK} \
 		--build-arg ROX_IMAGE_FLAVOR=$(ROX_IMAGE_FLAVOR) \

--- a/scripts/ci/jobs/check-generated.sh
+++ b/scripts/ci/jobs/check-generated.sh
@@ -34,6 +34,8 @@ generated_files-are-up-to-date
 # shellcheck disable=SC2016
 echo 'Check operator files are up to date (If this fails, run `make -C operator manifests generate bundle` and commit the result.)'
 function check-operator-generated-files-up-to-date() {
+    echo 'Checking consistency between EXPECTED_GO_VERSION file and Go version in operator Dockerfile'
+    make -C operator/ check-expected-go-version
     make -C operator/ generate
     make -C operator/ manifests
     echo 'Checking for diffs after making generate and manifests...'

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1098,7 +1098,7 @@ validate_expected_go_version() {
     info "Validating the expected go version against what was used to build roxctl"
 
     roxctl_go_version="$(roxctl version --json | jq '.GoVersion' -r)"
-    expected_go_version="$(cat EXPECTED_GO_VERSION)"
+    expected_go_version="$(head -n 1 EXPECTED_GO_VERSION)"
     if [[ "${roxctl_go_version}" != "${expected_go_version}" ]]; then
         echo "Got unexpected go version ${roxctl_go_version} (wanted ${expected_go_version})"
         exit 1


### PR DESCRIPTION
## Description

Hardcode the go version in the operator `Dockerfile`, rather than require it to be passed as a build argument.

This may seem counter-productive at first, but there is an important detail
outside of this repository. Namely `operator/Dockerfile` is also referenced
from the OpenShift CI configuration, which currently also needs to hardcode
the go version, since the value of the build arg there needs to be provided
literally (there does not seem to be a way to extract it from
`EXPECTED_GO_VERSION`).

So rather than have the Go version be defined in two separate repositories
(here and in openshift/release), we put it in two places in *this* repository,
and add CI- and build-time checks to make sure they are in sync, as well as
cross-references to remember to update them simultaneously.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

Not a user-visible change.

## Testing Performed

Manually ran the make target and make sure the output is expected both when values are in and out of sync.
Relying on CI otherwise.