### PR TITLE
CI: Change to build_root 0.3.34

### DIFF
--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -10,4 +10,4 @@
 # - `make update` and commit the results
 # - run `/test pj-rehearse-max` on the openshift/release PR to validate the change
 
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.42
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.43-2-gf192ea2c3b

--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -10,4 +10,4 @@
 # - `make update` and commit the results
 # - run `/test pj-rehearse-max` on the openshift/release PR to validate the change
 
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.43-2-gf192ea2c3b
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44


### PR DESCRIPTION
## Description

This is to support EKS under OpenShift CI.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Tested with an openshift/release PR: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/30842/rehearse-30842-pull-ci-stackrox-stackrox-gavin-OSCI-onboard-EKS-gke-qa-e2e-tests/1552134479538032640