### PR TITLE
Add the capability to DeleteByQuery to Postgres stores

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ActiveComponent) error
 	UpsertMany(ctx context.Context, objs []*storage.ActiveComponent) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ActiveComponent, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -445,6 +446,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ActiveComponent")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Alert) error
 	UpsertMany(ctx context.Context, objs []*storage.Alert) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Alert, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -518,6 +519,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "Alert")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/alert/datastore/internal/store/rocksdb/store.go
+++ b/central/alert/datastore/internal/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Alert, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -162,4 +163,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Alert, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TokenMetadata) error
 	UpsertMany(ctx context.Context, objs []*storage.TokenMetadata) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TokenMetadata, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -333,6 +334,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TokenMetadata")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/apitoken/datastore/internal/store/rocksdb/store.go
+++ b/central/apitoken/datastore/internal/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.TokenMetadata, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -162,4 +163,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.TokenMetadata, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.AuthProvider) error
 	UpsertMany(ctx context.Context, objs []*storage.AuthProvider) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.AuthProvider, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -349,6 +350,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "AuthProvider")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Cluster) error
 	UpsertMany(ctx context.Context, objs []*storage.Cluster) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Cluster, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -373,6 +374,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "Cluster")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/cluster/store/cluster/rocksdb/store.go
+++ b/central/cluster/store/cluster/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Cluster, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -172,4 +173,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Cluster, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ClusterHealthStatus) error
 	UpsertMany(ctx context.Context, objs []*storage.ClusterHealthStatus) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ClusterHealthStatus, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -380,6 +381,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ClusterHealthStatus")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/cluster/store/clusterhealth/rocksdb/store.go
+++ b/central/cluster/store/clusterhealth/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ClusterHealthStatus, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -172,4 +173,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ClusterHealthStatus, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.InitBundleMeta) error
 	UpsertMany(ctx context.Context, objs []*storage.InitBundleMeta) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.InitBundleMeta, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -320,6 +321,25 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "InitBundleMeta")
+
+	var sacQueryFilter *v1.Query
+	if ok, err := permissionCheckerSingleton().DeleteAllowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/clusterinit/store/rocksdb/store.go
+++ b/central/clusterinit/store/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.InitBundleMeta, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -168,4 +169,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.InitBundleMeta, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceDomain) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceDomain) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceDomain, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -378,6 +379,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ComplianceDomain")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceStrings) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceStrings) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceStrings, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -349,6 +350,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ComplianceStrings")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorCheckResult) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorCheckResult) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceOperatorCheckResult, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -333,6 +334,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ComplianceOperatorCheckResult")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/complianceoperator/checkresults/store/rocksdb/store.go
+++ b/central/complianceoperator/checkresults/store/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorCheckResult, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -168,4 +169,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorCheckResult, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorProfile) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorProfile) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceOperatorProfile, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -333,6 +334,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ComplianceOperatorProfile")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/complianceoperator/profiles/store/rocksdb/store.go
+++ b/central/complianceoperator/profiles/store/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorProfile, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -168,4 +169,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorProfile, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorRule) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorRule) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceOperatorRule, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -333,6 +334,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ComplianceOperatorRule")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/complianceoperator/rules/store/rocksdb/store.go
+++ b/central/complianceoperator/rules/store/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorRule, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -168,4 +169,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorRule, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorScan) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorScan) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceOperatorScan, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -333,6 +334,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ComplianceOperatorScan")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/complianceoperator/scans/store/rocksdb/store.go
+++ b/central/complianceoperator/scans/store/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorScan, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -168,4 +169,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorScan, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorScanSettingBinding) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorScanSettingBinding) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceOperatorScanSettingBinding, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -333,6 +334,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ComplianceOperatorScanSettingBinding")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/complianceoperator/scansettingbinding/store/rocksdb/store.go
+++ b/central/complianceoperator/scansettingbinding/store/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorScanSettingBinding, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -168,4 +169,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorScanSettingBinding, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ClusterCVE) error
 	UpsertMany(ctx context.Context, objs []*storage.ClusterCVE) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ClusterCVE, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -395,6 +396,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ClusterCVE")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ImageCVE) error
 	UpsertMany(ctx context.Context, objs []*storage.ImageCVE) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ImageCVE, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -390,6 +391,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ImageCVE")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NodeCVE) error
 	UpsertMany(ctx context.Context, objs []*storage.NodeCVE) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NodeCVE, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -390,6 +391,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "NodeCVE")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Deployment) error
 	UpsertMany(ctx context.Context, objs []*storage.Deployment) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Deployment, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -1057,6 +1058,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "Deployment")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ExternalBackup) error
 	UpsertMany(ctx context.Context, objs []*storage.ExternalBackup) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ExternalBackup, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -344,6 +345,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ExternalBackup")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Group) error
 	UpsertMany(ctx context.Context, objs []*storage.Group) error
 	Delete(ctx context.Context, propsId string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Group, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -344,6 +345,26 @@ func (s *storeImpl) Delete(ctx context.Context, propsId string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(propsId).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "Group")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/image/datastore/store/postgres/store.go
+++ b/central/image/datastore/store/postgres/store.go
@@ -1019,7 +1019,7 @@ func Destroy(ctx context.Context, db *pgxpool.Pool) {
 }
 
 // CreateTableAndNewStore returns a new Store instance for testing
-func CreateTableAndNewStore(ctx context.Context, db *pgxpool.Pool, gormDB *gorm.DB) store.Store {
+func CreateTableAndNewStore(ctx context.Context, db *pgxpool.Pool, gormDB *gorm.DB, noUpdateTimestamps bool) store.Store {
 	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImagesStmt)
 	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImageComponentsStmt)
 	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImageCvesStmt)

--- a/central/image/datastore/store/postgres/store.go
+++ b/central/image/datastore/store/postgres/store.go
@@ -1019,7 +1019,7 @@ func Destroy(ctx context.Context, db *pgxpool.Pool) {
 }
 
 // CreateTableAndNewStore returns a new Store instance for testing
-func CreateTableAndNewStore(ctx context.Context, db *pgxpool.Pool, gormDB *gorm.DB, noUpdateTimestamps bool) store.Store {
+func CreateTableAndNewStore(ctx context.Context, db *pgxpool.Pool, gormDB *gorm.DB) store.Store {
 	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImagesStmt)
 	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImageComponentsStmt)
 	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImageCvesStmt)

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ImageComponent) error
 	UpsertMany(ctx context.Context, objs []*storage.ImageComponent) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ImageComponent, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -380,6 +381,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ImageComponent")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ImageIntegration) error
 	UpsertMany(ctx context.Context, objs []*storage.ImageIntegration) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ImageIntegration, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -349,6 +350,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ImageIntegration")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.IntegrationHealth) error
 	UpsertMany(ctx context.Context, objs []*storage.IntegrationHealth) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.IntegrationHealth, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -320,6 +321,25 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "IntegrationHealth")
+
+	var sacQueryFilter *v1.Query
+	if ok, err := permissionCheckerSingleton().DeleteAllowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/integrationhealth/store/rocksdb/store.go
+++ b/central/integrationhealth/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.IntegrationHealth, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -162,4 +163,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.IntegrationHealth, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.LogImbue) error
 	UpsertMany(ctx context.Context, objs []*storage.LogImbue) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.LogImbue, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -344,6 +345,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "LogImbue")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NamespaceMetadata) error
 	UpsertMany(ctx context.Context, objs []*storage.NamespaceMetadata) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NamespaceMetadata, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -388,6 +389,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "NamespaceMetadata")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/namespace/store/rocksdb/store.go
+++ b/central/namespace/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NamespaceMetadata, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -162,4 +163,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NamespaceMetadata, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NetworkBaseline) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkBaseline) error
 	Delete(ctx context.Context, deploymentId string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NetworkBaseline, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -373,6 +374,29 @@ func (s *storeImpl) Delete(ctx context.Context, deploymentId string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(deploymentId).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "NetworkBaseline")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/networkbaseline/store/rocksdb/store.go
+++ b/central/networkbaseline/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkBaseline, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -162,4 +163,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkBaseline, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NetworkGraphConfig) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkGraphConfig) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NetworkGraphConfig, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -333,6 +334,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "NetworkGraphConfig")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/networkgraph/config/datastore/internal/store/rocksdb/store.go
+++ b/central/networkgraph/config/datastore/internal/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkGraphConfig, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -162,4 +163,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkGraphConfig, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NetworkEntity) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkEntity) error
 	Delete(ctx context.Context, infoId string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NetworkEntity, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -355,6 +356,29 @@ func (s *storeImpl) Delete(ctx context.Context, infoId string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(infoId).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "NetworkEntity")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/networkgraph/entity/datastore/internal/store/rocksdb/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkEntity, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -168,4 +169,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkEntity, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NetworkPolicy) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkPolicy) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NetworkPolicy, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -373,6 +374,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "NetworkPolicy")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NetworkPolicyApplicationUndoDeploymentRecord) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkPolicyApplicationUndoDeploymentRecord) error
 	Delete(ctx context.Context, deploymentId string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NetworkPolicyApplicationUndoDeploymentRecord, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -349,6 +350,29 @@ func (s *storeImpl) Delete(ctx context.Context, deploymentId string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(deploymentId).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "NetworkPolicyApplicationUndoDeploymentRecord")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/rocksdb/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkPolicyApplicationUndoDeploymentRecord, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -168,4 +169,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkPolicyApplicationUndoDeploymentRecord, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NetworkPolicyApplicationUndoRecord) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkPolicyApplicationUndoRecord) error
 	Delete(ctx context.Context, clusterId string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NetworkPolicyApplicationUndoRecord, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -349,6 +350,29 @@ func (s *storeImpl) Delete(ctx context.Context, clusterId string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(clusterId).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "NetworkPolicyApplicationUndoRecord")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NodeComponent) error
 	UpsertMany(ctx context.Context, objs []*storage.NodeComponent) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NodeComponent, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -375,6 +376,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "NodeComponent")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Notifier) error
 	UpsertMany(ctx context.Context, objs []*storage.Notifier) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Notifier, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -349,6 +350,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "Notifier")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Pod) error
 	UpsertMany(ctx context.Context, objs []*storage.Pod) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Pod, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -463,6 +464,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "Pod")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/pod/store/rocksdb/store.go
+++ b/central/pod/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Pod, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -162,4 +163,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Pod, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.PolicyCategory) error
 	UpsertMany(ctx context.Context, objs []*storage.PolicyCategory) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.PolicyCategory, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -339,6 +340,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "PolicyCategory")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/policycategory/store/rocksdb/store.go
+++ b/central/policycategory/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.PolicyCategory, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -166,4 +167,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.PolicyCategory, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ProcessBaseline) error
 	UpsertMany(ctx context.Context, objs []*storage.ProcessBaseline) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ProcessBaseline, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -378,6 +379,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ProcessBaseline")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/processbaseline/store/rocksdb/store.go
+++ b/central/processbaseline/store/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessBaseline, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -168,4 +169,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessBaseline, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/processbaselineresults/datastore/internal/store/rocksdb/store.go
+++ b/central/processbaselineresults/datastore/internal/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessBaselineResults, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -162,4 +163,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessBaselineResults, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/processindicator/datastore/datastore_impl.go
+++ b/central/processindicator/datastore/datastore_impl.go
@@ -159,6 +159,9 @@ func (ds *datastoreImpl) RemoveProcessIndicatorsByPod(ctx context.Context, id st
 		return sac.ErrResourceAccessDenied
 	}
 	q := pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.PodUID, id).ProtoQuery()
+	if features.PostgresDatastore.Enabled() {
+		return ds.storage.DeleteByQuery(ctx, q)
+	}
 	results, err := ds.Search(ctx, q)
 	if err != nil {
 		return err

--- a/central/processindicator/store/mocks/store.go
+++ b/central/processindicator/store/mocks/store.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -52,6 +53,20 @@ func (mr *MockStoreMockRecorder) AckKeysIndexed(ctx interface{}, keys ...interfa
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx}, keys...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AckKeysIndexed", reflect.TypeOf((*MockStore)(nil).AckKeysIndexed), varargs...)
+}
+
+// DeleteByQuery mocks base method.
+func (m *MockStore) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteByQuery", ctx, query)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteByQuery indicates an expected call of DeleteByQuery.
+func (mr *MockStoreMockRecorder) DeleteByQuery(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByQuery", reflect.TypeOf((*MockStore)(nil).DeleteByQuery), ctx, query)
 }
 
 // DeleteMany mocks base method.

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ProcessIndicator) error
 	UpsertMany(ctx context.Context, objs []*storage.ProcessIndicator) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ProcessIndicator, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -418,6 +419,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ProcessIndicator")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/processindicator/store/rocksdb/store.go
+++ b/central/processindicator/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -162,4 +163,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/processindicator/store/store.go
+++ b/central/processindicator/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -19,4 +20,5 @@ type Store interface {
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
 	Walk(context.Context, func(pi *storage.ProcessIndicator) error) error
+	DeleteByQuery(ctx context.Context, query *v1.Query) error
 }

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.K8SRole) error
 	UpsertMany(ctx context.Context, objs []*storage.K8SRole) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.K8SRole, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -398,6 +399,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "K8SRole")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/rbac/k8srole/internal/store/rocksdb/store.go
+++ b/central/rbac/k8srole/internal/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.K8SRole, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -162,4 +163,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.K8SRole, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.K8SRoleBinding) error
 	UpsertMany(ctx context.Context, objs []*storage.K8SRoleBinding) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.K8SRoleBinding, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -488,6 +489,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "K8SRoleBinding")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/rbac/k8srolebinding/internal/store/rocksdb/store.go
+++ b/central/rbac/k8srolebinding/internal/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.K8SRoleBinding, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -162,4 +163,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.K8SRoleBinding, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ReportConfiguration) error
 	UpsertMany(ctx context.Context, objs []*storage.ReportConfiguration) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ReportConfiguration, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -344,6 +345,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ReportConfiguration")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/reportconfigurations/store/rocksdb/store.go
+++ b/central/reportconfigurations/store/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ReportConfiguration, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -168,4 +169,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ReportConfiguration, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Risk) error
 	UpsertMany(ctx context.Context, objs []*storage.Risk) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Risk, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -383,6 +384,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "Risk")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/risk/datastore/internal/store/rocksdb/store.go
+++ b/central/risk/datastore/internal/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Risk, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -162,4 +163,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Risk, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.PermissionSet) error
 	UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.PermissionSet, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -338,6 +339,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "PermissionSet")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/role/store/permissionset/rocksdb/store.go
+++ b/central/role/store/permissionset/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.PermissionSet, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -172,4 +173,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.PermissionSet, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Role) error
 	UpsertMany(ctx context.Context, objs []*storage.Role) error
 	Delete(ctx context.Context, name string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Role, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -333,6 +334,26 @@ func (s *storeImpl) Delete(ctx context.Context, name string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(name).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "Role")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/role/store/role/rocksdb/store.go
+++ b/central/role/store/role/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Role, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -168,4 +169,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Role, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.SimpleAccessScope) error
 	UpsertMany(ctx context.Context, objs []*storage.SimpleAccessScope) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.SimpleAccessScope, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -338,6 +339,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "SimpleAccessScope")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/role/store/simpleaccessscope/rocksdb/store.go
+++ b/central/role/store/simpleaccessscope/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.SimpleAccessScope, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -172,4 +173,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.SimpleAccessScope, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Secret) error
 	UpsertMany(ctx context.Context, objs []*storage.Secret) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Secret, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -558,6 +559,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "Secret")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/secret/internal/store/rocksdb/store.go
+++ b/central/secret/internal/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Secret, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -162,4 +163,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Secret, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ServiceAccount) error
 	UpsertMany(ctx context.Context, objs []*storage.ServiceAccount) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ServiceAccount, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -393,6 +394,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ServiceAccount")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/serviceaccount/internal/store/rocksdb/store.go
+++ b/central/serviceaccount/internal/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ServiceAccount, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -162,4 +163,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ServiceAccount, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ServiceIdentity) error
 	UpsertMany(ctx context.Context, objs []*storage.ServiceIdentity) error
 	Delete(ctx context.Context, serialStr string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ServiceIdentity, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -344,6 +345,26 @@ func (s *storeImpl) Delete(ctx context.Context, serialStr string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(serialStr).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "ServiceIdentity")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.SignatureIntegration) error
 	UpsertMany(ctx context.Context, objs []*storage.SignatureIntegration) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.SignatureIntegration, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -338,6 +339,26 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "SignatureIntegration")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/signatureintegration/store/rocksdb/store.go
+++ b/central/signatureintegration/store/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.SignatureIntegration, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -172,4 +173,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.SignatureIntegration, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.VulnerabilityRequest) error
 	UpsertMany(ctx context.Context, objs []*storage.VulnerabilityRequest) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.VulnerabilityRequest, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -519,6 +520,25 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "VulnerabilityRequest")
+
+	var sacQueryFilter *v1.Query
+	if ok, err := permissionCheckerSingleton().DeleteAllowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/vulnerabilityrequest/datastore/internal/store/rocksdb/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/rocksdb/store.go
@@ -38,8 +38,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.VulnerabilityRequest, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -162,4 +163,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.VulnerabilityRequest, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -52,6 +52,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.WatchedImage) error
 	UpsertMany(ctx context.Context, objs []*storage.WatchedImage) error
 	Delete(ctx context.Context, name string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.WatchedImage, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -333,6 +334,26 @@ func (s *storeImpl) Delete(ctx context.Context, name string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(name).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "WatchedImage")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/central/watchedimage/datastore/internal/store/rocksdb/store.go
+++ b/central/watchedimage/datastore/internal/store/rocksdb/store.go
@@ -39,8 +39,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.WatchedImage, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -168,4 +169,9 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.WatchedImage, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }

--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Cluster) error
 	UpsertMany(ctx context.Context, objs []*storage.Cluster) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Cluster, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -294,6 +295,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NamespaceMetadata) error
 	UpsertMany(ctx context.Context, objs []*storage.NamespaceMetadata) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NamespaceMetadata, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -309,6 +310,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Deployment) error
 	UpsertMany(ctx context.Context, objs []*storage.Deployment) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Deployment, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -978,6 +979,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Alert) error
 	UpsertMany(ctx context.Context, objs []*storage.Alert) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Alert, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -439,6 +440,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TokenMetadata) error
 	UpsertMany(ctx context.Context, objs []*storage.TokenMetadata) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TokenMetadata, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -283,6 +284,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.AuthProvider) error
 	UpsertMany(ctx context.Context, objs []*storage.AuthProvider) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.AuthProvider, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -298,6 +299,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ClusterHealthStatus) error
 	UpsertMany(ctx context.Context, objs []*storage.ClusterHealthStatus) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ClusterHealthStatus, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -314,6 +315,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.InitBundleMeta) error
 	UpsertMany(ctx context.Context, objs []*storage.InitBundleMeta) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.InitBundleMeta, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -283,6 +284,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceDomain) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceDomain) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceDomain, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -299,6 +300,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorCheckResult) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorCheckResult) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceOperatorCheckResult, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -283,6 +284,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorProfile) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorProfile) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceOperatorProfile, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -283,6 +284,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorRule) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorRule) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceOperatorRule, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -283,6 +284,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorScanSettingBinding) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorScanSettingBinding) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceOperatorScanSettingBinding, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -283,6 +284,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorScan) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorScan) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceOperatorScan, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -283,6 +284,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceRunMetadata) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceRunMetadata) error
 	Delete(ctx context.Context, runId string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceRunMetadata, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -299,6 +300,19 @@ func (s *storeImpl) Delete(ctx context.Context, runId string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(runId).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceRunResults) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceRunResults) error
 	Delete(ctx context.Context, runMetadataRunId string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceRunResults, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -299,6 +300,19 @@ func (s *storeImpl) Delete(ctx context.Context, runMetadataRunId string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(runMetadataRunId).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceStrings) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceStrings) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComplianceStrings, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -283,6 +284,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ExternalBackup) error
 	UpsertMany(ctx context.Context, objs []*storage.ExternalBackup) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ExternalBackup, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -293,6 +294,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ImageIntegration) error
 	UpsertMany(ctx context.Context, objs []*storage.ImageIntegration) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ImageIntegration, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -298,6 +299,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.IntegrationHealth) error
 	UpsertMany(ctx context.Context, objs []*storage.IntegrationHealth) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.IntegrationHealth, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -283,6 +284,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.K8SRole) error
 	UpsertMany(ctx context.Context, objs []*storage.K8SRole) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.K8SRole, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -319,6 +320,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NetworkBaseline) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkBaseline) error
 	Delete(ctx context.Context, deploymentId string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NetworkBaseline, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -294,6 +295,19 @@ func (s *storeImpl) Delete(ctx context.Context, deploymentId string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(deploymentId).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NetworkEntity) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkEntity) error
 	Delete(ctx context.Context, infoId string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NetworkEntity, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -289,6 +290,19 @@ func (s *storeImpl) Delete(ctx context.Context, infoId string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(infoId).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NetworkGraphConfig) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkGraphConfig) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NetworkGraphConfig, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -283,6 +284,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NetworkPolicy) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkPolicy) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NetworkPolicy, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -294,6 +295,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NetworkPolicyApplicationUndoDeploymentRecord) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkPolicyApplicationUndoDeploymentRecord) error
 	Delete(ctx context.Context, deploymentId string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NetworkPolicyApplicationUndoDeploymentRecord, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -283,6 +284,19 @@ func (s *storeImpl) Delete(ctx context.Context, deploymentId string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(deploymentId).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.NetworkPolicyApplicationUndoRecord) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkPolicyApplicationUndoRecord) error
 	Delete(ctx context.Context, clusterId string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NetworkPolicyApplicationUndoRecord, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -283,6 +284,19 @@ func (s *storeImpl) Delete(ctx context.Context, clusterId string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(clusterId).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Notifier) error
 	UpsertMany(ctx context.Context, objs []*storage.Notifier) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Notifier, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -298,6 +299,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.PermissionSet) error
 	UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.PermissionSet, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -288,6 +289,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Pod) error
 	UpsertMany(ctx context.Context, objs []*storage.Pod) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Pod, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -384,6 +385,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
@@ -49,6 +49,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Policy) error
 	UpsertMany(ctx context.Context, objs []*storage.Policy) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Policy, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -349,6 +350,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ProcessBaselineResults) error
 	UpsertMany(ctx context.Context, objs []*storage.ProcessBaselineResults) error
 	Delete(ctx context.Context, deploymentId string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ProcessBaselineResults, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -294,6 +295,19 @@ func (s *storeImpl) Delete(ctx context.Context, deploymentId string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(deploymentId).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ProcessBaseline) error
 	UpsertMany(ctx context.Context, objs []*storage.ProcessBaseline) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ProcessBaseline, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -299,6 +300,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ProcessIndicator) error
 	UpsertMany(ctx context.Context, objs []*storage.ProcessIndicator) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ProcessIndicator, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -339,6 +340,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ReportConfiguration) error
 	UpsertMany(ctx context.Context, objs []*storage.ReportConfiguration) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ReportConfiguration, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -294,6 +295,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Risk) error
 	UpsertMany(ctx context.Context, objs []*storage.Risk) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Risk, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -304,6 +305,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.K8SRoleBinding) error
 	UpsertMany(ctx context.Context, objs []*storage.K8SRoleBinding) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.K8SRoleBinding, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -409,6 +410,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Role) error
 	UpsertMany(ctx context.Context, objs []*storage.Role) error
 	Delete(ctx context.Context, name string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Role, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -283,6 +284,19 @@ func (s *storeImpl) Delete(ctx context.Context, name string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(name).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Secret) error
 	UpsertMany(ctx context.Context, objs []*storage.Secret) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Secret, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -479,6 +480,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ServiceAccount) error
 	UpsertMany(ctx context.Context, objs []*storage.ServiceAccount) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ServiceAccount, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -314,6 +315,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ServiceIdentity) error
 	UpsertMany(ctx context.Context, objs []*storage.ServiceIdentity) error
 	Delete(ctx context.Context, serialStr string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ServiceIdentity, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -293,6 +294,19 @@ func (s *storeImpl) Delete(ctx context.Context, serialStr string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(serialStr).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.SignatureIntegration) error
 	UpsertMany(ctx context.Context, objs []*storage.SignatureIntegration) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.SignatureIntegration, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -288,6 +289,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.SimpleAccessScope) error
 	UpsertMany(ctx context.Context, objs []*storage.SimpleAccessScope) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.SimpleAccessScope, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -288,6 +289,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.VulnerabilityRequest) error
 	UpsertMany(ctx context.Context, objs []*storage.VulnerabilityRequest) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.VulnerabilityRequest, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -482,6 +483,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
@@ -47,6 +47,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.WatchedImage) error
 	UpsertMany(ctx context.Context, objs []*storage.WatchedImage) error
 	Delete(ctx context.Context, name string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.WatchedImage, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -283,6 +284,19 @@ func (s *storeImpl) Delete(ctx context.Context, name string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(name).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.PolicyCategory) error
 	UpsertMany(ctx context.Context, objs []*storage.PolicyCategory) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.PolicyCategory, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -289,6 +290,19 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
@@ -48,6 +48,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Group) error
 	UpsertMany(ctx context.Context, objs []*storage.Group) error
 	Delete(ctx context.Context, propsId string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Group, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -293,6 +294,19 @@ func (s *storeImpl) Delete(ctx context.Context, propsId string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(propsId).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TestSingleKeyStruct) error
 	UpsertMany(ctx context.Context, objs []*storage.TestSingleKeyStruct) error
 	Delete(ctx context.Context, key string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TestSingleKeyStruct, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -411,6 +412,29 @@ func (s *storeImpl) Delete(ctx context.Context, key string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(key).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TestSingleKeyStruct")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TestChild1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestChild1) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TestChild1, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -355,6 +356,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TestChild1")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TestChild1P4) error
 	UpsertMany(ctx context.Context, objs []*storage.TestChild1P4) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TestChild1P4, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -360,6 +361,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TestChild1P4")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TestChild2) error
 	UpsertMany(ctx context.Context, objs []*storage.TestChild2) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TestChild2, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -365,6 +366,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TestChild2")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TestG2GrandChild1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestG2GrandChild1) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TestG2GrandChild1, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -365,6 +366,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TestG2GrandChild1")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TestG3GrandChild1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestG3GrandChild1) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TestG3GrandChild1, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -355,6 +356,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TestG3GrandChild1")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TestGGrandChild1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestGGrandChild1) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TestGGrandChild1, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -355,6 +356,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TestGGrandChild1")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TestGrandChild1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestGrandChild1) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TestGrandChild1, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -365,6 +366,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TestGrandChild1")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TestGrandparent) error
 	UpsertMany(ctx context.Context, objs []*storage.TestGrandparent) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TestGrandparent, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -530,6 +531,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TestGrandparent")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TestParent1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestParent1) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TestParent1, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -440,6 +441,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TestParent1")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TestParent2) error
 	UpsertMany(ctx context.Context, objs []*storage.TestParent2) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TestParent2, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -360,6 +361,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TestParent2")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TestParent3) error
 	UpsertMany(ctx context.Context, objs []*storage.TestParent3) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TestParent3, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -360,6 +361,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TestParent3")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TestParent4) error
 	UpsertMany(ctx context.Context, objs []*storage.TestParent4) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TestParent4, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -360,6 +361,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TestParent4")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.TestShortCircuit) error
 	UpsertMany(ctx context.Context, objs []*storage.TestShortCircuit) error
 	Delete(ctx context.Context, id string) error
+	DeleteByQuery(ctx context.Context, q *v1.Query) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.TestShortCircuit, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
@@ -360,6 +361,29 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	q := search.ConjunctionQuery(
 		sacQueryFilter,
 		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects based on the passed query
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "TestShortCircuit")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.Modify(targetResource))
+	if err != nil {
+		return err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return err
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
 	)
 
 	return postgres.RunDeleteRequestForSchema(schema, q, s.db)

--- a/tools/generate-helpers/rocksdb-bindings/main.go
+++ b/tools/generate-helpers/rocksdb-bindings/main.go
@@ -54,8 +54,9 @@ type Store interface {
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
 
-	// Unused and only exists to satisfy interfaces used for Postgres
+	// Unused functions that only exist to satisfy interfaces used for Postgres
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.{{.Type}}, error)
+	DeleteByQuery(_ context.Context, _ *v1.Query) error
 }
 
 type storeImpl struct {
@@ -209,6 +210,11 @@ func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 // GetByQuery is unused and only exists to satisfy interfaces used for Postgres
 func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.{{.Type}}, error) {
 	panic("unimplemented")
+}
+
+// DeleteByQuery is a no-op added for compatibility with the Postgres implementation
+func (b *storeImpl) DeleteByQuery(_ context.Context, _ *v1.Query) error {
+	panic("Unimplemented")
 }
 `
 


### PR DESCRIPTION
## Description

There are some cases where we want to be able to delete by query and this allows it safely in the store (properly taking into account SAC)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Will run scale test to look at pod deletion time 