### PR TITLE
ROX-11136 implementation for action widget config persistence

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
@@ -54,7 +54,7 @@ jest.mock('hooks/useResizeObserver', () => ({
 }));
 
 beforeEach(() => {
-    jest.resetModules();
+    localStorage.clear();
 });
 
 const setup = () => {

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
@@ -95,7 +95,7 @@ jest.mock('hooks/useResizeObserver', () => ({
 }));
 
 beforeEach(() => {
-    jest.resetModules();
+    localStorage.clear();
 });
 
 const setup = () => {

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import {
     Flex,
     FlexItem,
@@ -22,6 +23,7 @@ import { sortBy } from 'lodash';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import useURLSearch from 'hooks/useURLSearch';
+import useWidgetConfig from 'hooks/useWidgetConfig';
 import { SearchFilter } from 'types/search';
 
 import {
@@ -118,10 +120,17 @@ type AggregationResult = {
 
 type SortBy = 'asc' | 'desc';
 
+const defaultConfig = { sortDataBy: 'asc' } as const;
+
 function ComplianceLevelsByStandard() {
     const { isOpen: isOptionsOpen, onToggle: toggleOptionsOpen } = useSelectToggle();
     const { searchFilter } = useURLSearch();
-    const [sortDataBy, setSortDataBy] = useState<SortBy>('asc');
+    const { pathname } = useLocation();
+    const [{ sortDataBy }, updateConfig] = useWidgetConfig<{ sortDataBy: SortBy }>(
+        'ComplianceLevelsByStandard',
+        pathname,
+        defaultConfig
+    );
 
     const where = getRequestQueryStringForSearchFilter({
         // We always need to include some value for Cluster, otherwise aggregation will be performed at the namespace level
@@ -173,13 +182,13 @@ function ComplianceLevelsByStandard() {
                                             text="Ascending"
                                             buttonId={`${fieldIdPrefix}-sort-by-asc`}
                                             isSelected={sortDataBy === 'asc'}
-                                            onChange={() => setSortDataBy('asc')}
+                                            onChange={() => updateConfig({ sortDataBy: 'asc' })}
                                         />
                                         <ToggleGroupItem
                                             text="Descending"
                                             buttonId={`${fieldIdPrefix}-sort-by-desc`}
                                             isSelected={sortDataBy === 'desc'}
-                                            onChange={() => setSortDataBy('desc')}
+                                            onChange={() => updateConfig({ sortDataBy: 'desc' })}
                                         />
                                     </ToggleGroup>
                                 </FormGroup>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
@@ -67,7 +67,7 @@ jest.mock('hooks/useResizeObserver', () => ({
 }));
 
 beforeEach(() => {
-    jest.resetModules();
+    localStorage.clear();
 });
 
 function setup() {

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
@@ -48,6 +48,10 @@ jest.mock('Containers/Dashboard/PatternFly/hooks/useAlertGroups', () => {
     };
 });
 
+beforeEach(() => {
+    localStorage.clear();
+});
+
 const setup = () => {
     const user = userEvent.setup();
     const utils = renderWithRouter(<ViolationsByPolicyCategory />);

--- a/ui/apps/platform/src/types/widgetConfig.ts
+++ b/ui/apps/platform/src/types/widgetConfig.ts
@@ -19,13 +19,13 @@ type WidgetConfigMap = Partial<Record<RouteId, WidgetConfig>>;
 export type RouteId = string;
 
 // Configuration read for a single instance of a widget.
-export type WidgetConfig = Partial<Record<string, ConfigOptionValue>>;
+export type WidgetConfig = Readonly<Partial<Record<string, ConfigOptionValue>>>;
 
 // A widget config is an object that can contain the following properties
-type ConfigOptionValue = OneOfValue | AnyOfValue | ToggleValue | ToggleValue[];
+type ConfigOptionValue = OneOfValue | AnyOfValue | ToggleValue | Readonly<ToggleValue[]>;
 // A simple, single string value. Used when the user can select exactly one option from a selection.
 type OneOfValue = string | number;
 // An array of selected options.
-type AnyOfValue = string[] | number[];
+type AnyOfValue = readonly string[] | readonly number[];
 // An editable value that can be toggled on or off.
-type ToggleValue = { enabled: boolean; value: number | string | boolean };
+type ToggleValue = Readonly<{ enabled: boolean; value: number | string | boolean }>;


### PR DESCRIPTION
## Description

This implements the `useWidgetConfig` hook to persist dashboard options in local storage.

Note: This hook makes a _synchronous_ read of local storage each time it is initialized as the starting state for an internal `useState` hook. If we transition this persistence to live on the backend in the future we will need to pull the initial call up to a higher level (Redux, useContext, react-query cache (?)) than it is in the current components.  An async read here will cause many of these components to make two network calls on mount; one when all the component has are the default options, and another when the saved options are loaded.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

- Edit existing unit/integration tests in response to failures (dirty local storage state between test runs).

Load the dashboard and update widget options:

- In "Images at most risk", set Image vulns to "All CVEs" and Image status to "All images"
- In "Aging images", deselect time buckets 1 and 3, and also set time bucket 4 to 265 days
- In "Policy violations by severity", set Sort by to "Total" and Lifecycle to "Deploy"
- In "Policy violations by severity" toggle _off_ the Critical, Medium, and Low violations via the legend
- In "Compliance by standard", set Sort By to "descending"

Refresh the page, and check that the above options for each widget remain set.

Visit other pages in the app and then revisit the dashboard via the "Dashboard" navigation link and check that the above options for each widget remain set.
