### PR TITLE
Re-enable CVE test "Verify IsFixable is correct when scoped (#digest, #fixable)" in postgres mode

### DIFF
--- a/qa-tests-backend/src/test/groovy/CVETest.groovy
+++ b/qa-tests-backend/src/test/groovy/CVETest.groovy
@@ -159,6 +159,14 @@ class CVETest extends BaseSpecification {
     }
     """
 
+    private static final SCOPED_FIXABLE_POSTGRES_QUERY = """
+    query getCve(\$id: ID!, \$scopeQuery: String) {
+      result: imageVulnerability(id: \$id) {
+        isFixable(query: \$scopeQuery)
+      }
+    }
+    """
+
     static final private String CVE_DEPLOYMENT_NAME = "cve-deployment"
 
     static final private Deployment CVE_DEPLOYMENT = new Deployment()
@@ -440,14 +448,26 @@ class CVETest extends BaseSpecification {
 
     @Unroll
     @Category(BAT)
-    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
     def "Verify IsFixable is correct when scoped (#digest, #fixable)"() {
         when:
         "Query fixable CVEs by a specific CVE in the image"
         def gqlService = new GraphQLService()
-        def ret = gqlService.Call(SCOPED_FIXABLE_QUERY, [
-                id: "CVE-2019-9893",
-                scopeQuery: "Image Sha:${digest}+CVE:CVE-2019-9893",
+        def scopedFixableQuery = ""
+        if (Env.CI_JOBNAME.contains("postgres")) {
+            scopedFixableQuery = SCOPED_FIXABLE_POSTGRES_QUERY
+        } else {
+            scopedFixableQuery = SCOPED_FIXABLE_QUERY
+        }
+        def cveId = "CVE-2019-9893"
+        def scopeQuery = "Image Sha:${digest}"
+        if (Env.CI_JOBNAME.contains("postgres")) {
+            cveId = cveId + "#" + "${os}"
+        } else {
+            scopeQuery = scopeQuery + "+CVE:" + cveId
+        }
+        def ret = gqlService.Call(scopedFixableQuery, [
+                id: cveId,
+                scopeQuery: scopeQuery,
         ])
 
         then:
@@ -458,9 +478,9 @@ class CVETest extends BaseSpecification {
         where:
         "data inputs"
 
-        digest | fixable
-        FIXABLE_VULN_IMAGE_DIGEST | true
-        UNFIXABLE_VULN_IMAGE_DIGEST | false
+        digest                      | os             | fixable
+        FIXABLE_VULN_IMAGE_DIGEST   | "ubuntu:18.04" | true
+        UNFIXABLE_VULN_IMAGE_DIGEST | "debian:10"    | false
     }
 
 }


### PR DESCRIPTION
## Description

Some end-to-end tests were disabled at the early stages of the postgres migration because the state of things at the time made them fail or made them instable.
As the migration progresses, it is time to re-enable those that work again.

For the test at hand, some adjustments had to be introduced in the GraphQL queries to cope with some underlying re-design around vulnerability management.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI run should be sufficient