### PR TITLE
ROX-12180: Fix test case to support both capitalizations of error msgs

### DIFF
--- a/tests/roxctl/bats-tests/local/roxctl-netpol-generate.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-netpol-generate.bats
@@ -30,7 +30,7 @@ teardown() {
 
   run roxctl-release generate netpol
   assert_failure
-  assert_line --partial "missing <folder-path> argument"
+  assert_line --partial "accepts 1 arg(s), received 0"
 }
 
 @test "roxctl-release generate netpol generates network policies" {

--- a/tests/roxctl/bats-tests/local/roxctl-netpol-generate.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-netpol-generate.bats
@@ -26,7 +26,7 @@ teardown() {
 @test "roxctl-release generate netpol should return error on empty or non-existing directory" {
   run roxctl-release generate netpol "$out_dir"
   assert_failure
-  assert_line --partial "Error synthesizing policies from folder: no deployment objects discovered in the repository"
+  assert_line --regexp "[eE]rror synthesizing policies from folder: no deployment objects discovered in the repository"
 
   run roxctl-release generate netpol
   assert_failure


### PR DESCRIPTION
## Description

As we are still integrating with NP-Guard, some error messages may fluctuate. This PR fixes one case of that where capitalization of error message has changed.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

- Running the affected test locally `./tests/roxctl/bats-tests/local/roxctl-netpol-generate.bats`