### PR TITLE
Update CVEs-By-CVSS-Score widget to use new GraphQL queries

### DIFF
--- a/ui/apps/platform/src/utils/queryService.js
+++ b/ui/apps/platform/src/utils/queryService.js
@@ -70,9 +70,14 @@ function entityContextToQueryObject(entityContext) {
         const entityQueryObj = {};
         if (key === entityTypes.IMAGE) {
             entityQueryObj[`${key} SHA`] = entityContext[key];
-        } else if (key === entityTypes.COMPONENT) {
+        } else if (
+            key === entityTypes.COMPONENT ||
+            key === entityTypes.IMAGE_COMPONENT ||
+            key === entityTypes.NODE_COMPONENT
+        ) {
             const parsedComponentID = entityContext[key].split(':').map(decodeBase64);
-            [entityQueryObj[`${key}`], entityQueryObj[`${key} VERSION`]] = parsedComponentID;
+            // eslint-disable-next-line dot-notation
+            [entityQueryObj['COMPONENT'], entityQueryObj[`COMPONENT VERSION`]] = parsedComponentID;
         } else if (key === entityTypes.CVE) {
             entityQueryObj[key] = entityContext[key];
         } else {


### PR DESCRIPTION
## Description

Fixes this bug from the bug list:

> CVES BY CVSS SCORE still points to old graphQL endpoint everywher

## Checklist
- [x] Investigated and inspected CI test results (failures are unrelated flakes)


## Testing Performed

Deployment scope => imageVulnerabilities
![deployment_cves_by_cvss](https://user-images.githubusercontent.com/715729/182453605-f810be99-964e-443b-990a-450d355bf455.png)

Image scope => imageVulnerabilities
![image_cves_by_cvss](https://user-images.githubusercontent.com/715729/182454512-017993fc-8d26-4d41-aedb-be209918e7b0.png)

Image Component scope => imageVulnerabilities 
**Note: UI is now using the correct query, but the API is not scoping the returned list correctly for an image component**
![image_component_cves_by_cvss](https://user-images.githubusercontent.com/715729/182454480-e690c10e-c98c-4e84-ba28-e8cbf5f7f3b4.png)

Node Component scope => nodeVulnerabilities
**Note: UI is now using the correct query, but the API is not scoping the returned list correctly for a node component**
![node_component_cves_by_cvss](https://user-images.githubusercontent.com/715729/182454449-0d926da4-43f6-4f1c-bf19-5eb604779465.png)

Node scope => nodeVulnerabilities
![node_cves_by_cvss](https://user-images.githubusercontent.com/715729/182454428-b1cfa5c2-5f66-4e2f-8820-83915fbbf45a.png)

**Note: I allowed for using `clusterVulnerabilities` when this widget is used on a Cluster Overview page, but we don't currently use it on that type of page, so there is no example to show.**
