### PR TITLE
ROX-11307: Sort auth provider types in API response

### DIFF
--- a/central/authprovider/service/service_impl.go
+++ b/central/authprovider/service/service_impl.go
@@ -121,6 +121,12 @@ func (s *serviceImpl) ListAvailableProviderTypes(_ context.Context, _ *v1.Empty)
 			SuggestedAttributes: attributes,
 		})
 	}
+
+	// List auth providers in the same order for consistency across requests.
+	sort.Slice(supportedTypes, func(i, j int) bool {
+		return supportedTypes[i].GetType() < supportedTypes[j].GetType()
+	})
+
 	return &v1.AvailableProviderTypesResponse{
 		AuthProviderTypes: supportedTypes,
 	}, nil


### PR DESCRIPTION
## Description

Prior to this patch, `"/v1/availableAuthProviders"` / `ListAvailableProviderTypes()` API endpoint returned items in random order, which was not overridden in the UI. To improve user experience, items are now lexicographically sorted by their type.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Launched Central and verified the order stays the same and lexicographic.
<img width="1174" alt="Screenshot 2022-07-26 at 17 14 53" src="https://user-images.githubusercontent.com/2613999/181045539-a70ec07c-6023-4107-ad52-0e8af81aa244.png">