### PR TITLE
hackathon: add PR number to GKE clusters

### DIFF
--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -93,7 +93,12 @@ create_cluster() {
     else
         die "Support is missing for this CI environment"
     fi
-    # . from branch names
+
+    if is_in_PR_context; then
+        labels="${labels},pr=$(get_PR_number)"
+    fi
+
+    # remove . from branch names
     tags="${tags//./-}"
     labels="${labels//./-}"
     # lowercase

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -647,7 +647,7 @@ get_PR_number() {
         fi
     fi
 
-    echo 2>&1 "ERROR: Could not determin a PR number"
+    echo 2>&1 "ERROR: Could not determine a PR number"
 
     return 1
 }
@@ -993,7 +993,7 @@ openshift_ci_mods() {
             info "Will checkout SHA to match PR: $sha"
             git checkout "$sha"
         else
-            echo "WARNING: Could not determin a SHA for this PR, ${sha:-}"
+            echo "WARNING: Could not determina a SHA for this PR, ${sha:-}"
         fi
     fi
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -993,7 +993,7 @@ openshift_ci_mods() {
             info "Will checkout SHA to match PR: $sha"
             git checkout "$sha"
         else
-            echo "WARNING: Could not determina a SHA for this PR, ${sha:-}"
+            echo "WARNING: Could not determine a SHA for this PR, ${sha:-}"
         fi
     fi
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -638,7 +638,7 @@ get_PR_number() {
         # bin, test-bin, images
         local pull_request
         pull_request=$(jq -r <<<"$CLONEREFS_OPTIONS" '.refs[0].pulls[0].number' 2>&1) || {
-            echo 2>&1 "ERROR: Could not determin a PR number"
+            echo 2>&1 "ERROR: Could not determine a PR number"
             return 1
         }
         if [[ "$pull_request" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Description

It can be useful to list all clusters in use for a PR.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient. [Works!](https://console.cloud.google.com/kubernetes/list/overview?authuser=1&project=stackrox-ci&pageState=(%22cluster_list_table%22:(%22f%22:%22%255B%257B_22k_22_3A_22Labels_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22pr_3A2673_5C_22_22_2C_22s_22_3Atrue_2C_22i_22_3A_22labels_22%257D%255D%22))) 
