### PR TITLE
CI: Bring back EKS

### DIFF
--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -13,7 +13,7 @@ from typing import List
 class PostTestsConstants:
 
     API_TIMEOUT = 5 * 60
-    COLLECT_TIMEOUT = 5 * 60
+    COLLECT_TIMEOUT = 10 * 60
     CHECK_TIMEOUT = 5 * 60
     STORE_TIMEOUT = 5 * 60
     FIXUP_TIMEOUT = 5 * 60


### PR DESCRIPTION
## Description

This PR verifies that EKS can be used for QA tests in `all` mode. A minor change was needed to extend the time spent gathering logs.

## Checklist
- [x] Investigated and inspected CI test results: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/2568/pull-ci-stackrox-stackrox-master-eks-qa-e2e-tests/1554561499123421184


## Testing Performed

CI is sufficient
