### PR TITLE
CI: Only run when the turbo label is added

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,8 +13,8 @@ jobs:
 
   pre-build-ui:
     if: |
-      (github.event.action == "labeled" && github.event.label.name == 'turbo-build') ||
-      (github.event.action != "labeled" && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
+      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,10 @@ env:
 jobs:
 
   pre-build-ui:
-    if: contains(github.event.pull_request.labels.*.name, 'turbo-build')
+    if: |
+      (github.event.action == "labeled" && github.event.label.name == 'turbo-build') ||
+      (github.event.action != "labeled" && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
+
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44
@@ -41,7 +44,9 @@ jobs:
             ui/monorepo.lock
 
   pre-build-cli:
-    if: contains(github.event.pull_request.labels.*.name, 'turbo-build')
+    if: |
+      (github.event.action == "labeled" && github.event.label.name == 'turbo-build') ||
+      (github.event.action != "labeled" && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44
@@ -67,7 +72,9 @@ jobs:
           path: cli-build.tgz
 
   pre-build-go-binaries:
-    if: contains(github.event.pull_request.labels.*.name, 'turbo-build')
+    if: |
+      (github.event.action == "labeled" && github.event.label.name == 'turbo-build') ||
+      (github.event.action != "labeled" && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44
@@ -103,7 +110,9 @@ jobs:
           path: go-binaries-build.tgz
 
   pre-build-docs:
-    if: contains(github.event.pull_request.labels.*.name, 'turbo-build')
+    if: |
+      (github.event.action == "labeled" && github.event.label.name == 'turbo-build') ||
+      (github.event.action != "labeled" && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44
@@ -133,7 +142,9 @@ jobs:
             image/docs
 
   build-and-push-main:
-    if: contains(github.event.pull_request.labels.*.name, 'turbo-build')
+    if: |
+      (github.event.action == "labeled" && github.event.label.name == 'turbo-build') ||
+      (github.event.action != "labeled" && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     needs: 
       - pre-build-ui
@@ -224,7 +235,9 @@ jobs:
             add_build_comment_to_pr
 
   build-and-push-operator:
-    if: contains(github.event.pull_request.labels.*.name, 'turbo-build')
+    if: |
+      (github.event.action == "labeled" && github.event.label.name == 'turbo-build') ||
+      (github.event.action != "labeled" && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,8 +45,8 @@ jobs:
 
   pre-build-cli:
     if: |
-      (github.event.action == "labeled" && github.event.label.name == 'turbo-build') ||
-      (github.event.action != "labeled" && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
+      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44
@@ -73,8 +73,8 @@ jobs:
 
   pre-build-go-binaries:
     if: |
-      (github.event.action == "labeled" && github.event.label.name == 'turbo-build') ||
-      (github.event.action != "labeled" && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
+      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44
@@ -111,8 +111,8 @@ jobs:
 
   pre-build-docs:
     if: |
-      (github.event.action == "labeled" && github.event.label.name == 'turbo-build') ||
-      (github.event.action != "labeled" && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
+      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44
@@ -143,8 +143,8 @@ jobs:
 
   build-and-push-main:
     if: |
-      (github.event.action == "labeled" && github.event.label.name == 'turbo-build') ||
-      (github.event.action != "labeled" && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
+      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     needs: 
       - pre-build-ui
@@ -236,8 +236,8 @@ jobs:
 
   build-and-push-operator:
     if: |
-      (github.event.action == "labeled" && github.event.label.name == 'turbo-build') ||
-      (github.event.action != "labeled" && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
+      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44


### PR DESCRIPTION
## Description

Prior to this PR, the build action would run when labels were altered and the PR had the turbo label.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Still does not run without the label
- [x] Runs if added
- [x] Does not run if other labels are [added or removed](https://github.com/stackrox/stackrox/actions/workflows/build.yaml?query=branch%3Agavin%2FCI-limit-turbos)