### PR TITLE
Use GetByQuery in Postgres stores

### DIFF
--- a/central/activecomponent/datastore/internal/store/dackbox/store_impl.go
+++ b/central/activecomponent/datastore/internal/store/dackbox/store_impl.go
@@ -10,6 +10,7 @@ import (
 	deploymentDackBox "github.com/stackrox/rox/central/deployment/dackbox"
 	componentDackBox "github.com/stackrox/rox/central/imagecomponent/dackbox"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/batcher"
 	"github.com/stackrox/rox/pkg/dackbox"
@@ -72,6 +73,10 @@ func (s *storeImpl) Get(_ context.Context, id string) (*storage.ActiveComponent,
 	}
 
 	return msg.(*storage.ActiveComponent), msg != nil, err
+}
+
+func (s *storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ActiveComponent, error) {
+	panic("unimplemented")
 }
 
 func (s *storeImpl) GetMany(_ context.Context, ids []string) ([]*storage.ActiveComponent, []int, error) {

--- a/central/activecomponent/datastore/internal/store/mocks/store.go
+++ b/central/activecomponent/datastore/internal/store/mocks/store.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -78,6 +79,21 @@ func (m *MockStore) Get(ctx context.Context, id string) (*storage.ActiveComponen
 func (mr *MockStoreMockRecorder) Get(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
+}
+
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ActiveComponent, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, q)
+	ret0, _ := ret[0].([]*storage.ActiveComponent)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, q interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, q)
 }
 
 // GetMany mocks base method.

--- a/central/activecomponent/datastore/internal/store/store.go
+++ b/central/activecomponent/datastore/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -13,6 +14,7 @@ type Store interface {
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ActiveComponent, bool, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ActiveComponent, []int, error)
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ActiveComponent, error)
 	UpsertMany(ctx context.Context, activeComponents []*storage.ActiveComponent) error
 	DeleteMany(ctx context.Context, ids []string) error
 }

--- a/central/activecomponent/datastore/search/searcher_impl_v2.go
+++ b/central/activecomponent/datastore/search/searcher_impl_v2.go
@@ -30,16 +30,7 @@ type searcherImplV2 struct {
 
 // SearchRawActiveComponents retrieves SearchResults from the indexer and storage
 func (s *searcherImplV2) SearchRawActiveComponents(ctx context.Context, q *v1.Query) ([]*storage.ActiveComponent, error) {
-	results, err := s.Search(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
-	images, _, err := s.storage.GetMany(ctx, search.ResultsToIDs(results))
-	if err != nil {
-		return nil, err
-	}
-	return images, nil
+	return s.storage.GetByQuery(ctx, q)
 }
 
 func (s *searcherImplV2) Search(ctx context.Context, q *v1.Query) (res []search.Result, err error) {

--- a/central/alert/datastore/internal/search/searcher_impl.go
+++ b/central/alert/datastore/internal/search/searcher_impl.go
@@ -55,8 +55,28 @@ func (ds *searcherImpl) SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.Se
 
 // SearchListAlerts retrieves list alerts from the indexer and storage
 func (ds *searcherImpl) SearchListAlerts(ctx context.Context, q *v1.Query) ([]*storage.ListAlert, error) {
-	alerts, _, err := ds.searchListAlerts(ctx, q)
-	return alerts, err
+	var alerts []*storage.Alert
+	var err error
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		alerts, err = ds.storage.GetByQuery(ctx, q)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		results, err := ds.Search(ctx, q)
+		if err != nil {
+			return nil, err
+		}
+		alerts, _, err = ds.storage.GetMany(ctx, search.ResultsToIDs(results))
+		if err != nil {
+			return nil, err
+		}
+	}
+	listAlerts := make([]*storage.ListAlert, 0, len(alerts))
+	for _, alert := range alerts {
+		listAlerts = append(listAlerts, convert.AlertToListAlert(alert))
+	}
+	return listAlerts, nil
 }
 
 // SearchRawAlerts retrieves Alerts from the indexer and storage
@@ -83,6 +103,9 @@ func (ds *searcherImpl) searchListAlerts(ctx context.Context, q *v1.Query) ([]*s
 }
 
 func (ds *searcherImpl) searchAlerts(ctx context.Context, q *v1.Query) ([]*storage.Alert, error) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return ds.storage.GetByQuery(ctx, q)
+	}
 	results, err := ds.Search(ctx, q)
 	if err != nil {
 		return nil, err

--- a/central/alert/datastore/internal/store/mocks/store.go
+++ b/central/alert/datastore/internal/store/mocks/store.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -96,6 +97,21 @@ func (m *MockStore) Get(ctx context.Context, id string) (*storage.Alert, bool, e
 func (mr *MockStoreMockRecorder) Get(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
+}
+
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Alert, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, query)
+	ret0, _ := ret[0].([]*storage.Alert)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, query)
 }
 
 // GetIDs mocks base method.

--- a/central/alert/datastore/internal/store/store.go
+++ b/central/alert/datastore/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -13,6 +14,7 @@ type Store interface {
 	Walk(ctx context.Context, fn func(*storage.Alert) error) error
 	GetIDs(ctx context.Context) ([]string, error)
 	Get(ctx context.Context, id string) (*storage.Alert, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Alert, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Alert, []int, error)
 	Upsert(ctx context.Context, alert *storage.Alert) error
 	UpsertMany(ctx context.Context, alerts []*storage.Alert) error

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -273,11 +273,7 @@ func (ds *datastoreImpl) Exists(ctx context.Context, id string) (bool, error) {
 }
 
 func (ds *datastoreImpl) SearchRawClusters(ctx context.Context, q *v1.Query) ([]*storage.Cluster, error) {
-	clusters, err := ds.searchRawClusters(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-	return clusters, nil
+	return ds.searchRawClusters(ctx, q)
 }
 
 func (ds *datastoreImpl) CountClusters(ctx context.Context) (int, error) {

--- a/central/cluster/datastore/internal/search/searcher_impl_v2.go
+++ b/central/cluster/datastore/internal/search/searcher_impl_v2.go
@@ -57,8 +57,7 @@ func (s *searcherImplV2) SearchResults(ctx context.Context, q *v1.Query) ([]*v1.
 }
 
 func (s *searcherImplV2) SearchClusters(ctx context.Context, q *v1.Query) ([]*storage.Cluster, error) {
-	clusters, _, err := s.searchClusters(ctx, q)
-	return clusters, err
+	return s.storage.GetByQuery(ctx, q)
 }
 
 func (s *searcherImplV2) searchClusters(ctx context.Context, q *v1.Query) ([]*storage.Cluster, []search.Result, error) {

--- a/central/cluster/store/cluster/mocks/store.go
+++ b/central/cluster/store/cluster/mocks/store.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -126,6 +127,21 @@ func (m *MockStore) Get(ctx context.Context, id string) (*storage.Cluster, bool,
 func (mr *MockStoreMockRecorder) Get(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
+}
+
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Cluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, q)
+	ret0, _ := ret[0].([]*storage.Cluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, q interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, q)
 }
 
 // GetIDs mocks base method.

--- a/central/cluster/store/cluster/store.go
+++ b/central/cluster/store/cluster/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -13,6 +14,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.Cluster, bool, error)
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Cluster, error)
 	Upsert(ctx context.Context, obj *storage.Cluster) error
 	UpsertMany(ctx context.Context, objs []*storage.Cluster) error
 	Delete(ctx context.Context, id string) error

--- a/central/clustercveedge/search/searcher_impl_v2.go
+++ b/central/clustercveedge/search/searcher_impl_v2.go
@@ -60,7 +60,7 @@ func (ds *searcherImplV2) Count(ctx context.Context, q *v1.Query) (count int, er
 
 // SearchRawEdges retrieves edges from the indexer and storage
 func (ds *searcherImplV2) SearchRawEdges(ctx context.Context, q *v1.Query) ([]*storage.ClusterCVEEdge, error) {
-	return ds.searchImageComponentEdges(ctx, q)
+	return ds.storage.GetByQuery(ctx, q)
 }
 
 func (ds *searcherImplV2) resultsToEdges(ctx context.Context, results []search.Result) ([]*storage.ClusterCVEEdge, []int, error) {
@@ -92,18 +92,4 @@ func convertOne(obj *storage.ClusterCVEEdge, result *search.Result) *v1.SearchRe
 		FieldToMatches: search.GetProtoMatchesMap(result.Matches),
 		Score:          result.Score,
 	}
-}
-
-func (ds *searcherImplV2) searchImageComponentEdges(ctx context.Context, q *v1.Query) ([]*storage.ClusterCVEEdge, error) {
-	results, err := ds.Search(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
-	ids := search.ResultsToIDs(results)
-	cves, _, err := ds.storage.GetMany(ctx, ids)
-	if err != nil {
-		return nil, err
-	}
-	return cves, nil
 }

--- a/central/clustercveedge/store/dackbox/store_impl.go
+++ b/central/clustercveedge/store/dackbox/store_impl.go
@@ -13,6 +13,7 @@ import (
 	vulnDackBox "github.com/stackrox/rox/central/cve/dackbox"
 	"github.com/stackrox/rox/central/cve/utils"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/batcher"
 	"github.com/stackrox/rox/pkg/dackbox"
@@ -116,6 +117,10 @@ func (b *storeImpl) Get(ctx context.Context, id string) (edges *storage.ClusterC
 	}
 
 	return msg.(*storage.ClusterCVEEdge), msg != nil, err
+}
+
+func (b *storeImpl) GetByQuery(_ context.Context, _ *v1.Query) ([]*storage.ClusterCVEEdge, error) {
+	panic("unimplemented")
 }
 
 func (b *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.ClusterCVEEdge, []int, error) {

--- a/central/clustercveedge/store/mocks/store.go
+++ b/central/clustercveedge/store/mocks/store.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	converter "github.com/stackrox/rox/central/cve/converter"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -99,6 +100,21 @@ func (m *MockStore) Get(ctx context.Context, id string) (*storage.ClusterCVEEdge
 func (mr *MockStoreMockRecorder) Get(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
+}
+
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ClusterCVEEdge, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, query)
+	ret0, _ := ret[0].([]*storage.ClusterCVEEdge)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, query)
 }
 
 // GetMany mocks base method.

--- a/central/clustercveedge/store/store.go
+++ b/central/clustercveedge/store/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/stackrox/rox/central/cve/converter"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -15,6 +16,7 @@ type Store interface {
 	Exists(ctx context.Context, id string) (bool, error)
 
 	Get(ctx context.Context, id string) (*storage.ClusterCVEEdge, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ClusterCVEEdge, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ClusterCVEEdge, []int, error)
 
 	Upsert(ctx context.Context, cveParts ...converter.ClusterCVEParts) error

--- a/central/cve/cluster/datastore/search/searcher_impl.go
+++ b/central/cve/cluster/datastore/search/searcher_impl.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/central/cve/cluster/datastore/store"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -77,6 +78,9 @@ func convertOne(cve *storage.ClusterCVE, result *search.Result) *v1.SearchResult
 }
 
 func (ds *searcherImpl) searchCVEs(ctx context.Context, q *v1.Query) ([]*storage.ClusterCVE, error) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return ds.storage.GetByQuery(ctx, q)
+	}
 	results, err := ds.Search(ctx, q)
 	if err != nil {
 		return nil, err

--- a/central/cve/cluster/datastore/store/mocks/store.go
+++ b/central/cve/cluster/datastore/store/mocks/store.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	converter "github.com/stackrox/rox/central/cve/converter/v2"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -94,6 +95,21 @@ func (m *MockStore) Get(ctx context.Context, id string) (*storage.ClusterCVE, bo
 func (mr *MockStoreMockRecorder) Get(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
+}
+
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ClusterCVE, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, query)
+	ret0, _ := ret[0].([]*storage.ClusterCVE)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, query)
 }
 
 // GetMany mocks base method.

--- a/central/cve/cluster/datastore/store/store.go
+++ b/central/cve/cluster/datastore/store/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/stackrox/rox/central/cve/converter/v2"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -15,6 +16,7 @@ type Store interface {
 	Exists(ctx context.Context, id string) (bool, error)
 
 	Get(ctx context.Context, id string) (*storage.ClusterCVE, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ClusterCVE, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ClusterCVE, []int, error)
 
 	UpsertMany(ctx context.Context, cves []*storage.ClusterCVE) error

--- a/central/cve/image/datastore/search/searcher_impl.go
+++ b/central/cve/image/datastore/search/searcher_impl.go
@@ -34,7 +34,7 @@ func (ds *searcherImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 }
 
 func (ds *searcherImpl) SearchRawImageCVEs(ctx context.Context, q *v1.Query) ([]*storage.ImageCVE, error) {
-	return ds.searchCVEs(ctx, q)
+	return ds.storage.GetByQuery(ctx, q)
 }
 
 func (ds *searcherImpl) getSearchResults(ctx context.Context, q *v1.Query) (res []search.Result, err error) {
@@ -74,18 +74,4 @@ func convertOne(cve *storage.ImageCVE, result *search.Result) *v1.SearchResult {
 		FieldToMatches: search.GetProtoMatchesMap(result.Matches),
 		Score:          result.Score,
 	}
-}
-
-func (ds *searcherImpl) searchCVEs(ctx context.Context, q *v1.Query) ([]*storage.ImageCVE, error) {
-	results, err := ds.Search(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
-	ids := search.ResultsToIDs(results)
-	cves, _, err := ds.storage.GetMany(ctx, ids)
-	if err != nil {
-		return nil, err
-	}
-	return cves, nil
 }

--- a/central/imagecomponent/search/searcher_impl_v2.go
+++ b/central/imagecomponent/search/searcher_impl_v2.go
@@ -60,21 +60,7 @@ func (s *searcherImplV2) SearchImageComponents(ctx context.Context, q *v1.Query)
 }
 
 func (s *searcherImplV2) SearchRawImageComponents(ctx context.Context, q *v1.Query) ([]*storage.ImageComponent, error) {
-	return s.searchImageComponents(ctx, q)
-}
-
-func (s *searcherImplV2) searchImageComponents(ctx context.Context, q *v1.Query) ([]*storage.ImageComponent, error) {
-	results, err := s.getSearchResults(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
-	ids := search.ResultsToIDs(results)
-	components, _, err := s.storage.GetMany(ctx, ids)
-	if err != nil {
-		return nil, err
-	}
-	return components, nil
+	return s.storage.GetByQuery(ctx, q)
 }
 
 func (s *searcherImplV2) getSearchResults(ctx context.Context, q *v1.Query) (res []search.Result, err error) {

--- a/central/imagecomponent/store/dackbox/store_impl.go
+++ b/central/imagecomponent/store/dackbox/store_impl.go
@@ -8,6 +8,7 @@ import (
 	componentDackBox "github.com/stackrox/rox/central/imagecomponent/dackbox"
 	"github.com/stackrox/rox/central/imagecomponent/store"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/dackbox"
 	"github.com/stackrox/rox/pkg/dackbox/concurrency"
@@ -77,6 +78,10 @@ func (b *storeImpl) Get(ctx context.Context, id string) (image *storage.ImageCom
 	}
 
 	return msg.(*storage.ImageComponent), msg != nil, err
+}
+
+func (b *storeImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ImageComponent, error) {
+	panic("unimplemented")
 }
 
 // GetImagesBatch returns image with given sha.

--- a/central/imagecomponent/store/mocks/store.go
+++ b/central/imagecomponent/store/mocks/store.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -79,6 +80,21 @@ func (m *MockStore) Get(ctx context.Context, id string) (*storage.ImageComponent
 func (mr *MockStoreMockRecorder) Get(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
+}
+
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ImageComponent, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, query)
+	ret0, _ := ret[0].([]*storage.ImageComponent)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, query)
 }
 
 // GetMany mocks base method.

--- a/central/imagecomponent/store/store.go
+++ b/central/imagecomponent/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -12,6 +13,7 @@ import (
 type Store interface {
 	Count(ctx context.Context) (int, error)
 	Get(ctx context.Context, id string) (*storage.ImageComponent, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ImageComponent, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ImageComponent, []int, error)
 
 	Exists(ctx context.Context, id string) (bool, error)

--- a/central/nodecomponent/datastore/search/searcher_impl.go
+++ b/central/nodecomponent/datastore/search/searcher_impl.go
@@ -34,21 +34,7 @@ func (s *searcherImpl) SearchNodeComponents(ctx context.Context, q *v1.Query) ([
 }
 
 func (s *searcherImpl) SearchRawNodeComponents(ctx context.Context, q *v1.Query) ([]*storage.NodeComponent, error) {
-	return s.searchNodeComponents(ctx, q)
-}
-
-func (s *searcherImpl) searchNodeComponents(ctx context.Context, q *v1.Query) ([]*storage.NodeComponent, error) {
-	results, err := s.getSearchResults(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
-	ids := search.ResultsToIDs(results)
-	components, _, err := s.storage.GetMany(ctx, ids)
-	if err != nil {
-		return nil, err
-	}
-	return components, nil
+	return s.storage.GetByQuery(ctx, q)
 }
 
 func (s *searcherImpl) getSearchResults(ctx context.Context, q *v1.Query) (res []search.Result, err error) {

--- a/central/policy/datastore/datastore.go
+++ b/central/policy/datastore/datastore.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stackrox/rox/central/policy/index"
 	"github.com/stackrox/rox/central/policy/search"
 	"github.com/stackrox/rox/central/policy/store"
-	"github.com/stackrox/rox/central/policy/store/boltdb"
 	categoriesDataStore "github.com/stackrox/rox/central/policycategory/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
@@ -58,7 +57,7 @@ func New(storage store.Store, indexer index.Indexer, searcher search.Searcher,
 }
 
 // newWithoutDefaults should be used only for testing purposes.
-func newWithoutDefaults(storage boltdb.Store, indexer index.Indexer,
+func newWithoutDefaults(storage store.Store, indexer index.Indexer,
 	searcher search.Searcher, clusterDatastore clusterDS.DataStore, notifierDatastore notifierDS.DataStore,
 	categoriesDatastore categoriesDataStore.DataStore) DataStore {
 	return &datastoreImpl{

--- a/central/policy/search/searcher_impl.go
+++ b/central/policy/search/searcher_impl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
@@ -37,6 +38,9 @@ type searcherImpl struct {
 
 // SearchRawPolicies retrieves Policies from the indexer and storage
 func (ds *searcherImpl) SearchRawPolicies(ctx context.Context, q *v1.Query) ([]*storage.Policy, error) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return ds.storage.GetByQuery(ctx, q)
+	}
 	policies, _, err := ds.searchPolicies(ctx, q)
 	return policies, err
 }

--- a/central/policy/store/boltdb/store.go
+++ b/central/policy/store/boltdb/store.go
@@ -76,7 +76,7 @@ type Store interface {
 }
 
 // New returns a new Store instance using the provided bolt DB instance.
-func New(db *bolt.DB) Store {
+func New(db *bolt.DB) *storeImpl {
 	bolthelper.RegisterBucketOrPanic(db, policyBucket)
 	bolthelper.RegisterBucketOrPanic(db, removedDefaultPolicyBucket)
 	s := &storeImpl{

--- a/central/policy/store/boltdb/store_impl.go
+++ b/central/policy/store/boltdb/store_impl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/dberrors"
 	"github.com/stackrox/rox/pkg/errorhelpers"
@@ -117,6 +118,10 @@ func (s *storeImpl) GetAll(_ context.Context) ([]*storage.Policy, error) {
 		})
 	})
 	return policies, err
+}
+
+func (s *storeImpl) GetByQuery(_ context.Context, _ *v1.Query) ([]*storage.Policy, error) {
+	panic("unimplemented")
 }
 
 func (s *storeImpl) GetMany(_ context.Context, ids []string) ([]*storage.Policy, []int, error) {

--- a/central/policy/store/mocks/store.go
+++ b/central/policy/store/mocks/store.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -111,6 +112,21 @@ func (m *MockStore) GetAll(ctx context.Context) ([]*storage.Policy, error) {
 func (mr *MockStoreMockRecorder) GetAll(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockStore)(nil).GetAll), ctx)
+}
+
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Policy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, q)
+	ret0, _ := ret[0].([]*storage.Policy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, q interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, q)
 }
 
 // GetIDs mocks base method.

--- a/central/policy/store/store.go
+++ b/central/policy/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -11,6 +12,7 @@ import (
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.Policy, bool, error)
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Policy, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Policy, []int, error)
 	GetAll(ctx context.Context) ([]*storage.Policy, error)
 	GetIDs(ctx context.Context) ([]string, error)

--- a/central/policycategory/search/searcher_impl.go
+++ b/central/policycategory/search/searcher_impl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
@@ -49,12 +50,15 @@ func (s *searcherImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 	return s.searcher.Count(ctx, q)
 }
 
-func (s searcherImpl) SearchRawCategories(ctx context.Context, q *v1.Query) ([]*storage.PolicyCategory, error) {
+func (s *searcherImpl) SearchRawCategories(ctx context.Context, q *v1.Query) ([]*storage.PolicyCategory, error) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return s.storage.GetByQuery(ctx, q)
+	}
 	categories, _, err := s.searchCategories(ctx, q)
 	return categories, err
 }
 
-func (s searcherImpl) SearchCategories(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
+func (s *searcherImpl) SearchCategories(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
 	categories, results, err := s.searchCategories(ctx, q)
 	if err != nil {
 		return nil, err

--- a/central/policycategory/store/mocks/store.go
+++ b/central/policycategory/store/mocks/store.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -141,6 +142,21 @@ func (m *MockStore) GetAll(ctx context.Context) ([]*storage.PolicyCategory, erro
 func (mr *MockStoreMockRecorder) GetAll(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockStore)(nil).GetAll), ctx)
+}
+
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.PolicyCategory, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, query)
+	ret0, _ := ret[0].([]*storage.PolicyCategory)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, query)
 }
 
 // GetIDs mocks base method.

--- a/central/policycategory/store/store.go
+++ b/central/policycategory/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -14,6 +15,7 @@ type Store interface {
 	Exists(ctx context.Context, id string) (bool, error)
 	GetIDs(ctx context.Context) ([]string, error)
 	Get(ctx context.Context, id string) (*storage.PolicyCategory, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.PolicyCategory, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.PolicyCategory, []int, error)
 	GetAll(ctx context.Context) ([]*storage.PolicyCategory, error)
 	Upsert(ctx context.Context, obj *storage.PolicyCategory) error

--- a/central/processbaseline/store/mocks/store.go
+++ b/central/processbaseline/store/mocks/store.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -63,6 +64,21 @@ func (m *MockStore) Get(ctx context.Context, id string) (*storage.ProcessBaselin
 func (mr *MockStoreMockRecorder) Get(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
+}
+
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessBaseline, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, q)
+	ret0, _ := ret[0].([]*storage.ProcessBaseline)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, q interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, q)
 }
 
 // GetMany mocks base method.

--- a/central/processbaseline/store/store.go
+++ b/central/processbaseline/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -11,6 +12,7 @@ import (
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.ProcessBaseline, bool, error)
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessBaseline, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ProcessBaseline, []int, error)
 	Walk(ctx context.Context, fn func(baseline *storage.ProcessBaseline) error) error
 

--- a/central/processindicator/search/searcher_impl.go
+++ b/central/processindicator/search/searcher_impl.go
@@ -27,6 +27,9 @@ type searcherImpl struct {
 
 // SearchRawProcessIndicators retrieves Policies from the indexer and storage
 func (s *searcherImpl) SearchRawProcessIndicators(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return s.storage.GetByQuery(ctx, q)
+	}
 	results, err := s.Search(ctx, q)
 	if err != nil {
 		return nil, err

--- a/central/processindicator/search/searcher_impl_test.go
+++ b/central/processindicator/search/searcher_impl_test.go
@@ -81,8 +81,7 @@ func (suite *IndicatorSearchTestSuite) TestAllowsSearch() {
 }
 
 func (suite *IndicatorSearchTestSuite) TestEnforcesSearchRaw() {
-	suite.indexer.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{{ID: "hgdskdf"}}, nil)
-	suite.storage.EXPECT().GetMany(gomock.Any(), gomock.Any()).Return([]*storage.ProcessIndicator{}, []int{}, nil)
+	suite.storage.EXPECT().GetByQuery(gomock.Any(), gomock.Any()).Return([]*storage.ProcessIndicator{}, nil)
 
 	processIndicators, err := suite.searcher.SearchRawProcessIndicators(suite.hasNoneCtx, search.EmptyQuery())
 	suite.NoError(err, "expected no error, should return nil without access")
@@ -90,15 +89,13 @@ func (suite *IndicatorSearchTestSuite) TestEnforcesSearchRaw() {
 }
 
 func (suite *IndicatorSearchTestSuite) TestAllowsSearchRaw() {
-	suite.indexer.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{{ID: ""}}, nil)
-	suite.storage.EXPECT().GetMany(gomock.Any(), gomock.Any()).Return([]*storage.ProcessIndicator{{}}, []int{}, nil)
+	suite.storage.EXPECT().GetByQuery(gomock.Any(), gomock.Any()).Return([]*storage.ProcessIndicator{{}}, nil)
 
 	processIndicators, err := suite.searcher.SearchRawProcessIndicators(suite.hasReadCtx, search.EmptyQuery())
 	suite.NoError(err, "expected no error trying to read with permissions")
 	suite.NotEmpty(processIndicators)
 
-	suite.indexer.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{{ID: "hgdskdf"}}, nil)
-	suite.storage.EXPECT().GetMany(gomock.Any(), gomock.Any()).Return([]*storage.ProcessIndicator{{}}, []int{}, nil)
+	suite.storage.EXPECT().GetByQuery(gomock.Any(), gomock.Any()).Return([]*storage.ProcessIndicator{{}}, nil)
 
 	processIndicators, err = suite.searcher.SearchRawProcessIndicators(suite.hasWriteCtx, search.EmptyQuery())
 	suite.NoError(err, "expected no error trying to read with permissions")

--- a/central/processindicator/store/mocks/store.go
+++ b/central/processindicator/store/mocks/store.go
@@ -99,6 +99,21 @@ func (mr *MockStoreMockRecorder) Get(ctx, id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
 }
 
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, q)
+	ret0, _ := ret[0].([]*storage.ProcessIndicator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, q interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, q)
+}
+
 // GetKeysToIndex mocks base method.
 func (m *MockStore) GetKeysToIndex(ctx context.Context) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/central/processindicator/store/store.go
+++ b/central/processindicator/store/store.go
@@ -12,6 +12,7 @@ import (
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.ProcessIndicator, bool, error)
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ProcessIndicator, []int, error)
 
 	UpsertMany(context.Context, []*storage.ProcessIndicator) error

--- a/central/rbac/k8srole/internal/store/store.go
+++ b/central/rbac/k8srole/internal/store/store.go
@@ -3,12 +3,14 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
 // Store encapsulates the k8srole store
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.K8SRole, bool, error)
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.K8SRole, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.K8SRole, []int, error)
 	Walk(ctx context.Context, fn func(role *storage.K8SRole) error) error
 

--- a/central/rbac/k8srole/search/searcher_impl.go
+++ b/central/rbac/k8srole/search/searcher_impl.go
@@ -47,6 +47,9 @@ func (ds *searcherImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 
 // SearchRawRoles returns the roles and relationships that match the query.
 func (ds *searcherImpl) SearchRawRoles(ctx context.Context, q *v1.Query) ([]*storage.K8SRole, error) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return ds.storage.GetByQuery(ctx, q)
+	}
 	roles, _, err := ds.searchRoles(ctx, q)
 	if err != nil {
 		return nil, err

--- a/central/rbac/k8srolebinding/internal/store/store.go
+++ b/central/rbac/k8srolebinding/internal/store/store.go
@@ -3,12 +3,14 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
 // Store encapsulates the role binding store
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.K8SRoleBinding, bool, error)
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.K8SRoleBinding, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.K8SRoleBinding, []int, error)
 	Walk(ctx context.Context, fn func(binding *storage.K8SRoleBinding) error) error
 	Upsert(ctx context.Context, rolebinding *storage.K8SRoleBinding) error

--- a/central/rbac/k8srolebinding/search/searcher_impl.go
+++ b/central/rbac/k8srolebinding/search/searcher_impl.go
@@ -55,7 +55,6 @@ func (ds *searcherImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 // SearchRawRoleBindings returns the rolebindings that match the query.
 func (ds *searcherImpl) SearchRawRoleBindings(ctx context.Context, q *v1.Query) ([]*storage.K8SRoleBinding, error) {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		log.Infof("Rolebindings search: %+v", q)
 		return ds.storage.GetByQuery(ctx, q)
 	}
 	bindings, _, err := ds.searchRoleBindings(ctx, q)

--- a/central/rbac/k8srolebinding/search/searcher_impl.go
+++ b/central/rbac/k8srolebinding/search/searcher_impl.go
@@ -54,6 +54,10 @@ func (ds *searcherImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 
 // SearchRawRoleBindings returns the rolebindings that match the query.
 func (ds *searcherImpl) SearchRawRoleBindings(ctx context.Context, q *v1.Query) ([]*storage.K8SRoleBinding, error) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		log.Infof("Rolebindings search: %+v", q)
+		return ds.storage.GetByQuery(ctx, q)
+	}
 	bindings, _, err := ds.searchRoleBindings(ctx, q)
 	if err != nil {
 		return nil, err

--- a/central/risk/datastore/internal/search/searcher_impl.go
+++ b/central/risk/datastore/internal/search/searcher_impl.go
@@ -35,6 +35,9 @@ type searcherImpl struct {
 
 // SearchRawRisks retrieves Risks from the indexer and storage
 func (s *searcherImpl) SearchRawRisks(ctx context.Context, q *v1.Query) ([]*storage.Risk, error) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return s.storage.GetByQuery(ctx, q)
+	}
 	results, err := s.Search(ctx, q)
 	if err != nil {
 		return nil, err

--- a/central/risk/datastore/internal/store/mocks/store.go
+++ b/central/risk/datastore/internal/store/mocks/store.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -63,6 +64,21 @@ func (m *MockStore) Get(ctx context.Context, id string) (*storage.Risk, bool, er
 func (mr *MockStoreMockRecorder) Get(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
+}
+
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Risk, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, q)
+	ret0, _ := ret[0].([]*storage.Risk)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, q interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, q)
 }
 
 // GetMany mocks base method.

--- a/central/risk/datastore/internal/store/store.go
+++ b/central/risk/datastore/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -11,6 +12,7 @@ import (
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.Risk, bool, error)
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Risk, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Risk, []int, error)
 	Walk(context.Context, func(risk *storage.Risk) error) error
 	Upsert(ctx context.Context, risk *storage.Risk) error

--- a/central/secret/internal/store/mocks/store.go
+++ b/central/secret/internal/store/mocks/store.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -78,6 +79,21 @@ func (m *MockStore) Get(ctx context.Context, id string) (*storage.Secret, bool, 
 func (mr *MockStoreMockRecorder) Get(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
+}
+
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Secret, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, q)
+	ret0, _ := ret[0].([]*storage.Secret)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, q interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, q)
 }
 
 // GetMany mocks base method.

--- a/central/secret/internal/store/store.go
+++ b/central/secret/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -12,6 +13,7 @@ import (
 type Store interface {
 	Count(ctx context.Context) (int, error)
 	Get(ctx context.Context, id string) (*storage.Secret, bool, error)
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Secret, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Secret, []int, error)
 	Walk(context.Context, func(secret *storage.Secret) error) error
 

--- a/central/secret/search/searcher_impl.go
+++ b/central/secret/search/searcher_impl.go
@@ -64,6 +64,9 @@ func (ds *searcherImpl) SearchListSecrets(ctx context.Context, q *v1.Query) ([]*
 
 // SearchRawSecrets retrieves secrets from the indexer and storage
 func (ds *searcherImpl) SearchRawSecrets(ctx context.Context, q *v1.Query) ([]*storage.Secret, error) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return ds.storage.GetByQuery(ctx, q)
+	}
 	return ds.searchSecrets(ctx, q)
 }
 

--- a/central/serviceaccount/internal/store/store.go
+++ b/central/serviceaccount/internal/store/store.go
@@ -3,12 +3,14 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
 // Store encapsulates the service account store interface
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.ServiceAccount, bool, error)
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ServiceAccount, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ServiceAccount, []int, error)
 	Walk(context.Context, func(sa *storage.ServiceAccount) error) error
 

--- a/central/serviceaccount/search/searcher_impl.go
+++ b/central/serviceaccount/search/searcher_impl.go
@@ -26,6 +26,9 @@ type searcherImpl struct {
 
 // SearchRawServiceAccounts returns the search results from indexed service accounts for the query.
 func (ds *searcherImpl) SearchRawServiceAccounts(ctx context.Context, q *v1.Query) ([]*storage.ServiceAccount, error) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return ds.storage.GetByQuery(ctx, q)
+	}
 	serviceAccounts, _, err := ds.searchServiceAccounts(ctx, q)
 	if err != nil {
 		return nil, err

--- a/central/vulnerabilityrequest/datastore/internal/searcher/searcher_impl.go
+++ b/central/vulnerabilityrequest/datastore/internal/searcher/searcher_impl.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/central/vulnerabilityrequest/index"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
@@ -63,6 +64,10 @@ func (s *searcherImpl) SearchRequests(ctx context.Context, q *v1.Query) ([]*v1.S
 func (s *searcherImpl) SearchRawRequests(ctx context.Context, q *v1.Query) ([]*storage.VulnerabilityRequest, error) {
 	if ok, err := requesterOrApproverSAC.ReadAllowedToAny(ctx); err != nil || !ok {
 		return nil, err
+	}
+
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return s.store.GetByQuery(ctx, q)
 	}
 
 	vulnReqs, _, err := s.searchRequests(ctx, q)

--- a/central/vulnerabilityrequest/datastore/internal/store/mocks/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/mocks/store.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -107,6 +108,21 @@ func (m *MockStore) Get(ctx context.Context, id string) (*storage.VulnerabilityR
 func (mr *MockStoreMockRecorder) Get(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
+}
+
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.VulnerabilityRequest, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, q)
+	ret0, _ := ret[0].([]*storage.VulnerabilityRequest)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, q interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, q)
 }
 
 // GetIDs mocks base method.

--- a/central/vulnerabilityrequest/datastore/internal/store/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -16,6 +17,7 @@ type Store interface {
 
 	GetIDs(ctx context.Context) ([]string, error)
 	Get(ctx context.Context, id string) (*storage.VulnerabilityRequest, bool, error)
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.VulnerabilityRequest, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.VulnerabilityRequest, []int, error)
 
 	Upsert(ctx context.Context, req *storage.VulnerabilityRequest) error

--- a/pkg/search/parser.go
+++ b/pkg/search/parser.go
@@ -133,28 +133,21 @@ func ConjunctionQuery(queries ...*v1.Query) *v1.Query {
 // Helper function that DisjunctionQuery and ConjunctionQuery proxy to.
 // Do NOT call this directly.
 func disjunctOrConjunctQueries(isConjunct bool, queries ...*v1.Query) *v1.Query {
-	nonNilQueries := make([]*v1.Query, 0, len(queries))
-	for _, q := range queries {
-		if q == nil {
-			continue
-		}
-		nonNilQueries = append(nonNilQueries, q)
-	}
-	if len(nonNilQueries) == 0 {
+	if len(queries) == 0 {
 		return &v1.Query{}
 	}
 
-	if len(nonNilQueries) == 1 {
-		return nonNilQueries[0]
+	if len(queries) == 1 {
+		return queries[0]
 	}
 	if isConjunct {
 		return &v1.Query{
-			Query: &v1.Query_Conjunction{Conjunction: &v1.ConjunctionQuery{Queries: nonNilQueries}},
+			Query: &v1.Query_Conjunction{Conjunction: &v1.ConjunctionQuery{Queries: queries}},
 		}
 	}
 
 	return &v1.Query{
-		Query: &v1.Query_Disjunction{Disjunction: &v1.DisjunctionQuery{Queries: nonNilQueries}},
+		Query: &v1.Query_Disjunction{Disjunction: &v1.DisjunctionQuery{Queries: queries}},
 	}
 }
 

--- a/pkg/search/parser.go
+++ b/pkg/search/parser.go
@@ -133,21 +133,28 @@ func ConjunctionQuery(queries ...*v1.Query) *v1.Query {
 // Helper function that DisjunctionQuery and ConjunctionQuery proxy to.
 // Do NOT call this directly.
 func disjunctOrConjunctQueries(isConjunct bool, queries ...*v1.Query) *v1.Query {
-	if len(queries) == 0 {
+	nonNilQueries := make([]*v1.Query, 0, len(queries))
+	for _, q := range queries {
+		if q == nil {
+			continue
+		}
+		nonNilQueries = append(nonNilQueries, q)
+	}
+	if len(nonNilQueries) == 0 {
 		return &v1.Query{}
 	}
 
-	if len(queries) == 1 {
-		return queries[0]
+	if len(nonNilQueries) == 1 {
+		return nonNilQueries[0]
 	}
 	if isConjunct {
 		return &v1.Query{
-			Query: &v1.Query_Conjunction{Conjunction: &v1.ConjunctionQuery{Queries: queries}},
+			Query: &v1.Query_Conjunction{Conjunction: &v1.ConjunctionQuery{Queries: nonNilQueries}},
 		}
 	}
 
 	return &v1.Query{
-		Query: &v1.Query_Disjunction{Disjunction: &v1.DisjunctionQuery{Queries: queries}},
+		Query: &v1.Query_Disjunction{Disjunction: &v1.DisjunctionQuery{Queries: nonNilQueries}},
 	}
 }
 


### PR DESCRIPTION
## Description

Migrate over the SearchRawXYZ to GetByQuery with the exceptions below:



Not needed:
- SearchRawCVEs

Probably don't want due to caches:
- SearchRawDeployments
- SearchRawPods

Probably don't want due to complexities and nested nature of objects:
- SearchRawImages
- SearchRawNodes

SAC constraints:
- SearchRawProcessBaselines

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI should check for correctness