### PR TITLE
ROX-12263: fix authz plugin removal migrator crash on recent DB

### DIFF
--- a/migrator/migrations/m_107_to_m_108_remove_auth_plugin/migration.go
+++ b/migrator/migrations/m_107_to_m_108_remove_auth_plugin/migration.go
@@ -72,10 +72,11 @@ func migratePS(db *gorocksdb.DB) error {
 
 func deleteAuthPluginBucket(db *bbolt.DB) error {
 	return db.Update(func(tx *bbolt.Tx) error {
-		if err := tx.DeleteBucket(authPluginBucket); err != nil && !errors.Is(err, bbolt.ErrBucketNotFound) {
-			return err
+		if b := tx.Bucket(authPluginBucket); b == nil {
+			// nothing to be done if the bucket doesn't exist
+			return nil
 		}
-		return nil
+		return tx.DeleteBucket(authPluginBucket)
 	})
 }
 

--- a/migrator/migrations/m_107_to_m_108_remove_auth_plugin/migration.go
+++ b/migrator/migrations/m_107_to_m_108_remove_auth_plugin/migration.go
@@ -72,7 +72,10 @@ func migratePS(db *gorocksdb.DB) error {
 
 func deleteAuthPluginBucket(db *bbolt.DB) error {
 	return db.Update(func(tx *bbolt.Tx) error {
-		return tx.DeleteBucket(authPluginBucket)
+		if err := tx.DeleteBucket(authPluginBucket); err != nil && !errors.Is(err, bbolt.ErrBucketNotFound) {
+			return err
+		}
+		return nil
 	})
 }
 

--- a/migrator/migrations/m_107_to_m_108_remove_auth_plugin/migration_test.go
+++ b/migrator/migrations/m_107_to_m_108_remove_auth_plugin/migration_test.go
@@ -134,3 +134,11 @@ func (suite *psMigrationTestSuite) TestMigration() {
 		return nil
 	}))
 }
+
+func (suite *psMigrationTestSuite) TestMigrationOnCleanDB() {
+	dbs := &types.Databases{
+		BoltDB:  suite.boltdb,
+		RocksDB: suite.db.DB,
+	}
+	suite.NoError(migration.Run(dbs))
+}

--- a/migrator/runner/runner.go
+++ b/migrator/runner/runner.go
@@ -37,15 +37,15 @@ func runMigrations(databases *types.Databases, startingSeqNum int) error {
 	for seqNum := startingSeqNum; seqNum < pkgMigrations.CurrentDBVersionSeqNum(); seqNum++ {
 		migration, ok := migrations.Get(seqNum)
 		if !ok {
-			return fmt.Errorf("no migration found starting at %d", startingSeqNum)
+			return fmt.Errorf("no migration found starting at %d", seqNum)
 		}
 		err := migration.Run(databases)
 		if err != nil {
-			return errors.Wrapf(err, "error running migration starting at %d", startingSeqNum)
+			return errors.Wrapf(err, "error running migration starting at %d", seqNum)
 		}
 		err = updateVersion(databases, &migration.VersionAfter)
 		if err != nil {
-			return errors.Wrapf(err, "failed to update version after migration %d", startingSeqNum)
+			return errors.Wrapf(err, "failed to update version after migration %d", seqNum)
 		}
 		log.WriteToStderrf("Successfully updated DB from version %d to %d", seqNum, migration.VersionAfter.GetSeqNum())
 	}


### PR DESCRIPTION
## Description

We stopped creating the bucket a while ago, but the migrator now fails if the `authzPlugins` bucket does not exist. This shouldn't happen, so make sure it doesn't fail if the error is a missing bucket.

Also fix some log messages to aid in debugging when a migration fails.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- Added a unit test
- Live test on scale test instance