### PR TITLE
ROX-12057: collect operator e2e test artifacts

### DIFF
--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -56,6 +56,12 @@ class OperatorE2eTest(BaseTest):
     E2E_TEST_TIMEOUT_SEC = 50 * 60
     SCORECARD_TEST_TIMEOUT_SEC = 20 * 60
 
+    def __init__(self):
+        self.test_outputs = [
+            "operator/build/kuttl-test-artifacts",
+            "operator/build/kuttl-test-artifacts-upgrade",
+        ]
+
     def run(self):
         print("Deploying operator")
         self.run_with_graceful_kill(

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -102,6 +102,7 @@ class PostClusterTest(StoreArtifacts):
 
     def __init__(
         self,
+        collect_central_artifacts=True,
         check_stackrox_logs=False,
         artifact_destination_prefix=None,
     ):
@@ -115,13 +116,12 @@ class PostClusterTest(StoreArtifacts):
             "openshift-etcd",
             "openshift-controller-manager",
         ]
-        self.central_is_responsive = False
+        self.collect_central_artifacts = collect_central_artifacts
 
     def run(self, test_outputs=None):
-        self.central_is_responsive = self.wait_for_central_api()
         self.collect_service_logs()
         self.collect_collector_metrics()
-        if self.central_is_responsive:
+        if self.collect_central_artifacts and self.wait_for_central_api():
             self.get_central_debug_dump()
             self.get_central_diagnostics()
             self.grab_central_data()

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -245,10 +245,10 @@ test-e2e-deployed: validate-crs kuttl ## Run e2e tests with manager deployed on 
 	KUTTL=$(KUTTL) REAL_KUBECONFIG=$${KUBECONFIG} SKIP_MANAGER_START=1 $(KUTTL) test
 
 test-upgrade: kuttl bundle-post-process ## Run OLM-based operator upgrade tests.
-	mkdir -p $(PROJECT_DIR)/build/kuttl-test-artifacts
+	mkdir -p $(PROJECT_DIR)/build/kuttl-test-artifacts-upgrade
 	SKIP_MANAGER_START=1 \
 	NEW_PRODUCT_VERSION=$$(make --quiet --no-print-directory -C .. tag) \
-	KUTTL=$(KUTTL) REAL_KUBECONFIG=$${KUBECONFIG} $(KUTTL) test --config kuttl-test.yaml tests/upgrade
+	KUTTL=$(KUTTL) REAL_KUBECONFIG=$${KUBECONFIG} $(KUTTL) test --config kuttl-test.yaml --artifacts-dir build/kuttl-test-artifacts-upgrade tests/upgrade
 
 stackrox-image-pull-secret: ## Create default image pull secret for StackRox images on Quay.io. Used by Helm chart.
 # Create stackrox namespace if not exists.

--- a/scripts/ci/jobs/openshift_4_operator_e2e_tests.py
+++ b/scripts/ci/jobs/openshift_4_operator_e2e_tests.py
@@ -6,6 +6,11 @@ Run operator e2e tests in a openshift 4 cluster provided via a hive cluster_clai
 from runners import ClusterTestRunner
 from ci_tests import OperatorE2eTest
 from pre_tests import PreSystemTests
+from post_tests import PostClusterTest, FinalPost
 
 
-ClusterTestRunner(pre_test=PreSystemTests(), test=OperatorE2eTest()).run()
+ClusterTestRunner(
+    pre_test=PreSystemTests(),
+    test=OperatorE2eTest(),
+    post_test=PostClusterTest(collect_central_artifacts=False),
+    final_post=FinalPost()).run()


### PR DESCRIPTION
## Description

- Make checking of central API status optional, even though `wait_for_central_api` is `run_with_best_effort`, it [causes the overall test to fail](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/stackrox_stackrox/2732/pull-ci-stackrox-stackrox-master-openshift-4-operator-e2e-tests/1560495042408222720/artifacts/openshift-4-operator-e2e-tests/stackrox-e2e/build-log.txt) for operator jobs
- Change the kuttl output directory for the upgrade test, to make it easier to gather results from both kuttl runs, this might be relevant to @ivan-degtiarenko 's [PR](https://github.com/stackrox/stackrox/pull/2562)
- Use the `PostClusterTest` and `FinalPost` to gather the kuttl artifacts and the various service logs

/cc @gavin-stackrox @ivan-degtiarenko @mtesseract 

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Relying on CI