### PR TITLE
ROX-11909: save kuttl JUnit XML to artifacts

### DIFF
--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -55,7 +55,6 @@ class OperatorE2eTest(BaseTest):
     UPGRADE_TEST_TIMEOUT_SEC = 50 * 60
     E2E_TEST_TIMEOUT_SEC = 50 * 60
     SCORECARD_TEST_TIMEOUT_SEC = 20 * 60
-    ARTIFACTS_TIMEOUT = 3 * 60
 
     def __init__(self):
         self.test_outputs = [
@@ -76,26 +75,10 @@ class OperatorE2eTest(BaseTest):
             OperatorE2eTest.UPGRADE_TEST_TIMEOUT_SEC
         )
 
-        print("Storing test-upgrade results in JUnit format")
-        self.run_with_graceful_kill(
-            ["scripts/ci/store-artifacts.sh", "store_test_results",
-             "operator/build/kuttl-test-artifacts",
-             "operator-test-results-upgrade"],
-            OperatorE2eTest.ARTIFACTS_TIMEOUT
-        )
-
         print("Executing operator e2e tests")
         self.run_with_graceful_kill(
             ["make", "-C", "operator", "test-e2e-deployed"],
             OperatorE2eTest.E2E_TEST_TIMEOUT_SEC,
-        )
-
-        print("Storing test-e2e-deployed results in JUnit format")
-        self.run_with_graceful_kill(
-            ["scripts/ci/store-artifacts.sh", "store_test_results",
-             "operator/build/kuttl-test-artifacts",
-             "operator-test-results-e2e-deployed"],
-            OperatorE2eTest.ARTIFACTS_TIMEOUT
         )
 
         print("Executing Operator Bundle Scorecard tests")

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -55,6 +55,7 @@ class OperatorE2eTest(BaseTest):
     UPGRADE_TEST_TIMEOUT_SEC = 50 * 60
     E2E_TEST_TIMEOUT_SEC = 50 * 60
     SCORECARD_TEST_TIMEOUT_SEC = 20 * 60
+    ARTIFACTS_TIMEOUT = 3 * 60
 
     def __init__(self):
         self.test_outputs = [
@@ -72,13 +73,29 @@ class OperatorE2eTest(BaseTest):
         print("Executing operator upgrade test")
         self.run_with_graceful_kill(
             ["make", "-C", "operator", "test-upgrade"],
-            OperatorE2eTest.UPGRADE_TEST_TIMEOUT_SEC,
+            OperatorE2eTest.UPGRADE_TEST_TIMEOUT_SEC
+        )
+
+        print("Storing test-upgrade results in JUnit format")
+        self.run_with_graceful_kill(
+            ["scripts/ci/store-artifacts.sh", "store_test_results",
+             "operator/build/kuttl-test-artifacts",
+             "operator-test-results-upgrade"],
+            OperatorE2eTest.ARTIFACTS_TIMEOUT
         )
 
         print("Executing operator e2e tests")
         self.run_with_graceful_kill(
             ["make", "-C", "operator", "test-e2e-deployed"],
             OperatorE2eTest.E2E_TEST_TIMEOUT_SEC,
+        )
+
+        print("Storing test-e2e-deployed results in JUnit format")
+        self.run_with_graceful_kill(
+            ["scripts/ci/store-artifacts.sh", "store_test_results",
+             "operator/build/kuttl-test-artifacts",
+             "operator-test-results-e2e-deployed"],
+            OperatorE2eTest.ARTIFACTS_TIMEOUT
         )
 
         print("Executing Operator Bundle Scorecard tests")

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -12,6 +12,7 @@ from common import popen_graceful_kill
 class BaseTest:
     def __init__(self):
         self.test_outputs = []
+        self.test_results = {}
 
     def run_with_graceful_kill(self, args, timeout, post_start_hook=None):
         with subprocess.Popen(args) as cmd:
@@ -57,10 +58,10 @@ class OperatorE2eTest(BaseTest):
     SCORECARD_TEST_TIMEOUT_SEC = 20 * 60
 
     def __init__(self):
-        self.test_outputs = [
-            "operator/build/kuttl-test-artifacts",
-            "operator/build/kuttl-test-artifacts-upgrade",
-        ]
+        self.test_results = {
+            "operator/build/kuttl-test-artifacts": "kuttl-test-artifacts",
+            "operator/build/kuttl-test-artifacts-upgrade": "kuttl-test-artifacts-upgrade",
+        }
 
     def run(self):
         print("Deploying operator")

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -58,9 +58,13 @@ class OperatorE2eTest(BaseTest):
     SCORECARD_TEST_TIMEOUT_SEC = 20 * 60
 
     def __init__(self):
+        self.test_outputs = [
+            "operator/build/kuttl-test-artifacts",
+            "operator/build/kuttl-test-artifacts-upgrade",
+        ]
         self.test_results = {
-            "operator/build/kuttl-test-artifacts": "kuttl-test-artifacts",
-            "operator/build/kuttl-test-artifacts-upgrade": "kuttl-test-artifacts-upgrade",
+            "kuttl-test-artifacts": "operator/build/kuttl-test-artifacts",
+            "kuttl-test-artifacts-upgrade": "operator/build/kuttl-test-artifacts-upgrade",
         }
 
     def run(self):

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -81,7 +81,7 @@ class StoreArtifacts(RunWithBestEffortMixin):
         self.handle_run_failure()
 
     def add_test_results(self, test_results):
-        if test_results is None:
+        if not test_results:
             return
         print("Storing test results in JUnit format")
         for to_dir, from_dir in test_results.items():
@@ -139,8 +139,8 @@ class PostClusterTest(StoreArtifacts):
         self.collect_service_logs()
         if self._check_stackrox_logs:
             self.check_stackrox_logs()
-        self.add_test_results(test_results)
         self.store_artifacts(test_outputs)
+        self.add_test_results(test_results)
         self.handle_run_failure()
 
     def wait_for_central_api(self):

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -31,7 +31,7 @@ class PostTestsConstants:
 
 
 class NullPostTest:
-    def run(self, test_outputs=None):
+    def run(self, test_outputs=None, test_results=None):
         pass
 
 
@@ -76,7 +76,7 @@ class StoreArtifacts(RunWithBestEffortMixin):
         self.artifact_destination_prefix = artifact_destination_prefix
         self.data_to_store = []
 
-    def run(self, test_outputs=None):
+    def run(self, test_outputs=None, test_results=None):
         self.store_artifacts(test_outputs)
         self.handle_run_failure()
 
@@ -234,7 +234,7 @@ class CheckStackroxLogs(StoreArtifacts):
         self._check_for_errors_in_stackrox_logs = check_for_errors_in_stackrox_logs
         self.central_is_responsive = False
 
-    def run(self, test_outputs=None):
+    def run(self, test_outputs=None, test_results=None):
         self.central_is_responsive = self.wait_for_central_api()
         if self.central_is_responsive:
             self.collect_stackrox_logs()
@@ -302,7 +302,7 @@ class FinalPost(StoreArtifacts):
             self.data_to_store.append(PostTestsConstants.QA_SPOCK_RESULTS)
         self._handle_e2e_progress_failures = handle_e2e_progress_failures
 
-    def run(self, test_outputs=None):
+    def run(self, test_outputs=None, test_results=None):
         self.store_artifacts()
         self.fixup_artifacts_content_type()
         self.make_artifacts_help()

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -84,7 +84,7 @@ class StoreArtifacts(RunWithBestEffortMixin):
         if test_results is None:
             return
         print("Storing test results in JUnit format")
-        for to_dir, from_dir in test_results:
+        for to_dir, from_dir in test_results.items():
             self.run_with_best_effort(
                 ["scripts/ci/store-artifacts.sh", "store_test_results",
                  from_dir, to_dir],

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -303,6 +303,7 @@ class FinalPost(StoreArtifacts):
 
     def run(self, test_outputs=None, test_results=None):
         self.store_artifacts()
+        self.add_test_results(test_results)
         self.fixup_artifacts_content_type()
         self.make_artifacts_help()
         self.handle_run_failure()

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -106,7 +106,7 @@ class PostClusterTest(StoreArtifacts):
         collect_central_artifacts=True,
         check_stackrox_logs=False,
         artifact_destination_prefix=None,
-        add_test_result=False,
+        add_test_result=True,
     ):
         super().__init__(artifact_destination_prefix=artifact_destination_prefix)
         self._check_stackrox_logs = check_stackrox_logs

--- a/.openshift-ci/runners.py
+++ b/.openshift-ci/runners.py
@@ -101,7 +101,8 @@ class ClusterTestSetsRunner:
                 hold = err
             try:
                 self.log_event("About to run post test", test_set)
-                test_set["post_test"].run(test_outputs=test_set["test"].test_outputs)
+                test_set["post_test"].run(test_outputs=test_set["test"].test_outputs,
+                                          test_results=test_set["test"].test_results)
                 self.log_event("post test completed", test_set)
             except Exception as err:
                 self.log_event("ERROR: post test failed", test_set)


### PR DESCRIPTION
## Description

Prow can display tests that fail in its JUnit panel. e.g. https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-go-unit-tests/1550162970292523008

For Prow to display tests that fail in its JUnit panel it needs files in JUnit XML format copied to $ARTIFACT_DIR. This PR does that for `openshift-4-operator-e2e-tests`, which are run via `kuttl`.

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

1. Verified in CI that artifacts are in place, see `ci/prow/openshift-4-operator-e2e-tests `

