### PR TITLE
ROX-11511: Wait for expected requests to reach a destination integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/clusters.js
+++ b/ui/apps/platform/cypress/helpers/clusters.js
@@ -2,6 +2,7 @@ import * as api from '../constants/apiEndpoints';
 import { clustersUrl, selectors } from '../constants/ClustersPage';
 
 import { visitFromLeftNavExpandable } from './nav';
+import { interactAndWaitForResponses } from './request';
 import { visit } from './visit';
 
 const routeMatcherMap = {
@@ -20,6 +21,16 @@ const routeMatcherMap = {
 };
 
 // Navigation
+
+/*
+ * Reach clusters by interaction from another container.
+ * For example, click View All button from System Health.
+ */
+export function reachClusters(interactionCallback, staticResponseMap) {
+    interactAndWaitForResponses(interactionCallback, { routeMatcherMap }, staticResponseMap);
+
+    cy.get(selectors.clustersListHeading).contains('Clusters');
+}
 
 export function visitClustersFromLeftNav() {
     visitFromLeftNavExpandable('Platform Configuration', 'Clusters', { routeMatcherMap });

--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -59,3 +59,14 @@ export function waitForResponses(requestConfig) {
         cy.wait(aliases, waitOptions);
     }
 }
+
+/*
+ * Intercept requests before interaction and then wait for responses.
+ */
+export function interactAndWaitForResponses(interactionCallback, requestConfig, staticResponseMap) {
+    interceptRequests(requestConfig, staticResponseMap);
+
+    interactionCallback();
+
+    waitForResponses(requestConfig);
+}

--- a/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
@@ -1,6 +1,7 @@
 import { clustersUrl } from '../../constants/ClustersPage';
 import { selectors } from '../../constants/SystemHealth';
 import withAuth from '../../helpers/basicAuth';
+import { reachClusters } from '../../helpers/clusters';
 import { setClock, visitSystemHealth } from '../../helpers/systemHealth';
 
 function visitSystemHealthWithClustersFixtureFilteredByNames(fixturePath, clusterNames) {
@@ -19,9 +20,10 @@ describe('System Health Clusters without fixture', () => {
     it('should go to Clusters via click View All', () => {
         visitSystemHealth();
 
-        cy.get(selectors.clusters.viewAllButton).click();
+        reachClusters(() => {
+            cy.get(selectors.clusters.viewAllButton).click();
+        });
         cy.location('pathname').should('eq', clustersUrl);
-        cy.get('h1:contains("Clusters")');
     });
 });
 


### PR DESCRIPTION
## Description

> System Health Clusters with fixture should have counts in Cluster Overview

> The following error originated from your application code, not from Cypress. It was caused by an unhandled promise rejection.

> Network Error

cypress/integration/systemHealth/clusters.test.js

### Analysis

Previous test in the file passes quickly with assertions which do not depend on responses to requests like /v1/clusters for Clusters page:

```js
        cy.location('pathname').should('eq', clustersUrl);
        cy.get('h1:contains("Clusters")');
```

Current test calls `cy.clock` and then `cy.intercept` to provide a fixture for /v1/clusters request **before** it visits System Health page:

```js
        setClock(currentDatetime); // call before visit
        visitSystemHealth({
            clusters: { fixture: clustersFixturePath },
        });
```

Because the previous test did not wait for a response to /v1/clusters request, a fixture for /v1/clusters request apparently can cause the in-flight request to fail, if the current test starts too soon.

Network Error has been a frequent failure for a small set of tests, which we knew had fixtures, involved clusters, and which will probably discover have timing problems between adjacent tests.

1. Cypress snapshot
    * Previous test `'should go to Clusters via click View All'` passed, but: **No clusters to show**
    * Current test `'System Health Clusters with fixture'` has no `beforeEach` block, which has puzzled me before this
    * BEFORE EACH in side panel displays requests to visit /main/clusters for previous test, instead of to visit /main/system-health for current test, which might be a diagnostic clue to other occurrences of this problem
    * TEST BODY in side panel displays `cy.clock` call for current test

    ![prow](https://user-images.githubusercontent.com/11862657/180851760-428cd908-e94a-4b00-8910-cc0da3688b2e.png)

2. Diagnostic bundle logimbue-data.json

    * Request from previous test for /main/system-health

        ```js
            {
            "timestamp": 1658558467.457,
            "type": "http",
            "category": "xhr",
            "data": { "method": "GET", "url": "/v1/clusters", "status_code": 200 }
            },
        ```

    * Action from previous test to click **View All** button

        ```js
        {
          "timestamp": 1658558467.751,
          "category": "ui.click",
          "message": "a.btn-sm.btn-base.whitespace-nowrap.no-underline"
        },
        {
          "timestamp": 1658558467.752,
          "category": "navigation",
          "data": { "to": "/main/clusters", "from": "/main/system-health" }
        },
        ```

    * Requests from previous test for /main/clusters

        ```js
        {
          "timestamp": 1658558468.21,
          "type": "http",
          "category": "xhr",
          "data": {
            "method": "GET",
            "url": "/v1/sensorupgrades/config",
            "status_code": 200
          }
        },
        {
          "timestamp": 1658558468.257,
          "type": "http",
          "category": "xhr",
          "data": {
            "method": "POST",
            "url": "/api/graphql?opname=searchOptions",
            "status_code": 200
          }
        },
        {
          "timestamp": 1658558468.26,
          "type": "http",
          "category": "xhr",
          "data": { "method": "GET", "url": "/v1/clusters", "status_code": 0 }
        },
        ```

### Solution

Add `interactAndWaitForResponses` which is similar but more generic than `visit` helper function.

### Residue

1. Investigate whether this pattern solves frequent Network Error failures for some skipped tests.
2. Apply this pattern to tests for other containers and to other interactions than address changes.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Ran the pair of adjacent tests in local deployment

See that the first test waits for /v1/clusters request
<img width="1440" alt="local-interact" src="https://user-images.githubusercontent.com/11862657/180851864-51d5f113-b862-4b05-9392-03488ebb8551.png">

