### PR TITLE
Dashrews/ROX-12271 check postgres for replica space

### DIFF
--- a/central/globaldb/export/backup.go
+++ b/central/globaldb/export/backup.go
@@ -50,6 +50,10 @@ func BackupPostgres(ctx context.Context, postgresDB *pgxpool.Pool, includeCerts 
 	zipWriter := zip.NewWriter(out)
 	defer utils.IgnoreError(zipWriter.Close)
 
+	if err := generators.PutStreamInZip(dbs.NewPostgresSize(postgresDB), backup.PostgresSizeFileName).WriteTo(ctx, zipWriter); err != nil {
+		return errors.Wrap(err, "unable to get postgres size")
+	}
+
 	if err := generators.PutStreamInZip(dbs.NewPostgresBackup(postgresDB), backup.PostgresFileName).WriteTo(ctx, zipWriter); err != nil {
 		return errors.Wrap(err, "backing up postgres")
 	}

--- a/central/globaldb/v2backuprestore/backup/generators/dbs/postgres_size.go
+++ b/central/globaldb/v2backuprestore/backup/generators/dbs/postgres_size.go
@@ -1,0 +1,46 @@
+package dbs
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/pkg/migrations"
+	"github.com/stackrox/rox/pkg/postgres/pgadmin"
+	"github.com/stackrox/rox/pkg/postgres/pgconfig"
+)
+
+// NewPostgresSize returns a generator for Postgres backups.
+// We take in the connection to connect to the DB
+func NewPostgresSize(db *pgxpool.Pool) *PostgresSize {
+	return &PostgresSize{
+		db: db,
+	}
+}
+
+// PostgresSize is an implementation of a StreamGenerator which writes a backup of PostgresDB to the input io.Writer.
+type PostgresSize struct {
+	db *pgxpool.Pool
+}
+
+// WriteTo writes a backup of Postgres to the writer
+func (ps *PostgresSize) WriteTo(ctx context.Context, out io.Writer) error {
+	_, config, err := pgconfig.GetPostgresConfig()
+	if err != nil {
+		log.Fatalf("Could not parse postgres config: %v", err)
+		return err
+	}
+
+	size, err := pgadmin.GetDatabaseSize(config, migrations.GetCurrentClone())
+	if err != nil {
+		return err
+	}
+
+	_, err = out.Write([]byte(fmt.Sprintf("%d", size)))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/central/globaldb/v2backuprestore/formats/postgresv1/format.go
+++ b/central/globaldb/v2backuprestore/formats/postgresv1/format.go
@@ -11,6 +11,7 @@ import (
 func init() {
 	formats.MustRegisterNewFormat(
 		"postgresv1",
+		common.NewFileHandler(backup.PostgresSizeFileName, false, checkPostgresSize),
 		common.NewFileHandler(backup.PostgresFileName, false, restorePostgresDB),
 		common.NewFileHandler(path.Join(backup.KeysBaseFolder, backup.CaCertPem), true, formats.Discard),
 		common.NewFileHandler(path.Join(backup.KeysBaseFolder, backup.CaKeyPem), true, formats.Discard),

--- a/central/globaldb/v2backuprestore/formats/postgresv1/postgres.go
+++ b/central/globaldb/v2backuprestore/formats/postgresv1/postgres.go
@@ -2,11 +2,16 @@ package postgresv1
 
 import (
 	"io"
+	"math"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/globaldb/v2backuprestore/common"
 	"github.com/stackrox/rox/central/globaldb/v2backuprestore/restore"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/migrations"
+	"github.com/stackrox/rox/pkg/postgres/pgadmin"
+	"github.com/stackrox/rox/pkg/postgres/pgconfig"
 )
 
 var (
@@ -14,10 +19,48 @@ var (
 )
 
 func restorePostgresDB(ctx common.RestoreFileContext, fileReader io.Reader, size int64) error {
-	log.Debugf("restorePostgresDB - dump size = %d", size)
+	log.Debug("restorePostgresDB")
 	err := restore.LoadRestoreStream(fileReader)
 	if err != nil {
 		return errors.Wrap(err, "unable to restore postgres")
+	}
+
+	return nil
+}
+
+func checkPostgresSize(ctx common.RestoreFileContext, fileReader io.Reader, size int64) error {
+	log.Debugf("checkPostgresSize -- check file size = %d", size)
+
+	bytes := make([]byte, size)
+
+	bytesRead, err := fileReader.Read(bytes)
+	if int64(bytesRead) < size || (err != nil && err != io.EOF) {
+		log.Warnf("Could not determine free disk space for Postgres: %v. Assuming free space is sufficient.", err)
+		return nil
+	}
+
+	restoreBytes, err := strconv.ParseInt(string(bytes[:]), 10, 64)
+	if err != nil {
+		log.Warnf("Could not determine free disk space for Postgres: %v. Assuming free space is sufficient.", err)
+		return nil
+	}
+
+	requiredBytes := int64(math.Ceil(float64(restoreBytes) * (1.0 + migrations.CapacityMarginFraction)))
+
+	_, dbConfig, err := pgconfig.GetPostgresConfig()
+	if err != nil {
+		return errors.Wrap(err, "Could not parse postgres config")
+	}
+
+	availableBytes, err := pgadmin.GetRemainingCapacity(dbConfig)
+	if err != nil {
+		log.Warnf("Could not determine free disk space for Postgres: %v. Assuming free space is sufficient for %d bytes.", err, requiredBytes)
+		return nil
+	}
+
+	hasSpace := float64(availableBytes) > float64(requiredBytes)
+	if !hasSpace {
+		return errors.Errorf("restoring backup requires %d bytes of free disk space, but Postgres only has %d bytes available", requiredBytes, availableBytes)
 	}
 
 	return nil

--- a/pkg/backup/backup_bundle.go
+++ b/pkg/backup/backup_bundle.go
@@ -7,15 +7,16 @@ import (
 
 // Backup bundle structure in zip archive.
 const (
-	BoltFileName       = "bolt.db"
-	RocksFileName      = "rocks.db"
-	PostgresFileName   = "postgres.dump"
-	KeysBaseFolder     = "keys"
-	CaKeyPem           = mtls.CAKeyFileName
-	CaCertPem          = mtls.CACertFileName
-	JwtKeyInDer        = certgen.JWTKeyDERFileName
-	JwtKeyInPem        = certgen.JWTKeyPEMFileName
-	MigrationVersion   = "migration_version.yaml"
-	DatabaseBaseFolder = "central-db"
-	DatabasePassword   = "password"
+	BoltFileName         = "bolt.db"
+	RocksFileName        = "rocks.db"
+	PostgresFileName     = "postgres.dump"
+	PostgresSizeFileName = "postgres.size"
+	KeysBaseFolder       = "keys"
+	CaKeyPem             = mtls.CAKeyFileName
+	CaCertPem            = mtls.CACertFileName
+	JwtKeyInDer          = certgen.JWTKeyDERFileName
+	JwtKeyInPem          = certgen.JWTKeyPEMFileName
+	MigrationVersion     = "migration_version.yaml"
+	DatabaseBaseFolder   = "central-db"
+	DatabasePassword     = "password"
 )

--- a/pkg/postgres/pgconfig/config.go
+++ b/pkg/postgres/pgconfig/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/config"
+	"github.com/stackrox/rox/pkg/size"
 	"github.com/stackrox/rox/pkg/stringutils"
 )
 
@@ -16,6 +17,10 @@ const (
 	DBPasswordFile = "/run/secrets/stackrox.io/db-password/password"
 
 	activeSuffix = "_active"
+
+	// TODO(ROX-12059):  Assuming capacity until we can figure out best way to determine that
+	// across the possible configurations which includes a managed Postgres.
+	capacity = 100 * size.GB
 )
 
 // GetPostgresConfig - gets the configuration used to connect to Postgres
@@ -63,4 +68,9 @@ func ParseSource(source string) (map[string]string, error) {
 // GetActiveDB - returns the name of the active database
 func GetActiveDB() string {
 	return fmt.Sprintf("%s%s", config.GetConfig().CentralDB.DatabaseName, activeSuffix)
+}
+
+// GetPostgresCapacity - returns the capacity of the Postgres instance
+func GetPostgresCapacity() int64 {
+	return capacity
 }

--- a/pkg/version/postgres/store.go
+++ b/pkg/version/postgres/store.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	pkgSchema "github.com/stackrox/rox/pkg/postgres/schema"
@@ -17,6 +18,11 @@ import (
 const (
 	getStmt    = "SELECT serialized FROM versions LIMIT 1"
 	deleteStmt = "DELETE FROM versions"
+)
+
+var (
+	log    = logging.LoggerForModule()
+	schema = pkgSchema.VersionsSchema
 )
 
 // Store access versions in database
@@ -144,6 +150,8 @@ func (s *storeImpl) Delete(ctx context.Context) error {
 	}
 	return nil
 }
+
+// Used for Testing
 
 // Destroy is Used for Testing
 func Destroy(ctx context.Context, db *pgxpool.Pool) {


### PR DESCRIPTION
## Description

Before creating clones to be used in upgrades and restores, we need to ensure that Postgres has enough space for the clone.  This PR does that calculation to ensure we have space.  There is one caveat to that.  

We do not yet know how to best get the available size of a Postgres installation because it could be local, managed, etc.  We would have to use provider mechanisms to get that information for a managed instance.  For a local instance it varies and may be difficult to do in a secure fashion.  So for now, we are doing the calculations based on the assumption we have 100GB of Postgres storage.  ROX-12059 will address that.

The other trick to this is backup/restores.  The backup generated by pg_dump does not contain database size information.  Additionally the size of the dump file is likely significantly smaller than the database itself.  So I had to write a new file `postgres.size` that gets written to the backup bundle first to ensure that it is processed first.  The restore process reads that file to determine if there is enough space or not to perform the backup.  The DB size is the only thing written to that file.


## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing to specifically drive cases like an invalid size in the backup bundle.  Modified the size constant to be incredibly small and ran upgrades and restores manully to make sure not enough space was reported as expected.
