### PR TITLE
[ROX-11969] : Add NodeComponents and NodeComponentCount to NodeScan

### DIFF
--- a/central/graphql/resolvers/cluster_vulnerabilities.go
+++ b/central/graphql/resolvers/cluster_vulnerabilities.go
@@ -368,11 +368,7 @@ func (resolver *clusterCVEResolver) VulnerabilityType() string {
 }
 
 func (resolver *clusterCVEResolver) VulnerabilityTypes() []string {
-	ret := make([]string, 0, len(storage.CVE_CVEType_name))
-	for _, t := range storage.CVE_CVEType_name {
-		ret = append(ret, t)
-	}
-	return ret
+	return []string{resolver.data.GetType().String()}
 }
 
 func (resolver *clusterCVEResolver) EnvImpact(ctx context.Context) (float64, error) {

--- a/central/graphql/resolvers/gen/main.go
+++ b/central/graphql/resolvers/gen/main.go
@@ -82,6 +82,10 @@ var (
 				ParentType: reflect.TypeOf(storage.NodeScan{}),
 				FieldName:  "Components",
 			},
+			{
+				ParentType: reflect.TypeOf(storage.Node{}),
+				FieldName:  "Scan",
+			},
 			// TODO(ROX-6194): Remove this entirely after the deprecation cycle started with the 55.0 release.
 			{
 				ParentType: reflect.TypeOf(storage.Policy{}),

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -878,7 +878,6 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"osImage: String!",
 		"priority: Int!",
 		"riskScore: Float!",
-		"scan: NodeScan",
 		"taints: [Taint]!",
 	}))
 	utils.Must(builder.AddType("NodeCVE", []string{
@@ -8073,11 +8072,6 @@ func (resolver *nodeResolver) Priority(ctx context.Context) int32 {
 func (resolver *nodeResolver) RiskScore(ctx context.Context) float64 {
 	value := resolver.data.GetRiskScore()
 	return float64(value)
-}
-
-func (resolver *nodeResolver) Scan(ctx context.Context) (*nodeScanResolver, error) {
-	value := resolver.data.GetScan()
-	return resolver.root.wrapNodeScan(value, true, nil)
 }
 
 func (resolver *nodeResolver) Taints(ctx context.Context) ([]*taintResolver, error) {

--- a/central/graphql/resolvers/node_components.go
+++ b/central/graphql/resolvers/node_components.go
@@ -191,9 +191,9 @@ func (resolver *nodeComponentResolver) FixedIn(ctx context.Context) string {
 }
 
 // NodeComponentLastScanned is the last time the node component was scanned in a node.
-func (resolver *nodeComponentResolver) NodeComponentLastScanned(ctx context.Context) (*graphql.Time, error) {
+func (resolver *nodeComponentResolver) NodeComponentLastScanned(_ context.Context) (*graphql.Time, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeComponents, "NodeComponentLastScanned")
-	nodeLoader, err := loaders.GetNodeLoader(ctx)
+	nodeLoader, err := loaders.GetNodeLoader(resolver.ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +210,7 @@ func (resolver *nodeComponentResolver) NodeComponentLastScanned(ctx context.Cont
 		},
 	}
 
-	nodes, err := nodeLoader.FromQuery(ctx, componentQuery)
+	nodes, err := nodeLoader.FromQuery(resolver.ctx, componentQuery)
 	if err != nil || len(nodes) == 0 {
 		return nil, err
 	} else if len(nodes) > 1 {

--- a/central/graphql/resolvers/node_components_v1.go
+++ b/central/graphql/resolvers/node_components_v1.go
@@ -32,8 +32,6 @@ func init() {
 			"priority: Int!",
 			"riskScore: Float!",
 		}),
-		schema.AddExtraResolver("NodeScan", `components(query: String, pagination: Pagination): [EmbeddedNodeScanComponent!]!`),
-		schema.AddExtraResolver("NodeScan", `componentCount(query: String): Int!`),
 		schema.AddExtraResolver("EmbeddedNodeScanComponent", `unusedVarSink(query: String): Int`),
 		schema.AddExtraResolver("EmbeddedNodeScanComponent", "plottedVulns(query: String): PlottedVulnerabilities!"),
 	)

--- a/central/graphql/resolvers/node_scan.go
+++ b/central/graphql/resolvers/node_scan.go
@@ -1,0 +1,33 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+func init() {
+	schema := getBuilder()
+	utils.Must(
+		schema.AddExtraResolvers("NodeScan", []string{
+			// NOTE: This list is and should remain alphabetically ordered
+			"nodeComponentCount(query: String): Int!",
+			"nodeComponents(query: String, pagination: Pagination): [NodeComponent!]!",
+		}),
+		// deprecated fields
+		schema.AddExtraResolvers("NodeScan", []string{
+			"componentCount(query: String): Int! " +
+				"@deprecated(reason: \"use 'nodeComponentCount'\")",
+			"components(query: String, pagination: Pagination): [EmbeddedNodeScanComponent!]! " +
+				"@deprecated(reason: \"use 'nodeComponents'\")",
+		}),
+	)
+}
+
+func (resolver *nodeScanResolver) NodeComponentCount(_ context.Context, args RawQuery) (int32, error) {
+	return resolver.root.NodeComponentCount(resolver.ctx, args)
+}
+
+func (resolver *nodeScanResolver) NodeComponents(_ context.Context, args PaginatedQuery) ([]NodeComponentResolver, error) {
+	return resolver.root.NodeComponents(resolver.ctx, args)
+}

--- a/central/graphql/resolvers/nodes.go
+++ b/central/graphql/resolvers/nodes.go
@@ -43,6 +43,7 @@ func init() {
 			"nodeVulnerabilityCounter(query: String): VulnerabilityCounter!",
 			"passingControls(query: String): [ComplianceControl!]!",
 			"plottedNodeVulnerabilities(query: String): PlottedNodeVulnerabilities!",
+			"scan: NodeScan",
 			"topNodeVulnerability(query: String): NodeVulnerability",
 			"unusedVarSink(query: String): Int",
 		}),
@@ -519,6 +520,15 @@ func (resolver *nodeResolver) PlottedNodeVulnerabilities(ctx context.Context, ar
 	// (ROX-10911) Cluster scoping the context is not able to resolve node vulns when combined with 'Fixable:true/false' query
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getNodeRawQuery())
 	return resolver.root.PlottedNodeVulnerabilities(ctx, RawQuery{Query: &query})
+}
+
+func (resolver *nodeResolver) Scan(ctx context.Context) (*nodeScanResolver, error) {
+	res, err := resolver.root.wrapNodeScan(resolver.data.GetScan(), true, nil)
+	if err != nil || res == nil {
+		return nil, err
+	}
+	res.ctx = resolver.withNodeScopeContext(ctx)
+	return res, nil
 }
 
 func (resolver *nodeResolver) UnusedVarSink(ctx context.Context, args RawQuery) *int32 {


### PR DESCRIPTION
## Description

- Added Scan sub resolver to nodeResolver
- Added nodeComponents and nodeComponentCount sub resolvers to nodeScanResolver
- Refactor and fix scoping

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Manually tested by comparing results of new and old resolvers.
