### PR TITLE
ROX-11526: Re-enable some E2E tests in postgres mode

### DIFF
--- a/qa-tests-backend/src/test/groovy/DeploymentEventGraphQLTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentEventGraphQLTest.groovy
@@ -6,11 +6,9 @@ import java.util.stream.Collectors
 import groups.GraphQL
 import objects.Deployment
 import services.GraphQLService
-import util.Env
 import util.Timer
 
 import org.junit.experimental.categories.Category
-import spock.lang.IgnoreIf
 
 class DeploymentEventGraphQLTest extends BaseSpecification {
     private static final String DEPLOYMENT_NAME = "eventnginx"
@@ -93,7 +91,6 @@ class DeploymentEventGraphQLTest extends BaseSpecification {
     private final gqlService = new GraphQLService()
 
     @Category(GraphQL)
-    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
     def "Verify Deployment Events in GraphQL"() {
         when:
         "Validate Policy Violation is Triggered"

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -249,7 +249,6 @@ class SACTest extends BaseSpecification {
         NAMESPACE_QA2 | _
     }
 
-    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
     def "Verify GetSummaryCounts using a token without access receives no results"() {
         when:
         "GetSummaryCounts is called using a token without access"
@@ -269,7 +268,6 @@ class SACTest extends BaseSpecification {
         deleteSecret(DEPLOYMENT_QA1.namespace)
     }
 
-    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
     def "Verify GetSummaryCounts using a token with partial access receives partial results"() {
         when:
         "GetSummaryCounts is called using a token with restricted access"
@@ -368,7 +366,6 @@ class SACTest extends BaseSpecification {
     }
 
     @Unroll
-    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
     def "Verify Search on #category resources using the #tokenName token returns #numResults results"() {
         when:
         "A search is performed using the given token"
@@ -470,7 +467,6 @@ class SACTest extends BaseSpecification {
     }
 
     @Unroll
-    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
     def "Verify using the #tokenName token with the #service service returns #numReturned results"() {
         when:
         "The service under test is called using the given token"
@@ -546,7 +542,6 @@ class SACTest extends BaseSpecification {
     }
 
     @Unroll
-    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
     def "Verify search with SAC and token #tokenName yields the same number of results as restricted search"() {
         when:
         "Searching for categories ${categories} in namespace ${namespace} with basic auth"
@@ -649,7 +644,6 @@ class SACTest extends BaseSpecification {
                 allAccessFlows.size() - allAccessFlowsWithoutNeighbors.size()
     }
 
-    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
     def "test role aggregation should not combine permissions sets"() {
         when:
         useToken("aggregatedToken")


### PR DESCRIPTION
## Description

Some E2E tests were disabled in postgres mode as some feature elements were missing. Some of the disabled tests are re-enabled here.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI should be sufficient