### PR TITLE
Cache go modules on turbo-mode

### DIFF
--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -19,6 +19,7 @@ runs:
           /github/home/.cache/go-build
           /github/home/.cache/golangci-lint
           /github/home/.cache/staticcheck
+          /github/home/go/pkg/mod
         key: go-v2-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           go-v2-


### PR DESCRIPTION
## Description

We can cache go modules to not download them from internet.

## Testing Performed

CI