### PR TITLE
CI: handle upgrade deployment path

### DIFF
--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -60,6 +60,8 @@ test_upgrade() {
     validate_sensor_bundle_via_upgrader "$TEST_ROOT/$DEPLOY_DIR"
     sensor_wait
 
+    touch "${STATE_DEPLOYED}"
+
     test_sensor_bundle
     test_upgrader
     remove_existing_stackrox_resources


### PR DESCRIPTION
## Description

This path needs to drop a state pin in order to avoid flagging a JUnit error e.g. https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-gke-upgrade-tests/1561582398586490880

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient