### PR TITLE
ROX-10068: VM deployment policies table data changes when switching tabs

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtEntityDeployment.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtEntityDeployment.js
@@ -120,6 +120,7 @@ const VulmMgmtDeployment = ({
                 Category: 'Vulnerability Management',
             }),
         },
+        fetchPolicy: 'no-cache',
     };
 
     return (


### PR DESCRIPTION
## Description

Policy statuses under deployments change when navigating UI. This only seems to happen with some deployments and the subset of policies affected varies by deployment. Steps to reproduce:

1. Navigate to the scanner-db deployment under Vulnerability Management
2. Click the button to expand the view of the deployment
3. Click the Policies tab under Security Findings
4. Note which policies show Pass and Fail
5. Click the CVEs tab, then click back to the Policies tab
6. In my test environment, two policies change from Pass to Fail

I had a hunch that there was some weird issue with the cache. I think I may have been right. I've seen similar caching issues related to policy data. I'm not 100% sure why it's behaving funky though. Seems like adding a `fetchPolicy` of `no-cache` just for the deployment section's list queries seems to do the trick.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))


## Testing Performed

### Before

https://user-images.githubusercontent.com/4805485/185721775-539c2d60-b688-4935-8852-f00ba6b62c22.mov

### After

https://user-images.githubusercontent.com/4805485/185721770-7129bcb4-b139-4d58-9875-29dd2e85abaf.mov

