### PR TITLE
Re-enable Vulnerability management SAC test "Verify permissions on vuln mgmt: role with no CVE permissions is rejected" in postgres mode

### DIFF
--- a/qa-tests-backend/src/test/groovy/VulnMgmtSACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtSACTest.groovy
@@ -141,7 +141,6 @@ class VulnMgmtSACTest extends BaseSpecification {
 
     @Retry(count = 0)
     @Unroll
-    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
     def "Verify permissions on vuln mgmt: role with no CVE permissions is rejected"() {
         when:
         "Get CVEs via GraphQL"


### PR DESCRIPTION
## Description

Some end-to-end tests were disabled at the early stages of the postgres migration because the state of things at the time made them fail or made them instable.
As the migration progresses, it is time to re-enable those that work again.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI run should be sufficient.