### PR TITLE
Set operating system for node components from scan

### DIFF
--- a/central/imagecomponent/datastoretest/datastore_sac_test.go
+++ b/central/imagecomponent/datastoretest/datastore_sac_test.go
@@ -273,8 +273,8 @@ var (
 		},
 	}
 
-	node1OS              = fixtures.GetScopedNode1("dummyNodeID", testconsts.Cluster1).GetOperatingSystem()
-	node2OS              = fixtures.GetScopedNode1("dummyNodeID", testconsts.Cluster2).GetOperatingSystem()
+	node1OS              = fixtures.GetScopedNode1("dummyNodeID", testconsts.Cluster1).GetScan().GetOperatingSystem()
+	node2OS              = fixtures.GetScopedNode1("dummyNodeID", testconsts.Cluster2).GetScan().GetOperatingSystem()
 	nodeComponent1x1     = fixtures.GetEmbeddedNodeComponent1x1()
 	nodeComponent1x2     = fixtures.GetEmbeddedNodeComponent1x2()
 	nodeComponent1s2x3   = fixtures.GetEmbeddedNodeComponent1s2x3()

--- a/central/node/datastore/dackbox/datastore/datastore_impl_postgres_test.go
+++ b/central/node/datastore/dackbox/datastore/datastore_impl_postgres_test.go
@@ -269,7 +269,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByVuln() {
 
 	// Search by CVE.
 	scopedCtx := scoped.Context(ctx, scoped.Scope{
-		ID:    cve.ID("cve1", ""),
+		ID:    cve.ID("cve1", "ubuntu"),
 		Level: v1.SearchCategory_NODE_VULNERABILITIES,
 	})
 	results, err := suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -277,7 +277,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByVuln() {
 	suite.Len(results, 2)
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    cve.ID("cve3", ""),
+		ID:    cve.ID("cve3", "ubuntu"),
 		Level: v1.SearchCategory_NODE_VULNERABILITIES,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -286,7 +286,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByVuln() {
 	suite.Equal("id2", results[0].ID)
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    cve.ID("cve4", ""),
+		ID:    cve.ID("cve4", "ubuntu"),
 		Level: v1.SearchCategory_NODE_VULNERABILITIES,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -297,7 +297,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByVuln() {
 
 	// Ensure search does not find anything.
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    cve.ID("cve1", ""),
+		ID:    cve.ID("cve1", "ubuntu"),
 		Level: v1.SearchCategory_NODE_VULNERABILITIES,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -305,7 +305,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByVuln() {
 	suite.Empty(results)
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    cve.ID("cve3", ""),
+		ID:    cve.ID("cve3", "ubuntu"),
 		Level: v1.SearchCategory_NODE_VULNERABILITIES,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -326,7 +326,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByComponent() {
 
 	// Search by Component.
 	scopedCtx := scoped.Context(ctx, scoped.Scope{
-		ID:    scancomponent.ComponentID("comp1", "ver1", ""),
+		ID:    scancomponent.ComponentID("comp1", "ver1", "ubuntu"),
 		Level: v1.SearchCategory_NODE_COMPONENTS,
 	})
 	results, err := suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -334,7 +334,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByComponent() {
 	suite.Len(results, 2)
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    scancomponent.ComponentID("comp3", "ver1", ""),
+		ID:    scancomponent.ComponentID("comp3", "ver1", "ubuntu"),
 		Level: v1.SearchCategory_NODE_COMPONENTS,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -343,7 +343,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByComponent() {
 	suite.Equal("id2", results[0].ID)
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    scancomponent.ComponentID("comp4", "ver1", ""),
+		ID:    scancomponent.ComponentID("comp4", "ver1", "ubuntu"),
 		Level: v1.SearchCategory_NODE_COMPONENTS,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -354,7 +354,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByComponent() {
 
 	// Ensure search does not find anything.
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    scancomponent.ComponentID("comp1", "ver1", ""),
+		ID:    scancomponent.ComponentID("comp1", "ver1", "ubuntu"),
 		Level: v1.SearchCategory_NODE_COMPONENTS,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -362,7 +362,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByComponent() {
 	suite.Empty(results)
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    scancomponent.ComponentID("comp3", "ver1", ""),
+		ID:    scancomponent.ComponentID("comp3", "ver1", "ubuntu"),
 		Level: v1.SearchCategory_NODE_COMPONENTS,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -618,7 +618,8 @@ func getTestNodeForPostgres(id, name string) *storage.Node {
 		Name:      name,
 		ClusterId: id,
 		Scan: &storage.NodeScan{
-			ScanTime: types.TimestampNow(),
+			ScanTime:        types.TimestampNow(),
+			OperatingSystem: "ubuntu",
 			Components: []*storage.EmbeddedNodeScanComponent{
 				{
 					Name:            "comp1",

--- a/central/node/datastore/internal/store/common/split.go
+++ b/central/node/datastore/internal/store/common/split.go
@@ -27,11 +27,12 @@ func Split(node *storage.Node, withComponents bool) *NodeParts {
 }
 
 func splitComponents(parts *NodeParts) []*ComponentParts {
+	os := parts.Node.GetScan().GetOperatingSystem()
 	components := parts.Node.GetScan().GetComponents()
 	addedComponents := set.NewStringSet()
 	ret := make([]*ComponentParts, 0, len(components))
 	for _, component := range parts.Node.GetScan().GetComponents() {
-		generatedComponent := generateNodeComponent(parts.Node.GetOperatingSystem(), component)
+		generatedComponent := generateNodeComponent(os, component)
 		if !addedComponents.Add(generatedComponent.GetId()) {
 			continue
 		}
@@ -39,7 +40,7 @@ func splitComponents(parts *NodeParts) []*ComponentParts {
 			Component: generatedComponent,
 		}
 		cp.Edge = generateNodeComponentEdge(parts.Node, cp.Component)
-		cp.Children = splitCVEs(parts.Node.GetScan().GetOperatingSystem(), cp, component)
+		cp.Children = splitCVEs(os, cp, component)
 
 		ret = append(ret, cp)
 	}

--- a/central/node/datastore/internal/store/common/v2/split.go
+++ b/central/node/datastore/internal/store/common/v2/split.go
@@ -27,11 +27,12 @@ func Split(node *storage.Node, withComponents bool) *NodeParts {
 }
 
 func splitComponents(parts *NodeParts) []*ComponentParts {
+	os := parts.Node.GetScan().GetOperatingSystem()
 	components := parts.Node.GetScan().GetComponents()
 	addedComponents := set.NewStringSet()
 	ret := make([]*ComponentParts, 0, len(components))
 	for _, component := range parts.Node.GetScan().GetComponents() {
-		generatedComponent := generateNodeComponent(parts.Node.GetOperatingSystem(), component)
+		generatedComponent := generateNodeComponent(os, component)
 		if !addedComponents.Add(generatedComponent.GetId()) {
 			continue
 		}
@@ -39,7 +40,7 @@ func splitComponents(parts *NodeParts) []*ComponentParts {
 			Component: generatedComponent,
 		}
 		cp.Edge = generateNodeComponentEdge(parts.Node, cp.Component)
-		cp.Children = splitCVEs(parts.Node.GetScan().GetOperatingSystem(), cp, component)
+		cp.Children = splitCVEs(os, cp, component)
 
 		ret = append(ret, cp)
 	}

--- a/migrator/migrations/n_35_to_n_36_postgres_nodes/common/split.go
+++ b/migrator/migrations/n_35_to_n_36_postgres_nodes/common/split.go
@@ -27,11 +27,12 @@ func Split(node *storage.Node, withComponents bool) *NodeParts {
 }
 
 func splitComponents(parts *NodeParts) []*ComponentParts {
+	os := parts.Node.GetScan().GetOperatingSystem()
 	components := parts.Node.GetScan().GetComponents()
 	addedComponents := set.NewStringSet()
 	ret := make([]*ComponentParts, 0, len(components))
 	for _, component := range parts.Node.GetScan().GetComponents() {
-		generatedComponent := generateNodeComponent(parts.Node.GetOperatingSystem(), component)
+		generatedComponent := generateNodeComponent(os, component)
 		if !addedComponents.Add(generatedComponent.GetId()) {
 			continue
 		}
@@ -39,7 +40,7 @@ func splitComponents(parts *NodeParts) []*ComponentParts {
 			Component: generatedComponent,
 		}
 		cp.Edge = generateNodeComponentEdge(parts.Node, cp.Component)
-		cp.Children = splitCVEs(parts.Node.GetScan().GetOperatingSystem(), cp, component)
+		cp.Children = splitCVEs(os, cp, component)
 
 		ret = append(ret, cp)
 	}

--- a/migrator/migrations/n_35_to_n_36_postgres_nodes/common/v2/split.go
+++ b/migrator/migrations/n_35_to_n_36_postgres_nodes/common/v2/split.go
@@ -27,11 +27,12 @@ func Split(node *storage.Node, withComponents bool) *NodeParts {
 }
 
 func splitComponents(parts *NodeParts) []*ComponentParts {
+	os := parts.Node.GetScan().GetOperatingSystem()
 	components := parts.Node.GetScan().GetComponents()
 	addedComponents := set.NewStringSet()
 	ret := make([]*ComponentParts, 0, len(components))
 	for _, component := range parts.Node.GetScan().GetComponents() {
-		generatedComponent := generateNodeComponent(parts.Node.GetOperatingSystem(), component)
+		generatedComponent := generateNodeComponent(os, component)
 		if !addedComponents.Add(generatedComponent.GetId()) {
 			continue
 		}
@@ -39,7 +40,7 @@ func splitComponents(parts *NodeParts) []*ComponentParts {
 			Component: generatedComponent,
 		}
 		cp.Edge = generateNodeComponentEdge(parts.Node, cp.Component)
-		cp.Children = splitCVEs(parts.Node.GetScan().GetOperatingSystem(), cp, component)
+		cp.Children = splitCVEs(os, cp, component)
 
 		ret = append(ret, cp)
 	}

--- a/pkg/fixtures/dackbox.go
+++ b/pkg/fixtures/dackbox.go
@@ -1079,7 +1079,6 @@ func GetScopedNode1(nodeID string, clusterID string) *storage.Node {
 			Version: "20.10.10",
 		},
 		KernelVersion:    "",
-		OperatingSystem:  "Docker Desktop",
 		OsImage:          "",
 		KubeletVersion:   "",
 		KubeProxyVersion: "",

--- a/sensor/kubernetes/listener/resources/node.go
+++ b/sensor/kubernetes/listener/resources/node.go
@@ -79,6 +79,7 @@ func (h *nodeDispatcher) ProcessEvent(obj, _ interface{}, action central.Resourc
 		ContainerRuntime:        k8sutil.ParseContainerRuntimeVersion(node.Status.NodeInfo.ContainerRuntimeVersion),
 		ContainerRuntimeVersion: node.Status.NodeInfo.ContainerRuntimeVersion,
 		KernelVersion:           node.Status.NodeInfo.KernelVersion,
+		OperatingSystem:         node.Status.NodeInfo.OperatingSystem,
 		OsImage:                 node.Status.NodeInfo.OSImage,
 		KubeletVersion:          node.Status.NodeInfo.KubeletVersion,
 		KubeProxyVersion:        node.Status.NodeInfo.KubeProxyVersion,


### PR DESCRIPTION
## Description

Node proto has multiple operating system fields, `.operatingSystem`, `.scan.operatingSystem`, and `.osImage`.

a. Make sure `.operatingSystem` is actually filled from k8s nodeinfo
b. Make sure components and vulnerabilities are using the correct operating system field for ID (dackbox and postgres).

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
Unit