### PR TITLE
ROX-12062: Fix crash when closing single views with TopRiskyEntities widget

### DIFF
--- a/ui/apps/platform/src/Components/Menu.tsx
+++ b/ui/apps/platform/src/Components/Menu.tsx
@@ -1,6 +1,6 @@
 import React, { useState, ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { ChevronDown } from 'react-feather';
+import { ChevronDown, ChevronUp } from 'react-feather';
 
 import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
 
@@ -129,7 +129,12 @@ const Menu = ({
                     <div className="flex flex-1 justify-center items-center text-left h-full">
                         {buttonIcon}
                         {buttonText && <span className={buttonTextClassName}>{buttonText}</span>}
-                        {!hideCaret && <ChevronDown className="h-4 ml-1 pointer-events-none w-4" />}
+                        {!hideCaret &&
+                            (isMenuOpen ? (
+                                <ChevronUp className="h-4 ml-1 pointer-events-none w-4" />
+                            ) : (
+                                <ChevronDown className="h-4 ml-1 pointer-events-none w-4" />
+                            ))}
                     </div>
                 </button>
                 {isMenuOpen && (

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
@@ -354,7 +354,7 @@ const getEntitiesByContext = (entityContext, showVmUpdates) => {
 
 function getCVEListType(entityType, showVmUpdates) {
     if (!showVmUpdates) {
-        return entityType.CVE;
+        return entityTypes.CVE;
     }
     switch (entityType) {
         case entityTypes.NODE:
@@ -389,7 +389,8 @@ const processData = (data, entityType, workflowState, showVmUpdates) => {
             const newState = workflowState.pushRelatedEntity(entityType, id);
 
             const url = newState.toUrl();
-            const cveListState = newState.pushList(getCVEListType(entityType, showVmUpdates));
+            const cveListType = getCVEListType(entityType, showVmUpdates);
+            const cveListState = newState.pushList(cveListType);
             const cvesUrl = cveListState.toUrl();
             const fixableUrl = cveListState.setSearch({ Fixable: true }).toUrl();
 

--- a/ui/apps/platform/src/Containers/Workflow/WorkflowListPageLayout.js
+++ b/ui/apps/platform/src/Containers/Workflow/WorkflowListPageLayout.js
@@ -80,10 +80,12 @@ const WorkflowListPageLayout = ({ location }) => {
     const showVmUpdates = isFeatureFlagEnabled('ROX_FRONTEND_VM_UPDATES');
     const useCaseOptions = useCaseEntityMap[useCase].filter((option) => {
         if (showVmUpdates) {
-            if (option === entityTypes.CVE) {
+            if (option === entityTypes.CVE || option === entityTypes.COMPONENT) {
                 return false;
             }
         } else if (
+            option === entityTypes.IMAGE_COMPONENT ||
+            option === entityTypes.NODE_COMPONENT ||
             option === entityTypes.IMAGE_CVE ||
             option === entityTypes.NODE_CVE ||
             option === entityTypes.CLUSTER_CVE


### PR DESCRIPTION
## Description

This would be the nirvana of PRs--a one-letter change--but I also refactored the call site for readability.

... And then I noticed that the two new, split Component types were "leaking" into the Entities shortcut menu even when the feature flag was off, so I fixed that, too.


## Checklist
- [x] Investigated and inspected CI test results


## Testing Performed

Tested with the feature flag off, as well as on.
