### PR TITLE
Fix scope lookups in image and cluster Vulnerabilities sub-resolvers

### DIFF
--- a/central/graphql/resolvers/cluster_vulnerabilities.go
+++ b/central/graphql/resolvers/cluster_vulnerabilities.go
@@ -386,7 +386,7 @@ func (resolver *clusterCVEResolver) EnvImpact(ctx context.Context) (float64, err
 	return float64(scopedCount) / float64(allCount), nil
 }
 
-func (resolver *clusterCVEResolver) FixedByVersion(ctx context.Context) (string, error) {
+func (resolver *clusterCVEResolver) FixedByVersion(_ context.Context) (string, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ClusterCVEs, "FixedByVersion")
 	scope, hasScope := scoped.GetScope(resolver.ctx)
 	if !hasScope {
@@ -397,14 +397,14 @@ func (resolver *clusterCVEResolver) FixedByVersion(ctx context.Context) (string,
 	}
 
 	query := search.NewQueryBuilder().AddExactMatches(search.ClusterID, scope.ID).AddExactMatches(search.CVEID, resolver.data.GetId()).ProtoQuery()
-	edges, err := resolver.root.ClusterCVEEdgeDataStore.SearchRawEdges(ctx, query)
+	edges, err := resolver.root.ClusterCVEEdgeDataStore.SearchRawEdges(resolver.ctx, query)
 	if err != nil || len(edges) == 0 {
 		return "", err
 	}
 	return edges[0].GetFixedBy(), nil
 }
 
-func (resolver *clusterCVEResolver) IsFixable(ctx context.Context, args RawQuery) (bool, error) {
+func (resolver *clusterCVEResolver) IsFixable(_ context.Context, args RawQuery) (bool, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ClusterCVEs, "IsFixable")
 	query, err := args.AsV1QueryOrEmpty(search.ExcludeFieldLabel(search.CVEID))
 	if err != nil {
@@ -421,11 +421,11 @@ func (resolver *clusterCVEResolver) IsFixable(ctx context.Context, args RawQuery
 	}
 
 	query = search.ConjunctionQuery(conjuncts...)
-	loader, err := loaders.GetClusterCVELoader(ctx)
+	loader, err := loaders.GetClusterCVELoader(resolver.ctx)
 	if err != nil {
 		return false, err
 	}
-	count, err := loader.CountFromQuery(ctx, query)
+	count, err := loader.CountFromQuery(resolver.ctx, query)
 	if err != nil {
 		return false, err
 	}

--- a/central/graphql/resolvers/image_vulnerabilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities.go
@@ -317,7 +317,7 @@ func (resolver *imageCVEResolver) EnvImpact(ctx context.Context) (float64, error
 	return float64(scopedCount) / float64(allCount), nil
 }
 
-func (resolver *imageCVEResolver) FixedByVersion(ctx context.Context) (string, error) {
+func (resolver *imageCVEResolver) FixedByVersion(_ context.Context) (string, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "FixedByVersion")
 
 	// Short path. Full image is embedded when image scan resolver is called.
@@ -334,14 +334,14 @@ func (resolver *imageCVEResolver) FixedByVersion(ctx context.Context) (string, e
 	}
 
 	query := search.NewQueryBuilder().AddExactMatches(search.ComponentID, scope.ID).AddExactMatches(search.CVEID, resolver.data.GetId()).ProtoQuery()
-	edges, err := resolver.root.ComponentCVEEdgeDataStore.SearchRawEdges(ctx, query)
+	edges, err := resolver.root.ComponentCVEEdgeDataStore.SearchRawEdges(resolver.ctx, query)
 	if err != nil || len(edges) == 0 {
 		return "", err
 	}
 	return edges[0].GetFixedBy(), nil
 }
 
-func (resolver *imageCVEResolver) IsFixable(ctx context.Context, args RawQuery) (bool, error) {
+func (resolver *imageCVEResolver) IsFixable(_ context.Context, args RawQuery) (bool, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "IsFixable")
 
 	// Short path. Full image is embedded when image scan resolver is called.
@@ -364,11 +364,11 @@ func (resolver *imageCVEResolver) IsFixable(ctx context.Context, args RawQuery) 
 	}
 
 	query = search.ConjunctionQuery(conjuncts...)
-	loader, err := loaders.GetImageCVELoader(ctx)
+	loader, err := loaders.GetImageCVELoader(resolver.ctx)
 	if err != nil {
 		return false, err
 	}
-	count, err := loader.CountFromQuery(ctx, query)
+	count, err := loader.CountFromQuery(resolver.ctx, query)
 	if err != nil {
 		return false, err
 	}
@@ -557,7 +557,7 @@ func (resolver *imageCVEResolver) Deployments(ctx context.Context, args Paginate
 	return resolver.root.Deployments(resolver.withImageVulnerabilityScope(ctx), args)
 }
 
-func (resolver *imageCVEResolver) DiscoveredAtImage(ctx context.Context, args RawQuery) (*graphql.Time, error) {
+func (resolver *imageCVEResolver) DiscoveredAtImage(_ context.Context, args RawQuery) (*graphql.Time, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "DiscoveredAtImage")
 
 	// Short path. Full image is embedded when image scan resolver is called.
@@ -571,7 +571,7 @@ func (resolver *imageCVEResolver) DiscoveredAtImage(ctx context.Context, args Ra
 		imageID = scope.ID
 	} else {
 		var err error
-		imageID, err = getImageIDFromIfImageShaQuery(ctx, resolver.root, args)
+		imageID, err = getImageIDFromIfImageShaQuery(resolver.ctx, resolver.root, args)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not determine vulnerability discovered time in image")
 		}
@@ -582,7 +582,7 @@ func (resolver *imageCVEResolver) DiscoveredAtImage(ctx context.Context, args Ra
 	}
 
 	query := search.NewQueryBuilder().AddExactMatches(search.ImageSHA, imageID).AddExactMatches(search.CVEID, resolver.data.GetId()).ProtoQuery()
-	edges, err := resolver.root.ImageCVEEdgeDataStore.SearchRawEdges(ctx, query)
+	edges, err := resolver.root.ImageCVEEdgeDataStore.SearchRawEdges(resolver.ctx, query)
 	if err != nil || len(edges) == 0 {
 		return nil, err
 	}

--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -63,10 +63,7 @@ func (resolver *Resolver) NodeVulnerability(ctx context.Context, args IDQuery) (
 		return nil, err
 	}
 	vuln, err := vulnLoader.FromID(ctx, string(*args.ID))
-	if err != nil {
-		return nil, err
-	}
-	vulnResolver, err := resolver.wrapNodeCVE(vuln, true, nil)
+	vulnResolver, err := resolver.wrapNodeCVE(vuln, true, err)
 	if err != nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -311,7 +311,7 @@ func (resolver *nodeCVEResolver) FixedByVersion(_ context.Context) (string, erro
 }
 
 // IsFixable returns whether node CVE is fixable by any component
-func (resolver *nodeCVEResolver) IsFixable(ctx context.Context, args RawQuery) (bool, error) {
+func (resolver *nodeCVEResolver) IsFixable(_ context.Context, args RawQuery) (bool, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "IsFixable")
 
 	query, err := args.AsV1QueryOrEmpty(search.ExcludeFieldLabel(search.CVEID))
@@ -329,11 +329,11 @@ func (resolver *nodeCVEResolver) IsFixable(ctx context.Context, args RawQuery) (
 	}
 
 	query = search.ConjunctionQuery(conjuncts...)
-	vulnLoader, err := loaders.GetNodeCVELoader(ctx)
+	vulnLoader, err := loaders.GetNodeCVELoader(resolver.ctx)
 	if err != nil {
 		return false, err
 	}
-	count, err := vulnLoader.CountFromQuery(ctx, query)
+	count, err := vulnLoader.CountFromQuery(resolver.ctx, query)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## Description

Some image and cluster vulnerability sub resolvers used to search the default ctx sent to the sub-resolver. The default ctx would not have the entity scoping added when vulnerabilities were queried from another entity. This PR updates the sub-resolvers in image and cluster vulnerability sub-resolvers to use the parent ctx to lookup scopes.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Manual testing 
- Check if `fixedByVersion`, `isFixable` and `discoveredAtImage` in ImageVulnerability graphQL work as expected when `imageVulnerabilities` are queries from other entities.
- Check if `fixedByVersion` and `isFixable` in ClusterVulnerability graphQl work as expected.
