### PR TITLE
ROX-11693: Add scale comparison to spyglass view

### DIFF
--- a/scripts/ci/compare-debug-metrics.sh
+++ b/scripts/ci/compare-debug-metrics.sh
@@ -25,8 +25,6 @@ main() {
         exit 1
     fi
 
-    set -x
-
     baseline="$1"
     to_compare="$2"
     comparison_out="$3"
@@ -35,10 +33,11 @@ main() {
     unzip -o "${to_compare}" -d to_compare
 
     prometheus-metric-parser compare --old-file baseline/metrics-2 --new-file to_compare/metrics-2 \
-        --metrics ${metrics_of_interest} --warn 15 --error 25
-    prometheus-metric-parser compare --old-file baseline/metrics-2 --new-file to_compare/metrics-2 \
         --metrics ${metrics_of_interest} --warn 15 --error 25 \
-        --format=html-table > "${comparison_out}"
+        --format=html-table > "${comparison_out}" || true
+
+    prometheus-metric-parser compare --old-file baseline/metrics-2 --new-file to_compare/metrics-2 \
+        --metrics ${metrics_of_interest} --warn 15 --error
 }
 
 main "$@"

--- a/scripts/ci/compare-debug-metrics.sh
+++ b/scripts/ci/compare-debug-metrics.sh
@@ -5,8 +5,8 @@ set -eu
 # intended to run in CI to compare a BASELINE versus a system under test run.
 
 usage() {
-    echo "$0 <baseline.zip> <to_compare.zip>"
-    echo "e.g. $0 stackrox_debug_2020_05_20_09_51_46.zip stackrox_debug_2020_05_21_09_54_08.zip"
+    echo "$0 <baseline.zip> <to_compare.zip> <table-output.html>"
+    echo "e.g. $0 stackrox_debug_2020_05_20_09_51_46.zip stackrox_debug_2020_05_21_09_54_08.zip out.html"
 }
 
 metrics_of_interest=\
@@ -20,18 +20,23 @@ metrics_of_interest=\
 'rox_central_k8s_event_processing_duration'
 
 main() {
-    if [ "$#" -ne 2 ]; then
+    if [ "$#" -ne 3 ]; then
         usage
         exit 1
     fi
 
     baseline="$1"
     to_compare="$2"
+    comparison_out="$3"
 
-    unzip -o ${baseline} -d baseline
-    unzip -o ${to_compare} -d to_compare
+    unzip -o "${baseline}" -d baseline
+    unzip -o "${to_compare}" -d to_compare
 
-    prometheus-metric-parser compare --old-file baseline/metrics-2 --new-file to_compare/metrics-2 --metrics ${metrics_of_interest} --warn 15 --error 25
+    prometheus-metric-parser compare --old-file baseline/metrics-2 --new-file to_compare/metrics-2 \
+        --metrics ${metrics_of_interest} --warn 15 --error 25
+    prometheus-metric-parser compare --old-file baseline/metrics-2 --new-file to_compare/metrics-2 \
+        --metrics ${metrics_of_interest} --warn 15 --error 25 \
+        --format=html-table > "${comparison_out}"
 }
 
 main "$@"

--- a/scripts/ci/compare-debug-metrics.sh
+++ b/scripts/ci/compare-debug-metrics.sh
@@ -25,6 +25,8 @@ main() {
         exit 1
     fi
 
+    set -x
+
     baseline="$1"
     to_compare="$2"
     comparison_out="$3"

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -70,7 +70,7 @@ run_scale_test() {
 }
 
 get_prometheus_metrics_parser() {
-    go install github.com/stackrox/prometheus-metric-parser@vtest
+    go install github.com/stackrox/prometheus-metric-parser@latest
     prometheus-metric-parser help
 }
 

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -54,7 +54,7 @@ run_scale_test() {
 
     mkdir -p "${pprof_dir}"
     # 45 min run so that we are confident that the run has completely finished.
-    "$ROOT/scale/profiler/pprof.sh" "${pprof_dir}" "${API_ENDPOINT}" 45
+    "$ROOT/scale/profiler/pprof.sh" "${pprof_dir}" "${API_ENDPOINT}" 10
     zip -r "${pprof_zip_output}" "${pprof_dir}"
 
     local debug_dump_dir="/tmp/scale-test-debug-dump"

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -70,7 +70,7 @@ run_scale_test() {
 }
 
 get_prometheus_metrics_parser() {
-      go install github.com/stackrox/prometheus-metric-parser@latest
+      go install github.com/stackrox/prometheus-metric-parser@d47b15a
       prometheus-metric-parser help
 }
 
@@ -95,8 +95,8 @@ compare_with_stored_metrics() {
     info "Comparing with ${this_run_metrics}"
 
     pushd /tmp
-    "${compare_cmd}" "${baseline_metrics}" "${this_run_metrics}" | tee comparison.txt || true
-    store_as_spyglass_artifact comparison.txt
+    "${compare_cmd}" "${baseline_metrics}" "${this_run_metrics}" comparison.html || true
+    store_as_spyglass_artifact comparison.html
     popd
 }
 

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -70,7 +70,7 @@ run_scale_test() {
 }
 
 get_prometheus_metrics_parser() {
-      go install github.com/stackrox/prometheus-metric-parser@d47b15a
+      go install github.com/stackrox/prometheus-metric-parser@vtest
       prometheus-metric-parser help
 }
 

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -117,7 +117,7 @@ store_metrics() {
 store_as_spyglass_artifact() {
     local comparison_output="$1"
 
-    artifact_file="$ARTIFACT_DIR/scale-comparison-with-baseline.html"
+    artifact_file="$ARTIFACT_DIR/scale-comparison-with-baseline-summary.html"
 
     cat > "$artifact_file" <<- HEAD
 <html>

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -94,8 +94,7 @@ compare_with_stored_metrics() {
     this_run_metrics=$(echo "${debug_dump_dir}"/stackrox_debug*.zip)
     info "Comparing with ${this_run_metrics}"
 
-    set -x
-    local comparison_output="/tmp/comparison.html"
+    local comparison_output="comparison.html"
     pushd /tmp
     "${compare_cmd}" "${baseline_metrics}" "${this_run_metrics}" "${comparison_output}" || true
     store_as_spyglass_artifact "${comparison_output}"

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -54,7 +54,7 @@ run_scale_test() {
 
     mkdir -p "${pprof_dir}"
     # 45 min run so that we are confident that the run has completely finished.
-    "$ROOT/scale/profiler/pprof.sh" "${pprof_dir}" "${API_ENDPOINT}" 10
+    "$ROOT/scale/profiler/pprof.sh" "${pprof_dir}" "${API_ENDPOINT}" 45
     zip -r "${pprof_zip_output}" "${pprof_dir}"
 
     local debug_dump_dir="/tmp/scale-test-debug-dump"

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -70,8 +70,8 @@ run_scale_test() {
 }
 
 get_prometheus_metrics_parser() {
-      go install github.com/stackrox/prometheus-metric-parser@vtest
-      prometheus-metric-parser help
+    go install github.com/stackrox/prometheus-metric-parser@vtest
+    prometheus-metric-parser help
 }
 
 compare_with_stored_metrics() {
@@ -94,9 +94,11 @@ compare_with_stored_metrics() {
     this_run_metrics=$(echo "${debug_dump_dir}"/stackrox_debug*.zip)
     info "Comparing with ${this_run_metrics}"
 
+    set -x
+    local comparison_output="/tmp/comparison.html"
     pushd /tmp
-    "${compare_cmd}" "${baseline_metrics}" "${this_run_metrics}" comparison.html || true
-    store_as_spyglass_artifact comparison.html
+    "${compare_cmd}" "${baseline_metrics}" "${this_run_metrics}" "${comparison_output}" || true
+    store_as_spyglass_artifact "${comparison_output}"
     popd
 }
 


### PR DESCRIPTION
## Description

Puts the scale test comparison with baseline on the first page of results. [e.g.](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/2733/pull-ci-stackrox-stackrox-master-gke-scale-tests/1560527515980664832)

https://github.com/stackrox/prometheus-metric-parser/pull/4 will need to merge before this and the version installed can switch back to latest.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient. There is a deployment failure with the postgres variant, but ~it is not clear that that ever worked~ that has been broken recently. And will be fixed by: #2497.