### PR TITLE
ROX-11701: Add EKS cluster e2e test support

### DIFF
--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -59,22 +59,34 @@ class OperatorE2eTest(BaseTest):
     def run(self):
         print("Deploying operator")
         self.run_with_graceful_kill(
-            ["make", "-C", "operator", "kuttl", "deploy-previous-via-olm"], OperatorE2eTest.DEPLOY_TIMEOUT_SEC
+            ["make", "-C", "operator", "kuttl", "deploy-previous-via-olm"],
+            OperatorE2eTest.DEPLOY_TIMEOUT_SEC,
         )
 
         print("Executing operator upgrade test")
         self.run_with_graceful_kill(
-            ["make", "-C", "operator", "test-upgrade"], OperatorE2eTest.UPGRADE_TEST_TIMEOUT_SEC
+            ["make", "-C", "operator", "test-upgrade"],
+            OperatorE2eTest.UPGRADE_TEST_TIMEOUT_SEC,
         )
 
         print("Executing operator e2e tests")
         self.run_with_graceful_kill(
-            ["make", "-C", "operator", "test-e2e-deployed"], OperatorE2eTest.E2E_TEST_TIMEOUT_SEC
+            ["make", "-C", "operator", "test-e2e-deployed"],
+            OperatorE2eTest.E2E_TEST_TIMEOUT_SEC,
         )
 
         print("Executing Operator Bundle Scorecard tests")
         self.run_with_graceful_kill(
-            ["./operator/scripts/retry.sh", "4", "2", "make", "-C", "operator", "bundle-test-image"], OperatorE2eTest.SCORECARD_TEST_TIMEOUT_SEC
+            [
+                "./operator/scripts/retry.sh",
+                "4",
+                "2",
+                "make",
+                "-C",
+                "operator",
+                "bundle-test-image",
+            ],
+            OperatorE2eTest.SCORECARD_TEST_TIMEOUT_SEC,
         )
 
 

--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -84,6 +84,8 @@ class GKECluster:
 
 
 class AutomationFlavorsCluster:
+    KUBECTL_TIMEOUT = 5 * 60
+
     def provision(self):
         if "SHARED_DIR" not in os.environ:
             raise RuntimeError("Error: there is no SHARED_DIR defined")
@@ -97,6 +99,15 @@ class AutomationFlavorsCluster:
             )
 
         os.environ["KUBECONFIG"] = kubeconfig
+
+        print(f"Using kubeconfig from {kubeconfig}")
+
+        print("Nodes:")
+        subprocess.run(
+            ["kubectl", "get" "nodes", "-o", "wide"],
+            check=True,
+            timeout=AutomationFlavorsCluster.KUBECTL_TIMEOUT,
+        )
 
         return self
 

--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -81,3 +81,12 @@ class GKECluster:
     def sigint_handler(self, signum, frame):
         print("Tearing down the cluster due to SIGINT", signum, frame)
         self.teardown()
+
+
+class AutomationFlavorsCluster:
+    def provision(self):
+        os.environ["KUBECONFIG"] = os.environ["SHARED_DIR"] + "/kubeconfig"
+        return self
+
+    def teardown(self):
+        pass

--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -104,7 +104,7 @@ class AutomationFlavorsCluster:
 
         print("Nodes:")
         subprocess.run(
-            ["kubectl", "get" "nodes", "-o", "wide"],
+            ["kubectl", "get", "nodes", "-o", "wide"],
             check=True,
             timeout=AutomationFlavorsCluster.KUBECTL_TIMEOUT,
         )

--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -85,7 +85,19 @@ class GKECluster:
 
 class AutomationFlavorsCluster:
     def provision(self):
-        os.environ["KUBECONFIG"] = os.environ["SHARED_DIR"] + "/kubeconfig"
+        if "SHARED_DIR" not in os.environ:
+            raise RuntimeError("Error: there is no SHARED_DIR defined")
+
+        kubeconfig = os.environ["SHARED_DIR"] + "/kubeconfig"
+
+        if not os.path.exists(kubeconfig):
+            raise RuntimeError(
+                f"Error: {kubeconfig} does not exist, "
+                + "this is expected from an automation-flavors cluster create"
+            )
+
+        os.environ["KUBECONFIG"] = kubeconfig
+
         return self
 
     def teardown(self):

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -24,7 +24,7 @@ ci_export CI_JOB_NAME "$ci_job"
 gate_job "$ci_job"
 
 case "$ci_job" in
-    gke*qa-e2e-tests|gke-nongroovy-e2e-tests|gke-upgrade-tests|gke-ui-e2e-tests)
+    gke*qa-e2e-tests|eks-qa-e2e-tests|gke-nongroovy-e2e-tests|gke-upgrade-tests|gke-ui-e2e-tests)
         openshift_ci_e2e_mods
         ;;
     openshift-*-operator-e2e-tests)

--- a/scripts/ci/jobs/eks_qa_e2e_tests.py
+++ b/scripts/ci/jobs/eks_qa_e2e_tests.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run qa-tests-backend in an EKS cluster provided via automation-flavors/eks.
+"""
+import os
+from base_qa_e2e_test import make_qa_e2e_test_runner
+from clusters import AutomationFlavorsCluster
+
+# set required test parameters
+os.environ["COLLECTION_METHOD"] = "kernel-module"
+
+make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/eks_qa_e2e_tests.py
+++ b/scripts/ci/jobs/eks_qa_e2e_tests.py
@@ -8,6 +8,7 @@ from base_qa_e2e_test import make_qa_e2e_test_runner
 from clusters import AutomationFlavorsCluster
 
 # set required test parameters
+os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 os.environ["COLLECTION_METHOD"] = "kernel-module"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()


### PR DESCRIPTION
## Description

The target repo side changes to support EKS e2e tests. Companion to: https://github.com/openshift/release/pull/30556

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient. Passes a rehearsal run targeting this branch: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/30556/rehearse-30556-pull-ci-stackrox-stackrox-gavin-stackrox-ROX-11701-onboard-EKS-eks-qa-e2e-tests/1552747723168419840