### PR TITLE
ROX-11693: Port scale tests to OSCI

### DIFF
--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -164,3 +164,21 @@ class NonGroovyE2e(BaseTest):
             NonGroovyE2e.TEST_TIMEOUT,
             post_start_hook=set_dirs_after_start,
         )
+
+
+class Scale(BaseTest):
+    TEST_TIMEOUT = 90 * 60
+    TEST_OUTPUT_DIR = "/tmp/scale-test"
+
+    def run(self):
+        print("Executing the Scale Test")
+
+        def set_dirs_after_start():
+            # let post test know where results are
+            self.test_output_dirs = [Scale.TEST_OUTPUT_DIR]
+
+        self.run_with_graceful_kill(
+            ["tests/e2e/run-scale.sh", Scale.TEST_OUTPUT_DIR],
+            Scale.TEST_TIMEOUT,
+            post_start_hook=set_dirs_after_start,
+        )

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -175,10 +175,10 @@ class ScaleTest(BaseTest):
 
         def set_dirs_after_start():
             # let post test know where results are
-            self.test_output_dirs = [Scale.TEST_OUTPUT_DIR]
+            self.test_output_dirs = [ScaleTest.TEST_OUTPUT_DIR]
 
         self.run_with_graceful_kill(
-            ["tests/e2e/run-scale.sh", Scale.TEST_OUTPUT_DIR],
-            Scale.TEST_TIMEOUT,
+            ["tests/e2e/run-scale.sh", ScaleTest.TEST_OUTPUT_DIR],
+            ScaleTest.TEST_TIMEOUT,
             post_start_hook=set_dirs_after_start,
         )

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -166,7 +166,7 @@ class NonGroovyE2e(BaseTest):
         )
 
 
-class Scale(BaseTest):
+class ScaleTest(BaseTest):
     TEST_TIMEOUT = 90 * 60
     TEST_OUTPUT_DIR = "/tmp/scale-test"
 

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -11,7 +11,7 @@ from common import popen_graceful_kill
 
 class BaseTest:
     def __init__(self):
-        self.test_output_dirs = []
+        self.test_outputs = []
 
     def run_with_graceful_kill(self, args, timeout, post_start_hook=None):
         with subprocess.Popen(args) as cmd:
@@ -40,7 +40,7 @@ class UpgradeTest(BaseTest):
 
         def set_dirs_after_start():
             # let post test know where logs are
-            self.test_output_dirs = [UpgradeTest.TEST_OUTPUT_DIR]
+            self.test_outputs = [UpgradeTest.TEST_OUTPUT_DIR]
 
         self.run_with_graceful_kill(
             ["tests/upgrade/run.sh", UpgradeTest.TEST_OUTPUT_DIR],
@@ -121,7 +121,7 @@ class QaE2eDBBackupRestoreTest(BaseTest):
 
         def set_dirs_after_start():
             # let post test know where logs are
-            self.test_output_dirs = [QaE2eDBBackupRestoreTest.TEST_OUTPUT_DIR]
+            self.test_outputs = [QaE2eDBBackupRestoreTest.TEST_OUTPUT_DIR]
 
         self.run_with_graceful_kill(
             [
@@ -157,7 +157,7 @@ class NonGroovyE2e(BaseTest):
 
         def set_dirs_after_start():
             # let post test know where logs are
-            self.test_output_dirs = [NonGroovyE2e.TEST_OUTPUT_DIR]
+            self.test_outputs = [NonGroovyE2e.TEST_OUTPUT_DIR]
 
         self.run_with_graceful_kill(
             ["tests/e2e/run.sh", NonGroovyE2e.TEST_OUTPUT_DIR],
@@ -168,17 +168,17 @@ class NonGroovyE2e(BaseTest):
 
 class ScaleTest(BaseTest):
     TEST_TIMEOUT = 90 * 60
-    TEST_OUTPUT_DIR = "/tmp/scale-test"
+    PPROF_ZIP_OUTPUT = "/tmp/scale-test/pprof.zip"
 
     def run(self):
         print("Executing the Scale Test")
 
         def set_dirs_after_start():
             # let post test know where results are
-            self.test_output_dirs = [ScaleTest.TEST_OUTPUT_DIR]
+            self.test_outputs = [ScaleTest.PPROF_ZIP_OUTPUT]
 
         self.run_with_graceful_kill(
-            ["tests/e2e/run-scale.sh", ScaleTest.TEST_OUTPUT_DIR],
+            ["tests/e2e/run-scale.sh", ScaleTest.PPROF_ZIP_OUTPUT],
             ScaleTest.TEST_TIMEOUT,
             post_start_hook=set_dirs_after_start,
         )

--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -26,13 +26,21 @@ class GKECluster:
     TEARDOWN_TIMEOUT = 5 * 60
     GKE_SCRIPT = "scripts/ci/gke.sh"
 
-    def __init__(self, cluster_id):
+    def __init__(self, cluster_id, num_nodes=3, machine_type="e2-standard-4"):
         self.cluster_id = cluster_id
+        self.num_nodes = num_nodes
+        self.machine_type = machine_type
         self.refresh_token_cmd = None
 
     def provision(self):
         with subprocess.Popen(
-            [GKECluster.GKE_SCRIPT, "provision_gke_cluster", self.cluster_id]
+            [
+                GKECluster.GKE_SCRIPT,
+                "provision_gke_cluster",
+                self.cluster_id,
+                self.num_nodes,
+                self.machine_type,
+            ]
         ) as cmd:
 
             try:

--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -38,7 +38,7 @@ class GKECluster:
                 GKECluster.GKE_SCRIPT,
                 "provision_gke_cluster",
                 self.cluster_id,
-                self.num_nodes,
+                str(self.num_nodes),
                 self.machine_type,
             ]
         ) as cmd:

--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -24,7 +24,11 @@ class GKECluster:
     PROVISION_TIMEOUT = 20 * 60
     WAIT_TIMEOUT = 20 * 60
     TEARDOWN_TIMEOUT = 5 * 60
-    GKE_SCRIPT = "scripts/ci/gke.sh"
+    # separate script names used for testability - test_clusters.py
+    PROVISION_PATH = "scripts/ci/gke.sh"
+    WAIT_PATH = "scripts/ci/gke.sh"
+    REFRESH_PATH = "scripts/ci/gke.sh"
+    TEARDOWN_PATH = "scripts/ci/gke.sh"
 
     def __init__(self, cluster_id, num_nodes=3, machine_type="e2-standard-4"):
         self.cluster_id = cluster_id
@@ -35,7 +39,7 @@ class GKECluster:
     def provision(self):
         with subprocess.Popen(
             [
-                GKECluster.GKE_SCRIPT,
+                GKECluster.PROVISION_PATH,
                 "provision_gke_cluster",
                 self.cluster_id,
                 str(self.num_nodes),
@@ -55,14 +59,14 @@ class GKECluster:
         signal.signal(signal.SIGINT, self.sigint_handler)
 
         subprocess.run(
-            [GKECluster.GKE_SCRIPT, "wait_for_cluster"],
+            [GKECluster.WAIT_PATH, "wait_for_cluster"],
             check=True,
             timeout=GKECluster.WAIT_TIMEOUT,
         )
 
         # pylint: disable=consider-using-with
         self.refresh_token_cmd = subprocess.Popen(
-            [GKECluster.GKE_SCRIPT, "refresh_gke_token"]
+            [GKECluster.REFRESH_PATH, "refresh_gke_token"]
         )
 
         return self
@@ -79,7 +83,7 @@ class GKECluster:
                 print(f"Could not terminate the token refresh: {err}")
 
         subprocess.run(
-            [GKECluster.GKE_SCRIPT, "teardown_gke_cluster"],
+            [GKECluster.TEARDOWN_PATH, "teardown_gke_cluster"],
             check=True,
             timeout=GKECluster.TEARDOWN_TIMEOUT,
         )

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -30,7 +30,7 @@ class PostTestsConstants:
 
 
 class NullPostTest:
-    def run(self, test_output_dirs=None):
+    def run(self, test_outputs=None):
         pass
 
 
@@ -75,13 +75,13 @@ class StoreArtifacts(RunWithBestEffortMixin):
         self.artifact_destination_prefix = artifact_destination_prefix
         self.data_to_store = []
 
-    def run(self, test_output_dirs=None):
-        self.store_artifacts(test_output_dirs)
+    def run(self, test_outputs=None):
+        self.store_artifacts(test_outputs)
         self.handle_run_failure()
 
-    def store_artifacts(self, test_output_dirs=None):
-        if test_output_dirs is not None:
-            self.data_to_store = test_output_dirs + self.data_to_store
+    def store_artifacts(self, test_outputs=None):
+        if test_outputs is not None:
+            self.data_to_store = test_outputs + self.data_to_store
         for source in self.data_to_store:
             args = ["scripts/ci/store-artifacts.sh", "store_artifacts", source]
             if self.artifact_destination_prefix:
@@ -117,7 +117,7 @@ class PostClusterTest(StoreArtifacts):
         ]
         self.central_is_responsive = False
 
-    def run(self, test_output_dirs=None):
+    def run(self, test_outputs=None):
         self.central_is_responsive = self.wait_for_central_api()
         self.collect_service_logs()
         self.collect_collector_metrics()
@@ -127,7 +127,7 @@ class PostClusterTest(StoreArtifacts):
             self.grab_central_data()
         if self._check_stackrox_logs:
             self.check_stackrox_logs()
-        self.store_artifacts(test_output_dirs)
+        self.store_artifacts(test_outputs)
         self.handle_run_failure()
 
     def wait_for_central_api(self):
@@ -219,7 +219,7 @@ class CheckStackroxLogs(StoreArtifacts):
         self._check_for_errors_in_stackrox_logs = check_for_errors_in_stackrox_logs
         self.central_is_responsive = False
 
-    def run(self, test_output_dirs=None):
+    def run(self, test_outputs=None):
         self.central_is_responsive = self.wait_for_central_api()
         if self.central_is_responsive:
             self.collect_stackrox_logs()
@@ -227,7 +227,7 @@ class CheckStackroxLogs(StoreArtifacts):
                 self.check_for_stackrox_restarts()
             if self._check_for_errors_in_stackrox_logs:
                 self.check_for_errors_in_stackrox_logs()
-        self.store_artifacts(test_output_dirs)
+        self.store_artifacts(test_outputs)
         self.handle_run_failure()
 
     def wait_for_central_api(self):
@@ -285,7 +285,7 @@ class FinalPost(StoreArtifacts):
         if self._store_qa_spock_results:
             self.data_to_store.append(PostTestsConstants.QA_SPOCK_RESULTS)
 
-    def run(self, test_output_dirs=None):
+    def run(self, test_outputs=None):
         self.store_artifacts()
         self.fixup_artifacts_content_type()
         self.make_artifacts_help()

--- a/.openshift-ci/runners.py
+++ b/.openshift-ci/runners.py
@@ -101,9 +101,7 @@ class ClusterTestSetsRunner:
                 hold = err
             try:
                 self.log_event("About to run post test", test_set)
-                test_set["post_test"].run(
-                    test_output_dirs=test_set["test"].test_output_dirs
-                )
+                test_set["post_test"].run(test_outputs=test_set["test"].test_outputs)
                 self.log_event("post test completed", test_set)
             except Exception as err:
                 self.log_event("ERROR: post test failed", test_set)

--- a/.openshift-ci/tests/test_runners.py
+++ b/.openshift-ci/tests/test_runners.py
@@ -36,10 +36,10 @@ class TestClusterTestRunner(unittest.TestCase):
 
     def test_post_gets_output_from_test(self):
         test = Mock()
-        test.test_output_dirs = ["a", "b"]
+        test.test_outputs = ["a", "b"]
         post_test = Mock()
         ClusterTestRunner(test=test, post_test=post_test).run()
-        post_test.run.assert_called_with(test_output_dirs=["a", "b"])
+        post_test.run.assert_called_with(test_outputs=["a", "b"])
 
     def test_provision_failure(self):
         cluster = Mock()

--- a/scripts/ci/gate-jobs-config.json
+++ b/scripts/ci/gate-jobs-config.json
@@ -86,5 +86,21 @@
         "changed_path_to_ignore": "",
         "run_on_master": "true",
         "run_on_tags": "true"
+    },
+    "gke-scale-tests": {
+        "run_with_labels": ["ci-scale-tests"],
+        "skip_with_label": "",
+        "run_with_changed_path": "",
+        "changed_path_to_ignore": "",
+        "run_on_master": "false",
+        "run_on_tags": "true"
+    },
+    "gke-postgres-scale-tests": {
+        "run_with_labels": ["ci-postgres-scale-tests"],
+        "skip_with_label": "",
+        "run_with_changed_path": "",
+        "changed_path_to_ignore": "",
+        "run_on_master": "false",
+        "run_on_tags": "false"
     }
 }

--- a/scripts/ci/gcp.sh
+++ b/scripts/ci/gcp.sh
@@ -35,4 +35,10 @@ setup_gcp() {
     gcloud config set compute/region us-central1
     gcloud config unset compute/zone
     gcloud config set core/disable_prompts True
+
+    # For API calls e.g. prometheus-metric-parser
+    touch /tmp/gcp.json
+    chmod 0600 /tmp/gcp.json
+    echo "$service_account" >/tmp/gcp.json
+    ci_export GOOGLE_APPLICATION_CREDENTIALS /tmp/gcp.json
 }

--- a/scripts/ci/jobs/gke-postgres-scale-tests.sh
+++ b/scripts/ci/jobs/gke-postgres-scale-tests.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/bash
-
-echo "A stub for a yet to be implemented test"

--- a/scripts/ci/jobs/gke-scale-tests.sh
+++ b/scripts/ci/jobs/gke-scale-tests.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/bash
-
-echo "A stub for a yet to be implemented test"

--- a/scripts/ci/jobs/gke_postgres_scale_tests.py
+++ b/scripts/ci/jobs/gke_postgres_scale_tests.py
@@ -19,7 +19,7 @@ os.environ["STORAGE_CLASS"] = "faster"
 os.environ["STORAGE_SIZE"] = "100"
 
 ClusterTestRunner(
-    cluster=GKECluster("scale-test"),
+    cluster=GKECluster("postgres-scale-test", machine_type="e2-standard-8"),
     pre_test=PreSystemTests(),
     test=ScaleTest(),
     post_test=PostClusterTest(

--- a/scripts/ci/jobs/gke_postgres_scale_tests.py
+++ b/scripts/ci/jobs/gke_postgres_scale_tests.py
@@ -12,7 +12,6 @@ from post_tests import PostClusterTest, FinalPost
 
 os.environ["COMPARISON_METRICS"] = "scale-test/gke"
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
-os.environ["OUTPUT_FORMAT"] = "helm"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["STORAGE"] = "pvc"
 os.environ["STORAGE_CLASS"] = "faster"

--- a/scripts/ci/jobs/gke_postgres_scale_tests.py
+++ b/scripts/ci/jobs/gke_postgres_scale_tests.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run the scale test in a GKE cluster
+"""
+import os
+from runners import ClusterTestRunner
+from clusters import GKECluster
+from pre_tests import PreSystemTests
+from ci_tests import ScaleTest
+from post_tests import PostClusterTest, FinalPost
+
+os.environ["COMPARISON_METRICS"] = "scale-test/gke"
+os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["OUTPUT_FORMAT"] = "helm"
+os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["STORAGE"] = "pvc"
+os.environ["STORAGE_CLASS"] = "faster"
+os.environ["STORAGE_SIZE"] = "100"
+
+ClusterTestRunner(
+    cluster=GKECluster("scale-test"),
+    pre_test=PreSystemTests(),
+    test=ScaleTest(),
+    post_test=PostClusterTest(
+        check_stackrox_logs=True,
+    ),
+    final_post=FinalPost(),
+).run()

--- a/scripts/ci/jobs/gke_scale_tests.py
+++ b/scripts/ci/jobs/gke_scale_tests.py
@@ -16,6 +16,8 @@ os.environ["OUTPUT_FORMAT"] = "helm"
 os.environ["STORAGE"] = "pvc"
 os.environ["STORAGE_CLASS"] = "faster"
 os.environ["STORAGE_SIZE"] = "100"
+os.environ["STORE_METRICS"] = os.environ["COMPARISON_METRICS"]
+
 
 ClusterTestRunner(
     cluster=GKECluster("scale-test", machine_type="e2-standard-8"),

--- a/scripts/ci/jobs/gke_scale_tests.py
+++ b/scripts/ci/jobs/gke_scale_tests.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run the scale test in a GKE cluster
+"""
+import os
+from runners import ClusterTestRunner
+from clusters import GKECluster
+from pre_tests import PreSystemTests
+from ci_tests import ScaleTest
+from post_tests import PostClusterTest, FinalPost
+
+os.environ["COMPARISON_METRICS"] = "scale-test/gke"
+os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["OUTPUT_FORMAT"] = "helm"
+os.environ["STORAGE"] = "pvc"
+os.environ["STORAGE_CLASS"] = "faster"
+os.environ["STORAGE_SIZE"] = "100"
+
+ClusterTestRunner(
+    cluster=GKECluster("scale-test"),
+    pre_test=PreSystemTests(),
+    test=ScaleTest(),
+    post_test=PostClusterTest(
+        check_stackrox_logs=True,
+    ),
+    final_post=FinalPost(),
+).run()

--- a/scripts/ci/jobs/gke_scale_tests.py
+++ b/scripts/ci/jobs/gke_scale_tests.py
@@ -18,7 +18,7 @@ os.environ["STORAGE_CLASS"] = "faster"
 os.environ["STORAGE_SIZE"] = "100"
 
 ClusterTestRunner(
-    cluster=GKECluster("scale-test"),
+    cluster=GKECluster("scale-test", machine_type="e2-standard-8"),
     pre_test=PreSystemTests(),
     test=ScaleTest(),
     post_test=PostClusterTest(

--- a/scripts/ci/jobs/openshift_4_operator_e2e_tests.py
+++ b/scripts/ci/jobs/openshift_4_operator_e2e_tests.py
@@ -8,7 +8,4 @@ from ci_tests import OperatorE2eTest
 from pre_tests import PreSystemTests
 
 
-ClusterTestRunner(
-    pre_test=PreSystemTests(),
-    test=OperatorE2eTest()
-).run()
+ClusterTestRunner(pre_test=PreSystemTests(), test=OperatorE2eTest()).run()

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -34,7 +34,7 @@ deploy_stackrox_in_scale_mode() {
     DEPLOY_DIR="deploy/${ORCHESTRATOR_FLAVOR}" \
     get_central_basic_auth_creds
 
-    "$ROOT/scale/launch_workload.sh scale-test"
+    "$ROOT/scale/launch_workload.sh" scale-test
 
     wait_for_api
 }

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -64,7 +64,7 @@ run_scale_test() {
 
     compare_with_stored_metrics "${debug_dump_dir}"
 
-    if [[ -n "${STORE_METRICS:-}" ]]; then
+    if is_nightly_run && [[ -n "${STORE_METRICS:-}" ]]; then
         store_metrics "${debug_dump_dir}"
     fi
 }

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Runs scale tests. Formerly CircleCI gke-api-scale-tests and gke-postgres-api-scale-tests.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+source "$ROOT/scripts/ci/lib.sh"
+source "$ROOT/scripts/ci/sensor-wait.sh"
+source "$ROOT/tests/e2e/lib.sh"
+source "$ROOT/tests/scripts/setup-certs.sh"
+
+set -euo pipefail
+
+scale_test() {
+    info "Starting scale test"
+
+    require_environment "ORCHESTRATOR_FLAVOR"
+    require_environment "KUBECONFIG"
+    require_environment "COMPARISON_METRICS"
+
+    export_test_environment
+
+    setup_deployment_env false false
+    remove_existing_stackrox_resources
+    setup_default_TLS_certs
+
+    deploy_stackrox_in_scale_mode
+
+    run_scale_test
+}
+
+deploy_stackrox_in_scale_mode() {
+    "$ROOT/deploy/k8s/deploy.sh"
+    
+    DEPLOY_DIR="deploy/${ORCHESTRATOR_FLAVOR}" \
+    get_central_basic_auth_creds
+
+    "$ROOT/scale/launch_workload.sh scale-test"
+
+    wait_for_api
+}
+
+run_scale_test() {
+    info "Running scale test"
+
+    mkdir /tmp/scale-tests/pprof
+    # 45 min run so that we are confident that the run has completely finished
+    "$ROOT/scale/profiler/pprof.sh" /tmp/scale-tests/pprof "${API_ENDPOINT}" 45
+    zip -r /tmp/scale-tests/pprof.zip /tmp/scale-tests/pprof
+
+    local debug_dump_dir="./debug-dump-scale-test"
+    get_central_debug_dump "${debug_dump_dir}"
+
+    get_prometheus_metrics_parser
+
+    compare_with_stored_metrics "${debug_dump_dir}"
+}
+
+get_prometheus_metrics_parser() {
+      go install github.com/stackrox/prometheus-metric-parser@latest
+      prometheus-metric-parser help
+}
+
+compare_with_stored_metrics() {
+    local debug_dump_dir="$1"
+    local gs_path="gs://stackrox-ci-metrics/${COMPARISON_METRICS}"
+    local compare_with
+
+    compare_with=$(gsutil ls "${gs_path}"/stackrox_debug\* | sort | tail -1)
+    echo "Using ${compare_with} as metrics for comparison"
+    mkdir /tmp/metrics
+    gsutil cp "${compare_with}" /tmp/metrics
+    compare_with=$(find /tmp/metrics -maxdepth 1 | sort | tail -1)
+
+    local this_run
+    this_run=$(echo "${debug_dump_dir}"/stackrox_debug*.zip)
+    echo "Comparing with ${this_run}"
+    local compare_cmd="${PWD}/scripts/ci/compare-debug-metrics.sh"
+
+    pushd /tmp/metrics
+    "${compare_cmd}" "${compare_with}" "${this_run}" || true
+    popd
+}
+
+scale_test

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -42,7 +42,7 @@ deploy_stackrox_in_scale_mode() {
 run_scale_test() {
     info "Running scale test"
 
-    mkdir /tmp/scale-tests/pprof
+    mkdir -p /tmp/scale-tests/pprof
     # 45 min run so that we are confident that the run has completely finished
     "$ROOT/scale/profiler/pprof.sh" /tmp/scale-tests/pprof "${API_ENDPOINT}" 45
     zip -r /tmp/scale-tests/pprof.zip /tmp/scale-tests/pprof

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -4,6 +4,7 @@
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 source "$ROOT/scripts/ci/lib.sh"
+source "$ROOT/scripts/ci/gcp.sh"
 source "$ROOT/scripts/ci/sensor-wait.sh"
 source "$ROOT/tests/e2e/lib.sh"
 source "$ROOT/tests/scripts/setup-certs.sh"
@@ -21,6 +22,7 @@ scale_test() {
 
     export_test_environment
 
+    setup_gcp
     setup_deployment_env false false
     remove_existing_stackrox_resources
     setup_default_TLS_certs

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -37,6 +37,8 @@ deploy_stackrox_in_scale_mode() {
     "$ROOT/scale/launch_workload.sh" scale-test
 
     wait_for_api
+
+    touch "${STATE_DEPLOYED}"
 }
 
 run_scale_test() {


### PR DESCRIPTION
## Description

Per title. This PR resurrects the CI scale tests that run on nightly and release builds (anything tagged).

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- pprof data saved.
- Baseline and GCP monitoring metrics saved once in test commit, only on nightly runs going forward.