### PR TITLE
Update clean-autogen-protos.py script

### DIFF
--- a/tools/clean_autogen_protos.py
+++ b/tools/clean_autogen_protos.py
@@ -4,33 +4,22 @@ import argparse
 import pathlib
 
 
-GENERATED_EXTENSIONS = ["pb.go", "pb.gw.go", "swagger.json"]
+GENERATED_EXTENSIONS = sorted(
+    [".pb.go", ".pb.gw.go", ".swagger.json"],
+    key=len, reverse=True)
 
 
-def find_files(path, fileglob):
-    files_full = list(path.glob(fileglob))
+def find_files_rel(path, fileglob):
+    files_full = set((str(f.relative_to(path)) for f in path.glob(fileglob)))
     return files_full
 
 
-def strip_path_extension(filelist):
-    # We cannot use Path.stem directly as it doesn't handle double extensions (.pb.go) correctly
-    files_extensionless = list(map(lambda f: (str(f).replace("".join(f.suffixes), "")), filelist))
-    files_name_only = list(map(lambda f: pathlib.Path(f).stem, files_extensionless))
-    return files_name_only
-
-
-def find_difference(generated_list, proto_list):
-    difference = set(generated_list) - set(proto_list)
-    return difference
-
-
-def filter_only_gen_files(candidates):
-    return [x for x in candidates if any(str(x.name).endswith(extension) for extension in GENERATED_EXTENSIONS)]
-
-
-def find_in_list(target_list, searchterms):
-    searchterms = [f"{x}." for x in searchterms]  # Add a dot to only match full filenames
-    return [x for x in target_list if any(str(x.name).startswith(term) for term in searchterms )]
+def proto_src(path):
+    # GENERATED_EXTENSIONS are sorted in reverse order, this ensures the longest match wins
+    for ext in GENERATED_EXTENSIONS:
+        if path.endswith(ext):
+            return path[:-len(ext)] + ".proto"
+    return None
 
 
 def remove_files(target_list):
@@ -44,22 +33,18 @@ def main():
     parser.add_argument("--generated", type=pathlib.Path, help="Path to generated sources dir")
     v = parser.parse_args()
 
-    proto_files = find_files(v.protos, "**/*.proto")
-    generated_files = [f
-                       for file_list in (find_files(v.generated, f'**/*.{ext}') for ext in GENERATED_EXTENSIONS)
-                       for f in file_list]
+    proto_files = find_files_rel(v.protos, "**/*.proto")
+    generated_files = set().union(*(
+        find_files_rel(v.generated, f'**/*{ext}') for ext in GENERATED_EXTENSIONS))
 
-    proto_stripped = strip_path_extension(proto_files)
-    generated_stripped = strip_path_extension(generated_files)
+    to_remove = []
+    for f in generated_files:
+        if proto_src(f) not in proto_files:
+            print(f"Removing {f} because {proto_src(f)} does not exist")
+            to_remove.append(v.generated / f)
 
-    diff = find_difference(generated_stripped, proto_stripped)
-
-    full_paths = find_in_list(generated_files, diff)
-    final_diff = filter_only_gen_files(full_paths)
-
-    if len(final_diff) > 0:
-        print(f"Removing: {final_diff}")
-        remove_files(final_diff)
+    if len(to_remove) > 0:
+        remove_files(to_remove)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

The current version of the script makes it somewhat hard to generalize the logic from proper extensions to suffixes (e.g., `_grpc.pb.go`). This is however necessary for some upcoming protobuf generation changes.

Additionally, the `find_in_list` logic to reconstruct the generated files was prone to false positives, since it did a pure prefix match (i.e., `foo_bar.pb.go` would not be removed if there was a `foo.proto`).

Refactor and simplify the logic to work on a file-by-file basis, determining the expected proto file for each individual generated file, rather than working on whole sets of stripped filenames with the above imprecisions.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

No functional changes, tested manually by re-generating protos.
