### PR TITLE
Add GetByQuery functionality to Postgres stores

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ActiveComponent, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ActiveComponent, error)
 	Upsert(ctx context.Context, obj *storage.ActiveComponent) error
 	UpsertMany(ctx context.Context, objs []*storage.ActiveComponent) error
 	Delete(ctx context.Context, id string) error
@@ -534,6 +535,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Activ
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ActiveComponent, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ActiveComponent")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ActiveComponent
+	for _, data := range rows {
+		msg := &storage.ActiveComponent{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Alert, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Alert, error)
 	Upsert(ctx context.Context, obj *storage.Alert) error
 	UpsertMany(ctx context.Context, objs []*storage.Alert) error
 	Delete(ctx context.Context, id string) error
@@ -607,6 +608,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Alert
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Alert, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "Alert")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.Alert
+	for _, data := range rows {
+		msg := &storage.Alert{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/alert/datastore/internal/store/rocksdb/store.go
+++ b/central/alert/datastore/internal/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.Alert) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Alert, error)
 }
 
 type storeImpl struct {
@@ -153,4 +157,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Alert, error) {
+	panic("unimplemented")
 }

--- a/central/apitoken/datastore/internal/store/rocksdb/store.go
+++ b/central/apitoken/datastore/internal/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.TokenMetadata) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.TokenMetadata, error)
 }
 
 type storeImpl struct {
@@ -153,4 +157,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.TokenMetadata, error) {
+	panic("unimplemented")
 }

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Cluster, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Cluster, error)
 	Upsert(ctx context.Context, obj *storage.Cluster) error
 	UpsertMany(ctx context.Context, objs []*storage.Cluster) error
 	Delete(ctx context.Context, id string) error
@@ -462,6 +463,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Cluster, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "Cluster")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.Cluster
+	for _, data := range rows {
+		msg := &storage.Cluster{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/cluster/store/cluster/rocksdb/store.go
+++ b/central/cluster/store/cluster/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.Cluster) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Cluster, error)
 }
 
 type storeImpl struct {
@@ -163,4 +167,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Cluster, error) {
+	panic("unimplemented")
 }

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ClusterHealthStatus, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ClusterHealthStatus, error)
 	Upsert(ctx context.Context, obj *storage.ClusterHealthStatus) error
 	UpsertMany(ctx context.Context, objs []*storage.ClusterHealthStatus) error
 	Delete(ctx context.Context, id string) error
@@ -469,6 +470,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ClusterHealthStatus, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ClusterHealthStatus")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ClusterHealthStatus
+	for _, data := range rows {
+		msg := &storage.ClusterHealthStatus{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/cluster/store/clusterhealth/rocksdb/store.go
+++ b/central/cluster/store/clusterhealth/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.ClusterHealthStatus) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ClusterHealthStatus, error)
 }
 
 type storeImpl struct {
@@ -163,4 +167,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ClusterHealthStatus, error) {
+	panic("unimplemented")
 }

--- a/central/clustercveedge/datastore/store/postgres/store.go
+++ b/central/clustercveedge/datastore/store/postgres/store.go
@@ -45,6 +45,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ClusterCVEEdge, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ClusterCVEEdge, error)
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ClusterCVEEdge, []int, error)
 
@@ -188,6 +189,35 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ClusterCVEEdge, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ClusterCVEEdge")
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ClusterCVEEdge
+	for _, data := range rows {
+		msg := &storage.ClusterCVEEdge{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/clusterinit/store/rocksdb/store.go
+++ b/central/clusterinit/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.InitBundleMeta) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.InitBundleMeta, error)
 }
 
 type storeImpl struct {
@@ -159,4 +163,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.InitBundleMeta, error) {
+	panic("unimplemented")
 }

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ComplianceDomain, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ComplianceDomain, error)
 	Upsert(ctx context.Context, obj *storage.ComplianceDomain) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceDomain) error
 	Delete(ctx context.Context, id string) error
@@ -467,6 +468,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ComplianceDomain, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ComplianceDomain")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ComplianceDomain
+	for _, data := range rows {
+		msg := &storage.ComplianceDomain{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, runId string) (bool, error)
 	Get(ctx context.Context, runId string) (*storage.ComplianceRunMetadata, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ComplianceRunMetadata, error)
 	Upsert(ctx context.Context, obj *storage.ComplianceRunMetadata) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceRunMetadata) error
 	Delete(ctx context.Context, runId string) error
@@ -467,6 +468,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ComplianceRunMetadata, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ComplianceRunMetadata")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ComplianceRunMetadata
+	for _, data := range rows {
+		msg := &storage.ComplianceRunMetadata{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, runMetadataRunId string) (bool, error)
 	Get(ctx context.Context, runMetadataRunId string) (*storage.ComplianceRunResults, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ComplianceRunResults, error)
 	Upsert(ctx context.Context, obj *storage.ComplianceRunResults) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceRunResults) error
 	Delete(ctx context.Context, runMetadataRunId string) error
@@ -467,6 +468,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ComplianceRunResults, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ComplianceRunResults")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ComplianceRunResults
+	for _, data := range rows {
+		msg := &storage.ComplianceRunResults{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/complianceoperator/checkresults/store/rocksdb/store.go
+++ b/central/complianceoperator/checkresults/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.ComplianceOperatorCheckResult) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorCheckResult, error)
 }
 
 type storeImpl struct {
@@ -159,4 +163,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorCheckResult, error) {
+	panic("unimplemented")
 }

--- a/central/complianceoperator/profiles/store/rocksdb/store.go
+++ b/central/complianceoperator/profiles/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.ComplianceOperatorProfile) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorProfile, error)
 }
 
 type storeImpl struct {
@@ -159,4 +163,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorProfile, error) {
+	panic("unimplemented")
 }

--- a/central/complianceoperator/rules/store/rocksdb/store.go
+++ b/central/complianceoperator/rules/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.ComplianceOperatorRule) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorRule, error)
 }
 
 type storeImpl struct {
@@ -159,4 +163,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorRule, error) {
+	panic("unimplemented")
 }

--- a/central/complianceoperator/scans/store/rocksdb/store.go
+++ b/central/complianceoperator/scans/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.ComplianceOperatorScan) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorScan, error)
 }
 
 type storeImpl struct {
@@ -159,4 +163,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorScan, error) {
+	panic("unimplemented")
 }

--- a/central/complianceoperator/scansettingbinding/store/rocksdb/store.go
+++ b/central/complianceoperator/scansettingbinding/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.ComplianceOperatorScanSettingBinding) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorScanSettingBinding, error)
 }
 
 type storeImpl struct {
@@ -159,4 +163,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ComplianceOperatorScanSettingBinding, error) {
+	panic("unimplemented")
 }

--- a/central/componentcveedge/datastore/internal/postgres/store.go
+++ b/central/componentcveedge/datastore/internal/postgres/store.go
@@ -45,6 +45,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ComponentCVEEdge, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ComponentCVEEdge, error)
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ComponentCVEEdge, []int, error)
 
@@ -188,6 +189,35 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compo
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ComponentCVEEdge, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ComponentCVEEdge")
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ComponentCVEEdge
+	for _, data := range rows {
+		msg := &storage.ComponentCVEEdge{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ClusterCVE, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ClusterCVE, error)
 	Upsert(ctx context.Context, obj *storage.ClusterCVE) error
 	UpsertMany(ctx context.Context, objs []*storage.ClusterCVE) error
 	Delete(ctx context.Context, id string) error
@@ -484,6 +485,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ClusterCVE, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ClusterCVE")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ClusterCVE
+	for _, data := range rows {
+		msg := &storage.ClusterCVE{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ImageCVE, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ImageCVE, error)
 	Upsert(ctx context.Context, obj *storage.ImageCVE) error
 	UpsertMany(ctx context.Context, objs []*storage.ImageCVE) error
 	Delete(ctx context.Context, id string) error
@@ -479,6 +480,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ImageCVE, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ImageCVE")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ImageCVE
+	for _, data := range rows {
+		msg := &storage.ImageCVE{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.NodeCVE, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NodeCVE, error)
 	Upsert(ctx context.Context, obj *storage.NodeCVE) error
 	UpsertMany(ctx context.Context, objs []*storage.NodeCVE) error
 	Delete(ctx context.Context, id string) error
@@ -479,6 +480,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NodeCVE, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "NodeCVE")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.NodeCVE
+	for _, data := range rows {
+		msg := &storage.NodeCVE{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Deployment, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Deployment, error)
 	Upsert(ctx context.Context, obj *storage.Deployment) error
 	UpsertMany(ctx context.Context, objs []*storage.Deployment) error
 	Delete(ctx context.Context, id string) error
@@ -1146,6 +1147,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Deplo
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Deployment, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "Deployment")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.Deployment
+	for _, data := range rows {
+		msg := &storage.Deployment{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ImageComponent, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ImageComponent, error)
 	Upsert(ctx context.Context, obj *storage.ImageComponent) error
 	UpsertMany(ctx context.Context, objs []*storage.ImageComponent) error
 	Delete(ctx context.Context, id string) error
@@ -469,6 +470,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ImageComponent, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ImageComponent")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ImageComponent
+	for _, data := range rows {
+		msg := &storage.ImageComponent{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -45,6 +45,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ImageComponentEdge, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ImageComponentEdge, error)
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ImageComponentEdge, []int, error)
 
@@ -188,6 +189,35 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ImageComponentEdge, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ImageComponentEdge")
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ImageComponentEdge
+	for _, data := range rows {
+		msg := &storage.ImageComponentEdge{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/imagecveedge/datastore/internal/postgres/store.go
+++ b/central/imagecveedge/datastore/internal/postgres/store.go
@@ -45,6 +45,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ImageCVEEdge, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ImageCVEEdge, error)
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ImageCVEEdge, []int, error)
 
@@ -188,6 +189,35 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ImageCVEEdge, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ImageCVEEdge")
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ImageCVEEdge
+	for _, data := range rows {
+		msg := &storage.ImageCVEEdge{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/integrationhealth/store/rocksdb/store.go
+++ b/central/integrationhealth/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.IntegrationHealth) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.IntegrationHealth, error)
 }
 
 type storeImpl struct {
@@ -153,4 +157,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.IntegrationHealth, error) {
+	panic("unimplemented")
 }

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.NamespaceMetadata, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NamespaceMetadata, error)
 	Upsert(ctx context.Context, obj *storage.NamespaceMetadata) error
 	UpsertMany(ctx context.Context, objs []*storage.NamespaceMetadata) error
 	Delete(ctx context.Context, id string) error
@@ -477,6 +478,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Names
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NamespaceMetadata, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "NamespaceMetadata")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.NamespaceMetadata
+	for _, data := range rows {
+		msg := &storage.NamespaceMetadata{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/namespace/store/rocksdb/store.go
+++ b/central/namespace/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.NamespaceMetadata) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NamespaceMetadata, error)
 }
 
 type storeImpl struct {
@@ -153,4 +157,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NamespaceMetadata, error) {
+	panic("unimplemented")
 }

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, deploymentId string) (bool, error)
 	Get(ctx context.Context, deploymentId string) (*storage.NetworkBaseline, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NetworkBaseline, error)
 	Upsert(ctx context.Context, obj *storage.NetworkBaseline) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkBaseline) error
 	Delete(ctx context.Context, deploymentId string) error
@@ -462,6 +463,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NetworkBaseline, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "NetworkBaseline")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.NetworkBaseline
+	for _, data := range rows {
+		msg := &storage.NetworkBaseline{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/networkbaseline/store/rocksdb/store.go
+++ b/central/networkbaseline/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.NetworkBaseline) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkBaseline, error)
 }
 
 type storeImpl struct {
@@ -153,4 +157,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkBaseline, error) {
+	panic("unimplemented")
 }

--- a/central/networkgraph/config/datastore/internal/store/rocksdb/store.go
+++ b/central/networkgraph/config/datastore/internal/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.NetworkGraphConfig) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkGraphConfig, error)
 }
 
 type storeImpl struct {
@@ -153,4 +157,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkGraphConfig, error) {
+	panic("unimplemented")
 }

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, infoId string) (bool, error)
 	Get(ctx context.Context, infoId string) (*storage.NetworkEntity, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NetworkEntity, error)
 	Upsert(ctx context.Context, obj *storage.NetworkEntity) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkEntity) error
 	Delete(ctx context.Context, infoId string) error
@@ -444,6 +445,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NetworkEntity, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "NetworkEntity")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.NetworkEntity
+	for _, data := range rows {
+		msg := &storage.NetworkEntity{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/networkgraph/entity/datastore/internal/store/rocksdb/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.NetworkEntity) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkEntity, error)
 }
 
 type storeImpl struct {
@@ -159,4 +163,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkEntity, error) {
+	panic("unimplemented")
 }

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.NetworkPolicy, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NetworkPolicy, error)
 	Upsert(ctx context.Context, obj *storage.NetworkPolicy) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkPolicy) error
 	Delete(ctx context.Context, id string) error
@@ -462,6 +463,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NetworkPolicy, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "NetworkPolicy")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.NetworkPolicy
+	for _, data := range rows {
+		msg := &storage.NetworkPolicy{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/rocksdb/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.NetworkPolicyApplicationUndoDeploymentRecord) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkPolicyApplicationUndoDeploymentRecord, error)
 }
 
 type storeImpl struct {
@@ -159,4 +163,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.NetworkPolicyApplicationUndoDeploymentRecord, error) {
+	panic("unimplemented")
 }

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -45,6 +45,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.NodeComponentEdge, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NodeComponentEdge, error)
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.NodeComponentEdge, []int, error)
 
@@ -188,6 +189,35 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NodeComponentEdge, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "NodeComponentEdge")
+
+	var sacQueryFilter *v1.Query
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.NodeComponentEdge
+	for _, data := range rows {
+		msg := &storage.NodeComponentEdge{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Pod, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Pod, error)
 	Upsert(ctx context.Context, obj *storage.Pod) error
 	UpsertMany(ctx context.Context, objs []*storage.Pod) error
 	Delete(ctx context.Context, id string) error
@@ -552,6 +553,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Pod, 
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Pod, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "Pod")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.Pod
+	for _, data := range rows {
+		msg := &storage.Pod{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/pod/store/rocksdb/store.go
+++ b/central/pod/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.Pod) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Pod, error)
 }
 
 type storeImpl struct {
@@ -153,4 +157,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Pod, error) {
+	panic("unimplemented")
 }

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Policy, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Policy, error)
 	GetAll(ctx context.Context) ([]*storage.Policy, error)
 	Upsert(ctx context.Context, obj *storage.Policy) error
 	UpsertMany(ctx context.Context, objs []*storage.Policy) error
@@ -480,6 +481,41 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Polic
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Policy, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "Policy")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, nil
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.Policy
+	for _, data := range rows {
+		msg := &storage.Policy{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/policycategory/store/rocksdb/store.go
+++ b/central/policycategory/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.PolicyCategory) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.PolicyCategory, error)
 }
 
 type storeImpl struct {
@@ -157,4 +161,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.PolicyCategory, error) {
+	panic("unimplemented")
 }

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ProcessBaseline, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ProcessBaseline, error)
 	Upsert(ctx context.Context, obj *storage.ProcessBaseline) error
 	UpsertMany(ctx context.Context, objs []*storage.ProcessBaseline) error
 	Delete(ctx context.Context, id string) error
@@ -467,6 +468,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ProcessBaseline, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ProcessBaseline")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ProcessBaseline
+	for _, data := range rows {
+		msg := &storage.ProcessBaseline{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/processbaseline/store/rocksdb/store.go
+++ b/central/processbaseline/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.ProcessBaseline) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessBaseline, error)
 }
 
 type storeImpl struct {
@@ -159,4 +163,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessBaseline, error) {
+	panic("unimplemented")
 }

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, deploymentId string) (bool, error)
 	Get(ctx context.Context, deploymentId string) (*storage.ProcessBaselineResults, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ProcessBaselineResults, error)
 	Upsert(ctx context.Context, obj *storage.ProcessBaselineResults) error
 	UpsertMany(ctx context.Context, objs []*storage.ProcessBaselineResults) error
 	Delete(ctx context.Context, deploymentId string) error
@@ -462,6 +463,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ProcessBaselineResults, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ProcessBaselineResults")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ProcessBaselineResults
+	for _, data := range rows {
+		msg := &storage.ProcessBaselineResults{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/processbaselineresults/datastore/internal/store/rocksdb/store.go
+++ b/central/processbaselineresults/datastore/internal/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.ProcessBaselineResults) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessBaselineResults, error)
 }
 
 type storeImpl struct {
@@ -153,4 +157,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessBaselineResults, error) {
+	panic("unimplemented")
 }

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ProcessIndicator, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ProcessIndicator, error)
 	Upsert(ctx context.Context, obj *storage.ProcessIndicator) error
 	UpsertMany(ctx context.Context, objs []*storage.ProcessIndicator) error
 	Delete(ctx context.Context, id string) error
@@ -507,6 +508,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ProcessIndicator, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ProcessIndicator")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ProcessIndicator
+	for _, data := range rows {
+		msg := &storage.ProcessIndicator{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/processindicator/store/rocksdb/store.go
+++ b/central/processindicator/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.ProcessIndicator) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error)
 }
 
 type storeImpl struct {
@@ -153,4 +157,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error) {
+	panic("unimplemented")
 }

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.K8SRole, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.K8SRole, error)
 	Upsert(ctx context.Context, obj *storage.K8SRole) error
 	UpsertMany(ctx context.Context, objs []*storage.K8SRole) error
 	Delete(ctx context.Context, id string) error
@@ -487,6 +488,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.K8SRole, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "K8SRole")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.K8SRole
+	for _, data := range rows {
+		msg := &storage.K8SRole{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/rbac/k8srole/internal/store/rocksdb/store.go
+++ b/central/rbac/k8srole/internal/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.K8SRole) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.K8SRole, error)
 }
 
 type storeImpl struct {
@@ -153,4 +157,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.K8SRole, error) {
+	panic("unimplemented")
 }

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.K8SRoleBinding, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.K8SRoleBinding, error)
 	Upsert(ctx context.Context, obj *storage.K8SRoleBinding) error
 	UpsertMany(ctx context.Context, objs []*storage.K8SRoleBinding) error
 	Delete(ctx context.Context, id string) error
@@ -577,6 +578,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.K8SRoleBinding, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "K8SRoleBinding")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.K8SRoleBinding
+	for _, data := range rows {
+		msg := &storage.K8SRoleBinding{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/rbac/k8srolebinding/internal/store/rocksdb/store.go
+++ b/central/rbac/k8srolebinding/internal/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.K8SRoleBinding) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.K8SRoleBinding, error)
 }
 
 type storeImpl struct {
@@ -153,4 +157,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.K8SRoleBinding, error) {
+	panic("unimplemented")
 }

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ReportConfiguration, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ReportConfiguration, error)
 	Upsert(ctx context.Context, obj *storage.ReportConfiguration) error
 	UpsertMany(ctx context.Context, objs []*storage.ReportConfiguration) error
 	Delete(ctx context.Context, id string) error
@@ -424,6 +425,41 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Repor
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ReportConfiguration, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ReportConfiguration")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	if ok, err := scopeChecker.Allowed(ctx); err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, nil
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ReportConfiguration
+	for _, data := range rows {
+		msg := &storage.ReportConfiguration{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/reportconfigurations/store/rocksdb/store.go
+++ b/central/reportconfigurations/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.ReportConfiguration) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ReportConfiguration, error)
 }
 
 type storeImpl struct {
@@ -159,4 +163,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ReportConfiguration, error) {
+	panic("unimplemented")
 }

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Risk, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Risk, error)
 	Upsert(ctx context.Context, obj *storage.Risk) error
 	UpsertMany(ctx context.Context, objs []*storage.Risk) error
 	Delete(ctx context.Context, id string) error
@@ -472,6 +473,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Risk,
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Risk, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "Risk")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.Risk
+	for _, data := range rows {
+		msg := &storage.Risk{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/risk/datastore/internal/store/rocksdb/store.go
+++ b/central/risk/datastore/internal/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.Risk) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Risk, error)
 }
 
 type storeImpl struct {
@@ -153,4 +157,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Risk, error) {
+	panic("unimplemented")
 }

--- a/central/role/datastore/singleton.go
+++ b/central/role/datastore/singleton.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/central/globaldb"
 	rolePkg "github.com/stackrox/rox/central/role"
 	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/central/role/store"
 	PermissionSetPGStore "github.com/stackrox/rox/central/role/store/permissionset/postgres"
 	permissionSetPGStore "github.com/stackrox/rox/central/role/store/permissionset/rocksdb"
 	postgresRolePGStore "github.com/stackrox/rox/central/role/store/role/postgres"
@@ -29,9 +30,9 @@ var (
 // Singleton returns the singleton providing access to the roles store.
 func Singleton() DataStore {
 	once.Do(func() {
-		var roleStorage roleStore.Store
-		var permissionSetStorage permissionSetPGStore.Store
-		var accessScopeStorage simpleAccessScopeStore.Store
+		var roleStorage store.RoleStore
+		var permissionSetStorage store.PermissionSetStore
+		var accessScopeStorage store.SimpleAccessScopeStore
 		if features.PostgresDatastore.Enabled() {
 			roleStorage = postgresRolePGStore.New(globaldb.GetPostgres())
 			permissionSetStorage = PermissionSetPGStore.New(globaldb.GetPostgres())

--- a/central/role/store/mocks/store.go
+++ b/central/role/store/mocks/store.go
@@ -79,6 +79,20 @@ func (mr *MockPermissionSetStoreMockRecorder) Upsert(ctx, obj interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*MockPermissionSetStore)(nil).Upsert), ctx, obj)
 }
 
+// UpsertMany mocks base method.
+func (m *MockPermissionSetStore) UpsertMany(ctx context.Context, obj []*storage.PermissionSet) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertMany", ctx, obj)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertMany indicates an expected call of UpsertMany.
+func (mr *MockPermissionSetStoreMockRecorder) UpsertMany(ctx, obj interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertMany", reflect.TypeOf((*MockPermissionSetStore)(nil).UpsertMany), ctx, obj)
+}
+
 // Walk mocks base method.
 func (m *MockPermissionSetStore) Walk(ctx context.Context, fn func(*storage.PermissionSet) error) error {
 	m.ctrl.T.Helper()
@@ -160,6 +174,20 @@ func (mr *MockSimpleAccessScopeStoreMockRecorder) Upsert(ctx, obj interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*MockSimpleAccessScopeStore)(nil).Upsert), ctx, obj)
 }
 
+// UpsertMany mocks base method.
+func (m *MockSimpleAccessScopeStore) UpsertMany(ctx context.Context, obj []*storage.SimpleAccessScope) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertMany", ctx, obj)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertMany indicates an expected call of UpsertMany.
+func (mr *MockSimpleAccessScopeStoreMockRecorder) UpsertMany(ctx, obj interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertMany", reflect.TypeOf((*MockSimpleAccessScopeStore)(nil).UpsertMany), ctx, obj)
+}
+
 // Walk mocks base method.
 func (m *MockSimpleAccessScopeStore) Walk(ctx context.Context, fn func(*storage.SimpleAccessScope) error) error {
 	m.ctrl.T.Helper()
@@ -239,6 +267,20 @@ func (m *MockRoleStore) Upsert(ctx context.Context, obj *storage.Role) error {
 func (mr *MockRoleStoreMockRecorder) Upsert(ctx, obj interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*MockRoleStore)(nil).Upsert), ctx, obj)
+}
+
+// UpsertMany mocks base method.
+func (m *MockRoleStore) UpsertMany(ctx context.Context, obj []*storage.Role) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertMany", ctx, obj)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertMany indicates an expected call of UpsertMany.
+func (mr *MockRoleStoreMockRecorder) UpsertMany(ctx, obj interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertMany", reflect.TypeOf((*MockRoleStore)(nil).UpsertMany), ctx, obj)
 }
 
 // Walk mocks base method.

--- a/central/role/store/permissionset/rocksdb/store.go
+++ b/central/role/store/permissionset/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.PermissionSet) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.PermissionSet, error)
 }
 
 type storeImpl struct {
@@ -163,4 +167,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.PermissionSet, error) {
+	panic("unimplemented")
 }

--- a/central/role/store/role/rocksdb/store.go
+++ b/central/role/store/role/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.Role) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Role, error)
 }
 
 type storeImpl struct {
@@ -159,4 +163,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Role, error) {
+	panic("unimplemented")
 }

--- a/central/role/store/simpleaccessscope/rocksdb/store.go
+++ b/central/role/store/simpleaccessscope/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.SimpleAccessScope) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.SimpleAccessScope, error)
 }
 
 type storeImpl struct {
@@ -163,4 +167,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.SimpleAccessScope, error) {
+	panic("unimplemented")
 }

--- a/central/role/store/store.go
+++ b/central/role/store/store.go
@@ -11,6 +11,7 @@ import (
 type PermissionSetStore interface {
 	Get(ctx context.Context, id string) (*storage.PermissionSet, bool, error)
 	Upsert(ctx context.Context, obj *storage.PermissionSet) error
+	UpsertMany(ctx context.Context, obj []*storage.PermissionSet) error
 	Delete(ctx context.Context, id string) error
 	Walk(ctx context.Context, fn func(obj *storage.PermissionSet) error) error
 }
@@ -20,6 +21,7 @@ type PermissionSetStore interface {
 type SimpleAccessScopeStore interface {
 	Get(ctx context.Context, id string) (*storage.SimpleAccessScope, bool, error)
 	Upsert(ctx context.Context, obj *storage.SimpleAccessScope) error
+	UpsertMany(ctx context.Context, obj []*storage.SimpleAccessScope) error
 	Delete(ctx context.Context, id string) error
 	Walk(ctx context.Context, fn func(obj *storage.SimpleAccessScope) error) error
 }
@@ -29,6 +31,7 @@ type SimpleAccessScopeStore interface {
 type RoleStore interface {
 	Get(ctx context.Context, id string) (*storage.Role, bool, error)
 	Upsert(ctx context.Context, obj *storage.Role) error
+	UpsertMany(ctx context.Context, obj []*storage.Role) error
 	Delete(ctx context.Context, id string) error
 	Walk(ctx context.Context, fn func(obj *storage.Role) error) error
 }

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Secret, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Secret, error)
 	Upsert(ctx context.Context, obj *storage.Secret) error
 	UpsertMany(ctx context.Context, objs []*storage.Secret) error
 	Delete(ctx context.Context, id string) error
@@ -647,6 +648,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Secre
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Secret, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "Secret")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.Secret
+	for _, data := range rows {
+		msg := &storage.Secret{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/secret/internal/store/rocksdb/store.go
+++ b/central/secret/internal/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.Secret) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Secret, error)
 }
 
 type storeImpl struct {
@@ -153,4 +157,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Secret, error) {
+	panic("unimplemented")
 }

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ServiceAccount, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ServiceAccount, error)
 	Upsert(ctx context.Context, obj *storage.ServiceAccount) error
 	UpsertMany(ctx context.Context, objs []*storage.ServiceAccount) error
 	Delete(ctx context.Context, id string) error
@@ -482,6 +483,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Servi
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ServiceAccount, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "ServiceAccount")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ServiceAccount
+	for _, data := range rows {
+		msg := &storage.ServiceAccount{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/serviceaccount/internal/store/rocksdb/store.go
+++ b/central/serviceaccount/internal/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.ServiceAccount) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ServiceAccount, error)
 }
 
 type storeImpl struct {
@@ -153,4 +157,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ServiceAccount, error) {
+	panic("unimplemented")
 }

--- a/central/signatureintegration/store/rocksdb/store.go
+++ b/central/signatureintegration/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.SignatureIntegration) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.SignatureIntegration, error)
 }
 
 type storeImpl struct {
@@ -163,4 +167,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.SignatureIntegration, error) {
+	panic("unimplemented")
 }

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -47,6 +47,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.VulnerabilityRequest, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.VulnerabilityRequest, error)
 	Upsert(ctx context.Context, obj *storage.VulnerabilityRequest) error
 	UpsertMany(ctx context.Context, objs []*storage.VulnerabilityRequest) error
 	Delete(ctx context.Context, id string) error
@@ -593,6 +594,39 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Vulne
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.VulnerabilityRequest, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "VulnerabilityRequest")
+
+	var sacQueryFilter *v1.Query
+	if ok, err := permissionCheckerSingleton().GetManyAllowed(ctx); err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, nil
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.VulnerabilityRequest
+	for _, data := range rows {
+		msg := &storage.VulnerabilityRequest{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/vulnerabilityrequest/datastore/internal/store/rocksdb/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -36,6 +37,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.VulnerabilityRequest) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.VulnerabilityRequest, error)
 }
 
 type storeImpl struct {
@@ -153,4 +157,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.VulnerabilityRequest, error) {
+	panic("unimplemented")
 }

--- a/central/watchedimage/datastore/internal/store/rocksdb/store.go
+++ b/central/watchedimage/datastore/internal/store/rocksdb/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -37,6 +38,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.WatchedImage) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.WatchedImage, error)
 }
 
 type storeImpl struct {
@@ -159,4 +163,9 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.WatchedImage, error) {
+	panic("unimplemented")
 }

--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Cluster, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Cluster, error)
 	Upsert(ctx context.Context, obj *storage.Cluster) error
 	UpsertMany(ctx context.Context, objs []*storage.Cluster) error
 	Delete(ctx context.Context, id string) error
@@ -358,6 +359,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Cluster, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.Cluster
+	for _, data := range rows {
+		msg := &storage.Cluster{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.NamespaceMetadata, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NamespaceMetadata, error)
 	Upsert(ctx context.Context, obj *storage.NamespaceMetadata) error
 	UpsertMany(ctx context.Context, objs []*storage.NamespaceMetadata) error
 	Delete(ctx context.Context, id string) error
@@ -373,6 +374,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Names
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NamespaceMetadata, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.NamespaceMetadata
+	for _, data := range rows {
+		msg := &storage.NamespaceMetadata{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Alert, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Alert, error)
 	Upsert(ctx context.Context, obj *storage.Alert) error
 	UpsertMany(ctx context.Context, objs []*storage.Alert) error
 	Delete(ctx context.Context, id string) error
@@ -503,6 +504,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Alert
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Alert, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.Alert
+	for _, data := range rows {
+		msg := &storage.Alert{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ClusterHealthStatus, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ClusterHealthStatus, error)
 	Upsert(ctx context.Context, obj *storage.ClusterHealthStatus) error
 	UpsertMany(ctx context.Context, objs []*storage.ClusterHealthStatus) error
 	Delete(ctx context.Context, id string) error
@@ -378,6 +379,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ClusterHealthStatus, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ClusterHealthStatus
+	for _, data := range rows {
+		msg := &storage.ClusterHealthStatus{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ComplianceDomain, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ComplianceDomain, error)
 	Upsert(ctx context.Context, obj *storage.ComplianceDomain) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceDomain) error
 	Delete(ctx context.Context, id string) error
@@ -363,6 +364,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ComplianceDomain, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ComplianceDomain
+	for _, data := range rows {
+		msg := &storage.ComplianceDomain{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, runId string) (bool, error)
 	Get(ctx context.Context, runId string) (*storage.ComplianceRunMetadata, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ComplianceRunMetadata, error)
 	Upsert(ctx context.Context, obj *storage.ComplianceRunMetadata) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceRunMetadata) error
 	Delete(ctx context.Context, runId string) error
@@ -363,6 +364,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ComplianceRunMetadata, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ComplianceRunMetadata
+	for _, data := range rows {
+		msg := &storage.ComplianceRunMetadata{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, runMetadataRunId string) (bool, error)
 	Get(ctx context.Context, runMetadataRunId string) (*storage.ComplianceRunResults, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ComplianceRunResults, error)
 	Upsert(ctx context.Context, obj *storage.ComplianceRunResults) error
 	UpsertMany(ctx context.Context, objs []*storage.ComplianceRunResults) error
 	Delete(ctx context.Context, runMetadataRunId string) error
@@ -363,6 +364,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ComplianceRunResults, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ComplianceRunResults
+	for _, data := range rows {
+		msg := &storage.ComplianceRunResults{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.K8SRole, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.K8SRole, error)
 	Upsert(ctx context.Context, obj *storage.K8SRole) error
 	UpsertMany(ctx context.Context, objs []*storage.K8SRole) error
 	Delete(ctx context.Context, id string) error
@@ -383,6 +384,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.K8SRole, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.K8SRole
+	for _, data := range rows {
+		msg := &storage.K8SRole{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, deploymentId string) (bool, error)
 	Get(ctx context.Context, deploymentId string) (*storage.NetworkBaseline, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NetworkBaseline, error)
 	Upsert(ctx context.Context, obj *storage.NetworkBaseline) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkBaseline) error
 	Delete(ctx context.Context, deploymentId string) error
@@ -358,6 +359,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NetworkBaseline, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.NetworkBaseline
+	for _, data := range rows {
+		msg := &storage.NetworkBaseline{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Pod, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Pod, error)
 	Upsert(ctx context.Context, obj *storage.Pod) error
 	UpsertMany(ctx context.Context, objs []*storage.Pod) error
 	Delete(ctx context.Context, id string) error
@@ -448,6 +449,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Pod, 
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Pod, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.Pod
+	for _, data := range rows {
+		msg := &storage.Pod{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Policy, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Policy, error)
 	GetAll(ctx context.Context) ([]*storage.Policy, error)
 	Upsert(ctx context.Context, obj *storage.Policy) error
 	UpsertMany(ctx context.Context, objs []*storage.Policy) error
@@ -413,6 +414,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Polic
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Policy, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.Policy
+	for _, data := range rows {
+		msg := &storage.Policy{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ProcessBaseline, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ProcessBaseline, error)
 	Upsert(ctx context.Context, obj *storage.ProcessBaseline) error
 	UpsertMany(ctx context.Context, objs []*storage.ProcessBaseline) error
 	Delete(ctx context.Context, id string) error
@@ -363,6 +364,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ProcessBaseline, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ProcessBaseline
+	for _, data := range rows {
+		msg := &storage.ProcessBaseline{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ReportConfiguration, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ReportConfiguration, error)
 	Upsert(ctx context.Context, obj *storage.ReportConfiguration) error
 	UpsertMany(ctx context.Context, objs []*storage.ReportConfiguration) error
 	Delete(ctx context.Context, id string) error
@@ -358,6 +359,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Repor
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ReportConfiguration, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ReportConfiguration
+	for _, data := range rows {
+		msg := &storage.ReportConfiguration{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Risk, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Risk, error)
 	Upsert(ctx context.Context, obj *storage.Risk) error
 	UpsertMany(ctx context.Context, objs []*storage.Risk) error
 	Delete(ctx context.Context, id string) error
@@ -368,6 +369,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Risk,
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Risk, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.Risk
+	for _, data := range rows {
+		msg := &storage.Risk{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.K8SRoleBinding, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.K8SRoleBinding, error)
 	Upsert(ctx context.Context, obj *storage.K8SRoleBinding) error
 	UpsertMany(ctx context.Context, objs []*storage.K8SRoleBinding) error
 	Delete(ctx context.Context, id string) error
@@ -473,6 +474,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.K8SRoleBinding, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.K8SRoleBinding
+	for _, data := range rows {
+		msg := &storage.K8SRoleBinding{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Secret, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Secret, error)
 	Upsert(ctx context.Context, obj *storage.Secret) error
 	UpsertMany(ctx context.Context, objs []*storage.Secret) error
 	Delete(ctx context.Context, id string) error
@@ -543,6 +544,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Secre
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Secret, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.Secret
+	for _, data := range rows {
+		msg := &storage.Secret{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ServiceAccount, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ServiceAccount, error)
 	Upsert(ctx context.Context, obj *storage.ServiceAccount) error
 	UpsertMany(ctx context.Context, objs []*storage.ServiceAccount) error
 	Delete(ctx context.Context, id string) error
@@ -378,6 +379,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Servi
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ServiceAccount, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ServiceAccount
+	for _, data := range rows {
+		msg := &storage.ServiceAccount{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.VulnerabilityRequest, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.VulnerabilityRequest, error)
 	Upsert(ctx context.Context, obj *storage.VulnerabilityRequest) error
 	UpsertMany(ctx context.Context, objs []*storage.VulnerabilityRequest) error
 	Delete(ctx context.Context, id string) error
@@ -546,6 +547,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Vulne
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.VulnerabilityRequest, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.VulnerabilityRequest
+	for _, data := range rows {
+		msg := &storage.VulnerabilityRequest{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.PolicyCategory, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.PolicyCategory, error)
 	Upsert(ctx context.Context, obj *storage.PolicyCategory) error
 	UpsertMany(ctx context.Context, objs []*storage.PolicyCategory) error
 	Delete(ctx context.Context, id string) error
@@ -353,6 +354,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Polic
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.PolicyCategory, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.PolicyCategory
+	for _, data := range rows {
+		msg := &storage.PolicyCategory{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/pkg/metrics/op_string.go
+++ b/pkg/metrics/op_string.go
@@ -17,25 +17,26 @@ func _() {
 	_ = x[GetAll-6]
 	_ = x[GetMany-7]
 	_ = x[GetFlowsForDeployment-8]
-	_ = x[GetGrouped-9]
-	_ = x[List-10]
-	_ = x[Prune-11]
-	_ = x[Reset-12]
-	_ = x[Rename-13]
-	_ = x[Remove-14]
-	_ = x[RemoveMany-15]
-	_ = x[RemoveFlowsByDeployment-16]
-	_ = x[Search-17]
-	_ = x[Sync-18]
-	_ = x[Update-19]
-	_ = x[UpdateMany-20]
-	_ = x[Upsert-21]
-	_ = x[UpsertAll-22]
+	_ = x[GetByQuery-9]
+	_ = x[GetGrouped-10]
+	_ = x[List-11]
+	_ = x[Prune-12]
+	_ = x[Reset-13]
+	_ = x[Rename-14]
+	_ = x[Remove-15]
+	_ = x[RemoveMany-16]
+	_ = x[RemoveFlowsByDeployment-17]
+	_ = x[Search-18]
+	_ = x[Sync-19]
+	_ = x[Update-20]
+	_ = x[UpdateMany-21]
+	_ = x[Upsert-22]
+	_ = x[UpsertAll-23]
 }
 
-const _Op_name = "AddAddManyCountDedupeExistsGetGetAllGetManyGetFlowsForDeploymentGetGroupedListPruneResetRenameRemoveRemoveManyRemoveFlowsByDeploymentSearchSyncUpdateUpdateManyUpsertUpsertAll"
+const _Op_name = "AddAddManyCountDedupeExistsGetGetAllGetManyGetFlowsForDeploymentGetByQueryGetGroupedListPruneResetRenameRemoveRemoveManyRemoveFlowsByDeploymentSearchSyncUpdateUpdateManyUpsertUpsertAll"
 
-var _Op_index = [...]uint8{0, 3, 10, 15, 21, 27, 30, 36, 43, 64, 74, 78, 83, 88, 94, 100, 110, 133, 139, 143, 149, 159, 165, 174}
+var _Op_index = [...]uint8{0, 3, 10, 15, 21, 27, 30, 36, 43, 64, 74, 84, 88, 93, 98, 104, 110, 120, 143, 149, 153, 159, 169, 175, 184}
 
 func (i Op) String() string {
 	if i < 0 || i >= Op(len(_Op_index)-1) {

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -19,6 +19,7 @@ const (
 	GetAll
 	GetMany
 	GetFlowsForDeployment
+	GetByQuery
 
 	// Special operation currently used only for processes.
 	GetGrouped

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, key1 string, key2 string) (bool, error)
 	Get(ctx context.Context, key1 string, key2 string) (*storage.TestMultiKeyStruct, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestMultiKeyStruct, error)
 	Upsert(ctx context.Context, obj *storage.TestMultiKeyStruct) error
 	UpsertMany(ctx context.Context, objs []*storage.TestMultiKeyStruct) error
 	Delete(ctx context.Context, key1 string, key2 string) error
@@ -608,6 +609,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestM
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestMultiKeyStruct, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "TestMultiKeyStruct")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.TestMultiKeyStruct
+	for _, data := range rows {
+		msg := &storage.TestMultiKeyStruct{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -75,6 +75,9 @@ type Store interface {
     Count(ctx context.Context) (int, error)
     Exists(ctx context.Context, {{template "paramList" $pks}}) (bool, error)
     Get(ctx context.Context, {{template "paramList" $pks}}) (*{{.Type}}, bool, error)
+{{- if .SearchCategory }}
+    GetByQuery(ctx context.Context, query *v1.Query) ([]*{{.Type}}, error)
+{{- end }}
 {{- if .GetAll }}
     GetAll(ctx context.Context) ([]*{{.Type}}, error)
 {{- end }}
@@ -765,6 +768,70 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []{{$singlePK.Type}}) ([]*{
 	}
 	return elems, missingIndices, nil
 }
+{{- if .SearchCategory }}
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*{{.Type}}, error) {
+    {{- if not $inMigration}}
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "{{.TrimmedType}}")
+    {{- end}}{{/* if not .inMigration */}}
+
+    var sacQueryFilter *v1.Query
+    {{- if not $inMigration}}
+    {{ if .Obj.HasPermissionChecker -}}
+    if ok, err := {{ .PermissionChecker }}.GetManyAllowed(ctx); err != nil {
+        return nil, err
+    } else if !ok {
+        return nil, nil
+    }
+    {{- else if .Obj.IsGloballyScoped }}
+    {{ template "defineScopeChecker" "READ" }}
+    if ok, err := scopeChecker.Allowed(ctx); err != nil {
+        return nil, err
+    } else if !ok {
+        return nil, nil
+    }
+    {{- else if or (.Obj.IsDirectlyScoped) (.Obj.IsIndirectlyScoped) }}
+    {{ template "defineScopeChecker" "READ" }}
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+        return nil, err
+	}
+    {{- if .Obj.IsClusterScope }}
+    sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+    {{- else}}
+    sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+    {{- end }}
+	if err != nil {
+        return nil, err
+	}
+    {{- end }}
+    {{- end}}{{/* if not .inMigration */}}
+    q := search.ConjunctionQuery(
+        sacQueryFilter,
+        query,
+    )
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+		    return nil, nil
+		}
+		return nil, err
+	}
+	var results []*{{.Type}}
+    for _, data := range rows {
+		msg := &{{.Type}}{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+		    return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
+}
+{{- end }}
 
 {{- if not .JoinTable }}
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, key string) (bool, error)
 	Get(ctx context.Context, key string) (*storage.TestSingleKeyStruct, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestSingleKeyStruct, error)
 	GetAll(ctx context.Context) ([]*storage.TestSingleKeyStruct, error)
 	Upsert(ctx context.Context, obj *storage.TestSingleKeyStruct) error
 	UpsertMany(ctx context.Context, objs []*storage.TestSingleKeyStruct) error
@@ -500,6 +501,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestS
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestSingleKeyStruct, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "TestSingleKeyStruct")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.TestSingleKeyStruct
+	for _, data := range rows {
+		msg := &storage.TestSingleKeyStruct{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestChild1, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestChild1, error)
 	Upsert(ctx context.Context, obj *storage.TestChild1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestChild1) error
 	Delete(ctx context.Context, id string) error
@@ -444,6 +445,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestC
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestChild1, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "TestChild1")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.TestChild1
+	for _, data := range rows {
+		msg := &storage.TestChild1{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestChild1P4, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestChild1P4, error)
 	Upsert(ctx context.Context, obj *storage.TestChild1P4) error
 	UpsertMany(ctx context.Context, objs []*storage.TestChild1P4) error
 	Delete(ctx context.Context, id string) error
@@ -449,6 +450,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestC
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestChild1P4, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "TestChild1P4")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.TestChild1P4
+	for _, data := range rows {
+		msg := &storage.TestChild1P4{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestChild2, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestChild2, error)
 	Upsert(ctx context.Context, obj *storage.TestChild2) error
 	UpsertMany(ctx context.Context, objs []*storage.TestChild2) error
 	Delete(ctx context.Context, id string) error
@@ -454,6 +455,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestC
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestChild2, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "TestChild2")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.TestChild2
+	for _, data := range rows {
+		msg := &storage.TestChild2{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestG2GrandChild1, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestG2GrandChild1, error)
 	Upsert(ctx context.Context, obj *storage.TestG2GrandChild1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestG2GrandChild1) error
 	Delete(ctx context.Context, id string) error
@@ -454,6 +455,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestG2GrandChild1, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "TestG2GrandChild1")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.TestG2GrandChild1
+	for _, data := range rows {
+		msg := &storage.TestG2GrandChild1{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestG3GrandChild1, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestG3GrandChild1, error)
 	Upsert(ctx context.Context, obj *storage.TestG3GrandChild1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestG3GrandChild1) error
 	Delete(ctx context.Context, id string) error
@@ -444,6 +445,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestG3GrandChild1, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "TestG3GrandChild1")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.TestG3GrandChild1
+	for _, data := range rows {
+		msg := &storage.TestG3GrandChild1{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestGGrandChild1, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestGGrandChild1, error)
 	Upsert(ctx context.Context, obj *storage.TestGGrandChild1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestGGrandChild1) error
 	Delete(ctx context.Context, id string) error
@@ -444,6 +445,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestGGrandChild1, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "TestGGrandChild1")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.TestGGrandChild1
+	for _, data := range rows {
+		msg := &storage.TestGGrandChild1{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestGrandChild1, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestGrandChild1, error)
 	Upsert(ctx context.Context, obj *storage.TestGrandChild1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestGrandChild1) error
 	Delete(ctx context.Context, id string) error
@@ -454,6 +455,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestGrandChild1, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "TestGrandChild1")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.TestGrandChild1
+	for _, data := range rows {
+		msg := &storage.TestGrandChild1{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestGrandparent, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestGrandparent, error)
 	Upsert(ctx context.Context, obj *storage.TestGrandparent) error
 	UpsertMany(ctx context.Context, objs []*storage.TestGrandparent) error
 	Delete(ctx context.Context, id string) error
@@ -619,6 +620,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestGrandparent, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "TestGrandparent")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.TestGrandparent
+	for _, data := range rows {
+		msg := &storage.TestGrandparent{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestParent1, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestParent1, error)
 	Upsert(ctx context.Context, obj *storage.TestParent1) error
 	UpsertMany(ctx context.Context, objs []*storage.TestParent1) error
 	Delete(ctx context.Context, id string) error
@@ -529,6 +530,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestParent1, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "TestParent1")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.TestParent1
+	for _, data := range rows {
+		msg := &storage.TestParent1{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestParent2, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestParent2, error)
 	Upsert(ctx context.Context, obj *storage.TestParent2) error
 	UpsertMany(ctx context.Context, objs []*storage.TestParent2) error
 	Delete(ctx context.Context, id string) error
@@ -449,6 +450,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestParent2, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "TestParent2")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.TestParent2
+	for _, data := range rows {
+		msg := &storage.TestParent2{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestParent3, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestParent3, error)
 	Upsert(ctx context.Context, obj *storage.TestParent3) error
 	UpsertMany(ctx context.Context, objs []*storage.TestParent3) error
 	Delete(ctx context.Context, id string) error
@@ -449,6 +450,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestParent3, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "TestParent3")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.TestParent3
+	for _, data := range rows {
+		msg := &storage.TestParent3{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.TestShortCircuit, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestShortCircuit, error)
 	Upsert(ctx context.Context, obj *storage.TestShortCircuit) error
 	UpsertMany(ctx context.Context, objs []*storage.TestShortCircuit) error
 	Delete(ctx context.Context, id string) error
@@ -449,6 +450,47 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestS
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TestShortCircuit, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "TestShortCircuit")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.TestShortCircuit
+	for _, data := range rows {
+		msg := &storage.TestShortCircuit{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/rocksdb-bindings/main.go
+++ b/tools/generate-helpers/rocksdb-bindings/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
@@ -52,6 +53,9 @@ type Store interface {
 	Walk(ctx context.Context, fn func(obj *storage.{{.Type}}) error) error
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
+
+	// Unused and only exists to satisfy interfaces used for Postgres
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.{{.Type}}, error)
 }
 
 type storeImpl struct {
@@ -200,6 +204,11 @@ func (b *storeImpl) AckKeysIndexed(_ context.Context, keys ...string) error {
 // GetKeysToIndex returns the keys that need to be indexed
 func (b *storeImpl) GetKeysToIndex(_ context.Context) ([]string, error) {
 	return b.crud.GetKeysToIndex()
+}
+
+// GetByQuery is unused and only exists to satisfy interfaces used for Postgres
+func (b * storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.{{.Type}}, error) {
+	panic("unimplemented")
 }
 `
 


### PR DESCRIPTION
## Description

Will allow to query objects by search instead of the two step getting of IDs then objects

Will benefit calls to:
```
SearchRawActiveComponents
SearchRawAlerts
SearchRawCVEs
SearchRawCategories
SearchRawClusterCVEs
SearchRawClusters
SearchRawDeployments
SearchRawEdges
SearchRawImageCVEs
SearchRawImageComponents
SearchRawImages
SearchRawNodeComponents
SearchRawNodes
SearchRawPods
SearchRawPolicies
SearchRawPolicyCategories
SearchRawProcessBaselines
SearchRawProcessIndicators
SearchRawRequests
SearchRawRisks
SearchRawRoleBindings
SearchRawRoles
SearchRawSecrets
SearchRawServiceAccounts
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Will add more testing in a follow up
