### PR TITLE
Fix update default group by props

### DIFF
--- a/central/group/datastore/internal/store/store_impl.go
+++ b/central/group/datastore/internal/store/store_impl.go
@@ -166,17 +166,6 @@ func updateInTransaction(tx *bolt.Tx, group *storage.Group) error {
 	id := group.GetProps().GetId()
 	buc := tx.Bucket(groupsBucket)
 
-	defaultGroup, err := getDefaultGroupForProps(tx, group.GetProps())
-	if err != nil {
-		return err
-	}
-
-	// Only disallow update of a default group if it does not update the existing default group, if there is any.
-	if defaultGroup != nil && defaultGroup.GetProps().GetId() != id {
-		return errox.AlreadyExists.Newf("a default group already exists for auth provider %q",
-			group.GetProps().GetAuthProviderId())
-	}
-
 	// TODO(ROX-11592): Once the deprecation of retrieving groups by their properties is fully deprecated, this condition
 	// can be removed and groups shall only be retrievable via their id.
 	if id != "" {
@@ -193,6 +182,17 @@ func updateInTransaction(tx *bolt.Tx, group *storage.Group) error {
 				group.GetProps().GetAuthProviderId(), group.GetProps().GetKey(), group.GetProps().GetValue())
 		}
 		id = group.GetProps().GetId()
+	}
+
+	defaultGroup, err := getDefaultGroupForProps(tx, group.GetProps())
+	if err != nil {
+		return err
+	}
+
+	// Only disallow update of a default group if it does not update the existing default group, if there is any.
+	if defaultGroup != nil && defaultGroup.GetProps().GetId() != id {
+		return errox.AlreadyExists.Newf("a default group already exists for auth provider %q",
+			group.GetProps().GetAuthProviderId())
 	}
 
 	bytes, err := proto.Marshal(group)

--- a/central/group/datastore/internal/store/store_test.go
+++ b/central/group/datastore/internal/store/store_test.go
@@ -545,13 +545,13 @@ func (s *GroupStoreTestSuite) TestDefaultGroup() {
 
 	// 3. Updating the initially existing group to make it a default group should fail.
 	// Fetch the group by its properties.
-	initialGroup, err = s.sto.Get(initialGroup.GetProps())
+	updatedInitialGroups, err := s.sto.Get(initialGroup.GetProps())
 	s.NoError(err)
 	// Unset Key / Value fields, making it a default group.
-	initialGroup.GetProps().Key = ""
-	initialGroup.GetProps().Value = ""
+	updatedInitialGroups.GetProps().Key = ""
+	updatedInitialGroups.GetProps().Value = ""
 	// Ensure a "AlreadyExists" error is yielded when trying to update the group.
-	err = s.sto.Update(initialGroup)
+	err = s.sto.Update(updatedInitialGroups)
 	s.Error(err)
 	s.ErrorIs(err, errox.AlreadyExists)
 
@@ -584,4 +584,16 @@ func (s *GroupStoreTestSuite) TestDefaultGroup() {
 	// Adding the initial default group should now work, as we have made the existing default group a non-default group.
 	defaultGroup.Props.Id = "new-id"
 	s.NoError(s.sto.Add(defaultGroup))
+
+	// 6. Updating the initially existing group to make it a default group without setting an ID should work.
+	updateInitialToDefaultGroup, err := s.sto.Get(initialGroup.GetProps())
+	s.NoError(err)
+	// Unset Key / Value fields, making it a default group.
+	updateInitialToDefaultGroup.GetProps().Key = ""
+	updateInitialToDefaultGroup.GetProps().Value = ""
+	// Unset the ID to fetch the group by its properties.
+	updateInitialToDefaultGroup.GetProps().Id = ""
+	err = s.sto.Update(updateInitialToDefaultGroup)
+	s.NoError(err)
+
 }


### PR DESCRIPTION
## Description

Based on the comment left [here](https://github.com/stackrox/stackrox/pull/2529#discussion_r933699601).

If the ID is not set initially due to fetching groups via property, we should only check the default group after we are sure the ID is set.

## Testing Performed

- added Unit tests.
