### PR TITLE
ROX-11319: Adding delete modal to policy categories

### DIFF
--- a/ui/apps/platform/src/Containers/PolicyCategories/DeletePolicyCategoryModal.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/DeletePolicyCategoryModal.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from 'react';
+import {
+    Modal,
+    ModalVariant,
+    ModalBoxBody,
+    ModalBoxFooter,
+    Button,
+    List,
+    ListItem,
+    ListComponent,
+    OrderType,
+    Flex,
+    FlexItem,
+    Panel,
+    PanelMain,
+    PanelMainBody,
+} from '@patternfly/react-core';
+
+import { getPolicies } from 'services/PoliciesService';
+import { deletePolicyCategory } from 'services/PolicyCategoriesService';
+import { PolicyCategory, ListPolicy } from 'types/policy.proto';
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+
+type DeletePolicyCategoryModalType = {
+    isOpen: boolean;
+    onClose: () => void;
+    addToast: (toast) => void;
+    refreshPolicyCategories: () => void;
+    selectedCategory?: PolicyCategory;
+    setSelectedCategory: (category?: PolicyCategory) => void;
+};
+
+function DeletePolicyCategoryModal({
+    isOpen,
+    onClose,
+    addToast,
+    refreshPolicyCategories,
+    selectedCategory,
+    setSelectedCategory,
+}: DeletePolicyCategoryModalType) {
+    const [affectedPolicies, setAffectedPolicies] = useState<ListPolicy[]>([]);
+
+    function handleDelete() {
+        deletePolicyCategory(selectedCategory?.id || '')
+            .then(() => {
+                addToast('Successfully deleted category');
+                setSelectedCategory();
+                refreshPolicyCategories();
+            })
+            .catch((error) => {
+                addToast(error.message);
+            })
+            .finally(() => {
+                onClose();
+            });
+    }
+
+    useEffect(() => {
+        const query = getRequestQueryStringForSearchFilter({ Category: selectedCategory?.name });
+        getPolicies(query)
+            .then((policies) => {
+                setAffectedPolicies(policies);
+            })
+            .catch((error) => {
+                addToast(error.message);
+            });
+    }, []);
+
+    return (
+        <Modal
+            title="Permanently delete category?"
+            isOpen={isOpen}
+            variant={ModalVariant.small}
+            onClose={onClose}
+            data-testid="delete-category-modal"
+            aria-label="Permanently delete category?"
+            hasNoBodyWrapper
+        >
+            <ModalBoxBody>
+                {affectedPolicies.length > 0 && (
+                    <Flex direction={{ default: 'column' }}>
+                        <FlexItem>
+                            This will permanently delete and remove the
+                            <b> {selectedCategory?.name} </b>
+                            policy category from the following policies:
+                        </FlexItem>
+                        <FlexItem>
+                            <Panel variant="bordered" isScrollable>
+                                <PanelMain>
+                                    <PanelMainBody>
+                                        <List component={ListComponent.ol} type={OrderType.number}>
+                                            {affectedPolicies.map(({ name }) => (
+                                                <ListItem key={name}>{name}</ListItem>
+                                            ))}
+                                        </List>
+                                    </PanelMainBody>
+                                </PanelMain>
+                            </Panel>
+                        </FlexItem>
+                    </Flex>
+                )}
+                {affectedPolicies.length === 0 && (
+                    <div>There are no policies affected by this policy category.</div>
+                )}
+            </ModalBoxBody>
+            <ModalBoxFooter>
+                <Button key="delete" variant="danger" onClick={() => handleDelete()}>
+                    Delete
+                </Button>
+                <Button key="cancel" variant="link" onClick={onClose}>
+                    Cancel
+                </Button>
+            </ModalBoxFooter>
+        </Modal>
+    );
+}
+
+export default DeletePolicyCategoryModal;

--- a/ui/apps/platform/src/Containers/PolicyCategories/DeletePolicyCategoryModal.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/DeletePolicyCategoryModal.tsx
@@ -56,15 +56,19 @@ function DeletePolicyCategoryModal({
     }
 
     useEffect(() => {
-        const query = getRequestQueryStringForSearchFilter({ Category: selectedCategory?.name });
-        getPolicies(query)
-            .then((policies) => {
-                setAffectedPolicies(policies);
-            })
-            .catch((error) => {
-                addToast(error.message);
+        if (selectedCategory?.name) {
+            const query = getRequestQueryStringForSearchFilter({
+                Category: selectedCategory?.name,
             });
-    }, []);
+            getPolicies(query)
+                .then((policies) => {
+                    setAffectedPolicies(policies);
+                })
+                .catch((error) => {
+                    addToast(error.message);
+                });
+        }
+    }, [selectedCategory?.name, addToast]);
 
     return (
         <Modal

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesListSection.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesListSection.tsx
@@ -5,6 +5,7 @@ import { PolicyCategory } from 'types/policy.proto';
 import PolicyCategoriesList from './PolicyCategoriesList';
 import PolicyCategoriesFilterSelect, { CategoryFilter } from './PolicyCategoriesFilterSelect';
 import PolicyCategorySidePanel from './PolicyCategorySidePanel';
+import DeletePolicyCategoryModal from './DeletePolicyCategoryModal';
 
 type PolicyCategoriesListSectionProps = {
     policyCategories: PolicyCategory[];
@@ -27,6 +28,8 @@ function PolicyCategoriesListSection({
         'Default categories',
         'Custom categories',
     ]);
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
     let currentPolicyCategories = policyCategories;
     if (selectedFilters.length === 1) {
         if (selectedFilters[0] === 'Default categories') {
@@ -49,70 +52,81 @@ function PolicyCategoriesListSection({
     }, [filterTerm, selectedFilters, policyCategories]);
 
     return (
-        <PageSection id="policy-categories-list-section">
-            <Flex
-                spaceItems={{ default: 'spaceItemsNone' }}
-                alignItems={{ default: 'alignItemsStretch' }}
-                className="pf-u-h-100"
-            >
-                <FlexItem flex={{ default: 'flex_1' }}>
-                    <PageSection isFilled variant="light" className="pf-u-h-100">
-                        <Flex direction={{ default: 'column' }}>
-                            <Title headingLevel="h2">
+        <>
+            <PageSection id="policy-categories-list-section">
+                <Flex
+                    spaceItems={{ default: 'spaceItemsNone' }}
+                    alignItems={{ default: 'alignItemsStretch' }}
+                    className="pf-u-h-100"
+                >
+                    <FlexItem flex={{ default: 'flex_1' }}>
+                        <PageSection isFilled variant="light" className="pf-u-h-100">
+                            <Flex direction={{ default: 'column' }}>
+                                <Title headingLevel="h2">
+                                    <Flex
+                                        justifyContent={{ default: 'justifyContentSpaceBetween' }}
+                                        fullWidth={{ default: 'fullWidth' }}
+                                    >
+                                        <span>Categories</span>
+                                        <span>{filteredCategories.length} results found</span>
+                                    </Flex>
+                                </Title>
                                 <Flex
                                     justifyContent={{ default: 'justifyContentSpaceBetween' }}
                                     fullWidth={{ default: 'fullWidth' }}
+                                    flexWrap={{ default: 'nowrap' }}
                                 >
-                                    <span>Categories</span>
-                                    <span>{filteredCategories.length} results found</span>
+                                    <TextInput
+                                        onChange={setFilterTerm}
+                                        type="text"
+                                        value={filterTerm}
+                                        placeholder="Filter by category name..."
+                                        id="policy-categories-filter-input"
+                                        isDisabled={!!selectedCategory}
+                                    />
+                                    <PolicyCategoriesFilterSelect
+                                        selectedFilters={selectedFilters}
+                                        setSelectedFilters={setSelectedFilters}
+                                        isDisabled={!!selectedCategory}
+                                    />
                                 </Flex>
-                            </Title>
-                            <Flex
-                                justifyContent={{ default: 'justifyContentSpaceBetween' }}
-                                fullWidth={{ default: 'fullWidth' }}
-                                flexWrap={{ default: 'nowrap' }}
-                            >
-                                <TextInput
-                                    onChange={setFilterTerm}
-                                    type="text"
-                                    value={filterTerm}
-                                    placeholder="Filter by category name..."
-                                    id="policy-categories-filter-input"
-                                    isDisabled={!!selectedCategory}
-                                />
-                                <PolicyCategoriesFilterSelect
-                                    selectedFilters={selectedFilters}
-                                    setSelectedFilters={setSelectedFilters}
-                                    isDisabled={!!selectedCategory}
-                                />
+                                {filteredCategories.length > 0 && (
+                                    <PolicyCategoriesList
+                                        policyCategories={filteredCategories}
+                                        setSelectedCategory={setSelectedCategory}
+                                    />
+                                )}
+                                {filteredCategories.length === 0 && (
+                                    <div>No policy categories found.</div>
+                                )}
                             </Flex>
-                            {filteredCategories.length > 0 && (
-                                <PolicyCategoriesList
-                                    policyCategories={filteredCategories}
+                        </PageSection>
+                    </FlexItem>
+                    {selectedCategory && (
+                        <>
+                            <Divider component="div" isVertical />
+                            <FlexItem flex={{ default: 'flex_1' }}>
+                                <PolicyCategorySidePanel
+                                    selectedCategory={selectedCategory}
                                     setSelectedCategory={setSelectedCategory}
+                                    addToast={addToast}
+                                    openDeleteModal={() => setIsDeleteModalOpen(true)}
+                                    refreshPolicyCategories={refreshPolicyCategories}
                                 />
-                            )}
-                            {filteredCategories.length === 0 && (
-                                <div>No policy categories found.</div>
-                            )}
-                        </Flex>
-                    </PageSection>
-                </FlexItem>
-                {selectedCategory && (
-                    <>
-                        <Divider component="div" isVertical />
-                        <FlexItem flex={{ default: 'flex_1' }}>
-                            <PolicyCategorySidePanel
-                                selectedCategory={selectedCategory}
-                                setSelectedCategory={setSelectedCategory}
-                                addToast={addToast}
-                                refreshPolicyCategories={refreshPolicyCategories}
-                            />
-                        </FlexItem>
-                    </>
-                )}
-            </Flex>
-        </PageSection>
+                            </FlexItem>
+                        </>
+                    )}
+                </Flex>
+            </PageSection>
+            <DeletePolicyCategoryModal
+                isOpen={isDeleteModalOpen}
+                onClose={() => setIsDeleteModalOpen(false)}
+                refreshPolicyCategories={() => {}}
+                addToast={addToast}
+                selectedCategory={selectedCategory}
+                setSelectedCategory={setSelectedCategory}
+            />
+        </>
     );
 }
 

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesListSection.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesListSection.tsx
@@ -121,7 +121,7 @@ function PolicyCategoriesListSection({
             <DeletePolicyCategoryModal
                 isOpen={isDeleteModalOpen}
                 onClose={() => setIsDeleteModalOpen(false)}
-                refreshPolicyCategories={() => {}}
+                refreshPolicyCategories={refreshPolicyCategories}
                 addToast={addToast}
                 selectedCategory={selectedCategory}
                 setSelectedCategory={setSelectedCategory}

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategorySidePanel.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategorySidePanel.tsx
@@ -19,6 +19,7 @@ type PolicyCategoriesSidePanelProps = {
     setSelectedCategory: (selectedCategory?: PolicyCategory) => void;
     addToast: (toast) => void;
     refreshPolicyCategories: () => void;
+    openDeleteModal: () => void;
 };
 
 function PolicyCategorySidePanel({
@@ -26,6 +27,7 @@ function PolicyCategorySidePanel({
     setSelectedCategory,
     addToast,
     refreshPolicyCategories,
+    openDeleteModal,
 }: PolicyCategoriesSidePanelProps) {
     const formik = useFormik({
         initialValues: selectedCategory,
@@ -69,7 +71,7 @@ function PolicyCategorySidePanel({
                         flexWrap={{ default: 'nowrap' }}
                     >
                         <Title headingLevel="h3">{name}</Title>
-                        <Button variant="secondary" isDanger>
+                        <Button variant="secondary" isDanger onClick={openDeleteModal}>
                             Delete category
                         </Button>
                     </Flex>

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -116,6 +116,12 @@ button.pf-c-tree-view__node {
     word-break: break-all;
 }
 
+/* Override none value for list-style in Tailwind stylesheet. */
+.pf-c-modal-box ol,
+.pf-c-page__main-section ol {
+    list-style: decimal;
+}
+
 /* For classic components to equal or exceed z-index of PatternFly elements. */
 
 .z-xs-100 {


### PR DESCRIPTION
## Description

As title suggests  -- adding a delete confirmation modal to the policy category page/side panel. it should look as below and function as expected. 
<img width="678" alt="image" src="https://user-images.githubusercontent.com/10412893/182992796-0ce2e2bf-546e-4846-b6b9-2721df7eaebf.png">
<img width="673" alt="image" src="https://user-images.githubusercontent.com/10412893/182992810-ee407544-9c2a-400f-954d-1abc9bedee66.png">


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
