### PR TITLE
Remove PerformChecks method

### DIFF
--- a/central/node/datastore/dackbox/globaldatastore/datastore.go
+++ b/central/node/datastore/dackbox/globaldatastore/datastore.go
@@ -62,10 +62,6 @@ func (s *globalDataStore) GetAllClusterNodeStores(ctx context.Context, writeAcce
 		return nil, err
 	} else if !ok {
 		scopeChecker := nodesSAC.ScopeChecker(ctx, accessMode)
-		// Pass 1: Mark requests for all clusters as pending
-		for clusterID := range clusterIDs {
-			scopeChecker.TryAllowed(sac.ClusterScopeKey(clusterID))
-		}
 		// Pass 2: Filter out clusters for which we have no access.
 		for clusterID := range clusterIDs {
 			if scopeChecker.TryAllowed(sac.ClusterScopeKey(clusterID)) != sac.Allow {

--- a/central/node/datastore/dackbox/globaldatastore/datastore.go
+++ b/central/node/datastore/dackbox/globaldatastore/datastore.go
@@ -66,9 +66,6 @@ func (s *globalDataStore) GetAllClusterNodeStores(ctx context.Context, writeAcce
 		for clusterID := range clusterIDs {
 			scopeChecker.TryAllowed(sac.ClusterScopeKey(clusterID))
 		}
-		if err := scopeChecker.PerformChecks(ctx); err != nil {
-			return nil, err
-		}
 		// Pass 2: Filter out clusters for which we have no access.
 		for clusterID := range clusterIDs {
 			if scopeChecker.TryAllowed(sac.ClusterScopeKey(clusterID)) != sac.Allow {

--- a/central/sac/authorizer/builtin_scoped_authorizer.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer.go
@@ -85,10 +85,6 @@ func (a *globalScopeChecker) TryAllowed() sac.TryAllowedResult {
 	return sac.Deny
 }
 
-func (a *globalScopeChecker) PerformChecks(_ context.Context) error {
-	return nil
-}
-
 func (a *globalScopeChecker) EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {
 	return a.
 		SubScopeChecker(sac.AccessModeScopeKey(resource.Access)).

--- a/central/sac/authorizer/builtin_scoped_authorizer.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer.go
@@ -65,10 +65,6 @@ func newGlobalScopeCheckerCore(clusters []*storage.Cluster, namespaces []*storag
 // if the request should be allowed. This simplifies logic as only user with
 // admin rights can be allowed on global scope.
 //
-// PerformChecks() has nothing to do because built-in authorizer never defers
-// authorization decisions, i.e., TryAllowed() returns sac.Deny in case
-// of a non-recoverable error.
-//
 // SubScopeChecker() extracts the access mode from the scope key and returns
 // an accessModeLevelScopeCheckerCore embedding the current instance and setting
 // the desired access mode.
@@ -104,8 +100,7 @@ func (a *globalScopeChecker) SubScopeChecker(scopeKey sac.ScopeKey) sac.ScopeChe
 }
 
 // accessModeLevelScopeCheckerCore embeds globalScopeChecker and additionally
-// maintains the access mode. It inherits TryAllowed() and PerformChecks()
-// behavior.
+// maintains the access mode. It inherits TryAllowed() behavior.
 //
 // SubScopeChecker() extracts the resource from the scope key and returns a
 // resourceLevelScopeCheckerCore with the list of resolved roles filtered down

--- a/central/sac/authorizer/builtin_scoped_authorizer_test.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer_test.go
@@ -1,7 +1,6 @@
 package authorizer
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stackrox/default-authz-plugin/pkg/payload"
@@ -654,7 +653,6 @@ func checkEffectiveAccessScope(t *testing.T, scc sac.ScopeCheckerCore, resource 
 func TestGlobalScopeCheckerCore(t *testing.T) {
 	t.Parallel()
 	scc := newGlobalScopeCheckerCore(nil, nil, nil, nil)
-	assert.Equal(t, nil, scc.PerformChecks(context.Background()))
 	assert.Equal(t, sac.Deny, scc.TryAllowed())
 }
 
@@ -696,8 +694,6 @@ func TestBuiltInScopeAuthorizerPanicsWhenErrorOnComputeAccessScope(t *testing.T)
 					expected := tc.results[i]
 					assert.Equal(t, expected, scc.TryAllowed())
 				}
-				err := scc.PerformChecks(context.Background())
-				assert.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/sac/allow_fixed_scopes_checker_core.go
+++ b/pkg/sac/allow_fixed_scopes_checker_core.go
@@ -1,8 +1,6 @@
 package sac
 
 import (
-	"context"
-
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
 )
@@ -35,10 +33,6 @@ func (c allowFixedScopesCheckerCore) TryAllowed() TryAllowedResult {
 		return Allow
 	}
 	return Deny
-}
-
-func (c allowFixedScopesCheckerCore) PerformChecks(_ context.Context) error {
-	return nil
 }
 
 func (c allowFixedScopesCheckerCore) SubScopeChecker(key ScopeKey) ScopeCheckerCore {

--- a/pkg/sac/error_scope_checker_core.go
+++ b/pkg/sac/error_scope_checker_core.go
@@ -1,8 +1,6 @@
 package sac
 
 import (
-	"context"
-
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
@@ -21,10 +19,6 @@ func (s errScopeCheckerCore) TryAllowed() TryAllowedResult {
 	logging.LoggerForModule().Error("This should not be called", s.err)
 	utils.Must(s.err)
 	return Deny
-}
-
-func (s errScopeCheckerCore) PerformChecks(ctx context.Context) error {
-	return s.err
 }
 
 // ErrorAccessScopeCheckerCore returns an access scope checker that always returns an error.

--- a/pkg/sac/mocks/scope_checker.go
+++ b/pkg/sac/mocks/scope_checker.go
@@ -188,20 +188,6 @@ func (mr *MockScopeCheckerMockRecorder) Namespace(namespace interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Namespace", reflect.TypeOf((*MockScopeChecker)(nil).Namespace), namespace)
 }
 
-// PerformChecks mocks base method.
-func (m *MockScopeChecker) PerformChecks(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PerformChecks", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// PerformChecks indicates an expected call of PerformChecks.
-func (mr *MockScopeCheckerMockRecorder) PerformChecks(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PerformChecks", reflect.TypeOf((*MockScopeChecker)(nil).PerformChecks), ctx)
-}
-
 // Resource mocks base method.
 func (m *MockScopeChecker) Resource(resource permissions.ResourceHandle) sac.ScopeChecker {
 	m.ctrl.T.Helper()

--- a/pkg/sac/mocks/scope_checker_core.go
+++ b/pkg/sac/mocks/scope_checker_core.go
@@ -5,7 +5,6 @@
 package mocks
 
 import (
-	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -50,20 +49,6 @@ func (m *MockScopeCheckerCore) EffectiveAccessScope(resource permissions.Resourc
 func (mr *MockScopeCheckerCoreMockRecorder) EffectiveAccessScope(resource interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EffectiveAccessScope", reflect.TypeOf((*MockScopeCheckerCore)(nil).EffectiveAccessScope), resource)
-}
-
-// PerformChecks mocks base method.
-func (m *MockScopeCheckerCore) PerformChecks(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PerformChecks", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// PerformChecks indicates an expected call of PerformChecks.
-func (mr *MockScopeCheckerCoreMockRecorder) PerformChecks(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PerformChecks", reflect.TypeOf((*MockScopeCheckerCore)(nil).PerformChecks), ctx)
 }
 
 // SubScopeChecker mocks base method.

--- a/pkg/sac/scope_checker.go
+++ b/pkg/sac/scope_checker.go
@@ -14,7 +14,6 @@ import (
 //go:generate mockgen-wrapper
 type ScopeChecker interface {
 	SubScopeChecker(keys ...ScopeKey) ScopeChecker
-	PerformChecks(ctx context.Context) error
 	TryAllowed(subScopeKeys ...ScopeKey) TryAllowedResult
 	Allowed(ctx context.Context, subScopeKeys ...ScopeKey) (bool, error)
 	TryAnyAllowed(subScopeKeyss [][]ScopeKey) TryAllowedResult
@@ -57,11 +56,6 @@ func (c scopeChecker) SubScopeChecker(keys ...ScopeKey) ScopeChecker {
 	return scopeChecker{
 		core: curr,
 	}
-}
-
-// PerformChecks calls the `PerformChecks()` method on the wrapped ScopeCheckerCore.
-func (c scopeChecker) PerformChecks(ctx context.Context) error {
-	return c.core.PerformChecks(ctx)
 }
 
 // TryAllowed checks (in a non-blocking way) if access to the given (sub-)scope is allowed.

--- a/pkg/sac/scope_checker_core.go
+++ b/pkg/sac/scope_checker_core.go
@@ -1,8 +1,6 @@
 package sac
 
 import (
-	"context"
-
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
 )
@@ -32,14 +30,8 @@ type ScopeCheckerCore interface {
 	// SubScopeChecker obtains an access scope checker for the access scope directly underneath
 	// this scope, keyed by the given key.
 	SubScopeChecker(scopeKey ScopeKey) ScopeCheckerCore
-	// TryAllowed checks if access to the scope being checked is allowed. If the result is `Unknown`, the
-	// attempt is recorded and the corresponding data will be queried in the next call to `PerformChecks`.
+	// TryAllowed checks if access to the scope being checked is allowed.
 	TryAllowed() TryAllowedResult
-	// PerformChecks queries the Authorization Plugin for the set of access scopes underneath (and including)
-	// this scope for which `TryAllowed` calls have returned `Unknown` previously.
-	// Note: Only scopes that have been obtained from this scope via a call to `SubScopeChecker` are guaranteed
-	// to be considered. Similarly, only requests made in the current goroutine are guaranteed to be considered.
-	PerformChecks(ctx context.Context) error
 	// EffectiveAccessScope returns effective access scope for given principal stored in context.
 	// If checker is not at resource level then it returns an error.
 	EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error)

--- a/pkg/sac/scope_checker_or.go
+++ b/pkg/sac/scope_checker_or.go
@@ -31,17 +31,6 @@ func (s orScopeChecker) SubScopeChecker(keys ...ScopeKey) ScopeChecker {
 	}
 }
 
-func (s orScopeChecker) PerformChecks(ctx context.Context) error {
-	var performChecksErrs *multierror.Error
-	for _, checker := range s.scopeCheckers {
-		err := checker.PerformChecks(ctx)
-		if err != nil {
-			performChecksErrs = multierror.Append(performChecksErrs, err)
-		}
-	}
-	return performChecksErrs.ErrorOrNil()
-}
-
 func (s orScopeChecker) TryAllowed(subScopeKeys ...ScopeKey) TryAllowedResult {
 	result := Deny
 	for _, checker := range s.scopeCheckers {

--- a/pkg/sac/test_scope_checker_core.go
+++ b/pkg/sac/test_scope_checker_core.go
@@ -1,7 +1,6 @@
 package sac
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stackrox/rox/generated/storage"
@@ -90,10 +89,6 @@ func (c *testScopeCheckerCore) EffectiveAccessScope(resource permissions.Resourc
 		}
 	}
 	return effectiveaccessscope.FromClustersAndNamespacesMap(includedClusters, includedClusterNamespacePairs), nil
-}
-
-func (c *testScopeCheckerCore) PerformChecks(_ context.Context) error {
-	return nil
 }
 
 func (c *testScopeCheckerCore) SubScopeChecker(key ScopeKey) ScopeCheckerCore {

--- a/pkg/sac/tests/scope_checker_or_test.go
+++ b/pkg/sac/tests/scope_checker_or_test.go
@@ -34,29 +34,6 @@ func (suite *orScopeCheckerTestSuite) SetupTest() {
 	suite.orScopeChecker = sac.NewOrScopeChecker(suite.scopeChecker1, suite.scopeChecker2)
 }
 
-func (suite *orScopeCheckerTestSuite) TestPerformChecks() {
-	// 1. Expect no error when ScopeCheckers will not return any.
-	suite.scopeChecker1.EXPECT().PerformChecks(gomock.Any()).Return(nil)
-	suite.scopeChecker2.EXPECT().PerformChecks(gomock.Any()).Return(nil)
-
-	err := suite.orScopeChecker.PerformChecks(context.Background())
-	suite.NoError(err)
-	// Regression: It happened that the returned value was non-nil.
-	suite.Nil(err)
-
-	// 2. Expect an error when at least 1 ScopeChecker will return an error.
-	suite.scopeChecker1.EXPECT().PerformChecks(gomock.Any()).Return(errors.New("something happened"))
-	suite.scopeChecker2.EXPECT().PerformChecks(gomock.Any()).Return(nil)
-	err = suite.orScopeChecker.PerformChecks(context.Background())
-	suite.Error(err)
-
-	// 3. Expect an error when all ScopeCheckers will return an error.
-	suite.scopeChecker1.EXPECT().PerformChecks(gomock.Any()).Return(errors.New("something happened"))
-	suite.scopeChecker2.EXPECT().PerformChecks(gomock.Any()).Return(errors.New("something happened"))
-	err = suite.orScopeChecker.PerformChecks(context.Background())
-	suite.Error(err)
-}
-
 func (suite *orScopeCheckerTestSuite) TestTryAllowed() {
 	// 1. Expect Allow when at least 1 ScopeChecker returns Allow.
 	suite.scopeChecker1.EXPECT().TryAllowed().Return(sac.Allow)

--- a/pkg/sac/uniform_scope_checker_core.go
+++ b/pkg/sac/uniform_scope_checker_core.go
@@ -1,8 +1,6 @@
 package sac
 
 import (
-	"context"
-
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
 )
@@ -33,10 +31,6 @@ func (s uniformScopeCheckerCore) TryAllowed() TryAllowedResult {
 		return Allow
 	}
 	return Deny
-}
-
-func (s uniformScopeCheckerCore) PerformChecks(ctx context.Context) error {
-	return nil
 }
 
 func (s uniformScopeCheckerCore) EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {


### PR DESCRIPTION
## Description

After AuthPlugin removal we no longer need do PerfomCheck as we will never get undefined on TryAllowed.
This means we can remove this method.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
