### PR TITLE
Enable local building on Mac M1s using custom builder image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,6 @@ ROX_IMAGE_FLAVOR ?= $(shell \
 	  echo "development_build"; \
 	fi)
 
-BUILD_IMAGE := quay.io/stackrox-io/apollo-ci:$(shell sed 's/\s*\#.*//' BUILD_IMAGE_VERSION)
-
 DEFAULT_IMAGE_REGISTRY := quay.io/stackrox-io
 ifeq ($(ROX_PRODUCT_BRANDING),RHACS_BRANDING)
 	DEFAULT_IMAGE_REGISTRY := quay.io/rhacs-eng
@@ -65,6 +63,14 @@ DEBUG_BUILD ?= no
 # The latter is painfully slow on Mac OS X with Docker Desktop, so we default to using a
 # standalone volume in that case, and to bind mounting otherwise.
 UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
+
+BUILD_IMAGE := quay.io/stackrox-io/apollo-ci:$(shell sed 's/\s*\#.*//' BUILD_IMAGE_VERSION)
+ifeq ($(UNAME_S),Darwin)
+ifeq ($(UNAME_M),arm64)
+	BUILD_IMAGE = quay.io/rhacs-eng/sandbox:apollo-ci-stackrox-build-0.3.44-arm64
+endif
+endif
 
 ifeq ($(UNAME_S),Darwin)
 BIND_GOCACHE ?= 0

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ UNAME_M := $(shell uname -m)
 BUILD_IMAGE := quay.io/stackrox-io/apollo-ci:$(shell sed 's/\s*\#.*//' BUILD_IMAGE_VERSION)
 ifeq ($(UNAME_S),Darwin)
 ifeq ($(UNAME_M),arm64)
+	# TODO(ROX-12064) build these images in the CI pipeline
 	BUILD_IMAGE = quay.io/rhacs-eng/sandbox:apollo-ci-stackrox-build-0.3.44-arm64
 endif
 endif

--- a/image/postgres/create-bundle.sh
+++ b/image/postgres/create-bundle.sh
@@ -36,7 +36,6 @@ fi
 postgres_repo_url="https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-${arch}/pgdg-redhat-repo-latest.noarch.rpm"
 postgres_major="14"
 pg_rhel_version="8.5"
-gpg_check=""
 
 if [[ "${NATIVE_PG_INSTALL}" == "true" ]]; then
     dnf install --disablerepo='*' -y "${postgres_repo_url}"

--- a/image/postgres/create-bundle.sh
+++ b/image/postgres/create-bundle.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Creates a tgz bundle of all binary artifacts needed for scanner-db-rhel
 
-set -euox pipefail
+set -euo pipefail
 
 die() {
     echo >&2 "$@"

--- a/image/postgres/create-bundle.sh
+++ b/image/postgres/create-bundle.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Creates a tgz bundle of all binary artifacts needed for scanner-db-rhel
 
-set -euo pipefail
+set -euox pipefail
 
 die() {
     echo >&2 "$@"
@@ -29,23 +29,31 @@ chmod -R 755 "${bundle_root}"
 
 # =============================================================================
 # Get latest postgres minor version
-
-postgres_repo_url="https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
+arch="x86_64"
+if [[ $(uname -m) == "arm64" ]]; then
+  arch="aarch64"
+  gpg_check="--nogpgcheck"
+fi
+postgres_repo_url="https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-${arch}/pgdg-redhat-repo-latest.noarch.rpm"
 postgres_major="14"
 pg_rhel_version="8.5"
+gpg_check=""
 
 if [[ "${NATIVE_PG_INSTALL}" == "true" ]]; then
     dnf install --disablerepo='*' -y "${postgres_repo_url}"
-    postgres_minor="$(dnf list --disablerepo='*' --enablerepo=pgdg${postgres_major} -y "postgresql${postgres_major}-devel.x86_64" | tail -n 1 | awk '{print $2}').x86_64"
+    postgres_minor="$(dnf list --disablerepo='*' --enablerepo=pgdg${postgres_major} ${gpg_check} -y "postgresql${postgres_major}-devel.${arch}" | tail -n 1 | awk '{print $2}').${arch}"
     echo "PG minor version: ${postgres_minor}"
 else
     build_dir="$(mktemp -d)"
+#    echo registry.access.redhat.com/ubi8/ubi:${pg_rhel_version}
+#    echo dnf install --disablerepo='*' -y "${postgres_repo_url}"
+#    echo dnf list --disablerepo='*' --enablerepo=pgdg${postgres_major} -y postgresql${postgres_major}-server.$arch | tail -n 1 | awk '{print \$2}'
     docker build -q -t postgres-minor-image "${build_dir}" -f - <<EOF
 FROM registry.access.redhat.com/ubi8/ubi:${pg_rhel_version}
 RUN dnf install --disablerepo='*' -y "${postgres_repo_url}"
-ENTRYPOINT dnf list --disablerepo='*' --enablerepo=pgdg${postgres_major} -y postgresql${postgres_major}-server.x86_64 | tail -n 1 | awk '{print \$2}'
+ENTRYPOINT dnf list --disablerepo='*' --enablerepo=pgdg${postgres_major} ${gpg_check} -y postgresql${postgres_major}-server.$arch | tail -n 1 | awk '{print \$2}'
 EOF
-    postgres_minor="$(docker run --rm postgres-minor-image).x86_64"
+    postgres_minor="$(docker run --rm postgres-minor-image).${arch}"
     rm -rf "${build_dir}"
 fi
 
@@ -58,7 +66,8 @@ fi
 cp -p "${INPUT_ROOT}"/*.conf "${bundle_root}/etc/"
 
 # Get postgres RPMs directly
-postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_version}-x86_64"
+postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_version}-${arch}"
+
 curl -sS --fail -o "${bundle_root}/postgres.rpm" \
     "${postgres_url}/postgresql${postgres_major}-${postgres_minor}.rpm"
 curl -sS --fail -o "${bundle_root}/postgres-server.rpm" \

--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -2,7 +2,7 @@
 # Creates a scripts directory and a tgz bundle of binaries and data files
 # needed for main-rhel
 
-set -euox pipefail
+set -euo pipefail
 
 die() {
     echo >&2 "$@"

--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -2,7 +2,7 @@
 # Creates a scripts directory and a tgz bundle of binaries and data files
 # needed for main-rhel
 
-set -euo pipefail
+set -euox pipefail
 
 die() {
     echo >&2 "$@"
@@ -88,12 +88,20 @@ cp -p "${INPUT_ROOT}/bin/admission-control" "${bundle_root}/stackrox/bin/"
 cp -pr "${INPUT_ROOT}/THIRD_PARTY_NOTICES"  "${bundle_root}/"
 cp -pr "${INPUT_ROOT}/ui/build/"*           "${bundle_root}/ui/"
 
+arch="x86_64"
+goarch=$arch
+if [[ $(uname -m) == "arm64" ]]; then
+  arch="aarch64"
+  goarch="arm64"
+  gpg_check="--nogpgcheck"
+fi
+
 mkdir -p "${bundle_root}/go/bin"
 if [[ "$DEBUG_BUILD" == "yes" ]]; then
   if [[ "$OSTYPE" != "linux-gnu"* ]]; then
-    GOBIN= GOOS=linux GOARCH=amd64 GOPATH="${bundle_root}/go" go install github.com/go-delve/delve/cmd/dlv@latest
-    mv "$bundle_root"/go/bin/linux_amd64/dlv "$bundle_root"/go/bin/dlv
-    rm -r "$bundle_root"/go/bin/linux_amd64
+    GOBIN= GOOS=linux GOARCH=${goarch} GOPATH="${bundle_root}/go" go install github.com/go-delve/delve/cmd/dlv@latest
+    mv "$bundle_root"/go/bin/linux_${goarch}/dlv "$bundle_root"/go/bin/dlv
+    rm -r "$bundle_root"/go/bin/linux_${goarch}
   else
     GOBIN="${bundle_root}/go/bin" go install github.com/go-delve/delve/cmd/dlv@latest
   fi
@@ -109,8 +117,8 @@ else
 fi
 
 # Install all the required compression packages for RocksDB to compile
-rpm_base_url="http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages"
-rpm_suffix="el8.x86_64.rpm"
+rpm_base_url="http://mirror.centos.org/centos/8-stream/BaseOS/${arch}/os/Packages"
+rpm_suffix="el8.${arch}.rpm"
 
 curl -s -f -o "${bundle_root}/snappy.rpm" "${rpm_base_url}/snappy-1.1.8-3.${rpm_suffix}"
 
@@ -118,8 +126,8 @@ curl -s -f -o "${bundle_root}/snappy.rpm" "${rpm_base_url}/snappy-1.1.8-3.${rpm_
 # Get postgres RPMs directly
 postgres_major="14"
 pg_rhel_version="8.5"
-postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_version}-x86_64"
-postgres_minor="14.2-1PGDG.rhel8.x86_64"
+postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_version}-${arch}"
+postgres_minor="14.2-1PGDG.rhel8.${arch}"
 
 curl -sS --fail -o "${bundle_root}/postgres.rpm" \
     "${postgres_url}/postgresql${postgres_major}-${postgres_minor}.rpm"

--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -89,11 +89,10 @@ cp -pr "${INPUT_ROOT}/THIRD_PARTY_NOTICES"  "${bundle_root}/"
 cp -pr "${INPUT_ROOT}/ui/build/"*           "${bundle_root}/ui/"
 
 arch="x86_64"
-goarch=$arch
+goarch="amd64"
 if [[ $(uname -m) == "arm64" ]]; then
   arch="aarch64"
   goarch="arm64"
-  gpg_check="--nogpgcheck"
 fi
 
 mkdir -p "${bundle_root}/go/bin"

--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -98,9 +98,9 @@ fi
 mkdir -p "${bundle_root}/go/bin"
 if [[ "$DEBUG_BUILD" == "yes" ]]; then
   if [[ "$OSTYPE" != "linux-gnu"* ]]; then
-    GOBIN= GOOS=linux GOARCH=${goarch} GOPATH="${bundle_root}/go" go install github.com/go-delve/delve/cmd/dlv@latest
-    mv "$bundle_root"/go/bin/linux_${goarch}/dlv "$bundle_root"/go/bin/dlv
-    rm -r "$bundle_root"/go/bin/linux_${goarch}
+    GOBIN= GOOS=linux GOARCH="${goarch}" GOPATH="${bundle_root}/go" go install github.com/go-delve/delve/cmd/dlv@latest
+    mv "${bundle_root}/go/bin/linux_${goarch}/dlv" "${bundle_root}/go/bin/dlv"
+    rm -r "${bundle_root}/go/bin/linux_${goarch}"
   else
     GOBIN="${bundle_root}/go/bin" go install github.com/go-delve/delve/cmd/dlv@latest
   fi

--- a/make/env.mk
+++ b/make/env.mk
@@ -17,6 +17,8 @@ CGO_ENABLED := 1
 # Update the arch to arm64 but only for Macs running on Apple Silicon (M1)
 ifeq ($(shell uname -ms),Darwin arm64)
 	GOARCH := arm64
+else ifeq ($(shell uname -ms),Linux aarch64)
+	GOARCH := arm64
 else
 	GOARCH := amd64
 endif


### PR DESCRIPTION
## Description

Builder image is from this PR that was built on an ARM box on GCP: https://github.com/stackrox/rox-ci-image/pull/153

Allow local builds and fast reload. Scanners will still need to pulled locally, but that can probably be addressed in a follow up if people start using this

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Built on my M1 and deployed to colima