### PR TITLE
ROX-12274: Update apollo-ci image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.46
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -49,7 +49,7 @@ jobs:
       (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.46
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
       (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.46
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -115,7 +115,7 @@ jobs:
       (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.46
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -152,7 +152,7 @@ jobs:
       - pre-build-go-binaries
       - pre-build-docs
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.46
       env:
         QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -240,7 +240,7 @@ jobs:
       (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.46
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}

--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -10,4 +10,4 @@
 # - `make update` and commit the results
 # - run `/test pj-rehearse-max` on the openshift/release PR to validate the change
 
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.44
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.45-4-gc4033c65e8

--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -10,4 +10,4 @@
 # - `make update` and commit the results
 # - run `/test pj-rehearse-max` on the openshift/release PR to validate the change
 
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.45-5-g0e8c9473d6
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.46

--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -10,4 +10,4 @@
 # - `make update` and commit the results
 # - run `/test pj-rehearse-max` on the openshift/release PR to validate the change
 
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.45-4-gc4033c65e8
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.45-5-g0e8c9473d6

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,1 @@
-stackrox-build-0.3.42
+stackrox-build-0.3.45-4-gc4033c65e8 # TODO(do not merge): After upstream PR is merged, cut a tag and update this

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,1 @@
-stackrox-build-0.3.45-5-g0e8c9473d6 # TODO(do not merge): After upstream PR is merged, cut a tag and update this
+stackrox-build-0.3.46

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,1 @@
-stackrox-build-0.3.45-4-gc4033c65e8 # TODO(do not merge): After upstream PR is merged, cut a tag and update this
+stackrox-build-0.3.45-5-g0e8c9473d6 # TODO(do not merge): After upstream PR is merged, cut a tag and update this

--- a/EXPECTED_GO_VERSION
+++ b/EXPECTED_GO_VERSION
@@ -1,2 +1,2 @@
-go1.17.2
+go1.17.12
 # When changing the above, please update operator/Dockerfile accordingly.

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -2,7 +2,7 @@
 ARG roxpath=/workspace/src/github.com/stackrox/rox
 
 # Note: the following version needs to be in sync with the ../EXPECTED_GO_VERSION file.
-FROM golang:1.17.2 as builder
+FROM golang:1.17.12 as builder
 
 # Build the manager binary
 ARG roxpath

--- a/qa-tests-backend/local-test-example/step1-setup-macos.sh
+++ b/qa-tests-backend/local-test-example/step1-setup-macos.sh
@@ -3,7 +3,7 @@ set -eu
 source "local-test-example/common.sh"
 source "local-test-example/config.sh"
 
-function install_golang_1_17_2 {
+function install_golang_1_17_12 {
   # Default path to 'go' is /usr/local/go/bin/go
   # But ACS requires 1.17.12 which will be installed at $HOME/go/bin/go1.17.12
 
@@ -129,7 +129,7 @@ function docker_login {
 # __MAIN__
 install_gradle
 install_helm
-install_golang_1_17_2
+install_golang_1_17_12
 install_openjdk11
 install_rocksdb
 test_stackrox_workflow_roxhelp

--- a/qa-tests-backend/local-test-example/step1-setup-macos.sh
+++ b/qa-tests-backend/local-test-example/step1-setup-macos.sh
@@ -5,12 +5,12 @@ source "local-test-example/config.sh"
 
 function install_golang_1_17_2 {
   # Default path to 'go' is /usr/local/go/bin/go
-  # But ACS requires 1.17.2 which will be installed at $HOME/go/bin/go1.17.2
+  # But ACS requires 1.17.12 which will be installed at $HOME/go/bin/go1.17.12
 
-  if ! go version | grep 'go1.17.2' &> /dev/null; then
-    echo "Installing go v1.17.2"
-    go install golang.org/dl/go1.17.2@latest
-    ln -sf "$HOME/go/bin/go1.17.2" "$HOME/go/bin/go"
+  if ! go version | grep 'go1.17.12' &> /dev/null; then
+    echo "Installing go v1.17.12"
+    go install golang.org/dl/go1.17.12@latest
+    ln -sf "$HOME/go/bin/go1.17.12" "$HOME/go/bin/go"
     path_prepend "$HOME/go/bin/"
   fi
 


### PR DESCRIPTION
This started as an automated PR created from https://github.com/stackrox/rox-ci-image/pull/163.

Originally, it bumped version of apollo-ci image used in CircleCI and then was augmented by @rukletsov to also bump golang version to 1.17.12.

The PR is being tested here: https://github.com/openshift/release/pull/31561

Required tests are failing because the builder image uses a different golang version, which this PR aims to change.