### PR TITLE
[ROX-12209] Populate alert's first occurrence ts from violation time

### DIFF
--- a/central/detection/alertmanager/alert_manager_impl.go
+++ b/central/detection/alertmanager/alert_manager_impl.go
@@ -308,7 +308,8 @@ func (d *alertManagerImpl) mergeManyAlerts(
 	// Merge any alerts that have new and old alerts.
 	for _, alert := range incomingAlerts {
 		if pkgAlert.IsDeployTimeAttemptedAlert(alert) {
-			alert.FirstOccurred = ptypes.TimestampNow()
+			// `alert.time` is the latest violation time.
+			alert.FirstOccurred = alert.GetTime()
 			newAlerts = append(newAlerts, alert)
 			continue
 		}
@@ -321,7 +322,8 @@ func (d *alertManagerImpl) mergeManyAlerts(
 			continue
 		}
 
-		alert.FirstOccurred = ptypes.TimestampNow()
+		// `alert.time` is the latest violation time.
+		alert.FirstOccurred = alert.GetTime()
 		newAlerts = append(newAlerts, alert)
 	}
 

--- a/pkg/detection/runtime/utils.go
+++ b/pkg/detection/runtime/utils.go
@@ -16,7 +16,7 @@ func constructProcessAlert(policy *storage.Policy, deployment *storage.Deploymen
 	}
 	alert := constructGenericRuntimeAlert(policy, deployment, violations.AlertViolations)
 	alert.ProcessViolation = violations.ProcessViolation
-	if action, msg := buildEnforcement(policy, deployment); action != storage.EnforcementAction_UNSET_ENFORCEMENT {
+	if action, msg := buildEnforcement(policy); action != storage.EnforcementAction_UNSET_ENFORCEMENT {
 		alert.Enforcement = &storage.Alert_Enforcement{
 			Action:  action,
 			Message: msg,
@@ -44,7 +44,7 @@ func constructKubeEventAlert(
 	}
 
 	alert := constructGenericRuntimeAlert(policy, kubeResource.(*storage.Deployment), violations.AlertViolations)
-	if action, msg := buildKubeEventEnforcement(policy, kubeEvent); action != storage.EnforcementAction_UNSET_ENFORCEMENT {
+	if action, msg := buildKubeEventEnforcement(policy); action != storage.EnforcementAction_UNSET_ENFORCEMENT {
 		alert.Enforcement = &storage.Alert_Enforcement{
 			Action:  action,
 			Message: msg,
@@ -97,7 +97,7 @@ func constructResourceRuntimeAlert(
 	}
 }
 
-func buildEnforcement(policy *storage.Policy, deployment *storage.Deployment) (enforcement storage.EnforcementAction, message string) {
+func buildEnforcement(policy *storage.Policy) (enforcement storage.EnforcementAction, message string) {
 	for _, enforcementAction := range policy.GetEnforcementActions() {
 		if enforcementAction == storage.EnforcementAction_KILL_POD_ENFORCEMENT {
 			return storage.EnforcementAction_KILL_POD_ENFORCEMENT,
@@ -107,7 +107,7 @@ func buildEnforcement(policy *storage.Policy, deployment *storage.Deployment) (e
 	return storage.EnforcementAction_UNSET_ENFORCEMENT, ""
 }
 
-func buildKubeEventEnforcement(policy *storage.Policy, kubeEvent *storage.KubernetesEvent) (enforcement storage.EnforcementAction, message string) {
+func buildKubeEventEnforcement(policy *storage.Policy) (enforcement storage.EnforcementAction, message string) {
 	for _, enforcementAction := range policy.GetEnforcementActions() {
 		if enforcementAction == storage.EnforcementAction_FAIL_KUBE_REQUEST_ENFORCEMENT {
 			return storage.EnforcementAction_FAIL_KUBE_REQUEST_ENFORCEMENT,


### PR DESCRIPTION
## Description

Populate alert's `first_occurred` field from `time` field. `first_occurred` was populated in Central and hence differed (and lagged) from actual violation time as captured by Sensor. `time` field indicates the latest occurrence of the alert as captured by Sensor. For deploy-time policies latest occurrence is the only occurrence since we overwrite the alerts. For runtime alerts, we merge alerts and copy the first occurrence from stored alerts. Nonetheless, the first occurrence was always incorrect in both, deploy-time and runtime alerts.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed

