### PR TITLE
Bump protoc to (3.)21.4

### DIFF
--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -34,7 +34,7 @@ endif
 ##############
 # Set some platform variables for protoc.
 # If the proto version is changed, be sure it is also changed in qa-tests-backend/build.gradle.
-PROTOC_VERSION := 3.20.1
+PROTOC_VERSION := 21.4
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 PROTOC_ARCH = linux

--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.google.protobuf" version "0.8.18"
+    id "com.google.protobuf" version "0.8.19"
     id "groovy"
     id "codenarc"
 }
@@ -17,8 +17,8 @@ repositories {
 
 def grpcVersion = '1.21.0'
 // If the proto versions are changed, be sure it is also changed in make/protogen.mk.
-def protocVersion = '3.20.1'
-def protobufVersion = '3.20.1'
+def protocVersion = '3.21.4'
+def protobufVersion = '3.21.4'
 def nettyTcNativeVersion = '2.0.45.Final'
 def fabric8Version = '5.12.2'
 def jacksonVersion = '2.13.2'


### PR DESCRIPTION
## Description

Bump protoc & java protobuf dependencies to v21.4/v3.21.4.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Covered by automated tests.