### PR TITLE
Replace `grpc.WithInsecure()`

### DIFF
--- a/pkg/clientconn/client.go
+++ b/pkg/clientconn/client.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 )
 
@@ -366,7 +367,7 @@ func GRPCConnection(dialCtx context.Context, server mtls.Subject, endpoint strin
 			return nil, errors.Wrap(err, "instantiating TLS config")
 		}
 	} else {
-		allDialOpts = append(allDialOpts, grpc.WithInsecure())
+		allDialOpts = append(allDialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
 	if perRPCCreds := clientConnOpts.PerRPCCreds; perRPCCreds != nil {

--- a/pkg/clientconn/dial_tls.go
+++ b/pkg/clientconn/dial_tls.go
@@ -14,7 +14,8 @@ type DialTLSFunc func(ctx context.Context, endpoint string, tlsClientConf *tls.C
 
 // DialTLS establishes a gRPC connection to the given endpoint, optionally using TLS for securing the transport layer
 // and the given dial options.
-// Note: if tlsClientConf is nil, the options *must* contain `WithInsecure()`, otherwise the connection will fail.
+// Note: if tlsClientConf is nil, the options *must* contain `WithInsecure()` or `WithTransportCredentials(insecure.NewCredentials())`,
+// otherwise the connection will fail.
 func DialTLS(ctx context.Context, endpoint string, tlsClientConf *tls.Config, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	allOpts := make([]grpc.DialOption, 0, len(opts)+1)
 	if tlsClientConf != nil {
@@ -27,7 +28,8 @@ func DialTLS(ctx context.Context, endpoint string, tlsClientConf *tls.Config, op
 
 // DialTLSWebSocket establishes a gRPC connection via a WebSocket proxy to the given endpoint,
 // optionally using TLS for securing the transport layer and the given dial options.
-// Note: if tlsClientConf is nil, the options *must* contain `WithInsecure()`, otherwise the connection will fail.
+// Note: if tlsClientConf is nil, the options *must* contain `WithInsecure()` or `WithTransportCredentials(insecure.NewCredentials())`,
+// otherwise the connection will fail.
 func DialTLSWebSocket(ctx context.Context, endpoint string, tlsClientConf *tls.Config, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	return client.ConnectViaProxy(ctx, endpoint, tlsClientConf, client.DialOpts(opts...), client.UseWebSocket(true))
 }

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stackrox/rox/pkg/netutil/pipeconn"
 	promhttp "github.com/travelaudience/go-promhttp"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 
 	// All our gRPC servers should support gzip
@@ -223,7 +224,7 @@ func (a *apiImpl) listenOnLocalEndpoint(server *grpc.Server) pipeconn.DialContex
 }
 
 func (a *apiImpl) connectToLocalEndpoint(dialCtxFunc pipeconn.DialContextFunc) (*grpc.ClientConn, error) {
-	return grpc.Dial("", grpc.WithInsecure(),
+	return grpc.Dial("", grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(func(ctx context.Context, endpoint string) (net.Conn, error) {
 			return dialCtxFunc(ctx)
 		}),

--- a/pkg/grpc/util/lazy_conn_test.go
+++ b/pkg/grpc/util/lazy_conn_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/examples/helloworld/helloworld"
 )
 
@@ -75,7 +76,7 @@ func TestLazyConn(t *testing.T) {
 	assert.True(t, errors.Is(failCtx.Err(), context.DeadlineExceeded), "Error types did not match")
 
 	// connect to gRPC server
-	conn, err := grpc.Dial(listener.Addr().String(), grpc.WithInsecure(), grpc.WithBlock())
+	conn, err := grpc.Dial(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	require.NoError(t, err)
 	defer utils.IgnoreError(conn.Close)
 

--- a/roxctl/central/whoami/whoami_test.go
+++ b/roxctl/central/whoami/whoami_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/roxctl/common/mocks"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -69,7 +70,7 @@ func (c *centralWhoAmITestSuite) createGRPCMockServices(mockServer *mockAuthServ
 
 	conn, err := grpc.DialContext(context.Background(), "", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
 		return listener.Dial()
-	}), grpc.WithInsecure())
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	c.Require().NoError(err)
 
 	closeFunction := func() {

--- a/roxctl/cluster/delete/delete_test.go
+++ b/roxctl/cluster/delete/delete_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/roxctl/common/mocks"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -55,7 +56,7 @@ func (c *clusterDeleteTestSuite) createGRPCMockClustersService(clusters []*stora
 
 	conn, err := grpc.DialContext(context.Background(), "", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
 		return listener.Dial()
-	}), grpc.WithInsecure())
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	c.Require().NoError(err)
 
 	closeFunction := func() {

--- a/roxctl/deployment/check/check_test.go
+++ b/roxctl/deployment/check/check_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stackrox/rox/roxctl/summaries/policy"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -250,7 +251,7 @@ func (d *deployCheckTestSuite) createGRPCMockDetectionService(alerts []*storage.
 
 	conn, err := grpc.DialContext(context.Background(), "", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
 		return listener.Dial()
-	}), grpc.WithInsecure())
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	d.Require().NoError(err)
 
 	closeFunction := func() {

--- a/roxctl/image/check/check_test.go
+++ b/roxctl/image/check/check_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stackrox/rox/roxctl/summaries/policy"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -213,7 +214,7 @@ func (suite *imageCheckTestSuite) createGRPCServerWithDetectionService(alerts []
 
 	conn, _ := grpc.DialContext(context.Background(), "", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
 		return listener.Dial()
-	}), grpc.WithInsecure())
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
 
 	closeF := func() {
 		utils.IgnoreError(listener.Close)

--- a/roxctl/image/scan/scan_test.go
+++ b/roxctl/image/scan/scan_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stackrox/rox/roxctl/common/printer"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -241,7 +242,7 @@ func (s *imageScanTestSuite) createGRPCMockImageService(components []*storage.Em
 
 	conn, err := grpc.DialContext(context.Background(), "", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
 		return listener.Dial()
-	}), grpc.WithInsecure())
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	s.Require().NoError(err)
 
 	closeF := func() {

--- a/roxctl/sensor/generate/generate_test.go
+++ b/roxctl/sensor/generate/generate_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
@@ -103,7 +104,7 @@ func (s *sensorGenerateTestSuite) createGRPCMockClustersService(getDefaultsF get
 
 	conn, err := grpc.DialContext(context.Background(), "", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
 		return listener.Dial()
-	}), grpc.WithInsecure())
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	s.Require().NoError(err)
 
 	closeF := func() {

--- a/tests/endpoints_test.go
+++ b/tests/endpoints_test.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
@@ -213,13 +214,13 @@ func (c *endpointsTestCase) verifyAuthStatus(t *testing.T, testCtx *endpointsTes
 }
 
 func (c *endpointsTestCase) runGRPCTest(t *testing.T, testCtx *endpointsTestContext) {
-	var dialOpt grpc.DialOption
+	var creds credentials.TransportCredentials
 	if c.skipTLS {
-		dialOpt = grpc.WithInsecure()
+		creds = insecure.NewCredentials()
 	} else {
-		dialOpt = grpc.WithTransportCredentials(credentials.NewTLS(testCtx.tlsConfig(c.clientCert, c.validServerNames[0], true)))
+		creds = credentials.NewTLS(testCtx.tlsConfig(c.clientCert, c.validServerNames[0], true))
 	}
-	conn, err := grpc.Dial(c.endpoint(), dialOpt)
+	conn, err := grpc.Dial(c.endpoint(), grpc.WithTransportCredentials(creds))
 	if !assert.NoError(t, err, "expected gRPC dial to succeed") {
 		return
 	}


### PR DESCRIPTION
## Description

`grpc.WithInsecure()` is deprecated. It is recommended to replace it with `grpc.WithTransportCredentials(insecure.NewCredentials())`. See https://pkg.go.dev/google.golang.org/grpc#WithInsecure.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI