### PR TITLE
CI: Migrate to a new credentials location

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -992,6 +992,9 @@ openshift_ci_import_creds() {
     for cred in /tmp/secret/**/[A-Z]*; do
         export "$(basename "$cred")"="$(cat "$cred")"
     done
+    for cred in /tmp/vault/**/[A-Z]*; do
+        export "$(basename "$cred")"="$(cat "$cred")"
+    done
 }
 
 unset_namespace_env_var() {


### PR DESCRIPTION
## Description

This is to avoid a conflict with OpenShift CIs use of `/tmp/secret`. Once this PR is merged a followup PR in openshift/release will change the mount point for credentials. The openshift/release will be a breaking change for outstanding PRs which will have to be rebased.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient