### PR TITLE
Dedupe dackbox index writes

### DIFF
--- a/central/deployment/datastoretest/datastore_sac_test.go
+++ b/central/deployment/datastoretest/datastore_sac_test.go
@@ -353,6 +353,7 @@ func (s *deploymentDatastoreSACSuite) TestUpsertDeployment() {
 
 func (s *deploymentDatastoreSACSuite) TestGetDeployment() {
 	deployment := s.pushDeploymentToStore(testconsts.Cluster2, testconsts.NamespaceB)
+	s.waitForIndexing()
 	deployment.Priority = 1
 
 	cases := testutils.GenericNamespaceSACGetTestCases(s.T())

--- a/go.mod
+++ b/go.mod
@@ -413,7 +413,7 @@ require (
 // The `go mod tidy` takes care of normalizing the symbol version information (e.g. branch name) which is required
 // for Go build tools to accept the `go.mod`.
 replace (
-	github.com/blevesearch/bleve => github.com/stackrox/bleve v0.0.0-20220906230509-6926dbdce8af
+	github.com/blevesearch/bleve => github.com/stackrox/bleve v0.0.0-20220907142141-15a243523c74
 
 	github.com/facebookincubator/nvdtools => github.com/stackrox/nvdtools v0.0.0-20210326191554-5daeb6395b56
 	github.com/fullsailor/pkcs7 => github.com/misberner/pkcs7 v0.0.0-20190417093538-a48bf0f78dea

--- a/go.mod
+++ b/go.mod
@@ -413,7 +413,7 @@ require (
 // The `go mod tidy` takes care of normalizing the symbol version information (e.g. branch name) which is required
 // for Go build tools to accept the `go.mod`.
 replace (
-	github.com/blevesearch/bleve => github.com/stackrox/bleve v0.0.0-20220907142141-15a243523c74
+	github.com/blevesearch/bleve => github.com/stackrox/bleve v0.0.0-20220907150529-4ecbd2543f9e
 
 	github.com/facebookincubator/nvdtools => github.com/stackrox/nvdtools v0.0.0-20210326191554-5daeb6395b56
 	github.com/fullsailor/pkcs7 => github.com/misberner/pkcs7 v0.0.0-20190417093538-a48bf0f78dea

--- a/go.mod
+++ b/go.mod
@@ -413,7 +413,7 @@ require (
 // The `go mod tidy` takes care of normalizing the symbol version information (e.g. branch name) which is required
 // for Go build tools to accept the `go.mod`.
 replace (
-	github.com/blevesearch/bleve => github.com/stackrox/bleve v0.0.0-20200807170555-6c4fa9f5e726
+	github.com/blevesearch/bleve => github.com/stackrox/bleve v0.0.0-20220906230509-6926dbdce8af
 
 	github.com/facebookincubator/nvdtools => github.com/stackrox/nvdtools v0.0.0-20210326191554-5daeb6395b56
 	github.com/fullsailor/pkcs7 => github.com/misberner/pkcs7 v0.0.0-20190417093538-a48bf0f78dea

--- a/go.sum
+++ b/go.sum
@@ -2747,8 +2747,8 @@ github.com/spiffe/go-spiffe/v2 v2.1.0/go.mod h1:5qg6rpqlwIub0JAiF1UK9IMD6BpPTmvG
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/ssgreg/nlreturn/v2 v2.1.0/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRkkxBiELzh2I=
 github.com/ssgreg/nlreturn/v2 v2.2.1/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRkkxBiELzh2I=
-github.com/stackrox/bleve v0.0.0-20220906230509-6926dbdce8af h1:LOPoov1ZoqcCCx4LE3TmoiEE4OpAqo7j4VXwUiAE9LI=
-github.com/stackrox/bleve v0.0.0-20220906230509-6926dbdce8af/go.mod h1:iEpZccUqBH5f0BOF0uH78s8+dUaG/OWu4xuYMXBOdGs=
+github.com/stackrox/bleve v0.0.0-20220907142141-15a243523c74 h1:A5av7t6k5T8bwlX4vwVwm7u9uV7xORENDD60rk4Bouc=
+github.com/stackrox/bleve v0.0.0-20220907142141-15a243523c74/go.mod h1:iEpZccUqBH5f0BOF0uH78s8+dUaG/OWu4xuYMXBOdGs=
 github.com/stackrox/default-authz-plugin v0.0.0-20210608105219-00ad9c9f3855 h1:5pQczch8XO6MddfAHXdoYEVFMv5kqBBrpzJ/p5M5AkA=
 github.com/stackrox/default-authz-plugin v0.0.0-20210608105219-00ad9c9f3855/go.mod h1:hJeI5MbszujJq1W6nrGMoO0ACa85iQi5pqHl68id0h0=
 github.com/stackrox/docker-registry-client v0.0.0-20220204234128-07f109db0819 h1:1jcyovr8lC0vBax5TFNzpXOChl/sJr/IoLVUFkYEMpM=

--- a/go.sum
+++ b/go.sum
@@ -2747,8 +2747,8 @@ github.com/spiffe/go-spiffe/v2 v2.1.0/go.mod h1:5qg6rpqlwIub0JAiF1UK9IMD6BpPTmvG
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/ssgreg/nlreturn/v2 v2.1.0/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRkkxBiELzh2I=
 github.com/ssgreg/nlreturn/v2 v2.2.1/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRkkxBiELzh2I=
-github.com/stackrox/bleve v0.0.0-20220907142141-15a243523c74 h1:A5av7t6k5T8bwlX4vwVwm7u9uV7xORENDD60rk4Bouc=
-github.com/stackrox/bleve v0.0.0-20220907142141-15a243523c74/go.mod h1:iEpZccUqBH5f0BOF0uH78s8+dUaG/OWu4xuYMXBOdGs=
+github.com/stackrox/bleve v0.0.0-20220907150529-4ecbd2543f9e h1:+gtD6n44cUn+WHL68MPZZvOz4ZObSx/cmk8IZ3a6s+w=
+github.com/stackrox/bleve v0.0.0-20220907150529-4ecbd2543f9e/go.mod h1:iEpZccUqBH5f0BOF0uH78s8+dUaG/OWu4xuYMXBOdGs=
 github.com/stackrox/default-authz-plugin v0.0.0-20210608105219-00ad9c9f3855 h1:5pQczch8XO6MddfAHXdoYEVFMv5kqBBrpzJ/p5M5AkA=
 github.com/stackrox/default-authz-plugin v0.0.0-20210608105219-00ad9c9f3855/go.mod h1:hJeI5MbszujJq1W6nrGMoO0ACa85iQi5pqHl68id0h0=
 github.com/stackrox/docker-registry-client v0.0.0-20220204234128-07f109db0819 h1:1jcyovr8lC0vBax5TFNzpXOChl/sJr/IoLVUFkYEMpM=

--- a/go.sum
+++ b/go.sum
@@ -2747,8 +2747,8 @@ github.com/spiffe/go-spiffe/v2 v2.1.0/go.mod h1:5qg6rpqlwIub0JAiF1UK9IMD6BpPTmvG
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/ssgreg/nlreturn/v2 v2.1.0/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRkkxBiELzh2I=
 github.com/ssgreg/nlreturn/v2 v2.2.1/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRkkxBiELzh2I=
-github.com/stackrox/bleve v0.0.0-20200807170555-6c4fa9f5e726 h1:mgY/2FQz67/zbDEkfr8YcMMyhAl4n83F2I9ffAgo5FU=
-github.com/stackrox/bleve v0.0.0-20200807170555-6c4fa9f5e726/go.mod h1:iEpZccUqBH5f0BOF0uH78s8+dUaG/OWu4xuYMXBOdGs=
+github.com/stackrox/bleve v0.0.0-20220906230509-6926dbdce8af h1:LOPoov1ZoqcCCx4LE3TmoiEE4OpAqo7j4VXwUiAE9LI=
+github.com/stackrox/bleve v0.0.0-20220906230509-6926dbdce8af/go.mod h1:iEpZccUqBH5f0BOF0uH78s8+dUaG/OWu4xuYMXBOdGs=
 github.com/stackrox/default-authz-plugin v0.0.0-20210608105219-00ad9c9f3855 h1:5pQczch8XO6MddfAHXdoYEVFMv5kqBBrpzJ/p5M5AkA=
 github.com/stackrox/default-authz-plugin v0.0.0-20210608105219-00ad9c9f3855/go.mod h1:hJeI5MbszujJq1W6nrGMoO0ACa85iQi5pqHl68id0h0=
 github.com/stackrox/docker-registry-client v0.0.0-20220204234128-07f109db0819 h1:1jcyovr8lC0vBax5TFNzpXOChl/sJr/IoLVUFkYEMpM=

--- a/pkg/dackbox/indexer/lazy.go
+++ b/pkg/dackbox/indexer/lazy.go
@@ -90,14 +90,14 @@ func (li *lazyImpl) runIndexing() {
 	}
 }
 
-func (li *lazyImpl) isDeduped(key string, value proto.Message) bool {
+func (li *lazyImpl) evaluateDeduping(key string, value proto.Message) bool {
 	if value == nil {
 		delete(li.deduper, key)
 		return false
 	}
-	li.hasher.Reset()
 	hashValue, err := hashstructure.Hash(value, &hashstructure.HashOptions{
-		Hasher: li.hasher,
+		Hasher:  li.hasher,
+		TagName: "search",
 	})
 	if err != nil {
 		log.Errorf("error calculating hash: %v", err)
@@ -119,7 +119,7 @@ func (li *lazyImpl) consumeFromQueue() {
 		}
 
 		if key != nil {
-			if li.isDeduped(string(key), value) {
+			if li.evaluateDeduping(string(key), value) {
 				indexObjectsDeduped.Inc()
 				continue
 			}

--- a/pkg/dackbox/indexer/metrics.go
+++ b/pkg/dackbox/indexer/metrics.go
@@ -1,0 +1,28 @@
+package indexer
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
+)
+
+var (
+	indexObjectsDeduped = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: pkgMetrics.PrometheusNamespace,
+		Subsystem: pkgMetrics.CentralSubsystem.String(),
+		Name:      "dackbox_index_objects_deduped",
+		Help:      "Number of objects deduped in the indexer",
+	})
+	indexObjectsIndexed = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: pkgMetrics.PrometheusNamespace,
+		Subsystem: pkgMetrics.CentralSubsystem.String(),
+		Name:      "dackbox_index_objects_indexed",
+		Help:      "Number of objects indexer in the indexer",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(
+		indexObjectsDeduped,
+		indexObjectsIndexed,
+	)
+}


### PR DESCRIPTION
## Description

Hashing the objects going to be indexed in dackbox should significantly alleviate load on the indexer. Something similar will need to be used for Postgres, but that can be done within Postgres

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Will run in CI and look at the metrics