### PR TITLE
Update Observed, Deferred, and False Positive tabs to use updated vuln fields

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable react/no-array-index-key */
 import React, { ReactElement, useState } from 'react';
 
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import usePagination from 'hooks/patternfly/usePagination';
 import { SearchFilter } from 'types/search';
 import { SortOption } from 'types/table';
@@ -28,6 +29,9 @@ function DeferredCVEs({ imageId }: DeferredCVEsProps): ReactElement {
         defaultSortOption,
     });
 
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const showVMUpdates = isFeatureFlagEnabled('ROX_FRONTEND_VM_UPDATES');
+
     const vulnsQuery = queryService.objectToWhereClause({
         ...searchFilter,
         'Vulnerability State': 'DEFERRED',
@@ -41,6 +45,7 @@ function DeferredCVEs({ imageId }: DeferredCVEsProps): ReactElement {
             offset: (page - 1) * perPage,
             sortOption,
         },
+        showVMUpdates,
     });
 
     const itemCount = data?.image?.vulnCount || 0;

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable react/no-array-index-key */
 import React, { ReactElement, useState } from 'react';
 
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import usePagination from 'hooks/patternfly/usePagination';
 import { SearchFilter } from 'types/search';
 import queryService from 'utils/queryService';
@@ -28,6 +29,9 @@ function FalsePositiveCVEs({ imageId }: FalsePositiveCVEsProps): ReactElement {
         defaultSortOption,
     });
 
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const showVMUpdates = isFeatureFlagEnabled('ROX_FRONTEND_VM_UPDATES');
+
     const vulnsQuery = queryService.objectToWhereClause({
         ...searchFilter,
         'Vulnerability State': 'FALSE_POSITIVE',
@@ -41,6 +45,7 @@ function FalsePositiveCVEs({ imageId }: FalsePositiveCVEsProps): ReactElement {
             offset: (page - 1) * perPage,
             sortOption,
         },
+        showVMUpdates,
     });
 
     const itemCount = data?.image?.vulnCount || 0;

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable react/no-array-index-key */
 import React, { ReactElement, useState } from 'react';
 
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import usePagination from 'hooks/patternfly/usePagination';
 import { SearchFilter } from 'types/search';
 import queryService from 'utils/queryService';
@@ -28,6 +29,9 @@ function ObservedCVEs({ imageId }: ObservedCVEsProps): ReactElement {
         defaultSortOption,
     });
 
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const showVMUpdates = isFeatureFlagEnabled('ROX_FRONTEND_VM_UPDATES');
+
     const vulnsQuery = queryService.objectToWhereClause({
         ...searchFilter,
         'Vulnerability State': 'OBSERVED',
@@ -41,6 +45,7 @@ function ObservedCVEs({ imageId }: ObservedCVEsProps): ReactElement {
             offset: (page - 1) * perPage,
             sortOption,
         },
+        showVMUpdates,
     });
 
     const itemCount = data?.image?.vulnCount || 0;

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/imageVulnerabilities.graphql.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/imageVulnerabilities.graphql.ts
@@ -75,6 +75,75 @@ export const GET_IMAGE_VULNERABILITIES = gql`
                 remote
                 tag
             }
+            vulnCount: imageVulnerabilityCount(query: $vulnsQuery)
+            vulns: imageVulnerabilities(query: $vulnsQuery, pagination: $pagination) {
+                id
+                cve
+                isFixable
+                severity
+                scoreVersion
+                cvss
+                discoveredAtImage
+                components: imageComponents {
+                    id
+                    name
+                    version
+                    fixedIn
+                }
+                vulnerabilityRequest: effectiveVulnerabilityRequest {
+                    id
+                    targetState
+                    status
+                    expired
+                    requestor {
+                        id
+                        name
+                    }
+                    approvers {
+                        id
+                        name
+                    }
+                    comments {
+                        createdAt
+                        id
+                        message
+                        user {
+                            id
+                            name
+                        }
+                    }
+                    deferralReq {
+                        expiresOn
+                        expiresWhenFixed
+                    }
+                    updatedDeferralReq {
+                        expiresOn
+                        expiresWhenFixed
+                    }
+                    scope {
+                        imageScope {
+                            registry
+                            remote
+                            tag
+                        }
+                    }
+                    cves {
+                        ids
+                    }
+                }
+            }
+        }
+    }
+`;
+
+export const GET_IMAGE_VULNERABILITIES_LEGACY = gql`
+    query getImageVulnerabilities($imageId: ID!, $vulnsQuery: String, $pagination: Pagination) {
+        image(id: $imageId) {
+            name {
+                registry
+                remote
+                tag
+            }
             vulnCount(query: $vulnsQuery)
             vulns(query: $vulnsQuery, pagination: $pagination) {
                 id

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/useImageVulnerabilities.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/useImageVulnerabilities.ts
@@ -3,30 +3,36 @@ import {
     GetImageVulnerabilitiesData,
     GetImageVulnerabilitiesVars,
     GET_IMAGE_VULNERABILITIES,
+    GET_IMAGE_VULNERABILITIES_LEGACY,
 } from './imageVulnerabilities.graphql';
 
-function useImageVulnerabilities({ imageId, vulnsQuery, pagination }) {
+function useImageVulnerabilities({ imageId, vulnsQuery, pagination, showVMUpdates = false }) {
     const client = useApolloClient();
+    const queryToUse = showVMUpdates ? GET_IMAGE_VULNERABILITIES : GET_IMAGE_VULNERABILITIES_LEGACY;
+
     const {
         loading: isLoading,
         data,
         error,
-    } = useQuery<GetImageVulnerabilitiesData, GetImageVulnerabilitiesVars>(
-        GET_IMAGE_VULNERABILITIES,
-        {
-            variables: {
-                imageId,
-                vulnsQuery,
-                pagination,
-            },
-            fetchPolicy: 'network-only',
-        }
-    );
+    } = useQuery<GetImageVulnerabilitiesData, GetImageVulnerabilitiesVars>(queryToUse, {
+        variables: {
+            imageId,
+            vulnsQuery,
+            pagination,
+        },
+        fetchPolicy: 'network-only',
+    });
 
     async function refetchQuery() {
-        await client.refetchQueries({
-            include: [GET_IMAGE_VULNERABILITIES],
-        });
+        if (showVMUpdates) {
+            await client.refetchQueries({
+                include: [GET_IMAGE_VULNERABILITIES],
+            });
+        } else {
+            await client.refetchQueries({
+                include: [GET_IMAGE_VULNERABILITIES_LEGACY],
+            });
+        }
     }
 
     return { isLoading, data, error, refetchQuery };


### PR DESCRIPTION
## Description

Some of the resolver names changed for the Observed, Deferred, and False Positive queries for image vulnerabilities.

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Verified that they work again

Observed
![Screen Shot 2022-08-10 at 5 01 28 PM](https://user-images.githubusercontent.com/715729/184020725-4c133e52-95e4-4c9e-b218-644c3be540a5.png)


Deferred
![Screen Shot 2022-08-10 at 5 01 32 PM](https://user-images.githubusercontent.com/715729/184020711-1eda4d2b-2974-4a63-970e-010102e7b8cf.png)


False Positive
![Screen Shot 2022-08-10 at 5 01 36 PM](https://user-images.githubusercontent.com/715729/184020693-7e500885-1be2-4f79-b0b7-636715beef39.png)
