### PR TITLE
ROX-11894: Skip unauthorized error messages when fetching image signatures

### DIFF
--- a/pkg/signatures/public_key_fetcher.go
+++ b/pkg/signatures/public_key_fetcher.go
@@ -129,11 +129,11 @@ func makeTransientErrorRetryable(err error) error {
 	var urlError *url.Error
 	// We don't expect any transient errors that are coming from cosign at the moment.
 	if errors.As(err, &transportErr) && transportErr.Temporary() {
-		return retry.MakeRetryable(transportErr)
+		return retry.MakeRetryable(err)
 	}
 
 	if errors.As(err, &urlError) && urlError.Temporary() {
-		return retry.MakeRetryable(urlError)
+		return retry.MakeRetryable(err)
 	}
 
 	return err


### PR DESCRIPTION
## Description

When an issue occurs during authentication with a registry, i.e. the wrong credentials are used, the error returned by the call `FetchSignaturesForReference` will be of the type `registry.HttpStatusCode`.

Previously, we only expected either a `transport.Error` or a `error.Wrap` which contained a `url.Error` and subsequently a `registry.HttpStatusCode` error.

This led to additional logs being printed within central logs when credentials were used that didn't fit for a registry. Those logs are false, as they are not indicating an actual error within the signature fetching, as it will 
not stop the enriching of the image.

Now, instead of casting the errors, we use `errors.As`. This way, we can skip unwrapping errors manually, which was the issue beforehand of not casting the plain `registry.HttpStatusCode` error.

## Testing Performed
- see added unit tests.
- Manual tests:
1. Use a any registry of your liking (quay.io/docker.io/demo.harbor.io).
2. Create a private repository, if you do not already have one.
3. Create an image integration for the registry but with wrong credentials.
4. Deploy a pod, observe that no unauthorized log messages are printed.
