### PR TITLE
[ROX-12301] Support regex for image OS policy criteria

### DIFF
--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -2096,6 +2096,10 @@ func (suite *DefaultPoliciesTestSuite) TestImageOS() {
 		},
 		{
 			value:           "alpine",
+			expectedMatches: []string{},
+		},
+		{
+			value:           "alpine.*",
 			expectedMatches: []string{"alpine:v3.4", "alpine:v3.11"},
 		},
 		{

--- a/pkg/booleanpolicy/field_metadata.go
+++ b/pkg/booleanpolicy/field_metadata.go
@@ -372,7 +372,7 @@ func initializeFieldMetadata() FieldMetadata {
 		[]RuntimeFieldType{}, negationForbidden)
 
 	f.registerFieldMetadata(fieldnames.ImageOS,
-		querybuilders.ForFieldLabel(search.ImageOS),
+		querybuilders.ForFieldLabelRegex(search.ImageOS),
 		violationmessages.ImageContextFields,
 		func(*validateConfiguration) *regexp.Regexp {
 			return stringValueRegex

--- a/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
@@ -528,7 +528,7 @@ class PolicyFieldsTest extends BaseSpecification {
     static final private IS_BASED_ON_ALPINE = setPolicyFieldANDValues(
             BASE_POLICY.clone().setName("AAA_BASED_ON_ALPINE"),
             "Image OS",
-            ["alpine"]
+            ["alpine.*"]
     )
 
     // "Image Registry"


### PR DESCRIPTION
## Description

Support regex in `Image OS` policy criteria. Several other policy criteria such `Image Registry`, `CVE`, etc. support regex. To have `Image OS` behave differently is confusing, and seems to be an unintentionally introduced behavior. Hence, the change to make the criteria behavior consistent.
 Furthermore, our documentation indicates that the `Image OS` policy criteria support regular expression.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
Unit