### PR TITLE
ROX-12281 Fix deploy.sh not creating upgrader SA

### DIFF
--- a/deploy/common/deploy.sh
+++ b/deploy/common/deploy.sh
@@ -151,7 +151,7 @@ function get_cluster_zip {
 
     echo "Getting zip file for cluster ${ID}"
     STATUS=$(curl_central -X POST \
-        -d "{\"id\": \"$ID\"}" \
+        -d "{\"id\": \"$ID\", \"createUpgraderSA\": true}" \
         -s \
         -o "$OUTPUT_DIR/sensor-deploy.zip" \
         -w "%{http_code}\n" \


### PR DESCRIPTION
## Description

`deploy.sh` won't bundle `upgrader-serviceaccount.yaml` file when providing a custom `MAIN_IMAGE_TAG` that doesn't match `roxctl version`. This happens because if the versions doesn't match `roxctl sensor generate` won't be called. Instead, `deploy.sh` will create and fetch the zip directly from central API:

```bash
if [[ -x "$(command -v roxctl)" && "$(roxctl version)" == "$MAIN_IMAGE_TAG" ]]; then
    [[ -n "${ROX_ADMIN_PASSWORD}" ]] || { echo >&2 "ROX_ADMIN_PASSWORD not found! Cannot launch sensor."; return 1; }
    roxctl -p ${ROX_ADMIN_PASSWORD} --endpoint "${API_ENDPOINT}" sensor generate --main-image-repository="${MAIN_IMAGE_REPO}" --central="$CLUSTER_API_ENDPOINT" --name="$CLUSTER" \
         --collection-method="$COLLECTION_METHOD" \
         "${ORCH}" \
         "${extra_config[@]+"${extra_config[@]}"}"
    mv "sensor-${CLUSTER}" "$k8s_dir/sensor-deploy"
else
    get_cluster_zip "$API_ENDPOINT" "$CLUSTER" ${CLUSTER_TYPE} "${MAIN_IMAGE_REPO}" "$CLUSTER_API_ENDPOINT" "$k8s_dir" "$COLLECTION_METHOD" "$extra_json_config"
    unzip "$k8s_dir/sensor-deploy.zip" -d "$k8s_dir/sensor-deploy"
    rm "$k8s_dir/sensor-deploy.zip"
fi
```

However, the default value `createUpgraderSA` in the API is set to false.

This PR adds `createUpgraderSA: true` to the generate bundle API request body.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

```
$ export MAIN_IMAGE_TAG='3.70.0'
$ STORAGE=pvc SENSOR_HELM_DEPLOY=false ./deploy/k8s/deploy.sh
```

The scenario above must:
- Contain an upgrade service account in the generated bundle: `stat ./deploy/k8s/sensor-deploy/upgrader-serviceaccount.yaml`
- Trigger and successfully upgrade sensor if central image is bumped to `3.71.0`