### PR TITLE
ROX-9766: Add severity column to Image CVEs and Node CVEs tables

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.js
@@ -33,6 +33,9 @@ export function getFilteredCVEColumns(columns, workflowState) {
     const shouldKeepCveType =
         currentEntityType === entityTypes.CVE || currentEntityType === entityTypes.CLUSTER_CVE;
 
+    const shouldKeepSeverity =
+        currentEntityType === entityTypes.IMAGE_CVE || currentEntityType === entityTypes.NODE_CVE;
+
     return columns.filter((col) => {
         switch (col.accessor) {
             // TODO: remove after generic CVE list is removed
@@ -55,7 +58,7 @@ export function getFilteredCVEColumns(columns, workflowState) {
                 return shouldKeepEntitiesColumn;
             }
             case 'severity': {
-                return shouldKeepDiscoveredAtImageColumn;
+                return shouldKeepSeverity || shouldKeepDiscoveredAtImageColumn;
             }
             default: {
                 return true;


### PR DESCRIPTION
## Description

This change ensures that we show the severity column in the Image and Node CVEs tables

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

<img width="1508" alt="Screen Shot 2022-08-19 at 4 41 22 PM" src="https://user-images.githubusercontent.com/4805485/185719998-be03a472-0fac-49c9-bcaf-cfeac17cd36c.png">
<img width="1552" alt="Screen Shot 2022-08-19 at 4 41 28 PM" src="https://user-images.githubusercontent.com/4805485/185720005-bc194670-4d79-44a8-ac51-2b815b7b0107.png">

