### PR TITLE
make gke-upgrade-test fail with message on value comparison

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -76,6 +76,26 @@ is_linux() {
     uname -a | grep -i linux >/dev/null 2>&1
 }
 
+test_equals_non_silent() {
+  if [[ "$#" -lt 2 ]]; then
+    die "usage: test_equals_non_silent <arg1> <arg2>"
+  fi
+
+  if [[ "$1" != "$2" ]]; then
+    die "Comparison failed: \"$1\" != \"$2\""
+  fi
+}
+
+test_gt_non_silent() {
+  if [[ "$#" -lt 2 ]]; then
+    die "usage: test_gt_non_silent <arg1> <arg2>"
+  fi
+
+  if [[ "$1"  -le "$2" ]]; then
+    die "Comparison failed: \"$1\" <= \"$2\""
+  fi
+}
+
 require_environment() {
     if [[ "$#" -lt 1 ]]; then
         die "usage: require_environment NAME [reason]"

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -444,10 +444,10 @@ force_rollback() {
     local upgradeStatus
     upgradeStatus="$(curl -sSk -X GET -u "admin:$ROX_PASSWORD" "https://$API_ENDPOINT/v1/centralhealth/upgradestatus")"
     echo "upgrade status: $upgradeStatus"
-    [[ "$(echo "$upgradeStatus" | jq '.upgradeStatus.version' -r)" == "$(make --quiet tag)" ]]
-    [[ "$(echo "$upgradeStatus" | jq '.upgradeStatus.forceRollbackTo' -r)" == "$FORCE_ROLLBACK_VERSION" ]]
-    [[ "$(echo "$upgradeStatus" | jq '.upgradeStatus.canRollbackAfterUpgrade' -r)" == "true" ]]
-    [[ "$(echo "$upgradeStatus" | jq '.upgradeStatus.spaceAvailableForRollbackAfterUpgrade' -r)" -gt "$(echo "$upgradeStatus" | jq '.upgradeStatus.spaceRequiredForRollbackAfterUpgrade' -r)" ]]
+    test_equals_non_silent "$(echo "$upgradeStatus" | jq '.upgradeStatus.version' -r)" "$(make --quiet tag)"
+    test_equals_non_silent "$(echo "$upgradeStatus" | jq '.upgradeStatus.forceRollbackTo' -r)" "$FORCE_ROLLBACK_VERSION"
+    test_equals_non_silent "$(echo "$upgradeStatus" | jq '.upgradeStatus.canRollbackAfterUpgrade' -r)" "true"
+    test_gt_non_silent "$(echo "$upgradeStatus" | jq '.upgradeStatus.spaceAvailableForRollbackAfterUpgrade' -r)" "$(echo "$upgradeStatus" | jq '.upgradeStatus.spaceRequiredForRollbackAfterUpgrade' -r)"
 
     kubectl -n stackrox get configmap/central-config -o yaml | yq e '{"data": .data}' - >/tmp/force_rollback_patch
     local central_config


### PR DESCRIPTION
## Description

`test` function(often used as `[[ expression ]]`), when returning exit code 1, does not produce any message. This leads to upgrade test script to fail silently in some cases, making it harder to pinpoint the error. 

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Locally tested new functions
2. CI
