### PR TITLE
RS-555: Onboard GKE kernel-module tests

### DIFF
--- a/scripts/ci/gate-jobs-config.json
+++ b/scripts/ci/gate-jobs-config.json
@@ -55,6 +55,14 @@
         "run_on_master": "true",
         "run_on_tags": "true"
     },
+    "gke-kernel-qa-e2e-tests": {
+        "run_with_labels": ["ci-kernel-module-tests"],
+        "skip_with_label": "",
+        "run_with_changed_path": "^.*$",
+        "changed_path_to_ignore": "^ui/",
+        "run_on_master": "true",
+        "run_on_tags": "true"
+    },
     "gke-postgres-qa-e2e-tests": {
         "run_with_labels": ["ci-postgres-tests"],
         "skip_with_label": "",

--- a/scripts/ci/gate-jobs-config.json
+++ b/scripts/ci/gate-jobs-config.json
@@ -58,8 +58,8 @@
     "gke-kernel-qa-e2e-tests": {
         "run_with_labels": ["ci-kernel-module-tests"],
         "skip_with_label": "",
-        "run_with_changed_path": "^.*$",
-        "changed_path_to_ignore": "^ui/",
+        "run_with_changed_path": "",
+        "changed_path_to_ignore": "",
         "run_on_master": "true",
         "run_on_tags": "true"
     },

--- a/scripts/ci/jobs/gke-kernel-qa-e2e-tests.sh
+++ b/scripts/ci/jobs/gke-kernel-qa-e2e-tests.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/bash
-
-echo "A stub for a yet to be implemented test"

--- a/scripts/ci/jobs/gke_kernel_qa_e2e_tests.py
+++ b/scripts/ci/jobs/gke_kernel_qa_e2e_tests.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run qa-tests-backend in a GKE cluster with kernel modules
+"""
+import os
+from base_qa_e2e_test import make_qa_e2e_test_runner
+from clusters import GKECluster
+
+# set required test parameters
+os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+
+# use modules
+os.environ["COLLECTION_METHOD"] = "kernel-module"
+
+make_qa_e2e_test_runner(cluster=GKECluster("kernel-qa-e2e-test")).run()


### PR DESCRIPTION
## Description

Per title.

## Checklist
- [x] Investigated and inspected CI test results


## Testing Performed

CI is sufficient:
- [x] - normally [skipped](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/2792/pull-ci-stackrox-stackrox-master-gke-kernel-qa-e2e-tests/1562020817989013504)
- [x] - [runs](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/2792/pull-ci-stackrox-stackrox-master-gke-kernel-qa-e2e-tests/1562029605760536576) with label
