### PR TITLE
Add environment variable for Postgres port in tests

### DIFF
--- a/pkg/postgres/pgtest/conn/conn.go
+++ b/pkg/postgres/pgtest/conn/conn.go
@@ -25,7 +25,8 @@ func GetConnectionStringWithDatabaseName(database string) string {
 	}
 	pass := env.GetString("POSTGRES_PASSWORD", "")
 	host := env.GetString("POSTGRES_HOST", "localhost")
-	src := fmt.Sprintf("host=%s port=5432 user=%s database=%s sslmode=disable statement_timeout=600000", host, user, database)
+	port := env.GetString("POSTGRES_PORT", "5432")
+	src := fmt.Sprintf("host=%s port=%s user=%s database=%s sslmode=disable statement_timeout=600000", host, port, user, database)
 	if pass != "" {
 		src += fmt.Sprintf(" password=%s", pass)
 	}


### PR DESCRIPTION
## Description

This PR adds an option to define Postgres port when running Postgres tests. It's helpful for local development if Postgres runs on another port or if several instances running on different ports.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

1. Run Postgres on custom port:
```
docker run --name test-sr -p 5433:5432 -e POSTGRES_USER=sr -e POSTGRES_PASSWORD=sr -e POSTGRES_DB=sr -d postgres
```

2. Export new variable and other required variables for the Postgres test
```
export POSTGRES_PORT=5433

export ROX_POSTGRES_DATASTORE=true
export USER=sr
export POSTGRES_PASSWORD=sr
export POSTGRES_DB=sr
export POSTGRES_HOST=localhost
```

3. Run some unit test where Postgres DB is used. i.e.
```
cd central/cluster/datastore

go test -v -run "TestClusterDatastoreSAC" .
```

