### PR TITLE
ROX-11774: Add basic BATS tests for roxctl netpol generate

### DIFF
--- a/tests/roxctl/bats-tests/local/roxctl-netpol-generate.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-netpol-generate.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+load "../helpers.bash"
+
+out_dir=""
+
+setup_file() {
+  echo "Testing roxctl version: '$(roxctl-release version)'" >&3
+  command -v yq > /dev/null || skip "Tests in this file require yq"
+  # remove binaries from the previous runs
+  rm -f "$(roxctl-development-cmd)" "$(roxctl-development-release)"
+}
+
+setup() {
+  out_dir="$(mktemp -d -u)"
+}
+
+teardown() {
+  rm -rf "$out_dir"
+}
+
+@test "roxctl-release generate netpol should return error on empty or non-existing directory" {
+  run roxctl-release generate netpol "$out_dir"
+  assert_failure
+  assert_line --partial "Error synthesizing policies from folder: no deployment objects discovered in the repository"
+}
+
+@test "roxctl-release generate netpol generates network policies" {
+  assert_file_exist "${test_data}/np-guard/scenario-minimal-service/frontend.yaml"
+  assert_file_exist "${test_data}/np-guard/scenario-minimal-service/backend.yaml"
+  ofile="$(mktemp)"
+  echo "Writing network policies to ${ofile}" >&3
+  run roxctl-release generate netpol "${test_data}/np-guard/scenario-minimal-service"
+  assert_success
+  echo "$output" > "$ofile"
+  assert_file_exist "$ofile"
+  yaml_valid "$ofile"
+
+  # There must be at least 2 yaml documents in the output
+  run yq e 'document_index' "${ofile}"
+  assert_line '0'
+  assert_line '1'
+
+  # Ensure that both yaml docs are of kind 'NetworkPolicy'
+  run yq e '.kind | ({"match": ., "doc": document_index})' "${ofile}"
+  assert_line --index 0 'match: NetworkPolicy'
+  assert_line --index 1 'doc: 0'
+  assert_line --index 2 'match: NetworkPolicy'
+  assert_line --index 3 'doc: 1'
+
+
+}
+
+

--- a/tests/roxctl/bats-tests/local/roxctl-netpol-generate.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-netpol-generate.bats
@@ -23,6 +23,10 @@ teardown() {
   run roxctl-release generate netpol "$out_dir"
   assert_failure
   assert_line --partial "Error synthesizing policies from folder: no deployment objects discovered in the repository"
+
+  run roxctl-release generate netpol
+  assert_failure
+  assert_line --partial "missing <folder-path> argument"
 }
 
 @test "roxctl-release generate netpol generates network policies" {

--- a/tests/roxctl/bats-tests/local/roxctl-netpol-generate.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-netpol-generate.bats
@@ -5,10 +5,11 @@ load "../helpers.bash"
 out_dir=""
 
 setup_file() {
-  echo "Testing roxctl version: '$(roxctl-release version)'" >&3
   command -v yq > /dev/null || skip "Tests in this file require yq"
+  echo "yq version: '$(yq --version)'" >&3
   # remove binaries from the previous runs
   rm -f "$(roxctl-development-cmd)" "$(roxctl-development-release)"
+  echo "Testing roxctl version: '$(roxctl-release version)'" >&3
 }
 
 setup() {

--- a/tests/roxctl/bats-tests/local/roxctl-netpol-generate.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-netpol-generate.bats
@@ -5,19 +5,22 @@ load "../helpers.bash"
 out_dir=""
 
 setup_file() {
-  command -v yq > /dev/null || skip "Tests in this file require yq"
-  echo "yq version: '$(yq --version)'" >&3
-  # remove binaries from the previous runs
-  rm -f "$(roxctl-development-cmd)" "$(roxctl-development-release)"
-  echo "Testing roxctl version: '$(roxctl-release version)'" >&3
+    command -v yq >/dev/null || skip "Tests in this file require yq"
+    echo "Using yq version: '$(yq4.16 --version)'" >&3
+    # as of Aug 2022, we run yq version 4.16.2
+    # remove binaries from the previous runs
+    rm -f "$(roxctl-development-cmd)" "$(roxctl-development-release)"
+    echo "Testing roxctl version: '$(roxctl-release version)'" >&3
 }
 
 setup() {
   out_dir="$(mktemp -d -u)"
+  ofile="$(mktemp)"
 }
 
 teardown() {
   rm -rf "$out_dir"
+  rm -f "$ofile"
 }
 
 @test "roxctl-release generate netpol should return error on empty or non-existing directory" {
@@ -33,27 +36,26 @@ teardown() {
 @test "roxctl-release generate netpol generates network policies" {
   assert_file_exist "${test_data}/np-guard/scenario-minimal-service/frontend.yaml"
   assert_file_exist "${test_data}/np-guard/scenario-minimal-service/backend.yaml"
-  ofile="$(mktemp)"
   echo "Writing network policies to ${ofile}" >&3
   run roxctl-release generate netpol "${test_data}/np-guard/scenario-minimal-service"
   assert_success
+
   echo "$output" > "$ofile"
   assert_file_exist "$ofile"
   yaml_valid "$ofile"
 
   # There must be at least 2 yaml documents in the output
-  run yq e 'document_index' "${ofile}"
+  # yq version 4.16.2 has problems with handling 'document_index', thus we use 'di'
+  run yq e 'di' "${ofile}"
   assert_line '0'
   assert_line '1'
 
   # Ensure that both yaml docs are of kind 'NetworkPolicy'
-  run yq e '.kind | ({"match": ., "doc": document_index})' "${ofile}"
+  run yq e '.kind | ({"match": ., "doc": di})' "${ofile}"
   assert_line --index 0 'match: NetworkPolicy'
   assert_line --index 1 'doc: 0'
   assert_line --index 2 'match: NetworkPolicy'
   assert_line --index 3 'doc: 1'
-
-
 }
 
 

--- a/tests/roxctl/bats-tests/test-data/np-guard/scenario-minimal-service/backend.yaml
+++ b/tests/roxctl/bats-tests/test-data/np-guard/scenario-minimal-service/backend.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  selector:
+    matchLabels:
+      app: backendservice
+  template:
+    metadata:
+      labels:
+        app: backendservice
+    spec:
+      containers:
+      - name: server
+        image: backendservice
+        ports:
+        - containerPort: 9090
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 9090
+        livenessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 9090
+        env:
+        - name: PORT
+          value: "9090"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendservice
+spec:
+  type: ClusterIP
+  selector:
+    app: backendservice
+  ports:
+  - name: http
+    port: 9090
+    targetPort: 9090
+

--- a/tests/roxctl/bats-tests/test-data/np-guard/scenario-minimal-service/frontend.yaml
+++ b/tests/roxctl/bats-tests/test-data/np-guard/scenario-minimal-service/frontend.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: frontend
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 8080
+        livenessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 8080
+        env:
+        - name: PORT
+          value: "8080"
+        - name: BACKEND_SERVICE_ADDR
+          value: "backendservice:9090"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: frontend
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-external
+spec:
+  type: LoadBalancer
+  selector:
+    app: frontend
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080


### PR DESCRIPTION
## Description

This PR adds basic tests for the new command `roxctl netpol generate`.
Note that we do not test here the output of the the NP-Guard library (e.g., whether the produced network policies are correct), but the wrapper code in `roxctl` binary.

These tests are simple e2e tests and can be extended by adding Go unit tests in cobra.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

- [x] Executed the tests locally with `bats /tests/roxctl/bats-tests/local/roxctl-netpol-generate.bats`
- [ ] CI
