### PR TITLE
ROX-11741: Wait for images on Quay.io before creating clusters

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -289,9 +289,32 @@ jobs:
             create next milestone `${{needs.variables.outputs.next-milestone}}`." }}
             ]}
 
+  wait-for-images:
+    name: Wait for images on Quay.io
+    needs: [variables, cut-rc]
+    runs-on: ubuntu-latest
+    if: >- # Skip if no clusters are going to be created.
+      github.event.inputs.create-gke-cluster != 'false' ||
+      github.event.inputs.create-os4-cluster != 'false' ||
+      needs.variables.outputs.rc == '1' &&
+      github.event.inputs.create-long-cluster != 'false'
+    env:
+      QUAY_TOKEN: ${{secrets.QUAY_RHACS_ENG_BEARER_TOKEN}}
+    strategy:
+      matrix:
+        image: [main, scanner, scanner-db, collector]
+    steps:
+      - name: Wait for the ${{matrix.image}} image
+        run: |
+          set -uo pipefail
+          gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
+            wait-for-image \
+            "${{matrix.image}}" \
+            "${{needs.variables.outputs.milestone}}"
+
   create-k8s-cluster:
     name: Create k8s cluster
-    needs: [variables, cut-rc]
+    needs: [variables, wait-for-images]
     # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
     if: github.event.inputs.dry-run != 'true' && github.event.inputs.create-gke-cluster != 'false'
     uses: ./.github/workflows/create-cluster.yml
@@ -304,7 +327,7 @@ jobs:
 
   create-os4-cluster:
     name: Create OS4 cluster
-    needs: [variables, cut-rc]
+    needs: [variables, wait-for-images]
     # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
     if: github.event.inputs.dry-run != 'true' && github.event.inputs.create-os4-cluster != 'false'
     uses: ./.github/workflows/create-cluster.yml
@@ -393,7 +416,7 @@ jobs:
 
   create-long-running-cluster:
     name: Create GKE long-running cluster
-    needs: [variables, cut-rc]
+    needs: [variables, wait-for-images]
     # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
     if: >-
       github.event.inputs.dry-run != 'true' &&

--- a/.github/workflows/scripts/wait-for-image.sh
+++ b/.github/workflows/scripts/wait-for-image.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Wait for an image to appear on Quay.io
+#
+set -euo pipefail
+
+NAME="$1"
+TAG="$2"
+
+check_not_empty \
+    NAME \
+    TAG \
+    \
+    QUAY_TOKEN \
+    DRY_RUN
+
+find_tag() {
+    curl --silent --show-error --fail --location \
+        -H "Authorization: Bearer $QUAY_TOKEN" \
+        -X GET "https://quay.io/api/v1/repository/rhacs-eng/$1/tag?specificTag=$2" |
+        jq -r ".tags[0].name"
+}
+
+# Seconds:
+TIME_LIMIT=1200
+INTERVAL=10
+
+# bash built-in variable
+SECONDS=0
+
+FOUND_TAG=""
+while [ "$SECONDS" -le "$TIME_LIMIT" ]; do
+    FOUND_TAG=$(find_tag "$NAME" "$TAG")
+    if [ "$FOUND_TAG" = "$TAG" ]; then
+        gh_log notice "Image '$NAME:$TAG' has been found on Quay.io."
+        break
+    fi
+    if [ "$DRY_RUN" == "true" ]; then
+        break
+    fi
+    echo "Waiting..."
+    sleep "$INTERVAL"
+done
+
+if [ "$FOUND_TAG" != "$TAG" ]; then
+    gh_log error "Image '$NAME:$TAG' has not been found on Quay.io."
+    exit 1
+fi

--- a/.github/workflows/scripts/wait-for-image.sh
+++ b/.github/workflows/scripts/wait-for-image.sh
@@ -23,26 +23,24 @@ find_tag() {
 
 # Seconds:
 TIME_LIMIT=1200
-INTERVAL=10
+INTERVAL=30
 
 # bash built-in variable
 SECONDS=0
 
 FOUND_TAG=""
 while [ "$SECONDS" -le "$TIME_LIMIT" ]; do
-    FOUND_TAG=$(find_tag "$NAME" "$TAG")
+    FOUND_TAG="$(find_tag "$NAME" "$TAG")"
     if [ "$FOUND_TAG" = "$TAG" ]; then
         gh_log notice "Image '$NAME:$TAG' has been found on Quay.io."
-        break
+        exit 0
     fi
-    if [ "$DRY_RUN" == "true" ]; then
+    if [ "$DRY_RUN" = "true" ]; then
         break
     fi
     echo "Waiting..."
     sleep "$INTERVAL"
 done
 
-if [ "$FOUND_TAG" != "$TAG" ]; then
-    gh_log error "Image '$NAME:$TAG' has not been found on Quay.io."
-    exit 1
-fi
+gh_log error "Image '$NAME:$TAG' has not been found on Quay.io."
+exit 1


### PR DESCRIPTION
## Description

Introducing `wait-for-image.sh` script which waits (up to 20 minutes) for the given image to be available on Quay.io.

## Checklist
- [ ] ~Investigated and inspected CI test results~
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Tested in local and on `test-gh-actions` repository:
https://github.com/stackrox/test-gh-actions/actions/runs/2912132210

