### PR TITLE
ROX-11136 persist dashboard widget config

### DIFF
--- a/ui/apps/platform/src/hooks/useWidgetConfig.test.tsx
+++ b/ui/apps/platform/src/hooks/useWidgetConfig.test.tsx
@@ -1,0 +1,242 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import React from 'react';
+import { render, act as reactAct } from '@testing-library/react';
+import { renderHook, act as hooksAct } from '@testing-library/react-hooks';
+import useWidgetConfig, { defaultStorageKey } from 'hooks/useWidgetConfig';
+
+beforeEach(() => {
+    localStorage.clear();
+});
+
+describe('useWidgetConfig hook', () => {
+    it('should persist a widget configuration in localStorage', () => {
+        const widgetId = 'single-component';
+        const routeId = '/';
+        const defaultConfig = {
+            sort: 'asc',
+            filter: '',
+        };
+        const { result: firstResult } = renderHook(() =>
+            useWidgetConfig(widgetId, routeId, defaultConfig)
+        );
+
+        // Expect the initial state to be clean and return the provided defaults
+        expect(firstResult.current[0]).toEqual(defaultConfig);
+
+        // By default changes should merge the new and old configs
+        hooksAct(() => {
+            const [, updateConfig] = firstResult.current;
+            updateConfig({ filter: 'Namespace:stackrox' });
+        });
+        expect(firstResult.current[0]).toEqual({ sort: 'asc', filter: 'Namespace:stackrox' });
+
+        hooksAct(() => {
+            const [, updateConfig] = firstResult.current;
+            updateConfig({ sort: 'desc' });
+        });
+        expect(firstResult.current[0]).toEqual({ sort: 'desc', filter: 'Namespace:stackrox' });
+
+        // Loading the same widget/route config in a new component, i.e. a page reload
+        const { result: secondResult } = renderHook(() =>
+            useWidgetConfig(widgetId, routeId, defaultConfig)
+        );
+
+        // Results should be the persisted config instead of the default
+        expect(secondResult.current[0]).toEqual({ sort: 'desc', filter: 'Namespace:stackrox' });
+    });
+
+    it('should allow a custom update method to be used when updating the configuration', () => {
+        const widgetId = 'single-component';
+        const routeId = '/';
+        const defaultConfig = {
+            sort: 'asc',
+            filter: '',
+        };
+        type Config = typeof defaultConfig;
+
+        // Reducer that does a full config replace instead of merge
+        const reducer = (_oldConfig, payload: Partial<Config>) => payload;
+
+        const { result: firstResult } = renderHook(() =>
+            useWidgetConfig(widgetId, routeId, defaultConfig, reducer)
+        );
+
+        expect(firstResult.current[0]).toEqual(defaultConfig);
+
+        hooksAct(() => {
+            const [, updateConfig] = firstResult.current;
+            updateConfig({ filter: 'Namespace:stackrox' });
+        });
+
+        // Even though the `sort` property was overwritten, the hook ensures type safety by
+        // replacing it with the default value
+        expect(firstResult.current[0]).toEqual({ sort: 'asc', filter: 'Namespace:stackrox' });
+
+        hooksAct(() => {
+            const [, updateConfig] = firstResult.current;
+            updateConfig({ sort: 'desc' });
+        });
+
+        // The `filter` property is overwritten and replaced with the default value
+        expect(firstResult.current[0]).toEqual({ sort: 'desc', filter: '' });
+
+        hooksAct(() => {
+            const [, updateConfig] = firstResult.current;
+            updateConfig({});
+        });
+        expect(firstResult.current[0]).toEqual(defaultConfig);
+    });
+
+    it('should store separate configurations for the same widget at different routes', () => {
+        const widgetId = 'single-component';
+        const defaultConfig = {
+            sort: 'asc',
+            filter: '',
+        };
+        const { result: firstResult } = renderHook(() => [
+            useWidgetConfig(widgetId, '/pathA', defaultConfig),
+            useWidgetConfig(widgetId, '/pathB', defaultConfig),
+        ]);
+
+        expect(firstResult.current[0][0]).toEqual(defaultConfig);
+        expect(firstResult.current[1][0]).toEqual(defaultConfig);
+
+        // Update the state of each widget config
+        hooksAct(() => {
+            firstResult.current[0][1]({ sort: 'desc' });
+            firstResult.current[1][1]({ filter: 'Namespace:stackrox' });
+        });
+        expect(firstResult.current[0][0]).toEqual({ sort: 'desc', filter: '' });
+        expect(firstResult.current[1][0]).toEqual({ sort: 'asc', filter: 'Namespace:stackrox' });
+
+        // Reload the widget configurations
+        const { result: secondResult } = renderHook(() => [
+            useWidgetConfig(widgetId, '/pathA', defaultConfig),
+            useWidgetConfig(widgetId, '/pathB', defaultConfig),
+        ]);
+
+        // Results should be persisted separately
+        expect(secondResult.current[0][0]).toEqual({ sort: 'desc', filter: '' });
+        expect(secondResult.current[1][0]).toEqual({ sort: 'asc', filter: 'Namespace:stackrox' });
+    });
+
+    it('should handle multiple unrelated widget configs simultaneously', () => {
+        const idA = 'widgetA';
+        const idB = 'widgetB';
+        const renderSpies = { [idA]: jest.fn(), [idB]: jest.fn() };
+        const hookReturns = { [idA]: {}, [idB]: {} };
+
+        const defaultConfig = { sort: 'asc', filter: '' };
+
+        function Widget({ id }) {
+            renderSpies[id]();
+            hookReturns[id] = useWidgetConfig(id, '/', defaultConfig);
+            return <></>;
+        }
+        render(
+            <>
+                <Widget id={idA} />
+                <Widget id={idB} />
+            </>
+        );
+
+        expect(renderSpies[idA]).toBeCalledTimes(1);
+        expect(renderSpies[idB]).toBeCalledTimes(1);
+
+        reactAct(() => {
+            hookReturns[idA][1]({ sort: 'desc' });
+        });
+
+        // Updating the config for one component should not cause the other component to rerender
+        // and should only update the config state of the changed component.
+        expect(renderSpies[idA]).toBeCalledTimes(2);
+        expect(renderSpies[idB]).toBeCalledTimes(1);
+        expect(hookReturns[idA][0]).toEqual({ sort: 'desc', filter: '' });
+        expect(hookReturns[idB][0]).toEqual({ sort: 'asc', filter: '' });
+
+        reactAct(() => {
+            hookReturns[idB][1]({ filter: 'Namespace:stackrox' });
+        });
+
+        expect(renderSpies[idA]).toBeCalledTimes(2);
+        expect(renderSpies[idB]).toBeCalledTimes(2);
+        expect(hookReturns[idA][0]).toEqual({ sort: 'desc', filter: '' });
+        expect(hookReturns[idB][0]).toEqual({ sort: 'asc', filter: 'Namespace:stackrox' });
+
+        // Simulate page reload for the same configurations
+        const { result: resultA } = renderHook(() => useWidgetConfig(idA, '/', defaultConfig));
+        const { result: resultB } = renderHook(() => useWidgetConfig(idB, '/', defaultConfig));
+
+        // This check is important since all dashboard configurations are stored in a
+        // single object in local storage. This ensures that a write to one config does not result
+        // in data loss when a second config is saved.
+        expect(resultA.current[0]).toEqual({ sort: 'desc', filter: '' });
+        expect(resultB.current[0]).toEqual({ sort: 'asc', filter: 'Namespace:stackrox' });
+    });
+
+    it('should provide resiliency against invalid external writes to localStorage', () => {
+        const widgetId = 'single-component';
+        const routeId = '/';
+        const defaultConfig = { sort: 'asc', filter: '' };
+        let result;
+
+        // Write a value to the root widget config
+        function storeRootConfig(config) {
+            localStorage.setItem(defaultStorageKey, config);
+        }
+
+        // "Control" assertion to ensure pre-existing, type-compatible properties are saved and loaded correctly
+        storeRootConfig(
+            JSON.stringify({
+                [widgetId]: {
+                    [routeId]: {
+                        filter: 'Namespace:stackrox',
+                        sort: 'desc',
+                    },
+                },
+            })
+        );
+        ({ result } = renderHook(() => useWidgetConfig(widgetId, routeId, defaultConfig)));
+        expect(result.current[0]).toEqual({ sort: 'desc', filter: 'Namespace:stackrox' });
+
+        // Force overwrite top level config as a string instead of object
+        storeRootConfig('bogus-string');
+        ({ result } = renderHook(() => useWidgetConfig(widgetId, routeId, defaultConfig)));
+        expect(result.current[0]).toEqual(defaultConfig);
+
+        // Force overwrite individual widget config as a string instead of object
+        storeRootConfig(JSON.stringify({ [widgetId]: 'bogus-string' }));
+        ({ result } = renderHook(() => useWidgetConfig(widgetId, routeId, defaultConfig)));
+        expect(result.current[0]).toEqual(defaultConfig);
+
+        // Force overwrite individual widget route config as a string instead of object
+        storeRootConfig(JSON.stringify({ [widgetId]: { [routeId]: 'bogus-string' } }));
+        ({ result } = renderHook(() => useWidgetConfig(widgetId, routeId, defaultConfig)));
+        expect(result.current[0]).toEqual(defaultConfig);
+
+        // Force overwrite top level config as an invalid JSON object
+        storeRootConfig('{ "test": ["}""a }');
+        ({ result } = renderHook(() => useWidgetConfig(widgetId, routeId, defaultConfig)));
+        expect(result.current[0]).toEqual(defaultConfig);
+
+        // Force overwrite individual widget route config with incompatible types
+        storeRootConfig(
+            JSON.stringify({
+                [widgetId]: {
+                    [routeId]: {
+                        invalidKey: 'test',
+                        sort: [
+                            'valid key',
+                            'but',
+                            'invalid value type',
+                            '(should be a string, not array)',
+                        ],
+                        filter: true, // Should also be a string
+                    },
+                },
+            })
+        );
+        ({ result } = renderHook(() => useWidgetConfig(widgetId, routeId, defaultConfig)));
+        expect(result.current[0]).toEqual(defaultConfig);
+    });
+});

--- a/ui/apps/platform/src/hooks/useWidgetConfig.ts
+++ b/ui/apps/platform/src/hooks/useWidgetConfig.ts
@@ -1,0 +1,133 @@
+import { useCallback, useState } from 'react';
+import isPlainObject from 'lodash/isPlainObject';
+
+import { WidgetConfigStorage, RouteId, WidgetId, WidgetConfig } from 'types/widgetConfig';
+
+export type UseWidgetConfigReturn<ConfigT extends WidgetConfig, UpdateAction> = [
+    ConfigT,
+    (action: UpdateAction) => Promise<ConfigT>
+];
+
+export const defaultStorageKey = 'widgetConfigurations';
+
+function loadConfigs(): WidgetConfigStorage {
+    try {
+        const configs = localStorage.getItem(defaultStorageKey) ?? '{}';
+        return JSON.parse(configs) as WidgetConfigStorage;
+    } catch (err) {
+        return {};
+    }
+}
+
+// This attempts to do basic runtime checks of the stored value to avoid app errors
+// in the case of corrupted localStorage, usage from plain JS files, etc.
+//
+// This will ensure that the returned config:
+//  - is a regular object
+//  - contains all properties specified on the `defaultConfig` value provided to the hook
+//  - has property values that match the types on the provided `defaultConfig`
+//
+// This is not an exhaustive type check (won't check array length, union types, ...) but
+// should cover most possible error states.
+function loadSafeConfig<T>(widgetId: string, routeId: string, defaultConfig: T): T {
+    const rootConfigs = loadConfigs();
+    const parsedConfig = rootConfigs[widgetId]?.[routeId] ?? {};
+    const configObject = isPlainObject(parsedConfig) ? parsedConfig : {};
+    const cleanConfig = {};
+    Object.entries(defaultConfig).forEach(([defaultKey, defaultValue]) => {
+        if (configObject[defaultKey] && typeof configObject[defaultKey] === typeof defaultValue) {
+            cleanConfig[defaultKey] = configObject[defaultKey];
+        }
+    });
+    return { ...defaultConfig, ...cleanConfig };
+}
+
+function saveConfigs(newConfigs: WidgetConfigStorage): Promise<void> {
+    return new Promise((resolve, reject) => {
+        try {
+            localStorage.setItem(defaultStorageKey, JSON.stringify(newConfigs));
+            resolve();
+        } catch (error) {
+            reject(error);
+        }
+    });
+}
+
+/**
+ * Hook used to persist configuration for UI widgets. The current implementation uses
+ * localStorage, but this may be updated to load from the server in the future. Separate
+ * configurations are stored for the unique combination of a `widgetId` and a `routeId`, which
+ * can be used to store different configs for the same widget in multiple locations throughout
+ * the app.
+ *
+ * @param widgetId A unique identifier for a widget. All instances
+ *      of a widget sharing this identifier should use the same data type for
+ *      configuration storage.
+ * @param routeId
+ *      A route that identifies a specific instance of a configuration for
+ *      a widget. This is typically the URL pathname for a widget, but can be any `string`.
+ * @param defaultConfig
+ *      The default configuration to be used for this widget when initializing
+ *      storage, or as a fallback in case of errors.
+ * @param reducer
+ *      An optional update function used to make custom state updates to a widget config.
+ *
+ * @template ConfigT
+ *      The object type used for config storage.
+ * @template ActionT
+ *      The object type provided to the update function for updating the config. Defaults
+ *      to an object that is a partial version of the config type as the default update function
+ *      is a shallow object merge.
+ *
+ * @returns
+ *      A 2-tuple of the current state of the configuration and a function to update the
+ *      configuration. The update function defaults to merging the provided object with the current
+ *      state if no `reducer` parameter is provided.
+ */
+function useWidgetConfig<ConfigT extends WidgetConfig, ActionT = Partial<ConfigT>>(
+    widgetId: WidgetId,
+    routeId: RouteId,
+    defaultConfig: ConfigT,
+    reducer?: (oldConfig: ConfigT, action: ActionT) => ConfigT
+): UseWidgetConfigReturn<ConfigT, ActionT> {
+    const [widgetRouteConfig, setWidgetRouteConfig] = useState<ConfigT>(() => {
+        return loadSafeConfig<ConfigT>(widgetId, routeId, defaultConfig);
+    });
+
+    const configUpdateFn = useCallback(
+        (config) => {
+            const nextValue = reducer
+                ? reducer(widgetRouteConfig, config)
+                : { ...widgetRouteConfig, ...config };
+            // This helps ensure type-safety by applying the updated config on top of
+            // the defaults, e.g. in cases where a custom reducer that deleted these properties.
+            // This is not possible in TypeScript but will prevent plain JS implementations from
+            // breaking TS consumers at runtime.
+            const mergedDefault: ConfigT = { ...defaultConfig, ...nextValue };
+
+            // Note, when persisting changes we need to load in the saved configs for all
+            // widgets instead of keeping the value in state because it is possible
+            // that other widgets will save changes after this instance of the hook has been initialized.
+            // If we kept the top level config value in state, unrelated changes would be overwritten.
+            const rootConfigs = loadConfigs();
+            const widgetConfigs = rootConfigs[widgetId] ?? {};
+            const newConfigs = {
+                ...rootConfigs,
+                [widgetId]: {
+                    ...widgetConfigs,
+                    [routeId]: {
+                        ...widgetRouteConfig,
+                        ...mergedDefault,
+                    },
+                },
+            };
+            setWidgetRouteConfig(mergedDefault);
+            return saveConfigs(newConfigs).then(() => mergedDefault);
+        },
+        [widgetId, routeId, defaultConfig, reducer, widgetRouteConfig]
+    );
+
+    return [widgetRouteConfig, configUpdateFn];
+}
+
+export default useWidgetConfig;

--- a/ui/apps/platform/src/types/widgetConfig.ts
+++ b/ui/apps/platform/src/types/widgetConfig.ts
@@ -1,0 +1,31 @@
+// The main configuration storage type. Reading directly from localStorage would provide this type
+// of result at the top level.
+export type WidgetConfigStorage = Record<WidgetId, WidgetConfigMap>;
+
+// A unique identifier for a widget. Short term this will be the name of the widget, but if
+// we move to server side storage this could become a UUID.
+export type WidgetId = string;
+
+// A configuration object that maps routes to configurations for a specific widget.
+type WidgetConfigMap = Partial<Record<RouteId, WidgetConfig>>;
+
+// A path identifier in the application. This should be a route that maps to a route in the app, with a hash
+// parameter used to reference individual sections of a page.
+//
+// e.g. /main/dashboard
+//      /main/dashboard/trends-tab
+//      /main/dashboard/trends-tab#modal
+//      /main/dashboard/trends-tab#sidebar
+export type RouteId = string;
+
+// Configuration read for a single instance of a widget.
+export type WidgetConfig = Partial<Record<string, ConfigOptionValue>>;
+
+// A widget config is an object that can contain the following properties
+type ConfigOptionValue = OneOfValue | AnyOfValue | ToggleValue | ToggleValue[];
+// A simple, single string value. Used when the user can select exactly one option from a selection.
+type OneOfValue = string | number;
+// An array of selected options.
+type AnyOfValue = string[] | number[];
+// An editable value that can be toggled on or off.
+type ToggleValue = { enabled: boolean; value: number | string | boolean };


### PR DESCRIPTION
## Description

Adds a `useWidgetStorage` hook that will be used to persist widget configuration options across relevant dashboard widgets. Implementation for the current dashboard widgets will come in a follow up PR.

This hook implementation will use `localStorage` and store widget data under a single key in a structure like the following:
```javascript
{
    violationsByCategory: {
        '/main/dashboard': {
            sortBy: 'Severity',
            lifecycle: 'All',
        },
        '/some/other/page': {
            sortBy: 'Total',
            lifecycle: 'Deploy',
        },
    },
    agingImages: {
        '/main/dashboard': {
            ...
        },
    }
};
```

Note that this does not use our existing `useLocalStorage` hook due to the configurations being stored under a single key. I started out on that path but realized that I would run into issues with:
- Multiple unrelated changes overwriting existing configs with stale data
- **All** components using this hook on the same page re-rendering when any single one changed

## Known limitations

- If you were to use a widget on the same page more than one, with an identical `widgetId` and identical `routeId`, config changes would not update in-memory for the two widgets. I don't think this is a use case we will need to support but I wanted to mention it.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

Unit tests for hook included.
