### PR TITLE
[ROX-12056] Avoid loading full Image object into GraphQL image cache when postgres

### DIFF
--- a/central/image/datastore/datastore.go
+++ b/central/image/datastore/datastore.go
@@ -41,6 +41,7 @@ type DataStore interface {
 	CountImages(ctx context.Context) (int, error)
 	GetImage(ctx context.Context, sha string) (*storage.Image, bool, error)
 	GetImageMetadata(ctx context.Context, id string) (*storage.Image, bool, error)
+	GetManyImageMetadata(ctx context.Context, ids []string) ([]*storage.Image, error)
 	GetImagesBatch(ctx context.Context, shas []string) ([]*storage.Image, error)
 
 	UpsertImage(ctx context.Context, image *storage.Image) error

--- a/central/image/datastore/datastore_bench_postgres_test.go
+++ b/central/image/datastore/datastore_bench_postgres_test.go
@@ -1,0 +1,80 @@
+//go:build sql_integration
+// +build sql_integration
+
+package datastore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/central/image/datastore/store/postgres"
+	"github.com/stackrox/rox/central/ranking"
+	mockRisks "github.com/stackrox/rox/central/risk/datastore/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/testutils/envisolator"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkImageGetMany(b *testing.B) {
+	envIsolator := envisolator.NewEnvIsolator(b)
+	envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
+	defer envIsolator.RestoreAll()
+
+	if !features.PostgresDatastore.Enabled() {
+		b.Skip("Skip postgres store tests")
+		b.SkipNow()
+	}
+
+	ctx := sac.WithAllAccess(context.Background())
+
+	source := pgtest.GetConnectionString(b)
+	config, err := pgxpool.ParseConfig(source)
+	require.NoError(b, err)
+
+	pool, err := pgxpool.ConnectConfig(ctx, config)
+	require.NoError(b, err)
+	gormDB := pgtest.OpenGormDB(b, source)
+	defer pgtest.CloseGormDB(b, gormDB)
+
+	db := pool
+	defer db.Close()
+
+	postgres.Destroy(ctx, db)
+	mockRisk := mockRisks.NewMockDataStore(gomock.NewController(b))
+	datastore := NewWithPostgres(postgres.CreateTableAndNewStore(ctx, db, gormDB, false), postgres.NewIndexer(db), mockRisk, ranking.NewRanker(), ranking.NewRanker())
+
+	ids := make([]string, 0, 100)
+	images := make([]*storage.Image, 0, 100)
+	for i := 0; i < 100; i++ {
+		img := fixtures.GetImageWithUniqueComponents()
+		id := fmt.Sprintf("%d", i)
+		ids = append(ids, id)
+		img.Id = id
+		images = append(images, img)
+	}
+
+	for _, image := range images {
+		require.NoError(b, datastore.UpsertImage(ctx, image))
+	}
+
+	b.Run("GetImagesBatch", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err = datastore.GetImagesBatch(ctx, ids)
+			require.NoError(b, err)
+		}
+	})
+
+	b.Run("GetManyImageMetadata", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err = datastore.GetManyImageMetadata(ctx, ids)
+			require.NoError(b, err)
+		}
+	})
+}

--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -155,6 +155,21 @@ func (ds *datastoreImpl) canReadImage(ctx context.Context, sha string) (bool, er
 	return false, nil
 }
 
+// GetManyImageMetadata gets the image data without the scan.
+func (ds *datastoreImpl) GetManyImageMetadata(ctx context.Context, ids []string) ([]*storage.Image, error) {
+	imgs, missingIdx, err := ds.storage.GetManyImageMetadata(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	if len(missingIdx) > 0 {
+		log.Errorf("Could not fetch %d/%d some images", len(missingIdx), len(ids))
+	}
+	for _, img := range imgs {
+		ds.updateImagePriority(img)
+	}
+	return imgs, nil
+}
+
 // GetImageMetadata gets the image data without the scan
 func (ds *datastoreImpl) GetImageMetadata(ctx context.Context, id string) (*storage.Image, bool, error) {
 	img, found, err := ds.storage.GetImageMetadata(ctx, id)

--- a/central/image/datastore/datastore_impl_postgres_test.go
+++ b/central/image/datastore/datastore_impl_postgres_test.go
@@ -476,3 +476,29 @@ func (s *ImagePostgresDataStoreTestSuite) TestImageDeletes() {
 	s.NoError(err)
 	s.Equal(0, count)
 }
+
+func (s *ImagePostgresDataStoreTestSuite) TestGetManyImageMetadata() {
+	ctx := sac.WithAllAccess(context.Background())
+	testImage1 := fixtures.GetImageWithUniqueComponents()
+	s.NoError(s.datastore.UpsertImage(ctx, testImage1))
+
+	testImage2 := testImage1.Clone()
+	testImage2.Id = "2"
+	s.NoError(s.datastore.UpsertImage(ctx, testImage2))
+
+	testImage3 := testImage1.Clone()
+	testImage3.Id = "3"
+	s.NoError(s.datastore.UpsertImage(ctx, testImage3))
+
+	storedImages, err := s.datastore.GetManyImageMetadata(ctx, []string{testImage1.Id, testImage2.Id, testImage3.Id})
+	s.NoError(err)
+	s.Len(storedImages, 3)
+
+	testImage1.Scan.Components = nil
+	testImage1.Priority = 1
+	testImage2.Scan.Components = nil
+	testImage2.Priority = 1
+	testImage3.Scan.Components = nil
+	testImage3.Priority = 1
+	s.ElementsMatch([]*storage.Image{testImage1, testImage2, testImage3}, storedImages)
+}

--- a/central/image/datastore/mocks/datastore.go
+++ b/central/image/datastore/mocks/datastore.go
@@ -148,6 +148,21 @@ func (mr *MockDataStoreMockRecorder) GetImagesBatch(ctx, shas interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImagesBatch", reflect.TypeOf((*MockDataStore)(nil).GetImagesBatch), ctx, shas)
 }
 
+// GetManyImageMetadata mocks base method.
+func (m *MockDataStore) GetManyImageMetadata(ctx context.Context, ids []string) ([]*storage.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetManyImageMetadata", ctx, ids)
+	ret0, _ := ret[0].([]*storage.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetManyImageMetadata indicates an expected call of GetManyImageMetadata.
+func (mr *MockDataStoreMockRecorder) GetManyImageMetadata(ctx, ids interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManyImageMetadata", reflect.TypeOf((*MockDataStore)(nil).GetManyImageMetadata), ctx, ids)
+}
+
 // ListImage mocks base method.
 func (m *MockDataStore) ListImage(ctx context.Context, sha string) (*storage.ListImage, bool, error) {
 	m.ctrl.T.Helper()

--- a/central/image/datastore/store/dackbox/store_impl.go
+++ b/central/image/datastore/store/dackbox/store_impl.go
@@ -161,7 +161,7 @@ func (b *storeImpl) GetImageMetadata(_ context.Context, id string) (image *stora
 }
 
 func (b *storeImpl) GetManyImageMetadata(ctx context.Context, id []string) ([]*storage.Image, []int, error) {
-	utils.Must(errors.New("Unexpected call to GetManyImageMetadata when running on Postgres"))
+	utils.Must(errors.New("Unexpected call to GetManyImageMetadata in Dackbox when running on Postgres"))
 	return nil, nil, nil
 }
 

--- a/central/image/datastore/store/dackbox/store_impl.go
+++ b/central/image/datastore/store/dackbox/store_impl.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	protoTypes "github.com/gogo/protobuf/types"
+	"github.com/pkg/errors"
 	componentCVEEdgeDackBox "github.com/stackrox/rox/central/componentcveedge/dackbox"
 	cveDackBox "github.com/stackrox/rox/central/cve/dackbox"
 	cveUtil "github.com/stackrox/rox/central/cve/utils"
@@ -23,6 +24,7 @@ import (
 	"github.com/stackrox/rox/pkg/images/types"
 	ops "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/utils"
 )
 
 type storeImpl struct {
@@ -156,6 +158,11 @@ func (b *storeImpl) GetImageMetadata(_ context.Context, id string) (image *stora
 		return nil, false, err
 	}
 	return image, image != nil, err
+}
+
+func (b *storeImpl) GetManyImageMetadata(ctx context.Context, id []string) ([]*storage.Image, []int, error) {
+	utils.Must(errors.New("Unexpected call to GetManyImageMetadata when running on Postgres"))
+	return nil, nil, nil
 }
 
 // GetImagesBatch returns images with given ids.

--- a/central/image/datastore/store/mocks/store.go
+++ b/central/image/datastore/store/mocks/store.go
@@ -161,6 +161,22 @@ func (mr *MockStoreMockRecorder) GetMany(ctx, ids interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMany", reflect.TypeOf((*MockStore)(nil).GetMany), ctx, ids)
 }
 
+// GetManyImageMetadata mocks base method.
+func (m *MockStore) GetManyImageMetadata(ctx context.Context, id []string) ([]*storage.Image, []int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetManyImageMetadata", ctx, id)
+	ret0, _ := ret[0].([]*storage.Image)
+	ret1, _ := ret[1].([]int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetManyImageMetadata indicates an expected call of GetManyImageMetadata.
+func (mr *MockStoreMockRecorder) GetManyImageMetadata(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManyImageMetadata", reflect.TypeOf((*MockStore)(nil).GetManyImageMetadata), ctx, id)
+}
+
 // UpdateVulnState mocks base method.
 func (m *MockStore) UpdateVulnState(ctx context.Context, cve string, imageIDs []string, state storage.VulnerabilityState) error {
 	m.ctrl.T.Helper()

--- a/central/image/datastore/store/store.go
+++ b/central/image/datastore/store/store.go
@@ -14,8 +14,10 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storage.Image, bool, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Image, []int, error)
-	// GetImageMetadata gets the image without scan/component data.
+
+	// GetImageMetadata and GetImageMetadata returns the image without scan/component data.
 	GetImageMetadata(ctx context.Context, id string) (*storage.Image, bool, error)
+	GetManyImageMetadata(ctx context.Context, id []string) ([]*storage.Image, []int, error)
 
 	Upsert(ctx context.Context, image *storage.Image) error
 	Delete(ctx context.Context, id string) error

--- a/pkg/postgres/pgtest/postgres.go
+++ b/pkg/postgres/pgtest/postgres.go
@@ -86,7 +86,7 @@ func (tp *TestPostgres) Teardown(t testing.TB) {
 }
 
 // GetConnectionString returns a connection string for integration testing with Postgres
-func GetConnectionString(_ *testing.T) string {
+func GetConnectionString(_ testing.TB) string {
 	return conn.GetConnectionStringWithDatabaseName(env.GetString("POSTGRES_DB", "postgres"))
 }
 


### PR DESCRIPTION
## Description

Now that all graphQL image paths do not rely on embedded components and vulnerabilities, change graphQL image cache to load only image metadata, when running on postgres. This gives about 100% perf improvement.

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
Unit

```
BenchmarkImageGetMany/GetImagesBatch
BenchmarkImageGetMany/GetImagesBatch-8         	       8	 128664513 ns/op
BenchmarkImageGetMany/GetManyImageMetadata
BenchmarkImageGetMany/GetManyImageMetadata-8   	     998	   1055978 ns/op
```