### PR TITLE
Handle internal resources in builtin scoped authorizer

### DIFF
--- a/central/role/resources/list.go
+++ b/central/role/resources/list.go
@@ -268,3 +268,14 @@ func MetadataForResource(res permissions.Resource) (permissions.ResourceMetadata
 	}
 	return md, found
 }
+
+// MetadataForInternalResource returns the internal metadata for the given resource.
+// If the resource is unknown, metadata for this resource with global scope is returned.
+func MetadataForInternalResource(res permissions.Resource) (permissions.ResourceMetadata, bool) {
+	md, found := internalResourceToMetadata[res]
+	if !found {
+		md.Resource = res
+		md.Scope = permissions.GlobalScope
+	}
+	return md, found
+}

--- a/central/sac/authorizer/builtin_scoped_authorizer.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer.go
@@ -125,7 +125,11 @@ func (a *accessModeLevelScopeCheckerCore) SubScopeChecker(scopeKey sac.ScopeKey)
 	if !ok {
 		return errorScopeChecker(a, scopeKey)
 	}
-	resource, ok := resources.MetadataForResource(permissions.Resource(scope.String()))
+	res := permissions.Resource(scope.String())
+	resource, ok := resources.MetadataForResource(res)
+	if !ok {
+		resource, ok = resources.MetadataForInternalResource(res)
+	}
 	if !ok {
 		return sac.ErrorAccessScopeCheckerCore(errors.Wrapf(ErrUnknownResource, "on scope key %q", scopeKey))
 	}

--- a/central/sac/authorizer/builtin_scoped_authorizer_test.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer_test.go
@@ -135,6 +135,12 @@ func TestBuiltInScopeAuthorizerWithTracing(t *testing.T) {
 			scopeKeys: readCluster(firstCluster.ID, resources.Cluster.Resource),
 			results:   []sac.TryAllowedResult{sac.Deny, sac.Deny, sac.Deny},
 		},
+		{
+			name:      "deny read from anything when scope deny all",
+			roles:     []permissions.ResolvedRole{role(allResourcesView, rolePkg.AccessScopeExcludeAll)},
+			scopeKeys: []sac.ScopeKey{sac.AccessModeScopeKey(storage.Access_READ_ACCESS), sac.ResourceScopeKey(resources.InstallationInfo.Resource)},
+			results:   []sac.TryAllowedResult{sac.Deny, sac.Deny},
+		},
 	}
 	for _, tc := range tests {
 		tc := tc

--- a/pkg/sac/tests/test_scope_checker_core_test.go
+++ b/pkg/sac/tests/test_scope_checker_core_test.go
@@ -15,6 +15,7 @@ const (
 	resourceConfig       = permissions.Resource("Config")
 	resourceDeployment   = permissions.Resource("Deployment")
 	resourceImage        = permissions.Resource("Image")
+	resourceInstallation = permissions.Resource("InstallationInfo")
 	resourceNetworkGraph = permissions.Resource("NetworkGraph")
 	resourceNode         = permissions.Resource("Node")
 	resourceRisk         = permissions.Resource("Risk")
@@ -159,6 +160,24 @@ func (s *testScopeCheckerCoreTestSuite) TestFullMapTestScopeCheckerHierarchyTryA
 			},
 			tryResults: []sac.TryAllowedResult{sac.Deny, sac.Deny, sac.Allow},
 		},
+		{
+			name:                "Read from included internal resource is denied",
+			scopeCheckerBuilder: createTestResourceLevelReadAndReadWriteMixScope,
+			scopeKeys: []sac.ScopeKey{
+				sac.AccessModeScopeKey(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKey(resourceInstallation),
+			},
+			tryResults: []sac.TryAllowedResult{sac.Deny, sac.Deny, sac.Allow},
+		},
+		{
+			name:                "Write to NOT included internal resource is denied",
+			scopeCheckerBuilder: createTestResourceLevelReadAndReadWriteMixScope,
+			scopeKeys: []sac.ScopeKey{
+				sac.AccessModeScopeKey(storage.Access_READ_WRITE_ACCESS),
+				sac.ResourceScopeKey(resourceInstallation),
+			},
+			tryResults: []sac.TryAllowedResult{sac.Deny, sac.Deny, sac.Deny},
+		},
 	}
 
 	for ix := range testcases {
@@ -228,6 +247,7 @@ func createTestResourceLevelReadAndReadWriteMixScope(t *testing.T) sac.ScopeChec
 		resourceWithAccess(storage.Access_READ_ACCESS, resourceConfig),
 		resourceWithAccess(storage.Access_READ_ACCESS, resourceDeployment),
 		resourceWithAccess(storage.Access_READ_ACCESS, resourceImage),
+		resourceWithAccess(storage.Access_READ_ACCESS, resourceInstallation),
 		resourceWithAccess(storage.Access_READ_ACCESS, resourceRisk),
 		resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resourceAlert),
 		resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resourceDeployment),


### PR DESCRIPTION
## Description

We do not checked internal resources returning error scope checker for them while thy should be handled as normal resource.


## Testing Performed

CI
