### PR TITLE
ROX-11748: Add SAC tests for Node datastore and globaldatastore

### DIFF
--- a/central/node/datastore/dackbox/datastore/datastore_sac_test.go
+++ b/central/node/datastore/dackbox/datastore/datastore_sac_test.go
@@ -337,7 +337,6 @@ func (s *nodeDatastoreSACSuite) TestSearch() {
 	clusterID := testconsts.Cluster2
 
 	cases := getSACMultiNodeTestCases(context.Background(), s.T(), clusterID, "not-"+clusterID, resources.Node)
-
 	for name, c := range cases {
 		s.Run(name, func() {
 			ctx := c.Context
@@ -345,8 +344,8 @@ func (s *nodeDatastoreSACSuite) TestSearch() {
 			s.NoError(err)
 
 			fetchedNodeIDs := make([]string, 0, len(results))
-			for _, r := range results {
-				fetchedNodeIDs = append(fetchedNodeIDs, r.ID)
+			for _, result := range results {
+				fetchedNodeIDs = append(fetchedNodeIDs, result.ID)
 			}
 
 			var expectedNodeIds []string
@@ -363,16 +362,15 @@ func (s *nodeDatastoreSACSuite) TestSearchNodes() {
 	clusterID := testconsts.Cluster2
 
 	cases := getSACMultiNodeTestCases(context.Background(), s.T(), clusterID, "not-"+clusterID, resources.Node)
-
 	for name, c := range cases {
 		s.Run(name, func() {
 			ctx := c.Context
-			results, err := s.datastore.SearchNodes(ctx, nil)
+			nodes, err := s.datastore.SearchNodes(ctx, nil)
 			s.NoError(err)
 
-			fetchedNodeIDs := make([]string, 0, len(results))
-			for _, r := range results {
-				fetchedNodeIDs = append(fetchedNodeIDs, r.Id)
+			fetchedNodeIDs := make([]string, 0, len(nodes))
+			for _, node := range nodes {
+				fetchedNodeIDs = append(fetchedNodeIDs, node.Id)
 			}
 
 			var expectedNodeIds []string
@@ -389,16 +387,15 @@ func (s *nodeDatastoreSACSuite) TestSearchRawNodes() {
 	clusterID := testconsts.Cluster2
 
 	cases := getSACMultiNodeTestCases(context.Background(), s.T(), clusterID, "not-"+clusterID, resources.Node)
-
 	for name, c := range cases {
 		s.Run(name, func() {
 			ctx := c.Context
-			results, err := s.datastore.SearchRawNodes(ctx, nil)
+			rawNodes, err := s.datastore.SearchRawNodes(ctx, nil)
 			s.NoError(err)
 
-			fetchedNodeIDs := make([]string, 0, len(results))
-			for _, r := range results {
-				fetchedNodeIDs = append(fetchedNodeIDs, r.Id)
+			fetchedNodeIDs := make([]string, 0, len(rawNodes))
+			for _, rawNode := range rawNodes {
+				fetchedNodeIDs = append(fetchedNodeIDs, rawNode.Id)
 			}
 
 			var expectedNodeIds []string

--- a/central/node/datastore/dackbox/datastore/datastore_sac_test.go
+++ b/central/node/datastore/dackbox/datastore/datastore_sac_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/dackbox"
+	dackboxConcurrency "github.com/stackrox/rox/pkg/dackbox/concurrency"
 	"github.com/stackrox/rox/pkg/dackbox/indexer"
 	"github.com/stackrox/rox/pkg/dackbox/utils/queue"
 	"github.com/stackrox/rox/pkg/features"
@@ -45,7 +46,7 @@ type nodeDatastoreSACSuite struct {
 	// Elements for bleve+rocksdb mode
 	rocksEngine *rocksdb.RocksDB
 	bleveIndex  bleve.Index
-	keyFence    concurrency.KeyFence
+	keyFence    dackboxConcurrency.KeyFence
 	indexQ      queue.WaitableQueue
 	dacky       *dackbox.DackBox
 
@@ -72,7 +73,7 @@ func (s *nodeDatastoreSACSuite) setupRocks() {
 	s.Require().NoError(err)
 	s.bleveIndex, err = globalindex.MemOnlyIndex()
 	s.Require().NoError(err)
-	s.keyFence = concurrency.NewKeyFence()
+	s.keyFence = dackboxConcurrency.NewKeyFence()
 	s.indexQ = queue.NewWaitableQueue()
 	s.dacky, err = dackbox.NewRocksDBDackBox(s.rocksEngine, s.indexQ, []byte("graph"), []byte("dirty"), []byte("valid"))
 	s.Require().NoError(err)

--- a/central/node/datastore/dackbox/datastore/datastore_sac_test.go
+++ b/central/node/datastore/dackbox/datastore/datastore_sac_test.go
@@ -569,7 +569,7 @@ func (s *nodeDatastoreSACSuite) TestDeleteNodesMulti() {
 			if c.ExpectError {
 				s.ErrorIs(err, c.ExpectedError)
 
-				// Check that nodes are removed from datastore.
+				// Check that nodes are not removed from datastore.
 				for _, delNodeID := range delNodeIDs {
 					_, found, errGetNode := s.datastore.GetNode(s.testContexts[testutils.UnrestrictedReadWriteCtx], delNodeID)
 					s.True(found)

--- a/central/node/datastore/dackbox/datastore/datastore_sac_test.go
+++ b/central/node/datastore/dackbox/datastore/datastore_sac_test.go
@@ -122,7 +122,7 @@ func (s *nodeDatastoreSACSuite) TearDownTest() {
 func (s *nodeDatastoreSACSuite) addTestNode(clusterID string) string {
 	nodeID := uuid.NewV4().String()
 	node := fixtures.GetScopedNode(nodeID, clusterID)
-	node.Priority = 1
+	node.Priority = 10
 
 	errUpsert := s.datastore.UpsertNode(s.testContexts[testutils.UnrestrictedReadWriteCtx], node)
 	s.Require().NoError(errUpsert)

--- a/central/node/datastore/dackbox/datastore/datastore_sac_test.go
+++ b/central/node/datastore/dackbox/datastore/datastore_sac_test.go
@@ -88,8 +88,6 @@ func (s *nodeDatastoreSACSuite) setupRocks() {
 
 func (s *nodeDatastoreSACSuite) SetupSuite() {
 	if features.PostgresDatastore.Enabled() {
-		s.T().Skip("Skip Postgres tests!")
-
 		s.setupPostgres()
 	} else {
 		s.setupRocks()
@@ -303,9 +301,6 @@ func (s *nodeDatastoreSACSuite) TestCountNodes() {
 }
 
 func (s *nodeDatastoreSACSuite) TestCount() {
-	// TODO: Fix!!!
-	s.T().Skip("Skip because Count() panics for nil query.")
-
 	clusterID := testconsts.Cluster3
 
 	s.addTestNode(clusterID)
@@ -315,7 +310,7 @@ func (s *nodeDatastoreSACSuite) TestCount() {
 	for name, c := range cases {
 		s.Run(name, func() {
 			ctx := c.Context
-			numOfNodes, err := s.datastore.Count(ctx, nil)
+			numOfNodes, err := s.datastore.Count(ctx, searchPkg.EmptyQuery())
 			s.NoError(err)
 
 			// No accessible clusters.

--- a/central/node/datastore/dackbox/datastore/datastore_sac_test.go
+++ b/central/node/datastore/dackbox/datastore/datastore_sac_test.go
@@ -1,0 +1,490 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blevesearch/bleve"
+	"github.com/stackrox/rox/central/globalindex"
+	nodeDackbox "github.com/stackrox/rox/central/node/dackbox"
+	nodeIndex "github.com/stackrox/rox/central/node/index"
+	"github.com/stackrox/rox/central/node/index/mappings"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/dackbox"
+	"github.com/stackrox/rox/pkg/dackbox/indexer"
+	"github.com/stackrox/rox/pkg/dackbox/utils/queue"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/sac/testutils"
+	searchPkg "github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestNodeDatastoreSAC(t *testing.T) {
+	suite.Run(t, new(nodeDatastoreSACSuite))
+}
+
+type nodeDatastoreSACSuite struct {
+	suite.Suite
+
+	datastore  DataStore
+	optionsMap searchPkg.OptionsMap
+
+	// Elements for postgres mode
+	pgtestbase *pgtest.TestPostgres
+
+	// Elements for bleve+rocksdb mode
+	rocksEngine *rocksdb.RocksDB
+	bleveIndex  bleve.Index
+	keyFence    concurrency.KeyFence
+	indexQ      queue.WaitableQueue
+	dacky       *dackbox.DackBox
+
+	testContexts map[string]context.Context
+
+	testNodeIDs map[string][]string
+	testNodes   map[string]*storage.Node
+}
+
+func (s *nodeDatastoreSACSuite) setupPostgres() {
+	var err error
+
+	s.pgtestbase = pgtest.ForT(s.T())
+	s.NotNil(s.pgtestbase)
+	s.datastore, err = GetTestPostgresDataStore(s.T(), s.pgtestbase.Pool)
+	s.Require().NoError(err)
+	s.optionsMap = schema.ClustersSchema.OptionsMap
+}
+
+func (s *nodeDatastoreSACSuite) setupRocks() {
+	var err error
+
+	s.rocksEngine, err = rocksdb.NewTemp("nodeSACTest")
+	s.Require().NoError(err)
+	s.bleveIndex, err = globalindex.MemOnlyIndex()
+	s.Require().NoError(err)
+	s.keyFence = concurrency.NewKeyFence()
+	s.indexQ = queue.NewWaitableQueue()
+	s.dacky, err = dackbox.NewRocksDBDackBox(s.rocksEngine, s.indexQ, []byte("graph"), []byte("dirty"), []byte("valid"))
+	s.Require().NoError(err)
+
+	reg := indexer.NewWrapperRegistry()
+	indexer.NewLazy(s.indexQ, reg, s.bleveIndex, s.dacky.AckIndexed).Start()
+	reg.RegisterWrapper(nodeDackbox.Bucket, nodeIndex.Wrapper{})
+
+	s.datastore, err = GetTestRocksBleveDataStore(s.T(), s.rocksEngine, s.bleveIndex, s.dacky, s.keyFence)
+	s.Require().NoError(err)
+	s.optionsMap = mappings.OptionsMap
+}
+
+func (s *nodeDatastoreSACSuite) SetupSuite() {
+	if features.PostgresDatastore.Enabled() {
+		s.T().Skip("Skip Postgres tests!")
+
+		s.setupPostgres()
+	} else {
+		s.setupRocks()
+	}
+
+	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.Node)
+}
+
+func (s *nodeDatastoreSACSuite) TearDownSuite() {
+	if features.PostgresDatastore.Enabled() {
+		s.pgtestbase.Pool.Close()
+	} else {
+		s.Require().NoError(rocksdb.CloseAndRemove(s.rocksEngine))
+		s.Require().NoError(s.bleveIndex.Close())
+	}
+}
+
+func (s *nodeDatastoreSACSuite) SetupTest() {
+	s.testNodeIDs = make(map[string][]string, 0)
+	s.testNodes = make(map[string]*storage.Node, 0)
+
+	s.initTestResourceSet()
+}
+
+func (s *nodeDatastoreSACSuite) TearDownTest() {
+	for _, nodeIds := range s.testNodeIDs {
+		s.Require().NoError(s.datastore.DeleteNodes(s.testContexts[testutils.UnrestrictedReadWriteCtx], nodeIds...))
+	}
+}
+
+func (s *nodeDatastoreSACSuite) addTestNode(clusterID string) {
+	nodeID := uuid.NewV4().String()
+	node := fixtures.GetScopedNode(nodeID, clusterID)
+	node.Priority = 1
+
+	errUpsert := s.datastore.UpsertNode(s.testContexts[testutils.UnrestrictedReadWriteCtx], node)
+	s.NoError(errUpsert)
+	s.testNodeIDs[clusterID] = append(s.testNodeIDs[clusterID], nodeID)
+	s.testNodes[nodeID] = node
+}
+
+func (s *nodeDatastoreSACSuite) waitForIndexing() {
+	if !features.PostgresDatastore.Enabled() {
+		indexingCompleted := concurrency.NewSignal()
+		s.indexQ.PushSignal(&indexingCompleted)
+		<-indexingCompleted.Done()
+	}
+}
+
+func (s *nodeDatastoreSACSuite) initTestResourceSet() {
+	clusters := []string{testconsts.Cluster1, testconsts.Cluster2, testconsts.Cluster3}
+
+	const numberOfNodes = 3
+	for _, clusterID := range clusters {
+		s.testNodeIDs[clusterID] = make([]string, 0, numberOfNodes)
+		for i := 0; i < numberOfNodes; i++ {
+			s.addTestNode(clusterID)
+		}
+	}
+
+	s.waitForIndexing()
+}
+
+type sacMultiNodeTest struct {
+	Context            context.Context
+	SingleCluster      bool
+	ExpectedClusterIds []string
+}
+
+func getSACMultiNodeTestCases(baseContext context.Context, _ *testing.T, validClusterID string, wrongClusterID string, resources ...permissions.ResourceMetadata) map[string]sacMultiNodeTest {
+	resourceHandles := make([]permissions.ResourceHandle, 0, len(resources))
+	for _, r := range resources {
+		resourceHandles = append(resourceHandles, r)
+	}
+
+	return map[string]sacMultiNodeTest{
+		"(full) read-only can get": {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...))),
+			SingleCluster:      false,
+			ExpectedClusterIds: []string{testconsts.Cluster1, testconsts.Cluster2, testconsts.Cluster3},
+		},
+		"full read-write can get": {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...))),
+			SingleCluster:      false,
+			ExpectedClusterIds: []string{testconsts.Cluster1, testconsts.Cluster2, testconsts.Cluster3},
+		},
+		"full read-write on wrong cluster cannot get": {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(wrongClusterID))),
+			SingleCluster:      false,
+			ExpectedClusterIds: []string{},
+		},
+		"read-write on wrong cluster and partial namespace access cannot get": {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(wrongClusterID),
+					sac.NamespaceScopeKeys("someNamespace"))),
+			SingleCluster:      false,
+			ExpectedClusterIds: []string{},
+		},
+		"full read-write on right cluster can get": {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(validClusterID))),
+			SingleCluster:      true,
+			ExpectedClusterIds: []string{validClusterID},
+		},
+		"read-write on the right cluster and partial namespace access cannot get": {
+			Context: sac.WithGlobalAccessScopeChecker(baseContext,
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resourceHandles...),
+					sac.ClusterScopeKeys(validClusterID),
+					sac.NamespaceScopeKeys("someNamespace"))),
+			SingleCluster:      true,
+			ExpectedClusterIds: []string{},
+		},
+	}
+}
+
+func (s *nodeDatastoreSACSuite) TestExists() {
+	clusterID := testconsts.Cluster2
+	nodeID := s.testNodeIDs[clusterID][2]
+
+	cases := testutils.GenericClusterSACGetTestCases(context.Background(), s.T(), clusterID, "not-"+clusterID, resources.Node)
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			exists, err := s.datastore.Exists(ctx, nodeID)
+			s.NoError(err)
+			s.Equal(c.ExpectedFound, exists)
+		})
+	}
+}
+
+func (s *nodeDatastoreSACSuite) TestGetNode() {
+	clusterID := testconsts.Cluster2
+	nodeID := s.testNodeIDs[clusterID][1]
+
+	cases := testutils.GenericClusterSACGetTestCases(context.Background(), s.T(), clusterID, "not-"+clusterID, resources.Node)
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			fetchedNode, found, err := s.datastore.GetNode(ctx, nodeID)
+			s.NoError(err)
+			if c.ExpectedFound {
+				s.True(found)
+				s.Require().NotNil(fetchedNode)
+				s.Equal(*s.testNodes[nodeID], *fetchedNode)
+			} else {
+				s.False(found)
+				s.Nil(fetchedNode)
+			}
+		})
+	}
+}
+
+func (s *nodeDatastoreSACSuite) TestCountNodes() {
+	clusterID := testconsts.Cluster3
+
+	s.addTestNode(clusterID)
+	s.waitForIndexing()
+
+	cases := getSACMultiNodeTestCases(context.Background(), s.T(), clusterID, "not-"+clusterID, resources.Node)
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			numOfNodes, err := s.datastore.CountNodes(ctx)
+			s.NoError(err)
+
+			// No accessible clusters.
+			if len(c.ExpectedClusterIds) == 0 {
+				s.Equal(0, numOfNodes)
+
+				return
+			}
+
+			// Can access to single cluster.
+			if c.SingleCluster {
+				s.Require().Equal(len(s.testNodeIDs[clusterID]), numOfNodes)
+
+				return
+			}
+
+			// Can access to all clusters.
+			s.Require().Equal(len(s.testNodes), numOfNodes)
+		})
+	}
+}
+
+func (s *nodeDatastoreSACSuite) TestCount() {
+	// TODO: Fix!!!
+	s.T().Skip("Skip because Count() panics for nil query.")
+
+	clusterID := testconsts.Cluster3
+
+	s.addTestNode(clusterID)
+	s.waitForIndexing()
+
+	cases := getSACMultiNodeTestCases(context.Background(), s.T(), clusterID, "not-"+clusterID, resources.Node)
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			numOfNodes, err := s.datastore.Count(ctx, nil)
+			s.NoError(err)
+
+			// No accessible clusters.
+			if len(c.ExpectedClusterIds) == 0 {
+				s.Equal(0, numOfNodes)
+
+				return
+			}
+
+			// Can access to single cluster.
+			if c.SingleCluster {
+				s.Require().Equal(len(s.testNodeIDs[clusterID]), numOfNodes)
+
+				return
+			}
+
+			// Can access to all clusters.
+			s.Require().Equal(len(s.testNodes), numOfNodes)
+		})
+	}
+}
+
+func (s *nodeDatastoreSACSuite) TestSearch() {
+	clusterID := testconsts.Cluster2
+
+	cases := getSACMultiNodeTestCases(context.Background(), s.T(), clusterID, "not-"+clusterID, resources.Node)
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			results, err := s.datastore.Search(ctx, nil)
+			s.NoError(err)
+
+			fetchedNodeIDs := make([]string, 0, len(results))
+			for _, r := range results {
+				fetchedNodeIDs = append(fetchedNodeIDs, r.ID)
+			}
+
+			var expectedNodeIds []string
+			for _, expectedClusterID := range c.ExpectedClusterIds {
+				expectedNodeIds = append(expectedNodeIds, s.testNodeIDs[expectedClusterID]...)
+			}
+
+			s.ElementsMatch(expectedNodeIds, fetchedNodeIDs)
+		})
+	}
+}
+
+func (s *nodeDatastoreSACSuite) TestSearchNodes() {
+	clusterID := testconsts.Cluster2
+
+	cases := getSACMultiNodeTestCases(context.Background(), s.T(), clusterID, "not-"+clusterID, resources.Node)
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			results, err := s.datastore.SearchNodes(ctx, nil)
+			s.NoError(err)
+
+			fetchedNodeIDs := make([]string, 0, len(results))
+			for _, r := range results {
+				fetchedNodeIDs = append(fetchedNodeIDs, r.Id)
+			}
+
+			var expectedNodeIds []string
+			for _, expectedClusterID := range c.ExpectedClusterIds {
+				expectedNodeIds = append(expectedNodeIds, s.testNodeIDs[expectedClusterID]...)
+			}
+
+			s.ElementsMatch(expectedNodeIds, fetchedNodeIDs)
+		})
+	}
+}
+
+func (s *nodeDatastoreSACSuite) TestSearchRawNodes() {
+	clusterID := testconsts.Cluster2
+
+	cases := getSACMultiNodeTestCases(context.Background(), s.T(), clusterID, "not-"+clusterID, resources.Node)
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			results, err := s.datastore.SearchRawNodes(ctx, nil)
+			s.NoError(err)
+
+			fetchedNodeIDs := make([]string, 0, len(results))
+			for _, r := range results {
+				fetchedNodeIDs = append(fetchedNodeIDs, r.Id)
+			}
+
+			var expectedNodeIds []string
+			for _, expectedClusterID := range c.ExpectedClusterIds {
+				expectedNodeIds = append(expectedNodeIds, s.testNodeIDs[expectedClusterID]...)
+			}
+
+			s.ElementsMatch(expectedNodeIds, fetchedNodeIDs)
+		})
+	}
+}
+
+func (s *nodeDatastoreSACSuite) TestGetNodesBatch() {
+	clusterID := testconsts.Cluster2
+
+	allNodeIds := make([]string, 0, len(s.testNodes))
+	for _, node := range s.testNodes {
+		allNodeIds = append(allNodeIds, node.Id)
+	}
+
+	cases := getSACMultiNodeTestCases(context.Background(), s.T(), clusterID, "not-"+clusterID, resources.Node)
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := c.Context
+			results, err := s.datastore.GetNodesBatch(ctx, allNodeIds)
+			s.NoError(err)
+
+			fetchedNodeIDs := make([]string, 0, len(results))
+			for _, r := range results {
+				fetchedNodeIDs = append(fetchedNodeIDs, r.Id)
+			}
+
+			var expectedNodeIds []string
+			for _, expectedClusterID := range c.ExpectedClusterIds {
+				expectedNodeIds = append(expectedNodeIds, s.testNodeIDs[expectedClusterID]...)
+			}
+
+			s.ElementsMatch(expectedNodeIds, fetchedNodeIDs)
+		})
+	}
+}
+
+func (s *nodeDatastoreSACSuite) TestUpsertNode() {
+	clusterID := testconsts.Cluster2
+
+	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), "upsert")
+	for name, c := range cases {
+		s.Run(name, func() {
+			nodeID := uuid.NewV4().String()
+			node := fixtures.GetScopedNode(nodeID, clusterID)
+
+			ctx := s.testContexts[c.ScopeKey]
+			err := s.datastore.UpsertNode(ctx, node)
+			s.waitForIndexing()
+
+			if c.ExpectError {
+				s.ErrorIs(err, c.ExpectedError)
+			} else {
+				s.NoError(err)
+
+				s.testNodeIDs[clusterID] = append(s.testNodeIDs[clusterID], nodeID)
+				s.testNodes[nodeID] = node
+			}
+		})
+	}
+}
+
+func (s *nodeDatastoreSACSuite) TestDeleteNodes() {
+	cases := testutils.GenericGlobalSACDeleteTestCases(s.T())
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[c.ScopeKey]
+
+			err := s.datastore.DeleteNodes(ctx, s.testNodeIDs[testconsts.Cluster1][1])
+			s.waitForIndexing()
+
+			if c.ExpectError {
+				s.ErrorIs(err, c.ExpectedError)
+			} else {
+				s.NoError(err)
+			}
+
+			err = s.datastore.DeleteNodes(ctx, s.testNodeIDs[testconsts.Cluster2][0], s.testNodeIDs[testconsts.Cluster2][1])
+			s.waitForIndexing()
+
+			if c.ExpectError {
+				s.ErrorIs(err, c.ExpectedError)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}

--- a/central/node/datastore/dackbox/datastore/datastore_sac_test.go
+++ b/central/node/datastore/dackbox/datastore/datastore_sac_test.go
@@ -122,7 +122,7 @@ func (s *nodeDatastoreSACSuite) TearDownTest() {
 func (s *nodeDatastoreSACSuite) addTestNode(clusterID string) string {
 	nodeID := uuid.NewV4().String()
 	node := fixtures.GetScopedNode(nodeID, clusterID)
-	node.Priority = 10
+	node.Priority = 1
 
 	errUpsert := s.datastore.UpsertNode(s.testContexts[testutils.UnrestrictedReadWriteCtx], node)
 	s.Require().NoError(errUpsert)
@@ -261,6 +261,9 @@ func (s *nodeDatastoreSACSuite) TestGetNode() {
 			if c.ExpectedFound {
 				s.True(found)
 				s.NotNil(fetchedNode)
+
+				// Priority can have updated value, and we want to ignore it.
+				fetchedNode.Priority = s.testNodes[nodeID].Priority
 				s.Equal(*s.testNodes[nodeID], *fetchedNode)
 			} else {
 				s.False(found)

--- a/central/node/globaldatastore/datastore_sac_test.go
+++ b/central/node/globaldatastore/datastore_sac_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/dackbox"
+	dackboxConcurrency "github.com/stackrox/rox/pkg/dackbox/concurrency"
 	"github.com/stackrox/rox/pkg/dackbox/indexer"
 	"github.com/stackrox/rox/pkg/dackbox/utils/queue"
 	"github.com/stackrox/rox/pkg/features"
@@ -51,7 +52,7 @@ type nodeDatastoreSACSuite struct {
 	// Elements for bleve+rocksdb mode
 	rocksEngine *rocksdb.RocksDB
 	bleveIndex  bleve.Index
-	keyFence    concurrency.KeyFence
+	keyFence    dackboxConcurrency.KeyFence
 	indexQ      queue.WaitableQueue
 	dacky       *dackbox.DackBox
 
@@ -81,7 +82,7 @@ func (s *nodeDatastoreSACSuite) setupRocks() {
 	s.Require().NoError(err)
 	s.bleveIndex, err = globalindex.MemOnlyIndex()
 	s.Require().NoError(err)
-	s.keyFence = concurrency.NewKeyFence()
+	s.keyFence = dackboxConcurrency.NewKeyFence()
 	s.indexQ = queue.NewWaitableQueue()
 	s.dacky, err = dackbox.NewRocksDBDackBox(s.rocksEngine, s.indexQ, []byte("graph"), []byte("dirty"), []byte("valid"))
 	s.Require().NoError(err)

--- a/central/node/globaldatastore/datastore_sac_test.go
+++ b/central/node/globaldatastore/datastore_sac_test.go
@@ -97,8 +97,6 @@ func (s *nodeDatastoreSACSuite) setupRocks() {
 
 func (s *nodeDatastoreSACSuite) SetupSuite() {
 	if features.PostgresDatastore.Enabled() {
-		s.T().Skip("Skip Postgres tests!")
-
 		s.setupPostgres()
 	} else {
 		s.setupRocks()
@@ -355,7 +353,6 @@ func (s *nodeDatastoreSACSuite) TestGetAllClusterNodeStoresWriteAccess() {
 }
 
 func (s *nodeDatastoreSACSuite) TestGetClusterNodeStore() {
-	s.T().Skip("TODO - GetClusterNodeStore")
 	clusterID := testconsts.Cluster2
 
 	cases := testutils.GenericClusterSACGetTestCases(context.Background(), s.T(), clusterID, "not-"+clusterID, resources.Node)
@@ -363,10 +360,11 @@ func (s *nodeDatastoreSACSuite) TestGetClusterNodeStore() {
 		s.Run(name, func() {
 			ctx := c.Context
 			datastore, err := s.globalDatastore.GetClusterNodeStore(ctx, clusterID, false)
-			s.NoError(err)
 			if c.ExpectedFound {
+				s.NoError(err)
 				s.Require().NotNil(datastore)
 			} else {
+				s.ErrorIs(err, sac.ErrResourceAccessDenied)
 				s.Nil(datastore)
 			}
 		})
@@ -374,7 +372,6 @@ func (s *nodeDatastoreSACSuite) TestGetClusterNodeStore() {
 }
 
 func (s *nodeDatastoreSACSuite) TestGetClusterNodeStoreWriteAccess() {
-	s.T().Skip("TODO - GetClusterNodeStore")
 	clusterID := testconsts.Cluster2
 
 	cases := testutils.GenericClusterSACWriteTestCases(context.Background(), s.T(), "write", clusterID, "not-"+clusterID, resources.Node)
@@ -382,11 +379,12 @@ func (s *nodeDatastoreSACSuite) TestGetClusterNodeStoreWriteAccess() {
 		s.Run(name, func() {
 			ctx := c.Context
 			datastore, err := s.globalDatastore.GetClusterNodeStore(ctx, clusterID, true)
-			s.NoError(err)
-			if c.ExpectedFound {
-				s.Require().NotNil(datastore)
-			} else {
+			if c.ExpectError {
+				s.ErrorIs(err, sac.ErrResourceAccessDenied)
 				s.Nil(datastore)
+			} else {
+				s.NoError(err)
+				s.Require().NotNil(datastore)
 			}
 		})
 	}

--- a/pkg/fixtures/node.go
+++ b/pkg/fixtures/node.go
@@ -45,3 +45,11 @@ func getNodeWithComponents(components []*storage.EmbeddedNodeScanComponent) *sto
 		},
 	}
 }
+
+// GetScopedNode returns a mock Node belonging to the input scope.
+func GetScopedNode(ID string, clusterID string) *storage.Node {
+	return &storage.Node{
+		Id:        ID,
+		ClusterId: clusterID,
+	}
+}

--- a/pkg/postgres/pgtest/conn/conn.go
+++ b/pkg/postgres/pgtest/conn/conn.go
@@ -25,8 +25,12 @@ func GetConnectionStringWithDatabaseName(database string) string {
 	}
 	pass := env.GetString("POSTGRES_PASSWORD", "")
 	host := env.GetString("POSTGRES_HOST", "localhost")
+<<<<<<< HEAD
 	port := env.GetString("POSTGRES_PORT", "5432")
 	src := fmt.Sprintf("host=%s port=%s user=%s database=%s sslmode=disable statement_timeout=600000 client_encoding=UTF-8", host, port, user, database)
+=======
+	src := fmt.Sprintf("host=%s port=5432 user=%s database=%s sslmode=disable statement_timeout=600000", host, user, database)
+>>>>>>> cdb1fe53d3 (Revert test connection change)
 	if pass != "" {
 		src += fmt.Sprintf(" password=%s", pass)
 	}

--- a/pkg/postgres/pgtest/conn/conn.go
+++ b/pkg/postgres/pgtest/conn/conn.go
@@ -25,12 +25,8 @@ func GetConnectionStringWithDatabaseName(database string) string {
 	}
 	pass := env.GetString("POSTGRES_PASSWORD", "")
 	host := env.GetString("POSTGRES_HOST", "localhost")
-<<<<<<< HEAD
 	port := env.GetString("POSTGRES_PORT", "5432")
 	src := fmt.Sprintf("host=%s port=%s user=%s database=%s sslmode=disable statement_timeout=600000 client_encoding=UTF-8", host, port, user, database)
-=======
-	src := fmt.Sprintf("host=%s port=5432 user=%s database=%s sslmode=disable statement_timeout=600000", host, user, database)
->>>>>>> cdb1fe53d3 (Revert test connection change)
 	if pass != "" {
 		src += fmt.Sprintf(" password=%s", pass)
 	}


### PR DESCRIPTION
## Description

This PR adds SAC unit tests for Node datastore and globaldatastore.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

We have 2 branches of unit test execution:
1. Postgres
2. Rocks

**How to test**

1. To run Postgres tests you need to do the following steps
- start postgres instance in docker:
```
docker run --name test-stackrox -p 5432:5432 -e POSTGRES_USER=sr -e POSTGRES_PASSWORD=sr -e POSTGRES_DB=sr -d postgres
```
- export env variables:
```
export ROX_POSTGRES_DATASTORE=true 

export USER=sr
export POSTGRES_PASSWORD=sr
export POSTGRES_DB=sr
export POSTGRES_HOST=localhost
```

*for datastore*
- go to directory with new test: `cd central/node/datastore/dackbox/datastore`
- and run tests: `go test -v -run "TestNodeDatastoreSAC" .`

*for globaldatastore*
- go to directory with new test: `cd central/node/globaldatastore`
- and run tests: `go test -v -run "TestNodeGlobalDatastoreSAC" .`

2. To run Rocks tests you need to do the following steps
- export env variables:
```
export ROX_POSTGRES_DATASTORE=false
```

*for datastore*
- go to directory with new test: `cd central/node/datastore/dackbox/datastore`
- and run tests: `go test -v -run "TestNodeDatastoreSAC" .`

*for globaldatastore*
- go to directory with new test: `cd central/node/globaldatastore`
- and run tests: `go test -v -run "TestNodeGlobalDatastoreSAC" .`
