### PR TITLE
Simplify selector for failing loading indicator test for Vulnerability Management Dashboard in UI

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
@@ -112,13 +112,13 @@ describe('Vuln Management Dashboard Page', () => {
     });
 
     it('"Top Riskiest <entities>" widget should start with a loading indicator', () => {
+        const widgetSelector = selectors.getWidget(
+            'Top risky deployments by CVE count & CVSS score'
+        );
+        const loadingSelector = `${widgetSelector} ${selectors.widgetBody}:contains("Loading")`;
+
         cy.visit(url.dashboard); // do not call visit helper because it waits on the requests
-        cy.get(selectors.getWidget('Top risky deployments by CVE count & CVSS score'))
-            .find(selectors.widgetBody)
-            .invoke('text')
-            .then((bodyText) => {
-                expect(bodyText).to.contain('Loading');
-            });
+        cy.get(loadingSelector);
     });
 
     it('clicking the "Top Riskiest Images" widget\'s "View All" button should take you to the images list', () => {


### PR DESCRIPTION
## Description

> "Top Riskiest <entities>" widget should start with a loading indicator: Vuln Management Dashboard Page "Top Riskiest <entities>" widget should start with a loading indicator

![cypress-prow](https://user-images.githubusercontent.com/11862657/182920788-3129f39b-b9d1-4ac2-8b96-a9fb7292f37e.png)

Recently failed several times because responses are available and widget has rendered results before the assertion.

Opposite to usual problem that test gets ahead of UI.

Replace method chain with one selector.

If the test continues to fail, then delete it. Testing the loading state does not seem worth the risk of timing failures.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed

Ran test in local deployment