### PR TITLE
ROX-11984: Match network policies against pod labels instead of deployment labels

### DIFF
--- a/pkg/booleanpolicy/networkpolicy/networkpolicy_test.go
+++ b/pkg/booleanpolicy/networkpolicy/networkpolicy_test.go
@@ -65,11 +65,10 @@ func (suite *NetworkPolicySuite) Test_FilterForDeployment() {
 			expectedPoliciesMatched: 2,
 		},
 		"No Match: NW policies shall not match against the deployment label even if 0 pods match": {
-			deploymentLabels:      map[string]string{"app": "central", "env": "prod"},
-			specPodTemplateLabels: map[string]string{"app": "sensor", "env": "dev"},
+			deploymentLabels:      map[string]string{"app": "central-deployment", "env": "prod"},
+			specPodTemplateLabels: map[string]string{"app": "central-pod", "env": "prod"},
 			netpolSelectors: []map[string]string{
-				{"app": "central"},
-				{"env": "prod"},
+				{"app": "central-deployment", "env": "prod"},
 			},
 			expectedPoliciesMatched: 0,
 		},

--- a/pkg/booleanpolicy/networkpolicy/networkpolicy_test.go
+++ b/pkg/booleanpolicy/networkpolicy/networkpolicy_test.go
@@ -26,25 +26,29 @@ func policy(classificationEnums []storage.NetworkPolicyType) *storage.NetworkPol
 func (suite *NetworkPolicySuite) Test_FilterForDeployment() {
 	cases := map[string]struct {
 		deploymentLabels        map[string]string
+		specPodTemplateLabels   map[string]string
 		netpolSelectors         []map[string]string
 		expectedPoliciesMatched int
 	}{
 		"Match: one NW policy with one label": {
-			deploymentLabels: map[string]string{"app": "central"},
+			deploymentLabels:      map[string]string{"app": "central"},
+			specPodTemplateLabels: map[string]string{"app": "central"},
 			netpolSelectors: []map[string]string{
 				{"app": "central"},
 			},
 			expectedPoliciesMatched: 1,
 		},
 		"Match: one NW policy with two labels": {
-			deploymentLabels: map[string]string{"app": "central", "env": "prod"},
+			deploymentLabels:      map[string]string{"app": "central", "env": "prod"},
+			specPodTemplateLabels: map[string]string{"app": "central", "env": "prod"},
 			netpolSelectors: []map[string]string{
 				{"app": "central", "env": "prod"},
 			},
 			expectedPoliciesMatched: 1,
 		},
 		"One Match: two NW policies with one label": {
-			deploymentLabels: map[string]string{"app": "central", "env": "prod"},
+			deploymentLabels:      map[string]string{"app": "central", "env": "prod"},
+			specPodTemplateLabels: map[string]string{"app": "central", "env": "prod"},
 			netpolSelectors: []map[string]string{
 				{"app": "central"},
 				{"app": "sensor"},
@@ -52,22 +56,51 @@ func (suite *NetworkPolicySuite) Test_FilterForDeployment() {
 			expectedPoliciesMatched: 1,
 		},
 		"Two Matches: two NW policies with one label": {
-			deploymentLabels: map[string]string{"app": "central", "env": "prod"},
+			deploymentLabels:      map[string]string{"app": "central", "env": "prod"},
+			specPodTemplateLabels: map[string]string{"app": "central", "env": "prod"},
 			netpolSelectors: []map[string]string{
 				{"app": "central"},
 				{"env": "prod"},
 			},
 			expectedPoliciesMatched: 2,
 		},
+		"No Match: NW policies shall not match against the deployment label even if 0 pods match": {
+			deploymentLabels:      map[string]string{"app": "central", "env": "prod"},
+			specPodTemplateLabels: map[string]string{"app": "sensor", "env": "dev"},
+			netpolSelectors: []map[string]string{
+				{"app": "central"},
+				{"env": "prod"},
+			},
+			expectedPoliciesMatched: 0,
+		},
+		"No Match: NW policies shall ignore the deployment labels even if pods have 0 labels": {
+			deploymentLabels:      map[string]string{"app": "central", "env": "prod"},
+			specPodTemplateLabels: map[string]string{},
+			netpolSelectors: []map[string]string{
+				{"app": "central"},
+				{"env": "prod"},
+			},
+			expectedPoliciesMatched: 0,
+		},
+		"One Match: NW policies shall match against the pod labels only": {
+			deploymentLabels:      map[string]string{"app": "central-deployment"},
+			specPodTemplateLabels: map[string]string{"app": "central-pod"},
+			netpolSelectors: []map[string]string{
+				{"app": "central-pod"},
+			},
+			expectedPoliciesMatched: 1,
+		},
 		"No Match: one NW with two labels": {
-			deploymentLabels: map[string]string{"app": "central", "env": "prod"},
+			deploymentLabels:      map[string]string{"app": "central", "env": "prod"},
+			specPodTemplateLabels: map[string]string{"app": "central", "env": "prod"},
 			netpolSelectors: []map[string]string{
 				{"app": "central", "env": "dev"},
 			},
 			expectedPoliciesMatched: 0,
 		},
 		"No Match: one NW policy with different labels": {
-			deploymentLabels: map[string]string{"app": "central"},
+			deploymentLabels:      map[string]string{"app": "central"},
+			specPodTemplateLabels: map[string]string{"app": "central"},
 			netpolSelectors: []map[string]string{
 				{"app": "sensor"},
 			},
@@ -85,7 +118,10 @@ func (suite *NetworkPolicySuite) Test_FilterForDeployment() {
 				policies = append(policies, p)
 			}
 
-			dep := &storage.Deployment{PodLabels: testCase.deploymentLabels}
+			dep := &storage.Deployment{
+				Labels:    testCase.deploymentLabels,
+				PodLabels: testCase.specPodTemplateLabels,
+			}
 			suite.Len(FilterForDeployment(policies, dep), testCase.expectedPoliciesMatched)
 		})
 	}

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -414,7 +414,7 @@ func (d *detectorImpl) getNetworkPoliciesApplied(deployment *storage.Deployment)
 		// It is fine (from the Matcher perspective) to use nil augmented objects
 		return nil
 	}
-	networkPolicies := d.networkPolicyStore.Find(deployment.GetNamespace(), deployment.GetLabels())
+	networkPolicies := d.networkPolicyStore.Find(deployment.GetNamespace(), deployment.GetPodLabels())
 	return networkpolicy.GenerateNetworkPoliciesAppliedObj(networkPolicies)
 }
 

--- a/sensor/kubernetes/listener/resources/convert.go
+++ b/sensor/kubernetes/listener/resources/convert.go
@@ -177,7 +177,7 @@ func (w *deploymentWrap) populateNonStaticFields(obj interface{}, action *centra
 			return false, errors.Wrap(err, "error getting label selector")
 		}
 
-	// Pods don't have the abstractions that higher level objects have so maintain it's lifecycle independently
+	// Pods don't have the abstractions that higher level objects have, so we maintain their lifecycle independently
 	case *v1.Pod:
 		if o.Status.Phase == v1.PodSucceeded || o.Status.Phase == v1.PodFailed {
 			*action = central.ResourceAction_REMOVE_RESOURCE


### PR DESCRIPTION
## Description

Matching Network Policies selectors against the `deployment.GetLabels()` caused issues* in the following cases:

- When deployment labels were different than the labels of pods created by that deployment  - for an example, see test case below

It worked correctly for:

- Rouge pods (pods with no deployment)
- Pods with deployments where labels of the deployment and its pods were identical.

The (*) issues are described in the ticket but they mainly include false-negative and false-positive alerts for violating the system policies for network policies.

The fix is a oneliner - calling `deployment.GetPodLabels()` ensures that the correct fields are analyzed in all mentioned cases. 

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- Manually by starting a cluster and applying the scenarios from [the ticket comment](https://issues.redhat.com/browse/ROX-11984?focusedCommentId=20696841&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-20696841)

### Case 1 - Policy matches deployment labels

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
  labels:
    app: nginx
    xname: nginx-deployment
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
        xname: nginx-pod
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
---
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: default-deny-ingress-xname
spec:
  podSelector:
    matchLabels:
      xname: nginx-deployment
  policyTypes:
  - Ingress
```

1. Should cause policy violation ✅
2. Network graph should display `No network policies defined for this deployment` when clicking on the deployment in the graph and selecting the "Network Policies" tab ✅

### Case 2 - Policy matches pod labels

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
  labels:
    app: nginx
    xname: nginx-deployment
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
        xname: nginx-pod
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
---
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: default-deny-ingress-xname
spec:
  podSelector:
    matchLabels:
      xname: nginx-pod
  policyTypes:
  - Ingress
```

1. Should NOT cause policy violation ✅
1. Network graph should display network policy  `default-deny-ingress-xname` when clicking on the deployment in the graph and selecting the "Network Policies" tab ✅

