### PR TITLE
ROX-12029 Update the images at most risk dashboard query to not use deprecated gql sub-resolver.

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom/extend-expect';
 
 import renderWithRouter from 'test-utils/renderWithRouter';
 import { vulnManagementImagesPath, vulnManagementPath } from 'routePaths';
-import ImagesAtMostRisk, { imagesQuery } from './ImagesAtMostRisk';
+import ImagesAtMostRisk, { getImagesQuery } from './ImagesAtMostRisk';
 
 function makeMockImage(
     id: string,
@@ -48,7 +48,9 @@ const mockImages = [1, 2, 3, 4, 5, 6].map((n) =>
 const mocks = [
     {
         request: {
-            query: imagesQuery,
+            // The component for this uses a feature flag to swap sub-resolvers, so treat it as
+            // disabled here until the feature flag is enabled in the production release.
+            query: getImagesQuery(false),
             variables: {
                 query: '',
             },
@@ -62,6 +64,12 @@ const mocks = [
 ];
 
 jest.mock('hooks/useResizeObserver');
+jest.mock('hooks/useFeatureFlags', () => ({
+    __esModule: true,
+    default: () => ({
+        isFeatureFlagEnabled: jest.fn(),
+    }),
+}));
 
 beforeEach(() => {
     localStorage.clear();

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
@@ -13,13 +13,13 @@ function makeMockImage(
     remote: string,
     fullName: string,
     priority: number,
-    vulnCounter: VulnCounts
+    imageVulnerabilityCounter: VulnCounts
 ) {
     return {
         id,
         name: { remote, fullName },
         priority,
-        vulnCounter,
+        imageVulnerabilityCounter,
     };
 }
 

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.tsx
@@ -56,7 +56,11 @@ export function getImagesQuery(useUpdatedVmResolver: boolean) {
                 fullName
             }
             priority
-            ${true ? 'imageVulnerabilityCounter' : 'imageVulnerabilityCounter: vulnCounter'} {
+            ${
+                useUpdatedVmResolver
+                    ? 'imageVulnerabilityCounter'
+                    : 'imageVulnerabilityCounter: vulnCounter'
+            } {
                 important {
                     total
                     fixable

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.tsx
@@ -54,7 +54,7 @@ export const imagesQuery = gql`
                 fullName
             }
             priority
-            vulnCounter {
+            imageVulnerabilityCounter {
                 important {
                     total
                     fixable

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRiskTable.tsx
@@ -18,7 +18,7 @@ export type ImageData = {
         id: string;
         name: Partial<ImageName>;
         priority: number;
-        vulnCounter: {
+        imageVulnerabilityCounter: {
             important: VulnCounts;
             critical: VulnCounts;
         };
@@ -57,7 +57,7 @@ function ImagesAtMostRiskTable({ imageData: { images }, cveStatusOption }: Image
                 </Tr>
             </Thead>
             <Tbody>
-                {images.map(({ id, name, priority, vulnCounter }) => (
+                {images.map(({ id, name, priority, imageVulnerabilityCounter }) => (
                     <Tr key={id}>
                         <Td className="pf-u-pl-0" dataLabel={columnNames.imageName}>
                             <Link
@@ -91,8 +91,8 @@ function ImagesAtMostRiskTable({ imageData: { images }, cveStatusOption }: Image
                             />
                             <span>
                                 {cveStatusOption === 'Fixable'
-                                    ? `${vulnCounter.critical.fixable} fixable`
-                                    : `${vulnCounter.critical.total} CVEs`}
+                                    ? `${imageVulnerabilityCounter.critical.fixable} fixable`
+                                    : `${imageVulnerabilityCounter.critical.total} CVEs`}
                             </span>
                         </Td>
                         <Td className="pf-u-pr-0" dataLabel={columnNames.importantCves}>
@@ -101,8 +101,8 @@ function ImagesAtMostRiskTable({ imageData: { images }, cveStatusOption }: Image
                                 color={severityColors.HIGH_SEVERITY}
                             />
                             {cveStatusOption === 'Fixable'
-                                ? `${vulnCounter.important.fixable} fixable`
-                                : `${vulnCounter.important.total} CVEs`}
+                                ? `${imageVulnerabilityCounter.important.fixable} fixable`
+                                : `${imageVulnerabilityCounter.important.total} CVEs`}
                         </Td>
                     </Tr>
                 ))}


### PR DESCRIPTION
## Description

Replaces the deprecated `vulnCounter` subresolver with `imageVulnerabilityCounter` in the main page dashboard "Images at most risk" widget's graphql query.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Set up an infra cluster with the following ENV var
`ROX_POSTGRES_DATASTORE=true`

Behavior before this change:
<img width="1354" alt="image" src="https://user-images.githubusercontent.com/1292638/181796927-3084109e-b19f-428b-b028-58e4d06da79e.png">

Behavior after this change:
<img width="1354" alt="image" src="https://user-images.githubusercontent.com/1292638/181796977-29ab39a2-dd01-4d77-910f-e92ffdf97e90.png">

With "Image Vulns:All CVEs" setting:
<img width="1354" alt="image" src="https://user-images.githubusercontent.com/1292638/181797143-3d65052c-a8f1-461c-920a-911415306639.png">


