### PR TITLE
ROX-12307 Disable TLS test on postgres

### DIFF
--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -8,14 +8,21 @@ import objects.ConfigMap
 import objects.Deployment
 import objects.Secret
 import orchestratormanager.OrchestratorManagerException
+
+import util.Env
+
 import org.junit.experimental.categories.Category
 import services.ClusterService
+
+import spock.lang.IgnoreIf
 import spock.lang.Retry
 import spock.lang.Shared
 import util.ApplicationHealth
 import util.Timer
 
 @Retry(count = 1)
+// TODO: ROX-12307: Enable test
+@IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
 class TLSChallengeTest extends BaseSpecification {
     @Shared
     private EnvVar originalCentralEndpoint = new EnvVar()


### PR DESCRIPTION
## Description

In PG tests we can observe many connection refused exceptions in TLS tests.
This PR will skip this test on postgres.

```
waitUntilCentralSensorConnectionIs(HealthStatusLabel.UNHEALTHY, HealthStatusLabel.DEGRADED)
|
io.grpc.StatusRuntimeException: UNAVAILABLE: io exception
 org.spockframework.runtime.ConditionFailedWithExceptionError Condition failed with Exception:

waitUntilCentralSensorConnectionIs(HealthStatusLabel.UNHEALTHY, HealthStatusLabel.DEGRADED)
|
io.grpc.StatusRuntimeException: UNAVAILABLE: io exception

	at TLSChallengeTest.Verify sensor can communicate with central behind an untrusted load balancer(TLSChallengeTest.groovy:91)
Caused by: io.grpc.StatusRuntimeException: UNAVAILABLE: io exception
	at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:235)
	at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:216)
	at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:141)
	at io.stackrox.proto.api.v1.ClustersServiceGrpc$ClustersServiceBlockingStub.getClusters(ClustersServiceGrpc.java:489)
	at TLSChallengeTest.waitUntilCentralSensorConnectionIs(TLSChallengeTest.groovy:151)
	... 1 more
Caused by: io.netty.channel.AbstractChannel$AnnotatedConnectException: finishConnect(..) failed: Connection refused: /34.171.80.196:443
Caused by: java.net.ConnectException: finishConnect(..) failed: Connection refused
	at io.netty.channel.unix.Errors.throwConnectException(Errors.java:124)
	at io.netty.channel.unix.Socket.finishConnect(Socket.java:243)
	at io.netty.channel.epoll.AbstractEpollChannel$AbstractEpollUnsafe.doFinishConnect(AbstractEpollChannel.java:672)
	at io.netty.channel.epoll.AbstractEpollChannel$AbstractEpollUnsafe.finishConnect(AbstractEpollChannel.java:649)
	at io.netty.channel.epoll.AbstractEpollChannel$AbstractEpollUnsafe.epollOutReady(AbstractEpollChannel.java:529)
	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:465)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:750)
}
```

## Testing Performed

CI
