### PR TITLE
[ROX-12200] Add a postgres store generation flag for CopyFrom operation

### DIFF
--- a/central/cluster/store/cluster/postgres/gen.go
+++ b/central/cluster/store/cluster/postgres/gen.go
@@ -1,3 +1,5 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.Cluster --search-category CLUSTERS --migration-seq 1 --migrate-from rocksdb
+// Cluster store does not use Postgres CopyFrom operation to copy data into DB. This is because copyFrom requires an
+// explicit delete prior to copy consequently prohibiting references to clusters table.
+//go:generate pg-table-bindings-wrapper --type=storage.Cluster --search-category CLUSTERS --migration-seq 1 --migrate-from rocksdb --no-copy-from

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -99,99 +99,6 @@ func insertIntoClusters(ctx context.Context, batch *pgx.Batch, obj *storage.Clus
 	return nil
 }
 
-func (s *storeImpl) copyFromClusters(ctx context.Context, tx pgx.Tx, objs ...*storage.Cluster) error {
-
-	inputRows := [][]interface{}{}
-
-	var err error
-
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	var deletes []string
-
-	copyCols := []string{
-
-		"id",
-
-		"name",
-
-		"labels",
-
-		"serialized",
-	}
-
-	for idx, obj := range objs {
-		// Todo: ROX-9499 Figure out how to more cleanly template around this issue.
-		log.Debugf("This is here for now because there is an issue with pods_TerminatedInstances where the obj in the loop is not used as it only consists of the parent id and the idx.  Putting this here as a stop gap to simply use the object.  %s", obj)
-
-		serialized, marshalErr := obj.Marshal()
-		if marshalErr != nil {
-			return marshalErr
-		}
-
-		inputRows = append(inputRows, []interface{}{
-
-			obj.GetId(),
-
-			obj.GetName(),
-
-			obj.GetLabels(),
-
-			serialized,
-		})
-
-		// Add the id to be deleted.
-		deletes = append(deletes, obj.GetId())
-
-		// if we hit our batch size we need to push the data
-		if (idx+1)%batchSize == 0 || idx == len(objs)-1 {
-			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-			// delete for the top level parent
-
-			if err := s.DeleteMany(ctx, deletes); err != nil {
-				return err
-			}
-			// clear the inserts and vals for the next batch
-			deletes = nil
-
-			_, err = tx.CopyFrom(ctx, pgx.Identifier{"clusters"}, copyCols, pgx.CopyFromRows(inputRows))
-
-			if err != nil {
-				return err
-			}
-
-			// clear the input rows for the next batch
-			inputRows = inputRows[:0]
-		}
-	}
-
-	return err
-}
-
-func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Cluster) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Cluster")
-	if err != nil {
-		return err
-	}
-	defer release()
-
-	tx, err := conn.Begin(ctx)
-	if err != nil {
-		return err
-	}
-
-	if err := s.copyFromClusters(ctx, tx, objs...); err != nil {
-		if err := tx.Rollback(ctx); err != nil {
-			return err
-		}
-		return err
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return err
-	}
-	return nil
-}
-
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Cluster) error {
 	conn, release, err := s.acquireConn(ctx, ops.Get, "Cluster")
 	if err != nil {
@@ -254,18 +161,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Cluster) err
 			return errors.Wrapf(sac.ErrResourceAccessDenied, "modifying clusters with IDs [%s] was denied", strings.Join(deniedIds, ", "))
 		}
 	}
-
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+	return s.upsert(ctx, objs...)
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/main.go
+++ b/tools/generate-helpers/pg-table-bindings/main.go
@@ -114,6 +114,9 @@ type properties struct {
 	// Indicates the scope of search. Set this field to limit search to only some categories in case of overlapping
 	// search fields.
 	SearchScope []string
+
+	// Indicates whether stores should use Postgres copyFrom operation or not.
+	NoCopyFrom bool
 }
 
 func renderFile(templateMap map[string]interface{}, temp func(s string) *template.Template, templateFileName string) error {
@@ -178,6 +181,7 @@ func main() {
 	c.Flags().StringVar(&props.PermissionChecker, "permission-checker", "", "the permission checker that should be used")
 	c.Flags().StringSliceVar(&props.Refs, "references", []string{}, "additional foreign key references, comma seperated of <[table_name:]type>")
 	c.Flags().BoolVar(&props.JoinTable, "join-table", false, "indicates the schema represents a join table. The generation of mutating functions is skipped")
+	c.Flags().BoolVar(&props.NoCopyFrom, "no-copy-from", false, "if true, indicates that the store should not use Postgres copyFrom operation")
 	c.Flags().BoolVar(&props.SchemaOnly, "schema-only", false, "if true, generates only the schema and not store and index")
 	c.Flags().BoolVar(&props.GetAll, "get-all-func", false, "if true, generates a GetAll function")
 	c.Flags().StringVar(&props.SchemaDirectory, "schema-directory", "", "the directory in which to generate the schema")
@@ -269,6 +273,7 @@ func main() {
 				isJoinTable:              props.JoinTable,
 				schema:                   schema,
 			},
+			"NoCopyFrom": props.NoCopyFrom,
 		}
 
 		if err := generateSchema(schema, searchCategory, searchScope, parsedReferences, props.SchemaDirectory); err != nil {


### PR DESCRIPTION
## Description

Add a flag in pg store generator that controls whether or not to use the CopyFrom operation. CopyFrom operation requires explicit record deletion before copying data into DB, hence, we are unable to attach referential constraints to some Postgres stores. This will enable attaching references to `clusters` table (#2688).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed