### PR TITLE
Fix Vuln Mgmt scatterplot for Postgres

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cluster/VulnMgmtClusterOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cluster/VulnMgmtClusterOverview.js
@@ -116,6 +116,7 @@ const VulnMgmtClusterOverview = ({ data, entityContext }) => {
                                     entityTypes.NAMESPACE,
                                     entityTypes.DEPLOYMENT,
                                     entityTypes.IMAGE,
+                                    entityTypes.NODE,
                                 ]}
                                 entityContext={currentEntity}
                                 small

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.js
@@ -95,7 +95,11 @@ const VulnMgmtNamespaceOverview = ({ data, entityContext }) => {
                         <div className="sx-1 lg:sx-2 sy-1 min-h-55 h-full">
                             <TopRiskyEntitiesByVulnerabilities
                                 defaultSelection={entityTypes.DEPLOYMENT}
-                                riskEntityTypes={[entityTypes.DEPLOYMENT, entityTypes.IMAGE]}
+                                riskEntityTypes={[
+                                    entityTypes.DEPLOYMENT,
+                                    entityTypes.IMAGE,
+                                    entityTypes.NODE,
+                                ]}
                                 entityContext={currentEntity}
                                 small
                             />

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.js
@@ -19,7 +19,10 @@ import { LIST_PAGE_SIZE } from 'constants/workflowPages.constants';
 import WorkflowListPage from 'Containers/Workflow/WorkflowListPage';
 import workflowStateContext from 'Containers/workflowStateContext';
 import { imageWatchStatuses } from 'Containers/VulnMgmt/VulnMgmt.constants';
-import { IMAGE_LIST_FRAGMENT } from 'Containers/VulnMgmt/VulnMgmt.fragments';
+import {
+    IMAGE_LIST_FRAGMENT,
+    OLD_IMAGE_LIST_FRAGMENT,
+} from 'Containers/VulnMgmt/VulnMgmt.fragments';
 import getImageScanMessage from 'Containers/VulnMgmt/VulnMgmt.utils/getImageScanMessage';
 import { workflowListPropTypes, workflowListDefaultProps } from 'constants/entityPageProps';
 import removeEntityContextColumns from 'utils/tableUtils';
@@ -220,6 +223,8 @@ const VulnMgmtImages = ({
     const [showWatchedImagesDialog, setShowWatchedImagesDialog] = useState(false);
     const workflowState = useContext(workflowStateContext);
     const { isFeatureFlagEnabled } = useFeatureFlags();
+    const showVmUpdates = isFeatureFlagEnabled('ROX_FRONTEND_VM_UPDATES');
+    const fragmentToUse = showVmUpdates ? IMAGE_LIST_FRAGMENT : OLD_IMAGE_LIST_FRAGMENT;
 
     const inactiveImageScanningEnabled = workflowState.isBaseList(entityTypes.IMAGE);
 
@@ -230,7 +235,7 @@ const VulnMgmtImages = ({
             }
             count: imageCount(query: $query)
         }
-        ${IMAGE_LIST_FRAGMENT}
+        ${fragmentToUse}
     `;
 
     const tableSort = sort || defaultImageSort;

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
@@ -626,7 +626,7 @@ export const NODE_LIST_FRAGMENT_UPDATED = gql`
     }
 `;
 
-export const IMAGE_LIST_FRAGMENT = gql`
+export const OLD_IMAGE_LIST_FRAGMENT = gql`
     fragment imageFields on Image {
         id
         name {
@@ -652,6 +652,56 @@ export const IMAGE_LIST_FRAGMENT = gql`
             notes
         }
         vulnCounter {
+            all {
+                total
+                fixable
+            }
+            low {
+                total
+                fixable
+            }
+            moderate {
+                total
+                fixable
+            }
+            important {
+                total
+                fixable
+            }
+            critical {
+                total
+                fixable
+            }
+        }
+    }
+`;
+
+export const IMAGE_LIST_FRAGMENT = gql`
+    fragment imageFields on Image {
+        id
+        name {
+            fullName
+        }
+        watchStatus
+        deploymentCount(query: $query)
+        priority
+        topVuln: topImageVulnerability {
+            cvss
+            scoreVersion
+        }
+        metadata {
+            v1 {
+                created
+            }
+        }
+        componentCount: imageComponentCount(query: $query)
+        notes
+        scan {
+            scanTime
+            operatingSystem
+            notes
+        }
+        vulnCounter: imageVulnerabilityCounter {
             all {
                 total
                 fixable

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.js
@@ -25,9 +25,267 @@ import { getSeverityByCvss } from 'utils/vulnerabilityUtils';
 import { entitySortFieldsMap, cveSortFields } from 'constants/sortFields';
 import { WIDGET_PAGINATION_START_OFFSET } from 'constants/workflowPages.constants';
 import { entityPriorityField } from 'Containers/VulnMgmt/VulnMgmt.constants';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 
 const ENTITY_COUNT = 25;
 const VULN_COUNT = 50;
+
+// Data Queries
+const VULN_FRAGMENT = gql`
+    fragment vulnFields on EmbeddedVulnerability {
+        cve
+        cvss
+        severity
+    }
+`;
+const IMAGE_VULN_FRAGMENT = gql`
+    fragment vulnFields on ImageVulnerability {
+        id
+        cve
+        cvss
+        severity
+    }
+`;
+const NODE_VULN_FRAGMENT = gql`
+    fragment vulnFields on NodeVulnerability {
+        id
+        cve
+        cvss
+        severity
+    }
+`;
+
+const OLD_DEPLOYMENT_QUERY = gql`
+    query topRiskyDeployments(
+        $query: String
+        $vulnQuery: String
+        $entityPagination: Pagination
+        $vulnPagination: Pagination
+    ) {
+        results: deployments(query: $query, pagination: $entityPagination) {
+            id
+            name
+            clusterName
+            namespaceName: namespace
+            priority
+            plottedVulns(query: $vulnQuery) {
+                basicVulnCounter {
+                    all {
+                        total
+                        fixable
+                    }
+                }
+                vulns(pagination: $vulnPagination) {
+                    ...vulnFields
+                }
+            }
+        }
+    }
+    ${VULN_FRAGMENT}
+`;
+
+const DEPLOYMENT_QUERY = gql`
+    query topRiskyDeployments(
+        $query: String
+        $vulnQuery: String
+        $entityPagination: Pagination
+        $vulnPagination: Pagination
+    ) {
+        results: deployments(query: $query, pagination: $entityPagination) {
+            id
+            name
+            clusterName
+            namespaceName: namespace
+            priority
+            plottedVulns: plottedImageVulnerabilities(query: $vulnQuery) {
+                basicVulnCounter: basicImageVulnerabilityCounter {
+                    all {
+                        total
+                        fixable
+                    }
+                }
+                vulns: imageVulnerabilities(pagination: $vulnPagination) {
+                    ...vulnFields
+                }
+            }
+        }
+    }
+    ${IMAGE_VULN_FRAGMENT}
+`;
+
+const OLD_NODE_QUERY = gql`
+    query topRiskyNodes(
+        $query: String
+        $vulnQuery: String
+        $entityPagination: Pagination
+        $vulnPagination: Pagination
+    ) {
+        results: nodes(query: $query, pagination: $entityPagination) {
+            id
+            name
+            clusterName
+            priority
+            plottedVulns(query: $vulnQuery) {
+                basicVulnCounter {
+                    all {
+                        total
+                        fixable
+                    }
+                }
+                vulns(pagination: $vulnPagination) {
+                    ...vulnFields
+                }
+            }
+        }
+    }
+    ${VULN_FRAGMENT}
+`;
+
+const NODE_QUERY = gql`
+    query topRiskyNodes(
+        $query: String
+        $vulnQuery: String
+        $entityPagination: Pagination
+        $vulnPagination: Pagination
+    ) {
+        results: nodes(query: $query, pagination: $entityPagination) {
+            id
+            name
+            clusterName
+            priority
+            plottedVulns: plottedNodeVulnerabilities(query: $vulnQuery) {
+                basicVulnCounter: basicNodeVulnerabilityCounter {
+                    all {
+                        total
+                        fixable
+                    }
+                }
+                vulns: nodeVulnerabilities(pagination: $vulnPagination) {
+                    ...vulnFields
+                }
+            }
+        }
+    }
+    ${NODE_VULN_FRAGMENT}
+`;
+
+const OLD_NAMESPACE_QUERY = gql`
+    query topRiskyNamespaces(
+        $query: String
+        $vulnQuery: String
+        $entityPagination: Pagination
+        $vulnPagination: Pagination
+    ) {
+        results: namespaces(query: $query, pagination: $entityPagination) {
+            metadata {
+                clusterName
+                name
+                id
+                priority
+            }
+            plottedVulns(query: $vulnQuery) {
+                basicVulnCounter {
+                    all {
+                        total
+                        fixable
+                    }
+                }
+                vulns(pagination: $vulnPagination) {
+                    ...vulnFields
+                }
+            }
+        }
+    }
+    ${VULN_FRAGMENT}
+`;
+
+const NAMESPACE_QUERY = gql`
+    query topRiskyNamespaces(
+        $query: String
+        $vulnQuery: String
+        $entityPagination: Pagination
+        $vulnPagination: Pagination
+    ) {
+        results: namespaces(query: $query, pagination: $entityPagination) {
+            metadata {
+                clusterName
+                name
+                id
+                priority
+            }
+            plottedVulns: plottedImageVulnerabilities(query: $vulnQuery) {
+                basicVulnCounter: basicImageVulnerabilityCounter {
+                    all {
+                        total
+                        fixable
+                    }
+                }
+                vulns: imageVulnerabilities(pagination: $vulnPagination) {
+                    ...vulnFields
+                }
+            }
+        }
+    }
+    ${IMAGE_VULN_FRAGMENT}
+`;
+
+const OLD_IMAGE_QUERY = gql`
+    query topRiskyImages(
+        $query: String
+        $vulnQuery: String
+        $entityPagination: Pagination
+        $vulnPagination: Pagination
+    ) {
+        results: images(query: $query, pagination: $entityPagination) {
+            id
+            name {
+                fullName
+            }
+            priority
+            plottedVulns(query: $vulnQuery) {
+                basicVulnCounter {
+                    all {
+                        total
+                        fixable
+                    }
+                }
+                vulns(pagination: $vulnPagination) {
+                    ...vulnFields
+                }
+            }
+        }
+    }
+    ${VULN_FRAGMENT}
+`;
+
+const IMAGE_QUERY = gql`
+    query topRiskyImages(
+        $query: String
+        $vulnQuery: String
+        $entityPagination: Pagination
+        $vulnPagination: Pagination
+    ) {
+        results: images(query: $query, pagination: $entityPagination) {
+            id
+            name {
+                fullName
+            }
+            priority
+            plottedVulns: plottedImageVulnerabilities(query: $vulnQuery) {
+                basicVulnCounter: basicImageVulnerabilityCounter {
+                    all {
+                        total
+                        fixable
+                    }
+                }
+                vulns: imageVulnerabilities(pagination: $vulnPagination) {
+                    ...vulnFields
+                }
+            }
+        }
+    }
+    ${IMAGE_VULN_FRAGMENT}
+`;
 
 const TopRiskyEntitiesByVulnerabilities = ({
     entityContext,
@@ -36,12 +294,14 @@ const TopRiskyEntitiesByVulnerabilities = ({
     cveFilter,
     small,
 }) => {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const showVmUpdates = isFeatureFlagEnabled('ROX_FRONTEND_VM_UPDATES');
+
     const workflowState = useContext(workflowStateContext);
-    const typesToUse = riskEntityTypes.concat(entityTypes.NODE);
 
     // Entity Type selection
     const [selectedEntityType, setEntityType] = useState(defaultSelection);
-    const entityOptions = typesToUse.map((entityType) => ({
+    const entityOptions = riskEntityTypes.map((entityType) => ({
         label: `Top risky ${pluralize(entityLabels[entityType])} by CVE count & CVSS score`,
         value: entityType,
     }));
@@ -69,165 +329,23 @@ const TopRiskyEntitiesByVulnerabilities = ({
     );
     const viewAll = <ViewAllButton url={viewAllUrl} />;
 
-    // Data Queries
-    const VULN_FRAGMENT = gql`
-        fragment vulnFields on EmbeddedVulnerability {
-            cve
-            cvss
-            severity
-        }
-    `;
-    const DEPLOYMENT_QUERY = gql`
-        query topRiskyDeployments(
-            $query: String
-            $vulnQuery: String
-            $entityPagination: Pagination
-            $vulnPagination: Pagination
-        ) {
-            results: deployments(query: $query, pagination: $entityPagination) {
-                id
-                name
-                clusterName
-                namespaceName: namespace
-                priority
-                plottedVulns(query: $vulnQuery) {
-                    basicVulnCounter {
-                        all {
-                            total
-                            fixable
-                        }
-                    }
-                    vulns(pagination: $vulnPagination) {
-                        ...vulnFields
-                    }
-                }
-            }
-        }
-        ${VULN_FRAGMENT}
-    `;
-
-    const NODE_QUERY = gql`
-        query topRiskyNodes(
-            $query: String
-            $vulnQuery: String
-            $entityPagination: Pagination
-            $vulnPagination: Pagination
-        ) {
-            results: nodes(query: $query, pagination: $entityPagination) {
-                id
-                name
-                clusterName
-                priority
-                plottedVulns(query: $vulnQuery) {
-                    basicVulnCounter {
-                        all {
-                            total
-                            fixable
-                        }
-                    }
-                    vulns(pagination: $vulnPagination) {
-                        ...vulnFields
-                    }
-                }
-            }
-        }
-        ${VULN_FRAGMENT}
-    `;
-
-    const NAMESPACE_QUERY = gql`
-        query topRiskyNamespaces(
-            $query: String
-            $vulnQuery: String
-            $entityPagination: Pagination
-            $vulnPagination: Pagination
-        ) {
-            results: namespaces(query: $query, pagination: $entityPagination) {
-                metadata {
-                    clusterName
-                    name
-                    id
-                    priority
-                }
-                plottedVulns(query: $vulnQuery) {
-                    basicVulnCounter {
-                        all {
-                            total
-                            fixable
-                        }
-                    }
-                    vulns(pagination: $vulnPagination) {
-                        ...vulnFields
-                    }
-                }
-            }
-        }
-        ${VULN_FRAGMENT}
-    `;
-
-    const IMAGE_QUERY = gql`
-        query topRiskyImages(
-            $query: String
-            $vulnQuery: String
-            $entityPagination: Pagination
-            $vulnPagination: Pagination
-        ) {
-            results: images(query: $query, pagination: $entityPagination) {
-                id
-                name {
-                    fullName
-                }
-                priority
-                plottedVulns(query: $vulnQuery) {
-                    basicVulnCounter {
-                        all {
-                            total
-                            fixable
-                        }
-                    }
-                    vulns(pagination: $vulnPagination) {
-                        ...vulnFields
-                    }
-                }
-            }
-        }
-        ${VULN_FRAGMENT}
-    `;
-
-    const COMPONENT_QUERY = gql`
-        query topRiskyComponents(
-            $query: String
-            $vulnQuery: String
-            $entityPagination: Pagination
-            $vulnPagination: Pagination
-        ) {
-            results: components(query: $query, pagination: $entityPagination) {
-                id
-                name
-                priority
-                plottedVulns(query: $vulnQuery) {
-                    basicVulnCounter {
-                        all {
-                            total
-                            fixable
-                        }
-                    }
-                    vulns(pagination: $vulnPagination) {
-                        ...vulnFields
-                    }
-                }
-            }
-        }
-        ${VULN_FRAGMENT}
-    `;
+    const oldQueryMap = {
+        [entityTypes.DEPLOYMENT]: OLD_DEPLOYMENT_QUERY,
+        [entityTypes.NAMESPACE]: OLD_NAMESPACE_QUERY,
+        [entityTypes.IMAGE]: OLD_IMAGE_QUERY,
+        [entityTypes.NODE]: OLD_NODE_QUERY,
+    };
 
     const queryMap = {
         [entityTypes.DEPLOYMENT]: DEPLOYMENT_QUERY,
         [entityTypes.NAMESPACE]: NAMESPACE_QUERY,
-        [entityTypes.COMPONENT]: COMPONENT_QUERY,
         [entityTypes.IMAGE]: IMAGE_QUERY,
         [entityTypes.NODE]: NODE_QUERY,
     };
-    const query = queryMap[selectedEntityType];
+
+    const mapToUse = showVmUpdates ? queryMap : oldQueryMap;
+
+    const query = mapToUse[selectedEntityType];
 
     function getAverageSeverity(vulns) {
         if (vulns.length === 0) {
@@ -405,7 +523,12 @@ TopRiskyEntitiesByVulnerabilities.propTypes = {
 
 TopRiskyEntitiesByVulnerabilities.defaultProps = {
     entityContext: {},
-    riskEntityTypes: [entityTypes.DEPLOYMENT, entityTypes.NAMESPACE, entityTypes.IMAGE],
+    riskEntityTypes: [
+        entityTypes.DEPLOYMENT,
+        entityTypes.NAMESPACE,
+        entityTypes.IMAGE,
+        entityTypes.NODE,
+    ],
     cveFilter: 'All',
     small: false,
 };

--- a/ui/apps/platform/src/utils/queryService.js
+++ b/ui/apps/platform/src/utils/queryService.js
@@ -16,6 +16,7 @@ import { IMAGE_FRAGMENT } from 'queries/image';
 import {
     VULN_COMPONENT_LIST_FRAGMENT,
     VULN_CVE_LIST_FRAGMENT,
+    OLD_IMAGE_LIST_FRAGMENT as OLD_VULN_IMAGE_LIST_FRAGMENT,
     IMAGE_LIST_FRAGMENT as VULN_IMAGE_LIST_FRAGMENT,
     CLUSTER_LIST_FRAGMENT as VULN_CLUSTER_LIST_FRAGMENT,
     DEPLOYMENT_LIST_FRAGMENT as VULN_DEPLOYMENT_LIST_FRAGMENT,
@@ -274,7 +275,9 @@ function getFragment(entityType, listType, useCase, showVMUpdates = false) {
             [entityTypes.CLUSTER_CVE]: CLUSTER_CVE_LIST_FRAGMENT,
             [entityTypes.NODE_CVE]: NODE_CVE_LIST_FRAGMENT,
             [entityTypes.IMAGE_CVE]: VULN_IMAGE_CVE_LIST_FRAGMENT,
-            [entityTypes.IMAGE]: VULN_IMAGE_LIST_FRAGMENT,
+            [entityTypes.IMAGE]: showVMUpdates
+                ? VULN_IMAGE_LIST_FRAGMENT
+                : OLD_VULN_IMAGE_LIST_FRAGMENT,
             [entityTypes.CLUSTER]: VULN_CLUSTER_LIST_FRAGMENT,
             [entityTypes.NAMESPACE]: showVMUpdates
                 ? VULN_NAMESPACE_LIST_FRAGMENT_UPDATED


### PR DESCRIPTION
## Description

GraphQL queries for the Top Risky <X> scatterplots updated to use new split CVE fields.

## Checklist
- [x] Investigated and inspected CI test results (failures are unrelated flakes)


## Testing Performed

Dashboard, deployments
<img width="1542" alt="dashboard_top_risky_deployments" src="https://user-images.githubusercontent.com/715729/182722552-de2bcc24-c2d2-481f-bb17-0fcd14babb52.png">

Dashboard, namespaces
<img width="1542" alt="dashboard_top_risky_namespaces" src="https://user-images.githubusercontent.com/715729/182722576-11f2a17d-f90a-4875-8fc8-94fd2b57ff04.png">

Dashboard, images
<img width="1542" alt="dashboard_top_risky_images" src="https://user-images.githubusercontent.com/715729/182722640-d3ad5e98-9936-4b5b-a957-7ab74836a68b.png">

Dashboard, nodes
<img width="1542" alt="dashboard_top_risky_nodes" src="https://user-images.githubusercontent.com/715729/182722667-f331cfbf-3aa3-4a4b-b3c7-a8f9646e4bbc.png">


Example on Cluster overview page
<img width="1542" alt="cluster_top_risky_example" src="https://user-images.githubusercontent.com/715729/182722699-05b0c36a-312c-46bc-a64d-7ebfcc37adea.png">

Example of Namespace overview page
<img width="1542" alt="namespace_top_risky_example" src="https://user-images.githubusercontent.com/715729/182722723-c3e53fb5-935f-4c6a-a75f-9189e98a1d7b.png">
