### PR TITLE
 ROX-12416, ROX-12114: Enable email tests for non-TLS connections

### DIFF
--- a/qa-tests-backend/src/main/groovy/common/Constants.groovy
+++ b/qa-tests-backend/src/main/groovy/common/Constants.groovy
@@ -9,6 +9,7 @@ class Constants {
     static final EMAIL_NOTIFER_FROM = "stackrox"
     static final EMAIL_NOTIFER_SENDER = "${UUID.randomUUID()}@stackrox.com"
     static final EMAIL_NOTIFER_FULL_FROM = "${EMAIL_NOTIFER_FROM} <${EMAIL_NOTIFER_SENDER}>"
+    static final EMAIL_NOTIFIER_RECIPIENT = "stackrox.qa@gmail.com"
     static final FAILURE_DEBUG_DIR = "/tmp/qa-tests-backend-logs"
     static final FAILURE_DEBUG_LIMIT = 10
     static final AUTO_REGISTERED_STACKROX_SCANNER_INTEGRATION = "Stackrox Scanner"

--- a/qa-tests-backend/src/main/groovy/objects/Service.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/Service.groovy
@@ -40,6 +40,11 @@ class Service {
         return this
     }
 
+    def setTargetPort(Integer targetPort) {
+        this.targetport = targetPort
+        return this
+    }
+
     enum Type {
         CLUSTERIP("ClusterIP"),
         LOADBALANCER("LoadBalancer"),

--- a/qa-tests-backend/src/main/groovy/util/MailServer.groovy
+++ b/qa-tests-backend/src/main/groovy/util/MailServer.groovy
@@ -1,0 +1,121 @@
+package util
+
+import groovy.json.JsonSlurper
+import groovy.util.logging.Slf4j
+import io.fabric8.kubernetes.client.LocalPortForward
+import orchestratormanager.OrchestratorMain
+
+import objects.Deployment
+import objects.Service
+
+@Slf4j
+class MailServer {
+
+    public static final Integer WEB_PORT = 1080
+    public static final Integer SMTP_PORT = 1025
+    public static final String MAILSERVER_USER = "user123"
+    public static final String MAILSERVER_PASS = "soopersekret"
+
+    @SuppressWarnings(["UnusedPrivateField"])
+    private UUID uid
+    private Deployment deployment
+    private Service smtpSvc
+    private Service webSvc
+    private LocalPortForward webPortForward
+
+    private MailServer() { }
+
+    static MailServer createMailServer(OrchestratorMain orchestrator,
+                                       boolean authenticated = true,
+                                       boolean useTLS = false) {
+        def mailServer = new MailServer()
+        mailServer.uid = UUID.randomUUID()
+        def deploymentName = "maildev-${mailServer.uid}"
+        try {
+            def envVars = [
+                    "MAILDEV_SMTP_PORT": SMTP_PORT.toString(),
+                    "MAILDEV_WEB_PORT": WEB_PORT.toString(),
+            ]
+
+            if (authenticated) {
+                envVars += [
+                        "MAILDEV_INCOMING_USER": MAILSERVER_USER,
+                        "MAILDEV_INCOMING_PASS": MAILSERVER_PASS,
+                ]
+            }
+
+            mailServer.deployment =
+                    new Deployment()
+                            .setNamespace(orchestrator.getNameSpace())
+                            .setName(deploymentName)
+                            // The original is at docker.io/maildev/maildev:2.0.5
+                            // and https://github.com/maildev/maildev
+                            .setImage("quay.io/rhacs-eng/qa:docker-io-maildev-maildev-2-0-5")
+                            .addPort(WEB_PORT)
+                            .addPort(SMTP_PORT)
+                            .setEnv(envVars)
+                            .addLabel("app", "maildev")
+            orchestrator.createDeployment(mailServer.deployment)
+
+            mailServer.smtpSvc = new Service("maildev-smtp-${mailServer.uid}", orchestrator.getNameSpace())
+                    .addLabel("app", "maildev")
+                    .addPort(SMTP_PORT, "TCP")
+                    .setTargetPort(SMTP_PORT)
+                    .setType(Service.Type.CLUSTERIP)
+            orchestrator.createService(mailServer.smtpSvc)
+
+            mailServer.webSvc = new Service("maildev-web-${mailServer.uid}", orchestrator.getNameSpace())
+                    .addLabel("app", "maildev")
+                    .addPort(WEB_PORT, "TCP")
+                    .setTargetPort(WEB_PORT)
+                    .setType(Service.Type.CLUSTERIP)
+            orchestrator.createService(mailServer.webSvc)
+
+            mailServer.webPortForward = orchestrator.
+                    createPortForward(WEB_PORT, mailServer.deployment) as LocalPortForward
+        } catch (Exception e) {
+            log.info("Something bad happened, will run cleanup before failing", e)
+            if (mailServer.smtpSvc) {
+                orchestrator.deleteService(mailServer.smtpSvc.name, mailServer.smtpSvc.namespace)
+            }
+            if (mailServer.webSvc) {
+                orchestrator.deleteService(mailServer.webSvc.name, mailServer.webSvc.namespace)
+            }
+            if (mailServer.deployment) {
+                orchestrator.deleteDeployment(mailServer.deployment)
+            }
+            throw e
+        }
+        return mailServer
+    }
+
+    void teardown(OrchestratorMain orchestrator) {
+        def imagePullSecrets = deployment.getImagePullSecret()
+        for (String secret : imagePullSecrets) {
+            orchestrator.deleteSecret(secret, deployment.namespace)
+        }
+        orchestrator.deleteService(smtpSvc.name, smtpSvc.namespace)
+        orchestrator.deleteService(webSvc.name, webSvc.namespace)
+        orchestrator.waitForServiceDeletion(smtpSvc)
+        orchestrator.waitForServiceDeletion(webSvc)
+        orchestrator.deleteDeployment(deployment)
+    }
+
+    String smtpUrl() {
+        return "${smtpSvc.getName()}.${deployment.getNamespace()}:${SMTP_PORT}"
+    }
+
+    List findEmails(String fromEmail) {
+        def con = (HttpURLConnection) new URL(String.format(
+                "http://localhost:%s/email?from.address=%s", webPortForward.getLocalPort(),
+                URLEncoder.encode(fromEmail, "UTF-8"))
+        ).openConnection()
+        con.setRequestMethod("GET")
+
+        assert con.getResponseCode() == 200
+
+        def jsonSlurper = new JsonSlurper()
+        def objects = jsonSlurper.parseText(con.getInputStream().getText()) as List
+        return objects
+    }
+}


### PR DESCRIPTION
## Description

Email tests have been disabled for a while since the mailgun account that was used to test it was deactivated. This brings some of them back.

Uses a third party SMTP relay server called [maildev](https://github.com/maildev/maildev) ("As-Is" [license](https://github.com/maildev/maildev/blob/master/LICENSE)) which is deployed at the beginning of each test. The NodeJS SMTP server accepts emails and stores it in memory and it can be queried with a REST API. 

Unfortunately maildev doesn't support TLS or StartTLS and that was discovered late. So TLS related tests are still disabled. However, there is still benefit in enabling some of it as it tests the new unauthenticated SMTP feature.

Next up:
* Enable tests that actually read the email sent via notifiers (violations, NG, etc)
* Figure out how to test SMTP. Perhaps using a [TLS enabled mail forwarder](https://github.com/huan/docker-simple-mail-forwarder) that forwards to maildev?

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~
~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

This is a test
