### PR TITLE
ROX-12257: Fixed GraphQL fields: DiscoveredInImage in Image CVES, and Op.System in CVEs list

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
@@ -358,8 +358,8 @@ export const IMAGE_CVE_LIST_FRAGMENT = gql`
         lastModified
         lastScanned
         link
+        operatingSystem
         publishedOn
-        scoreVersion
         severity
         summary
         activeState(query: $query) {
@@ -432,6 +432,7 @@ export const VULN_IMAGE_CVE_LIST_FRAGMENT = gql`
         createdAt
         cve
         cvss
+        discoveredAtImage
         envImpact
         fixedByVersion
         id
@@ -440,6 +441,7 @@ export const VULN_IMAGE_CVE_LIST_FRAGMENT = gql`
         lastModified
         lastScanned
         link
+        operatingSystem
         publishedOn
         scoreVersion
         severity
@@ -451,7 +453,6 @@ export const VULN_IMAGE_CVE_LIST_FRAGMENT = gql`
         componentCount: imageComponentCount
         imageCount
         deploymentCount
-        operatingSystem
     }
 `;
 


### PR DESCRIPTION
## Description

A couple of GraphQL fields got snipped out of the Postgres updating work. This puts them back in (with a little editing for consistency between the two related queries)

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Look, ma, Discovered In Image
<img width="1552" alt="Screen Shot 2022-08-19 at 12 41 01 PM" src="https://user-images.githubusercontent.com/715729/185669986-2ed1b10c-16d5-4ac2-b5f9-bd470dc7e4ce.png">


and Operation System
![Screen Shot 2022-08-19 at 12 52 52 PM](https://user-images.githubusercontent.com/715729/185670005-3ed91706-3ff5-4243-950e-55e7930d9a4b.png)

