### PR TITLE
ROX-11748: Enabled Postgres functionality for Node datastore and globaldatastore

### DIFF
--- a/central/node/datastore/dackbox/datastore/datastore_impl.go
+++ b/central/node/datastore/dackbox/datastore/datastore_impl.go
@@ -128,10 +128,8 @@ func (ds *datastoreImpl) canReadNode(ctx context.Context, id string) (bool, erro
 
 // GetNode delegates to the underlying store.
 func (ds *datastoreImpl) GetNode(ctx context.Context, id string) (*storage.Node, bool, error) {
-	if !features.PostgresDatastore.Enabled() {
-		if ok, err := ds.canReadNode(ctx, id); err != nil || !ok {
-			return nil, false, err
-		}
+	if ok, err := ds.canReadNode(ctx, id); err != nil || !ok {
+		return nil, false, err
 	}
 
 	node, found, err := ds.storage.Get(ctx, id)
@@ -149,10 +147,9 @@ func (ds *datastoreImpl) GetNodesBatch(ctx context.Context, ids []string) ([]*st
 	var nodes []*storage.Node
 	var err error
 	ok := true
-	if !features.PostgresDatastore.Enabled() {
-		if ok, err = nodesSAC.ReadAllowed(ctx); err != nil {
-			return nil, err
-		}
+
+	if ok, err = nodesSAC.ReadAllowed(ctx); err != nil {
+		return nil, err
 	}
 
 	if ok {
@@ -181,12 +178,10 @@ func (ds *datastoreImpl) UpsertNode(ctx context.Context, node *storage.Node) err
 		return errors.New("cannot upsert a node without an id")
 	}
 
-	if !features.PostgresDatastore.Enabled() {
-		if ok, err := nodesSAC.WriteAllowed(ctx); err != nil {
-			return err
-		} else if !ok {
-			return sac.ErrResourceAccessDenied
-		}
+	if ok, err := nodesSAC.WriteAllowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
 	}
 
 	ds.keyedMutex.Lock(node.GetId())
@@ -206,12 +201,10 @@ func (ds *datastoreImpl) UpsertNode(ctx context.Context, node *storage.Node) err
 func (ds *datastoreImpl) DeleteNodes(ctx context.Context, ids ...string) error {
 	defer metrics.SetDatastoreFunctionDuration(time.Now(), typ, "DeleteNodes")
 
-	if !features.PostgresDatastore.Enabled() {
-		if ok, err := nodesSAC.WriteAllowed(ctx); err != nil {
-			return err
-		} else if !ok {
-			return sac.ErrResourceAccessDenied
-		}
+	if ok, err := nodesSAC.WriteAllowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
 	}
 
 	errorList := errorhelpers.NewErrorList("deleting nodes")

--- a/central/node/datastore/dackbox/datastore/datastore_impl.go
+++ b/central/node/datastore/dackbox/datastore/datastore_impl.go
@@ -146,7 +146,7 @@ func (ds *datastoreImpl) GetNode(ctx context.Context, id string) (*storage.Node,
 func (ds *datastoreImpl) GetNodesBatch(ctx context.Context, ids []string) ([]*storage.Node, error) {
 	var nodes []*storage.Node
 	var err error
-	ok := true
+	var ok bool
 
 	if ok, err = nodesSAC.ReadAllowed(ctx); err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

This PR enables Postgres functionality for Node datastore and globaldatastore.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~ - added with follow-up PR: #2600 
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

To test this functionality, it's best to use unit tests introduced in #2600. Also testing procedure is explained in that PR.
