### PR TITLE
Re-enable remaining SAC autocomplete test in postgres mode

### DIFF
--- a/central/globalindex/mapping/mapping.go
+++ b/central/globalindex/mapping/mapping.go
@@ -98,17 +98,6 @@ func singleTermAnalyzer() map[string]interface{} {
 
 func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 	// Note: with the dackbox graph split brought with the postgres migration, the concept
-	// of Component (ImageComponent) was split into ImageComponent and NodeComponent.
-	// The old content seems to focus mostly on image Components.
-	componentSearchOptions := search.CombineOptionsMaps(
-		schema.ImageComponentsSchema.OptionsMap,
-		schema.ImageComponentEdgesSchema.OptionsMap,
-		schema.ImageComponentCveEdgesSchema.OptionsMap,
-		schema.ImagesSchema.OptionsMap,
-		schema.ImageCvesSchema.OptionsMap,
-	)
-
-	// Note: with the dackbox graph split brought with the postgres migration, the concept
 	// of CVE was split into ClusterCVE, ImageCVE and NodeCVE. The old content seems to focus
 	// mostly on image CVEs.
 	cveSearchOptions := search.CombineOptionsMaps(
@@ -118,6 +107,17 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 		schema.ImageComponentEdgesSchema.OptionsMap,
 		schema.ImagesSchema.OptionsMap,
 		schema.DeploymentsSchema.OptionsMap,
+	)
+
+	// Note: with the dackbox graph split brought with the postgres migration, the concept
+	// of Component (ImageComponent) was split into ImageComponent and NodeComponent.
+	// The old content seems to focus mostly on image Components.
+	imageComponentSearchOptions := search.CombineOptionsMaps(
+		schema.ImageComponentsSchema.OptionsMap,
+		schema.ImageComponentEdgesSchema.OptionsMap,
+		schema.ImageComponentCveEdgesSchema.OptionsMap,
+		schema.ImagesSchema.OptionsMap,
+		schema.ImageCvesSchema.OptionsMap,
 	)
 
 	// Images in dackbox support an expanded set of search options
@@ -149,7 +149,8 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 		v1.SearchCategory_COMPONENT_VULN_EDGE:   schema.ImageComponentCveEdgesSchema.OptionsMap,
 		v1.SearchCategory_DEPLOYMENTS:           schema.DeploymentsSchema.OptionsMap,
 		v1.SearchCategory_IMAGE_COMPONENT_EDGE:  schema.ImageComponentEdgesSchema.OptionsMap,
-		v1.SearchCategory_IMAGE_COMPONENTS:      componentSearchOptions,
+		v1.SearchCategory_IMAGE_COMPONENTS:      imageComponentSearchOptions,
+		v1.SearchCategory_IMAGE_INTEGRATIONS:    schema.ImageIntegrationsSchema.OptionsMap,
 		v1.SearchCategory_IMAGE_VULN_EDGE:       schema.ImageCveEdgesSchema.OptionsMap,
 		v1.SearchCategory_IMAGES:                imageSearchOptions,
 		v1.SearchCategory_NAMESPACES:            schema.NamespacesSchema.OptionsMap,

--- a/central/globalindex/mapping/mapping.go
+++ b/central/globalindex/mapping/mapping.go
@@ -37,6 +37,8 @@ import (
 	serviceAccountOptions "github.com/stackrox/rox/central/serviceaccount/mappings"
 	vulnReqMapping "github.com/stackrox/rox/central/vulnerabilityrequest/mappings"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/options/deployments"
@@ -94,8 +96,144 @@ func singleTermAnalyzer() map[string]interface{} {
 	}
 }
 
+func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
+	// Note: with the dackbox graph split brought with the postgres migration, the concept
+	// of Component (ImageComponent) was split into ImageComponent and NodeComponent.
+	// The old content seems to focus mostly on image Components.
+	// componentSearchOptions := search.CombineOptionsMaps(
+	// 	imageComponentMapping.OptionsMap,
+	// 	imageComponentEdgeMapping.OptionsMap,
+	// 	componentVulnEdgeMapping.OptionsMap,
+	// 	imageMapping.OptionsMap,
+	// 	cveMapping.OptionsMap,
+	// 	imageMapping.ImageDeploymentOptions,
+	// )
+	componentSearchOptions := search.CombineOptionsMaps(
+		schema.ImageComponentsSchema.OptionsMap,
+		schema.ImageComponentEdgesSchema.OptionsMap,
+		schema.ImageComponentCveEdgesSchema.OptionsMap,
+		schema.ImagesSchema.OptionsMap,
+		schema.ImageCvesSchema.OptionsMap,
+	)
+
+	// Note: with the dackbox graph split brought with the postgres migration, the concept
+	// of CVE was split into ClusterCVE, ImageCVE and NodeCVE. The old content seems to focus
+	// mostly on image CVEs.
+	// cveSearchOptions := search.CombineOptionsMaps(
+	// 	cveMapping.OptionsMap,
+	// 	componentVulnEdgeMapping.OptionsMap,
+	// 	imageComponentMapping.OptionsMap,
+	// 	imageComponentEdgeMapping.OptionsMap,
+	// 	imageMapping.OptionsMap,
+	// 	deployments.OptionsMap,
+	// )
+	cveSearchOptions := search.CombineOptionsMaps(
+		schema.ImageCvesSchema.OptionsMap,
+		schema.ImageComponentCveEdgesSchema.OptionsMap,
+		schema.ImageComponentsSchema.OptionsMap,
+		schema.ImageComponentEdgesSchema.OptionsMap,
+		schema.ImagesSchema.OptionsMap,
+		schema.DeploymentsSchema.OptionsMap,
+	)
+
+	// Images in dackbox support an expanded set of search options
+	// imageSearchOptions := search.CombineOptionsMaps(
+	// 	imageMapping.OptionsMap,
+	// 	imageMapping.ImageDeploymentOptions,
+	// 	imageComponentEdgeMapping.OptionsMap,
+	// 	imageComponentMapping.OptionsMap,
+	// 	componentVulnEdgeMapping.OptionsMap,
+	// 	cveMapping.OptionsMap,
+	// )
+	imageSearchOptions := search.CombineOptionsMaps(
+		schema.ImagesSchema.OptionsMap,
+		schema.ImageComponentEdgesSchema.OptionsMap,
+		schema.ImageComponentsSchema.OptionsMap,
+		schema.ImageComponentCveEdgesSchema.OptionsMap,
+		schema.ImageCvesSchema.OptionsMap,
+	)
+
+	// nodeSearchOptions := search.CombineOptionsMaps(
+	// 	nodeMapping.OptionsMap,
+	// 	nodeComponentEdgeMapping.OptionsMap,
+	// 	imageComponentMapping.OptionsMap,
+	// 	componentVulnEdgeMapping.OptionsMap,
+	// 	cveMapping.OptionsMap,
+	// )
+	nodeSearchOptions := search.CombineOptionsMaps(
+		schema.NodesSchema.OptionsMap,
+		schema.NodeComponentEdgesSchema.OptionsMap,
+		schema.NodeComponentsSchema.OptionsMap,
+		schema.NodeComponentsCvesEdgesSchema.OptionsMap,
+		schema.NodeCvesSchema.OptionsMap,
+	)
+
+	// EntityOptionsMap is a mapping from search categories to the options map for that category.
+	// search document maps are also built off this map
+	entityOptionsMap := map[v1.SearchCategory]search.OptionsMap{
+		// v1.SearchCategory_ACTIVE_COMPONENT:      activeComponentMappings.OptionsMap,
+		v1.SearchCategory_ACTIVE_COMPONENT: schema.ActiveComponentsSchema.OptionsMap,
+		// v1.SearchCategory_ALERTS:                alertMapping.OptionsMap,
+		v1.SearchCategory_ALERTS: schema.AlertsSchema.OptionsMap,
+		// v1.SearchCategory_CLUSTER_VULN_EDGE:     clusterVulnEdgeMapping.OptionsMap,
+		v1.SearchCategory_CLUSTER_VULN_EDGE: schema.ClusterCveEdgesSchema.OptionsMap,
+		// v1.SearchCategory_CLUSTERS:              clusterMapping.OptionsMap,
+		v1.SearchCategory_CLUSTERS:            schema.ClustersSchema.OptionsMap,
+		v1.SearchCategory_COMPLIANCE_STANDARD: index.StandardOptions,
+		v1.SearchCategory_COMPLIANCE_CONTROL:  index.ControlOptions,
+		// v1.SearchCategory_COMPONENT_VULN_EDGE:   componentVulnEdgeMapping.OptionsMap,
+		v1.SearchCategory_COMPONENT_VULN_EDGE: schema.ImageComponentCveEdgesSchema.OptionsMap,
+		// v1.SearchCategory_DEPLOYMENTS:           deployments.OptionsMap,
+		v1.SearchCategory_DEPLOYMENTS: schema.DeploymentsSchema.OptionsMap,
+		// v1.SearchCategory_IMAGE_COMPONENT_EDGE:  imageComponentEdgeMapping.OptionsMap,
+		v1.SearchCategory_IMAGE_COMPONENT_EDGE: schema.ImageComponentEdgesSchema.OptionsMap,
+		v1.SearchCategory_IMAGE_COMPONENTS:     componentSearchOptions,
+		// v1.SearchCategory_IMAGE_VULN_EDGE:       imageCVEEdgeMapping.OptionsMap,
+		v1.SearchCategory_IMAGE_VULN_EDGE: schema.ImageCveEdgesSchema.OptionsMap,
+		v1.SearchCategory_IMAGES:          imageSearchOptions,
+		// v1.SearchCategory_NAMESPACES:            namespaceMapping.OptionsMap,
+		v1.SearchCategory_NAMESPACES: schema.NamespacesSchema.OptionsMap,
+		// v1.SearchCategory_NODE_COMPONENT_EDGE:   nodeComponentEdgeMappings.OptionsMap,
+		v1.SearchCategory_NODE_COMPONENT_EDGE: schema.NodeComponentEdgesSchema.OptionsMap,
+		v1.SearchCategory_NODE_COMPONENTS:     schema.NodeComponentsSchema.OptionsMap,
+		v1.SearchCategory_NODES:               nodeSearchOptions,
+		// v1.SearchCategory_PODS:                  podMapping.OptionsMap,
+		v1.SearchCategory_PODS: schema.PodsSchema.OptionsMap,
+		// v1.SearchCategory_POLICIES:              policyMapping.OptionsMap,
+		v1.SearchCategory_POLICIES: schema.PoliciesSchema.OptionsMap,
+		// v1.SearchCategory_POLICY_CATEGORIES:     policyCategoryMapping.OptionsMap,
+		v1.SearchCategory_POLICY_CATEGORIES: schema.PolicyCategoriesSchema.OptionsMap,
+		// v1.SearchCategory_PROCESS_BASELINES:     processBaselineMapping.OptionsMap,
+		v1.SearchCategory_PROCESS_BASELINES: schema.ProcessBaselinesSchema.OptionsMap,
+		// v1.SearchCategory_PROCESS_INDICATORS:    processindicators.OptionsMap,
+		v1.SearchCategory_PROCESS_INDICATORS: schema.ProcessIndicatorsSchema.OptionsMap,
+		// v1.SearchCategory_REPORT_CONFIGURATIONS: reportConfigurationsMapping.OptionsMap,
+		v1.SearchCategory_REPORT_CONFIGURATIONS: schema.ReportConfigurationsSchema.OptionsMap,
+		// v1.SearchCategory_RISKS:                 riskMappings.OptionsMap,
+		v1.SearchCategory_RISKS: schema.RisksSchema.OptionsMap,
+		// v1.SearchCategory_ROLES:                 roleOptions.OptionsMap,
+		v1.SearchCategory_ROLES: schema.K8sRolesSchema.OptionsMap,
+		// v1.SearchCategory_ROLEBINDINGS:          roleBindingOptions.OptionsMap,
+		v1.SearchCategory_ROLEBINDINGS: schema.RoleBindingsSchema.OptionsMap,
+		// v1.SearchCategory_SECRETS:               secretOptions.OptionsMap,
+		v1.SearchCategory_SECRETS: schema.SecretsSchema.OptionsMap,
+		// v1.SearchCategory_SERVICE_ACCOUNTS:      serviceAccountOptions.OptionsMap,
+		v1.SearchCategory_SERVICE_ACCOUNTS: schema.ServiceAccountsSchema.OptionsMap,
+		// v1.SearchCategory_SUBJECTS:              subjectMapping.OptionsMap,
+		v1.SearchCategory_SUBJECTS: schema.RoleBindingsSchema.OptionsMap,
+		//v1.SearchCategory_VULN_REQUEST:          vulnReqMapping.OptionsMap,
+		v1.SearchCategory_VULN_REQUEST:    schema.VulnerabilityRequestsSchema.OptionsMap,
+		v1.SearchCategory_VULNERABILITIES: cveSearchOptions,
+	}
+
+	return entityOptionsMap
+}
+
 // GetEntityOptionsMap is a mapping from search categories to the options
 func GetEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
+	if features.PostgresDatastore.Enabled() {
+		return getPostgresEntityOptionsMap()
+	}
 	nodeSearchOptions := search.CombineOptionsMaps(
 		nodeMapping.OptionsMap,
 		nodeComponentEdgeMapping.OptionsMap,

--- a/central/globalindex/mapping/mapping.go
+++ b/central/globalindex/mapping/mapping.go
@@ -108,9 +108,9 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 	// 	schema.DeploymentsSchema.OptionsMap,
 	// )
 	clusterToVulnerabilitySearchOptions := search.CombineOptionsMaps(
-		schema.ClusterCvesSchema.OptionsMaps,
-		schema.ClusterCveEdgesSchema.OptionsMaps,
-		schema.ClustersSchema.OptionsMaps,
+		schema.ClusterCvesSchema.OptionsMap,
+		schema.ClusterCveEdgesSchema.OptionsMap,
+		schema.ClustersSchema.OptionsMap,
 	)
 
 	// Note: with the dackbox graph split brought with the postgres migration, the concept

--- a/central/globalindex/mapping/mapping.go
+++ b/central/globalindex/mapping/mapping.go
@@ -99,39 +99,21 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 	// Note: with the dackbox graph split brought with the postgres migration, the concept
 	// of CVE was split into ClusterCVE, ImageCVE and NodeCVE. The old content seems to focus
 	// mostly on image CVEs.
-	// cveSearchOptions := search.CombineOptionsMaps(
-	// 	schema.ImageCvesSchema.OptionsMap,
-	// 	schema.ImageComponentCveEdgesSchema.OptionsMap,
-	// 	schema.ImageComponentsSchema.OptionsMap,
-	// 	schema.ImageComponentEdgesSchema.OptionsMap,
-	// 	schema.ImagesSchema.OptionsMap,
-	// 	schema.DeploymentsSchema.OptionsMap,
-	// )
+	// Note: with the dackbox graph split brought with the postgres migration, the concept
+	// of Component (ImageComponent) was split into ImageComponent and NodeComponent.
+	// The old content seems to focus mostly on image Components.
 	clusterToVulnerabilitySearchOptions := search.CombineOptionsMaps(
 		schema.ClusterCvesSchema.OptionsMap,
 		schema.ClusterCveEdgesSchema.OptionsMap,
 		schema.ClustersSchema.OptionsMap,
 	)
 
-	// Note: with the dackbox graph split brought with the postgres migration, the concept
-	// of Component (ImageComponent) was split into ImageComponent and NodeComponent.
-	// The old content seems to focus mostly on image Components.
-	// imageComponentSearchOptions := search.CombineOptionsMaps(
-	// 	schema.ImageComponentsSchema.OptionsMap,
-	// 	schema.ImageComponentEdgesSchema.OptionsMap,
-	// 	schema.ImageComponentCveEdgesSchema.OptionsMap,
-	// 	schema.ImagesSchema.OptionsMap,
-	// 	schema.ImageCvesSchema.OptionsMap,
-	// )
+	deploymentsCustomSearchOptions := search.CombineOptionsMaps(
+		schema.ImagesSchema.OptionsMap,
+		schema.ProcessIndicatorsSchema.OptionsMap,
+		schema.DeploymentsSchema.OptionsMap,
+	)
 
-	// Images in dackbox support an expanded set of search options
-	// imageSearchOptions := search.CombineOptionsMaps(
-	// 	schema.ImagesSchema.OptionsMap,
-	// 	schema.ImageComponentEdgesSchema.OptionsMap,
-	// 	schema.ImageComponentsSchema.OptionsMap,
-	// 	schema.ImageComponentCveEdgesSchema.OptionsMap,
-	// 	schema.ImageCvesSchema.OptionsMap,
-	// )
 	imageToVulnerabilitySearchOptions := search.CombineOptionsMaps(
 		schema.ImageCvesSchema.OptionsMap,
 		schema.ImageCveEdgesSchema.OptionsMap,
@@ -144,13 +126,6 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 		schema.ClustersSchema.OptionsMap,
 	)
 
-	// nodeSearchOptions := search.CombineOptionsMaps(
-	// 	schema.NodesSchema.OptionsMap,
-	// 	schema.NodeComponentEdgesSchema.OptionsMap,
-	// 	schema.NodeComponentsSchema.OptionsMap,
-	// 	schema.NodeComponentsCvesEdgesSchema.OptionsMap,
-	// 	schema.NodeCvesSchema.OptionsMap,
-	// )
 	nodeToVulnerabilitySearchOptions := search.CombineOptionsMaps(
 		schema.NodeCvesSchema.OptionsMap,
 		schema.NodeComponentsCvesEdgesSchema.OptionsMap,
@@ -171,7 +146,7 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 		v1.SearchCategory_COMPLIANCE_STANDARD:     index.StandardOptions,
 		v1.SearchCategory_COMPLIANCE_CONTROL:      index.ControlOptions,
 		v1.SearchCategory_COMPONENT_VULN_EDGE:     schema.ImageComponentCveEdgesSchema.OptionsMap,
-		v1.SearchCategory_DEPLOYMENTS:             schema.DeploymentsSchema.OptionsMap,
+		v1.SearchCategory_DEPLOYMENTS:             deploymentsCustomSearchOptions,
 		v1.SearchCategory_IMAGE_COMPONENT_EDGE:    imageToVulnerabilitySearchOptions,
 		v1.SearchCategory_IMAGE_COMPONENTS:        imageToVulnerabilitySearchOptions,
 		v1.SearchCategory_IMAGE_INTEGRATIONS:      schema.ImageIntegrationsSchema.OptionsMap,

--- a/central/globalindex/mapping/mapping.go
+++ b/central/globalindex/mapping/mapping.go
@@ -26,7 +26,6 @@ import (
 	podMapping "github.com/stackrox/rox/central/pod/mappings"
 	policyMapping "github.com/stackrox/rox/central/policy/index/mappings"
 	policyCategoryMapping "github.com/stackrox/rox/central/policycategory/index/mappings"
-
 	processBaselineMapping "github.com/stackrox/rox/central/processbaseline/index/mappings"
 	roleOptions "github.com/stackrox/rox/central/rbac/k8srole/mappings"
 	roleBindingOptions "github.com/stackrox/rox/central/rbac/k8srolebinding/mappings"
@@ -100,77 +99,104 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 	// Note: with the dackbox graph split brought with the postgres migration, the concept
 	// of CVE was split into ClusterCVE, ImageCVE and NodeCVE. The old content seems to focus
 	// mostly on image CVEs.
-	cveSearchOptions := search.CombineOptionsMaps(
-		schema.ImageCvesSchema.OptionsMap,
-		schema.ImageComponentCveEdgesSchema.OptionsMap,
-		schema.ImageComponentsSchema.OptionsMap,
-		schema.ImageComponentEdgesSchema.OptionsMap,
-		schema.ImagesSchema.OptionsMap,
-		schema.DeploymentsSchema.OptionsMap,
+	// cveSearchOptions := search.CombineOptionsMaps(
+	// 	schema.ImageCvesSchema.OptionsMap,
+	// 	schema.ImageComponentCveEdgesSchema.OptionsMap,
+	// 	schema.ImageComponentsSchema.OptionsMap,
+	// 	schema.ImageComponentEdgesSchema.OptionsMap,
+	// 	schema.ImagesSchema.OptionsMap,
+	// 	schema.DeploymentsSchema.OptionsMap,
+	// )
+	clusterToVulnerabilitySearchOptions := search.CombineOptionsMaps(
+		schema.ClusterCvesSchema.OptionsMaps,
+		schema.ClusterCveEdgesSchema.OptionsMaps,
+		schema.ClustersSchema.OptionsMaps,
 	)
 
 	// Note: with the dackbox graph split brought with the postgres migration, the concept
 	// of Component (ImageComponent) was split into ImageComponent and NodeComponent.
 	// The old content seems to focus mostly on image Components.
-	imageComponentSearchOptions := search.CombineOptionsMaps(
-		schema.ImageComponentsSchema.OptionsMap,
-		schema.ImageComponentEdgesSchema.OptionsMap,
-		schema.ImageComponentCveEdgesSchema.OptionsMap,
-		schema.ImagesSchema.OptionsMap,
-		schema.ImageCvesSchema.OptionsMap,
-	)
+	// imageComponentSearchOptions := search.CombineOptionsMaps(
+	// 	schema.ImageComponentsSchema.OptionsMap,
+	// 	schema.ImageComponentEdgesSchema.OptionsMap,
+	// 	schema.ImageComponentCveEdgesSchema.OptionsMap,
+	// 	schema.ImagesSchema.OptionsMap,
+	// 	schema.ImageCvesSchema.OptionsMap,
+	// )
 
 	// Images in dackbox support an expanded set of search options
-	imageSearchOptions := search.CombineOptionsMaps(
-		schema.ImagesSchema.OptionsMap,
-		schema.ImageComponentEdgesSchema.OptionsMap,
-		schema.ImageComponentsSchema.OptionsMap,
-		schema.ImageComponentCveEdgesSchema.OptionsMap,
+	// imageSearchOptions := search.CombineOptionsMaps(
+	// 	schema.ImagesSchema.OptionsMap,
+	// 	schema.ImageComponentEdgesSchema.OptionsMap,
+	// 	schema.ImageComponentsSchema.OptionsMap,
+	// 	schema.ImageComponentCveEdgesSchema.OptionsMap,
+	// 	schema.ImageCvesSchema.OptionsMap,
+	// )
+	imageToVulnerabilitySearchOptions := search.CombineOptionsMaps(
 		schema.ImageCvesSchema.OptionsMap,
+		schema.ImageCveEdgesSchema.OptionsMap,
+		schema.ImageComponentCveEdgesSchema.OptionsMap,
+		schema.ImageComponentsSchema.OptionsMap,
+		schema.ImageComponentEdgesSchema.OptionsMap,
+		schema.ImagesSchema.OptionsMap,
+		schema.DeploymentsSchema.OptionsMap,
+		schema.NamespacesSchema.OptionsMap,
+		schema.ClustersSchema.OptionsMap,
 	)
 
-	nodeSearchOptions := search.CombineOptionsMaps(
-		schema.NodesSchema.OptionsMap,
-		schema.NodeComponentEdgesSchema.OptionsMap,
-		schema.NodeComponentsSchema.OptionsMap,
-		schema.NodeComponentsCvesEdgesSchema.OptionsMap,
+	// nodeSearchOptions := search.CombineOptionsMaps(
+	// 	schema.NodesSchema.OptionsMap,
+	// 	schema.NodeComponentEdgesSchema.OptionsMap,
+	// 	schema.NodeComponentsSchema.OptionsMap,
+	// 	schema.NodeComponentsCvesEdgesSchema.OptionsMap,
+	// 	schema.NodeCvesSchema.OptionsMap,
+	// )
+	nodeToVulnerabilitySearchOptions := search.CombineOptionsMaps(
 		schema.NodeCvesSchema.OptionsMap,
+		schema.NodeComponentsCvesEdgesSchema.OptionsMap,
+		schema.NodeComponentsSchema.OptionsMap,
+		schema.NodeComponentEdgesSchema.OptionsMap,
+		schema.NodesSchema.OptionsMap,
+		schema.ClustersSchema.OptionsMap,
 	)
 
 	// EntityOptionsMap is a mapping from search categories to the options map for that category.
 	// search document maps are also built off this map
 	entityOptionsMap := map[v1.SearchCategory]search.OptionsMap{
-		v1.SearchCategory_ACTIVE_COMPONENT:      schema.ActiveComponentsSchema.OptionsMap,
-		v1.SearchCategory_ALERTS:                schema.AlertsSchema.OptionsMap,
-		v1.SearchCategory_CLUSTER_VULN_EDGE:     schema.ClusterCveEdgesSchema.OptionsMap,
-		v1.SearchCategory_CLUSTERS:              schema.ClustersSchema.OptionsMap,
-		v1.SearchCategory_COMPLIANCE_STANDARD:   index.StandardOptions,
-		v1.SearchCategory_COMPLIANCE_CONTROL:    index.ControlOptions,
-		v1.SearchCategory_COMPONENT_VULN_EDGE:   schema.ImageComponentCveEdgesSchema.OptionsMap,
-		v1.SearchCategory_DEPLOYMENTS:           schema.DeploymentsSchema.OptionsMap,
-		v1.SearchCategory_IMAGE_COMPONENT_EDGE:  schema.ImageComponentEdgesSchema.OptionsMap,
-		v1.SearchCategory_IMAGE_COMPONENTS:      imageComponentSearchOptions,
-		v1.SearchCategory_IMAGE_INTEGRATIONS:    schema.ImageIntegrationsSchema.OptionsMap,
-		v1.SearchCategory_IMAGE_VULN_EDGE:       schema.ImageCveEdgesSchema.OptionsMap,
-		v1.SearchCategory_IMAGES:                imageSearchOptions,
-		v1.SearchCategory_NAMESPACES:            schema.NamespacesSchema.OptionsMap,
-		v1.SearchCategory_NODE_COMPONENT_EDGE:   schema.NodeComponentEdgesSchema.OptionsMap,
-		v1.SearchCategory_NODE_COMPONENTS:       schema.NodeComponentsSchema.OptionsMap,
-		v1.SearchCategory_NODES:                 nodeSearchOptions,
-		v1.SearchCategory_PODS:                  schema.PodsSchema.OptionsMap,
-		v1.SearchCategory_POLICIES:              schema.PoliciesSchema.OptionsMap,
-		v1.SearchCategory_POLICY_CATEGORIES:     schema.PolicyCategoriesSchema.OptionsMap,
-		v1.SearchCategory_PROCESS_BASELINES:     schema.ProcessBaselinesSchema.OptionsMap,
-		v1.SearchCategory_PROCESS_INDICATORS:    schema.ProcessIndicatorsSchema.OptionsMap,
-		v1.SearchCategory_REPORT_CONFIGURATIONS: schema.ReportConfigurationsSchema.OptionsMap,
-		v1.SearchCategory_RISKS:                 schema.RisksSchema.OptionsMap,
-		v1.SearchCategory_ROLES:                 schema.K8sRolesSchema.OptionsMap,
-		v1.SearchCategory_ROLEBINDINGS:          schema.RoleBindingsSchema.OptionsMap,
-		v1.SearchCategory_SECRETS:               schema.SecretsSchema.OptionsMap,
-		v1.SearchCategory_SERVICE_ACCOUNTS:      schema.ServiceAccountsSchema.OptionsMap,
-		v1.SearchCategory_SUBJECTS:              schema.RoleBindingsSchema.OptionsMap,
-		v1.SearchCategory_VULN_REQUEST:          schema.VulnerabilityRequestsSchema.OptionsMap,
-		v1.SearchCategory_VULNERABILITIES:       cveSearchOptions,
+		v1.SearchCategory_ACTIVE_COMPONENT:        schema.ActiveComponentsSchema.OptionsMap,
+		v1.SearchCategory_ALERTS:                  schema.AlertsSchema.OptionsMap,
+		v1.SearchCategory_CLUSTER_VULN_EDGE:       clusterToVulnerabilitySearchOptions,
+		v1.SearchCategory_CLUSTER_VULNERABILITIES: clusterToVulnerabilitySearchOptions,
+		v1.SearchCategory_CLUSTERS:                schema.ClustersSchema.OptionsMap,
+		v1.SearchCategory_COMPLIANCE_STANDARD:     index.StandardOptions,
+		v1.SearchCategory_COMPLIANCE_CONTROL:      index.ControlOptions,
+		v1.SearchCategory_COMPONENT_VULN_EDGE:     schema.ImageComponentCveEdgesSchema.OptionsMap,
+		v1.SearchCategory_DEPLOYMENTS:             schema.DeploymentsSchema.OptionsMap,
+		v1.SearchCategory_IMAGE_COMPONENT_EDGE:    imageToVulnerabilitySearchOptions,
+		v1.SearchCategory_IMAGE_COMPONENTS:        imageToVulnerabilitySearchOptions,
+		v1.SearchCategory_IMAGE_INTEGRATIONS:      schema.ImageIntegrationsSchema.OptionsMap,
+		v1.SearchCategory_IMAGE_VULN_EDGE:         imageToVulnerabilitySearchOptions,
+		v1.SearchCategory_IMAGE_VULNERABILITIES:   imageToVulnerabilitySearchOptions,
+		v1.SearchCategory_IMAGES:                  imageToVulnerabilitySearchOptions,
+		v1.SearchCategory_NAMESPACES:              schema.NamespacesSchema.OptionsMap,
+		v1.SearchCategory_NODE_COMPONENT_EDGE:     nodeToVulnerabilitySearchOptions,
+		v1.SearchCategory_NODE_COMPONENTS:         nodeToVulnerabilitySearchOptions,
+		v1.SearchCategory_NODE_VULNERABILITIES:    nodeToVulnerabilitySearchOptions,
+		v1.SearchCategory_NODES:                   nodeToVulnerabilitySearchOptions,
+		v1.SearchCategory_PODS:                    schema.PodsSchema.OptionsMap,
+		v1.SearchCategory_POLICIES:                schema.PoliciesSchema.OptionsMap,
+		v1.SearchCategory_POLICY_CATEGORIES:       schema.PolicyCategoriesSchema.OptionsMap,
+		v1.SearchCategory_PROCESS_BASELINES:       schema.ProcessBaselinesSchema.OptionsMap,
+		v1.SearchCategory_PROCESS_INDICATORS:      schema.ProcessIndicatorsSchema.OptionsMap,
+		v1.SearchCategory_REPORT_CONFIGURATIONS:   schema.ReportConfigurationsSchema.OptionsMap,
+		v1.SearchCategory_RISKS:                   schema.RisksSchema.OptionsMap,
+		v1.SearchCategory_ROLES:                   schema.K8sRolesSchema.OptionsMap,
+		v1.SearchCategory_ROLEBINDINGS:            schema.RoleBindingsSchema.OptionsMap,
+		v1.SearchCategory_SECRETS:                 schema.SecretsSchema.OptionsMap,
+		v1.SearchCategory_SERVICE_ACCOUNTS:        schema.ServiceAccountsSchema.OptionsMap,
+		v1.SearchCategory_SUBJECTS:                schema.RoleBindingsSchema.OptionsMap,
+		v1.SearchCategory_VULN_REQUEST:            schema.VulnerabilityRequestsSchema.OptionsMap,
+		// v1.SearchCategory_VULNERABILITIES:       cveSearchOptions,
 	}
 
 	return entityOptionsMap

--- a/central/globalindex/mapping/mapping.go
+++ b/central/globalindex/mapping/mapping.go
@@ -169,7 +169,7 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 		v1.SearchCategory_ROLEBINDINGS:            schema.RoleBindingsSchema.OptionsMap,
 		v1.SearchCategory_SECRETS:                 schema.SecretsSchema.OptionsMap,
 		v1.SearchCategory_SERVICE_ACCOUNTS:        schema.ServiceAccountsSchema.OptionsMap,
-		v1.SearchCategory_SUBJECTS:                schema.RoleBindingsSchema.OptionsMap,
+		v1.SearchCategory_SUBJECTS:                subjectMapping.OptionsMap,
 		v1.SearchCategory_VULN_REQUEST:            schema.VulnerabilityRequestsSchema.OptionsMap,
 		// v1.SearchCategory_VULNERABILITIES:       cveSearchOptions,
 	}

--- a/central/globalindex/mapping/mapping.go
+++ b/central/globalindex/mapping/mapping.go
@@ -100,14 +100,6 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 	// Note: with the dackbox graph split brought with the postgres migration, the concept
 	// of Component (ImageComponent) was split into ImageComponent and NodeComponent.
 	// The old content seems to focus mostly on image Components.
-	// componentSearchOptions := search.CombineOptionsMaps(
-	// 	imageComponentMapping.OptionsMap,
-	// 	imageComponentEdgeMapping.OptionsMap,
-	// 	componentVulnEdgeMapping.OptionsMap,
-	// 	imageMapping.OptionsMap,
-	// 	cveMapping.OptionsMap,
-	// 	imageMapping.ImageDeploymentOptions,
-	// )
 	componentSearchOptions := search.CombineOptionsMaps(
 		schema.ImageComponentsSchema.OptionsMap,
 		schema.ImageComponentEdgesSchema.OptionsMap,
@@ -119,14 +111,6 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 	// Note: with the dackbox graph split brought with the postgres migration, the concept
 	// of CVE was split into ClusterCVE, ImageCVE and NodeCVE. The old content seems to focus
 	// mostly on image CVEs.
-	// cveSearchOptions := search.CombineOptionsMaps(
-	// 	cveMapping.OptionsMap,
-	// 	componentVulnEdgeMapping.OptionsMap,
-	// 	imageComponentMapping.OptionsMap,
-	// 	imageComponentEdgeMapping.OptionsMap,
-	// 	imageMapping.OptionsMap,
-	// 	deployments.OptionsMap,
-	// )
 	cveSearchOptions := search.CombineOptionsMaps(
 		schema.ImageCvesSchema.OptionsMap,
 		schema.ImageComponentCveEdgesSchema.OptionsMap,
@@ -137,14 +121,6 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 	)
 
 	// Images in dackbox support an expanded set of search options
-	// imageSearchOptions := search.CombineOptionsMaps(
-	// 	imageMapping.OptionsMap,
-	// 	imageMapping.ImageDeploymentOptions,
-	// 	imageComponentEdgeMapping.OptionsMap,
-	// 	imageComponentMapping.OptionsMap,
-	// 	componentVulnEdgeMapping.OptionsMap,
-	// 	cveMapping.OptionsMap,
-	// )
 	imageSearchOptions := search.CombineOptionsMaps(
 		schema.ImagesSchema.OptionsMap,
 		schema.ImageComponentEdgesSchema.OptionsMap,
@@ -153,13 +129,6 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 		schema.ImageCvesSchema.OptionsMap,
 	)
 
-	// nodeSearchOptions := search.CombineOptionsMaps(
-	// 	nodeMapping.OptionsMap,
-	// 	nodeComponentEdgeMapping.OptionsMap,
-	// 	imageComponentMapping.OptionsMap,
-	// 	componentVulnEdgeMapping.OptionsMap,
-	// 	cveMapping.OptionsMap,
-	// )
 	nodeSearchOptions := search.CombineOptionsMaps(
 		schema.NodesSchema.OptionsMap,
 		schema.NodeComponentEdgesSchema.OptionsMap,
@@ -171,59 +140,36 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 	// EntityOptionsMap is a mapping from search categories to the options map for that category.
 	// search document maps are also built off this map
 	entityOptionsMap := map[v1.SearchCategory]search.OptionsMap{
-		// v1.SearchCategory_ACTIVE_COMPONENT:      activeComponentMappings.OptionsMap,
-		v1.SearchCategory_ACTIVE_COMPONENT: schema.ActiveComponentsSchema.OptionsMap,
-		// v1.SearchCategory_ALERTS:                alertMapping.OptionsMap,
-		v1.SearchCategory_ALERTS: schema.AlertsSchema.OptionsMap,
-		// v1.SearchCategory_CLUSTER_VULN_EDGE:     clusterVulnEdgeMapping.OptionsMap,
-		v1.SearchCategory_CLUSTER_VULN_EDGE: schema.ClusterCveEdgesSchema.OptionsMap,
-		// v1.SearchCategory_CLUSTERS:              clusterMapping.OptionsMap,
-		v1.SearchCategory_CLUSTERS:            schema.ClustersSchema.OptionsMap,
-		v1.SearchCategory_COMPLIANCE_STANDARD: index.StandardOptions,
-		v1.SearchCategory_COMPLIANCE_CONTROL:  index.ControlOptions,
-		// v1.SearchCategory_COMPONENT_VULN_EDGE:   componentVulnEdgeMapping.OptionsMap,
-		v1.SearchCategory_COMPONENT_VULN_EDGE: schema.ImageComponentCveEdgesSchema.OptionsMap,
-		// v1.SearchCategory_DEPLOYMENTS:           deployments.OptionsMap,
-		v1.SearchCategory_DEPLOYMENTS: schema.DeploymentsSchema.OptionsMap,
-		// v1.SearchCategory_IMAGE_COMPONENT_EDGE:  imageComponentEdgeMapping.OptionsMap,
-		v1.SearchCategory_IMAGE_COMPONENT_EDGE: schema.ImageComponentEdgesSchema.OptionsMap,
-		v1.SearchCategory_IMAGE_COMPONENTS:     componentSearchOptions,
-		// v1.SearchCategory_IMAGE_VULN_EDGE:       imageCVEEdgeMapping.OptionsMap,
-		v1.SearchCategory_IMAGE_VULN_EDGE: schema.ImageCveEdgesSchema.OptionsMap,
-		v1.SearchCategory_IMAGES:          imageSearchOptions,
-		// v1.SearchCategory_NAMESPACES:            namespaceMapping.OptionsMap,
-		v1.SearchCategory_NAMESPACES: schema.NamespacesSchema.OptionsMap,
-		// v1.SearchCategory_NODE_COMPONENT_EDGE:   nodeComponentEdgeMappings.OptionsMap,
-		v1.SearchCategory_NODE_COMPONENT_EDGE: schema.NodeComponentEdgesSchema.OptionsMap,
-		v1.SearchCategory_NODE_COMPONENTS:     schema.NodeComponentsSchema.OptionsMap,
-		v1.SearchCategory_NODES:               nodeSearchOptions,
-		// v1.SearchCategory_PODS:                  podMapping.OptionsMap,
-		v1.SearchCategory_PODS: schema.PodsSchema.OptionsMap,
-		// v1.SearchCategory_POLICIES:              policyMapping.OptionsMap,
-		v1.SearchCategory_POLICIES: schema.PoliciesSchema.OptionsMap,
-		// v1.SearchCategory_POLICY_CATEGORIES:     policyCategoryMapping.OptionsMap,
-		v1.SearchCategory_POLICY_CATEGORIES: schema.PolicyCategoriesSchema.OptionsMap,
-		// v1.SearchCategory_PROCESS_BASELINES:     processBaselineMapping.OptionsMap,
-		v1.SearchCategory_PROCESS_BASELINES: schema.ProcessBaselinesSchema.OptionsMap,
-		// v1.SearchCategory_PROCESS_INDICATORS:    processindicators.OptionsMap,
-		v1.SearchCategory_PROCESS_INDICATORS: schema.ProcessIndicatorsSchema.OptionsMap,
-		// v1.SearchCategory_REPORT_CONFIGURATIONS: reportConfigurationsMapping.OptionsMap,
+		v1.SearchCategory_ACTIVE_COMPONENT:      schema.ActiveComponentsSchema.OptionsMap,
+		v1.SearchCategory_ALERTS:                schema.AlertsSchema.OptionsMap,
+		v1.SearchCategory_CLUSTER_VULN_EDGE:     schema.ClusterCveEdgesSchema.OptionsMap,
+		v1.SearchCategory_CLUSTERS:              schema.ClustersSchema.OptionsMap,
+		v1.SearchCategory_COMPLIANCE_STANDARD:   index.StandardOptions,
+		v1.SearchCategory_COMPLIANCE_CONTROL:    index.ControlOptions,
+		v1.SearchCategory_COMPONENT_VULN_EDGE:   schema.ImageComponentCveEdgesSchema.OptionsMap,
+		v1.SearchCategory_DEPLOYMENTS:           schema.DeploymentsSchema.OptionsMap,
+		v1.SearchCategory_IMAGE_COMPONENT_EDGE:  schema.ImageComponentEdgesSchema.OptionsMap,
+		v1.SearchCategory_IMAGE_COMPONENTS:      componentSearchOptions,
+		v1.SearchCategory_IMAGE_VULN_EDGE:       schema.ImageCveEdgesSchema.OptionsMap,
+		v1.SearchCategory_IMAGES:                imageSearchOptions,
+		v1.SearchCategory_NAMESPACES:            schema.NamespacesSchema.OptionsMap,
+		v1.SearchCategory_NODE_COMPONENT_EDGE:   schema.NodeComponentEdgesSchema.OptionsMap,
+		v1.SearchCategory_NODE_COMPONENTS:       schema.NodeComponentsSchema.OptionsMap,
+		v1.SearchCategory_NODES:                 nodeSearchOptions,
+		v1.SearchCategory_PODS:                  schema.PodsSchema.OptionsMap,
+		v1.SearchCategory_POLICIES:              schema.PoliciesSchema.OptionsMap,
+		v1.SearchCategory_POLICY_CATEGORIES:     schema.PolicyCategoriesSchema.OptionsMap,
+		v1.SearchCategory_PROCESS_BASELINES:     schema.ProcessBaselinesSchema.OptionsMap,
+		v1.SearchCategory_PROCESS_INDICATORS:    schema.ProcessIndicatorsSchema.OptionsMap,
 		v1.SearchCategory_REPORT_CONFIGURATIONS: schema.ReportConfigurationsSchema.OptionsMap,
-		// v1.SearchCategory_RISKS:                 riskMappings.OptionsMap,
-		v1.SearchCategory_RISKS: schema.RisksSchema.OptionsMap,
-		// v1.SearchCategory_ROLES:                 roleOptions.OptionsMap,
-		v1.SearchCategory_ROLES: schema.K8sRolesSchema.OptionsMap,
-		// v1.SearchCategory_ROLEBINDINGS:          roleBindingOptions.OptionsMap,
-		v1.SearchCategory_ROLEBINDINGS: schema.RoleBindingsSchema.OptionsMap,
-		// v1.SearchCategory_SECRETS:               secretOptions.OptionsMap,
-		v1.SearchCategory_SECRETS: schema.SecretsSchema.OptionsMap,
-		// v1.SearchCategory_SERVICE_ACCOUNTS:      serviceAccountOptions.OptionsMap,
-		v1.SearchCategory_SERVICE_ACCOUNTS: schema.ServiceAccountsSchema.OptionsMap,
-		// v1.SearchCategory_SUBJECTS:              subjectMapping.OptionsMap,
-		v1.SearchCategory_SUBJECTS: schema.RoleBindingsSchema.OptionsMap,
-		//v1.SearchCategory_VULN_REQUEST:          vulnReqMapping.OptionsMap,
-		v1.SearchCategory_VULN_REQUEST:    schema.VulnerabilityRequestsSchema.OptionsMap,
-		v1.SearchCategory_VULNERABILITIES: cveSearchOptions,
+		v1.SearchCategory_RISKS:                 schema.RisksSchema.OptionsMap,
+		v1.SearchCategory_ROLES:                 schema.K8sRolesSchema.OptionsMap,
+		v1.SearchCategory_ROLEBINDINGS:          schema.RoleBindingsSchema.OptionsMap,
+		v1.SearchCategory_SECRETS:               schema.SecretsSchema.OptionsMap,
+		v1.SearchCategory_SERVICE_ACCOUNTS:      schema.ServiceAccountsSchema.OptionsMap,
+		v1.SearchCategory_SUBJECTS:              schema.RoleBindingsSchema.OptionsMap,
+		v1.SearchCategory_VULN_REQUEST:          schema.VulnerabilityRequestsSchema.OptionsMap,
+		v1.SearchCategory_VULNERABILITIES:       cveSearchOptions,
 	}
 
 	return entityOptionsMap

--- a/central/globalindex/mapping/mapping.go
+++ b/central/globalindex/mapping/mapping.go
@@ -149,7 +149,7 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 		v1.SearchCategory_CLUSTERS:                schema.ClustersSchema.OptionsMap,
 		v1.SearchCategory_COMPLIANCE_STANDARD:     index.StandardOptions,
 		v1.SearchCategory_COMPLIANCE_CONTROL:      index.ControlOptions,
-		v1.SearchCategory_COMPONENT_VULN_EDGE:     schema.ImageComponentCveEdgesSchema.OptionsMap,
+		v1.SearchCategory_COMPONENT_VULN_EDGE:     imageToVulnerabilitySearchOptions,
 		v1.SearchCategory_DEPLOYMENTS:             deploymentsCustomSearchOptions,
 		v1.SearchCategory_IMAGE_COMPONENT_EDGE:    imageToVulnerabilitySearchOptions,
 		v1.SearchCategory_IMAGE_COMPONENTS:        imageToVulnerabilitySearchOptions,
@@ -175,7 +175,6 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 		v1.SearchCategory_SERVICE_ACCOUNTS:        schema.ServiceAccountsSchema.OptionsMap,
 		v1.SearchCategory_SUBJECTS:                subjectMapping.OptionsMap,
 		v1.SearchCategory_VULN_REQUEST:            schema.VulnerabilityRequestsSchema.OptionsMap,
-		// v1.SearchCategory_VULNERABILITIES:       cveSearchOptions,
 	}
 
 	return entityOptionsMap

--- a/central/globalindex/mapping/mapping.go
+++ b/central/globalindex/mapping/mapping.go
@@ -135,11 +135,15 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 		schema.ClustersSchema.OptionsMap,
 	)
 
+	// alerts has a reconciliation mechanism implemented in postgres mode in order to keep only search fields
+	// linked to the ListAlert type (goal is backward compatibility with the search strategy implemented on bleve.
+	alertSearchOptions := alertMapping.OptionsMap
+
 	// EntityOptionsMap is a mapping from search categories to the options map for that category.
 	// search document maps are also built off this map
 	entityOptionsMap := map[v1.SearchCategory]search.OptionsMap{
 		v1.SearchCategory_ACTIVE_COMPONENT:        schema.ActiveComponentsSchema.OptionsMap,
-		v1.SearchCategory_ALERTS:                  schema.AlertsSchema.OptionsMap,
+		v1.SearchCategory_ALERTS:                  alertSearchOptions,
 		v1.SearchCategory_CLUSTER_VULN_EDGE:       clusterToVulnerabilitySearchOptions,
 		v1.SearchCategory_CLUSTER_VULNERABILITIES: clusterToVulnerabilitySearchOptions,
 		v1.SearchCategory_CLUSTERS:                schema.ClustersSchema.OptionsMap,

--- a/central/processbaseline/datastore/datastore_impl_test.go
+++ b/central/processbaseline/datastore/datastore_impl_test.go
@@ -57,7 +57,6 @@ func (suite *ProcessBaselineDataStoreTestSuite) SetupTest() {
 			sac.ResourceScopeKeys(resources.ProcessWhitelist),
 		),
 	)
-
 	var err error
 
 	if features.PostgresDatastore.Enabled() {

--- a/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
@@ -7,6 +7,11 @@ import services.SearchService
 import spock.lang.Unroll
 
 class AutocompleteTest extends BaseSpecification {
+    def VULNERABILITY_SEARCH_CATEGORY =
+        isPostgresRun() ?
+            SearchCategory.IMAGE_VULNERABILITIES :
+            SearchCategory.VULNERABILITIES
+
     @Category([BAT])
     def "Verify Autocomplete: #query #category #contains"() {
         when:
@@ -49,9 +54,7 @@ class AutocompleteTest extends BaseSpecification {
                                                 "Image Tag", "Dockerfile Instruction Keyword", "CVE", "Component"]
         SearchCategory.IMAGES                | ["Cluster", "Deployment",
                                                 "Image Tag", "Dockerfile Instruction Keyword", "CVE", "Component"]
-        isPostgresRun() ?
-            SearchCategory.IMAGE_VULNERABILITIES :
-            SearchCategory.VULNERABILITIES   | ["Cluster", "Deployment",
+        VULNERABILITY_SEARCH_CATEGORY        | ["Cluster", "Deployment",
                                                 "Image Tag", "Dockerfile Instruction Keyword", "CVE", "Component"]
         SearchCategory.IMAGE_COMPONENTS      | ["Cluster", "Deployment",
                                                 "Image Tag", "Dockerfile Instruction Keyword", "CVE", "Component"]

--- a/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
@@ -12,6 +12,8 @@ class AutocompleteTest extends BaseSpecification {
             SearchCategory.IMAGE_VULNERABILITIES :
             SearchCategory.VULNERABILITIES
 
+    private static final String GROUP_UC_AUTOCOMPLETE = isPostgresRun() ? "GROUP" : "group"
+
     @Category([BAT])
     def "Verify Autocomplete: #query #category #contains"() {
         when:
@@ -30,8 +32,7 @@ class AutocompleteTest extends BaseSpecification {
         query                 | category                   | contains
         "Subject:system:auth" | []                         | "system:authenticated"
         "Subject:system:auth" | [SearchCategory.SUBJECTS]  | "system:authenticated"
-
-        "Subject Kind:GROUP"  | []                         | isPostgresRun() ? "GROUP" : "group"
+        "Subject Kind:GROUP"  | []                         | GROUP_UC_AUTOCOMPLETE
         "Subject Kind:group"  | []                         | "group"
         "Subject Kind:gr"     | []                         | "group"
     }

--- a/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
@@ -26,7 +26,7 @@ class AutocompleteTest extends BaseSpecification {
         "Subject:system:auth" | []                         | "system:authenticated"
         "Subject:system:auth" | [SearchCategory.SUBJECTS]  | "system:authenticated"
 
-        "Subject Kind:GROUP"  | []                         | "group"
+        "Subject Kind:GROUP"  | []                         | isPostgresRun() ? "GROUP" : "group"
         "Subject Kind:group"  | []                         | "group"
         "Subject Kind:gr"     | []                         | "group"
     }
@@ -49,7 +49,9 @@ class AutocompleteTest extends BaseSpecification {
                                                 "Image Tag", "Dockerfile Instruction Keyword", "CVE", "Component"]
         SearchCategory.IMAGES                | ["Cluster", "Deployment",
                                                 "Image Tag", "Dockerfile Instruction Keyword", "CVE", "Component"]
-        SearchCategory.VULNERABILITIES       | ["Cluster", "Deployment",
+        isPostgresRun() ?
+            SearchCategory.IMAGE_VULNERABILITIES :
+            SearchCategory.VULNERABILITIES   | ["Cluster", "Deployment",
                                                 "Image Tag", "Dockerfile Instruction Keyword", "CVE", "Component"]
         SearchCategory.IMAGE_COMPONENTS      | ["Cluster", "Deployment",
                                                 "Image Tag", "Dockerfile Instruction Keyword", "CVE", "Component"]

--- a/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
@@ -12,7 +12,7 @@ class AutocompleteTest extends BaseSpecification {
             SearchCategory.IMAGE_VULNERABILITIES :
             SearchCategory.VULNERABILITIES
 
-    private static final String GROUP_UC_AUTOCOMPLETE = isPostgresRun() ? "GROUP" : "group"
+    private static final String GROUP_AUTOCOMPLETE = isPostgresRun() ? "GROUP" : "group"
 
     @Category([BAT])
     def "Verify Autocomplete: #query #category #contains"() {
@@ -32,9 +32,9 @@ class AutocompleteTest extends BaseSpecification {
         query                 | category                   | contains
         "Subject:system:auth" | []                         | "system:authenticated"
         "Subject:system:auth" | [SearchCategory.SUBJECTS]  | "system:authenticated"
-        "Subject Kind:GROUP"  | []                         | GROUP_UC_AUTOCOMPLETE
-        "Subject Kind:group"  | []                         | "group"
-        "Subject Kind:gr"     | []                         | "group"
+        "Subject Kind:GROUP"  | []                         | GROUP_AUTOCOMPLETE
+        "Subject Kind:group"  | []                         | GROUP_AUTOCOMPLETE
+        "Subject Kind:gr"     | []                         | GROUP_AUTOCOMPLETE
     }
 
     @Unroll

--- a/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
@@ -30,6 +30,7 @@ class AutocompleteTest extends BaseSpecification {
         where:
         "Data inputs are: "
         query                 | category                   | contains
+
         "Subject:system:auth" | []                         | "system:authenticated"
         "Subject:system:auth" | [SearchCategory.SUBJECTS]  | "system:authenticated"
         "Subject Kind:GROUP"  | []                         | GROUP_AUTOCOMPLETE

--- a/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
@@ -7,7 +7,7 @@ import services.SearchService
 import spock.lang.Unroll
 
 class AutocompleteTest extends BaseSpecification {
-    def VULNERABILITY_SEARCH_CATEGORY =
+    private static final SearchCategory VULNERABILITY_SEARCH_CATEGORY =
         isPostgresRun() ?
             SearchCategory.IMAGE_VULNERABILITIES :
             SearchCategory.VULNERABILITIES

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -427,7 +427,6 @@ class SACTest extends BaseSpecification {
     }
 
     @Unroll
-    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
     def "Verify Autocomplete on #category resources using the #tokenName token returns #numResults results"() {
         when:
         "Search is called using a token without view access to Deployments"

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -31,7 +31,6 @@ import util.NetworkGraphUtil
 
 import org.junit.AssumptionViolatedException
 import org.junit.experimental.categories.Category
-import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Unroll
 


### PR DESCRIPTION
## Description

Some end-to-end tests were disabled at the early stages of the postgres migration because the state of things at the time made them fail or made them instable.
As the migration progresses, it is time to re-enable those that work again.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI run should be sufficient.