### PR TITLE
Fix a couple of UI tests flakes

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
@@ -6,8 +6,6 @@ import '@testing-library/jest-dom/extend-expect';
 import renderWithRouter from 'test-utils/renderWithRouter';
 import ViolationsByPolicyCategory from 'Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory';
 
-jest.setTimeout(10000);
-
 jest.mock('@patternfly/react-charts', () => {
     const { Chart, ...rest } = jest.requireActual('@patternfly/react-charts');
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
@@ -6,6 +6,8 @@ import '@testing-library/jest-dom/extend-expect';
 import renderWithRouter from 'test-utils/renderWithRouter';
 import ViolationsByPolicyCategory from 'Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory';
 
+jest.setTimeout(10000);
+
 jest.mock('@patternfly/react-charts', () => {
     const { Chart, ...rest } = jest.requireActual('@patternfly/react-charts');
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/VulnRequestedAction/VulnRequestedAction.test.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/VulnRequestedAction/VulnRequestedAction.test.tsx
@@ -1,11 +1,8 @@
 /* eslint-disable jest/no-disabled-tests */
-import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { format } from 'date-fns';
+import { addDays } from 'date-fns';
 
 import VulnRequestedAction from './VulnRequestedAction';
-
-const expiresOnFormat = 'YYYY-MM-DD[T]HH:mm:ss.SSSSSSSSS[Z]';
 
 describe('VulnRequestedAction', () => {
     it('should show requested action for false positives', () => {
@@ -40,10 +37,8 @@ describe('VulnRequestedAction', () => {
 
     it('should show the requested action for a 2 week deferral', () => {
         const currentDate = new Date();
-        const expiresOnDate = new Date();
         const daysToAdd = 14;
-        expiresOnDate.setDate(expiresOnDate.getDate() + daysToAdd);
-        const expiresOn = format(expiresOnDate, expiresOnFormat);
+        const expiresOnDate = addDays(currentDate, daysToAdd);
 
         render(
             <VulnRequestedAction
@@ -51,7 +46,7 @@ describe('VulnRequestedAction', () => {
                 requestStatus="PENDING"
                 deferralReq={{
                     expiresWhenFixed: false,
-                    expiresOn,
+                    expiresOn: expiresOnDate.toISOString(),
                 }}
                 currentDate={currentDate}
             />
@@ -61,10 +56,8 @@ describe('VulnRequestedAction', () => {
 
     it('should show the requested action for a 30 day deferral', () => {
         const currentDate = new Date();
-        const expiresOnDate = new Date();
         const daysToAdd = 30;
-        expiresOnDate.setDate(currentDate.getDate() + daysToAdd);
-        const expiresOn = format(expiresOnDate, expiresOnFormat);
+        const expiresOnDate = addDays(currentDate, daysToAdd);
 
         render(
             <VulnRequestedAction
@@ -72,7 +65,7 @@ describe('VulnRequestedAction', () => {
                 requestStatus="PENDING"
                 deferralReq={{
                     expiresWhenFixed: false,
-                    expiresOn,
+                    expiresOn: expiresOnDate.toISOString(),
                 }}
                 currentDate={currentDate}
             />
@@ -82,10 +75,8 @@ describe('VulnRequestedAction', () => {
 
     it('should show the requested action for a 90 day deferral', () => {
         const currentDate = new Date();
-        const expiresOnDate = new Date();
         const daysToAdd = 90;
-        expiresOnDate.setDate(currentDate.getDate() + daysToAdd);
-        const expiresOn = format(expiresOnDate, expiresOnFormat);
+        const expiresOnDate = addDays(currentDate, daysToAdd);
 
         render(
             <VulnRequestedAction
@@ -93,7 +84,7 @@ describe('VulnRequestedAction', () => {
                 requestStatus="PENDING"
                 deferralReq={{
                     expiresWhenFixed: false,
-                    expiresOn,
+                    expiresOn: expiresOnDate.toISOString(),
                 }}
                 currentDate={currentDate}
             />

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/VulnRequestedAction/VulnRequestedAction.test.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/VulnRequestedAction/VulnRequestedAction.test.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable jest/no-disabled-tests */
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { addDays } from 'date-fns';
 


### PR DESCRIPTION
## Description

Fixing two flaky tests:
- increased timeout to 10 seconds for `ViolationsByPolicyCategory.test.tsx`;
- add days to the exact start date, use ISO date format for `VulnRequestedAction.test.tsx`;

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

```sh
cd ui
make test
```