### PR TITLE
Explicitly click to close actions menu in integration test for violations

### DIFF
--- a/ui/apps/platform/cypress/constants/ViolationsPage.js
+++ b/ui/apps/platform/cypress/constants/ViolationsPage.js
@@ -13,7 +13,7 @@ export const selectors = {
     resultsFoundHeader: (number) =>
         `h2:contains("${number} result${number === 1 ? '' : 's'} found")`,
     actions: {
-        btn: 'td.pf-c-table__action button',
+        btn: 'td.pf-c-table__action button[aria-label="Actions"]',
         excludeDeploymentBtn: 'button:contains("Exclude deployment")',
         resolveBtn: 'button:contains("Mark as resolved")',
         resolveAndAddToBaselineBtn: 'button:contains("Resolve and add to process baseline")',

--- a/ui/apps/platform/cypress/integration/violations/violations.test.js
+++ b/ui/apps/platform/cypress/integration/violations/violations.test.js
@@ -88,7 +88,7 @@ describe('Violations page', () => {
         visitViolationsWithFixture('alerts/alerts.json');
 
         // Lifecycle: Runtime
-        cy.get(`${selectors.firstTableRow} ${selectors.actions.btn}`).click();
+        cy.get(`${selectors.firstTableRow} ${selectors.actions.btn}`).click(); // click kabob to open actions menu
         cy.get(selectors.firstTableRow)
             .get(selectors.actions.excludeDeploymentBtn)
             .should('exist')
@@ -96,12 +96,10 @@ describe('Violations page', () => {
             .should('exist')
             .get(selectors.actions.resolveAndAddToBaselineBtn)
             .should('exist');
-
-        // to click out and reset the actions dropdown
-        cy.get('body').type('{esc}');
+        cy.get(`${selectors.firstTableRow} ${selectors.actions.btn}`).click(); // click kabob to close actions menu
 
         // Lifecycle: Deploy
-        cy.get(`${selectors.lastTableRow} ${selectors.actions.btn}`).click();
+        cy.get(`${selectors.lastTableRow} ${selectors.actions.btn}`).click(); // click kabob to open actions menu
         cy.get(selectors.lastTableRow)
             .get(selectors.actions.resolveBtn)
             .should('not.exist')
@@ -109,6 +107,7 @@ describe('Violations page', () => {
             .should('not.exist')
             .get(selectors.actions.excludeDeploymentBtn)
             .should('exist');
+        cy.get(`${selectors.lastTableRow} ${selectors.actions.btn}`).click(); // click kabob to close actions menu
     });
 
     // TODO test of bulk actions


### PR DESCRIPTION
## Description

### Test failure

1560369927628525568 from master build for #2715 on 2022-08-18

> should contain correct action buttons for the lifecycle stage

> Timed out retrying after 4050ms: `cy.click()` failed because this element:

> `<button aria-label="Actions" id="pf-dropdown-toggle-id-17" class="pf-c-dropdown__toggle pf-m-plain" type="button" aria-expanded="false" aria-haspopup="true">...</button>`

> is being covered by another element:

> `<button tabindex="-1" data-ouia-component-type="PF4/DropdownItem" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-DropdownItem-2" data-key="1" aria-disabled="false" type="button" class="pf-c-dropdown__menu-item" role="menuitem">Mark as...</button>`

Indeed, the kabob button of the second row is covered by the action menu of the first row.
![prow](https://user-images.githubusercontent.com/11862657/186461206-fa7bf1df-3289-464f-b9d2-0312b62547be.png)

Although hard to say why it failed this time this way, it seems like a good habit to use most direct interaction to put UI back into a neutral state for each of the 2 sub-tests.
### Changed files

1. Edit cypress/constants/ViolationsPage.js
    * Make selector specific enough not to match the buttons in an open actions menu.
        Initial attempt to click button again to close the menu failed because the selector also matched the `button` elements for action menu items.

2. Edit cypress/integration/violations/violations.test.js
    * Replace indirect with direct interaction to close action menu.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed

* For local deployment: ran the test individually, and then ran all tests in the file.
* Inspect elements in readonly demo to see the elements in open and closed action menu.