### PR TITLE
ROX-11740: dackbox cluster sac tests

### DIFF
--- a/central/cluster/datastore/datastore.go
+++ b/central/cluster/datastore/datastore.go
@@ -2,17 +2,26 @@ package datastore
 
 import (
 	"context"
+	"testing"
 
+	"github.com/blevesearch/bleve"
+	"github.com/jackc/pgx/v4/pgxpool"
 	alertDataStore "github.com/stackrox/rox/central/alert/datastore"
 	"github.com/stackrox/rox/central/cluster/datastore/internal/search"
 	"github.com/stackrox/rox/central/cluster/index"
 	clusterStore "github.com/stackrox/rox/central/cluster/store/cluster"
+	clusterPostgresStore "github.com/stackrox/rox/central/cluster/store/cluster/postgres"
+	clusterRocksDBStore "github.com/stackrox/rox/central/cluster/store/cluster/rocksdb"
 	clusterHealthStore "github.com/stackrox/rox/central/cluster/store/clusterhealth"
+	clusterHealthPostgresStore "github.com/stackrox/rox/central/cluster/store/clusterhealth/postgres"
+	clusterHealthRocksDBStore "github.com/stackrox/rox/central/cluster/store/clusterhealth/rocksdb"
 	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
 	namespaceDataStore "github.com/stackrox/rox/central/namespace/datastore"
 	networkBaselineManager "github.com/stackrox/rox/central/networkbaseline/manager"
 	netEntityDataStore "github.com/stackrox/rox/central/networkgraph/entity/datastore"
 	netFlowsDataStore "github.com/stackrox/rox/central/networkgraph/flow/datastore"
+	nodeNodeDataStore "github.com/stackrox/rox/central/node/datastore/dackbox/datastore"
+	nodeGlobalDataStore "github.com/stackrox/rox/central/node/datastore/dackbox/globaldatastore"
 	nodeDataStore "github.com/stackrox/rox/central/node/globaldatastore"
 	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
 	podDataStore "github.com/stackrox/rox/central/pod/datastore"
@@ -27,12 +36,15 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/dackbox"
 	"github.com/stackrox/rox/pkg/dackbox/graph"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
+	rocksdbBase "github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/sac"
 	pkgSearch "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/simplecache"
+	"go.etcd.io/bbolt"
 )
 
 var (
@@ -140,4 +152,146 @@ func New(
 
 	go ds.cleanUpNodeStore(cleanupCtx)
 	return ds, nil
+}
+
+// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetTestPostgresDataStore(t *testing.T, pool *pgxpool.Pool) (DataStore, error) {
+	clusterdbstore := clusterPostgresStore.New(pool)
+	clusterhealthdbstore := clusterHealthPostgresStore.New(pool)
+	indexer := clusterPostgresStore.NewIndexer(pool)
+	alertStore, err := alertDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	namespaceStore, err := namespaceDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	deploymentStore, err := deploymentDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	nodeInternalStore, err := nodeNodeDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	nodeStore, err := nodeGlobalDataStore.New(nodeInternalStore)
+	if err != nil {
+		return nil, err
+	}
+	podStore, err := podDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	secretStore, err := secretDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	netFlowStore, err := netFlowsDataStore.GetTestPostgresClusterDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	netEntityStore, err := netEntityDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	serviceAccountStore, err := serviceAccountDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	k8sRoleStore, err := roleDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	k8sRoleBindingStore, err := roleBindingDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	networkBaselineManager, err := networkBaselineManager.GetTestPostgresManager(t, pool)
+	if err != nil {
+		return nil, err
+	}
+
+	sensorCnxMgr := connection.ManagerSingleton()
+	clusterRanker := ranking.ClusterRanker()
+
+	return New(clusterdbstore, clusterhealthdbstore, indexer,
+		alertStore, namespaceStore, deploymentStore,
+		nodeStore, podStore, secretStore, netFlowStore, netEntityStore,
+		serviceAccountStore, k8sRoleStore, k8sRoleBindingStore, sensorCnxMgr, nil,
+		nil, clusterRanker, networkBaselineManager)
+}
+
+// GetTestRocksBleveDataStore provides a datastore connected to rocksdb and bleve for testing purposes.
+func GetTestRocksBleveDataStore(t *testing.T, rocksengine *rocksdbBase.RocksDB, bleveIndex bleve.Index, dacky *dackbox.DackBox, keyFence concurrency.KeyFence, boltengine *bbolt.DB) (DataStore, error) {
+	clusterdbstore, err := clusterRocksDBStore.New(rocksengine)
+	if err != nil {
+		return nil, err
+	}
+	clusterhealthdbstore, err := clusterHealthRocksDBStore.New(rocksengine)
+	if err != nil {
+		return nil, err
+	}
+	indexer := index.New(bleveIndex)
+	alertStore, err := alertDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
+	if err != nil {
+		return nil, err
+	}
+	namespaceStore, err := namespaceDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex, dacky, keyFence)
+	if err != nil {
+		return nil, err
+	}
+	deploymentStore, err := deploymentDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex, dacky, keyFence)
+	if err != nil {
+		return nil, err
+	}
+	nodeInternalStore, err := nodeNodeDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex, dacky, keyFence)
+	if err != nil {
+		return nil, err
+	}
+	nodeStore, err := nodeGlobalDataStore.New(nodeInternalStore)
+	if err != nil {
+		return nil, err
+	}
+	podStore, err := podDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
+	if err != nil {
+		return nil, err
+	}
+	secretStore, err := secretDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
+	if err != nil {
+		return nil, err
+	}
+	netFlowStore, err := netFlowsDataStore.GetTestRocksBleveClusterDataStore(t, rocksengine)
+	if err != nil {
+		return nil, err
+	}
+	netEntityStore, err := netEntityDataStore.GetTestRocksBleveDataStore(t, rocksengine)
+	if err != nil {
+		return nil, err
+	}
+	serviceAccountStore, err := serviceAccountDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
+	if err != nil {
+		return nil, err
+	}
+	k8sRoleStore, err := roleDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
+	if err != nil {
+		return nil, err
+	}
+	k8sRoleBindingStore, err := roleBindingDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
+	if err != nil {
+		return nil, err
+	}
+	networkBaselineManager, err := networkBaselineManager.GetTestRocksBleveManager(t, rocksengine, bleveIndex, dacky, keyFence, boltengine)
+	if err != nil {
+		return nil, err
+	}
+
+	sensorCnxMgr := connection.ManagerSingleton()
+	clusterRanker := ranking.ClusterRanker()
+
+	return New(clusterdbstore, clusterhealthdbstore, indexer,
+		alertStore, namespaceStore, deploymentStore,
+		nodeStore, podStore, secretStore, netFlowStore, netEntityStore,
+		serviceAccountStore, k8sRoleStore, k8sRoleBindingStore, sensorCnxMgr, nil,
+		dacky, clusterRanker, networkBaselineManager)
 }

--- a/central/cluster/datastore/datastore_sac_test.go
+++ b/central/cluster/datastore/datastore_sac_test.go
@@ -247,8 +247,7 @@ func getMultiClusterTestCases(baseContext context.Context, clusterID1 string, cl
 }
 
 func (s *clusterDatastoreSACSuite) TestAddCluster() {
-	testedVerb := "add"
-	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testedVerb)
+	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testutils.VerbAdd)
 
 	for name, c := range cases {
 		s.Run(name, func() {
@@ -577,7 +576,7 @@ func (s *clusterDatastoreSACSuite) TestUpdateCluster() {
 	newCluster.CentralApiEndpoint = newAPIEndpoint
 	newCluster.Priority = 1
 
-	cases := testutils.GenericClusterSACWriteTestCases(context.Background(), s.T(), "update", clusterID, "not"+clusterID, resources.Cluster)
+	cases := testutils.GenericClusterSACWriteTestCases(context.Background(), s.T(), testutils.VerbUpdate, clusterID, "not"+clusterID, resources.Cluster)
 
 	for name, c := range cases {
 		s.Run(name, func() {

--- a/central/cluster/datastore/datastore_sac_test.go
+++ b/central/cluster/datastore/datastore_sac_test.go
@@ -1,0 +1,1152 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blevesearch/bleve"
+	"github.com/gogo/protobuf/types"
+	"github.com/stackrox/rox/central/cluster/index/mappings"
+	"github.com/stackrox/rox/central/globalindex"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/generated/storage"
+	boltPkg "github.com/stackrox/rox/pkg/bolthelper"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/dackbox"
+	"github.com/stackrox/rox/pkg/dackbox/utils/queue"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/sac/testutils"
+	searchPkg "github.com/stackrox/rox/pkg/search"
+	"github.com/stretchr/testify/suite"
+	"go.etcd.io/bbolt"
+)
+
+var (
+	someNamespace = "someNamespace"
+)
+
+func TestClusterDatastoreSAC(t *testing.T) {
+	suite.Run(t, new(clusterDatastoreSACSuite))
+}
+
+type clusterDatastoreSACSuite struct {
+	suite.Suite
+
+	datastore DataStore
+
+	// Elements for postgres mode
+	pgtestbase *pgtest.TestPostgres
+
+	// Elements for bleve+rocksdb mode
+	boltengine *bbolt.DB
+	engine     *rocksdb.RocksDB
+	index      bleve.Index
+
+	optionsMap searchPkg.OptionsMap
+
+	testContexts   map[string]context.Context
+	testClusterIDs []string
+}
+
+func (s *clusterDatastoreSACSuite) SetupSuite() {
+	var err error
+	if features.PostgresDatastore.Enabled() {
+		s.pgtestbase = pgtest.ForT(s.T())
+		s.NotNil(s.pgtestbase)
+		s.datastore, err = GetTestPostgresDataStore(s.T(), s.pgtestbase.Pool)
+		s.Require().NoError(err)
+		s.optionsMap = schema.ClustersSchema.OptionsMap
+	} else {
+		s.boltengine, err = boltPkg.NewTemp("clusterSACTestBolt")
+		s.Require().NoError(err)
+		s.engine, err = rocksdb.NewTemp("clusterSACTest")
+		s.Require().NoError(err)
+		s.index, err = globalindex.MemOnlyIndex()
+		s.Require().NoError(err)
+		keyFence := concurrency.NewKeyFence()
+		indexQ := queue.NewWaitableQueue()
+		dacky, err := dackbox.NewRocksDBDackBox(s.engine, indexQ, []byte("graph"), []byte("dirty"), []byte("valid"))
+		s.Require().NoError(err)
+		s.datastore, err = GetTestRocksBleveDataStore(s.T(), s.engine, s.index, dacky, keyFence, s.boltengine)
+		s.Require().NoError(err)
+		s.optionsMap = mappings.OptionsMap
+	}
+	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.Cluster)
+}
+
+func (s *clusterDatastoreSACSuite) TearDownSuite() {
+	if features.PostgresDatastore.Enabled() {
+		s.pgtestbase.Pool.Close()
+	} else {
+		s.Require().NoError(s.boltengine.Close())
+		s.Require().NoError(rocksdb.CloseAndRemove(s.engine))
+		s.Require().NoError(s.index.Close())
+	}
+}
+
+func (s *clusterDatastoreSACSuite) SetupTest() {
+	s.testClusterIDs = make([]string, 0)
+}
+
+func (s *clusterDatastoreSACSuite) TearDownTest() {
+	for _, id := range s.testClusterIDs {
+		s.deleteCluster(id)
+	}
+}
+
+func (s *clusterDatastoreSACSuite) deleteCluster(id string) {
+	exists, err := s.datastore.Exists(s.testContexts[testutils.UnrestrictedReadCtx], id)
+	if !exists || err != nil {
+		return
+	}
+	doneSignal := concurrency.NewSignal()
+	s.datastore.RemoveCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], id, &doneSignal)
+	<-doneSignal.Done()
+}
+
+type mutiClusterTest struct {
+	Name                 string
+	Context              context.Context
+	ExpectedClusterIDs   []string
+	ExpectedClusterNames []string
+}
+
+func getMultiClusterTestCases(baseContext context.Context, clusterID1 string, clusterID2 string, otherClusterID string) []mutiClusterTest {
+	return []mutiClusterTest{
+		{
+			Name: "Cluster full read-only",
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster))),
+			ExpectedClusterIDs:   []string{clusterID1, clusterID2},
+			ExpectedClusterNames: []string{testconsts.Cluster1, testconsts.Cluster2},
+		},
+		{
+			Name: "Cluster full read-write",
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster))),
+			ExpectedClusterIDs:   []string{clusterID1, clusterID2},
+			ExpectedClusterNames: []string{testconsts.Cluster1, testconsts.Cluster2},
+		},
+		{
+			Name: "Cluster read Cluster1",
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(clusterID1))),
+			ExpectedClusterIDs:   []string{clusterID1},
+			ExpectedClusterNames: []string{testconsts.Cluster1},
+		},
+		{
+			Name: "Cluster partial read Cluster1",
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(clusterID1),
+					sac.NamespaceScopeKeys(someNamespace))),
+			ExpectedClusterIDs:   []string{},
+			ExpectedClusterNames: []string{},
+		},
+		{
+			Name: "Cluster read Cluster2",
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(clusterID2))),
+			ExpectedClusterIDs:   []string{clusterID2},
+			ExpectedClusterNames: []string{testconsts.Cluster2},
+		},
+		{
+			Name: "Cluster partial read Cluster2",
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(clusterID2),
+					sac.NamespaceScopeKeys(someNamespace))),
+			ExpectedClusterIDs:   []string{},
+			ExpectedClusterNames: []string{},
+		},
+		{
+			Name: "Cluster read other cluster",
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(otherClusterID))),
+			ExpectedClusterIDs:   []string{},
+			ExpectedClusterNames: []string{},
+		},
+		{
+			Name: "Cluster partial read other cluster",
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(otherClusterID),
+					sac.NamespaceScopeKeys(someNamespace))),
+			ExpectedClusterIDs:   []string{},
+			ExpectedClusterNames: []string{},
+		},
+		{
+			Name: "Cluster read Cluster1 and Cluster2",
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(clusterID1, clusterID2))),
+			ExpectedClusterIDs:   []string{clusterID1, clusterID2},
+			ExpectedClusterNames: []string{testconsts.Cluster1, testconsts.Cluster2},
+		},
+		{
+			Name: "Cluster partial read Cluster1 and Cluster2",
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(clusterID1, clusterID2),
+					sac.NamespaceScopeKeys(someNamespace))),
+			ExpectedClusterIDs:   []string{},
+			ExpectedClusterNames: []string{},
+		},
+		{
+			Name: "Cluster read Cluster1 and some other cluster",
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(clusterID1, otherClusterID))),
+			ExpectedClusterIDs:   []string{clusterID1},
+			ExpectedClusterNames: []string{testconsts.Cluster1},
+		},
+		{
+			Name: "Cluster partial read Cluster1 and some other cluster",
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(clusterID1, otherClusterID),
+					sac.NamespaceScopeKeys(someNamespace))),
+			ExpectedClusterIDs:   []string{},
+			ExpectedClusterNames: []string{},
+		},
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestAddCluster() {
+	testedVerb := "add"
+	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testedVerb)
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[c.ScopeKey]
+			cluster := fixtures.GetCluster(testconsts.Cluster2)
+			// Erase cluster Id to allow insertion
+			cluster.Id = ""
+			id, err := s.datastore.AddCluster(ctx, cluster)
+			if len(id) > 0 {
+				s.testClusterIDs = append(s.testClusterIDs, id)
+				defer s.deleteCluster(id)
+			}
+			if c.ExpectError {
+				s.ErrorIs(err, c.ExpectedError)
+				s.Equal("", id)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestExists() {
+	cluster := fixtures.GetCluster(testconsts.Cluster2)
+	clusterID, err := s.datastore.AddCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], cluster)
+	defer s.deleteCluster(clusterID)
+	s.Require().NoError(err)
+	cases := testutils.GenericClusterSACGetTestCases(context.Background(), s.T(), clusterID, "not-"+clusterID, resources.Cluster)
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			exists, err := s.datastore.Exists(ctx, clusterID)
+			s.NoError(err)
+			s.Equal(c.ExpectedFound, exists)
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestGetCluster() {
+	cluster := fixtures.GetCluster(testconsts.Cluster2)
+	clusterID, err := s.datastore.AddCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], cluster)
+	defer s.deleteCluster(clusterID)
+	s.Require().NoError(err)
+	cluster.Id = clusterID
+	cluster.Priority = 1
+
+	cases := testutils.GenericClusterSACGetTestCases(context.Background(), s.T(), clusterID, "not-"+clusterID, resources.Cluster)
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			fetchedCluster, found, err := s.datastore.GetCluster(ctx, clusterID)
+			s.NoError(err)
+			if c.ExpectedFound {
+				s.True(found)
+				s.Require().NotNil(fetchedCluster)
+				s.Equal(*cluster, *fetchedCluster)
+			} else {
+				s.False(found)
+				s.Nil(fetchedCluster)
+			}
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestGetClusterName() {
+	cluster := fixtures.GetCluster(testconsts.Cluster2)
+	clusterID, err := s.datastore.AddCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], cluster)
+	defer s.deleteCluster(clusterID)
+	s.Require().NoError(err)
+	cluster.Id = clusterID
+	cluster.Priority = 1
+
+	cases := testutils.GenericClusterSACGetTestCases(context.Background(), s.T(), clusterID, "not-"+clusterID, resources.Cluster)
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			clusterName, found, err := s.datastore.GetClusterName(ctx, clusterID)
+			s.NoError(err)
+			if c.ExpectedFound {
+				s.True(found)
+				s.Equal(cluster.GetName(), clusterName)
+			} else {
+				s.False(found)
+				s.Equal(0, len(clusterName))
+			}
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestGetClusters() {
+	cluster1 := fixtures.GetCluster(testconsts.Cluster1)
+	clusterID1, err := s.datastore.AddCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], cluster1)
+	defer s.deleteCluster(clusterID1)
+	s.Require().NoError(err)
+	cluster1.Id = clusterID1
+	cluster2 := fixtures.GetCluster(testconsts.Cluster2)
+	clusterID2, err := s.datastore.AddCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], cluster2)
+	defer s.deleteCluster(clusterID2)
+	s.Require().NoError(err)
+	cluster2.Id = clusterID2
+	otherClusterID := "someOtherClusterID"
+
+	cases := getMultiClusterTestCases(context.Background(), clusterID1, clusterID2, otherClusterID)
+
+	for _, c := range cases {
+		s.Run(c.Name, func() {
+			ctx := c.Context
+			clusters, err := s.datastore.GetClusters(ctx)
+			s.NoError(err)
+			clusterNames := make([]string, 0, len(clusters))
+			for _, cluster := range clusters {
+				clusterNames = append(clusterNames, cluster.GetName())
+			}
+			s.ElementsMatch(c.ExpectedClusterNames, clusterNames)
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestRemoveCluster() {
+	// The cluster ID is generated at cluster insertion.
+	// In order to have a context having the cluster in or out of scope, the context has to be generated
+	// after the insertion. Considering each case is trying to remove the cluster, addition of the cluster
+	// has to be performed within the test case. This means each test case has to be written independently.
+	baseContext := context.Background()
+	s.Run("(full) read-only cannot delete", func() {
+		doneSignal := concurrency.NewSignal()
+		globalReadWriteCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+		cluster := fixtures.GetCluster(testconsts.Cluster2)
+		clusterID, err := s.datastore.AddCluster(globalReadWriteCtx, cluster)
+		defer s.deleteCluster(clusterID)
+		s.Require().NoError(err)
+		ctx := sac.WithGlobalAccessScopeChecker(baseContext,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resources.Cluster)))
+		removeErr := s.datastore.RemoveCluster(ctx, clusterID, &doneSignal)
+		s.ErrorIs(removeErr, sac.ErrResourceAccessDenied)
+		if removeErr == nil {
+			// Wait for post-delete asynchronous cleanup in case the removal was allowed
+			<-doneSignal.Done()
+		}
+		// Verify cluster was not removed
+		exists, err := s.datastore.Exists(globalReadWriteCtx, clusterID)
+		s.True(exists)
+		s.NoError(err)
+	})
+	s.Run("full read-write can delete", func() {
+		doneSignal := concurrency.NewSignal()
+		globalReadWriteCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+		cluster := fixtures.GetCluster(testconsts.Cluster2)
+		clusterID, err := s.datastore.AddCluster(globalReadWriteCtx, cluster)
+		defer s.deleteCluster(clusterID)
+		s.Require().NoError(err)
+		ctx := sac.WithGlobalAccessScopeChecker(baseContext,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resources.Cluster)))
+		removeErr := s.datastore.RemoveCluster(ctx, clusterID, &doneSignal)
+		s.NoError(removeErr)
+		if removeErr == nil {
+			// Wait for post-delete asynchronous cleanup in case the removal was allowed
+			<-doneSignal.Done()
+		}
+		// Verify cluster was removed
+		exists, err := s.datastore.Exists(globalReadWriteCtx, clusterID)
+		s.False(exists)
+		s.NoError(err)
+	})
+	s.Run("read-write on wrong cluster cannot delete", func() {
+		doneSignal := concurrency.NewSignal()
+		globalReadWriteCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+		cluster := fixtures.GetCluster(testconsts.Cluster2)
+		clusterID, err := s.datastore.AddCluster(globalReadWriteCtx, cluster)
+		defer s.deleteCluster(clusterID)
+		s.Require().NoError(err)
+		ctx := sac.WithGlobalAccessScopeChecker(baseContext,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resources.Cluster),
+				sac.ClusterScopeKeys("not"+clusterID)))
+		removeErr := s.datastore.RemoveCluster(ctx, clusterID, &doneSignal)
+		s.ErrorIs(removeErr, sac.ErrResourceAccessDenied)
+		if removeErr == nil {
+			// Wait for post-delete asynchronous cleanup in case the removal was allowed
+			<-doneSignal.Done()
+		}
+		// Verify cluster was not removed
+		exists, err := s.datastore.Exists(globalReadWriteCtx, clusterID)
+		s.True(exists)
+		s.NoError(err)
+	})
+	s.Run("read-write on wrong cluster and partial namespace access cannot delete", func() {
+		doneSignal := concurrency.NewSignal()
+		globalReadWriteCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+		cluster := fixtures.GetCluster(testconsts.Cluster2)
+		clusterID, err := s.datastore.AddCluster(globalReadWriteCtx, cluster)
+		defer s.deleteCluster(clusterID)
+		s.Require().NoError(err)
+		ctx := sac.WithGlobalAccessScopeChecker(baseContext,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resources.Cluster),
+				sac.ClusterScopeKeys("not"+clusterID),
+				sac.NamespaceScopeKeys(someNamespace)))
+		removeErr := s.datastore.RemoveCluster(ctx, clusterID, &doneSignal)
+		s.ErrorIs(removeErr, sac.ErrResourceAccessDenied)
+		if removeErr == nil {
+			// Wait for post-delete asynchronous cleanup in case the removal was allowed
+			<-doneSignal.Done()
+		}
+		// Verify cluster was not removed
+		exists, err := s.datastore.Exists(globalReadWriteCtx, clusterID)
+		s.True(exists)
+		s.NoError(err)
+	})
+	s.Run("read-write on right cluster can delete", func() {
+		doneSignal := concurrency.NewSignal()
+		globalReadWriteCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+		cluster := fixtures.GetCluster(testconsts.Cluster2)
+		clusterID, err := s.datastore.AddCluster(globalReadWriteCtx, cluster)
+		defer s.deleteCluster(clusterID)
+		s.Require().NoError(err)
+		ctx := sac.WithGlobalAccessScopeChecker(baseContext,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resources.Cluster),
+				sac.ClusterScopeKeys(clusterID)))
+		removeErr := s.datastore.RemoveCluster(ctx, clusterID, &doneSignal)
+		s.NoError(removeErr)
+		if removeErr == nil {
+			// Wait for post-delete asynchronous cleanup in case the removal was allowed
+			<-doneSignal.Done()
+		}
+		// Verify cluster was removed
+		exists, err := s.datastore.Exists(globalReadWriteCtx, clusterID)
+		s.False(exists)
+		s.NoError(err)
+	})
+	s.Run("read-write on the right cluster and partial namespace access cannot delete", func() {
+		doneSignal := concurrency.NewSignal()
+		globalReadWriteCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+		cluster := fixtures.GetCluster(testconsts.Cluster2)
+		clusterID, err := s.datastore.AddCluster(globalReadWriteCtx, cluster)
+		defer s.deleteCluster(clusterID)
+		s.Require().NoError(err)
+		ctx := sac.WithGlobalAccessScopeChecker(baseContext,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resources.Cluster),
+				sac.ClusterScopeKeys(clusterID),
+				sac.NamespaceScopeKeys(someNamespace)))
+		removeErr := s.datastore.RemoveCluster(ctx, clusterID, &doneSignal)
+		s.ErrorIs(removeErr, sac.ErrResourceAccessDenied)
+		if removeErr == nil {
+			// Wait for post-delete asynchronous cleanup in case the removal was allowed
+			<-doneSignal.Done()
+		}
+		// Verify cluster was not removed
+		exists, err := s.datastore.Exists(globalReadWriteCtx, clusterID)
+		s.True(exists)
+		s.NoError(err)
+	})
+	s.Run("read-write on at least the right cluster can delete", func() {
+		doneSignal := concurrency.NewSignal()
+		globalReadWriteCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+		cluster := fixtures.GetCluster(testconsts.Cluster2)
+		clusterID, err := s.datastore.AddCluster(globalReadWriteCtx, cluster)
+		defer s.deleteCluster(clusterID)
+		s.Require().NoError(err)
+		ctx := sac.WithGlobalAccessScopeChecker(baseContext,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKeys(resources.Cluster),
+				sac.ClusterScopeKeys(clusterID, "otherthan"+clusterID)))
+		removeErr := s.datastore.RemoveCluster(ctx, clusterID, &doneSignal)
+		s.NoError(removeErr)
+		if removeErr == nil {
+			// Wait for post-delete asynchronous cleanup in case the removal was allowed
+			<-doneSignal.Done()
+		}
+		// Verify cluster was removed
+		exists, err := s.datastore.Exists(globalReadWriteCtx, clusterID)
+		s.False(exists)
+		s.NoError(err)
+	})
+	s.Run("read-write on at least the right cluster but partial namespace access cannot delete", func() {
+		doneSignal := concurrency.NewSignal()
+		globalReadWriteCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+		cluster := fixtures.GetCluster(testconsts.Cluster2)
+		clusterID, err := s.datastore.AddCluster(globalReadWriteCtx, cluster)
+		defer s.deleteCluster(clusterID)
+		s.Require().NoError(err)
+		ctx := sac.WithGlobalAccessScopeChecker(baseContext,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resources.Cluster),
+				sac.ClusterScopeKeys(clusterID, "otherthan"+clusterID),
+				sac.NamespaceScopeKeys(someNamespace)))
+		removeErr := s.datastore.RemoveCluster(ctx, clusterID, &doneSignal)
+		s.ErrorIs(removeErr, sac.ErrResourceAccessDenied)
+		if removeErr == nil {
+			// Wait for post-delete asynchronous cleanup in case the removal was allowed
+			<-doneSignal.Done()
+		}
+		// Verify cluster was not removed
+		exists, err := s.datastore.Exists(globalReadWriteCtx, clusterID)
+		s.True(exists)
+		s.NoError(err)
+	})
+}
+
+func (s *clusterDatastoreSACSuite) TestUpdateCluster() {
+	globalReadWriteCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+	oldCluster := fixtures.GetCluster(testconsts.Cluster2)
+	clusterID, err := s.datastore.AddCluster(globalReadWriteCtx, oldCluster)
+	defer s.deleteCluster(clusterID)
+	s.Require().NoError(err)
+	oldCluster.Id = clusterID
+	oldApiEndpoint := oldCluster.GetCentralApiEndpoint()
+	newApiEndpoint := "some.central.endpoint:443"
+	newCluster := fixtures.GetCluster(testconsts.Cluster2)
+	newCluster.Id = clusterID
+	newCluster.CentralApiEndpoint = newApiEndpoint
+	newCluster.Priority = 1
+
+	cases := testutils.GenericClusterSACWriteTestCases(context.Background(), s.T(), "update", clusterID, "not"+clusterID, resources.Cluster)
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			preUpdateCluster, preUpdateFound, preUpdateErr := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.NoError(preUpdateErr)
+			s.True(preUpdateFound)
+			updateErr := s.datastore.UpdateCluster(ctx, newCluster)
+			postUpdateCluster, postUpdateFound, postUpdateErr := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.NoError(postUpdateErr)
+			s.True(postUpdateFound)
+			if c.ExpectError {
+				s.Equal(oldApiEndpoint, preUpdateCluster.GetCentralApiEndpoint())
+				s.ErrorIs(updateErr, c.ExpectedError)
+				s.Equal(oldApiEndpoint, postUpdateCluster.GetCentralApiEndpoint())
+			} else {
+				s.Equal(oldApiEndpoint, preUpdateCluster.GetCentralApiEndpoint())
+				s.NoError(updateErr)
+				s.Equal(newApiEndpoint, postUpdateCluster.GetCentralApiEndpoint())
+			}
+			// Revert to pre-test state
+			err := s.datastore.UpdateCluster(globalReadWriteCtx, oldCluster)
+			s.Require().NoError(err)
+			fetchedCluster, found, err := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.Require().NoError(err)
+			s.Require().True(found)
+			s.Require().Equal(oldApiEndpoint, fetchedCluster.GetCentralApiEndpoint())
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestUpdateClusterCertExpiryStatus() {
+	globalReadWriteCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+	oldCluster := fixtures.GetCluster(testconsts.Cluster2)
+	oldSensorExpiry := &types.Timestamp{Seconds: 1659478729}
+	oldSensorCertNotBefore := &types.Timestamp{Seconds: 1658458729}
+	oldCertExpiryStatus := &storage.ClusterCertExpiryStatus{
+		SensorCertExpiry:    oldSensorExpiry,
+		SensorCertNotBefore: oldSensorCertNotBefore,
+	}
+	if oldCluster.Status == nil {
+		oldCluster.Status = &storage.ClusterStatus{
+			SensorVersion:         "3.71.x-88-g9798e675e5-dirty",
+			DEPRECATEDLastContact: nil,
+			ProviderMetadata:      nil,
+			OrchestratorMetadata:  nil,
+			UpgradeStatus:         nil,
+			CertExpiryStatus:      oldCertExpiryStatus,
+		}
+	}
+	newSensorExpiry := &types.Timestamp{Seconds: 1659479729}
+	newSensorCertNotBefore := &types.Timestamp{Seconds: 1658468729}
+	newCertExpiryStatus := &storage.ClusterCertExpiryStatus{
+		SensorCertExpiry:    newSensorExpiry,
+		SensorCertNotBefore: newSensorCertNotBefore,
+	}
+	clusterID, err := s.datastore.AddCluster(globalReadWriteCtx, oldCluster)
+	defer s.deleteCluster(clusterID)
+	s.Require().NoError(err)
+	oldCluster.Id = clusterID
+
+	cases := testutils.GenericClusterSACWriteTestCases(context.Background(), s.T(), "update certificate expiry status", clusterID, "not"+clusterID, resources.Cluster)
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			preUpdateCluster, preUpdateFound, preUpdateErr := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.NoError(preUpdateErr)
+			s.True(preUpdateFound)
+			updateErr := s.datastore.UpdateClusterCertExpiryStatus(ctx, clusterID, newCertExpiryStatus)
+			postUpdateCluster, postUpdateFound, postUpdateErr := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.NoError(postUpdateErr)
+			s.True(postUpdateFound)
+			if c.ExpectError {
+				s.Equal(*oldSensorExpiry, *preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
+				s.Equal(*oldSensorCertNotBefore, *preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+				s.ErrorIs(updateErr, c.ExpectedError)
+				s.Equal(*oldSensorExpiry, *postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
+				s.Equal(*oldSensorCertNotBefore, *postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+			} else {
+				s.Equal(*oldSensorExpiry, *preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
+				s.Equal(*oldSensorCertNotBefore, *preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+				s.NoError(updateErr)
+				s.Equal(*newSensorExpiry, *postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
+				s.Equal(*newSensorCertNotBefore, *postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+			}
+			// Revert to pre-test state
+			err := s.datastore.UpdateClusterCertExpiryStatus(globalReadWriteCtx, clusterID, oldCertExpiryStatus)
+			s.Require().NoError(err)
+			fetchedCluster, found, err := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.Require().NoError(err)
+			s.Require().True(found)
+			s.Require().Equal(*oldSensorExpiry, *fetchedCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
+			s.Require().Equal(*oldSensorCertNotBefore, *fetchedCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestUpdateClusterHealth() {
+	globalReadWriteCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+	oldCluster := fixtures.GetCluster(testconsts.Cluster2)
+	oldLastContact := &types.Timestamp{Seconds: 1659478729}
+	oldHealthStatus := &storage.ClusterHealthStatus{
+		Id:                           "",
+		CollectorHealthInfo:          nil,
+		AdmissionControlHealthInfo:   nil,
+		ScannerHealthInfo:            nil,
+		SensorHealthStatus:           storage.ClusterHealthStatus_HEALTHY,
+		CollectorHealthStatus:        storage.ClusterHealthStatus_UNHEALTHY,
+		OverallHealthStatus:          storage.ClusterHealthStatus_UNHEALTHY,
+		AdmissionControlHealthStatus: storage.ClusterHealthStatus_HEALTHY,
+		ScannerHealthStatus:          storage.ClusterHealthStatus_HEALTHY,
+		LastContact:                  oldLastContact,
+		HealthInfoComplete:           true,
+	}
+	oldCluster.HealthStatus = oldHealthStatus
+	newLastContact := &types.Timestamp{Seconds: 1659479729}
+	newHealthStatus := &storage.ClusterHealthStatus{
+		Id:                           "",
+		CollectorHealthInfo:          nil,
+		AdmissionControlHealthInfo:   nil,
+		ScannerHealthInfo:            nil,
+		SensorHealthStatus:           storage.ClusterHealthStatus_HEALTHY,
+		CollectorHealthStatus:        storage.ClusterHealthStatus_HEALTHY,
+		OverallHealthStatus:          storage.ClusterHealthStatus_HEALTHY,
+		AdmissionControlHealthStatus: storage.ClusterHealthStatus_HEALTHY,
+		ScannerHealthStatus:          storage.ClusterHealthStatus_HEALTHY,
+		LastContact:                  newLastContact,
+		HealthInfoComplete:           true,
+	}
+	clusterID, err := s.datastore.AddCluster(globalReadWriteCtx, oldCluster)
+	defer s.deleteCluster(clusterID)
+	s.Require().NoError(err)
+	oldCluster.Id = clusterID
+	oldCluster.HealthStatus = oldHealthStatus
+
+	var cases map[string]testutils.ClusterSACCrudTestCase
+	testedVerb := "update cluster health"
+	if features.PostgresDatastore.Enabled() {
+		cases = testutils.GenericGlobalClusterSACWriteTestCases(context.Background(), s.T(), testedVerb, clusterID, "not"+clusterID, resources.Cluster)
+	} else {
+		cases = testutils.GenericClusterSACWriteTestCases(context.Background(), s.T(), testedVerb, clusterID, "not"+clusterID, resources.Cluster)
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			preUpdateCluster, preUpdateFound, preUpdateErr := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.NoError(preUpdateErr)
+			s.True(preUpdateFound)
+			updateErr := s.datastore.UpdateClusterHealth(ctx, clusterID, newHealthStatus)
+			postUpdateCluster, postUpdateFound, postUpdateErr := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.NoError(postUpdateErr)
+			s.True(postUpdateFound)
+			if c.ExpectError {
+				s.Equal(oldHealthStatus.GetCollectorHealthStatus(), preUpdateCluster.GetHealthStatus().GetCollectorHealthStatus())
+				s.Equal(oldHealthStatus.GetOverallHealthStatus(), preUpdateCluster.GetHealthStatus().GetOverallHealthStatus())
+				s.Equal(*oldHealthStatus.GetLastContact(), *preUpdateCluster.GetHealthStatus().GetLastContact())
+				s.ErrorIs(updateErr, c.ExpectedError)
+				s.Equal(oldHealthStatus.GetCollectorHealthStatus(), postUpdateCluster.GetHealthStatus().GetCollectorHealthStatus())
+				s.Equal(oldHealthStatus.GetOverallHealthStatus(), postUpdateCluster.GetHealthStatus().GetOverallHealthStatus())
+				s.Equal(*oldHealthStatus.GetLastContact(), *preUpdateCluster.GetHealthStatus().GetLastContact())
+			} else {
+				s.Equal(oldHealthStatus.GetCollectorHealthStatus(), preUpdateCluster.GetHealthStatus().GetCollectorHealthStatus())
+				s.Equal(oldHealthStatus.GetOverallHealthStatus(), preUpdateCluster.GetHealthStatus().GetOverallHealthStatus())
+				s.Equal(*oldHealthStatus.GetLastContact(), *preUpdateCluster.GetHealthStatus().GetLastContact())
+				s.NoError(updateErr)
+				s.Equal(newHealthStatus.GetCollectorHealthStatus(), postUpdateCluster.GetHealthStatus().GetCollectorHealthStatus())
+				s.Equal(newHealthStatus.GetOverallHealthStatus(), postUpdateCluster.GetHealthStatus().GetOverallHealthStatus())
+				s.Equal(*newHealthStatus.GetLastContact(), *postUpdateCluster.GetHealthStatus().GetLastContact())
+			}
+			// Revert to pre-test state
+			err := s.datastore.UpdateClusterHealth(globalReadWriteCtx, clusterID, oldHealthStatus)
+			s.Require().NoError(err)
+			fetchedCluster, found, err := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.Require().NoError(err)
+			s.Require().True(found)
+			s.Require().Equal(oldHealthStatus.GetCollectorHealthStatus(), fetchedCluster.GetHealthStatus().GetCollectorHealthStatus())
+			s.Require().Equal(oldHealthStatus.GetOverallHealthStatus(), fetchedCluster.GetHealthStatus().GetOverallHealthStatus())
+			s.Require().Equal(*oldHealthStatus.GetLastContact(), *preUpdateCluster.GetHealthStatus().GetLastContact())
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestUpdateClusterStatus() {
+	globalReadWriteCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+	oldCluster := fixtures.GetCluster(testconsts.Cluster2)
+	oldStatus := &storage.ClusterStatus{
+		SensorVersion: "3.71.x-88-g9798e675e5-dirty",
+	}
+	newStatus := &storage.ClusterStatus{
+		SensorVersion: "3.71.x-95-gb7a8e625e9-dirty",
+	}
+	oldCluster.Status = oldStatus
+	clusterID, err := s.datastore.AddCluster(globalReadWriteCtx, oldCluster)
+	defer s.deleteCluster(clusterID)
+	s.Require().NoError(err)
+	oldCluster.Id = clusterID
+
+	cases := testutils.GenericClusterSACWriteTestCases(context.Background(), s.T(), "update cluster status", clusterID, "not"+clusterID, resources.Cluster)
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			preUpdateCluster, preUpdateFound, preUpdateErr := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.NoError(preUpdateErr)
+			s.True(preUpdateFound)
+			updateErr := s.datastore.UpdateClusterStatus(ctx, clusterID, newStatus)
+			postUpdateCluster, postUpdateFound, postUpdateErr := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.NoError(postUpdateErr)
+			s.True(postUpdateFound)
+			if c.ExpectError {
+				s.Equal(oldStatus.GetSensorVersion(), preUpdateCluster.GetStatus().GetSensorVersion())
+				s.ErrorIs(updateErr, c.ExpectedError)
+				s.Equal(oldStatus.GetSensorVersion(), postUpdateCluster.GetStatus().GetSensorVersion())
+			} else {
+				s.Equal(oldStatus.GetSensorVersion(), preUpdateCluster.GetStatus().GetSensorVersion())
+				s.NoError(updateErr)
+				s.Equal(newStatus.GetSensorVersion(), postUpdateCluster.GetStatus().GetSensorVersion())
+			}
+			// Revert to pre-test state
+			err := s.datastore.UpdateClusterStatus(globalReadWriteCtx, clusterID, oldStatus)
+			s.Require().NoError(err)
+			fetchedCluster, found, err := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.Require().NoError(err)
+			s.Require().True(found)
+			s.Require().Equal(oldStatus.GetSensorVersion(), fetchedCluster.GetStatus().GetSensorVersion())
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestUpdateClusterUpgradeStatus() {
+	globalReadWriteCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+	oldCluster := fixtures.GetCluster(testconsts.Cluster2)
+	oldUpgradeStatus := &storage.ClusterUpgradeStatus{
+		Upgradability:             storage.ClusterUpgradeStatus_MANUAL_UPGRADE_REQUIRED,
+		UpgradabilityStatusReason: "Manual upgrade required",
+	}
+	oldStatus := &storage.ClusterStatus{
+		SensorVersion: "3.71.x-88-g9798e675e5-dirty",
+		UpgradeStatus: oldUpgradeStatus,
+	}
+	oldCluster.Status = oldStatus
+	clusterID, err := s.datastore.AddCluster(globalReadWriteCtx, oldCluster)
+	defer s.deleteCluster(clusterID)
+	s.Require().NoError(err)
+	oldCluster.Id = clusterID
+	newUpgradeStatus := &storage.ClusterUpgradeStatus{
+		Upgradability:             storage.ClusterUpgradeStatus_AUTO_UPGRADE_POSSIBLE,
+		UpgradabilityStatusReason: "Automatic upgrade possible",
+	}
+
+	cases := testutils.GenericClusterSACWriteTestCases(context.Background(), s.T(), "update cluster upgrade status", clusterID, "not"+clusterID, resources.Cluster)
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			preUpdateCluster, preUpdateFound, preUpdateErr := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.NoError(preUpdateErr)
+			s.True(preUpdateFound)
+			updateErr := s.datastore.UpdateClusterUpgradeStatus(ctx, clusterID, newUpgradeStatus)
+			postUpdateCluster, postUpdateFound, postUpdateErr := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.NoError(postUpdateErr)
+			s.True(postUpdateFound)
+			if c.ExpectError {
+				s.Require().Equal(oldStatus.GetUpgradeStatus().GetUpgradability(), preUpdateCluster.GetStatus().GetUpgradeStatus().GetUpgradability())
+				s.Require().Equal(oldStatus.GetUpgradeStatus().GetUpgradabilityStatusReason(), preUpdateCluster.GetStatus().GetUpgradeStatus().GetUpgradabilityStatusReason())
+				s.ErrorIs(updateErr, c.ExpectedError)
+				s.Require().Equal(oldStatus.GetUpgradeStatus().GetUpgradability(), postUpdateCluster.GetStatus().GetUpgradeStatus().GetUpgradability())
+				s.Require().Equal(oldStatus.GetUpgradeStatus().GetUpgradabilityStatusReason(), postUpdateCluster.GetStatus().GetUpgradeStatus().GetUpgradabilityStatusReason())
+			} else {
+				s.Require().Equal(oldStatus.GetUpgradeStatus().GetUpgradability(), preUpdateCluster.GetStatus().GetUpgradeStatus().GetUpgradability())
+				s.Require().Equal(oldStatus.GetUpgradeStatus().GetUpgradabilityStatusReason(), preUpdateCluster.GetStatus().GetUpgradeStatus().GetUpgradabilityStatusReason())
+				s.NoError(updateErr)
+				s.Require().Equal(newUpgradeStatus.GetUpgradability(), postUpdateCluster.GetStatus().GetUpgradeStatus().GetUpgradability())
+				s.Require().Equal(newUpgradeStatus.GetUpgradabilityStatusReason(), postUpdateCluster.GetStatus().GetUpgradeStatus().GetUpgradabilityStatusReason())
+			}
+			// Revert to pre-test state
+			err := s.datastore.UpdateClusterUpgradeStatus(globalReadWriteCtx, clusterID, oldUpgradeStatus)
+			s.Require().NoError(err)
+			fetchedCluster, found, err := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.Require().NoError(err)
+			s.Require().True(found)
+			s.Require().Equal(oldStatus.GetUpgradeStatus().GetUpgradability(), fetchedCluster.GetStatus().GetUpgradeStatus().GetUpgradability())
+			s.Require().Equal(oldStatus.GetUpgradeStatus().GetUpgradabilityStatusReason(), fetchedCluster.GetStatus().GetUpgradeStatus().GetUpgradabilityStatusReason())
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestUpdateSensorDeploymentIdentification() {
+	globalReadWriteCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+	oldCluster := fixtures.GetCluster(testconsts.Cluster2)
+	oldSensorDeploymentIdentification := oldCluster.GetMostRecentSensorId()
+	clusterID, err := s.datastore.AddCluster(globalReadWriteCtx, oldCluster)
+	defer s.deleteCluster(clusterID)
+	s.Require().NoError(err)
+	oldCluster.Id = clusterID
+	newSensorDeploymentIdentification := &storage.SensorDeploymentIdentification{
+		SystemNamespaceId:   "fcab1a6d-07a3-4da9-a9cf-e286537ed4e3",
+		DefaultNamespaceId:  "cd14a849-21d3-4351-9a56-8a066c2e83e1",
+		AppNamespace:        "stackrox",
+		AppNamespaceId:      "dbcbf202-6086-4bf9-8bc1-d10af3e36883",
+		AppServiceaccountId: "",
+		K8SNodeName:         "colima",
+	}
+
+	cases := testutils.GenericClusterSACWriteTestCases(context.Background(), s.T(), "update sensor deployment identification", clusterID, "not"+clusterID, resources.Cluster)
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			preUpdateCluster, preUpdateFound, preUpdateErr := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.NoError(preUpdateErr)
+			s.True(preUpdateFound)
+			updateErr := s.datastore.UpdateSensorDeploymentIdentification(ctx, clusterID, newSensorDeploymentIdentification)
+			postUpdateCluster, postUpdateFound, postUpdateErr := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.NoError(postUpdateErr)
+			s.True(postUpdateFound)
+			if c.ExpectError {
+				s.Require().Equal(oldSensorDeploymentIdentification.GetSystemNamespaceId(), preUpdateCluster.GetMostRecentSensorId().GetSystemNamespaceId())
+				s.Require().Equal(oldSensorDeploymentIdentification.GetDefaultNamespaceId(), preUpdateCluster.GetMostRecentSensorId().GetDefaultNamespaceId())
+				s.ErrorIs(updateErr, c.ExpectedError)
+				s.Require().Equal(oldSensorDeploymentIdentification.GetSystemNamespaceId(), postUpdateCluster.GetMostRecentSensorId().GetSystemNamespaceId())
+				s.Require().Equal(oldSensorDeploymentIdentification.GetDefaultNamespaceId(), postUpdateCluster.GetMostRecentSensorId().GetDefaultNamespaceId())
+			} else {
+				s.Require().Equal(oldSensorDeploymentIdentification.GetSystemNamespaceId(), preUpdateCluster.GetMostRecentSensorId().GetSystemNamespaceId())
+				s.Require().Equal(oldSensorDeploymentIdentification.GetDefaultNamespaceId(), preUpdateCluster.GetMostRecentSensorId().GetDefaultNamespaceId())
+				s.NoError(updateErr)
+				s.Require().Equal(newSensorDeploymentIdentification.GetSystemNamespaceId(), postUpdateCluster.GetMostRecentSensorId().GetSystemNamespaceId())
+				s.Require().Equal(newSensorDeploymentIdentification.GetDefaultNamespaceId(), postUpdateCluster.GetMostRecentSensorId().GetDefaultNamespaceId())
+			}
+			// Revert to pre-test state
+			err := s.datastore.UpdateSensorDeploymentIdentification(globalReadWriteCtx, clusterID, oldSensorDeploymentIdentification)
+			s.Require().NoError(err)
+			fetchedCluster, found, err := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.Require().NoError(err)
+			s.Require().True(found)
+			s.Require().Equal(oldSensorDeploymentIdentification.GetSystemNamespaceId(), fetchedCluster.GetMostRecentSensorId().GetSystemNamespaceId())
+			s.Require().Equal(oldSensorDeploymentIdentification.GetDefaultNamespaceId(), fetchedCluster.GetMostRecentSensorId().GetDefaultNamespaceId())
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestUpdateAuditLogFileStates() {
+	// Note: The tested function, when the scope allows it, actually adds the new state to the old one,
+	// erasing old values with the new ones when a conflict arises.
+	// The goal of the current test is to test whether the scope allows the action. As a consequence,
+	// only one value is used in the test, and moves from initial to replaced state and back.
+	globalReadWriteCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+	oldCluster := fixtures.GetCluster(testconsts.Cluster2)
+	oldCollectTimestamp := &types.Timestamp{Seconds: 1659478729}
+	oldAuditLogFileState := map[string]*storage.AuditLogFileState{
+		"fileState": {
+			CollectLogsSince: oldCollectTimestamp,
+			LastAuditId:      "oldAuditID",
+		},
+	}
+	oldCluster.AuditLogState = oldAuditLogFileState
+	clusterID, err := s.datastore.AddCluster(globalReadWriteCtx, oldCluster)
+	defer s.deleteCluster(clusterID)
+	s.Require().NoError(err)
+	oldCluster.Id = clusterID
+	newCollectTimestamp := &types.Timestamp{Seconds: 1659479729}
+	newAuditLogFileState := map[string]*storage.AuditLogFileState{
+		"fileState": {
+			CollectLogsSince: newCollectTimestamp,
+			LastAuditId:      "newAuditID",
+		},
+	}
+
+	cases := testutils.GenericClusterSACWriteTestCases(context.Background(), s.T(), "update sensor deployment identification", clusterID, "not"+clusterID, resources.Cluster)
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			preUpdateCluster, preUpdateFound, preUpdateErr := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.NoError(preUpdateErr)
+			s.True(preUpdateFound)
+			updateErr := s.datastore.UpdateAuditLogFileStates(ctx, clusterID, newAuditLogFileState)
+			postUpdateCluster, postUpdateFound, postUpdateErr := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+			s.NoError(postUpdateErr)
+			s.True(postUpdateFound)
+			if c.ExpectError {
+				s.Require().Equal(len(oldAuditLogFileState), len(preUpdateCluster.GetAuditLogState()))
+				for k := range oldAuditLogFileState {
+					s.Require().Equal(oldAuditLogFileState[k].GetLastAuditId(), preUpdateCluster.GetAuditLogState()[k].GetLastAuditId())
+					s.Require().NotNil(*preUpdateCluster.GetAuditLogState()[k])
+					s.Require().Equal(*oldAuditLogFileState[k].GetCollectLogsSince(), *preUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
+				}
+				s.ErrorIs(updateErr, c.ExpectedError)
+				s.Require().Equal(len(oldAuditLogFileState), len(postUpdateCluster.GetAuditLogState()))
+				for k := range oldAuditLogFileState {
+					s.Require().Equal(oldAuditLogFileState[k].GetLastAuditId(), postUpdateCluster.GetAuditLogState()[k].GetLastAuditId())
+					s.Require().NotNil(*postUpdateCluster.GetAuditLogState()[k])
+					s.Require().Equal(*oldAuditLogFileState[k].GetCollectLogsSince(), *postUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
+				}
+			} else {
+				s.Require().Equal(len(oldAuditLogFileState), len(preUpdateCluster.GetAuditLogState()))
+				for k := range oldAuditLogFileState {
+					s.Require().Equal(oldAuditLogFileState[k].GetLastAuditId(), preUpdateCluster.GetAuditLogState()[k].GetLastAuditId())
+					s.Require().NotNil(*preUpdateCluster.GetAuditLogState()[k])
+					s.Require().Equal(*oldAuditLogFileState[k].GetCollectLogsSince(), *preUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
+				}
+				s.NoError(updateErr)
+				s.Require().Equal(len(newAuditLogFileState), len(postUpdateCluster.GetAuditLogState()))
+				for k := range newAuditLogFileState {
+					s.Require().Equal(newAuditLogFileState[k].GetLastAuditId(), postUpdateCluster.GetAuditLogState()[k].GetLastAuditId())
+					s.Require().NotNil(*postUpdateCluster.GetAuditLogState()[k])
+					s.Require().Equal(*newAuditLogFileState[k].GetCollectLogsSince(), *postUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
+				}
+				// Revert to pre-test state
+				err := s.datastore.UpdateAuditLogFileStates(globalReadWriteCtx, clusterID, oldAuditLogFileState)
+				s.Require().NoError(err)
+				fetchedCluster, found, err := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
+				s.Require().NoError(err)
+				s.Require().True(found)
+				s.Require().Equal(len(oldAuditLogFileState), len(fetchedCluster.GetAuditLogState()))
+				for k := range oldAuditLogFileState {
+					s.Require().Equal(oldAuditLogFileState[k].GetLastAuditId(), fetchedCluster.GetAuditLogState()[k].GetLastAuditId())
+					s.Require().NotNil(*fetchedCluster.GetAuditLogState()[k])
+					s.Require().Equal(*oldAuditLogFileState[k].GetCollectLogsSince(), *fetchedCluster.GetAuditLogState()[k].GetCollectLogsSince())
+				}
+			}
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestCount() {
+	cluster1 := fixtures.GetCluster(testconsts.Cluster1)
+	clusterID1, err := s.datastore.AddCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], cluster1)
+	defer s.deleteCluster(clusterID1)
+	s.Require().NoError(err)
+	cluster1.Id = clusterID1
+	cluster2 := fixtures.GetCluster(testconsts.Cluster2)
+	clusterID2, err := s.datastore.AddCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], cluster2)
+	defer s.deleteCluster(clusterID2)
+	s.Require().NoError(err)
+	cluster2.Id = clusterID2
+	otherClusterID := "someOtherClusterID"
+
+	cases := getMultiClusterTestCases(context.Background(), clusterID1, clusterID2, otherClusterID)
+
+	for _, c := range cases {
+		s.Run(c.Name, func() {
+			ctx := c.Context
+			clusterCount, err := s.datastore.Count(ctx, nil)
+			s.NoError(err)
+			s.Equal(len(c.ExpectedClusterNames), clusterCount)
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestCountClusters() {
+	cluster1 := fixtures.GetCluster(testconsts.Cluster1)
+	clusterID1, err := s.datastore.AddCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], cluster1)
+	defer s.deleteCluster(clusterID1)
+	s.Require().NoError(err)
+	cluster1.Id = clusterID1
+	cluster2 := fixtures.GetCluster(testconsts.Cluster2)
+	clusterID2, err := s.datastore.AddCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], cluster2)
+	defer s.deleteCluster(clusterID2)
+	s.Require().NoError(err)
+	cluster2.Id = clusterID2
+	otherClusterID := "someOtherClusterID"
+
+	cases := getMultiClusterTestCases(context.Background(), clusterID1, clusterID2, otherClusterID)
+
+	for _, c := range cases {
+		s.Run(c.Name, func() {
+			ctx := c.Context
+			clusterCount, err := s.datastore.CountClusters(ctx)
+			s.NoError(err)
+			s.Equal(len(c.ExpectedClusterNames), clusterCount)
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestSearch() {
+	cluster1 := fixtures.GetCluster(testconsts.Cluster1)
+	clusterID1, err := s.datastore.AddCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], cluster1)
+	defer s.deleteCluster(clusterID1)
+	s.Require().NoError(err)
+	cluster1.Id = clusterID1
+	cluster2 := fixtures.GetCluster(testconsts.Cluster2)
+	clusterID2, err := s.datastore.AddCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], cluster2)
+	defer s.deleteCluster(clusterID2)
+	s.Require().NoError(err)
+	cluster2.Id = clusterID2
+	otherClusterID := "someOtherClusterID"
+
+	cases := getMultiClusterTestCases(context.Background(), clusterID1, clusterID2, otherClusterID)
+
+	for _, c := range cases {
+		s.Run(c.Name, func() {
+			ctx := c.Context
+			results, err := s.datastore.Search(ctx, nil)
+			s.NoError(err)
+			fetchedIDs := make([]string, 0, len(results))
+			for _, r := range results {
+				fetchedIDs = append(fetchedIDs, r.ID)
+			}
+			s.ElementsMatch(c.ExpectedClusterIDs, fetchedIDs)
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestSearchRawClusters() {
+	cluster1 := fixtures.GetCluster(testconsts.Cluster1)
+	clusterID1, err := s.datastore.AddCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], cluster1)
+	defer s.deleteCluster(clusterID1)
+	s.Require().NoError(err)
+	cluster1.Id = clusterID1
+	cluster2 := fixtures.GetCluster(testconsts.Cluster2)
+	clusterID2, err := s.datastore.AddCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], cluster2)
+	defer s.deleteCluster(clusterID2)
+	s.Require().NoError(err)
+	cluster2.Id = clusterID2
+	otherClusterID := "someOtherClusterID"
+
+	cases := getMultiClusterTestCases(context.Background(), clusterID1, clusterID2, otherClusterID)
+
+	for _, c := range cases {
+		s.Run(c.Name, func() {
+			ctx := c.Context
+			results, err := s.datastore.SearchRawClusters(ctx, nil)
+			s.NoError(err)
+			fetchedIDs := make([]string, 0, len(results))
+			for _, r := range results {
+				fetchedIDs = append(fetchedIDs, r.GetId())
+			}
+			fetchedNames := make([]string, 0, len(results))
+			for _, r := range results {
+				fetchedNames = append(fetchedNames, r.GetName())
+			}
+			s.ElementsMatch(c.ExpectedClusterIDs, fetchedIDs)
+			s.ElementsMatch(c.ExpectedClusterNames, fetchedNames)
+		})
+	}
+}
+
+func (s *clusterDatastoreSACSuite) TestSearchResults() {
+	cluster1 := fixtures.GetCluster(testconsts.Cluster1)
+	clusterID1, err := s.datastore.AddCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], cluster1)
+	defer s.deleteCluster(clusterID1)
+	s.Require().NoError(err)
+	cluster1.Id = clusterID1
+	cluster2 := fixtures.GetCluster(testconsts.Cluster2)
+	clusterID2, err := s.datastore.AddCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], cluster2)
+	defer s.deleteCluster(clusterID2)
+	s.Require().NoError(err)
+	cluster2.Id = clusterID2
+	otherClusterID := "someOtherClusterID"
+
+	cases := getMultiClusterTestCases(context.Background(), clusterID1, clusterID2, otherClusterID)
+
+	for _, c := range cases {
+		s.Run(c.Name, func() {
+			ctx := c.Context
+			results, err := s.datastore.SearchResults(ctx, nil)
+			s.NoError(err)
+			fetchedIDs := make([]string, 0, len(results))
+			for _, r := range results {
+				fetchedIDs = append(fetchedIDs, r.GetId())
+			}
+			s.ElementsMatch(c.ExpectedClusterIDs, fetchedIDs)
+		})
+	}
+}
+
+// The LookupOrCreateClusterFromConfig function seems a bit more complex to test.
+// On the other hand, Scoped Access Control for that function should behave the same as
+// for the other write (UpdateXXX) functions.
+// It will not be tested here.

--- a/central/cluster/datastore/datastore_sac_test.go
+++ b/central/cluster/datastore/datastore_sac_test.go
@@ -569,11 +569,11 @@ func (s *clusterDatastoreSACSuite) TestUpdateCluster() {
 	defer s.deleteCluster(clusterID)
 	s.Require().NoError(err)
 	oldCluster.Id = clusterID
-	oldApiEndpoint := oldCluster.GetCentralApiEndpoint()
-	newApiEndpoint := "some.central.endpoint:443"
+	oldAPIEndpoint := oldCluster.GetCentralApiEndpoint()
+	newAPIEndpoint := "some.central.endpoint:443"
 	newCluster := fixtures.GetCluster(testconsts.Cluster2)
 	newCluster.Id = clusterID
-	newCluster.CentralApiEndpoint = newApiEndpoint
+	newCluster.CentralApiEndpoint = newAPIEndpoint
 	newCluster.Priority = 1
 
 	cases := testutils.GenericClusterSACWriteTestCases(context.Background(), s.T(), "update", clusterID, "not"+clusterID, resources.Cluster)
@@ -589,13 +589,13 @@ func (s *clusterDatastoreSACSuite) TestUpdateCluster() {
 			s.NoError(postUpdateErr)
 			s.True(postUpdateFound)
 			if c.ExpectError {
-				s.Equal(oldApiEndpoint, preUpdateCluster.GetCentralApiEndpoint())
+				s.Equal(oldAPIEndpoint, preUpdateCluster.GetCentralApiEndpoint())
 				s.ErrorIs(updateErr, c.ExpectedError)
-				s.Equal(oldApiEndpoint, postUpdateCluster.GetCentralApiEndpoint())
+				s.Equal(oldAPIEndpoint, postUpdateCluster.GetCentralApiEndpoint())
 			} else {
-				s.Equal(oldApiEndpoint, preUpdateCluster.GetCentralApiEndpoint())
+				s.Equal(oldAPIEndpoint, preUpdateCluster.GetCentralApiEndpoint())
 				s.NoError(updateErr)
-				s.Equal(newApiEndpoint, postUpdateCluster.GetCentralApiEndpoint())
+				s.Equal(newAPIEndpoint, postUpdateCluster.GetCentralApiEndpoint())
 			}
 			// Revert to pre-test state
 			err := s.datastore.UpdateCluster(globalReadWriteCtx, oldCluster)
@@ -603,7 +603,7 @@ func (s *clusterDatastoreSACSuite) TestUpdateCluster() {
 			fetchedCluster, found, err := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
 			s.Require().NoError(err)
 			s.Require().True(found)
-			s.Require().Equal(oldApiEndpoint, fetchedCluster.GetCentralApiEndpoint())
+			s.Require().Equal(oldAPIEndpoint, fetchedCluster.GetCentralApiEndpoint())
 		})
 	}
 }

--- a/central/cluster/datastore/datastore_sac_test.go
+++ b/central/cluster/datastore/datastore_sac_test.go
@@ -106,7 +106,8 @@ func (s *clusterDatastoreSACSuite) deleteCluster(id string) {
 		return
 	}
 	doneSignal := concurrency.NewSignal()
-	s.datastore.RemoveCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], id, &doneSignal)
+	err = s.datastore.RemoveCluster(s.testContexts[testutils.UnrestrictedReadWriteCtx], id, &doneSignal)
+	s.NoError(err)
 	<-doneSignal.Done()
 }
 

--- a/central/networkpolicies/datastore/datastore.go
+++ b/central/networkpolicies/datastore/datastore.go
@@ -2,12 +2,22 @@ package store
 
 import (
 	"context"
+	"testing"
 
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/central/networkpolicies/datastore/internal/store"
+	"github.com/stackrox/rox/central/networkpolicies/datastore/internal/store/bolt"
+	"github.com/stackrox/rox/central/networkpolicies/datastore/internal/store/postgres"
 	"github.com/stackrox/rox/central/networkpolicies/datastore/internal/undodeploymentstore"
+	undoDeploymentPostgres "github.com/stackrox/rox/central/networkpolicies/datastore/internal/undodeploymentstore/postgres"
+	undoDeploymentRocksDB "github.com/stackrox/rox/central/networkpolicies/datastore/internal/undodeploymentstore/rocksdb"
 	"github.com/stackrox/rox/central/networkpolicies/datastore/internal/undostore"
+	undobolt "github.com/stackrox/rox/central/networkpolicies/datastore/internal/undostore/bolt"
+	undopostgres "github.com/stackrox/rox/central/networkpolicies/datastore/internal/undostore/postgres"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
+	rocksdbBase "github.com/stackrox/rox/pkg/rocksdb"
+	"go.etcd.io/bbolt"
 )
 
 var (
@@ -50,4 +60,23 @@ func New(storage store.Store, undoStorage undostore.UndoStore, undoDeploymentSto
 		undoStorage:           undoStorage,
 		undoDeploymentStorage: undoDeploymentStorage,
 	}
+}
+
+// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetTestPostgresDataStore(_ *testing.T, pool *pgxpool.Pool) (DataStore, error) {
+	dbstore := postgres.New(pool)
+	undodbstore := undopostgres.New(pool)
+	undodeploymentdbstore := undoDeploymentPostgres.New(pool)
+	return New(dbstore, undodbstore, undodeploymentdbstore), nil
+}
+
+// GetTestRocksBleveDataStore provides a datastore connected to rocksdb and bleve for testing purposes.
+func GetTestRocksBleveDataStore(_ *testing.T, rocksengine *rocksdbBase.RocksDB, boltengine *bbolt.DB) (DataStore, error) {
+	dbstore := bolt.New(boltengine)
+	undodbstore := undobolt.New(boltengine)
+	undodeploymentdbstore, err := undoDeploymentRocksDB.New(rocksengine)
+	if err != nil {
+		return nil, err
+	}
+	return New(dbstore, undodbstore, undodeploymentdbstore), nil
 }

--- a/pkg/fixtures/cluster.go
+++ b/pkg/fixtures/cluster.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 )
 
+// GetCluster provides a filled cluster object for testing purposes.
 func GetCluster(name string) *storage.Cluster {
 	return &storage.Cluster{
 		Id:                         "",

--- a/pkg/fixtures/cluster.go
+++ b/pkg/fixtures/cluster.go
@@ -1,0 +1,50 @@
+package fixtures
+
+import (
+	"github.com/stackrox/rox/generated/storage"
+)
+
+func GetCluster(name string) *storage.Cluster {
+	return &storage.Cluster{
+		Id:                         "",
+		Name:                       name,
+		Type:                       storage.ClusterType_KUBERNETES_CLUSTER,
+		Labels:                     nil,
+		MainImage:                  "quay.io/stackrox-io/main",
+		CollectorImage:             "quay.io/stackrox-io/collector",
+		CentralApiEndpoint:         "central.stackrox:443",
+		RuntimeSupport:             true,
+		CollectionMethod:           storage.CollectionMethod_EBPF,
+		AdmissionController:        true,
+		AdmissionControllerUpdates: false,
+		AdmissionControllerEvents:  true,
+		Status:                     nil,
+		DynamicConfig: &storage.DynamicClusterConfig{
+			AdmissionControllerConfig: &storage.AdmissionControllerConfig{
+				Enabled:          false,
+				TimeoutSeconds:   20,
+				ScanInline:       false,
+				DisableBypass:    false,
+				EnforceOnUpdates: false,
+			},
+			RegistryOverride: "",
+			DisableAuditLogs: true,
+		},
+		TolerationsConfig: nil,
+		Priority:          0,
+		HealthStatus:      nil,
+		SlimCollector:     true,
+		HelmConfig:        nil,
+		MostRecentSensorId: &storage.SensorDeploymentIdentification{
+			SystemNamespaceId:   "dbcbf202-6086-4bf9-8bc1-d10af3e36883",
+			DefaultNamespaceId:  "fcab1a6d-07a3-4da9-a9cf-e286537ed4e3",
+			AppNamespace:        "stackrox",
+			AppNamespaceId:      "cd14a849-21d3-4351-9a56-8a066c2e83e1",
+			AppServiceaccountId: "",
+			K8SNodeName:         "colima",
+		},
+		AuditLogState: nil,
+		InitBundleId:  "bb0e13e0-621a-4b2e-8fb9-af4e466763ff",
+		ManagedBy:     storage.ManagerType_MANAGER_TYPE_MANUAL,
+	}
+}

--- a/pkg/sac/testutils/crud_test_cases.go
+++ b/pkg/sac/testutils/crud_test_cases.go
@@ -1,8 +1,11 @@
 package testutils
 
 import (
+	"context"
 	"testing"
 
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/sac"
 )
 
@@ -18,6 +21,15 @@ const (
 // are referred to by their key in test cases.
 type SACCrudTestCase struct {
 	ScopeKey      string
+	ExpectedError error
+	ExpectError   bool
+	ExpectedFound bool
+}
+
+// ClusterSACCrudTestCase is used within SAC tests. It describes the expected behaviour of a datastore CRUD function
+// for a given scoped context.
+type ClusterSACCrudTestCase struct {
+	Context       context.Context
 	ExpectedError error
 	ExpectError   bool
 	ExpectedFound bool
@@ -190,10 +202,139 @@ func GenericNamespaceSACDeleteTestCases(_ *testing.T) map[string]SACCrudTestCase
 	}
 }
 
+// GenericClusterSACGetTestCases returns a generic set of ClusterSACCrudTestCase.
+// It is appropriate for use in the context of testing Get function on cluster scoped resources
+// when the scope checks are expected to assess whether the retrieved object belongs to a cluster
+// in scope.
+func GenericClusterSACGetTestCases(baseContext context.Context, _ *testing.T, validClusterID string, wrongClusterID string, resources ...permissions.ResourceMetadata) map[string]ClusterSACCrudTestCase {
+	resourceHandles := make([]permissions.ResourceHandle, 0, len(resources))
+	for _, r := range resources {
+		resourceHandles = append(resourceHandles, r)
+	}
+	return map[string]ClusterSACCrudTestCase{
+		"(full) read-only can get": {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...))),
+			ExpectedFound: true,
+		},
+		"full read-write can get": {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...))),
+			ExpectedFound: true,
+		},
+		"full read-write on wrong cluster cannot get": {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(wrongClusterID))),
+			ExpectedFound: false,
+		},
+		"read-write on wrong cluster and partial namespace access cannot get": {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(wrongClusterID),
+					sac.NamespaceScopeKeys("someNamespace"))),
+			ExpectedFound: false,
+		},
+		"full read-write on right cluster can get": {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(validClusterID))),
+			ExpectedFound: true,
+		},
+		"read-write on the right cluster and partial namespace access cannot get": {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(validClusterID),
+					sac.NamespaceScopeKeys("someNamespace"))),
+			ExpectedFound: false,
+		},
+	}
+}
+
+// GenericClusterSACWriteTestCases returns a generic set of ClusterSACCrudTestCase.
+// It is appropriate for use in the context of testing Get function on cluster scoped resources
+// when the scope checks are expected to assess whether the retrieved object belongs to a cluster
+// in scope.
+func GenericClusterSACWriteTestCases(baseContext context.Context, _ *testing.T, verb string, validClusterID string, wrongClusterID string, resources ...permissions.ResourceMetadata) map[string]ClusterSACCrudTestCase {
+	resourceHandles := make([]permissions.ResourceHandle, 0, len(resources))
+	for _, r := range resources {
+		resourceHandles = append(resourceHandles, r)
+	}
+	return map[string]ClusterSACCrudTestCase{
+		"(full) read-only cannot " + verb: {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...))),
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write can " + verb: {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...))),
+			ExpectError:   false,
+			ExpectedError: nil,
+		},
+		"full read-write on wrong cluster cannot " + verb: {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(wrongClusterID))),
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and partial namespace access cannot " + verb: {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(wrongClusterID),
+					sac.NamespaceScopeKeys("someNamespace"))),
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write on right cluster can " + verb: {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(validClusterID))),
+			ExpectError:   false,
+			ExpectedError: nil,
+		},
+		"read-write on the right cluster and partial namespace access cannot " + verb: {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(validClusterID),
+					sac.NamespaceScopeKeys("someNamespace"))),
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+	}
+}
+
 // GenericGlobalSACUpsertTestCases returns a generic set of SACCrudTestCase.
 // It is appropriate for use in the context of testing Upsert function on resources when the scope checks
 // are expected to check global resource access only. These test cases assume the inserted test object
-// belongs to Cluster2 and NamespaceB.
+// belongs to Cluster2 for cluster-scoped object types or Cluster2 and NamespaceB for namespace-scoped
+// object types.
 func GenericGlobalSACUpsertTestCases(_ *testing.T, verb string) map[string]SACCrudTestCase {
 	return map[string]SACCrudTestCase{
 		"global read-only should not be able to " + verb: {
@@ -211,32 +352,32 @@ func GenericGlobalSACUpsertTestCases(_ *testing.T, verb string) map[string]SACCr
 			ExpectError:   true,
 			ExpectedError: sac.ErrResourceAccessDenied,
 		},
-		"read-write on wrong cluster and namespace should not be able to " + verb: {
+		"read-write on wrong cluster and namespace (when any) should not be able to " + verb: {
 			ScopeKey:      Cluster1NamespaceAReadWriteCtx,
 			ExpectError:   true,
 			ExpectedError: sac.ErrResourceAccessDenied,
 		},
-		"read-write on wrong cluster and matching namespace should not be able to " + verb: {
+		"read-write on wrong cluster and matching namespace (when any) should not be able to " + verb: {
 			ScopeKey:      Cluster1NamespaceBReadWriteCtx,
 			ExpectError:   true,
 			ExpectedError: sac.ErrResourceAccessDenied,
 		},
-		"read-write on matching cluster and wrong namespace should not be able to " + verb: {
+		"read-write on matching cluster and wrong namespace (when any) should not be able to " + verb: {
 			ScopeKey:      Cluster2NamespaceAReadWriteCtx,
 			ExpectError:   true,
 			ExpectedError: sac.ErrResourceAccessDenied,
 		},
-		"read-write on matching cluster and wrong namespaces should not be able to " + verb: {
+		"read-write on matching cluster and wrong namespaces (when any) should not be able to " + verb: {
 			ScopeKey:      Cluster2NamespacesACReadWriteCtx,
 			ExpectError:   true,
 			ExpectedError: sac.ErrResourceAccessDenied,
 		},
-		"read-write on matching cluster and matching namespace should be able to " + verb: {
+		"read-write on matching cluster and matching namespace (when any) should not be able to " + verb: {
 			ScopeKey:      Cluster2NamespaceBReadWriteCtx,
 			ExpectError:   true,
 			ExpectedError: sac.ErrResourceAccessDenied,
 		},
-		"read-write on matching cluster and at least one matching namespace should be able to " + verb: {
+		"read-write on matching cluster and at least one matching namespace (when any) should not be able to " + verb: {
 			ScopeKey:      Cluster2NamespacesABReadWriteCtx,
 			ExpectError:   true,
 			ExpectedError: sac.ErrResourceAccessDenied,
@@ -346,6 +487,73 @@ func GenericGlobalSACDeleteTestCases(_ *testing.T) map[string]SACCrudTestCase {
 		},
 		"read-write on matching cluster and at least one matching namespace should not be able to delete": {
 			ScopeKey:      Cluster2NamespacesABReadWriteCtx,
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+	}
+}
+
+// GenericGlobalClusterSACWriteTestCases returns a generic set of ClusterSACCrudTestCase.
+// It is appropriate for use in the context of testing Get function on cluster scoped resources
+// when the scope checks are expected to assess whether the retrieved object belongs to a cluster
+// in scope.
+func GenericGlobalClusterSACWriteTestCases(baseContext context.Context, _ *testing.T, verb string, validClusterID string, wrongClusterID string, resources ...permissions.ResourceMetadata) map[string]ClusterSACCrudTestCase {
+	resourceHandles := make([]permissions.ResourceHandle, 0, len(resources))
+	for _, r := range resources {
+		resourceHandles = append(resourceHandles, r)
+	}
+	return map[string]ClusterSACCrudTestCase{
+		"(full) read-only cannot " + verb: {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...))),
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write can " + verb: {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...))),
+			ExpectError:   false,
+			ExpectedError: nil,
+		},
+		"full read-write on wrong cluster cannot " + verb: {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(wrongClusterID))),
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on wrong cluster and partial namespace access cannot " + verb: {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(wrongClusterID),
+					sac.NamespaceScopeKeys("someNamespace"))),
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"full read-write on right cluster cannot " + verb: {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(validClusterID))),
+			ExpectError:   true,
+			ExpectedError: sac.ErrResourceAccessDenied,
+		},
+		"read-write on the right cluster and partial namespace access cannot " + verb: {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(validClusterID),
+					sac.NamespaceScopeKeys("someNamespace"))),
 			ExpectError:   true,
 			ExpectedError: sac.ErrResourceAccessDenied,
 		},


### PR DESCRIPTION
## Description

The goal here is to have a test harness that ensures Scoped Access Control behaves similarly when the application is running against the bolt/rocksdb/bleve datastores and when it is running against the postgres datastores.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Added tests.
Manual run of the added tests with the postgres datastor feature flag activated and deactivated.