### PR TITLE
ROX-9770: adding operating system to the vulnerability table columns

### DIFF
--- a/ui/apps/platform/cypress/constants/VulnManagementPage.js
+++ b/ui/apps/platform/cypress/constants/VulnManagementPage.js
@@ -82,6 +82,7 @@ export const listSelectors = {
     fixableCVELink: '[data-testid="fixableCvesLink"]',
     numCVEColLink: '.rt-tr > .rt-td',
     cveDescription: '[data-testid="cve-description"]',
+    metadataDescription: '[data-testid="metadata-description"]',
     statusChips: '[data-testid="label-chip"]',
     deploymentCountLink: '[data-testid="deploymentCountLink"]',
     failingDeploymentCountLink: '[data-testid="failingDeploymentsCountLink"]',

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -72,6 +72,6 @@ export function visitVulnerabilityManagementEntities(entitiesKey, search = '') {
 
     visit(`${url.list[entitiesKey]}${search}`);
 
-    cy.wait(['@searchOptions', `@${entitiesKey}`]);
+    cy.wait(['@searchOptions', `@${entitiesKey}`], { timeout: 10000 });
     cy.get(`h1:contains("${headingPlural[entitiesKey]}")`);
 }

--- a/ui/apps/platform/cypress/integration/vulnmanagement/componentsListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/componentsListPages.test.js
@@ -61,6 +61,7 @@ describe('Components list Page and its entity detail page, (related entities) su
             visitVulnerabilityManagementEntities('image-components');
             hasExpectedHeaderColumns([
                 'Component',
+                'Operating System',
                 'CVEs',
                 'Fixed In',
                 'Top CVSS',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/cvesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/cvesListPages.test.js
@@ -164,6 +164,7 @@ describe('CVEs list Page and its entity detail page, sub list validations ', () 
                 hasExpectedHeaderColumns(
                     [
                         'CVE',
+                        'Operating System',
                         'Fixable',
                         'CVSS Score',
                         'Env. Impact',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/cvesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/cvesListPages.test.js
@@ -224,6 +224,7 @@ describe('CVEs list Page and its entity detail page, sub list validations ', () 
                 hasExpectedHeaderColumns(
                     [
                         'CVE',
+                        'Operating System',
                         'Fixable',
                         'CVSS Score',
                         'Env. Impact',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
@@ -300,7 +300,7 @@ describe('Entities single views', () => {
                 cy.get(`${selectors.tableBodyRows}:eq(0)`).click();
                 cy.wait('@cve');
 
-                cy.get(`${selectors.entityOverview} ${selectors.cveDescription}`)
+                cy.get(`${selectors.entityOverview} ${selectors.metadataDescription}`)
                     .invoke('text')
                     .then((descriptionInSidePanel) => {
                         expect(descriptionInSidePanel).to.equal(descriptionInList);

--- a/ui/apps/platform/src/Components/Metadata/Metadata.js
+++ b/ui/apps/platform/src/Components/Metadata/Metadata.js
@@ -21,13 +21,14 @@ const Metadata = ({
     annotations,
     exclusions,
     secrets,
+    description,
     className,
     ...rest
 }) => {
     const keyValueList = keyValuePairs.map(({ key, value }) => (
         <li className="flex border-b border-base-300 py-3" key={key}>
             <span className="text-base-600 font-700 mr-2">{key}:</span>
-            <span className="flex-grow font-600 min-w-0" data-testid={`${key}-value`}>
+            <span className="font-600 min-w-0" data-testid={`${key}-value`}>
                 {value}
             </span>
         </li>
@@ -41,7 +42,7 @@ const Metadata = ({
         <Widget header={title} className={className} {...rest}>
             <div className="flex flex-col w-full">
                 {statTiles && statTiles.length > 0 && <MetadataStatsList statTiles={statTiles} />}
-                <div className="flex w-full h-full">
+                <div className="flex">
                     <ul className={keyValueClasses}>{keyValueList}</ul>
                     <ul>
                         {labels && (
@@ -84,6 +85,7 @@ const Metadata = ({
                         )}
                     </ul>
                 </div>
+                {description && <div className="p-4">{description}</div>}
             </div>
         </Widget>
     );
@@ -102,6 +104,7 @@ Metadata.propTypes = {
     annotations: PropTypes.arrayOf(PropTypes.shape({})),
     exclusions: PropTypes.arrayOf(PropTypes.shape({})),
     secrets: PropTypes.arrayOf(PropTypes.shape({})),
+    description: PropTypes.string,
     className: PropTypes.string,
 };
 
@@ -112,6 +115,7 @@ Metadata.defaultProps = {
     annotations: null,
     exclusions: null,
     secrets: null,
+    description: null,
     className: '',
 };
 

--- a/ui/apps/platform/src/Components/Metadata/Metadata.js
+++ b/ui/apps/platform/src/Components/Metadata/Metadata.js
@@ -85,7 +85,11 @@ const Metadata = ({
                         )}
                     </ul>
                 </div>
-                {description && <div className="p-4">{description}</div>}
+                {description && (
+                    <div className="p-4" data-testid="metadata-description">
+                        {description}
+                    </div>
+                )}
             </div>
         </Widget>
     );

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.js
@@ -41,6 +41,7 @@ function VulnMgmtComponentOverview({ data, entityContext }) {
     const safeData = { ...emptyComponent, ...data };
 
     const { fixedIn, version, priority, topVuln, id, location, vulnCount, activeState } = safeData;
+    const operatingSystem = safeData?.operatingSystem;
 
     const metadataKeyValuePairs = [
         {
@@ -56,6 +57,13 @@ function VulnMgmtComponentOverview({ data, entityContext }) {
         metadataKeyValuePairs.push({
             key: 'Location',
             value: location || 'N/A',
+        });
+    }
+
+    if (operatingSystem !== undefined) {
+        metadataKeyValuePairs.push({
+            key: 'Operating System',
+            value: operatingSystem,
         });
     }
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtEntityImageComponent.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtEntityImageComponent.js
@@ -42,6 +42,7 @@ const VulnMgmtEntityImageComponent = ({
                     cvss
                     scoreVersion
                 }
+                operatingSystem
             }
         }
     `;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtEntityNodeComponent.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtEntityNodeComponent.js
@@ -48,6 +48,7 @@ const VulnMgmtEntityNodeComponent = ({
                     cvss
                     scoreVersion
                 }
+                operatingSystem
             }
         }
     `;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtCveOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtCveOverview.js
@@ -6,7 +6,6 @@ import CollapsibleSection from 'Components/CollapsibleSection';
 import CveType from 'Components/CveType';
 import Metadata from 'Components/Metadata';
 import LabelChip from 'Components/LabelChip';
-import Widget from 'Components/Widget';
 import dateTimeFormat from 'constants/dateTimeFormat';
 import entityTypes from 'constants/entityTypes';
 import { getSeverityChipType } from 'utils/vulnerabilityUtils';
@@ -50,6 +49,7 @@ const VulnMgmtCveOverview = ({ data, entityContext }) => {
         scoreVersion,
         vulnerabilityTypes,
     } = safeData;
+    const operatingSystem = safeData?.operatingSystem;
 
     const linkToMoreInfo = isValidURL(link) ? (
         <a
@@ -117,71 +117,58 @@ const VulnMgmtCveOverview = ({ data, entityContext }) => {
             ? vulnerabilityTypes
             : [cveType];
 
+    const metaDataDetails = [
+        {
+            key: 'CVE',
+            value: cve,
+        },
+        {
+            key: 'Environment Impact',
+            value: `${(envImpact * 100).toFixed(0)}%`,
+        },
+        {
+            key: 'CVE Type',
+            value: <CveType context="callout" types={legacyTypeList} />,
+        },
+        {
+            key: 'CVSS Score',
+            value: <LabelChip text={`CVSS ${cvss && cvss.toFixed(1)}`} type={severityStyle} />,
+        },
+        {
+            key: 'Fixability',
+            value: isFixable ? (
+                <LabelChip text="Fixable" type="success" />
+            ) : (
+                <LabelChip text="Not fixable" type="base" />
+            ),
+        },
+    ];
+    if (cveType === entityTypes.NODE_CVE || cveType === entityTypes.IMAGE_CVE) {
+        metaDataDetails.push({
+            key: 'Operating System',
+            value: operatingSystem,
+        });
+    }
+
     return (
         <div className="flex h-full" data-testid="entity-overview">
             <div className="flex flex-col flex-grow min-w-0">
                 <CollapsibleSection title="CVE Summary">
                     <div className="mx-4 grid-dense grid-auto-fit grid grid-gap-6 xxxl:grid-gap-8 lg:grid-columns-2 xl:grid-columns-3 mb-4">
-                        <Widget
-                            header="Description & Details"
-                            headerComponents={linkToMoreInfo}
-                            className="bg-base-100 min-h-48 lg:s-2 pdf-page pdf-stretch"
-                        >
-                            <div className="flex flex-col w-full">
-                                <div className="bg-tertiary-200 text-2xl text-base-500 flex flex-col md:flex-row items-start md:items-center justify-between">
-                                    <div className="w-full flex-grow p-4">
-                                        <span className="text-tertiary-800">{cve}</span>
-                                    </div>
-                                    <div className="w-full flex border-t border-base-400 md:border-t-0 justify-end items-center">
-                                        {
-                                            // eslint-disable-next-line eqeqeq
-                                            envImpact == Number(envImpact) && (
-                                                <span className="w-full md:w-auto p-4 border-base-400 text-base-600 border-l whitespace-nowrap">
-                                                    <span>
-                                                        {' '}
-                                                        {`Env. Impact: ${(envImpact * 100).toFixed(
-                                                            0
-                                                        )}%`}
-                                                    </span>
-                                                </span>
-                                            )
-                                        }
-                                        <span
-                                            className="w-full md:w-auto p-4 border-base-400 border-l"
-                                            data-testid="cve-type"
-                                        >
-                                            <CveType context="callout" types={legacyTypeList} />
-                                        </span>
-                                        <span className="w-full md:w-auto p-4 border-base-400 border-l">
-                                            <LabelChip
-                                                text={`CVSS ${cvss && cvss.toFixed(1)}`}
-                                                type={severityStyle}
-                                            />
-                                        </span>
-                                        <span className="w-full md:w-auto p-4 border-base-400 border-l">
-                                            {isFixable ? (
-                                                <LabelChip text="Fixable" type="success" />
-                                            ) : (
-                                                <LabelChip text="Not fixable" type="base" />
-                                            )}
-                                        </span>
-                                    </div>
-                                </div>
-                                <div
-                                    className="p-4 pb-12 leading-loose"
-                                    data-testid="cve-description"
-                                >
-                                    {summary || 'No description available.'}
-                                </div>
-                            </div>
-                        </Widget>
                         <Metadata
-                            className="bg-base-100 min-h-48 pdf-page"
+                            className="h-full min-w-48 bg-base-100 pdf-page s-2"
+                            headerComponents={linkToMoreInfo}
+                            keyValuePairs={metaDataDetails}
+                            description={summary || 'No description available.'}
+                            title="Description & Details"
+                        />
+                        <Metadata
+                            className="bg-base-100 min-h-48 pdf-page s-1"
                             keyValuePairs={cvssScoreBreakdown}
                             title="CVSS Score Breakdown"
                         />
                         <Metadata
-                            className="bg-base-100 min-h-48 pdf-page"
+                            className="bg-base-100 min-h-48 pdf-page s-1"
                             keyValuePairs={scanningDetails}
                             title="Scanning Details"
                         />

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
@@ -247,7 +247,7 @@ export function getCveTableColumns(workflowState) {
     ];
 
     if (currentEntityType === entityTypes.NODE_CVE || currentEntityType === entityTypes.IMAGE_CVE) {
-        tableColumns.push({
+        tableColumns.splice(3, 0, {
             Header: `Operating System`,
             headerClassName: `w-1/10 ${defaultHeaderClassName}`,
             className: `w-1/10 ${defaultColumnClassName}`,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
@@ -246,6 +246,17 @@ export function getCveTableColumns(workflowState) {
         },
     ];
 
+    if (currentEntityType === entityTypes.NODE_CVE || currentEntityType === entityTypes.IMAGE_CVE) {
+        tableColumns.push({
+            Header: `Operating System`,
+            headerClassName: `w-1/10 ${defaultHeaderClassName}`,
+            className: `w-1/10 ${defaultColumnClassName}`,
+            id: cveSortFields.OPERATING_SYSTEM,
+            accessor: 'operatingSystem',
+            sortField: cveSortFields.OPERATING_SYSTEM,
+        });
+    }
+
     const nonNullTableColumns = tableColumns.filter((col) => col);
 
     const cveColumnsBasedOnContext = getFilteredCVEColumns(nonNullTableColumns, workflowState);

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.js
@@ -201,6 +201,14 @@ export function getComponentTableColumns(showVMUpdates) {
                 accessor: 'priority',
                 sortField: componentSortFields.PRIORITY,
             },
+            {
+                Header: `Operating System`,
+                headerClassName: `w-1/10 ${defaultHeaderClassName}`,
+                className: `w-1/10 ${defaultColumnClassName}`,
+                id: componentSortFields.OPERATING_SYSTEM,
+                accessor: 'operatingSystem',
+                sortField: componentSortFields.OPERATING_SYSTEM,
+            },
         ];
 
         const componentColumnsBasedOnContext = getFilteredComponentColumns(

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.js
@@ -52,6 +52,14 @@ export function getComponentTableColumns(showVMUpdates) {
                 sortField: componentSortFields.COMPONENT,
             },
             {
+                Header: `Operating System`,
+                headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+                className: `w-1/8 ${defaultColumnClassName}`,
+                id: componentSortFields.OPERATING_SYSTEM,
+                accessor: 'operatingSystem',
+                sortField: componentSortFields.OPERATING_SYSTEM,
+            },
+            {
                 Header: showVMUpdates ? `Image CVEs` : 'CVEs',
                 entityType: entityTypes.CVE,
                 headerClassName: `w-1/8 ${defaultHeaderClassName}`,
@@ -200,14 +208,6 @@ export function getComponentTableColumns(showVMUpdates) {
                 id: componentSortFields.PRIORITY,
                 accessor: 'priority',
                 sortField: componentSortFields.PRIORITY,
-            },
-            {
-                Header: `Operating System`,
-                headerClassName: `w-1/10 ${defaultHeaderClassName}`,
-                className: `w-1/10 ${defaultColumnClassName}`,
-                id: componentSortFields.OPERATING_SYSTEM,
-                accessor: 'operatingSystem',
-                sortField: componentSortFields.OPERATING_SYSTEM,
             },
         ];
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.js
@@ -52,6 +52,14 @@ export function getComponentTableColumns(showVMUpdates) {
                 sortField: componentSortFields.COMPONENT,
             },
             {
+                Header: `Operating System`,
+                headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+                className: `w-1/8 ${defaultColumnClassName}`,
+                id: componentSortFields.OPERATING_SYSTEM,
+                accessor: 'operatingSystem',
+                sortField: componentSortFields.OPERATING_SYSTEM,
+            },
+            {
                 Header: showVMUpdates ? `Node CVEs` : 'CVEs',
                 entityType: entityTypes.CVE,
                 headerClassName: `w-1/8 ${defaultHeaderClassName}`,
@@ -183,14 +191,6 @@ export function getComponentTableColumns(showVMUpdates) {
                 id: componentSortFields.PRIORITY,
                 accessor: 'priority',
                 sortField: componentSortFields.PRIORITY,
-            },
-            {
-                Header: `Operating System`,
-                headerClassName: `w-1/10 ${defaultHeaderClassName}`,
-                className: `w-1/10 ${defaultColumnClassName}`,
-                id: componentSortFields.OPERATING_SYSTEM,
-                accessor: 'operatingSystem',
-                sortField: componentSortFields.OPERATING_SYSTEM,
             },
         ];
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.js
@@ -184,6 +184,14 @@ export function getComponentTableColumns(showVMUpdates) {
                 accessor: 'priority',
                 sortField: componentSortFields.PRIORITY,
             },
+            {
+                Header: `Operating System`,
+                headerClassName: `w-1/10 ${defaultHeaderClassName}`,
+                className: `w-1/10 ${defaultColumnClassName}`,
+                id: componentSortFields.OPERATING_SYSTEM,
+                accessor: 'operatingSystem',
+                sortField: componentSortFields.OPERATING_SYSTEM,
+            },
         ];
 
         const componentColumnsBasedOnContext = getFilteredComponentColumns(

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
@@ -408,6 +408,7 @@ export const NODE_CVE_LIST_FRAGMENT = gql`
         suppressed
         componentCount: nodeComponentCount
         nodeCount
+        operatingSystem
     }
 `;
 
@@ -435,6 +436,7 @@ export const VULN_IMAGE_CVE_LIST_FRAGMENT = gql`
         componentCount: imageComponentCount
         imageCount
         deploymentCount
+        operatingSystem
     }
 `;
 
@@ -803,6 +805,7 @@ export const VULN_NODE_COMPONENT_LIST_FRAGMENT = gql`
         }
         nodeCount(query: $query)
         priority
+        operatingSystem
     }
 `;
 
@@ -843,6 +846,7 @@ export const VULN_IMAGE_COMPONENT_LIST_FRAGMENT = gql`
         imageCount(query: $query)
         deploymentCount(query: $query)
         priority
+        operatingSystem
     }
 `;
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
@@ -224,6 +224,7 @@ export const IMAGE_CVE_DETAIL_FRAGMENT = gql`
         deploymentCount(query: $query)
         discoveredAtImage(query: $query)
         imageCount(query: $query)
+        operatingSystem
     }
 `;
 
@@ -260,6 +261,7 @@ export const NODE_CVE_DETAIL_FRAGMENT = gql`
         }
         nodeComponentCount(query: $query)
         nodeCount(query: $query)
+        operatingSystem
     }
 `;
 

--- a/ui/apps/platform/src/constants/sortFields.js
+++ b/ui/apps/platform/src/constants/sortFields.js
@@ -50,6 +50,7 @@ export const componentSortFields = {
     DEPLOYMENT_COUNT: 'Deployment Count',
     PRIORITY: 'Component Risk Priority',
     FIXEDIN: 'Component Fixed By', // This field does not exist. However, seems like every column has to follow a template.
+    OPERATING_SYSTEM: 'Operating System',
 };
 
 /**
@@ -79,6 +80,7 @@ export const cveSortFields = {
     CVE_DISCOVERED_AT_IMAGE_TIME: 'CVE Discovered at Image Time',
     IMAGE_SCAN_TIME: 'Image Scan Time',
     PUBLISHED: 'CVE Published On',
+    OPERATING_SYSTEM: 'Operating System',
 };
 
 /**


### PR DESCRIPTION
## Description

This PR adds the operating system information to the table columns for the following tables:
1. Node CVEs
2. Image CVEs
3. Node Components
4. Image Components

The Nodes and Images tables have the operating system column already

This also adds the operating system information to the singles for each of those entity tables too

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Lists
<img width="1552" alt="Screen Shot 2022-08-02 at 4 21 45 PM" src="https://user-images.githubusercontent.com/4805485/182492794-d4142e4c-7501-4622-b4a0-b69818d69c45.png">
<img width="1552" alt="Screen Shot 2022-08-02 at 4 21 52 PM" src="https://user-images.githubusercontent.com/4805485/182492796-e944e8c1-3a14-4531-8f9a-32605b6674cb.png">
<img width="1552" alt="Screen Shot 2022-08-02 at 4 22 03 PM" src="https://user-images.githubusercontent.com/4805485/182492799-1a9f2c2e-e54e-47d9-bcf0-5cb5971e9fe4.png">
<img width="1552" alt="Screen Shot 2022-08-02 at 4 22 06 PM" src="https://user-images.githubusercontent.com/4805485/182492800-e4a6d923-22d1-4d2e-9ea5-11689e2c7b10.png">

### Singles
<img width="1552" alt="Screen Shot 2022-08-02 at 5 05 39 PM" src="https://user-images.githubusercontent.com/4805485/182497422-797f048b-52e6-45da-8d0e-b057e5f98078.png">
<img width="1552" alt="Screen Shot 2022-08-02 at 5 05 51 PM" src="https://user-images.githubusercontent.com/4805485/182497428-ec858e6f-7f98-4f65-a4a8-ab896a29d1b1.png">
<img width="1552" alt="Screen Shot 2022-08-02 at 5 06 03 PM" src="https://user-images.githubusercontent.com/4805485/182497430-2982e057-af8f-45c6-ba52-8307e1c06d3f.png">
<img width="1552" alt="Screen Shot 2022-08-02 at 5 06 09 PM" src="https://user-images.githubusercontent.com/4805485/182497433-45ba277b-6a90-4441-b61d-5851ca97e3ef.png">




