### PR TITLE
ROX-11775: Introduce different file outputs for roxctl generate netpol

### DIFF
--- a/roxctl/generate/netpol/cta.go
+++ b/roxctl/generate/netpol/cta.go
@@ -22,6 +22,8 @@ func (cmd *generateNetpolCommand) generateNetpol() error {
 		}
 		cmd.env.Logger().WarnfLn("Removed output path %s", cmd.outputFolderPath)
 	}
+	cmd.env.Logger().InfofLn("Writing generated Network Policies to %s", cmd.outputFolderPath)
+
 	var mergedPolicy string
 	yamlPolicies := make([]string, 0, len(recommendedNetpols))
 	for _, netpol := range recommendedNetpols {

--- a/roxctl/generate/netpol/cta.go
+++ b/roxctl/generate/netpol/cta.go
@@ -96,7 +96,7 @@ func (cmd *generateNetpolCommand) saveNetpolsToFolder(recommendedNetpols []*v1.N
 
 func writeFile(filename string, destDir string, content string) error {
 	outputPath := filepath.Join(destDir, filename)
-	if err := os.MkdirAll(filepath.Dir(destDir), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
 		return errors.Wrapf(err, "error creating directory for file %q", filename)
 	}
 

--- a/roxctl/generate/netpol/cta.go
+++ b/roxctl/generate/netpol/cta.go
@@ -28,22 +28,21 @@ func (cmd *generateNetpolCommand) generateNetpol() error {
 	}
 	mergedPolicy = strings.Join(yamlPolicies, "\n---\n")
 
-	if !cmd.mergePolicies && !cmd.splitPolicies {
-		cmd.printNetpols(mergedPolicy)
-		return nil
-	}
-
-	if cmd.mergePolicies {
+	if cmd.mergeMode {
 		if err := cmd.saveNetpolsToMergedFile(mergedPolicy); err != nil {
 			return errors.Wrapf(err, "error saving merged Network Policies")
 		}
+		return nil
 	}
 
-	if cmd.splitPolicies {
+	if cmd.splitMode {
 		if err := cmd.saveNetpolsToFolder(recommendedNetpols); err != nil {
 			return errors.Wrapf(err, "error saving split Network Policies")
 		}
+		return nil
 	}
+
+	cmd.printNetpols(mergedPolicy)
 
 	return nil
 }

--- a/roxctl/generate/netpol/cta.go
+++ b/roxctl/generate/netpol/cta.go
@@ -23,9 +23,8 @@ func (cmd *generateNetpolCommand) generateNetpol() error {
 		if err != nil {
 			return errors.Wrap(err, "error converting Network Policy object to YAML")
 		}
-		mergedPolicy = fmt.Sprintf("%s---\n%s", mergedPolicy, yamlPolicy)
 	}
-
+mergedPolicy = strings.Join(yamlPolicies, "\n---\n")
 	if !cmd.mergePolicies && !cmd.splitPolicies {
 		cmd.printNetpols(mergedPolicy)
 		return nil

--- a/roxctl/generate/netpol/cta.go
+++ b/roxctl/generate/netpol/cta.go
@@ -42,8 +42,12 @@ func (cmd *generateNetpolCommand) generateNetpol() error {
 		return nil
 	}
 
-	cmd.printNetpols(mergedPolicy)
+	if cmd.stdoutMode {
+		cmd.printNetpols(mergedPolicy)
+		return nil
+	}
 
+	cmd.env.Logger().WarnfLn("No mode selected, not providing any output.")
 	return nil
 }
 

--- a/roxctl/generate/netpol/cta.go
+++ b/roxctl/generate/netpol/cta.go
@@ -30,14 +30,14 @@ func (cmd *generateNetpolCommand) generateNetpol() error {
 
 	if cmd.mergeMode {
 		if err := cmd.saveNetpolsToMergedFile(mergedPolicy); err != nil {
-			return errors.Wrapf(err, "error saving merged Network Policies")
+			return errors.Wrap(err, "error saving merged Network Policies")
 		}
 		return nil
 	}
 
 	if cmd.splitMode {
 		if err := cmd.saveNetpolsToFolder(recommendedNetpols); err != nil {
-			return errors.Wrapf(err, "error saving split Network Policies")
+			return errors.Wrap(err, "error saving split Network Policies")
 		}
 		return nil
 	}
@@ -62,7 +62,7 @@ func (cmd *generateNetpolCommand) saveNetpolsToMergedFile(combinedNetpols string
 	}
 
 	if err := writeFile(filename, dirpath, combinedNetpols); err != nil {
-		return errors.Wrapf(err, "error writing merged Network Policies")
+		return errors.Wrap(err, "error writing merged Network Policies")
 	}
 	return nil
 }
@@ -81,7 +81,7 @@ func (cmd *generateNetpolCommand) saveNetpolsToFolder(recommendedNetpols []*v1.N
 		}
 
 		if err := writeFile(filename, cmd.outputFolderPath, yamlPolicy); err != nil {
-			return errors.Wrapf(err, "error writing policy to file")
+			return errors.Wrap(err, "error writing policy to file")
 		}
 	}
 	return nil

--- a/roxctl/generate/netpol/cta.go
+++ b/roxctl/generate/netpol/cta.go
@@ -16,7 +16,12 @@ func (cmd *generateNetpolCommand) generateNetpol() error {
 	if err != nil {
 		return errors.Wrap(err, "error synthesizing policies from folder")
 	}
-
+	if _, err := os.Stat(cmd.outputFolderPath); err == nil {
+		if err := os.RemoveAll(cmd.outputFolderPath); err != nil {
+			return errors.Wrapf(err, "failed to remove output path %s", cmd.outputFolderPath)
+		}
+		cmd.env.Logger().WarnfLn("Removed output path %s", cmd.outputFolderPath)
+	}
 	var mergedPolicy string
 	yamlPolicies := make([]string, 0, len(recommendedNetpols))
 	for _, netpol := range recommendedNetpols {

--- a/roxctl/generate/netpol/cta.go
+++ b/roxctl/generate/netpol/cta.go
@@ -1,6 +1,10 @@
 package netpol
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/np-guard/cluster-topology-analyzer/pkg/controller"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/protoconv/networkpolicy"
@@ -12,12 +16,56 @@ func (cmd *generateNetpolCommand) generateNetpol() error {
 		return errors.Wrap(err, "Error synthesizing policies from folder")
 	}
 
+	var yamlPolicies []string
+	var mergedPolicy string
 	for _, netpol := range recommendedNetpols {
 		yamlPolicy, err := networkpolicy.KubernetesNetworkPolicyWrap{NetworkPolicy: netpol}.ToYaml()
 		if err != nil {
-			return errors.Wrap(err, "Error converting YAML into Network Policy")
+			return errors.Wrap(err, "Error converting Network Policy object to YAML")
 		}
-		cmd.env.Logger().PrintfLn("---\n\n%s", yamlPolicy)
+		yamlPolicies = append(yamlPolicies, yamlPolicy)
+		mergedPolicy = fmt.Sprintf("%s---\n%s", mergedPolicy, yamlPolicy)
+	}
+
+	if !cmd.mergePolicies && !cmd.splitPolicies {
+		cmd.printNetpolsToStdout(mergedPolicy)
+		return nil
+	}
+
+	if cmd.mergePolicies {
+		if err := cmd.saveNetpolsToMergedFile(mergedPolicy); err != nil {
+			return errors.Wrapf(err, "Error writing merged Network Policies to file")
+		}
+	}
+
+	return nil
+}
+
+func (cmd *generateNetpolCommand) printNetpolsToStdout(combinedNetpols string) {
+	cmd.env.Logger().PrintfLn(combinedNetpols)
+}
+
+func (cmd *generateNetpolCommand) saveNetpolsToMergedFile(combinedNetpols string) error {
+	dirpath, filename := filepath.Split(cmd.outputFilePath)
+	if dirpath == "" {
+		dirpath = "./"
+	}
+	if filename == "" {
+		filename = "policies.yaml"
+	}
+
+	if err := writeFile(filename, dirpath, combinedNetpols); err != nil {
+		return errors.Wrapf(err, "Error writing policy to file")
 	}
 	return nil
+}
+
+func writeFile(filename string, destDir string, content string) error {
+	outputPath := filepath.Join(destDir, filename)
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+		return errors.Wrapf(err, "Error creating directory for file %q", filename)
+	}
+
+	perms := os.FileMode(0644)
+	return errors.Wrap(os.WriteFile(outputPath, []byte(content), perms), "Error writing file")
 }

--- a/roxctl/generate/netpol/cta.go
+++ b/roxctl/generate/netpol/cta.go
@@ -89,7 +89,7 @@ func (cmd *generateNetpolCommand) saveNetpolsToFolder(recommendedNetpols []*v1.N
 
 func writeFile(filename string, destDir string, content string) error {
 	outputPath := filepath.Join(destDir, filename)
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(destDir), 0755); err != nil {
 		return errors.Wrapf(err, "error creating directory for file %q", filename)
 	}
 

--- a/roxctl/generate/netpol/cta.go
+++ b/roxctl/generate/netpol/cta.go
@@ -73,7 +73,7 @@ func (cmd *generateNetpolCommand) saveNetpolsToFolder(recommendedNetpols []*v1.N
 
 		yamlPolicy, err := networkpolicy.KubernetesNetworkPolicyWrap{NetworkPolicy: netpol}.ToYaml()
 		if err != nil {
-			return errors.Wrap(err, "error converting Network Policy object to YAML")
+			return errors.Wrap(err, "error converting Network Policy object to yaml")
 		}
 
 		if err := writeFile(filename, cmd.outputFolderPath, yamlPolicy); err != nil {

--- a/roxctl/generate/netpol/netpol.go
+++ b/roxctl/generate/netpol/netpol.go
@@ -19,6 +19,7 @@ type generateNetpolCommand struct {
 	removeOutputPath bool
 	mergeMode        bool
 	splitMode        bool
+	stdoutMode       bool
 
 	// injected or constructed values
 	env     environment.Environment
@@ -52,6 +53,9 @@ func (cmd *generateNetpolCommand) construct(args []string, c *cobra.Command) err
 	cmd.folderPath = args[0]
 	cmd.splitMode = c.Flags().Changed("output-dir")
 	cmd.mergeMode = c.Flags().Changed("output-file")
+	if !cmd.splitMode && !cmd.mergeMode {
+		cmd.stdoutMode = true
+	}
 	return nil
 }
 
@@ -77,8 +81,7 @@ func (cmd *generateNetpolCommand) setupPath(path string) error {
 			}
 			cmd.env.Logger().WarnfLn("Removed output path %s", path)
 		} else {
-			cmd.env.Logger().ErrfLn("Output path %s already exists. Use --remove to overwrite or select a different path.", path)
-			return errox.AlreadyExists.Newf("path %s already exists", path)
+			return errox.AlreadyExists.Newf("path %s already exists. Use --remove to overwrite or select a different path.", path)
 		}
 	} else if !os.IsNotExist(err) {
 		return errors.Wrapf(err, "failed to check if path %s exists", path)

--- a/roxctl/generate/netpol/netpol.go
+++ b/roxctl/generate/netpol/netpol.go
@@ -77,12 +77,7 @@ func (cmd *generateNetpolCommand) validate() error {
 
 func (cmd *generateNetpolCommand) setupPath(path string) error {
 	if _, err := os.Stat(path); err == nil {
-		if cmd.removeOutputPath {
-			if err := os.RemoveAll(path); err != nil {
-				return errors.Wrapf(err, "failed to remove output path %s", path)
-			}
-			cmd.env.Logger().WarnfLn("Removed output path %s", path)
-		} else {
+		if !cmd.removeOutputPath {
 			return errox.AlreadyExists.Newf("path %s already exists. Use --remove to overwrite or select a different path.", path)
 		}
 	} else if !os.IsNotExist(err) {

--- a/roxctl/generate/netpol/netpol.go
+++ b/roxctl/generate/netpol/netpol.go
@@ -39,7 +39,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	c.Flags().StringVar(&generateNetpolCmd.outputFolderPath, "output-dir", "./policies", "path to the output directory for generated policies")
 	c.Flags().StringVar(&generateNetpolCmd.outputFilePath, "output-file", "./policies.yaml", "path to the output file for merged policies")
-	c.Flags().BoolVar(&generateNetpolCmd.mergePolicies, "merge-policies", false, "Merge all generated Network Policies into a single file. Combine with -f for target file")
+	c.Flags().BoolVar(&generateNetpolCmd.mergePolicies, "merge-policies", false, "Merge all generated Network Policies into a single file. Combine with --output-file for target file")
 	c.Flags().BoolVar(&generateNetpolCmd.splitPolicies, "split-policies", false, "Create one file per Network Policy. Combine with --output-dir for target folder")
 
 	c.MarkFlagsRequiredTogether("split-policies", "output-dir")

--- a/roxctl/generate/netpol/netpol.go
+++ b/roxctl/generate/netpol/netpol.go
@@ -45,7 +45,6 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c.Flags().BoolVar(&generateNetpolCmd.removeOutputPath, "remove", false, "remove the output path if it already exists")
 	c.Flags().StringVarP(&generateNetpolCmd.outputFolderPath, "output-dir", "d", "", "save generated policies into target folder - one file per policy")
 	c.Flags().StringVarP(&generateNetpolCmd.outputFilePath, "output-file", "f", "", "save and merge generated policies into a single yaml file")
-	c.MarkFlagsMutuallyExclusive("output-dir", "output-file")
 	return c
 }
 
@@ -60,6 +59,9 @@ func (cmd *generateNetpolCommand) construct(args []string, c *cobra.Command) err
 }
 
 func (cmd *generateNetpolCommand) validate() error {
+	if cmd.outputFolderPath != "" && cmd.outputFilePath != "" {
+		return errors.New("Flags [-d|--output-dir, -f|--output-file] cannot be used together")
+	}
 	if cmd.splitMode {
 		if err := cmd.setupPath(cmd.outputFolderPath); err != nil {
 			return errors.Wrap(err, "failed to set up folder path")

--- a/roxctl/generate/netpol/netpol.go
+++ b/roxctl/generate/netpol/netpol.go
@@ -76,13 +76,10 @@ func (cmd *generateNetpolCommand) validate() error {
 }
 
 func (cmd *generateNetpolCommand) setupPath(path string) error {
-	if _, err := os.Stat(path); err == nil {
-		if !cmd.removeOutputPath {
-			return errox.AlreadyExists.Newf("path %s already exists. Use --remove to overwrite or select a different path.", path)
-		}
+	if _, err := os.Stat(path); err == nil && !cmd.removeOutputPath {
+		return errox.AlreadyExists.Newf("path %s already exists. Use --remove to overwrite or select a different path.", path)
 	} else if !os.IsNotExist(err) {
 		return errors.Wrapf(err, "failed to check if path %s exists", path)
 	}
-	cmd.env.Logger().InfofLn("Writing generated Network Policies to %s", path)
 	return nil
 }

--- a/roxctl/generate/netpol/netpol.go
+++ b/roxctl/generate/netpol/netpol.go
@@ -37,10 +37,10 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		},
 	}
 
-	c.Flags().StringVar(&generateNetpolCmd.outputFolderPath, "output-dir", "./policies", "path to the output directory for generated policies")
-	c.Flags().StringVar(&generateNetpolCmd.outputFilePath, "output-file", "./policies.yaml", "path to the output file for merged policies")
-	c.Flags().BoolVar(&generateNetpolCmd.mergePolicies, "merge-policies", false, "Merge all generated Network Policies into a single file. Combine with --output-file for target file")
-	c.Flags().BoolVar(&generateNetpolCmd.splitPolicies, "split-policies", false, "Create one file per Network Policy. Combine with --output-dir for target folder")
+	c.Flags().StringVarP(&generateNetpolCmd.outputFolderPath, "output-dir", "d", "./policies", "path to the output directory for generated policies")
+	c.Flags().StringVarP(&generateNetpolCmd.outputFilePath, "output-file", "f", "./policies.yaml", "path to the output file for merged policies")
+	c.Flags().BoolVar(&generateNetpolCmd.mergePolicies, "merge-policies", false, "Merge all generated Network Policies into a single file. Combine with -f for target file")
+	c.Flags().BoolVar(&generateNetpolCmd.splitPolicies, "split-policies", false, "Create one file per Network Policy. Combine with -d for target folder")
 
 	c.MarkFlagsRequiredTogether("split-policies", "output-dir")
 	c.MarkFlagsRequiredTogether("merge-policies", "output-file")

--- a/roxctl/generate/netpol/netpol.go
+++ b/roxctl/generate/netpol/netpol.go
@@ -43,7 +43,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		},
 	}
 	c.Flags().BoolVar(&generateNetpolCmd.removeOutputPath, "remove", false, "remove the output path if it already exists")
-	c.Flags().StringVarP(&generateNetpolCmd.outputFolderPath, "output-dir", "d", "", "save generated policies into target folder - 1 file per policy")
+	c.Flags().StringVarP(&generateNetpolCmd.outputFolderPath, "output-dir", "d", "", "save generated policies into target folder - one file per policy")
 	c.Flags().StringVarP(&generateNetpolCmd.outputFilePath, "output-file", "f", "", "save and merge generated policies into a single yaml file")
 	c.MarkFlagsMutuallyExclusive("output-dir", "output-file")
 	return c

--- a/roxctl/generate/netpol/netpol.go
+++ b/roxctl/generate/netpol/netpol.go
@@ -62,11 +62,11 @@ func (cmd *generateNetpolCommand) construct(args []string, c *cobra.Command) err
 func (cmd *generateNetpolCommand) validate() error {
 	if cmd.splitMode {
 		if err := cmd.setupPath(cmd.outputFolderPath); err != nil {
-			return errors.Wrapf(err, "failed to set up folder path")
+			return errors.Wrap(err, "failed to set up folder path")
 		}
 	} else if cmd.mergeMode {
 		if err := cmd.setupPath(cmd.outputFilePath); err != nil {
-			return errors.Wrapf(err, "failed to set up file path")
+			return errors.Wrap(err, "failed to set up file path")
 		}
 	}
 

--- a/roxctl/generate/netpol/netpol.go
+++ b/roxctl/generate/netpol/netpol.go
@@ -43,7 +43,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	}
 	c.Flags().BoolVar(&generateNetpolCmd.removeOutputPath, "remove", false, "remove the output path if it already exists")
 	c.Flags().StringVarP(&generateNetpolCmd.outputFolderPath, "output-dir", "d", "", "save generated policies into target folder - 1 file per policy")
-	c.Flags().StringVarP(&generateNetpolCmd.outputFilePath, "output-file", "f", "", "save and merge generated policies into a single YAML file")
+	c.Flags().StringVarP(&generateNetpolCmd.outputFilePath, "output-file", "f", "", "save and merge generated policies into a single yaml file")
 	c.MarkFlagsMutuallyExclusive("output-dir", "output-file")
 	return c
 }

--- a/roxctl/generate/netpol/netpol.go
+++ b/roxctl/generate/netpol/netpol.go
@@ -9,8 +9,12 @@ import (
 
 type generateNetpolCommand struct {
 	// Properties that are bound to cobra flags.
-	offline    bool
-	folderPath string
+	offline          bool
+	folderPath       string
+	outputFolderPath string
+	outputFilePath   string
+	mergePolicies    bool
+	splitPolicies    bool
 
 	// injected or constructed values
 	env     environment.Environment
@@ -34,6 +38,13 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	}
 
 	c.Flags().BoolVar(&generateNetpolCmd.offline, "offline", false, "whether to connect to a central instace for additional information")
+	c.Flags().StringVar(&generateNetpolCmd.outputFolderPath, "output-dir", "./policies", "path to the output directory for generated policies")
+	c.Flags().StringVar(&generateNetpolCmd.outputFilePath, "output-file", "./policies.yaml", "path to the output file for merged policies")
+	c.Flags().BoolVar(&generateNetpolCmd.mergePolicies, "merge-policies", false, "Merge all generated Network Policies into a single file. Combine with -f for target file")
+	c.Flags().BoolVar(&generateNetpolCmd.splitPolicies, "split-policies", false, "Create one file per Network Policy. Combine with --output-dir for target folder")
+
+	c.MarkFlagsRequiredTogether("split-policies", "output-dir")
+	c.MarkFlagsRequiredTogether("merge-policies", "output-file")
 	return c
 }
 

--- a/roxctl/generate/netpol/netpol.go
+++ b/roxctl/generate/netpol/netpol.go
@@ -37,7 +37,6 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		},
 	}
 
-	c.Flags().BoolVar(&generateNetpolCmd.offline, "offline", false, "whether to connect to a central instace for additional information")
 	c.Flags().StringVar(&generateNetpolCmd.outputFolderPath, "output-dir", "./policies", "path to the output directory for generated policies")
 	c.Flags().StringVar(&generateNetpolCmd.outputFilePath, "output-file", "./policies.yaml", "path to the output file for merged policies")
 	c.Flags().BoolVar(&generateNetpolCmd.mergePolicies, "merge-policies", false, "Merge all generated Network Policies into a single file. Combine with -f for target file")

--- a/roxctl/help/help.properties
+++ b/roxctl/help/help.properties
@@ -185,7 +185,7 @@ generate.short = Commands related to generating different resources.
 generate.long =
 
 generate.netpol.short = Recommend Network Policies based on deployment information.
-generate.netpol.long = Based on a given folder containing deployment YAMLs, will generate a list of recommended Network Policies.
+generate.netpol.long = Based on a given folder containing deployment YAMLs, will generate a list of recommended Network Policies. Will write to stdout if no output flags are provided.
 
 version.short = Display the current roxctl version.
 version.long = Display the current roxctl version.


### PR DESCRIPTION
## Description

This PR introduces more output formats for roxctl generate netpol.
I'm not set with the names and combinations of flags, the focus was getting the functionality implemented

- To stdout (merged copy-paste-ready yaml)
  - If no additional flags are provided
- To a single file (merged, same as stdout)
  - If `--merge-policies` combined with `-output-file` is provided
- 1 file per network policy
  - If `--split-policies` combined with `-output-folder` is provided

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] ~~Determined and documented upgrade steps~~
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

~~We're not announcing the new functionality until the online mode is done and working, so no Changelog and Docs updates.~~
Also, as this is not touching existing functionality, no upgrade steps are needed.
Tests are added in a second PR, https://github.com/stackrox/stackrox/pull/2601 

## Testing Performed
To test the new functionality, point `roxctl generate netpol` to any folder containing any pod-creating YAML resources.
It will recursively scan all YAMLs and generate a list of recommended Network Policies to stdout.
```
git clone https://github.com/nadgowdas/microservices-demo /tmp/microservices-demo
./roxctl netpol generate /tmp/microservices-demo
```
Observe the recommended Network Policies being generated and output, depending on which combination of flags you use.
