### PR TITLE
[ROX-11954] Add support for nested scoping in Postgres

### DIFF
--- a/central/cluster/datastore/datastore_impl_postgres_test.go
+++ b/central/cluster/datastore/datastore_impl_postgres_test.go
@@ -139,193 +139,224 @@ func (s *ClusterPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 	s.NoError(s.nsDatastore.UpdateNamespace(ctx, ns1C2))
 
 	for _, tc := range []struct {
-		desc         string
-		ctx          context.Context
-		query        *v1.Query
-		orderMatters bool
-		expectedIDs  []string
-		queryNs      bool
+		desc        string
+		ctx         context.Context
+		query       *v1.Query
+		expectedIDs []string
+		queryNs     bool
 	}{
 		{
-			desc:         "Search clusters with empty query",
-			ctx:          ctx,
-			query:        pkgSearch.EmptyQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{c1ID, c2ID},
+			desc:  "Search clusters with empty query",
+			ctx:   ctx,
+			query: pkgSearch.EmptyQuery(),
+
+			expectedIDs: []string{c1ID, c2ID},
 		},
 		{
-			desc:         "Search clusters with cluster query",
-			ctx:          ctx,
-			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.ClusterID, c1ID).ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{c1ID},
+			desc:  "Search clusters with cluster query",
+			ctx:   ctx,
+			query: pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.ClusterID, c1ID).ProtoQuery(),
+
+			expectedIDs: []string{c1ID},
 		},
 		{
-			desc:         "Search clusters with namespace query",
-			ctx:          ctx,
-			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n2").ProtoQuery(),
-			orderMatters: true,
-			expectedIDs:  []string{c1ID},
+			desc:        "Search clusters with namespace query",
+			ctx:         ctx,
+			query:       pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n2").ProtoQuery(),
+			expectedIDs: []string{c1ID},
 		},
 		{
-			desc:         "Search clusters with cluster+namespace query",
-			ctx:          ctx,
-			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n1").AddMapQuery(pkgSearch.ClusterLabel, "team", "team").ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{c1ID, c2ID},
+			desc:  "Search clusters with cluster+namespace query",
+			ctx:   ctx,
+			query: pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n1").AddMapQuery(pkgSearch.ClusterLabel, "team", "team").ProtoQuery(),
+
+			expectedIDs: []string{c1ID, c2ID},
 		},
 		{
-			desc:         "Search clusters with cluster scope",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
-			query:        pkgSearch.EmptyQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{c1ID},
+			desc:  "Search clusters with cluster scope",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
+			query: pkgSearch.EmptyQuery(),
+
+			expectedIDs: []string{c1ID},
 		},
 		{
-			desc:         "Search clusters with cluster scope and in-scope cluster query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
-			query:        pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "prod").ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{c1ID},
+			desc:  "Search clusters with cluster scope and in-scope cluster query",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
+			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "prod").ProtoQuery(),
+
+			expectedIDs: []string{c1ID},
 		},
 		{
-			desc:         "Search clusters with cluster scope and out-of-scope cluster query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
-			query:        pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "test").ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{},
+			desc:  "Search clusters with cluster scope and out-of-scope cluster query",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
+			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "test").ProtoQuery(),
+
+			expectedIDs: []string{},
 		},
 		{
-			desc:         "Search clusters with cluster scope and in-scope namespace query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
-			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n1").ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{c1ID},
+			desc:  "Search clusters with cluster scope and in-scope namespace query",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
+			query: pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n1").ProtoQuery(),
+
+			expectedIDs: []string{c1ID},
 		},
 		{
-			desc:         "Search clusters with cluster scope and out-of-scope namespace query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: c2ID, Level: v1.SearchCategory_CLUSTERS}),
-			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n2").ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{},
+			desc:  "Search clusters with cluster scope and out-of-scope namespace query",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: c2ID, Level: v1.SearchCategory_CLUSTERS}),
+			query: pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n2").ProtoQuery(),
+
+			expectedIDs: []string{},
 		},
 		{
-			desc:         "Search clusters with namespace scope",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
-			query:        pkgSearch.EmptyQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{c1ID},
+			desc:  "Search clusters with namespace scope",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			query: pkgSearch.EmptyQuery(),
+
+			expectedIDs: []string{c1ID},
 		},
 		{
-			desc:         "Search clusters with namespace scope and in-scope cluster query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
-			query:        pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "prod").ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{c1ID},
+			desc:  "Search clusters with namespace scope and in-scope cluster query",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "prod").ProtoQuery(),
+
+			expectedIDs: []string{c1ID},
 		},
 		{
-			desc:         "Search clusters with namespace scope and out-of-scope cluster query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
-			query:        pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "test").ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{},
+			desc:  "Search clusters with namespace scope and out-of-scope cluster query",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "test").ProtoQuery(),
+
+			expectedIDs: []string{},
 		},
 
 		{
-			desc:         "Search namespaces with empty query",
-			ctx:          ctx,
-			query:        pkgSearch.EmptyQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{ns1C1.Id, ns2C1.Id, ns1C2.Id},
-			queryNs:      true,
+			desc:  "Search namespaces with empty query",
+			ctx:   ctx,
+			query: pkgSearch.EmptyQuery(),
+
+			expectedIDs: []string{ns1C1.Id, ns2C1.Id, ns1C2.Id},
+			queryNs:     true,
 		},
 		{
-			desc:         "Search namespaces with cluster query",
-			ctx:          ctx,
-			query:        pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "test").ProtoQuery(),
-			orderMatters: true,
-			expectedIDs:  []string{ns1C2.Id},
-			queryNs:      true,
+			desc:        "Search namespaces with cluster query",
+			ctx:         ctx,
+			query:       pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "test").ProtoQuery(),
+			expectedIDs: []string{ns1C2.Id},
+			queryNs:     true,
 		},
 		{
-			desc:         "Search namespaces with cluster+namespace query",
-			ctx:          ctx,
-			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n1").AddMapQuery(pkgSearch.ClusterLabel, "team", "team").ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{ns1C1.Id, ns1C2.Id},
-			queryNs:      true,
+			desc:  "Search namespaces with cluster+namespace query",
+			ctx:   ctx,
+			query: pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n1").AddMapQuery(pkgSearch.ClusterLabel, "team", "team").ProtoQuery(),
+
+			expectedIDs: []string{ns1C1.Id, ns1C2.Id},
+			queryNs:     true,
 		},
 		{
-			desc:         "Search namespaces with cluster+namespace non-matching search fields",
-			ctx:          ctx,
-			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n1").AddMapQuery(pkgSearch.ClusterLabel, "team", "blah").ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{},
-			queryNs:      true,
+			desc:  "Search namespaces with cluster+namespace non-matching search fields",
+			ctx:   ctx,
+			query: pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n1").AddMapQuery(pkgSearch.ClusterLabel, "team", "blah").ProtoQuery(),
+
+			expectedIDs: []string{},
+			queryNs:     true,
 		},
 		{
-			desc:         "Search namespace with namespace scope",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
-			query:        pkgSearch.EmptyQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{ns1C1.Id},
-			queryNs:      true,
+			desc:  "Search namespace with namespace scope",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			query: pkgSearch.EmptyQuery(),
+
+			expectedIDs: []string{ns1C1.Id},
+			queryNs:     true,
 		},
 		{
-			desc:         "Search namespace with namespace scope and in-scope cluster query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
-			query:        pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "prod").ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{ns1C1.Id},
-			queryNs:      true,
+			desc:  "Search namespace with namespace scope and in-scope cluster query",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "prod").ProtoQuery(),
+
+			expectedIDs: []string{ns1C1.Id},
+			queryNs:     true,
 		},
 		{
-			desc:         "Search namespace with namespace scope and out-of-scope cluster query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
-			query:        pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "test").ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{},
-			queryNs:      true,
+			desc:  "Search namespace with namespace scope and out-of-scope cluster query",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "test").ProtoQuery(),
+
+			expectedIDs: []string{},
+			queryNs:     true,
 		},
 		{
-			desc:         "Search namespace with namespace scope and in-scope namespace query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
-			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n1").ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{ns1C1.Id},
-			queryNs:      true,
+			desc:  "Search namespace with namespace scope and in-scope namespace query",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			query: pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n1").ProtoQuery(),
+
+			expectedIDs: []string{ns1C1.Id},
+			queryNs:     true,
 		},
 		{
-			desc:         "Search namespace with namespace scope and out-of-scope namespace query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
-			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n2").ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{},
-			queryNs:      true,
+			desc:  "Search namespace with namespace scope and out-of-scope namespace query",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			query: pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n2").ProtoQuery(),
+
+			expectedIDs: []string{},
+			queryNs:     true,
 		},
 		{
-			desc:         "Search namespaces with cluster scope",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
-			query:        pkgSearch.EmptyQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{ns1C1.Id, ns2C1.Id},
-			queryNs:      true,
+			desc:  "Search namespaces with cluster scope",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
+			query: pkgSearch.EmptyQuery(),
+
+			expectedIDs: []string{ns1C1.Id, ns2C1.Id},
+			queryNs:     true,
 		},
 		{
-			desc:         "Search namespaces with cluster scope and in-scope cluster query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
-			query:        pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "prod").ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{ns1C1.Id, ns2C1.Id},
-			queryNs:      true,
+			desc:  "Search namespaces with cluster scope and in-scope cluster query",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
+			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "prod").ProtoQuery(),
+
+			expectedIDs: []string{ns1C1.Id, ns2C1.Id},
+			queryNs:     true,
 		},
 		{
-			desc:         "Search namespaces with cluster scope and out-of-scope cluster query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
-			query:        pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "test").ProtoQuery(),
-			orderMatters: false,
-			expectedIDs:  []string{},
-			queryNs:      true,
+			desc:  "Search namespaces with cluster scope and out-of-scope cluster query",
+			ctx:   scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
+			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "test").ProtoQuery(),
+
+			expectedIDs: []string{},
+			queryNs:     true,
+		},
+		{
+			desc: "Search namespaces with cluster+namespace scope",
+			ctx: scoped.Context(ctx,
+				scoped.Scope{
+					ID:    ns1C1.Id,
+					Level: v1.SearchCategory_NAMESPACES,
+					Parent: &scoped.Scope{
+						ID:    c1ID,
+						Level: v1.SearchCategory_CLUSTERS,
+					},
+				},
+			),
+			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "prod").ProtoQuery(),
+
+			expectedIDs: []string{ns1C1.Id},
+			queryNs:     true,
+		},
+		{
+			desc: "Search namespaces with cluster+namespace scope and out-of-scope cluster query",
+			ctx: scoped.Context(ctx,
+				scoped.Scope{
+					ID:    ns1C1.Id,
+					Level: v1.SearchCategory_NAMESPACES,
+					Parent: &scoped.Scope{
+						ID:    c1ID,
+						Level: v1.SearchCategory_CLUSTERS,
+					},
+				},
+			),
+			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "test").ProtoQuery(),
+
+			expectedIDs: []string{},
+			queryNs:     true,
 		},
 	} {
 		s.T().Run(tc.desc, func(t *testing.T) {
@@ -339,11 +370,7 @@ func (s *ClusterPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 			assert.NoError(t, err)
 			assert.Len(t, actual, len(tc.expectedIDs))
 			actualIDs := pkgSearch.ResultsToIDs(actual)
-			if tc.orderMatters {
-				assert.Equal(t, tc.expectedIDs, actualIDs)
-			} else {
-				assert.ElementsMatch(t, tc.expectedIDs, actualIDs)
-			}
+			assert.ElementsMatch(t, tc.expectedIDs, actualIDs)
 		})
 	}
 }

--- a/pkg/postgres/walker/schema.go
+++ b/pkg/postgres/walker/schema.go
@@ -283,7 +283,7 @@ func (s *Schema) ID() Field {
 			return f
 		}
 	}
-	// If there is only one primary key, that is considered Id column by default even if not specified explicitly.
+	// If there is only one primary key, that is considered ID column by default even if not specified explicitly.
 	pks := s.PrimaryKeys()
 	if len(pks) == 1 {
 		return pks[0]

--- a/pkg/search/scoped/context.go
+++ b/pkg/search/scoped/context.go
@@ -32,6 +32,20 @@ func Context(ctx context.Context, scope Scope) context.Context {
 	})
 }
 
+// GetAllScopes returns all the scopes in the scope chain from the input context as well as a boolean indicating if there was a Scope attached.
+func GetAllScopes(ctx context.Context) ([]Scope, bool) {
+	scope, found := GetScope(ctx)
+	if !found {
+		return nil, false
+	}
+	ret := []Scope{scope}
+	for scope.Parent != nil {
+		ret = append(ret, *scope.Parent)
+		scope = *scope.Parent
+	}
+	return ret, len(ret) > 0
+}
+
 // GetScope returns the Scope from the input context as well as a boolean indicating if there was a Scope attached.
 func GetScope(hasGraphContext context.Context) (Scope, bool) {
 	if hasGraphContext == nil {

--- a/pkg/search/scoped/postgres/searcher_test.go
+++ b/pkg/search/scoped/postgres/searcher_test.go
@@ -1,0 +1,82 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/dackbox/keys/transformation"
+	"github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/mocks"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
+	"github.com/stackrox/rox/pkg/search/scoped"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestWithScoping(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(scopedSearcherTestSuite))
+}
+
+type scopedSearcherTestSuite struct {
+	suite.Suite
+
+	mockSearcher *mocks.MockSearcher
+
+	mockCtrl *gomock.Controller
+}
+
+func (s *scopedSearcherTestSuite) SetupTest() {
+	s.mockCtrl = gomock.NewController(s.T())
+	s.mockSearcher = mocks.NewMockSearcher(s.mockCtrl)
+}
+
+func (s *scopedSearcherTestSuite) TearDownTest() {
+	s.mockCtrl.Finish()
+}
+
+func (s *scopedSearcherTestSuite) TestScoping() {
+	mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTERS, schema.ClustersSchema)
+	mapping.RegisterCategoryToTable(v1.SearchCategory_NAMESPACES, schema.NamespacesSchema)
+
+	query := search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "dep").ProtoQuery()
+	scopes := []scoped.Scope{
+		{
+			ID:    "c1",
+			Level: v1.SearchCategory_CLUSTERS,
+		},
+	}
+	expected := search.ConjunctionQuery(
+		query,
+		search.NewQueryBuilder().AddExactMatches(search.ClusterID, "c1").ProtoQuery(),
+	)
+	actual, err := scopeQuery(query, scopes)
+	s.NoError(err)
+	s.Equal(expected, actual)
+
+	scopes = []scoped.Scope{
+		{
+			ID:    "c1",
+			Level: v1.SearchCategory_CLUSTERS,
+		},
+		{
+			ID:    "n1",
+			Level: v1.SearchCategory_NAMESPACES,
+		},
+	}
+	expected = search.ConjunctionQuery(
+		query,
+		search.NewQueryBuilder().AddExactMatches(search.ClusterID, "c1").ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.NamespaceID, "n1").ProtoQuery(),
+	)
+	actual, err = scopeQuery(query, scopes)
+	s.NoError(err)
+	s.Equal(expected, actual)
+}
+
+type testProvider map[v1.SearchCategory]transformation.OneToMany
+
+func (tp testProvider) Get(sc v1.SearchCategory) transformation.OneToMany {
+	return tp[sc]
+}

--- a/pkg/search/scoped/postgres/searcher_test.go
+++ b/pkg/search/scoped/postgres/searcher_test.go
@@ -3,40 +3,15 @@ package postgres
 import (
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/pkg/dackbox/keys/transformation"
 	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/search"
-	"github.com/stackrox/rox/pkg/search/mocks"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 	"github.com/stackrox/rox/pkg/search/scoped"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestWithScoping(t *testing.T) {
-	t.Parallel()
-	suite.Run(t, new(scopedSearcherTestSuite))
-}
-
-type scopedSearcherTestSuite struct {
-	suite.Suite
-
-	mockSearcher *mocks.MockSearcher
-
-	mockCtrl *gomock.Controller
-}
-
-func (s *scopedSearcherTestSuite) SetupTest() {
-	s.mockCtrl = gomock.NewController(s.T())
-	s.mockSearcher = mocks.NewMockSearcher(s.mockCtrl)
-}
-
-func (s *scopedSearcherTestSuite) TearDownTest() {
-	s.mockCtrl.Finish()
-}
-
-func (s *scopedSearcherTestSuite) TestScoping() {
+func TestScoping(t *testing.T) {
 	mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTERS, schema.ClustersSchema)
 	mapping.RegisterCategoryToTable(v1.SearchCategory_NAMESPACES, schema.NamespacesSchema)
 
@@ -52,8 +27,8 @@ func (s *scopedSearcherTestSuite) TestScoping() {
 		search.NewQueryBuilder().AddExactMatches(search.ClusterID, "c1").ProtoQuery(),
 	)
 	actual, err := scopeQuery(query, scopes)
-	s.NoError(err)
-	s.Equal(expected, actual)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
 
 	scopes = []scoped.Scope{
 		{
@@ -71,12 +46,6 @@ func (s *scopedSearcherTestSuite) TestScoping() {
 		search.NewQueryBuilder().AddExactMatches(search.NamespaceID, "n1").ProtoQuery(),
 	)
 	actual, err = scopeQuery(query, scopes)
-	s.NoError(err)
-	s.Equal(expected, actual)
-}
-
-type testProvider map[v1.SearchCategory]transformation.OneToMany
-
-func (tp testProvider) Get(sc v1.SearchCategory) transformation.OneToMany {
-	return tp[sc]
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
## Description

Add support for nested scoping in Postgres. Scoped context is used primarily in graphQL to control the scope of the query result. Now that the graphQL has been streamlined, the scope chain built in graphQL is guaranteed to contain supported hierarchy. For example, combinations like namespace+node+vuln will no require occur.

**This functionality was not available previously.**

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
