### PR TITLE
refactor graphql deprecations on various components

### DIFF
--- a/central/graphql/resolvers/cluster_vulnerabilities.go
+++ b/central/graphql/resolvers/cluster_vulnerabilities.go
@@ -57,7 +57,7 @@ type ClusterVulnerabilityResolver interface {
 func (resolver *Resolver) ClusterVulnerability(ctx context.Context, args IDQuery) (ClusterVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "ClusterVulnerability")
 	if !features.PostgresDatastore.Enabled() {
-		return resolver.vulnerabilityV2(ctx, args)
+		return resolver.clusterVulnerabilityV2(ctx, args)
 	}
 
 	// check permissions
@@ -199,7 +199,7 @@ func (resolver *Resolver) ClusterVulnerabilityCounter(ctx context.Context, args 
 func (resolver *Resolver) K8sClusterVulnerability(ctx context.Context, args IDQuery) (ClusterVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "K8sClusterVulnerability")
 	if !features.PostgresDatastore.Enabled() {
-		return resolver.vulnerabilityV2(ctx, args)
+		return resolver.clusterVulnerabilityV2(ctx, args)
 	}
 	return resolver.ClusterVulnerability(ctx, args)
 }
@@ -228,7 +228,7 @@ func (resolver *Resolver) K8sClusterVulnerabilityCount(ctx context.Context, args
 func (resolver *Resolver) IstioClusterVulnerability(ctx context.Context, args IDQuery) (ClusterVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "IstioClusterVulnerability")
 	if !features.PostgresDatastore.Enabled() {
-		return resolver.vulnerabilityV2(ctx, args)
+		return resolver.clusterVulnerabilityV2(ctx, args)
 	}
 	return resolver.ClusterVulnerability(ctx, args)
 }
@@ -257,7 +257,7 @@ func (resolver *Resolver) IstioClusterVulnerabilityCount(ctx context.Context, ar
 func (resolver *Resolver) OpenShiftClusterVulnerability(ctx context.Context, args IDQuery) (ClusterVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "OpenShiftClusterVulnerability")
 	if !features.PostgresDatastore.Enabled() {
-		return resolver.vulnerabilityV2(ctx, args)
+		return resolver.clusterVulnerabilityV2(ctx, args)
 	}
 	return resolver.ClusterVulnerability(ctx, args)
 }

--- a/central/graphql/resolvers/common_vulnerabilities.go
+++ b/central/graphql/resolvers/common_vulnerabilities.go
@@ -13,49 +13,68 @@ import (
  * NOTE: This list is and should remain alphabetically ordered
  */
 var commonVulnerabilitySubResolvers = []string{
-	"createdAt: Time", // Discovered At System
-	"cve: String!",
+	"cveBaseInfo: CVEInfo",
 	"cvss: Float!",
 	"envImpact: Float!",
 	"fixedByVersion: String!",
 	"id: ID!",
 	"impactScore: Float!",
 	"isFixable(query: String): Boolean!",
-	"lastModified: Time",
 	"lastScanned: Time",
-	"link: String!",
-	"publishedOn: Time",
-	"scoreVersion: String!",
 	"severity: String!",
-	"summary: String!",
-	"suppressActivation: Time",
-	"suppressExpiry: Time",
-	"suppressed: Boolean!",
+	"snoozeExpiry: Time",
+	"snoozeStart: Time",
+	"snoozed: Boolean!",
 	"unusedVarSink(query: String): Int",
 	"vectors: EmbeddedVulnerabilityVectors",
+
+	// deprecated fields
+	"suppressActivation: Time @deprecated(reason: \"use 'snoozeStart'\")",
+	"suppressExpiry: Time @deprecated(reason: \"use 'snoozeExpiry'\")",
+	"suppressed: Boolean! @deprecated(reason: \"use 'snoozed'\")",
+
+	// CVEInfo fields
+	"createdAt: Time @deprecated(reason: \"use 'cveBaseInfo'\")",
+	"cve: String! @deprecated(reason: \"use 'cveBaseInfo'\")",
+	"lastModified: Time @deprecated(reason: \"use 'cveBaseInfo'\")",
+	"link: String! @deprecated(reason: \"use 'cveBaseInfo'\")",
+	"publishedOn: Time @deprecated(reason: \"use 'cveBaseInfo'\")",
+	"scoreVersion: String! @deprecated(reason: \"use 'cveBaseInfo'\")",
+	"summary: String! @deprecated(reason: \"use 'cveBaseInfo'\")",
 }
 
 // CommonVulnerabilityResolver represents the supported API on all vulnerabilities
 //  NOTE: This list is and should remain alphabetically ordered
 type CommonVulnerabilityResolver interface {
-	CreatedAt(ctx context.Context) (*graphql.Time, error)
-	CVE(ctx context.Context) string
+	CveBaseInfo(ctx context.Context) (*cVEInfoResolver, error)
 	Cvss(ctx context.Context) float64
 	EnvImpact(ctx context.Context) (float64, error)
 	FixedByVersion(ctx context.Context) (string, error)
-	ID(ctx context.Context) graphql.ID
+	Id(ctx context.Context) graphql.ID
 	ImpactScore(ctx context.Context) float64
 	IsFixable(ctx context.Context, args RawQuery) (bool, error)
-	LastModified(ctx context.Context) (*graphql.Time, error)
 	LastScanned(ctx context.Context) (*graphql.Time, error)
-	Link(ctx context.Context) string
-	PublishedOn(ctx context.Context) (*graphql.Time, error)
-	ScoreVersion(ctx context.Context) string
 	Severity(ctx context.Context) string
-	Summary(ctx context.Context) string
+	SnoozeStart(ctx context.Context) (*graphql.Time, error)
+	SnoozeExpiry(ctx context.Context) (*graphql.Time, error)
+	Snoozed(ctx context.Context) bool
+	UnusedVarSink(ctx context.Context, args RawQuery) *int32
+	Vectors() *EmbeddedVulnerabilityVectorsResolver
+
+	// deprecated functions
+
+	ID(ctx context.Context) graphql.ID
 	SuppressActivation(ctx context.Context) (*graphql.Time, error)
 	SuppressExpiry(ctx context.Context) (*graphql.Time, error)
 	Suppressed(ctx context.Context) bool
-	UnusedVarSink(ctx context.Context, args RawQuery) *int32
-	Vectors() *EmbeddedVulnerabilityVectorsResolver
+
+	// CVEInfo functions
+
+	CreatedAt(ctx context.Context) (*graphql.Time, error)
+	CVE(ctx context.Context) string
+	LastModified(ctx context.Context) (*graphql.Time, error)
+	Link(ctx context.Context) string
+	PublishedOn(ctx context.Context) (*graphql.Time, error)
+	ScoreVersion(ctx context.Context) string
+	Summary(ctx context.Context) string
 }

--- a/central/graphql/resolvers/common_vulnerabilities.go
+++ b/central/graphql/resolvers/common_vulnerabilities.go
@@ -13,6 +13,8 @@ import (
  * NOTE: This list is and should remain alphabetically ordered
  */
 var commonVulnerabilitySubResolvers = []string{
+	"createdAt: Time",
+	"cve: String!",
 	"cveBaseInfo: CVEInfo",
 	"cvss: Float!",
 	"envImpact: Float!",
@@ -20,32 +22,25 @@ var commonVulnerabilitySubResolvers = []string{
 	"id: ID!",
 	"impactScore: Float!",
 	"isFixable(query: String): Boolean!",
+	"lastModified: Time",
 	"lastScanned: Time",
+	"link: String!",
+	"publishedOn: Time",
+	"scoreVersion: String!",
 	"severity: String!",
-	"snoozeExpiry: Time",
-	"snoozeStart: Time",
-	"snoozed: Boolean!",
+	"summary: String!",
+	"suppressActivation: Time",
+	"suppressExpiry: Time",
+	"suppressed: Boolean!",
 	"unusedVarSink(query: String): Int",
 	"vectors: EmbeddedVulnerabilityVectors",
-
-	// deprecated fields
-	"suppressActivation: Time @deprecated(reason: \"use 'snoozeStart'\")",
-	"suppressExpiry: Time @deprecated(reason: \"use 'snoozeExpiry'\")",
-	"suppressed: Boolean! @deprecated(reason: \"use 'snoozed'\")",
-
-	// CVEInfo fields
-	"createdAt: Time @deprecated(reason: \"use 'cveBaseInfo'\")",
-	"cve: String! @deprecated(reason: \"use 'cveBaseInfo'\")",
-	"lastModified: Time @deprecated(reason: \"use 'cveBaseInfo'\")",
-	"link: String! @deprecated(reason: \"use 'cveBaseInfo'\")",
-	"publishedOn: Time @deprecated(reason: \"use 'cveBaseInfo'\")",
-	"scoreVersion: String! @deprecated(reason: \"use 'cveBaseInfo'\")",
-	"summary: String! @deprecated(reason: \"use 'cveBaseInfo'\")",
 }
 
 // CommonVulnerabilityResolver represents the supported API on all vulnerabilities
 //  NOTE: This list is and should remain alphabetically ordered
 type CommonVulnerabilityResolver interface {
+	CreatedAt(ctx context.Context) (*graphql.Time, error)
+	CVE(ctx context.Context) string
 	CveBaseInfo(ctx context.Context) (*cVEInfoResolver, error)
 	Cvss(ctx context.Context) float64
 	EnvImpact(ctx context.Context) (float64, error)
@@ -53,28 +48,16 @@ type CommonVulnerabilityResolver interface {
 	Id(ctx context.Context) graphql.ID
 	ImpactScore(ctx context.Context) float64
 	IsFixable(ctx context.Context, args RawQuery) (bool, error)
-	LastScanned(ctx context.Context) (*graphql.Time, error)
-	Severity(ctx context.Context) string
-	SnoozeStart(ctx context.Context) (*graphql.Time, error)
-	SnoozeExpiry(ctx context.Context) (*graphql.Time, error)
-	Snoozed(ctx context.Context) bool
-	UnusedVarSink(ctx context.Context, args RawQuery) *int32
-	Vectors() *EmbeddedVulnerabilityVectorsResolver
-
-	// deprecated functions
-
-	ID(ctx context.Context) graphql.ID
-	SuppressActivation(ctx context.Context) (*graphql.Time, error)
-	SuppressExpiry(ctx context.Context) (*graphql.Time, error)
-	Suppressed(ctx context.Context) bool
-
-	// CVEInfo functions
-
-	CreatedAt(ctx context.Context) (*graphql.Time, error)
-	CVE(ctx context.Context) string
 	LastModified(ctx context.Context) (*graphql.Time, error)
+	LastScanned(ctx context.Context) (*graphql.Time, error)
 	Link(ctx context.Context) string
 	PublishedOn(ctx context.Context) (*graphql.Time, error)
 	ScoreVersion(ctx context.Context) string
+	Severity(ctx context.Context) string
 	Summary(ctx context.Context) string
+	SuppressActivation(ctx context.Context) (*graphql.Time, error)
+	SuppressExpiry(ctx context.Context) (*graphql.Time, error)
+	Suppressed(ctx context.Context) bool
+	UnusedVarSink(ctx context.Context, args RawQuery) *int32
+	Vectors() *EmbeddedVulnerabilityVectorsResolver
 }

--- a/central/graphql/resolvers/components.go
+++ b/central/graphql/resolvers/components.go
@@ -60,7 +60,7 @@ func init() {
 // ComponentResolver represents a generic resolver of component fields.
 // Values may come from either an embedded component context, or a top level component context.
 type ComponentResolver interface {
-	ID(ctx context.Context) graphql.ID
+	Id(ctx context.Context) graphql.ID
 	Name(ctx context.Context) string
 	Version(ctx context.Context) string
 	Priority(ctx context.Context) int32

--- a/central/graphql/resolvers/image_components.go
+++ b/central/graphql/resolvers/image_components.go
@@ -82,7 +82,6 @@ type ImageComponentResolver interface {
 	// deprecated functions
 
 	FixedIn(ctx context.Context) string
-	ID(ctx context.Context) graphql.ID
 }
 
 // ImageComponent returns an image component based on an input id (name:version)
@@ -419,10 +418,6 @@ func (resolver *imageComponentResolver) TopImageVulnerability(ctx context.Contex
 		return vulnResolver, nil
 	}
 	return resolver.root.TopImageVulnerability(resolver.withImageComponentScope(ctx), RawQuery{})
-}
-
-func (resolver *imageComponentResolver) ID(_ context.Context) graphql.ID {
-	return graphql.ID(resolver.data.GetId())
 }
 
 func (resolver *imageComponentResolver) LayerIndex() (*int32, error) {

--- a/central/graphql/resolvers/image_components.go
+++ b/central/graphql/resolvers/image_components.go
@@ -30,7 +30,6 @@ func init() {
 			"activeState(query: String): ActiveState",
 			"deploymentCount(query: String, scopeQuery: String): Int!",
 			"deployments(query: String, scopeQuery: String, pagination: Pagination): [Deployment!]!",
-			"fixedIn: String! @deprecated(reason: \"use 'fixedBy'\")",
 			"imageCount(query: String, scopeQuery: String): Int!",
 			"images(query: String, scopeQuery: String, pagination: Pagination): [Image!]!",
 			"imageVulnerabilityCount(query: String, scopeQuery: String): Int!",
@@ -42,6 +41,9 @@ func init() {
 			"plottedImageVulnerabilities(query: String): PlottedImageVulnerabilities!",
 			"topImageVulnerability: ImageVulnerability",
 			"unusedVarSink(query: String): Int",
+
+			// deprecated functions
+			"fixedIn: String! @deprecated(reason: \"use 'fixedBy'\")",
 		}),
 		schema.AddQuery("imageComponent(id: ID): ImageComponent"),
 		schema.AddQuery("imageComponents(query: String, scopeQuery: String, pagination: Pagination): [ImageComponent!]!"),
@@ -56,9 +58,8 @@ type ImageComponentResolver interface {
 	ActiveState(ctx context.Context, args RawQuery) (*activeStateResolver, error)
 	DeploymentCount(ctx context.Context, args RawQuery) (int32, error)
 	Deployments(ctx context.Context, args PaginatedQuery) ([]*deploymentResolver, error)
-	FixedIn(ctx context.Context) string
 	FixedBy(ctx context.Context) string
-	ID(ctx context.Context) graphql.ID
+	Id(ctx context.Context) graphql.ID
 	ImageCount(ctx context.Context, args RawQuery) (int32, error)
 	Images(ctx context.Context, args PaginatedQuery) ([]*imageResolver, error)
 	ImageVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error)
@@ -77,6 +78,11 @@ type ImageComponentResolver interface {
 	TopImageVulnerability(ctx context.Context) (ImageVulnerabilityResolver, error)
 	UnusedVarSink(ctx context.Context, args RawQuery) *int32
 	Version(ctx context.Context) string
+
+	// deprecated functions
+
+	FixedIn(ctx context.Context) string
+	ID(ctx context.Context) graphql.ID
 }
 
 // ImageComponent returns an image component based on an input id (name:version)

--- a/central/graphql/resolvers/vulnerabilities_v2.go
+++ b/central/graphql/resolvers/vulnerabilities_v2.go
@@ -609,18 +609,6 @@ func (resolver *cVEResolver) CveBaseInfo(_ context.Context) (*cVEInfoResolver, e
 	return nil, nil
 }
 
-func (resolver *cVEResolver) SnoozeExpiry(_ context.Context) (*graphql.Time, error) {
-	return nil, nil
-}
-
-func (resolver *cVEResolver) SnoozeStart(_ context.Context) (*graphql.Time, error) {
-	return nil, nil
-}
-
-func (resolver *cVEResolver) Snoozed(_ context.Context) bool {
-	return false
-}
-
 // EnvImpact is the fraction of deployments that contains the CVE
 func (resolver *cVEResolver) EnvImpact(ctx context.Context) (float64, error) {
 	var numerator, denominator int

--- a/central/graphql/resolvers/vulnerabilities_v2.go
+++ b/central/graphql/resolvers/vulnerabilities_v2.go
@@ -262,6 +262,14 @@ func (resolver *Resolver) nodeVulnerabilitiesV2(ctx context.Context, args Pagina
 	return ret, nil
 }
 
+func (resolver *Resolver) clusterVulnerabilityV2(ctx context.Context, args IDQuery) (ClusterVulnerabilityResolver, error) {
+	vulnResolver, err := resolver.unwrappedVulnerabilityV2(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	return vulnResolver, nil
+}
+
 func (resolver *Resolver) clusterVulnerabilitiesV2(ctx context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
 	vulnResolvers, err := resolver.unwrappedVulnerabilitiesV2(ctx, args)
 	if err != nil {
@@ -591,6 +599,26 @@ func (resolver *cVEResolver) getEnvImpactComponentsForNodes(ctx context.Context)
 		return 0, 0, err
 	}
 	return int(withThisCVECount), allNodesCount, nil
+}
+
+func (resolver *cVEResolver) OperatingSystem(_ context.Context) string {
+	return ""
+}
+
+func (resolver *cVEResolver) CveBaseInfo(_ context.Context) (*cVEInfoResolver, error) {
+	return nil, nil
+}
+
+func (resolver *cVEResolver) SnoozeExpiry(_ context.Context) (*graphql.Time, error) {
+	return nil, nil
+}
+
+func (resolver *cVEResolver) SnoozeStart(_ context.Context) (*graphql.Time, error) {
+	return nil, nil
+}
+
+func (resolver *cVEResolver) Snoozed(_ context.Context) bool {
+	return false
 }
 
 // EnvImpact is the fraction of deployments that contains the CVE
@@ -1056,10 +1084,6 @@ func (resolver *cVEResolver) VulnerabilityState(ctx context.Context) string {
 	}
 
 	return storage.VulnerabilityState_OBSERVED.String()
-}
-
-func (resolver *cVEResolver) OperatingSystem(ctx context.Context) string {
-	return ""
 }
 
 func (resolver *cVEResolver) addScopeContext(query *v1.Query) (context.Context, *v1.Query) {


### PR DESCRIPTION
## Description

This refactor is to more clearly define fields to be deprecated in the future and allow FE querying on the nested CVEInfo object to allow for migration towards in the future.