### PR TITLE
Split Violations by category chart and card components.

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -22,19 +22,9 @@ import useWidgetConfig from 'hooks/useWidgetConfig';
 import useAlertGroups from '../hooks/useAlertGroups';
 import WidgetCard from './WidgetCard';
 import NoDataEmptyState from './NoDataEmptyState';
-import ViolationsByPolicyCategoryChart, {
-    LifecycleOption,
-} from './ViolationsByPolicyCategoryChart';
-
-type SortTypeOption = 'Severity' | 'Total';
+import ViolationsByPolicyCategoryChart, { Config } from './ViolationsByPolicyCategoryChart';
 
 const fieldIdPrefix = 'policy-category-violations';
-
-type Config = {
-    sortType: SortTypeOption;
-    lifecycle: LifecycleOption;
-    hiddenSeverities: Readonly<PolicySeverity[]>;
-};
 
 const defaultHiddenSeverities = ['MEDIUM_SEVERITY', 'LOW_SEVERITY'] as const;
 

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useMemo, useCallback } from 'react';
-import { useLocation, useHistory } from 'react-router-dom';
+import React, { useMemo, useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
 import {
     Dropdown,
     DropdownToggle,
@@ -11,274 +11,22 @@ import {
     ToggleGroup,
     ToggleGroupItem,
 } from '@patternfly/react-core';
-import {
-    Chart,
-    ChartAxis,
-    ChartStack,
-    ChartBar,
-    ChartTooltip,
-    ChartLabelProps,
-    ChartLegend,
-    getInteractiveLegendEvents,
-    getInteractiveLegendItemStyles,
-} from '@patternfly/react-charts';
-import sortBy from 'lodash/sortBy';
 
-import { LinkableChartLabel } from 'Components/PatternFly/Charts/LinkableChartLabel';
-import { AlertGroup } from 'services/AlertsService';
-import { severityLabels } from 'messages/common';
-import {
-    navigateOnClickEvent,
-    patternflySeverityTheme,
-    defaultChartHeight as chartHeight,
-    defaultChartBarWidth,
-} from 'utils/chartUtils';
-import { getQueryString } from 'utils/queryStringUtils';
-import { violationsBasePath } from 'routePaths';
-import useResizeObserver from 'hooks/useResizeObserver';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import useURLSearch from 'hooks/useURLSearch';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';
-import {
-    LifecycleStage,
-    policySeverities as severitiesLowToCritical,
-    PolicySeverity,
-} from 'types/policy.proto';
+import { PolicySeverity } from 'types/policy.proto';
 
-import { SearchFilter } from 'types/search';
 import useWidgetConfig from 'hooks/useWidgetConfig';
 import useAlertGroups from '../hooks/useAlertGroups';
 import WidgetCard from './WidgetCard';
 import NoDataEmptyState from './NoDataEmptyState';
-
-/**
- * This function iterates an array of AlertGroups and zeros out severities that
- * have been filtered by the user in the widget's legend.
- */
-function zeroOutFilteredSeverities(
-    groups: AlertGroup[],
-    hiddenSeverities: Set<PolicySeverity>
-): AlertGroup[] {
-    return groups.map(({ group, counts }) => ({
-        group,
-        counts: counts.map(({ severity, count }) => ({
-            severity,
-            count: hiddenSeverities.has(severity) ? '0' : count,
-        })),
-    }));
-}
-
-function pluckSeverityCount(severity: PolicySeverity): (group: AlertGroup) => number {
-    return ({ counts }) => {
-        const severityCount = counts.find((ct) => ct.severity === severity)?.count ?? '0';
-        return -parseInt(severityCount, 10);
-    };
-}
-
-function sortByVolume(groups: AlertGroup[]) {
-    const sum = (a: number, b: number) => a + b;
-    return sortBy(groups, ({ counts }) => {
-        return -counts.map(({ count }) => parseInt(count, 10)).reduce(sum);
-    });
-}
-
-function sortBySeverity(groups: AlertGroup[]) {
-    return sortBy(groups, [
-        pluckSeverityCount('CRITICAL_SEVERITY'),
-        pluckSeverityCount('HIGH_SEVERITY'),
-        pluckSeverityCount('MEDIUM_SEVERITY'),
-        pluckSeverityCount('LOW_SEVERITY'),
-    ]);
-}
-
-type CountsBySeverity = Record<PolicySeverity, Record<string, number>>;
-
-function getCountsBySeverity(groups: AlertGroup[]): CountsBySeverity {
-    const result = {
-        LOW_SEVERITY: {},
-        MEDIUM_SEVERITY: {},
-        HIGH_SEVERITY: {},
-        CRITICAL_SEVERITY: {},
-    };
-
-    groups.forEach(({ group, counts }) => {
-        result.LOW_SEVERITY[group] = 0;
-        result.MEDIUM_SEVERITY[group] = 0;
-        result.HIGH_SEVERITY[group] = 0;
-        result.CRITICAL_SEVERITY[group] = 0;
-
-        counts.forEach(({ severity, count }) => {
-            result[severity][group] = parseInt(count, 10);
-        });
-    });
-
-    return result;
-}
-
-function linkForViolationsCategory(
-    category: string,
-    searchFilter: SearchFilter,
-    lifecycle: LifecycleOption,
-    hiddenSeverities: Set<PolicySeverity>
-) {
-    const search: SearchFilter = {
-        ...searchFilter,
-        Category: category,
-    };
-
-    if (lifecycle !== 'ALL') {
-        search['Lifecycle Stage'] = lifecycle;
-    }
-    if (hiddenSeverities.size > 0) {
-        search.Severity = severitiesLowToCritical.filter((s) => !hiddenSeverities.has(s));
-    }
-
-    const queryString = getQueryString({
-        s: search,
-        sortOption: { field: 'Severity', direction: 'desc' },
-    });
-    return `${violationsBasePath}${queryString}`;
-}
+import ViolationsByPolicyCategoryChart, {
+    LifecycleOption,
+} from './ViolationsByPolicyCategoryChart';
 
 type SortTypeOption = 'Severity' | 'Total';
-
-type ViolationsByPolicyCategoryChartProps = {
-    alertGroups: AlertGroup[];
-    sortType: SortTypeOption;
-    lifecycle: LifecycleOption;
-    searchFilter: SearchFilter;
-    hiddenSeverities: Set<PolicySeverity>;
-    setHiddenSeverities: (severities: Set<PolicySeverity>) => Promise<Config>;
-};
-
-function tooltipForCategory(
-    category: string,
-    countsBySeverity: CountsBySeverity,
-    hiddenSeverities: Set<PolicySeverity>
-): string {
-    return severitiesLowToCritical
-        .filter((severity) => !hiddenSeverities.has(severity))
-        .map((severity) => `${severityLabels[severity]}: ${countsBySeverity[severity][category]}`)
-        .join('\n');
-}
-
-const chartTheme = patternflySeverityTheme;
-
-function ViolationsByPolicyCategoryChart({
-    alertGroups,
-    sortType,
-    lifecycle,
-    hiddenSeverities,
-    setHiddenSeverities,
-    searchFilter,
-}: ViolationsByPolicyCategoryChartProps) {
-    const history = useHistory();
-    const [widgetContainer, setWidgetContainer] = useState<HTMLDivElement | null>(null);
-    const widgetContainerResizeEntry = useResizeObserver(widgetContainer);
-
-    const labelLinkCallback = useCallback(
-        ({ text }: ChartLabelProps) =>
-            linkForViolationsCategory(String(text), searchFilter, lifecycle, hiddenSeverities),
-        [searchFilter, lifecycle, hiddenSeverities]
-    );
-
-    const filteredAlertGroups = zeroOutFilteredSeverities(alertGroups, hiddenSeverities);
-    const sortedAlertGroups =
-        sortType === 'Severity'
-            ? sortBySeverity(filteredAlertGroups)
-            : sortByVolume(filteredAlertGroups);
-    // We reverse here, because PF/Victory charts stack the bars from bottom->up
-    const topOrderedGroups = sortedAlertGroups.slice(0, 5).reverse();
-    const countsBySeverity = getCountsBySeverity(topOrderedGroups);
-
-    const bars = severitiesLowToCritical.map((severity) => {
-        const counts = countsBySeverity[severity];
-        const data = Object.entries(counts).map(([group, count]) => ({
-            name: severity,
-            x: group,
-            y: count,
-            label: tooltipForCategory(group, countsBySeverity, hiddenSeverities),
-        }));
-
-        return (
-            <ChartBar
-                barWidth={defaultChartBarWidth}
-                key={severity}
-                data={data}
-                labelComponent={<ChartTooltip constrainToVisibleArea />}
-                events={[
-                    navigateOnClickEvent(history, (targetProps) => {
-                        const category = targetProps?.datum?.xName;
-                        return linkForViolationsCategory(
-                            category,
-                            searchFilter,
-                            lifecycle,
-                            hiddenSeverities
-                        );
-                    }),
-                ]}
-            />
-        );
-    });
-
-    function getLegendData() {
-        const legendData = severitiesLowToCritical.map((severity) => {
-            return {
-                name: severityLabels[severity],
-                ...getInteractiveLegendItemStyles(hiddenSeverities.has(severity)),
-            };
-        });
-        return legendData;
-    }
-
-    function onLegendClick({ index }: { index: number }) {
-        const newHidden = new Set(hiddenSeverities);
-        const targetSeverity = severitiesLowToCritical[index];
-        if (newHidden.has(targetSeverity)) {
-            newHidden.delete(targetSeverity);
-            // Do not allow the user to disable all severities
-        } else if (hiddenSeverities.size < 3) {
-            newHidden.add(targetSeverity);
-        }
-        return setHiddenSeverities(newHidden);
-    }
-
-    return (
-        <div ref={setWidgetContainer}>
-            <Chart
-                ariaDesc="Number of violations by policy category, grouped by severity"
-                animate={{ duration: 300 }}
-                domainPadding={{ x: [20, 20] }}
-                events={getInteractiveLegendEvents({
-                    chartNames: [Object.values(severityLabels)],
-                    isHidden: (index) => hiddenSeverities.has(severitiesLowToCritical[index]),
-                    legendName: 'legend',
-                    onLegendClick,
-                })}
-                legendComponent={<ChartLegend name="legend" data={getLegendData()} />}
-                legendPosition="bottom"
-                height={chartHeight}
-                width={widgetContainerResizeEntry?.contentRect.width} // Victory defaults to 450
-                padding={{
-                    // TODO Auto-adjust padding based on screen size and/or max text length, if possible
-                    left: 180, // left padding is dependent on the length of the text on the left axis
-                    bottom: 55, // Adjusted to accommodate legend
-                    right: 35,
-                }}
-                theme={chartTheme}
-            >
-                <ChartAxis
-                    tickLabelComponent={<LinkableChartLabel linkWith={labelLinkCallback} />}
-                />
-                <ChartAxis dependentAxis tickFormat={String} />
-                <ChartStack horizontal>{bars}</ChartStack>
-            </Chart>
-        </div>
-    );
-}
-
-type LifecycleOption = 'ALL' | Exclude<LifecycleStage, 'BUILD'>;
 
 const fieldIdPrefix = 'policy-category-violations';
 

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategoryChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategoryChart.tsx
@@ -73,8 +73,6 @@ function sortBySeverity(groups: AlertGroup[]) {
     ]);
 }
 
-export type LifecycleOption = 'ALL' | Exclude<LifecycleStage, 'BUILD'>;
-
 type CountsBySeverity = Record<PolicySeverity, Record<string, number>>;
 
 function getCountsBySeverity(groups: AlertGroup[]): CountsBySeverity {
@@ -124,15 +122,6 @@ function linkForViolationsCategory(
     return `${violationsBasePath}${queryString}`;
 }
 
-type ViolationsByPolicyCategoryChartProps = {
-    alertGroups: AlertGroup[];
-    sortType: SortTypeOption;
-    lifecycle: LifecycleOption;
-    searchFilter: SearchFilter;
-    hiddenSeverities: Set<PolicySeverity>;
-    setHiddenSeverities: (severities: Set<PolicySeverity>) => Promise<Config>;
-};
-
 function tooltipForCategory(
     category: string,
     countsBySeverity: CountsBySeverity,
@@ -145,6 +134,26 @@ function tooltipForCategory(
 }
 
 const chartTheme = patternflySeverityTheme;
+
+type SortTypeOption = 'Severity' | 'Total';
+
+type LifecycleOption = 'ALL' | Exclude<LifecycleStage, 'BUILD'>;
+
+export type Config = {
+    sortType: SortTypeOption;
+    lifecycle: LifecycleOption;
+    hiddenSeverities: Readonly<PolicySeverity[]>;
+};
+
+type ViolationsByPolicyCategoryChartProps = {
+    alertGroups: AlertGroup[];
+    sortType: SortTypeOption;
+    lifecycle: LifecycleOption;
+    searchFilter: SearchFilter;
+    hiddenSeverities: Set<PolicySeverity>;
+    setHiddenSeverities: (severities: Set<PolicySeverity>) => Promise<Config>;
+};
+
 function ViolationsByPolicyCategoryChart({
     alertGroups,
     sortType,

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategoryChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategoryChart.tsx
@@ -1,0 +1,261 @@
+import React, { useState, useCallback } from 'react';
+import { useHistory } from 'react-router-dom';
+import {
+    Chart,
+    ChartAxis,
+    ChartStack,
+    ChartBar,
+    ChartTooltip,
+    ChartLabelProps,
+    ChartLegend,
+    getInteractiveLegendEvents,
+    getInteractiveLegendItemStyles,
+} from '@patternfly/react-charts';
+import sortBy from 'lodash/sortBy';
+
+import { LinkableChartLabel } from 'Components/PatternFly/Charts/LinkableChartLabel';
+import { AlertGroup } from 'services/AlertsService';
+import { severityLabels } from 'messages/common';
+import {
+    navigateOnClickEvent,
+    patternflySeverityTheme,
+    defaultChartHeight as chartHeight,
+    defaultChartBarWidth,
+} from 'utils/chartUtils';
+import { getQueryString } from 'utils/queryStringUtils';
+import { violationsBasePath } from 'routePaths';
+import useResizeObserver from 'hooks/useResizeObserver';
+import {
+    LifecycleStage,
+    policySeverities as severitiesLowToCritical,
+    PolicySeverity,
+} from 'types/policy.proto';
+
+import { SearchFilter } from 'types/search';
+
+/**
+ * This function iterates an array of AlertGroups and zeros out severities that
+ * have been filtered by the user in the widget's legend.
+ */
+function zeroOutFilteredSeverities(
+    groups: AlertGroup[],
+    hiddenSeverities: Set<PolicySeverity>
+): AlertGroup[] {
+    return groups.map(({ group, counts }) => ({
+        group,
+        counts: counts.map(({ severity, count }) => ({
+            severity,
+            count: hiddenSeverities.has(severity) ? '0' : count,
+        })),
+    }));
+}
+
+function pluckSeverityCount(severity: PolicySeverity): (group: AlertGroup) => number {
+    return ({ counts }) => {
+        const severityCount = counts.find((ct) => ct.severity === severity)?.count ?? '0';
+        return -parseInt(severityCount, 10);
+    };
+}
+
+function sortByVolume(groups: AlertGroup[]) {
+    const sum = (a: number, b: number) => a + b;
+    return sortBy(groups, ({ counts }) => {
+        return -counts.map(({ count }) => parseInt(count, 10)).reduce(sum);
+    });
+}
+
+function sortBySeverity(groups: AlertGroup[]) {
+    return sortBy(groups, [
+        pluckSeverityCount('CRITICAL_SEVERITY'),
+        pluckSeverityCount('HIGH_SEVERITY'),
+        pluckSeverityCount('MEDIUM_SEVERITY'),
+        pluckSeverityCount('LOW_SEVERITY'),
+    ]);
+}
+
+export type LifecycleOption = 'ALL' | Exclude<LifecycleStage, 'BUILD'>;
+
+type CountsBySeverity = Record<PolicySeverity, Record<string, number>>;
+
+function getCountsBySeverity(groups: AlertGroup[]): CountsBySeverity {
+    const result = {
+        LOW_SEVERITY: {},
+        MEDIUM_SEVERITY: {},
+        HIGH_SEVERITY: {},
+        CRITICAL_SEVERITY: {},
+    };
+
+    groups.forEach(({ group, counts }) => {
+        result.LOW_SEVERITY[group] = 0;
+        result.MEDIUM_SEVERITY[group] = 0;
+        result.HIGH_SEVERITY[group] = 0;
+        result.CRITICAL_SEVERITY[group] = 0;
+
+        counts.forEach(({ severity, count }) => {
+            result[severity][group] = parseInt(count, 10);
+        });
+    });
+
+    return result;
+}
+
+function linkForViolationsCategory(
+    category: string,
+    searchFilter: SearchFilter,
+    lifecycle: LifecycleOption,
+    hiddenSeverities: Set<PolicySeverity>
+) {
+    const search: SearchFilter = {
+        ...searchFilter,
+        Category: category,
+    };
+
+    if (lifecycle !== 'ALL') {
+        search['Lifecycle Stage'] = lifecycle;
+    }
+    if (hiddenSeverities.size > 0) {
+        search.Severity = severitiesLowToCritical.filter((s) => !hiddenSeverities.has(s));
+    }
+
+    const queryString = getQueryString({
+        s: search,
+        sortOption: { field: 'Severity', direction: 'desc' },
+    });
+    return `${violationsBasePath}${queryString}`;
+}
+
+type ViolationsByPolicyCategoryChartProps = {
+    alertGroups: AlertGroup[];
+    sortType: SortTypeOption;
+    lifecycle: LifecycleOption;
+    searchFilter: SearchFilter;
+    hiddenSeverities: Set<PolicySeverity>;
+    setHiddenSeverities: (severities: Set<PolicySeverity>) => Promise<Config>;
+};
+
+function tooltipForCategory(
+    category: string,
+    countsBySeverity: CountsBySeverity,
+    hiddenSeverities: Set<PolicySeverity>
+): string {
+    return severitiesLowToCritical
+        .filter((severity) => !hiddenSeverities.has(severity))
+        .map((severity) => `${severityLabels[severity]}: ${countsBySeverity[severity][category]}`)
+        .join('\n');
+}
+
+const chartTheme = patternflySeverityTheme;
+function ViolationsByPolicyCategoryChart({
+    alertGroups,
+    sortType,
+    lifecycle,
+    hiddenSeverities,
+    setHiddenSeverities,
+    searchFilter,
+}: ViolationsByPolicyCategoryChartProps) {
+    const history = useHistory();
+    const [widgetContainer, setWidgetContainer] = useState<HTMLDivElement | null>(null);
+    const widgetContainerResizeEntry = useResizeObserver(widgetContainer);
+
+    const labelLinkCallback = useCallback(
+        ({ text }: ChartLabelProps) =>
+            linkForViolationsCategory(String(text), searchFilter, lifecycle, hiddenSeverities),
+        [searchFilter, lifecycle, hiddenSeverities]
+    );
+
+    const filteredAlertGroups = zeroOutFilteredSeverities(alertGroups, hiddenSeverities);
+    const sortedAlertGroups =
+        sortType === 'Severity'
+            ? sortBySeverity(filteredAlertGroups)
+            : sortByVolume(filteredAlertGroups);
+    // We reverse here, because PF/Victory charts stack the bars from bottom->up
+    const topOrderedGroups = sortedAlertGroups.slice(0, 5).reverse();
+    const countsBySeverity = getCountsBySeverity(topOrderedGroups);
+
+    const bars = severitiesLowToCritical.map((severity) => {
+        const counts = countsBySeverity[severity];
+        const data = Object.entries(counts).map(([group, count]) => ({
+            name: severity,
+            x: group,
+            y: count,
+            label: tooltipForCategory(group, countsBySeverity, hiddenSeverities),
+        }));
+
+        return (
+            <ChartBar
+                barWidth={defaultChartBarWidth}
+                key={severity}
+                data={data}
+                labelComponent={<ChartTooltip constrainToVisibleArea />}
+                events={[
+                    navigateOnClickEvent(history, (targetProps) => {
+                        const category = targetProps?.datum?.xName;
+                        return linkForViolationsCategory(
+                            category,
+                            searchFilter,
+                            lifecycle,
+                            hiddenSeverities
+                        );
+                    }),
+                ]}
+            />
+        );
+    });
+
+    function getLegendData() {
+        const legendData = severitiesLowToCritical.map((severity) => {
+            return {
+                name: severityLabels[severity],
+                ...getInteractiveLegendItemStyles(hiddenSeverities.has(severity)),
+            };
+        });
+        return legendData;
+    }
+
+    function onLegendClick({ index }: { index: number }) {
+        const newHidden = new Set(hiddenSeverities);
+        const targetSeverity = severitiesLowToCritical[index];
+        if (newHidden.has(targetSeverity)) {
+            newHidden.delete(targetSeverity);
+            // Do not allow the user to disable all severities
+        } else if (hiddenSeverities.size < 3) {
+            newHidden.add(targetSeverity);
+        }
+        return setHiddenSeverities(newHidden);
+    }
+
+    return (
+        <div ref={setWidgetContainer}>
+            <Chart
+                ariaDesc="Number of violations by policy category, grouped by severity"
+                animate={{ duration: 300 }}
+                domainPadding={{ x: [20, 20] }}
+                events={getInteractiveLegendEvents({
+                    chartNames: [Object.values(severityLabels)],
+                    isHidden: (index) => hiddenSeverities.has(severitiesLowToCritical[index]),
+                    legendName: 'legend',
+                    onLegendClick,
+                })}
+                legendComponent={<ChartLegend name="legend" data={getLegendData()} />}
+                legendPosition="bottom"
+                height={chartHeight}
+                width={widgetContainerResizeEntry?.contentRect.width} // Victory defaults to 450
+                padding={{
+                    // TODO Auto-adjust padding based on screen size and/or max text length, if possible
+                    left: 180, // left padding is dependent on the length of the text on the left axis
+                    bottom: 55, // Adjusted to accommodate legend
+                    right: 35,
+                }}
+                theme={chartTheme}
+            >
+                <ChartAxis
+                    tickLabelComponent={<LinkableChartLabel linkWith={labelLinkCallback} />}
+                />
+                <ChartAxis dependentAxis tickFormat={String} />
+                <ChartStack horizontal>{bars}</ChartStack>
+            </Chart>
+        </div>
+    );
+}
+
+export default ViolationsByPolicyCategoryChart;


### PR DESCRIPTION
## Description

This is a purely mechanical cleanup change that separates the outer part of the `ViolationsByPolicyCategory` component (widget card, options, data loading) from the inner part of the card (chart display). This was the first widget developed and the only one where both of the above components were contained in a single file, so this PR breaks them apart to be in line with the other widgets and keep the code consistent.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Manual testing of widget on the dashboard, local run of existing unit tests.
