### PR TITLE
ROX-11995: Fix Component entities e2e test for vuln management

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
@@ -326,17 +326,30 @@ describe('Entities single views', () => {
     });
 
     it('should show the active state in Component overview when scoped under a deployment', () => {
+        const usingVMUpdates = hasFeatureFlag('ROX_FRONTEND_VM_UPDATES');
+
         visitVulnerabilityManagementEntities('deployments');
 
         // click on the first deployment in the list
         cy.intercept('POST', api.vulnMgmt.graphqlEntity('deployments')).as('deployment');
         cy.get(`${selectors.tableRows}`, { timeout: 10000 }).eq(1).click();
         cy.wait('@deployment');
-        // now, go the components for that deployment
-        cy.intercept('POST', api.vulnMgmt.graphqlEntities2('deployments', 'IMAGE_COMPONENT')).as(
-            'deploymentsCOMPONENT'
-        );
-        cy.get(selectors.imageComponentTileLink).click();
+
+        // now, go to the components for that deployment
+        if (usingVMUpdates) {
+            cy.intercept(
+                'POST',
+                api.vulnMgmt.graphqlEntities2('deployments', 'IMAGE_COMPONENT')
+            ).as('deploymentsCOMPONENT');
+
+            cy.get(selectors.imageComponentTileLink).click();
+        } else {
+            cy.intercept('POST', api.vulnMgmt.graphqlEntities2('deployments', 'COMPONENT')).as(
+                'deploymentsCOMPONENT'
+            );
+
+            cy.get(selectors.componentTileLink).click();
+        }
         cy.wait('@deploymentsCOMPONENT');
         // click on the first component in that list
         cy.get(`[data-testid="side-panel"] ${selectors.tableRows}`, { timeout: 10000 })


### PR DESCRIPTION
## Description

I verified this failure in nightly, by running cypress locally with the flag off.

I verified the fix in this PR with the flag off, and checked that it behaves correctly with the flag on.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added


## Testing Performed

Ran ui-e2e tests locally, both with the flag off, and with the flag on.