### PR TITLE
Prevent timing failures in auth providers integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -115,7 +115,7 @@ export const images = {
 
 export const auth = {
     loginAuthProviders: '/v1/login/authproviders',
-    authProviders: '/v1/authProviders*',
+    authProviders: '/v1/authProviders',
     authStatus: '/v1/auth/status',
     logout: '/sso/session/logout',
     tokenRefresh: '/sso/session/tokenrefresh',
@@ -161,7 +161,7 @@ export const policies = {
 };
 
 export const roles = {
-    list: '/v1/roles/*',
+    list: '/v1/roles',
     mypermissions: 'v1/mypermissions',
 };
 
@@ -174,7 +174,8 @@ export const accessScopes = {
 };
 
 export const groups = {
-    list: '/v1/groups/*',
+    batch: '/v1/groupsbatch',
+    list: '/v1/groups',
 };
 
 export const userAttributes = {

--- a/ui/apps/platform/cypress/fixtures/auth/mypermissionsMinimalAccess.json
+++ b/ui/apps/platform/cypress/fixtures/auth/mypermissionsMinimalAccess.json
@@ -1,6 +1,4 @@
 {
-    "name": "",
-    "globalAccess": "NO_ACCESS",
     "resourceToAccess": {
         "APIToken": "NO_ACCESS",
         "Alert": "READ_ACCESS",

--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -8,6 +8,9 @@
  *
  * Optionally assign aliases for multiple GraphQL requests with routeMatcher opname key:
  * opnameAliasesMap: { opname: { aliases, routeHandler }, … }
+ *
+ * @param {{ routeMatcherMap?: Record<string, { method: string, url: string }>, opnameAliasesMap?: Record<string, (request: Object) => boolean> }} [requestConfig]
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
 export function interceptRequests(requestConfig, staticResponseMap) {
     if (requestConfig?.routeMatcherMap) {
@@ -40,6 +43,8 @@ export function interceptRequests(requestConfig, staticResponseMap) {
  * Wait for responses after initial page visit or subsequent interaction.
  *
  * Optionally wait with waitOptions: { requestTimeout, responseTimeout }
+ *
+ * @param {{ routeMatcherMap?: Record<string, { method: string, url: string }>, opnameAliasesMap?: Record<string, (request: Object) => boolean>, waitOptions?: { requestTimeout?: number, responseTimeout?: number } }} [requestConfig]
  */
 export function waitForResponses(requestConfig) {
     if (requestConfig?.routeMatcherMap) {
@@ -62,6 +67,10 @@ export function waitForResponses(requestConfig) {
 
 /*
  * Intercept requests before interaction and then wait for responses.
+ *
+ * @param {() => void} interactionCallback
+ * @param {{ routeMatcherMap?: Record<string, { method: string, url: string }>, opnameAliasesMap?: Record<string, (request: Object) => boolean>, waitOptions?: { requestTimeout?: number, responseTimeout?: number } }} [requestConfig]
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
 export function interactAndWaitForResponses(interactionCallback, requestConfig, staticResponseMap) {
     interceptRequests(requestConfig, staticResponseMap);

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -30,3 +30,26 @@ export function visit(pageUrl, requestConfig, staticResponseMap) {
     cy.wait(['@featureflags', '@mypermissions', '@config/public']);
     waitForResponses(requestConfig);
 }
+
+/*
+ * Visit page to test conditional rendering for user role permissions.
+ *
+ * { body: { resourceToAccess: { … } } }
+ * { fixture: 'fixtures/wherever/whatever.json' }
+ */
+export function visitWithPermissions(
+    pageUrl,
+    permissionsStaticResponse,
+    requestConfig,
+    staticResponseMap
+) {
+    cy.intercept('GET', api.featureFlags).as('featureflags');
+    cy.intercept('GET', api.roles.mypermissions, permissionsStaticResponse).as('mypermissions');
+    cy.intercept('GET', api.system.configPublic).as('config/public');
+    interceptRequests(requestConfig, staticResponseMap);
+
+    cy.visit(pageUrl);
+
+    cy.wait(['@featureflags', '@mypermissions', '@config/public']);
+    waitForResponses(requestConfig);
+}

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -18,6 +18,10 @@ import { interceptRequests, waitForResponses } from './request';
  * graphqlMultiAliasMap: { opname: { aliases, routeHandler }, … }
  *
  * Optionally wait for responses with waitOptions: { requestTimeout, responseTimeout }
+ *
+ * @param {string} pageUrl
+ * @param {{ routeMatcherMap?: Record<string, { method: string, url: string }>, opnameAliasesMap?: Record<string, (request: Object) => boolean>, waitOptions?: { requestTimeout?: number, responseTimeout?: number } }} [requestConfig]
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
 export function visit(pageUrl, requestConfig, staticResponseMap) {
     cy.intercept('GET', api.featureFlags).as('featureflags');
@@ -32,10 +36,15 @@ export function visit(pageUrl, requestConfig, staticResponseMap) {
 }
 
 /*
- * Visit page to test conditional rendering for user role permissions.
+ * Visit page to test conditional rendering for user role permissions specified as response or fixture.
  *
  * { body: { resourceToAccess: { … } } }
  * { fixture: 'fixtures/wherever/whatever.json' }
+ *
+ * @param {string} pageUrl
+ * @param {{ body: { resourceToAccess: Record<string, string> } } | { fixture: string }} permissionsStaticResponseMap
+ * @param {{ routeMatcherMap?: Record<string, { method: string, url: string }>, opnameAliasesMap?: Record<string, (request: Object) => boolean>, waitOptions?: { requestTimeout?: number, responseTimeout?: number } }} [requestConfig]
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
 export function visitWithPermissions(
     pageUrl,


### PR DESCRIPTION
## Description

### Failing test

1562110050078560256 from master build for #2796 on 2022-08-23

> Timed out retrying after 4000ms: Expected to find element: `main button:contains("Create")`, but never found it.

`'add SAML 2.0'` in cypress/integration/accessControl/accessControlAuthProviders.test.js

![prow-accessControlAuthProviders-saml](https://user-images.githubusercontent.com/11862657/186281343-ba981843-d282-4532-8761-79f96df6b545.png)

### Analysis

Not specific to the test, prerequisite requests to render the page were slow enough that the DOM assertion timed out.

Although it looks like the failing test waits on the correct /v1/authProviders request, the preceding test makes requests including /v1/authProviders which it does not wait on, which opens the door to the next test to get ahead of UI which might have been delayed by finishing rendering the preceding test scenario, plus any unfortunately timed delays in responses from central.

### Solution

Provide several time intervals for requests and assertions to prevent timing failures.

Apply composable convention for helper function arguments that was added in #2176

* `routeMatcherMap` https://docs.cypress.io/api/commands/intercept#Matching-with-RouteMatcher
* `permissionsStaticResponse` and `staticResponseMap` https://docs.cypress.io/api/commands/intercept#StaticResponse-objects

### Changed files

1. Edit cypress/constants/apiEndpoints.js
    * Delete unneeded wildcards from `list` properties for more precise matches and use in template literals.
    * Add `batch` property to `groups` object.

2. Edit cypress/fixtures/auth/mypermissionsMinimalAccess.json
    * Delete obsolete properties.
        https://github.com/stackrox/stackrox/blob/master/proto/api/v1/role_service.proto#L27-L31

3. Edit cypress/helpers/visit.js
    * Add `visitWithPermissions` helper function to test conditional rendering for user role permissions.

4. Edit cypress/integration/accessControl/accessControlAuthProviders.test.js
    * Replace temporary local endpoints with import from constants/apiEndpoints
    * Rewrite local function based on import from helpers/visit
    * Factor out generic assertions from tests into `visitAuthProviders` function to provide an additional time interval before test specific assertions.
    * Move `mockUserCertResponse` argument into the specific test.
    * Rewrite `cy.location` assertions.
    * Uncomment assertion which was waiting for cypress 7 or later.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

For local deployment: ran each test individually, and then ran all tests in the file.