### PR TITLE
Ignore unknown mime type error when fetching signatures

### DIFF
--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -1354,8 +1354,10 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 	}))
 	utils.Must(builder.AddType("Traits", []string{
 		"mutabilityMode: Traits_MutabilityMode!",
+		"visibility: Traits_Visibility!",
 	}))
 	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.Traits_MutabilityMode(0)))
+	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.Traits_Visibility(0)))
 	utils.Must(builder.AddType("UpgradeProgress", []string{
 		"since: Time",
 		"upgradeState: UpgradeProgress_UpgradeState!",
@@ -11540,6 +11542,11 @@ func (resolver *traitsResolver) MutabilityMode(ctx context.Context) string {
 	return value.String()
 }
 
+func (resolver *traitsResolver) Visibility(ctx context.Context) string {
+	value := resolver.data.GetVisibility()
+	return value.String()
+}
+
 func toTraits_MutabilityMode(value *string) storage.Traits_MutabilityMode {
 	if value != nil {
 		return storage.Traits_MutabilityMode(storage.Traits_MutabilityMode_value[*value])
@@ -11554,6 +11561,24 @@ func toTraits_MutabilityModes(values *[]string) []storage.Traits_MutabilityMode 
 	output := make([]storage.Traits_MutabilityMode, len(*values))
 	for i, v := range *values {
 		output[i] = toTraits_MutabilityMode(&v)
+	}
+	return output
+}
+
+func toTraits_Visibility(value *string) storage.Traits_Visibility {
+	if value != nil {
+		return storage.Traits_Visibility(storage.Traits_Visibility_value[*value])
+	}
+	return storage.Traits_Visibility(0)
+}
+
+func toTraits_Visibilities(values *[]string) []storage.Traits_Visibility {
+	if values == nil {
+		return nil
+	}
+	output := make([]storage.Traits_Visibility, len(*values))
+	for i, v := range *values {
+		output[i] = toTraits_Visibility(&v)
 	}
 	return output
 }

--- a/generated/api/v1/group_service.swagger.json
+++ b/generated/api/v1/group_service.swagger.json
@@ -48,6 +48,17 @@
             "default": "ALLOW_MUTATE"
           },
           {
+            "name": "traits.visibility",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "VISIBLE",
+              "HIDDEN"
+            ],
+            "default": "VISIBLE"
+          },
+          {
             "name": "authProviderId",
             "in": "query",
             "required": false,
@@ -281,6 +292,15 @@
       "default": "ALLOW_MUTATE",
       "description": "EXPERIMENTAL.\n\nMutabilityMode specifies whether and how an object can be modified. Default\nis ALLOW_MUTATE and means there are no modification restrictions; this is equivalent\nto the absence of MutabilityMode specification. ALLOW_MUTATE_FORCED forbids all\nmodifying operations except object removal with force bit on.\n\nBe careful when changing the state of this field. For example, modifying an\nobject from ALLOW_MUTATE to ALLOW_MUTATE_FORCED is allowed but will prohibit any further\nchanges to it, including modifying it back to ALLOW_MUTATE."
     },
+    "TraitsVisibility": {
+      "type": "string",
+      "enum": [
+        "VISIBLE",
+        "HIDDEN"
+      ],
+      "default": "VISIBLE",
+      "description": "EXPERIMENTAL.\nvisibility allows to specify whether the object should be visible for certain APIs."
+    },
     "protobufAny": {
       "type": "object",
       "properties": {
@@ -358,6 +378,9 @@
       "properties": {
         "mutabilityMode": {
           "$ref": "#/definitions/TraitsMutabilityMode"
+        },
+        "visibility": {
+          "$ref": "#/definitions/TraitsVisibility"
         }
       },
       "description": "EXPERIMENTAL."

--- a/pkg/signatures/public_key_fetcher.go
+++ b/pkg/signatures/public_key_fetcher.go
@@ -53,6 +53,12 @@ func init() {
 // NOTE: No error will be returned when the image has no signature available. All occurring errors will be logged.
 func (c *cosignPublicKeySignatureFetcher) FetchSignatures(ctx context.Context, image *storage.Image,
 	registry registryTypes.Registry) ([]*storage.Signature, error) {
+	// Short-circuit for images that do not have V2 metadata associated with them. These would be older images manifest
+	// schemes that are not supported by cosign, like the docker v1 manifest.
+	if image.GetMetadata().GetV2() == nil {
+		return nil, nil
+	}
+
 	// Since cosign makes heavy use of google/go-containerregistry, we need to parse the image's full name as a
 	// name.Reference.
 	imgFullName := image.GetName().GetFullName()

--- a/pkg/signatures/public_key_fetcher.go
+++ b/pkg/signatures/public_key_fetcher.go
@@ -76,7 +76,7 @@ func (c *cosignPublicKeySignatureFetcher) FetchSignatures(ctx context.Context, i
 	// error types are exposed need to check for string comparison.
 	// Cosign ref:
 	//  https://github.com/sigstore/cosign/blob/44f3814667ba6a398aef62814cabc82aee4896e5/pkg/cosign/fetch.go#L84-L86
-	if err != nil && !isMissingSignatureError(err) {
+	if err != nil && !isMissingSignatureError(err) && !isUnknownMimeTypeError(err) {
 		// Specifically mark an error as errox.NotAuthorized so we skip using the same credentials for fetching.
 		// We can safely skip the potential marking of retryable errors as unauthorized errors are not transient.
 		if isUnauthorizedError(err) {
@@ -186,6 +186,17 @@ func isMissingSignatureError(err error) bool {
 	// Cosign ref:
 	// https://github.com/sigstore/cosign/blob/b1024041754c8171375bf1a8411d86436c654b95/pkg/oci/remote/signatures.go#L35-L40
 	return checkIfErrorContainsCode(err, http.StatusNotFound)
+}
+
+// isUnkownMimeTypeError is checking whether the error indicates that the image is an unkown mime type for cosign.
+// Cosign itself only supports OCI or DockerV2 manifest schemes and will error out on any other, older manifest schemes.
+// Cosign ref:
+// https://github.com/sigstore/cosign/blob/6bfac1a470492d8964778b1b8c41e0056bf5dbdd/pkg/oci/remote/remote.go#L65-L76
+func isUnknownMimeTypeError(err error) bool {
+	// Cosign doesn't provide error types we can easily use for checking, hence we need to do a string comparison.
+	// Cosign ref:
+	// https://github.com/sigstore/cosign/blob/6bfac1a470492d8964778b1b8c41e0056bf5dbdd/pkg/oci/remote/remote.go#L76
+	return strings.Contains(err.Error(), "unknown mime type")
 }
 
 // isUnauthorizedError is checking whether the returned error indicates that there was a http.StatusUnauthorized was

--- a/pkg/signatures/public_key_fetcher_test.go
+++ b/pkg/signatures/public_key_fetcher_test.go
@@ -124,6 +124,7 @@ func TestPublicKey_FetchSignature_Success(t *testing.T) {
 	cimg, err := imgUtils.GenerateImageFromString(imgRef)
 	require.NoError(t, err, "creating test image")
 	img := types.ToImage(cimg)
+	img.Metadata = &storage.ImageMetadata{V2: &storage.V2Metadata{Digest: "something"}}
 
 	rawSig1, err := base64.StdEncoding.DecodeString(sig1)
 	require.NoError(t, err, "decoding signature")
@@ -182,6 +183,7 @@ func TestPublicKey_FetchSignature_Failure(t *testing.T) {
 	// Fail with a non-retryable error when an image is given with a wrong reference.
 	cimg.Name.FullName = "fa@wrongreference"
 	img := types.ToImage(cimg)
+	img.Metadata = &storage.ImageMetadata{V2: &storage.V2Metadata{Digest: "something"}}
 	res, err := f.FetchSignatures(context.Background(), img, nil)
 	assert.Nil(t, res)
 	require.Error(t, err)

--- a/pkg/signatures/public_key_fetcher_test.go
+++ b/pkg/signatures/public_key_fetcher_test.go
@@ -394,3 +394,24 @@ func TestOptionsFromRegistry(t *testing.T) {
 		})
 	}
 }
+
+func TestIsUnknownMimeTypeError(t *testing.T) {
+	cases := map[string]struct {
+		err         error
+		expectedRes bool
+	}{
+		"should indicate unknown mime type error when error contains unknown mime type": {
+			err:         errors.New("unknown mime type: application/vnd.docker.distribution.manifest.v1+prettyjws"),
+			expectedRes: true,
+		},
+		"should not indicate unknown mime type error when error does not contain unknown mime type": {
+			err: errors.New("some other error"),
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, c.expectedRes, isUnknownMimeTypeError(c.err))
+		})
+	}
+}


### PR DESCRIPTION
## Description

Currently, older images that do not use [docker manifest schema type](https://github.com/google/go-containerregistry/blob/771a9b4471049aa1b25ef5c1e51907f86e4db07a/pkg/v1/types/types.go#L33-L34) or [OCI manifest 
schema](https://github.com/google/go-containerregistry/blob/main/pkg/v1/types/types.go#L24) are leading to an error when fetching image signatures, specifically:
`unknown mime type: application/vnd.docker.distribution.manifest.v1+prettyjws`

This leads to error logs being logged, although this doesn't necessarily indicate an error, simply that we cannot fetch signatures for the specific image.
