### PR TITLE
Simplify tabs and table for global search results in UI

### DIFF
--- a/ui/apps/platform/cypress/constants/SearchPage.js
+++ b/ui/apps/platform/cypress/constants/SearchPage.js
@@ -16,6 +16,7 @@ export const selectors = {
         body: '.pf-c-empty-state__body',
     }),
     tab: 'li.pf-c-tabs__item',
+    count: '.pf-c-badge',
     globalSearchResults: scopeSelectors('[data-testid="global-search-results"]', {
         header: 'h1',
     }),

--- a/ui/apps/platform/cypress/fixtures/search/globalSearchResults.json
+++ b/ui/apps/platform/cypress/fixtures/search/globalSearchResults.json
@@ -44,5 +44,55 @@
             "score": 0,
             "location": ""
         }
+    ],
+    "counts": [
+        {
+            "category": "ALERTS",
+            "count": "1"
+        },
+        {
+            "category": "IMAGES",
+            "count": "1"
+        },
+        {
+            "category": "POLICIES",
+            "count": "1"
+        },
+        {
+            "category": "DEPLOYMENTS",
+            "count": "1"
+        },
+        {
+            "category": "SECRETS",
+            "count": "0"
+        },
+        {
+            "category": "CLUSTERS",
+            "count": "0"
+        },
+        {
+            "category": "NAMESPACES",
+            "count": "0"
+        },
+        {
+            "category": "NODES",
+            "count": "0"
+        },
+        {
+            "category": "SERVICE_ACCOUNTS",
+            "count": "0"
+        },
+        {
+            "category": "ROLES",
+            "count": "0"
+        },
+        {
+            "category": "ROLEBINDINGS",
+            "count": "0"
+        },
+        {
+            "category": "SUBJECTS",
+            "count": "0"
+        }
     ]
 }

--- a/ui/apps/platform/cypress/integration/search.test.js
+++ b/ui/apps/platform/cypress/integration/search.test.js
@@ -48,11 +48,16 @@ describe('Global Search Modal', () => {
         cy.get(`${selectors.tab}:contains("Secrets")`).should('not.have.class', 'pf-m-current');
     });
 
-    it('Should filter search results', () => {
+    it('Should display counts of search results on tabs', () => {
         visitSearch();
         searchWithFixture([['Cluster:', 'remote']], 'search/globalSearchResults.json');
 
-        cy.get(selectors.globalSearchResults.header).should('have.text', '4 search results');
+        cy.get(`${selectors.tab}:contains("All") ${selectors.count}:contains("4")`);
+        cy.get(`${selectors.tab}:contains("Violations") ${selectors.count}:contains("1")`);
+        cy.get(`${selectors.tab}:contains("Policies") ${selectors.count}:contains("1")`);
+        cy.get(`${selectors.tab}:contains("Deployments") ${selectors.count}:contains("1")`);
+        cy.get(`${selectors.tab}:contains("Images") ${selectors.count}:contains("1")`);
+        cy.get(`${selectors.tab}:contains("Secrets") ${selectors.count}:contains("0")`);
     });
 
     it('Should send you to the Violations page', () => {


### PR DESCRIPTION
## Description

### Goal

Simplify `SearchResults` component as a prerequisite for future improvements:
* Replace global sagas with container requests.
* Replace redundant requests for each selected tab categories with filtering of the response for all categories.
* Replace last occurrence of `ReduxSearchInput` with `SearchFilterInput` element.

### Changes

1. Add `TabCategory` type. Use for reduced and renamed `tabs` array.
2. Replace `searchResults` with `[...globalSearchResults]` in `useEffect` hook because it bends the rules of Redux to mutate the state via impure `sort` array method).
3. Add `getTabCategoryCount` function with comment about future simplification.
4. Replace `{searchResults.length} search results` in `h1` element with Search in `Title` element:
    * It can become incorrect because of redundant requests for each selected tab categories.
    * Instead lean forward from search modal to future search page.
5. Replace selector for default tab with `searchCategory` prop from store and `tabCategory !== searchCategory` inline conditions.
6. Replace `eventKey={index}` with `eventKey={tabCategory}` for the preceding point.
7. Factor out `SearchResultsTable` element. Delete unneeded `key` and `data-testid` props.
8. Replace render functions (probably left over from when `SearchResults` was a component instead of a function) with inline rendering.
9. At cost of controversial 3-level nested ternary, render `null` for inactive tabs instead of incorrect and redundant (although hidden) copies of table for active tab.
10. Replace parentheses with `Badge` element for counts in tabs.

### Residue

1. For category without value in search filter input, prevent unneeded GET /v1/search?query= request which has 400 Bad Request status.

2. Ask core workflows team whether the 12 categories in `counts` array are the **only** categories ever in `results` array:

    ```js
    {
        results: [{id, name, category, fieldToMatches, score, location}, …],
        counts: [
            {category: "ALERTS", count: "19"},
            {category: "IMAGES", count: "2"},
            {category: "POLICIES", count: "0"},
            {category: "DEPLOYMENTS", count: "1"},
            {category: "SECRETS", count: "0"},
            {category: "CLUSTERS", count: "0"},
            {category: "NAMESPACES", count: "0"},
            {category: "NODES", count: "0"},
            {category: "SERVICE_ACCOUNTS", count: "0"},
            {category: "ROLES", count: "0"},
            {category: "ROLEBINDINGS", count: "0"},
            {category: "SUBJECTS", count: "0"}
        ],
    }
    ```

3. Look more carefully at sorting. For example, search modal forgets changes to sort column and direction, which is in component state.

4. Investigate double requests for **Network** under **Filter On** column of deployment row.

5. Investigate empty search filter for **Violations** in **Filter On** column of image row.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### manual testing

1. `yarn build` in ui
2. `yarn start` in ui

    * Open at /main/dashboard

        See GET /v1/search/metadata/options? request for global search from searchSagas.js

    * Click **Search**

        See no search requests
        See **Search all data** Choose one or more filter values to search
    
    * Enter **Add Capability: NET_BIND_SERVICE** in search filter

        See GET /v1/search?query=Add%20Capabilities%3ANET_BIND_SERVICE request
        **Search** table displays results with **All** 1 and **Deployments** 1

    * Click to clear the search value and then the search category

        See GET /v1/search?query= request which has status 400 Bad Request

    * Enter **Image:** category in search filter

        See no search requests
        **Search** table displays results with **All** 0 and **No results with your chosen filters for the type** Try changing the filter values.

    * Enter **quay.io/stackrox-io/main:3.71.x-…** value in search filter

        See GET /v1/search?query=Image%3Aquay.io%2Fstackrox-io%2Fmain%3A3.71.x-… request
        **Search** table displays results sorted ascending by **Type** with **All** 5 **Deployments** 4 **Images** 1
        ![All](https://user-images.githubusercontent.com/11862657/181580708-fa5bcc71-7a60-4212-b8cc-c100ec57e794.png)

    * Click **Violations** tab

        See GET /v1/search?query=Image%3Aquay.io%2Fstackrox-io%2Fmain%3A3.71.x-…&categories=ALERTS whose response has empty results array
        See **No results with your chosen filters for the type** Try changing the filter values.
        ![Violations](https://user-images.githubusercontent.com/11862657/181580795-716740f4-be73-4bf7-b273-73723b1a3edb.png)

    * Click **Deployments** tab

        See GET /v1/search?query=Image%3Aquay.io%2Fstackrox-io%2Fmain%3A3.71.x-…&categories=DEPLOYMENTS request
        ![Deployments](https://user-images.githubusercontent.com/11862657/181580871-73d8f60e-e65a-4d3d-a42b-ea283622c86f.png)

    * Click **Risk** button in **View On** column of **collector** row

        See /main/risk/id
        See empty search filter
        See GET /v1/deploymentswithprocessinfo?pagination.offset=0&pagination.limit=50&pagination.sortOption.field=Deployment%20Risk%20Priority&pagination.sortOption.reversed=false&query=Orchestrator%20Component%3Afalse request
        See GET /v1/deploymentscount?query=Orchestrator%20Component%3Afalse
        See GET /v1/deploymentswithrisk/id

    * Click **Search** and then click **Violations** button in **Filter On** column of **collector** row

        See /main/violations?s[Image]=quay.io%2Fstackrox-io%2Fmain%3A3.71.x-…&s[Deployment]=collector
        See **Deployment: collector** in search filter
        See GET /v1/alerts?query=Image%3Aquay.io%2Fstackrox-io%2Fmain%3A3.71.x-…%2BDeployment%3Acollector&pagination.offset=0&pagination.limit=50&pagination.sortOption.field=Violation%20Time&pagination.sortOption.reversed=true request
        See GET /v1/alertscount?query=Image%3Aquay.io%2Fstackrox-io%2Fmain%3A3.71.x-…%2BDeployment%3Acollector

    * Click **Search** and then click **Network** button in **Filter On** column of **collector** row

        See /main/network?s[Image]=quay.io%2Fstackrox-io%2Fmain%3A3.71.x-…&s[Deployment]=collector
        See **Image: quay.io/stackrox-io/main:3.71.x-…** and **Deployment: collector** in search filter
        See /v1/search/metadata/options?categories=DEPLOYMENTS
        See /v1/networkgraph/cluster/…?query=Image%3Aquay.io%2Fstackrox-io%2Fmain%3A3.71.x-…%2BDeployment%3Acollector%2BNamespace%3Astackrox&since=2022-07-28T14%3A17%3A48.978Z&includePorts=true&scope.query=Orchestrator%20Component%3Afalse
        See /v1/networkgraph/cluster/…?query=Image%3Aquay.io%2Fstackrox-io%2Fmain%3A3.71.x-…%2BDeployment%3Acollector%2BNamespace%3Astackrox&since=2022-07-28T14%3A17%3A49.093Z&includePorts=true&scope.query=Orchestrator%20Component%3Afalse
        See /v1/networkpolicies/cluster/…?query=Image%3Aquay.io%2Fstackrox-io%2Fmain%3A3.71.x-…%2BDeployment%3Acollector%2BNamespace%3Astackrox&includePorts=true&scope.query=Orchestrator%20Component%3Afalse
        See /v1/networkpolicies/cluster/…?query=Image%3Aquay.io%2Fstackrox-io%2Fmain%3A3.71.x-…%2BDeployment%3Acollector%2BNamespace%3Astackrox&includePorts=true&scope.query=Orchestrator%20Component%3Afalse

    * Click **Search** and then click **Images** tab

        See GET /v1/search?query=Image%3Aquay.io%2Fstackrox-io%2Fmain%3A3.71.x-…&categories=IMAGES request
        ![Images](https://user-images.githubusercontent.com/11862657/181580952-22f24267-512b-4852-a76b-100bbf2f3a37.png)

    * Click **Image** button in **View On** column of image row

        See /main/vulnerability-management/images/sha256:…

    * Click **Risk** button in **Filter On** column of image row

        See /main/risk?s[Image]=quay.io%2Fstackrox-io%2Fmain%3A3.71.x-…
        See **Image: quay.io/stackrox-io/main:3.71.x-…** in search filter
        See /v1/deploymentswithprocessinfo?pagination.offset=0&pagination.limit=50&pagination.sortOption.field=Deployment%20Risk%20Priority&pagination.sortOption.reversed=false&query=Image%3Aquay.io%2Fstackrox-io%2Fmain%3A3.71.x-…%2BOrchestrator%20Component%3Afalse request
        See /v1/deploymentscount?query=Image%3Aquay.io%2Fstackrox-io%2Fmain%3A3.71.x-…%2BOrchestrator%20Component%3Afalse request

    * Click **Violations** button in **Filter On** column of image row

        See /main/violations?s[Image]=quay.io%2Fstackrox-io%2Fmain%3A3.71.x-…
        See empty search filter
        See GET /v1/alerts?query=Image%3Aquay.io%2Fstackrox-io%2Fmain%3A3.71.x-…&pagination.offset=0&pagination.limit=50&pagination.sortOption.field=Violation%20Time&pagination.sortOption.reversed=true request
        See GET /v1/alertscount?query=Image%3Aquay.io%2Fstackrox-io%2Fmain%3A3.71.x-… request

### integration testing

1. `yarn cypress-open` in ui/apps/platform
    * search.test.js