### PR TITLE
Delete obsolete Containers MainPage index file

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/index.ts
+++ b/ui/apps/platform/src/Containers/MainPage/index.ts
@@ -1,1 +1,0 @@
-export { default } from './MainPage';


### PR DESCRIPTION
## Description

No occurrence of `import MainPage from 'Containers/MainPage';`

1. src/index.tsx: `import AppPage from 'Containers/AppPage';`
2. src/Containers/AppPage.tsx: `import AuthenticatedRoutes from 'Containers/MainPage/AuthenticatedRoutes';`
3. src/Containers/MainPage/AuthenticatedRoutes.tsx: `import MainPage from './MainPage';`

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn build` in ui
2. `wc build/static/js/*.chunk.js` in ui
    * branch - master: 0 = 5999821 - 5999821 confirms that is was not referenced

Dave, did you notice delta build size from webpack 5 upgrade included in react-scripts 5 upgrade?

Although I forgot to compare before and after, here is a similar measurement from #2437

> branch - master: -4300 = 10410170 - 10414470

1. In case there is more to lose, let’s investigate next week what is the project browserslist configuration.

    https://webpack.js.org/configuration/target/

    > If a project has a browserslist config, then webpack will use it to determinate ES-features that may be used to generate runtime-code.

2. Webpack 5 opens the door to review `"target": "es5"` in tsconfig.json file.

    https://www.typescriptlang.org/tsconfig#target

    > Modern browsers support all ES6 features, so ES6 is a good choice.