### PR TITLE
Run dependabot daily for main codebase

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,8 +24,7 @@ updates:
   - package-ecosystem: 'gradle'
     directory: 'qa-tests-backend/'
     schedule:
-      interval: 'weekly'
-      day: 'wednesday'
+      interval: 'daily'
     open-pull-requests-limit: 1
     labels:
       - "ci-aks-tests"
@@ -42,8 +41,7 @@ updates:
   - package-ecosystem: 'gomod'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'wednesday'
+      interval: 'daily'
     open-pull-requests-limit: 3
     reviewers:
       - "stackrox/backend-dep-updaters"


### PR DESCRIPTION
## Description

Currently we run dependabot only once a week and limit number of PRs to 3 (go code) and 1 (e2e tests). If we switch to daily schedule then everytime we close bump PR we can have new PR on the next day. We should not be overwhelmed by the number of PRs as we will still have limit to 3 and 1. 

## Testing Performed

N/A