### PR TITLE
Re-enable VulnScanWithGraphQL end-to-end test in posgres mode

### DIFF
--- a/qa-tests-backend/src/test/groovy/VulnScanWithGraphQLTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnScanWithGraphQLTest.groovy
@@ -9,7 +9,6 @@ import util.Env
 import util.Timer
 
 import org.junit.experimental.categories.Category
-import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Unroll
 
@@ -152,11 +151,10 @@ class VulnScanWithGraphQLTest extends BaseSpecification {
 
     @Unroll
     @Category(GraphQL)
-    @IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
     def "Verify image info from #CVEID in GraphQL"() {
         when:
         "Fetch the results of the CVE,image from GraphQL "
-        GraphQLService.Response result2Ret = waitForImagesTobeFetched(CVEID)
+        GraphQLService.Response result2Ret = waitForImagesTobeFetched(CVEID, OS)
         assert result2Ret.getValue()?.result?.images  != null
         then :
         List<Object> imagesReturned = result2Ret.getValue().result.images
@@ -165,14 +163,19 @@ class VulnScanWithGraphQLTest extends BaseSpecification {
         assert !(StringUtils.isEmpty(imgName))
         where:
         "Data inputs are :"
-        CVEID | imageToBeVerified
-        "CVE-2017-18190" | STRUTS_DEP.getImage()
+        CVEID            | OS      | imageToBeVerified
+        "CVE-2017-18190" | "Linux" | STRUTS_DEP.getImage()
     }
 
-    private GraphQLService.Response waitForImagesTobeFetched(String cveId , int retries = 30, int interval = 4) {
+    private GraphQLService.Response waitForImagesTobeFetched(String cveId, String os,
+     int retries = 30, int interval = 4) {
         Timer t = new Timer(retries, interval)
+        def objId = cveId
+        if (Env.CI_JOBNAME.contains("postgres")) {
+            objId = cveId + "#" + os
+        }
         while (t.IsValid()) {
-            def result2Ret = gqlService.Call(GET_IMAGE_INFO_FROM_VULN_QUERY, [id: cveId])
+            def result2Ret = gqlService.Call(GET_IMAGE_INFO_FROM_VULN_QUERY, [id: objId])
             assert result2Ret.getCode() == 200
             if (result2Ret.getValue().result != null) {
                 log.info "images fetched from cve"


### PR DESCRIPTION
## Description

Some end-to-end tests were disabled at the early stages of the postgres migration because the state of things at the time made them fail or made them instable.
As the migration progresses, it is time to re-enable those that work again.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI run should be sufficient.