### PR TITLE
Delete failing loading indicator test for Vulnerability Management Dashboard in UI

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
@@ -111,16 +111,6 @@ describe('Vuln Management Dashboard Page', () => {
         cy.location('pathname').should('eq', url.list.deployments);
     });
 
-    it('"Top Riskiest <entities>" widget should start with a loading indicator', () => {
-        cy.visit(url.dashboard); // do not call visit helper because it waits on the requests
-        cy.get(selectors.getWidget('Top risky deployments by CVE count & CVSS score'))
-            .find(selectors.widgetBody)
-            .invoke('text')
-            .then((bodyText) => {
-                expect(bodyText).to.contain('Loading');
-            });
-    });
-
     it('clicking the "Top Riskiest Images" widget\'s "View All" button should take you to the images list', () => {
         visitVulnerabilityManagementDashboard();
         cy.intercept('POST', api.vulnMgmt.graphqlEntities('images')).as('images');


### PR DESCRIPTION
## Description

Delete failing loading indicator test for Vulnerability Management Dashboard in UI

> "Top Riskiest <entities>" widget should start with a loading indicator: Vuln Management Dashboard Page "Top Riskiest <entities>" widget should start with a loading indicator

![cypress-prow-2](https://user-images.githubusercontent.com/11862657/183127730-3794cd17-6c2d-4d56-b6b1-bcaa5835fdc5.png)

Quote from #2627

> If the test continues to fail, then delete it.

It failed on the master build for that pull request.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Deleted integration test

## Testing Performed