### PR TITLE
Dashrews/ROX-12307 turn on tls test

### DIFF
--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -9,20 +9,15 @@ import objects.Deployment
 import objects.Secret
 import orchestratormanager.OrchestratorManagerException
 
-import util.Env
-
 import org.junit.experimental.categories.Category
 import services.ClusterService
 
-import spock.lang.IgnoreIf
 import spock.lang.Retry
 import spock.lang.Shared
 import util.ApplicationHealth
 import util.Timer
 
 @Retry(count = 1)
-// TODO: ROX-12307: Enable test
-@IgnoreIf({ Env.CI_JOBNAME.contains("postgres") })
 class TLSChallengeTest extends BaseSpecification {
     @Shared
     private EnvVar originalCentralEndpoint = new EnvVar()


### PR DESCRIPTION
## Description

Now that ROX-11677 ROX-11235 and ROX-11922 have been merged, migrations should be working.  The issue wasn't so much that TLS was messed up it was that central was stuck crashing on migrations so the TLS tests couldn't connect to the service.  The merging of those changes above resolve that issue and as such we can turn the test back on for postgres.

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

The change is a test.  CI should be sufficient.
