### PR TITLE
[Rox-11968] : Add ImageComponents and ImageComponentCount sub resolvers to ImageScan

### DIFF
--- a/central/graphql/resolvers/components.go
+++ b/central/graphql/resolvers/components.go
@@ -46,8 +46,6 @@ func init() {
 			"vulnCounter(query: String): VulnerabilityCounter!",
 			"vulns(query: String, scopeQuery: String, pagination: Pagination): [EmbeddedVulnerability]!",
 		}),
-		schema.AddExtraResolver("ImageScan", `components(query: String, pagination: Pagination): [EmbeddedImageScanComponent!]!`),
-		schema.AddExtraResolver("ImageScan", `componentCount(query: String): Int!`),
 		schema.AddQuery("component(id: ID): EmbeddedImageScanComponent"+
 			"@deprecated(reason: \"use 'imageComponent' or 'nodeComponent'\")"),
 		schema.AddQuery("components(query: String, scopeQuery: String, pagination: Pagination): [EmbeddedImageScanComponent!]!"+

--- a/central/graphql/resolvers/gen/main.go
+++ b/central/graphql/resolvers/gen/main.go
@@ -75,6 +75,10 @@ var (
 		},
 		SkipFields: []generator.TypeAndField{
 			{
+				ParentType: reflect.TypeOf(storage.Image{}),
+				FieldName:  "Scan",
+			},
+			{
 				ParentType: reflect.TypeOf(storage.ImageScan{}),
 				FieldName:  "Components",
 			},

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -644,7 +644,6 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"notes: [Image_Note!]!",
 		"priority: Int!",
 		"riskScore: Float!",
-		"scan: ImageScan",
 		"signature: ImageSignature",
 		"signatureVerificationData: ImageSignatureVerificationData",
 	}))
@@ -6305,12 +6304,6 @@ func (resolver *imageResolver) RiskScore(ctx context.Context) float64 {
 	resolver.ensureData(ctx)
 	value := resolver.data.GetRiskScore()
 	return float64(value)
-}
-
-func (resolver *imageResolver) Scan(ctx context.Context) (*imageScanResolver, error) {
-	resolver.ensureData(ctx)
-	value := resolver.data.GetScan()
-	return resolver.root.wrapImageScan(value, true, nil)
 }
 
 func (resolver *imageResolver) Signature(ctx context.Context) (*imageSignatureResolver, error) {

--- a/central/graphql/resolvers/image_components.go
+++ b/central/graphql/resolvers/image_components.go
@@ -333,14 +333,9 @@ func (resolver *imageComponentResolver) ImageVulnerabilities(ctx context.Context
 	return resolver.root.ImageVulnerabilities(resolver.withImageComponentScope(ctx), args)
 }
 
-func (resolver *imageComponentResolver) LastScanned(ctx context.Context) (*graphql.Time, error) {
+func (resolver *imageComponentResolver) LastScanned(_ context.Context) (*graphql.Time, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageComponents, "LastScanned")
-
-	scope, ok := scoped.GetScope(resolver.ctx)
-	if ok && scope.Level == v1.SearchCategory_IMAGES {
-		log.Infof("Has Image scope")
-		ctx = resolver.ctx
-	}
+	ctx := resolver.ctx
 
 	imageLoader, err := loaders.GetImageLoader(ctx)
 	if err != nil {

--- a/central/graphql/resolvers/image_components.go
+++ b/central/graphql/resolvers/image_components.go
@@ -338,6 +338,7 @@ func (resolver *imageComponentResolver) LastScanned(ctx context.Context) (*graph
 
 	scope, ok := scoped.GetScope(resolver.ctx)
 	if ok && scope.Level == v1.SearchCategory_IMAGES {
+		log.Infof("Has Image scope")
 		ctx = resolver.ctx
 	}
 
@@ -346,7 +347,7 @@ func (resolver *imageComponentResolver) LastScanned(ctx context.Context) (*graph
 		return nil, err
 	}
 
-	q := search.EmptyQuery()
+	q := resolver.componentQuery()
 	q.Pagination = &v1.QueryPagination{
 		Limit:  1,
 		Offset: 0,
@@ -358,7 +359,7 @@ func (resolver *imageComponentResolver) LastScanned(ctx context.Context) (*graph
 		},
 	}
 
-	images, err := imageLoader.FromQuery(resolver.withImageComponentScope(ctx), q)
+	images, err := imageLoader.FromQuery(ctx, q)
 	if err != nil || len(images) == 0 {
 		return nil, err
 	} else if len(images) > 1 {

--- a/central/graphql/resolvers/image_components.go
+++ b/central/graphql/resolvers/image_components.go
@@ -46,10 +46,6 @@ func init() {
 		schema.AddQuery("imageComponent(id: ID): ImageComponent"),
 		schema.AddQuery("imageComponents(query: String, scopeQuery: String, pagination: Pagination): [ImageComponent!]!"),
 		schema.AddQuery("imageComponentCount(query: String): Int!"),
-
-		// TODO
-		schema.AddExtraResolver("ImageScan", `components(query: String, pagination: Pagination): [EmbeddedImageScanComponent!]!`),
-		schema.AddExtraResolver("ImageScan", `componentCount(query: String): Int!`),
 	)
 }
 
@@ -328,6 +324,7 @@ func (resolver *imageComponentResolver) ImageVulnerabilities(ctx context.Context
 
 func (resolver *imageComponentResolver) LastScanned(ctx context.Context) (*graphql.Time, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageComponents, "LastScanned")
+	log.Infof("Context inside scan.ImageComponents.LastScanned : %v", ctx)
 	imageLoader, err := loaders.GetImageLoader(ctx)
 	if err != nil {
 		return nil, err

--- a/central/graphql/resolvers/image_scan.go
+++ b/central/graphql/resolvers/image_scan.go
@@ -3,9 +3,6 @@ package resolvers
 import (
 	"context"
 
-	"github.com/pkg/errors"
-	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
@@ -28,13 +25,6 @@ func init() {
 }
 
 func (resolver *imageScanResolver) ImageComponents(_ context.Context, args PaginatedQuery) ([]ImageComponentResolver, error) {
-	scope, ok := scoped.GetScope(resolver.ctx)
-	if !ok {
-		return nil, errors.New("ImageScan.ImageComponents called without scope")
-	} else if scope.Level != v1.SearchCategory_IMAGES {
-		return nil, errors.New("ImageScan.ImageComponents called with improper scope context")
-	}
-
 	return resolver.root.ImageComponents(resolver.ctx, args)
 }
 

--- a/central/graphql/resolvers/image_scan.go
+++ b/central/graphql/resolvers/image_scan.go
@@ -1,0 +1,34 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+func init() {
+	schema := getBuilder()
+	utils.Must(
+		schema.AddExtraResolvers("ImageScan", []string{
+			// NOTE: This list is and should remain alphabetically ordered
+			"imageComponentCount(query: String): Int!",
+			"imageComponents(query: String, pagination: Pagination): [ImageComponent!]!",
+		}),
+		// deprecated fields
+		schema.AddExtraResolvers("ImageScan", []string{
+			"componentCount(query: String): Int! " +
+				"@deprecated(reason: \"use 'imageComponentCount'\")",
+			"components(query: String, pagination: Pagination): [EmbeddedImageScanComponent!]! " +
+				"@deprecated(reason: \"use 'imageComponents'\")",
+		}),
+	)
+}
+
+func (resolver *imageScanResolver) ImageComponents(ctx context.Context, args PaginatedQuery) ([]ImageComponentResolver, error) {
+	log.Infof("Context inside scan.ImageComponents : %v", ctx)
+	return resolver.root.ImageComponents(ctx, args)
+}
+
+func (resolver *imageScanResolver) ImageComponentCount(ctx context.Context, args RawQuery) (int32, error) {
+	return resolver.root.ImageComponentCount(ctx, args)
+}

--- a/central/graphql/resolvers/images.go
+++ b/central/graphql/resolvers/images.go
@@ -407,10 +407,9 @@ func (resolver *imageResolver) PlottedImageVulnerabilities(ctx context.Context, 
 func (resolver *imageResolver) Scan(ctx context.Context) (*imageScanResolver, error) {
 	resolver.ensureData(ctx)
 	res, err := resolver.root.wrapImageScan(resolver.data.GetScan(), true, nil)
-	if err != nil {
+	if err != nil || res == nil {
 		return nil, err
 	}
-	log.Infof("ImageScan resolver: %v", res)
 	res.ctx = resolver.imageScopeContext(ctx)
 	return res, nil
 }

--- a/central/graphql/resolvers/images.go
+++ b/central/graphql/resolvers/images.go
@@ -45,6 +45,7 @@ func init() {
 			"imageVulnerabilityCounter(query: String): VulnerabilityCounter!",
 			"imageVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [ImageVulnerability]!",
 			"plottedImageVulnerabilities(query: String): PlottedImageVulnerabilities!",
+			"scan: ImageScan",
 			"topImageVulnerability(query: String): ImageVulnerability",
 			"unusedVarSink(query: String): Int",
 			"watchStatus: ImageWatchStatus!",
@@ -401,6 +402,17 @@ func (resolver *imageResolver) PlottedVulns(ctx context.Context, args RawQuery) 
 func (resolver *imageResolver) PlottedImageVulnerabilities(ctx context.Context, args RawQuery) (*PlottedImageVulnerabilitiesResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Images, "PlottedImageVulnerabilities")
 	return resolver.root.PlottedImageVulnerabilities(resolver.imageScopeContext(ctx), args)
+}
+
+func (resolver *imageResolver) Scan(ctx context.Context) (*imageScanResolver, error) {
+	resolver.ensureData(ctx)
+	res, err := resolver.root.wrapImageScan(resolver.data.GetScan(), true, nil)
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("ImageScan resolver: %v", res)
+	res.ctx = resolver.imageScopeContext(ctx)
+	return res, nil
 }
 
 func (resolver *imageResolver) WatchStatus(ctx context.Context) (string, error) {


### PR DESCRIPTION
## Description

- Added Scan sub resolver to imageResolver
- Added ImageComponents and ImageComponentCount sub resolvers to imageScanResolver
- Refactor and fix scoping

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Manually tested by comparing results of new and old resolvers.
