### PR TITLE
Update CVE links in more Finding sections

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtDeploymentOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtDeploymentOverview.js
@@ -127,6 +127,7 @@ const VulnMgmtDeploymentOverview = ({ data, entityContext }) => {
                             entityType={entityTypes.DEPLOYMENT}
                             name={safeData?.name}
                             id={safeData?.id}
+                            vulnType={entityTypes.IMAGE_CVE}
                         />
                     </Tab>
                 </BinderTabs>

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtDeploymentOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtDeploymentOverview.js
@@ -18,6 +18,7 @@ import workflowStateContext from 'Containers/workflowStateContext';
 import { getPolicyTableColumns } from 'Containers/VulnMgmt/List/Policies/VulnMgmtListPolicies';
 import { entityGridContainerClassName } from 'Containers/Workflow/WorkflowEntityPage';
 import ViolationsAcrossThisDeployment from 'Containers/Workflow/widgets/ViolationsAcrossThisDeployment';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 
 import RelatedEntitiesSideList from '../RelatedEntitiesSideList';
 import TableWidgetFixableCves from '../TableWidgetFixableCves';
@@ -43,6 +44,9 @@ const emptyDeployment = {
 };
 
 const VulnMgmtDeploymentOverview = ({ data, entityContext }) => {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const showVMUpdates = isFeatureFlagEnabled('ROX_FRONTEND_VM_UPDATES');
+
     const workflowState = useContext(workflowStateContext);
 
     // guard against incomplete GraphQL-cached data
@@ -127,7 +131,7 @@ const VulnMgmtDeploymentOverview = ({ data, entityContext }) => {
                             entityType={entityTypes.DEPLOYMENT}
                             name={safeData?.name}
                             id={safeData?.id}
-                            vulnType={entityTypes.IMAGE_CVE}
+                            vulnType={showVMUpdates ? entityTypes.IMAGE_CVE : entityTypes.CVE}
                         />
                     </Tab>
                 </BinderTabs>

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.js
@@ -16,6 +16,7 @@ import TopRiskiestEntities from 'Containers/VulnMgmt/widgets/TopRiskiestEntities
 import DeploymentsWithMostSeverePolicyViolations from 'Containers/VulnMgmt/widgets/DeploymentsWithMostSeverePolicyViolations';
 import { getPolicyTableColumns } from 'Containers/VulnMgmt/List/Policies/VulnMgmtListPolicies';
 import { entityGridContainerClassName } from 'Containers/Workflow/WorkflowEntityPage';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 
 import RelatedEntitiesSideList from '../RelatedEntitiesSideList';
 import TableWidgetFixableCves from '../TableWidgetFixableCves';
@@ -41,6 +42,9 @@ const emptyNamespace = {
 };
 
 const VulnMgmtNamespaceOverview = ({ data, entityContext }) => {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const showVMUpdates = isFeatureFlagEnabled('ROX_FRONTEND_VM_UPDATES');
+
     const workflowState = useContext(workflowStateContext);
 
     // guard against incomplete GraphQL-cached data
@@ -141,7 +145,9 @@ const VulnMgmtNamespaceOverview = ({ data, entityContext }) => {
                                     entityType={entityTypes.NAMESPACE}
                                     name={safeData?.metadata?.name}
                                     id={safeData?.metadata?.id}
-                                    vulnType={entityTypes.IMAGE_CVE}
+                                    vulnType={
+                                        showVMUpdates ? entityTypes.IMAGE_CVE : entityTypes.CVE
+                                    }
                                 />
                             </Tab>
                         </BinderTabs>

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.js
@@ -141,6 +141,7 @@ const VulnMgmtNamespaceOverview = ({ data, entityContext }) => {
                                     entityType={entityTypes.NAMESPACE}
                                     name={safeData?.metadata?.name}
                                     id={safeData?.metadata?.id}
+                                    vulnType={entityTypes.IMAGE_CVE}
                                 />
                             </Tab>
                         </BinderTabs>

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.js
@@ -79,9 +79,7 @@ const TableWidgetFixableCves = ({
         query getFixableCvesForEntity(
             $id: ID!
             ${
-                entityType !== entityTypes.NODE_COMPONENT &&
-                vulnType !== entityTypes.NODE_CVE &&
-                vulnType !== entityTypes.CLUSTER_CVE
+                entityType !== entityTypes.NODE_COMPONENT && vulnType !== entityTypes.NODE_CVE
                     ? '$query: String'
                     : ''
             }


### PR DESCRIPTION
## Description

Some broken links in Findings section > Fixable CVEs tables of Namespace Overview and Deployment Overview.

Plus, the Findings section > Platform CVEs table of Cluster Overview had broken in a regression. Fixed that, too.

## Checklist
- [x] Investigated and inspected CI test results (failure is in flakey unrelated test suite)


## Testing Performed

Cluster Overview > Findings section > Platform CVEs table
BEFORE
<img width="1540" alt="Screen Shot 2022-08-23 at 11 23 31 AM" src="https://user-images.githubusercontent.com/715729/186261048-893dc37f-098e-49d8-97b1-f04cf7691fbb.png">

AFTER
<img width="1540" alt="Screen Shot 2022-08-23 at 4 12 04 PM" src="https://user-images.githubusercontent.com/715729/186261144-1c96c82c-ca28-4b36-8b7f-f705fb1b64c8.png">


Namespace Overview > Findings section > Image CVEs table
BEFORE
<img width="1540" alt="Screen Shot 2022-08-23 at 11 23 43 AM" src="https://user-images.githubusercontent.com/715729/186261059-d2f6049f-8508-40fa-8ca5-5efa3a244902.png">

AFTER
<img width="1540" alt="Screen Shot 2022-08-23 at 4 12 19 PM" src="https://user-images.githubusercontent.com/715729/186261171-628124aa-6ea0-417b-bee2-0bb70ece64ba.png">


Deployment Overview > Findings section > Image CVEs table
BEFORE
<img width="1540" alt="Screen Shot 2022-08-23 at 11 23 55 AM" src="https://user-images.githubusercontent.com/715729/186261110-bd49bbc1-b137-4a1e-8344-71adefd52e26.png">


AFTER
<img width="1540" alt="Screen Shot 2022-08-23 at 4 12 31 PM" src="https://user-images.githubusercontent.com/715729/186261188-6838490f-da57-45a6-bfa1-31770c03d235.png">


