### PR TITLE
ROX-11832: Don't log exception msg twice

### DIFF
--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -95,12 +95,12 @@ class Helpers {
 
         if (exception && (exception instanceof AssumptionViolatedException ||
                 exception.getMessage()?.contains("org.junit.AssumptionViolatedException"))) {
-            log.info("Won't collect logs for: ${exception.getMessage()}", exception)
+            log.info("Won't collect logs for", exception)
             return
         }
 
         if (exception) {
-            log.error("An exception occurred in test: ${exception.getMessage()}", exception)
+            log.error("An exception occurred in test", exception)
         }
 
         try {


### PR DESCRIPTION
## Description

We are logging exception message twice. Let's fix it.

## Testing Performed

CI