### PR TITLE
Delete failing loading indicator test for Vulnerability Management Dashboard

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
@@ -111,16 +111,6 @@ describe('Vuln Management Dashboard Page', () => {
         cy.location('pathname').should('eq', url.list.deployments);
     });
 
-    it('"Top Riskiest <entities>" widget should start with a loading indicator', () => {
-        const widgetSelector = selectors.getWidget(
-            'Top risky deployments by CVE count & CVSS score'
-        );
-        const loadingSelector = `${widgetSelector} ${selectors.widgetBody}:contains("Loading")`;
-
-        cy.visit(url.dashboard); // do not call visit helper because it waits on the requests
-        cy.get(loadingSelector);
-    });
-
     it('clicking the "Top Riskiest Images" widget\'s "View All" button should take you to the images list', () => {
         visitVulnerabilityManagementDashboard();
         cy.intercept('POST', api.vulnMgmt.graphqlEntities('images')).as('images');


### PR DESCRIPTION
## Description

Delete failing loading indicator test for Vulnerability Management Dashboard

> "Top Riskiest <entities>" widget should start with a loading indicator: Vuln Management Dashboard Page "Top Riskiest <entities>" widget should start with a loading indicator

![cypress-prow-2](https://user-images.githubusercontent.com/11862657/183130718-a2fba6a5-a882-4287-a5b3-05dae6dbb9ae.png)

Quote from #2627

> If the test continues to fail, then delete it.

It failed on the master build for that pull request.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Deleted integration test

## Testing Performed