### PR TITLE
[Perf] Do not load full node objects into graphQL

### DIFF
--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -162,7 +162,7 @@ func (ds *datastoreImpl) GetManyImageMetadata(ctx context.Context, ids []string)
 		return nil, err
 	}
 	if len(missingIdx) > 0 {
-		log.Errorf("Could not fetch %d/%d some images", len(missingIdx), len(ids))
+		log.Errorf("Could not fetch %d/%d images", len(missingIdx), len(ids))
 	}
 	for _, img := range imgs {
 		ds.updateImagePriority(img)

--- a/central/node/datastore/dackbox/datastore/datastore.go
+++ b/central/node/datastore/dackbox/datastore/datastore.go
@@ -36,6 +36,7 @@ type DataStore interface {
 	CountNodes(ctx context.Context) (int, error)
 	GetNode(ctx context.Context, id string) (*storage.Node, bool, error)
 	GetNodesBatch(ctx context.Context, ids []string) ([]*storage.Node, error)
+	GetManyNodeMetadata(ctx context.Context, ids []string) ([]*storage.Node, error)
 
 	UpsertNode(ctx context.Context, node *storage.Node) error
 

--- a/central/node/datastore/dackbox/datastore/datastore_impl.go
+++ b/central/node/datastore/dackbox/datastore/datastore_impl.go
@@ -173,6 +173,19 @@ func (ds *datastoreImpl) GetNodesBatch(ctx context.Context, ids []string) ([]*st
 	return nodes, nil
 }
 
+// GetManyNodeMetadata gets the node data without the scan.
+func (ds *datastoreImpl) GetManyNodeMetadata(ctx context.Context, ids []string) ([]*storage.Node, error) {
+	nodes, missingIdx, err := ds.storage.GetManyNodeMetadata(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	if len(missingIdx) > 0 {
+		log.Errorf("Could not fetch %d/%d nodes", len(missingIdx), len(ids))
+	}
+	ds.updateNodePriority(nodes...)
+	return nodes, nil
+}
+
 // UpsertNode dedupes the node with the underlying storage and adds the node to the index.
 func (ds *datastoreImpl) UpsertNode(ctx context.Context, node *storage.Node) error {
 	defer metrics.SetDatastoreFunctionDuration(time.Now(), typ, "UpsertNode")

--- a/central/node/datastore/internal/store/dackbox/store_impl.go
+++ b/central/node/datastore/internal/store/dackbox/store_impl.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	protoTypes "github.com/gogo/protobuf/types"
+	"github.com/pkg/errors"
 	clusterDackBox "github.com/stackrox/rox/central/cluster/dackbox"
 	componentCVEEdgeDackBox "github.com/stackrox/rox/central/componentcveedge/dackbox"
 	cveDackBox "github.com/stackrox/rox/central/cve/dackbox"
@@ -22,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/dackbox/sortedkeys"
 	ops "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/utils"
 )
 
 const (
@@ -110,6 +112,11 @@ func (b *storeImpl) GetNodeMetadata(_ context.Context, id string) (*storage.Node
 		return nil, false, err
 	}
 	return node, node != nil, err
+}
+
+func (b *storeImpl) GetManyNodeMetadata(ctx context.Context, id []string) ([]*storage.Node, []int, error) {
+	utils.Must(errors.New("Unexpected call to GetManyNodeMetadata in Dackbox when running on Postgres"))
+	return nil, nil, nil
 }
 
 // GetNodesBatch returns nodes with given ids.

--- a/central/node/datastore/internal/store/postgres/store.go
+++ b/central/node/datastore/internal/store/postgres/store.go
@@ -67,8 +67,9 @@ type Store interface {
 	Delete(ctx context.Context, id string) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Node, []int, error)
-	// GetNodeMetadata gets the node without scan/component data.
+	// GetNodeMetadata and GetManyNodeMetadata gets the node without scan/component data.
 	GetNodeMetadata(ctx context.Context, id string) (*storage.Node, bool, error)
+	GetManyNodeMetadata(ctx context.Context, ids []string) ([]*storage.Node, []int, error)
 
 	AckKeysIndexed(ctx context.Context, keys ...string) error
 	GetKeysToIndex(ctx context.Context) ([]string, error)
@@ -913,10 +914,68 @@ func (s *storeImpl) GetNodeMetadata(ctx context.Context, id string) (*storage.No
 	return &msg, true, nil
 }
 
+// GetManyNodeMetadata returns nodes without scan/component data.
+func (s *storeImpl) GetManyNodeMetadata(ctx context.Context, ids []string) ([]*storage.Node, []int, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "Node")
+
+	if len(ids) == 0 {
+		return nil, nil, nil
+	}
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	scopeTree, err := scopeChecker.EffectiveAccessScope(permissions.ResourceWithAccess{
+		Resource: targetResource,
+		Access:   storage.Access_READ_ACCESS,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	sacQueryFilter, err := sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, nil, err
+	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddExactMatches(search.NodeID, ids...).ProtoQuery(),
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			missingIndices := make([]int, 0, len(ids))
+			for i := range ids {
+				missingIndices = append(missingIndices, i)
+			}
+			return nil, missingIndices, nil
+		}
+		return nil, nil, err
+	}
+	resultsByID := make(map[string]*storage.Node)
+	for _, data := range rows {
+		msg := &storage.Node{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, nil, err
+		}
+		resultsByID[msg.GetId()] = msg
+	}
+	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
+	// It is important that the elems are populated in the same order as the input ids
+	// slice, since some calling code relies on that to maintain order.
+	elems := make([]*storage.Node, 0, len(resultsByID))
+	for i, id := range ids {
+		if result, ok := resultsByID[id]; !ok {
+			missingIndices = append(missingIndices, i)
+		} else {
+			elems = append(elems, result)
+		}
+	}
+	return elems, missingIndices, nil
+}
+
 //// Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing
-func CreateTableAndNewStore(ctx context.Context, t *testing.T, db *pgxpool.Pool, gormDB *gorm.DB, noUpdateTimestamps bool) Store {
+func CreateTableAndNewStore(ctx context.Context, _ testing.TB, db *pgxpool.Pool, gormDB *gorm.DB, noUpdateTimestamps bool) Store {
 	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableClustersStmt)
 	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableNodesStmt)
 	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableNodeComponentsStmt)

--- a/central/node/datastore/internal/store/store.go
+++ b/central/node/datastore/internal/store/store.go
@@ -11,8 +11,10 @@ import (
 type Store interface {
 	Count(ctx context.Context) (int, error)
 	Get(ctx context.Context, id string) (*storage.Node, bool, error)
-	// GetNodeMetadata gets the node without scan/component data.
+	// GetNodeMetadata and GetManyNodeMetadata gets the node without scan/component data.
 	GetNodeMetadata(ctx context.Context, id string) (*storage.Node, bool, error)
+	GetManyNodeMetadata(ctx context.Context, ids []string) ([]*storage.Node, []int, error)
+
 	GetMany(ctx context.Context, ids []string) ([]*storage.Node, []int, error)
 
 	Exists(ctx context.Context, id string) (bool, error)


### PR DESCRIPTION
## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
```
BenchmarkGetManyNodes
    env_isolator.go:41: EnvIsolator: Setting ROX_POSTGRES_DATASTORE to true
BenchmarkGetManyNodes/GetNodesBatch
BenchmarkGetManyNodes/GetNodesBatch-8         	      13	  88549748 ns/op
BenchmarkGetManyNodes/GetManyNodeMetadata
BenchmarkGetManyNodes/GetManyNodeMetadata-8   	    1440	    954305 ns/op
PASS
```