### PR TITLE
[Rox-12255] : Disable decommissioned cluster removal  by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Changelog
 Entries in this file should be limited to:
 -  Any changes that introduce a deprecation in functionality, OR
@@ -14,8 +15,9 @@ authentication is still required for an email notifier, but the user can now cho
 - Support for violation tags and process tags has been removed.
 ### Deprecated Features
 ### Technical Changes
-- ROX-11181: Any clusters that have been unhealthy (defined as central being unable to reach sensor running on those clusters) for a period of time will be automatically removed. By default, it will remove if it's been unhealthy for 90 days, however that can be configured in the System Configuration page or using the cluster API.
+- ROX-11181: Any clusters that have been unhealthy (defined as central being unable to reach sensor running on those clusters) for a configured period of time will be automatically removed. Number of days after which an 'unhealthy' is removed can be configured in the System Configuration page or using the cluster API.
   - Any cluster that is expected to be unavailable for a period of time (e.g. clusters used in disaster recovery), can be tagged with a customizable label. Clusters with those labels will never be removed automatically.
+  - By default, this unhealthy cluster removal is disabled (number of days set to 0)
 
 ## [3.71.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # Changelog
 Entries in this file should be limited to:
 -  Any changes that introduce a deprecation in functionality, OR
@@ -15,7 +14,7 @@ authentication is still required for an email notifier, but the user can now cho
 - Support for violation tags and process tags has been removed.
 ### Deprecated Features
 ### Technical Changes
-- ROX-11181: Any clusters that have been unhealthy (defined as central being unable to reach sensor running on those clusters) for a configured period of time will be automatically removed. Number of days after which an 'unhealthy' is removed can be configured in the System Configuration page or using the cluster API.
+- ROX-11181: Any clusters that have been unhealthy (defined as central being unable to reach sensor running on those clusters) for a configured period of time will be automatically removed. The number of days after which an 'unhealthy' cluster is removed can be configured in the System Configuration page or using the cluster API.
   - Any cluster that is expected to be unavailable for a period of time (e.g. clusters used in disaster recovery), can be tagged with a customizable label. Clusters with those labels will never be removed automatically.
   - By default, this unhealthy cluster removal is disabled (number of days set to 0)
 

--- a/central/cluster/service/service_impl.go
+++ b/central/cluster/service/service_impl.go
@@ -137,7 +137,8 @@ func (s *serviceImpl) getClusterRetentionInfo(ctx context.Context, cluster *stor
 	}
 
 	clusterRetentionConfig := sysConfig.GetPrivateConfig().GetDecommissionedClusterRetention()
-	if clusterRetentionConfig == nil {
+	if clusterRetentionConfig == nil || clusterRetentionConfig.GetRetentionDurationDays() == 0 {
+		// If retention is disabled, there is no "days remaining" calculation to be done.
 		return nil, nil
 	}
 

--- a/central/config/datastore/singleton.go
+++ b/central/config/datastore/singleton.go
@@ -31,7 +31,7 @@ const (
 	// DefaultExpiredVulnReqRetention is the number of days to retain expired vulnerability requests.
 	DefaultExpiredVulnReqRetention = 90
 	// DefaultDecommissionedClusterRetentionDays is the number of days to retain a cluster that is unreachable.
-	DefaultDecommissionedClusterRetentionDays = 90
+	DefaultDecommissionedClusterRetentionDays = 0
 )
 
 var (

--- a/pkg/sliceutils/map.go
+++ b/pkg/sliceutils/map.go
@@ -52,13 +52,16 @@ func Map(slice, mapFunc interface{}) interface{} {
 	return outSlice.Interface()
 }
 
-// MapsIntersect returns true there is at least one key-value pair that is present in both maps
+// MapsIntersect returns true if there is at least one key-value pair that is present in both maps
 // If both, or either maps are empty, it returns false
 // TODO : Convert to generics after upgrade to go 1.18
 func MapsIntersect(m1 map[string]string, m2 map[string]string) bool {
+	if len(m2) == 0 {
+		return false
+	}
 	for k, v := range m1 {
 		if val, exists := m2[k]; exists {
-			if reflect.DeepEqual(v, val) {
+			if v == val {
 				return true
 			}
 		}


### PR DESCRIPTION
## Description

- Changed default count to 0, making the feature disabled by default
- Fixed bug causing cluster service's GetCluster to compute days_until_deletion even when cluster retention config is disabled

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Added a unit test to test if cluster service's  GetCluster does not compute days_until_deletion when cluster retention config is disabled.
