### PR TITLE
ROX-10979: Change suppress/unsuppress APIs

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
@@ -385,7 +385,7 @@ const VulnMgmtCves = ({
         e.stopPropagation();
 
         const cveIdsToToggle = cveId ? [cveId] : selectedCveIds;
-        suppressVulns(cveIdsToToggle, duration)
+        suppressVulns(cveType, cveIdsToToggle, duration)
             .then(() => {
                 setSelectedCveIds([]);
 
@@ -410,7 +410,7 @@ const VulnMgmtCves = ({
         e.stopPropagation();
 
         const cveIdsToToggle = cveId ? [cveId] : selectedCveIds;
-        unsuppressVulns(cveIdsToToggle, false)
+        unsuppressVulns(cveType, cveIdsToToggle)
             .then(() => {
                 setSelectedCveIds([]);
 

--- a/ui/apps/platform/src/services/VulnerabilitiesService.js
+++ b/ui/apps/platform/src/services/VulnerabilitiesService.js
@@ -2,10 +2,23 @@ import queryString from 'qs';
 import { saveFile } from 'services/DownloadService';
 import { cveSortFields } from 'constants/sortFields';
 import queryService from 'utils/queryService';
+import entityTypes from 'constants/entityTypes';
 import axios from './instance';
 
-const baseUrl = '/v1/cves';
 const csvUrl = '/api/vm/export/csv';
+
+function getBaseCveUrl(cveType) {
+    if (cveType === entityTypes.CLUSTER_CVE) {
+        return '/v1/clustercves';
+    }
+    if (cveType === entityTypes.NODE_CVE) {
+        return '/v1/nodecves';
+    }
+    if (cveType === entityTypes.IMAGE_CVE) {
+        return '/v1/imagecves';
+    }
+    return '/v1/cves';
+}
 
 /**
  * Send request to suppress CVEs with a given IDs.
@@ -14,7 +27,8 @@ const csvUrl = '/api/vm/export/csv';
  * @param {!string} CVE suppress duration, if 0 then CVEs are suppressed indefinitely
  * @returns {Promise<AxiosResponse, Error>} fulfilled in case of success or rejected with an error
  */
-export function suppressVulns(cveIds, duration = 0) {
+export function suppressVulns(cveType, cveIds, duration = 0) {
+    const baseUrl = getBaseCveUrl(cveType);
     return axios.patch(`${baseUrl}/suppress`, { ids: cveIds, duration });
 }
 
@@ -24,7 +38,8 @@ export function suppressVulns(cveIds, duration = 0) {
  * @param {!string} CVE unique identifier
  * @returns {Promise<AxiosResponse, Error>} fulfilled in case of success or rejected with an error
  */
-export function unsuppressVulns(cveIds) {
+export function unsuppressVulns(cveType, cveIds) {
+    const baseUrl = getBaseCveUrl(cveType);
     return axios.patch(`${baseUrl}/unsuppress`, { ids: cveIds });
 }
 


### PR DESCRIPTION
## Description

This PR will use the appropriate URLs for suppression/unsuppression based on the CVE type:

1. `CVE` -> /`v1/cves/suppress` and `/v1/cves/unsuppress`
2. `CLUSTER_CVE` -> /`v1/clustercves/suppress` and `/v1/clustercves/unsuppress`
3. `NODE_CVE` -> /`v1/nodecves/suppress` and `/v1/nodecves/unsuppress`
4. `IMAGE_CVE` -> /`v1/imagecves/suppress` and `/v1/imagecves/unsuppress`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

