### PR TITLE
Dashrews/ROX-12252 postgres analyze after restore

### DIFF
--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -224,6 +224,13 @@ func (d *dbCloneManagerImpl) Persist(cloneName string) error {
 
 	switch cloneName {
 	case RestoreClone:
+		// For a restore, we should analyze it to get the stats because pg_dump does not
+		// contain that information.
+		err := pgadmin.AnalyzeDatabase(d.adminConfig, "central_restore")
+		if err != nil {
+			log.Warnf("unable to force analyze restore database:  %v", err)
+		}
+
 		return d.doPersist(cloneName, BackupClone)
 	case CurrentClone:
 		// No need to persist

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -153,6 +153,20 @@ func GetDatabaseClones(pgConfig *pgxpool.Config) []string {
 	return clones
 }
 
+// AnalyzeDatabase - runs ANALYZE on the database named dbName
+func AnalyzeDatabase(config *pgxpool.Config, dbName string) error {
+	log.Debugf("Analyze - %q", dbName)
+
+	// Connect to different database for admin functions
+	connectPool := GetClonePool(config, dbName)
+	// Close the admin connection pool
+	defer connectPool.Close()
+
+	_, err := connectPool.Exec(context.Background(), "ANALYZE")
+
+	return err
+}
+
 // GetAdminPool - returns a pool to connect to the admin database.
 // This is useful for renaming databases such as a restore to active.
 // THIS POOL SHOULD BE CLOSED ONCE ITS PURPOSE HAS BEEN FULFILLED.
@@ -183,6 +197,7 @@ func GetClonePool(pgConfig *pgxpool.Config, clone string) *pgxpool.Pool {
 	postgresDB := getPool(tempConfig)
 
 	log.Debugf("Got connection pool for database %q", clone)
+
 	return postgresDB
 }
 

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -164,6 +164,7 @@ func AnalyzeDatabase(config *pgxpool.Config, dbName string) error {
 
 	_, err := connectPool.Exec(context.Background(), "ANALYZE")
 
+	log.Debug("Anaylze done")
 	return err
 }
 


### PR DESCRIPTION
## Description

Simply adding a call to analyze after a restore.  Dmitri mentioned this was typically the best practice because pg_dump does not contain statistical data.  If the call fails for whatever reason we will just log that as a warning and move on as Postgres will eventually analyze the data.  

The CI failure is failing pretty everywhere and is related to migrations running in Postgres mode and failing.  That will be solved when the upgrade/replica PR is pushed.  

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Just local testing to make sure the command was executed.
