### PR TITLE
Dashrews/rox-11971 create context after connect

### DIFF
--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -85,13 +85,15 @@ func RenameDB(adminPool *pgxpool.Pool, originalDB, newDB string) error {
 // CheckIfDBExists - checks to see if a restore database exists
 func CheckIfDBExists(config *pgxpool.Config, dbName string) bool {
 	log.Infof("CheckIfDBExists - %q", dbName)
-	ctx, cancel := context.WithTimeout(context.Background(), postgresQueryTimeout)
-	defer cancel()
 
 	// Connect to different database for admin functions
 	connectPool := GetAdminPool(config)
 	// Close the admin connection pool
 	defer connectPool.Close()
+
+	// Create a context with a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), postgresQueryTimeout)
+	defer cancel()
 
 	existsStmt := "SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_database WHERE datname = $1)"
 


### PR DESCRIPTION
## Description

Had an issue where on a restart central would not find the active database.  The reason for this was because the query to find the active database is on a timeout context.  This timeout context was created BEFORE the DB connection was retrieved.  If the DB connection fails it retries after 10 seconds.  The problem is the timeout on the query context was only 5 seconds.  So if central did not get the DB connection on the first try, the query would fail and not find the active database.  Fix was simply to move the creation of the context until after the DB connection had been acquired.

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested locally where I would destroy the central pod repeatedly and use the logs to ensure that it was executing correctly on restart and finding the active database.  This and CI testing should be sufficient.
