### PR TITLE
ROX-12190: [Hackathon] Replace search modal with search page in UI

### DIFF
--- a/ui/apps/platform/cypress/integration/search.test.js
+++ b/ui/apps/platform/cypress/integration/search.test.js
@@ -1,6 +1,7 @@
 import { selectors } from '../constants/SearchPage';
 import * as api from '../constants/apiEndpoints';
 import withAuth from '../helpers/basicAuth';
+import { hasFeatureFlag } from '../helpers/features';
 import { visitMainDashboard } from '../helpers/main';
 
 function visitSearch() {
@@ -23,6 +24,12 @@ function searchWithFixture(searchTuples, fixture) {
 
 describe('Global Search Modal', () => {
     withAuth();
+
+    before(function beforeHook() {
+        if (hasFeatureFlag('ROX_SEARCH_PAGE_UI')) {
+            this.skip();
+        }
+    });
 
     it('should have empty state instead of count and tabs if search filter is empty', () => {
         visitSearch();

--- a/ui/apps/platform/src/Components/SearchFilterInput/SearchFilterInput.tsx
+++ b/ui/apps/platform/src/Components/SearchFilterInput/SearchFilterInput.tsx
@@ -8,7 +8,7 @@ type SearchFilterInputProps = {
     className: string;
     handleChangeSearchFilter: (searchFilter: SearchFilter) => void;
     placeholder: string;
-    searchCategory: SearchCategory;
+    searchCategory?: SearchCategory;
     searchFilter: SearchFilter;
     searchOptions: string[]; // differs from searchOptions prop of SearchInput
     autocompleteQueryPrefix?: string;
@@ -45,7 +45,7 @@ function SearchFilterInput({
                 : getEntryValueForOption(valuelessOption);
 
             fetchAutoCompleteResults({
-                categories: [searchCategory],
+                categories: searchCategory && [searchCategory],
                 query,
             })
                 .then((values) => {

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -15,6 +15,7 @@ import {
     policyManagementBasePath,
     deprecatedPoliciesPath,
     riskPath,
+    searchPath,
     apidocsPath,
     accessControlPathV2,
     userBasePath,
@@ -44,6 +45,7 @@ function NotFoundPage(): ReactElement {
     );
 }
 
+const AsyncSearchPage = asyncComponent(() => import('Containers/Search/SearchPage'));
 const AsyncApiDocsPage = asyncComponent(() => import('Containers/Docs/ApiPage'));
 const AsyncDashboardPage = asyncComponent(() => import('Containers/Dashboard/DashboardPage'));
 // TODO Rename this and replace AsyncDashboardPage once Sec Metrics Phase One is complete
@@ -94,6 +96,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
     const { isDarkMode } = useTheme();
 
     const isSystemHealthPatternFlyEnabled = isFeatureFlagEnabled('ROX_SYSTEM_HEALTH_PF');
+    const isSearchPageEnabled = isFeatureFlagEnabled('ROX_SEARCH_PAGE_UI');
     const isDashboardPatternFlyEnabled = isFeatureFlagEnabled('ROX_SECURITY_METRICS_PHASE_ONE');
 
     const hasVulnerabilityReportsPermission = hasReadAccess('VulnerabilityReports');
@@ -122,6 +125,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     <Redirect exact from={deprecatedPoliciesPath} to={policiesPath} />
                     <Route path={riskPath} component={AsyncRiskPage} />
                     <Route path={accessControlPathV2} component={AsyncAccessControlPageV2} />
+                    {isSearchPageEnabled && <Route path={searchPath} component={AsyncSearchPage} />}
                     <Route path={apidocsPath} component={AsyncApiDocsPage} />
                     <Route path={userBasePath} component={AsyncUserPage} />
                     <Route path={systemConfigPath} component={AsyncSystemConfigPage} />

--- a/ui/apps/platform/src/Containers/MainPage/Header/GlobalSearchButton.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/GlobalSearchButton.tsx
@@ -1,37 +1,42 @@
 import React, { ReactElement } from 'react';
-import { withRouter } from 'react-router-dom';
-import { connect } from 'react-redux';
+import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import { Flex, FlexItem } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 
+import useFeatureFlagEnabled from 'hooks/useFeatureFlags';
 import { actions as globalSearchActions } from 'reducers/globalSearch';
-
-type GlobalSearchButtonProps = {
-    toggleGlobalSearchView: () => void;
-};
+import { searchPath } from 'routePaths';
 
 /*
  * Use HTML button with PatternFly Button class to inherit masthead color.
  */
-const GlobalSearchButton = ({ toggleGlobalSearchView }: GlobalSearchButtonProps): ReactElement => (
-    <button
-        type="button"
-        onClick={toggleGlobalSearchView}
-        className="pf-c-button ignore-react-onclickoutside"
-    >
-        <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsSm' }}>
-            <FlexItem>
-                <SearchIcon alt="" />
-            </FlexItem>
-            <FlexItem>Search</FlexItem>
-        </Flex>
-    </button>
-);
+function GlobalSearchButton(): ReactElement {
+    const dispatch = useDispatch();
+    const history = useHistory();
+    const { isFeatureFlagEnabled } = useFeatureFlagEnabled();
 
-const mapDispatchToProps = (dispatch) => ({
-    // TODO: type redux props
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    toggleGlobalSearchView: () => dispatch(globalSearchActions.toggleGlobalSearchView()),
-});
+    function onClick() {
+        if (isFeatureFlagEnabled('ROX_SEARCH_PAGE_UI')) {
+            history.push(searchPath);
+        } else {
+            dispatch(globalSearchActions.toggleGlobalSearchView());
+        }
+    }
 
-export default withRouter(connect(null, mapDispatchToProps)(GlobalSearchButton));
+    return (
+        <button type="button" onClick={onClick} className="pf-c-button ignore-react-onclickoutside">
+            <Flex
+                alignItems={{ default: 'alignItemsCenter' }}
+                spaceItems={{ default: 'spaceItemsSm' }}
+            >
+                <FlexItem>
+                    <SearchIcon alt="" />
+                </FlexItem>
+                <FlexItem>Search</FlexItem>
+            </Flex>
+        </button>
+    );
+}
+
+export default GlobalSearchButton;

--- a/ui/apps/platform/src/Containers/MainPage/Header/MastheadToolbar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/MastheadToolbar.tsx
@@ -4,6 +4,7 @@ import { PageHeaderTools, PageHeaderToolsGroup, PageHeaderToolsItem } from '@pat
 
 import useCases from 'constants/useCaseTypes';
 import parseURL from 'utils/URLParser';
+import { searchPath } from 'routePaths';
 
 import CLIDownloadMenu from './CLIDownloadMenu';
 import ClusterStatusProblems from './ClusterStatusProblems';
@@ -18,7 +19,9 @@ function MastheadToolbar(): ReactElement {
     const workflowState = parseURL(location);
     const useCase = workflowState.getUseCase();
     const showOrchestratorComponentsToggle =
-        useCase === useCases.RISK || useCase === useCases.NETWORK;
+        useCase === useCases.RISK ||
+        useCase === useCases.NETWORK ||
+        location.pathname === searchPath;
 
     return (
         <PageHeaderTools>

--- a/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
@@ -1,0 +1,54 @@
+import React, { ReactElement } from 'react';
+import { Button, Flex, FlexItem } from '@patternfly/react-core';
+
+import LinkShim from 'Components/PatternFly/LinkShim';
+import { SearchResultCategory } from 'services/SearchService';
+import { SearchFilter } from 'types/search';
+import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
+
+import NotApplicable from './NotApplicable';
+import { searchResultCategoryMap } from './searchCategories';
+
+type FilterLinksProps = {
+    filterValue: string;
+    resultCategory: SearchResultCategory;
+    searchFilter: SearchFilter;
+};
+
+function FilterLinks({
+    filterValue,
+    resultCategory,
+    searchFilter,
+}: FilterLinksProps): ReactElement {
+    const { filterOn } = searchResultCategoryMap[resultCategory];
+
+    if (filterOn !== null) {
+        const { filterCategory, filterLinks } = filterOn;
+
+        const queryString = getUrlQueryStringForSearchFilter({
+            ...searchFilter,
+            [filterCategory]: filterValue,
+        });
+
+        return (
+            <Flex spaceItems={{ default: 'spaceItemsMd' }}>
+                {filterLinks.map(({ basePath, linkText }) => (
+                    <FlexItem key={linkText}>
+                        <Button
+                            variant="link"
+                            isInline
+                            component={LinkShim}
+                            href={`${basePath}?${queryString}`}
+                        >
+                            {linkText}
+                        </Button>
+                    </FlexItem>
+                ))}
+            </Flex>
+        );
+    }
+
+    return <NotApplicable />;
+}
+
+export default FilterLinks;

--- a/ui/apps/platform/src/Containers/Search/NotApplicable.tsx
+++ b/ui/apps/platform/src/Containers/Search/NotApplicable.tsx
@@ -1,0 +1,7 @@
+import React, { ReactElement } from 'react';
+
+function NotApplicable(): ReactElement {
+    return <span className="pf-u-color-400 pf-u-text-nowrap">Not applicable</span>;
+}
+
+export default NotApplicable;

--- a/ui/apps/platform/src/Containers/Search/SearchNavAndTable.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchNavAndTable.tsx
@@ -8,34 +8,34 @@ import { SearchFilter } from 'types/search';
 import { searchPath } from 'routePaths';
 
 import SearchTable from './SearchTable';
-import { SearchTabCategory, searchResultCategoryMap, searchTabMap } from './searchCategories';
+import { SearchNavCategory, searchResultCategoryMap, searchNavMap } from './searchCategories';
 import { stringifyQueryObject } from './searchQuery';
 
-type SearchTabsProps = {
-    activeTabCategory: SearchTabCategory;
+type SearchNavAndTableProps = {
+    activeNavCategory: SearchNavCategory;
     searchFilter: SearchFilter;
     searchResponse: SearchResponse;
 };
 
-function SearchTabs({
-    activeTabCategory,
+function SearchNavAndTable({
+    activeNavCategory,
     searchFilter,
     searchResponse,
-}: SearchTabsProps): ReactElement {
+}: SearchNavAndTableProps): ReactElement {
     const { hasReadAccess } = usePermissions();
 
     const { counts, results } = searchResponse;
 
-    function getTabCategoryCount(tabCategory: SearchTabCategory) {
-        return tabCategory === 'SEARCH_UNSET'
+    function getNavCategoryCount(navCategory: SearchNavCategory) {
+        return navCategory === 'SEARCH_UNSET'
             ? results.length
-            : counts.find(({ category }) => category === tabCategory)?.count ?? 0;
+            : counts.find(({ category }) => category === navCategory)?.count ?? 0;
     }
 
-    const searchTabEntriesFiltered = Object.entries(searchTabMap).filter(
-        ([tabCategory]) =>
-            tabCategory === 'SEARCH_UNSET' ||
-            hasReadAccess(searchResultCategoryMap[tabCategory].resourceName)
+    const searchNavEntriesFiltered = Object.entries(searchNavMap).filter(
+        ([navCategory]) =>
+            navCategory === 'SEARCH_UNSET' ||
+            hasReadAccess(searchResultCategoryMap[navCategory].resourceName)
     );
 
     return (
@@ -43,12 +43,12 @@ function SearchTabs({
             <SplitItem>
                 <Nav aria-label="Categories" theme="light">
                     <NavList>
-                        {searchTabEntriesFiltered.map(([tabCategory, text]) => (
-                            <NavItem key={tabCategory} isActive={tabCategory === activeTabCategory}>
+                        {searchNavEntriesFiltered.map(([navCategory, text]) => (
+                            <NavItem key={navCategory} isActive={navCategory === activeNavCategory}>
                                 <Link
                                     to={`${searchPath}${stringifyQueryObject({
                                         searchFilter,
-                                        tabCategory: tabCategory as SearchTabCategory,
+                                        navCategory: navCategory as SearchNavCategory,
                                     })}`}
                                     replace
                                 >
@@ -58,7 +58,7 @@ function SearchTabs({
                                     >
                                         <FlexItem>{text}</FlexItem>
                                         <FlexItem>
-                                            {getTabCategoryCount(tabCategory as SearchTabCategory)}
+                                            {getNavCategoryCount(navCategory as SearchNavCategory)}
                                         </FlexItem>
                                     </Flex>
                                 </Link>
@@ -71,11 +71,11 @@ function SearchTabs({
                 <SearchTable
                     searchFilter={searchFilter}
                     searchResults={results}
-                    tabCategory={activeTabCategory}
+                    navCategory={activeNavCategory}
                 />
             </SplitItem>
         </Split>
     );
 }
 
-export default SearchTabs;
+export default SearchNavAndTable;

--- a/ui/apps/platform/src/Containers/Search/SearchPage.css
+++ b/ui/apps/platform/src/Containers/Search/SearchPage.css
@@ -1,0 +1,35 @@
+#search-page {
+    height: 100%;
+}
+
+#search-page .pf-l-stack__item:nth-child(1) {
+    flex-shrink: 0; /* shrink is counterpart to grow for sibling */
+}
+
+#search-page .pf-l-stack__item:nth-child(2) {
+    overflow-y: hidden;
+}
+
+#search-page .pf-l-split {
+    max-height: 100%;
+    overflow-y: hidden;
+}
+
+/*
+ * Independent scrolling for category nav links at the left and search results table at the right.
+ */
+#search-page .pf-l-split__item {
+    overflow-y: scroll;
+}
+
+#search-page .pf-l-split__item:nth-child(1) {
+    flex-shrink: 0; /* shrink is counterpart to grow for sibling */
+}
+
+#search-page .pf-c-nav__link {
+    color: var(--pf-global--Color--100); /* instead of blue to avoid confusion with links in table */
+    /* font-size and spacing of sub nav link which is compatible with table row */
+    font-size: var(--pf-global--FontSize--sm);
+    padding-top: var(--pf-global--spacer--sm);
+    padding-bottom: var(--pf-global--spacer--sm);
+}

--- a/ui/apps/platform/src/Containers/Search/SearchPage.css
+++ b/ui/apps/platform/src/Containers/Search/SearchPage.css
@@ -11,6 +11,7 @@
 }
 
 #search-page .pf-l-split {
+    height: 100%;
     max-height: 100%;
     overflow-y: hidden;
 }

--- a/ui/apps/platform/src/Containers/Search/SearchPage.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchPage.tsx
@@ -1,0 +1,205 @@
+import React, { useEffect, useState, ReactElement } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+import {
+    Alert,
+    Bullseye,
+    PageSection,
+    Spinner,
+    Stack,
+    StackItem,
+    Title,
+} from '@patternfly/react-core';
+
+import PageTitle from 'Components/PageTitle';
+import SearchFilterInput from 'Components/SearchFilterInput';
+import {
+    SearchResponse,
+    fetchGlobalSearchResults,
+    getSearchOptionsForCategory,
+} from 'services/SearchService';
+import { SearchFilter } from 'types/search';
+import { ORCHESTRATOR_COMPONENTS_KEY } from 'utils/orchestratorComponents';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { searchPath } from 'routePaths';
+
+import SearchTabs from './SearchTabs';
+import {
+    parseQueryString,
+    parseSearchFilter,
+    stringifyQueryObject,
+    stringifySearchFilter,
+} from './searchQuery';
+
+import './SearchPage.css';
+
+function SearchPage(): ReactElement {
+    const history = useHistory();
+    const { search } = useLocation();
+
+    /*
+     * To avoid incomplete updates to the query string which produce uneeded items in browser history,
+     * store a key which does not yet have a value in component state.
+     */
+    const [searchFilterKeyWithoutValue, setSearchFilterKeyWithoutValue] = useState<
+        string | undefined
+    >();
+
+    const [isLoadingSearchOptions, setIsLoadingSearchOptions] = useState(false);
+    const [searchOptions, setSearchOptions] = useState<string[]>([]);
+    const [searchOptionsErrorMessage, setSeachOptionsErrorMessage] = useState<string | null>(null);
+
+    const [isLoadingSearchResponse, setIsLoadingSearchResponse] = useState(false);
+    const [searchResponse, setSearchResponse] = useState<SearchResponse | null>(null);
+    const [searchResponseErrorMessage, setSeachResponseErrorMessage] = useState<string | null>(
+        null
+    );
+
+    useEffect(() => {
+        setIsLoadingSearchOptions(true);
+        const { request, cancel } = getSearchOptionsForCategory();
+        request
+            .then(setSearchOptions)
+            .catch((error) => {
+                setSeachOptionsErrorMessage(getAxiosErrorMessage(error));
+            })
+            .finally(() => {
+                setIsLoadingSearchOptions(false);
+            });
+
+        return cancel;
+    }, []);
+
+    const { searchFilter, tabCategory } = parseQueryString(search, searchOptions);
+    const stringifiedSearchFilter = stringifySearchFilter(searchFilter);
+
+    useEffect(() => {
+        if (stringifiedSearchFilter.length === 0) {
+            setSearchResponse(null);
+        } else {
+            setIsLoadingSearchResponse(true);
+            setSeachResponseErrorMessage(null);
+
+            const parsedSearchFilter = parseSearchFilter(stringifiedSearchFilter);
+            const query = getRequestQueryStringForSearchFilter(
+                localStorage.getItem(ORCHESTRATOR_COMPONENTS_KEY) !== 'true'
+                    ? { ...parsedSearchFilter, 'Orchestrator Component': 'false' }
+                    : parsedSearchFilter
+            );
+
+            fetchGlobalSearchResults({ query })
+                .then(setSearchResponse)
+                .catch((error) => {
+                    setSearchResponse(null);
+                    setSeachResponseErrorMessage(getAxiosErrorMessage(error));
+                })
+                .finally(() => {
+                    setIsLoadingSearchResponse(false);
+                });
+        }
+    }, [stringifiedSearchFilter]);
+
+    function handleChangeSearchFilter(searchFilterNext: SearchFilter) {
+        const searchFilterKeyWithoutValueNext = Object.keys(searchFilterNext).find(
+            (key) => !searchFilterNext[key]
+        );
+
+        // If the changed search filter is complete, push the updated query string.
+        if (!searchFilterKeyWithoutValueNext) {
+            const queryString = stringifyQueryObject({
+                searchFilter: searchFilterNext,
+                tabCategory,
+            });
+            const searchPathWithQueryString = `${searchPath}${queryString}`;
+
+            // If the current search filter is empty, then replace, else push.
+            if (stringifiedSearchFilter.length === 0) {
+                history.replace(searchPathWithQueryString);
+            } else {
+                history.push(searchPathWithQueryString);
+            }
+        }
+
+        setSearchFilterKeyWithoutValue(searchFilterKeyWithoutValueNext);
+    }
+
+    let content: ReactElement | null = null;
+
+    if (isLoadingSearchOptions || isLoadingSearchResponse) {
+        content = (
+            <Bullseye>
+                <Spinner isSVG />
+            </Bullseye>
+        );
+    } else if (searchOptions.length !== 0 && stringifiedSearchFilter.length === 0) {
+        content = (
+            <Alert variant="info" isInline title="Filter resources by categories and values">
+                <p>
+                    Instead of a new search, you can go back in browser history to see previous
+                    search results.
+                </p>
+                <p>
+                    To preserve the scroll location in search results, you can right-click a link,
+                    and then click Open Link in New Tab.
+                </p>
+            </Alert>
+        );
+    } else if (searchResponse) {
+        if (searchResponse.results.length === 0) {
+            content = <Alert variant="info" isInline title="No results match the search filter" />;
+        } else {
+            content = (
+                <SearchTabs
+                    activeTabCategory={tabCategory}
+                    searchFilter={searchFilter}
+                    searchResponse={searchResponse}
+                />
+            );
+        }
+    } else if (typeof searchResponseErrorMessage === 'string') {
+        content = (
+            <Alert variant="danger" isInline title="Request failed for search results">
+                {searchResponseErrorMessage}
+            </Alert>
+        );
+    }
+
+    const pageTitleItems = ['Search'];
+    Object.keys(searchFilter).forEach((key) => {
+        pageTitleItems.push(key);
+    });
+
+    return (
+        <PageSection variant="light" id="search-page">
+            <PageTitle title={pageTitleItems.join(' - ')} />
+            <Stack hasGutter>
+                <StackItem>
+                    <Title headingLevel="h1" className="pf-u-mb-md">
+                        Search
+                    </Title>
+                    {typeof searchOptionsErrorMessage === 'string' ? (
+                        <Alert variant="danger" isInline title="Request failed for search options">
+                            {searchOptionsErrorMessage}
+                        </Alert>
+                    ) : (
+                        <SearchFilterInput
+                            className="theme-light pf-search-shim z-xs-101"
+                            handleChangeSearchFilter={handleChangeSearchFilter}
+                            isDisabled={isLoadingSearchOptions || isLoadingSearchResponse}
+                            placeholder="Filter resources"
+                            searchFilter={
+                                searchFilterKeyWithoutValue
+                                    ? { ...searchFilter, [searchFilterKeyWithoutValue]: '' }
+                                    : searchFilter
+                            }
+                            searchOptions={searchOptions}
+                        />
+                    )}
+                </StackItem>
+                <StackItem isFilled>{content}</StackItem>
+            </Stack>
+        </PageSection>
+    );
+}
+
+export default SearchPage;

--- a/ui/apps/platform/src/Containers/Search/SearchPage.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchPage.tsx
@@ -23,7 +23,7 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { searchPath } from 'routePaths';
 
-import SearchTabs from './SearchTabs';
+import SearchNavAndTable from './SearchNavAndTable';
 import {
     parseQueryString,
     parseSearchFilter,
@@ -70,7 +70,7 @@ function SearchPage(): ReactElement {
         return cancel;
     }, []);
 
-    const { searchFilter, tabCategory } = parseQueryString(search, searchOptions);
+    const { searchFilter, navCategory } = parseQueryString(search, searchOptions);
     const stringifiedSearchFilter = stringifySearchFilter(searchFilter);
 
     useEffect(() => {
@@ -108,7 +108,7 @@ function SearchPage(): ReactElement {
         if (!searchFilterKeyWithoutValueNext) {
             const queryString = stringifyQueryObject({
                 searchFilter: searchFilterNext,
-                tabCategory,
+                navCategory,
             });
             const searchPathWithQueryString = `${searchPath}${queryString}`;
 
@@ -149,8 +149,8 @@ function SearchPage(): ReactElement {
             content = <Alert variant="info" isInline title="No results match the search filter" />;
         } else {
             content = (
-                <SearchTabs
-                    activeTabCategory={tabCategory}
+                <SearchNavAndTable
+                    activeNavCategory={navCategory}
                     searchFilter={searchFilter}
                     searchResponse={searchResponse}
                 />

--- a/ui/apps/platform/src/Containers/Search/SearchPage.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchPage.tsx
@@ -133,7 +133,7 @@ function SearchPage(): ReactElement {
         );
     } else if (searchOptions.length !== 0 && stringifiedSearchFilter.length === 0) {
         content = (
-            <Alert variant="info" isInline title="Filter resources by categories and values">
+            <Alert variant="info" isInline title="Enter a new search filter">
                 <p>
                     Instead of a new search, you can go back in browser history to see previous
                     search results.

--- a/ui/apps/platform/src/Containers/Search/SearchTable.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchTable.tsx
@@ -6,7 +6,7 @@ import { SearchFilter } from 'types/search';
 
 import FilterLinks from './FilterLinks';
 import ViewLinks from './ViewLinks';
-import { SearchTabCategory, searchResultCategoryMap, searchTabMap } from './searchCategories';
+import { SearchNavCategory, searchResultCategoryMap, searchNavMap } from './searchCategories';
 
 function getLocationTextForCategory(location: string, category: SearchResultCategory) {
     return category === 'DEPLOYMENTS' ? location.replace(/^\//, '') : location.replace(/\/.+/, '');
@@ -17,35 +17,35 @@ function getLocationLabelForCategory(category: SearchResultCategory) {
 }
 
 type SearchTableProps = {
+    navCategory: SearchNavCategory;
     searchFilter: SearchFilter;
     searchResults: SearchResult[];
-    tabCategory: SearchTabCategory;
 };
 
-function SearchTable({ searchFilter, searchResults, tabCategory }: SearchTableProps): ReactElement {
-    const firstColumnHeading = searchTabMap[tabCategory];
+function SearchTable({ navCategory, searchFilter, searchResults }: SearchTableProps): ReactElement {
+    const firstColumnHeading = searchNavMap[navCategory];
     const hasLocationColumn =
-        tabCategory === 'DEPLOYMENTS' || tabCategory === 'NAMESPACES' || tabCategory === 'NODES';
-    const locationColumnHeading = hasLocationColumn ? getLocationLabelForCategory(tabCategory) : '';
-    const hasCategoryColumn = tabCategory === 'SEARCH_UNSET';
+        navCategory === 'DEPLOYMENTS' || navCategory === 'NAMESPACES' || navCategory === 'NODES';
+    const locationColumnHeading = hasLocationColumn ? getLocationLabelForCategory(navCategory) : '';
+    const hasCategoryColumn = navCategory === 'SEARCH_UNSET';
     const hasViewLinkColumn =
-        tabCategory === 'SEARCH_UNSET' ||
-        searchResultCategoryMap[tabCategory].viewLinks.length !== 0;
+        navCategory === 'SEARCH_UNSET' ||
+        searchResultCategoryMap[navCategory].viewLinks.length !== 0;
     const hasFilterLinkColumn =
-        tabCategory === 'SEARCH_UNSET' || !!searchResultCategoryMap[tabCategory].filterOn;
+        navCategory === 'SEARCH_UNSET' || !!searchResultCategoryMap[navCategory].filterOn;
 
     const searchResultsFilteredAndSorted =
-        tabCategory === 'SEARCH_UNSET'
+        navCategory === 'SEARCH_UNSET'
             ? [...searchResults].sort((a: SearchResult, b: SearchResult) => {
                   const byName = a.name.localeCompare(b.name);
                   if (byName === 0) {
                       // If equal by name, secondary sort by category text.
-                      return searchTabMap[a.category].localeCompare(searchTabMap[b.category]);
+                      return searchNavMap[a.category].localeCompare(searchNavMap[b.category]);
                   }
                   return byName;
               })
             : searchResults
-                  .filter(({ category }) => category === tabCategory)
+                  .filter(({ category }) => category === navCategory)
                   .sort((a: SearchResult, b: SearchResult) => a.name.localeCompare(b.name));
 
     return (
@@ -65,7 +65,7 @@ function SearchTable({ searchFilter, searchResults, tabCategory }: SearchTablePr
                         <Tr key={id}>
                             <Td dataLabel={firstColumnHeading} modifier="breakWord">
                                 {name}
-                                {tabCategory === 'SEARCH_UNSET' &&
+                                {navCategory === 'SEARCH_UNSET' &&
                                     category !== 'CLUSTERS' &&
                                     typeof location === 'string' &&
                                     location.length !== 0 && (
@@ -84,7 +84,7 @@ function SearchTable({ searchFilter, searchResults, tabCategory }: SearchTablePr
                             )}
                             {hasCategoryColumn && (
                                 <Td dataLabel="Category" modifier="nowrap">
-                                    {searchTabMap[category]}
+                                    {searchNavMap[category]}
                                 </Td>
                             )}
                             {hasViewLinkColumn && (

--- a/ui/apps/platform/src/Containers/Search/SearchTable.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchTable.tsx
@@ -1,0 +1,112 @@
+import React, { ReactElement } from 'react';
+import { TableComposable, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+
+import { SearchResult, SearchResultCategory } from 'services/SearchService';
+import { SearchFilter } from 'types/search';
+
+import FilterLinks from './FilterLinks';
+import ViewLinks from './ViewLinks';
+import { SearchTabCategory, searchResultCategoryMap, searchTabMap } from './searchCategories';
+
+function getLocationTextForCategory(location: string, category: SearchResultCategory) {
+    return category === 'DEPLOYMENTS' ? location.replace(/^\//, '') : location.replace(/\/.+/, '');
+}
+
+function getLocationLabelForCategory(category: SearchResultCategory) {
+    return category === 'DEPLOYMENTS' ? 'Cluster/Namespace' : 'Cluster';
+}
+
+type SearchTableProps = {
+    searchFilter: SearchFilter;
+    searchResults: SearchResult[];
+    tabCategory: SearchTabCategory;
+};
+
+function SearchTable({ searchFilter, searchResults, tabCategory }: SearchTableProps): ReactElement {
+    const firstColumnHeading = searchTabMap[tabCategory];
+    const hasLocationColumn =
+        tabCategory === 'DEPLOYMENTS' || tabCategory === 'NAMESPACES' || tabCategory === 'NODES';
+    const locationColumnHeading = hasLocationColumn ? getLocationLabelForCategory(tabCategory) : '';
+    const hasCategoryColumn = tabCategory === 'SEARCH_UNSET';
+    const hasViewLinkColumn =
+        tabCategory === 'SEARCH_UNSET' ||
+        searchResultCategoryMap[tabCategory].viewLinks.length !== 0;
+    const hasFilterLinkColumn =
+        tabCategory === 'SEARCH_UNSET' || !!searchResultCategoryMap[tabCategory].filterOn;
+
+    const searchResultsFilteredAndSorted =
+        tabCategory === 'SEARCH_UNSET'
+            ? [...searchResults].sort((a: SearchResult, b: SearchResult) => {
+                  const byName = a.name.localeCompare(b.name);
+                  if (byName === 0) {
+                      // If equal by name, secondary sort by category text.
+                      return searchTabMap[a.category].localeCompare(searchTabMap[b.category]);
+                  }
+                  return byName;
+              })
+            : searchResults
+                  .filter(({ category }) => category === tabCategory)
+                  .sort((a: SearchResult, b: SearchResult) => a.name.localeCompare(b.name));
+
+    return (
+        <TableComposable aria-label="Search results" variant="compact" isStickyHeader>
+            <Thead>
+                <Tr>
+                    <Th>{firstColumnHeading}</Th>
+                    {hasLocationColumn && <Th>{locationColumnHeading}</Th>}
+                    {hasCategoryColumn && <Th>Category</Th>}
+                    {hasViewLinkColumn && <Th>View on</Th>}
+                    {hasFilterLinkColumn && <Th>Filter on</Th>}
+                </Tr>
+            </Thead>
+            <Tbody>
+                {searchResultsFilteredAndSorted.map(({ category, id, location, name }) => {
+                    return (
+                        <Tr key={id}>
+                            <Td dataLabel={firstColumnHeading} modifier="breakWord">
+                                {name}
+                                {tabCategory === 'SEARCH_UNSET' &&
+                                    category !== 'CLUSTERS' &&
+                                    typeof location === 'string' &&
+                                    location.length !== 0 && (
+                                        <div
+                                            aria-label={getLocationLabelForCategory(category)}
+                                            className="pf-u-color-400"
+                                        >
+                                            {getLocationTextForCategory(location, category)}
+                                        </div>
+                                    )}
+                            </Td>
+                            {hasLocationColumn && (
+                                <Td dataLabel={locationColumnHeading} className="pf-u-color-400">
+                                    {getLocationTextForCategory(location, category)}
+                                </Td>
+                            )}
+                            {hasCategoryColumn && (
+                                <Td dataLabel="Category" modifier="nowrap">
+                                    {searchTabMap[category]}
+                                </Td>
+                            )}
+                            {hasViewLinkColumn && (
+                                <Td dataLabel="View on">
+                                    <ViewLinks id={id} resultCategory={category} />
+                                </Td>
+                            )}
+                            {hasFilterLinkColumn && (
+                                <Td dataLabel="Filter on">
+                                    <FilterLinks
+                                        filterValue={name}
+                                        resultCategory={category}
+                                        searchFilter={searchFilter}
+                                    />
+                                </Td>
+                            )}
+                        </Tr>
+                    );
+                })}
+            </Tbody>
+        </TableComposable>
+    );
+}
+
+export default SearchTable;

--- a/ui/apps/platform/src/Containers/Search/SearchTabs.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchTabs.tsx
@@ -1,0 +1,81 @@
+import React, { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+import { Flex, FlexItem, Nav, NavItem, NavList, Split, SplitItem } from '@patternfly/react-core';
+
+import usePermissions from 'hooks/usePermissions';
+import { SearchResponse } from 'services/SearchService';
+import { SearchFilter } from 'types/search';
+import { searchPath } from 'routePaths';
+
+import SearchTable from './SearchTable';
+import { SearchTabCategory, searchResultCategoryMap, searchTabMap } from './searchCategories';
+import { stringifyQueryObject } from './searchQuery';
+
+type SearchTabsProps = {
+    activeTabCategory: SearchTabCategory;
+    searchFilter: SearchFilter;
+    searchResponse: SearchResponse;
+};
+
+function SearchTabs({
+    activeTabCategory,
+    searchFilter,
+    searchResponse,
+}: SearchTabsProps): ReactElement {
+    const { hasReadAccess } = usePermissions();
+
+    const { counts, results } = searchResponse;
+
+    function getTabCategoryCount(tabCategory: SearchTabCategory) {
+        return tabCategory === 'SEARCH_UNSET'
+            ? results.length
+            : counts.find(({ category }) => category === tabCategory)?.count ?? 0;
+    }
+
+    const searchTabEntriesFiltered = Object.entries(searchTabMap).filter(
+        ([tabCategory]) =>
+            tabCategory === 'SEARCH_UNSET' ||
+            hasReadAccess(searchResultCategoryMap[tabCategory].resourceName)
+    );
+
+    return (
+        <Split hasGutter>
+            <SplitItem>
+                <Nav aria-label="Categories" theme="light">
+                    <NavList>
+                        {searchTabEntriesFiltered.map(([tabCategory, text]) => (
+                            <NavItem key={tabCategory} isActive={tabCategory === activeTabCategory}>
+                                <Link
+                                    to={`${searchPath}${stringifyQueryObject({
+                                        searchFilter,
+                                        tabCategory: tabCategory as SearchTabCategory,
+                                    })}`}
+                                    replace
+                                >
+                                    <Flex
+                                        justifyContent={{ default: 'justifyContentSpaceBetween' }}
+                                        style={{ minWidth: '13em' }}
+                                    >
+                                        <FlexItem>{text}</FlexItem>
+                                        <FlexItem>
+                                            {getTabCategoryCount(tabCategory as SearchTabCategory)}
+                                        </FlexItem>
+                                    </Flex>
+                                </Link>
+                            </NavItem>
+                        ))}
+                    </NavList>
+                </Nav>
+            </SplitItem>
+            <SplitItem isFilled>
+                <SearchTable
+                    searchFilter={searchFilter}
+                    searchResults={results}
+                    tabCategory={activeTabCategory}
+                />
+            </SplitItem>
+        </Split>
+    );
+}
+
+export default SearchTabs;

--- a/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
@@ -1,0 +1,41 @@
+import React, { ReactElement } from 'react';
+import { Button, Flex, FlexItem } from '@patternfly/react-core';
+
+import LinkShim from 'Components/PatternFly/LinkShim';
+import { SearchResultCategory } from 'services/SearchService';
+
+import NotApplicable from './NotApplicable';
+import { searchResultCategoryMap } from './searchCategories';
+
+type ViewLinksProps = {
+    id: string;
+    resultCategory: SearchResultCategory;
+};
+
+function ViewLinks({ id, resultCategory }: ViewLinksProps): ReactElement {
+    const { viewLinks } = searchResultCategoryMap[resultCategory];
+
+    if (viewLinks.length !== 0) {
+        return (
+            <Flex spaceItems={{ default: 'spaceItemsMd' }}>
+                {viewLinks.map(({ basePath, linkText }) => (
+                    <FlexItem key={linkText}>
+                        <Button
+                            variant="link"
+                            isInline
+                            component={LinkShim}
+                            href={id ? `${basePath}/${id}` : basePath}
+                            className="pf-u-text-nowrap"
+                        >
+                            {linkText}
+                        </Button>
+                    </FlexItem>
+                ))}
+            </Flex>
+        );
+    }
+
+    return <NotApplicable />;
+}
+
+export default ViewLinks;

--- a/ui/apps/platform/src/Containers/Search/searchCategories.ts
+++ b/ui/apps/platform/src/Containers/Search/searchCategories.ts
@@ -2,7 +2,9 @@ import { SearchResultCategory } from 'services/SearchService';
 import { ResourceName } from 'types/roleResources';
 import {
     clustersBasePath,
-    configManagementPath,
+    configManagementRolesPath,
+    configManagementSecretsPath,
+    configManagementServiceAccountsPath,
     policiesBasePath,
     riskBasePath,
     violationsBasePath,
@@ -130,7 +132,7 @@ export const searchResultCategoryMap: Record<
         filterOn: null,
         viewLinks: [
             {
-                basePath: `${configManagementPath}/roles`,
+                basePath: configManagementRolesPath,
                 linkText: 'Configuration Management',
             },
         ],
@@ -148,7 +150,7 @@ export const searchResultCategoryMap: Record<
         },
         viewLinks: [
             {
-                basePath: `${configManagementPath}/secrets`,
+                basePath: configManagementSecretsPath,
                 linkText: 'Configuration Management',
             },
         ],
@@ -158,7 +160,7 @@ export const searchResultCategoryMap: Record<
         filterOn: null,
         viewLinks: [
             {
-                basePath: `${configManagementPath}/serviceaccounts`,
+                basePath: configManagementServiceAccountsPath,
                 linkText: 'Configuration Management',
             },
         ],

--- a/ui/apps/platform/src/Containers/Search/searchCategories.ts
+++ b/ui/apps/platform/src/Containers/Search/searchCategories.ts
@@ -1,0 +1,189 @@
+import { SearchResultCategory } from 'services/SearchService';
+import { ResourceName } from 'types/roleResources';
+import {
+    clustersBasePath,
+    configManagementPath,
+    policiesBasePath,
+    riskBasePath,
+    violationsBasePath,
+    vulnManagementImagesPath,
+    vulnManagementNamespacesPath,
+    vulnManagementNodesPath,
+} from 'routePaths';
+
+type SearchResultCategoryDescriptor = {
+    resourceName: ResourceName;
+    filterOn: FilterOnDescriptor | null;
+    viewLinks: SearchLinkDescriptor[];
+};
+
+type FilterOnDescriptor = {
+    filterCategory: string; // label and value in SearchEntry object which has type: 'categoryOption'
+    filterLinks: SearchLinkDescriptor[];
+};
+
+/*
+ * A filter link appends ?queryString which includes filterCategory and name from SearchResult.
+ * A view link appends /id from SearchResult.
+ */
+type SearchLinkDescriptor = {
+    basePath: string;
+    linkText: string;
+};
+
+const filterOnRisk = {
+    basePath: riskBasePath,
+    linkText: 'Risk',
+};
+
+const filterOnViolations = {
+    basePath: violationsBasePath,
+    linkText: 'Violations',
+};
+
+// prettier-ignore
+export const searchResultCategoryMap: Record<
+    SearchResultCategory,
+    SearchResultCategoryDescriptor
+> = {
+    ALERTS: {
+        resourceName: 'Alert',
+        filterOn: null,
+        viewLinks: [
+            {
+                basePath: violationsBasePath,
+                linkText: 'Violations',
+            },
+        ],
+    },
+    CLUSTERS: {
+        resourceName: 'Cluster',
+        filterOn: null,
+        viewLinks: [
+            {
+                basePath: clustersBasePath,
+                linkText: 'Clusters',
+            },
+        ],
+    },
+    DEPLOYMENTS: {
+        resourceName: 'Deployment',
+        filterOn: {
+            filterCategory: 'Deployment',
+            filterLinks: [filterOnViolations],
+        },
+        viewLinks: [
+            {
+                basePath: riskBasePath,
+                linkText: 'Risk',
+            },
+        ],
+    },
+    IMAGES: {
+        resourceName: 'Image',
+        filterOn: {
+            filterCategory: 'Image',
+            filterLinks: [filterOnViolations, filterOnRisk],
+        },
+        viewLinks: [
+            {
+                basePath: vulnManagementImagesPath,
+                linkText: 'Images',
+            },
+        ],
+    },
+    NAMESPACES: {
+        resourceName: 'Namespace',
+        filterOn: null,
+        viewLinks: [
+            {
+                basePath: vulnManagementNamespacesPath,
+                linkText: 'Vulnerability Management',
+            },
+        ],
+    },
+    NODES: {
+        resourceName: 'Node',
+        filterOn: null,
+        viewLinks: [
+            {
+                basePath: vulnManagementNodesPath,
+                linkText: 'Vulnerability Management',
+            },
+        ],
+    },
+    POLICIES: {
+        resourceName: 'Policy',
+        filterOn: {
+            filterCategory: 'Policy',
+            filterLinks: [filterOnViolations],
+        },
+        viewLinks: [
+            {
+                basePath: policiesBasePath,
+                linkText: 'Policies',
+            },
+        ],
+    },
+    ROLES: {
+        resourceName: 'K8sRole',
+        filterOn: null,
+        viewLinks: [
+            {
+                basePath: `${configManagementPath}/roles`,
+                linkText: 'Configuration Management',
+            },
+        ],
+    },
+    ROLEBINDINGS: {
+        resourceName: 'K8sRoleBinding',
+        filterOn: null,
+        viewLinks: [],
+    },
+    SECRETS: {
+        resourceName: 'Secret',
+        filterOn: {
+            filterCategory: 'Secret',
+            filterLinks: [filterOnRisk],
+        },
+        viewLinks: [
+            {
+                basePath: `${configManagementPath}/secrets`,
+                linkText: 'Configuration Management',
+            },
+        ],
+    },
+    SERVICE_ACCOUNTS: {
+        resourceName: 'ServiceAccount',
+        filterOn: null,
+        viewLinks: [
+            {
+                basePath: `${configManagementPath}/serviceaccounts`,
+                linkText: 'Configuration Management',
+            },
+        ],
+    },
+    SUBJECTS: {
+        resourceName: 'K8sSubject',
+        filterOn: null,
+        viewLinks: [], // because search result id property value is not the id, but the name
+    },
+};
+
+export type SearchTabCategory = 'SEARCH_UNSET' | SearchResultCategory;
+
+export const searchTabMap: Record<SearchTabCategory, string> = {
+    SEARCH_UNSET: 'All results',
+    CLUSTERS: 'Clusters',
+    DEPLOYMENTS: 'Deployments',
+    IMAGES: 'Images',
+    NAMESPACES: 'Namespaces',
+    NODES: 'Nodes',
+    POLICIES: 'Policies',
+    ROLES: 'Roles',
+    ROLEBINDINGS: 'Role bindings',
+    SECRETS: 'Secrets',
+    SERVICE_ACCOUNTS: 'Service accounts',
+    SUBJECTS: 'Users and groups',
+    ALERTS: 'Violations',
+};

--- a/ui/apps/platform/src/Containers/Search/searchCategories.ts
+++ b/ui/apps/platform/src/Containers/Search/searchCategories.ts
@@ -170,9 +170,9 @@ export const searchResultCategoryMap: Record<
     },
 };
 
-export type SearchTabCategory = 'SEARCH_UNSET' | SearchResultCategory;
+export type SearchNavCategory = 'SEARCH_UNSET' | SearchResultCategory;
 
-export const searchTabMap: Record<SearchTabCategory, string> = {
+export const searchNavMap: Record<SearchNavCategory, string> = {
     SEARCH_UNSET: 'All results',
     CLUSTERS: 'Clusters',
     DEPLOYMENTS: 'Deployments',

--- a/ui/apps/platform/src/Containers/Search/searchQuery.ts
+++ b/ui/apps/platform/src/Containers/Search/searchQuery.ts
@@ -48,7 +48,7 @@ export function stringifyQueryObject({ searchFilter, navCategory }: SearchQueryO
         return '';
     }
 
-    const queryObject: SearchQueryParse = { s: searchFilter }; // TODO early return if no keys?
+    const queryObject: SearchQueryParse = { s: searchFilter };
 
     if (navCategory !== 'SEARCH_UNSET') {
         queryObject.category = searchNavMap[navCategory];

--- a/ui/apps/platform/src/Containers/Search/searchQuery.ts
+++ b/ui/apps/platform/src/Containers/Search/searchQuery.ts
@@ -2,11 +2,11 @@ import qs from 'qs';
 
 import { SearchFilter } from 'types/search';
 
-import { SearchTabCategory, searchTabMap } from './searchCategories';
+import { SearchNavCategory, searchNavMap } from './searchCategories';
 
 export type SearchQueryObject = {
     searchFilter: SearchFilter;
-    tabCategory: SearchTabCategory;
+    navCategory: SearchNavCategory;
 };
 
 type SearchQueryParse = {
@@ -30,28 +30,28 @@ export function parseQueryString(search: string, searchOptions: string[]): Searc
         });
     }
 
-    let tabCategory: SearchTabCategory = 'SEARCH_UNSET';
+    let navCategory: SearchNavCategory = 'SEARCH_UNSET';
     if (Object.keys(searchFilter).length !== 0 && typeof category === 'string') {
-        const tabCategoryFound = Object.keys(searchTabMap).find(
-            (tabCategoryFinding) => category === searchTabMap[tabCategoryFinding]
+        const navCategoryFound = Object.keys(searchNavMap).find(
+            (navCategoryFinding) => category === searchNavMap[navCategoryFinding]
         );
-        if (tabCategoryFound) {
-            tabCategory = tabCategoryFound as SearchTabCategory;
+        if (navCategoryFound) {
+            navCategory = navCategoryFound as SearchNavCategory;
         }
     }
 
-    return { searchFilter, tabCategory };
+    return { searchFilter, navCategory };
 }
 
-export function stringifyQueryObject({ searchFilter, tabCategory }: SearchQueryObject) {
+export function stringifyQueryObject({ searchFilter, navCategory }: SearchQueryObject) {
     if (Object.keys(searchFilter).length === 0) {
         return '';
     }
 
     const queryObject: SearchQueryParse = { s: searchFilter }; // TODO early return if no keys?
 
-    if (tabCategory !== 'SEARCH_UNSET') {
-        queryObject.category = searchTabMap[tabCategory];
+    if (navCategory !== 'SEARCH_UNSET') {
+        queryObject.category = searchNavMap[navCategory];
     }
 
     return qs.stringify(queryObject, {

--- a/ui/apps/platform/src/Containers/Search/searchQuery.ts
+++ b/ui/apps/platform/src/Containers/Search/searchQuery.ts
@@ -1,0 +1,82 @@
+import qs from 'qs';
+
+import { SearchFilter } from 'types/search';
+
+import { SearchTabCategory, searchTabMap } from './searchCategories';
+
+export type SearchQueryObject = {
+    searchFilter: SearchFilter;
+    tabCategory: SearchTabCategory;
+};
+
+type SearchQueryParse = {
+    s: SearchFilter;
+    category?: string;
+};
+
+export function parseQueryString(search: string, searchOptions: string[]): SearchQueryObject {
+    const { category, s } = qs.parse(search, { ignoreQueryPrefix: true });
+
+    const searchFilter = {};
+    if (typeof s === 'object') {
+        Object.entries(s).forEach(([key, value]) => {
+            if (searchOptions.includes(key)) {
+                if (typeof value === 'string' || Array.isArray(value)) {
+                    if (value.length !== 0) {
+                        searchFilter[key] = value;
+                    }
+                }
+            }
+        });
+    }
+
+    let tabCategory: SearchTabCategory = 'SEARCH_UNSET';
+    if (Object.keys(searchFilter).length !== 0 && typeof category === 'string') {
+        const tabCategoryFound = Object.keys(searchTabMap).find(
+            (tabCategoryFinding) => category === searchTabMap[tabCategoryFinding]
+        );
+        if (tabCategoryFound) {
+            tabCategory = tabCategoryFound as SearchTabCategory;
+        }
+    }
+
+    return { searchFilter, tabCategory };
+}
+
+export function stringifyQueryObject({ searchFilter, tabCategory }: SearchQueryObject) {
+    if (Object.keys(searchFilter).length === 0) {
+        return '';
+    }
+
+    const queryObject: SearchQueryParse = { s: searchFilter }; // TODO early return if no keys?
+
+    if (tabCategory !== 'SEARCH_UNSET') {
+        queryObject.category = searchTabMap[tabCategory];
+    }
+
+    return qs.stringify(queryObject, {
+        addQueryPrefix: true,
+        arrayFormat: 'repeat',
+        encodeValuesOnly: true,
+    });
+}
+
+export function parseSearchFilter(stringifiedSearchFilter): SearchFilter {
+    const { s } = qs.parse(stringifiedSearchFilter, { ignoreQueryPrefix: true });
+
+    if (typeof s === 'object') {
+        return s as SearchFilter;
+    }
+
+    return {};
+}
+
+export function stringifySearchFilter(searchFilter: SearchFilter) {
+    const queryObject: SearchQueryParse = { s: searchFilter };
+
+    return qs.stringify(queryObject, {
+        addQueryPrefix: false,
+        arrayFormat: 'repeat',
+        encodeValuesOnly: true,
+    });
+}

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -31,6 +31,7 @@ export const deprecatedPoliciesPath = `${deprecatedPoliciesBasePath}/:policyId?/
 export const riskBasePath = `${mainPath}/risk`;
 export const riskPath = `${riskBasePath}/:deploymentId?`;
 export const secretsPath = `${mainPath}/configmanagement/secrets/:secretId?`;
+export const searchPath = `${mainPath}/search`;
 export const apidocsPath = `${mainPath}/apidocs`;
 export const accessControlPath = `${mainPath}/access`;
 export const accessControlBasePathV2 = `${mainPath}/access-control`;

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -41,11 +41,25 @@ export const userRolePath = `${userBasePath}/roles/:roleName`;
 export const systemConfigPath = `${mainPath}/systemconfig`;
 export const complianceBasePath = `${mainPath}/compliance`;
 export const compliancePath = `${mainPath}/:context(compliance)`;
-export const configManagementPath = `${mainPath}/configmanagement`;
 export const dataRetentionPath = `${mainPath}/retention`;
 export const systemHealthPath = `${mainPath}/system-health`;
 export const systemHealthPathPF = `${mainPath}/system-health-pf`;
 export const productDocsPath = '/docs/product';
+
+// Configuration Management
+
+export const configManagementPath = `${mainPath}/configmanagement`;
+export const configManagementClustersPath = `${configManagementPath}/clusters`;
+export const configManagementControlsPath = `${configManagementPath}/controls`;
+export const configManagementDeploymentsPath = `${configManagementPath}/deployments`;
+export const configManagementImagesPath = `${configManagementPath}/images`;
+export const configManagementNamespacesPath = `${configManagementPath}/namespaces`;
+export const configManagementNodesPath = `${configManagementPath}/nodes`;
+export const configManagementPoliciesPath = `${configManagementPath}/policies`;
+export const configManagementRolesPath = `${configManagementPath}/roles`;
+export const configManagementSecretsPath = `${configManagementPath}/secrets`;
+export const configManagementServiceAccountsPath = `${configManagementPath}/serviceaccounts`;
+export const configManagementSubjectsPath = `${configManagementPath}/subjects`;
 
 // Vuln Management Paths
 

--- a/ui/apps/platform/src/services/SearchService.ts
+++ b/ui/apps/platform/src/services/SearchService.ts
@@ -62,13 +62,27 @@ export type SearchCategory =
 // The search categories could be deployments, policies, images etc.
 export type RawSearchRequest = {
     query: string;
-    categories: SearchCategory[];
+    categories?: SearchCategory[];
 };
+
+export type SearchResultCategory =
+    | 'ALERTS'
+    | 'CLUSTERS'
+    | 'DEPLOYMENTS'
+    | 'IMAGES'
+    | 'NAMESPACES'
+    | 'NODES'
+    | 'POLICIES'
+    | 'ROLES'
+    | 'ROLEBINDINGS'
+    | 'SECRETS'
+    | 'SERVICE_ACCOUNTS'
+    | 'SUBJECTS';
 
 export type SearchResult = {
     id: string;
     name: string;
-    category: SearchCategory;
+    category: SearchResultCategory;
     fieldToMatches: Record<string, SearchResultMatches>;
     score: number; // double
     // Location is intended to be a unique, yet human readable,
@@ -84,7 +98,7 @@ export type SearchResultMatches = {
 };
 
 export type SearchCategoryCount = {
-    category: SearchCategory;
+    category: SearchResultCategory;
     count: string; // int64
 };
 
@@ -114,16 +128,14 @@ export function fetchOptions(query = ''): Promise<SearchEntry[]> {
  * Get search options for category.
  */
 export function getSearchOptionsForCategory(
-    searchCategory: SearchCategory
+    searchCategory?: SearchCategory
 ): CancellableRequest<string[]> {
+    const queryString = searchCategory ? `categories=${searchCategory}` : '';
     return makeCancellableAxiosRequest((signal) =>
         axios
-            .get<SearchOptionsResponse>(
-                `${baseUrl}/metadata/options?categories=${searchCategory}`,
-                {
-                    signal,
-                }
-            )
+            .get<SearchOptionsResponse>(`${baseUrl}/metadata/options?${queryString}`, {
+                signal,
+            })
             .then((response) => response?.data?.options ?? [])
     );
 }


### PR DESCRIPTION
## Description

### Objectives

1. External objectives
    * Behave more like many search results pages on the web.
    * In particular, allow users to choose whether to visit link in current tab or open link in new tab.
    * Also display selected search options on browser tab and in browser history.
    * Provide nav links for all search result categories (filtered according to user role permissions).
    * Conditionally render relevant columns and content for each search result category.
2. Internal objectives
    * Remove the special case in `MainPage` for rendering a modal.
    * Remove global dependencies for data in reducers and requests in sagas.
    * Avoid the need to fix more problems like #2577

### Acknowledgments

1. Dave Vail
    * Simplified implementation of links in classic search modal: #1363 #1510 #1511 #1804 
    * Reviewed incremental improvements: #2421 #2464 #2549
2. James Talton
    * Recommended that I seek an alternative to vertical tabs.
    * Explained with examples how to achieve independent scrolling for category nav links and search results table.

### Changed files

#### cypress

1. Edit integration/search.test.js
    * Skip classic tests if feature flag is enabled

#### src/Components/SearchFilterInput

1. Edit SearchFilterInput.tsx
    * Make `searchCategory` prop optional because global search needs autocomplete for all categories.

#### src/Containers/MainPage

1. Edit Body.tsx
    * Add conditional rendering for `searchPath` route and `SearchPage` component if feature flag is enabled.

2. Edit Header/GlobalSearchButton.tsx
    * Replace `connect` with `useDispatch` for search modal.
    * Add `isFeatureFlagEnabled` and `history` for search page.

3. Edit Header/MastheadToolbar.tsx
    * Render `OrchestratorComponentsToggle` for search path so search results are compatible with **Risk** links.

#### src/Containers/Search

1. Add FilterLinks.tsx
    * Factor out from classic SearchResults.tsx file.
    * Render link instead of button.

2. Add NotApplicable.tsx
    * Factor out from classic SearchResults.tsx file.

3. Add SearchPage.css
    * Write style rules for independent scrolling for category nav links at the left and search results table at the right.
    * Render nav links with normal text color and with secondary size and spacing which is compatible with table row.

4. Add SearchNavAndTable.tsx
    * Factor out from classic SearchResults.tsx file.
    * Render all and individual categories with counts as nav links (with secondary style).

5. Add SearchPage.tsx
    * To avoid incomplete updates to the query string which produce uneeded items in browser history, store `searchFilterKeyWithoutValue` which does not yet have a value in component state.
    * Replace Redux store with request for search options.
    * Parse search filter and active tab category from URL.
    * Replace Redux store with request for search results whenever `stringifiedSearchFilter` changes (and is non-empty).
    * Update URL when (complete) search filter changes.
    * Conditionally render page content: spinner, info alerts, search response, danger alert.
    * Render page title which includes search options in (complete) search filter.
    * Conditionally render search filter input or danger alert.

6. Add SearchTable.tsx
    * Factor out from classic SearchResults.tsx file.
    * Replace sorting (by type) with ability to select any individual type.
    * Conditionally render relevant columns and content for each search result category.

7. Add ViewLinks.tsx
    * Factor out from classic SearchResults.tsx file.
    * Render link instead of button.

8. Add searchCategories.ts
    * Adapt from searchCategoryDescriptorMap.ts file.
    * Add `resourceName` property to filter search result categories according to user role permissions.
    * Add links for categories which did not have them in **View on** column.
    * Delete network link from **Filter on** column because it is not compatible with improvement to filter by cluster and namespace. Te **View on** link to **Risk** for a deployment provides a better, although indirect, path to network graph.

9. Add searchQuery.ts
    * URL is source of truth for search filter and category via `parseQueryString` and `stringifyQueryObject` functions.
    * Ordinary equality comparison in `useEffect` dependency via `parseSearchFilter` and `stringifySearchFilter` functions.

#### src

1. Edit routePaths.ts
    * Export `searchPath` route.

#### src/services

1. Edit SearchService.ts
    * Export `SearchResultCategory` type.
    * Make `searchCategory` arg optional because global search needs options for all categories.

### Residue

1. Add integration tests.
2. Encapsulate orchestrator components setting.
3. Replace `location.reload()` with React context to re-rerender on change to orchestrator components setting?
    As a proof of concept to follow the example of light/dark them to replace Redux store for the small subset of legit global data:
    * feature flags
    * metadata
    * permissions

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### manual testing without feature flag

1. `yarn deploy-local` in ui
2. `yarn start` in ui
    * Click **Search** button: see classic search modal
    * Visit /main/search route: see not found page

### manual testing with feature flag

1. `export ROX_SEARCH_PAGE_UI=true` in ui
2. `yarn deploy-local` in ui
3. `yarn start` in ui

    * Click **Search** button on masthead: see **Search** page
        See **Search** in page title on browser tab
        /main/search
        /v1/search/metadata/options? request
        ![1-Search](https://user-images.githubusercontent.com/11862657/184656804-cfe62e2e-904b-43c0-ab31-eb1b80ad7860.png)

    * Enter **Namespace: stackrox** in search filter input: See **All results** active in nav and **All results** column heading in table        
        See **Search - Namespace** in page title on browser tab
        /main/search?s[Namespace]=stackrox
        /v1/search?query=Namespace%3Astackrox%2BOrchestrator%20Component%3Afalse request
        ![2-Namespace-stackrox](https://user-images.githubusercontent.com/11862657/184229035-c8dccf24-4fd5-4320-807f-2c36ebec1dd5.png)

    * Click **Deployments** in nav: See **Deployments** active in nav and **Cluster/Namespace** column headings in table
        See same page title on browser tab, because search filter remains the same
        /main/search?s[Namespace]=stackrox&category=Deployments
        No request because search filter remains the same
        ![3-Deployments](https://user-images.githubusercontent.com/11862657/184229161-bcb32332-79d0-4c60-9fae-611832c62801.png)

    * Click **All results** in nav: See **All results** active in nav and **All results** column heading in table (again)
        See same page title on browser tab, because search filter remains the same
        /main/search?s[Namespace]=stackrox
        No request because search filter remains the same

    * Scroll down to end of search results table
    ![4-scroll-down](https://user-images.githubusercontent.com/11862657/184229278-5722a144-bb0d-4b21-a6e6-fbae18599870.png)

    * Click **Vulnerability Management** link in **View on** column for **stackrox** row
        See **Vulnerability Management - Namespace** in page title on browser tab
        See **Search - Namespace** for previous page on browser back button
        /main/vulnerability-management/namespaces/id

    * Click browser back button
        See **Search - Namespace** in page title on browser tab
        See **Vulnerability Management - Namespace** for next page on browser forward button
        /main/search?s[Namespace]=stackrox
        /v1/search/metadata/options? request
        /v1/search?query=Namespace%3Astackrox%2BOrchestrator%20Component%3Afalse request
        See scroll location has been lost (as a solution, you can right-click, and then click Open Link in New Tab)

    * Either click **Search** button on masthead or click to clear **Namespace** in search filter input
        See **Search** in page title on browser tab
        See **Search - Namespace** for previous page on browser back button
        No request

    * Enter **Add Capabilities: NET_BIND_SERVICE** in search filter input: See **No results match the search filter**
        See **Search - Add Capabilities** in page title on browser tab
        See **Search - Namespace** for previous page on browser back button
        /main/search?s[Add%20Capabilities]=NET_BIND_SERVICE
        /v1/search?query=Add%20Capabilities%3ANET_BIND_SERVICE%2BOrchestrator%20Component%3Afalse

    * Click to select **Show Orchestrator Components** toggle on masthead
        Page reloads (see **Residue** point 3)
        /v1/search/metadata/options? request
        /v1/search?query=Add%20Capabilities%3ANET_BIND_SERVICE
        ![5-Show-Orchestrator-Components](https://user-images.githubusercontent.com/11862657/184229432-20ee7e75-993a-4738-b595-b767e5e3f2f0.png)

    * Right-click, and then click Open Link in New Tab for **Risk** link in **View on** column for **coredns** row
        See **Risk** in page title on browser tab
        /main/risk/id

    * Paste /main/search in browser address bar: see **Search** page and **Search** as page title
        See **Search - Add Capabilities** and **Search - Namespace** for previous page on browser back button

    * Click browser back and forward buttons to visit previous search results

### integration testing without feature flag

1. search.test.js: see tests pass

### integration testing with feature flag

1. `export CYPRESS_ROX_SEARCH_PAGE_UI=true` in ui/apps/platform
2. `yarn cypress-open` in ui/apps/platform
    * search.test.js: see tests skipped