### PR TITLE
[ROX-12303][POSTGRES] Change the string search from prefix matching to substring matching

### DIFF
--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -153,7 +153,7 @@ func TestMultiTableQueries(t *testing.T) {
 			expectedFrom:       "deployments",
 			expectedWhere:      "NOT (deployments_containers.Image_Name_FullName ilike $$)",
 			expectedJoinTables: []string{"deployments_containers"},
-			expectedData:       []interface{}{"central%"},
+			expectedData:       []interface{}{"%central%"},
 		},
 		{
 			desc:          "nil query",

--- a/pkg/search/postgres/index_test.go
+++ b/pkg/search/postgres/index_test.go
@@ -164,6 +164,21 @@ func (s *IndexSuite) TestString() {
 			expectedResults: []*storage.TestMultiKeyStruct{testStruct0, testStruct2},
 		},
 		{
+			desc:            "substring",
+			q:               search.NewQueryBuilder().AddStrings(search.TestString, "irs").ProtoQuery(),
+			expectedResults: []*storage.TestMultiKeyStruct{testStruct0},
+		},
+		{
+			desc:            "substring (but case insensitive)",
+			q:               search.NewQueryBuilder().AddStrings(search.TestString, "CON").ProtoQuery(),
+			expectedResults: []*storage.TestMultiKeyStruct{testStruct1},
+		},
+		{
+			desc:            "suffix",
+			q:               search.NewQueryBuilder().AddStrings(search.TestString, "rst").ProtoQuery(),
+			expectedResults: []*storage.TestMultiKeyStruct{testStruct0},
+		},
+		{
 			desc:            "regex",
 			q:               search.NewQueryBuilder().AddRegexes(search.TestString, "f.*").ProtoQuery(),
 			expectedResults: []*storage.TestMultiKeyStruct{testStruct0, testStruct2},

--- a/pkg/search/postgres/query/string_query.go
+++ b/pkg/search/postgres/query/string_query.go
@@ -26,7 +26,7 @@ func newStringQueryWhereClause(columnName string, value string, queryModifiers .
 	if len(queryModifiers) == 0 {
 		return WhereClause{
 			Query:  fmt.Sprintf("%s ilike $$", columnName),
-			Values: []interface{}{value + "%"},
+			Values: []interface{}{"%" + value + "%"},
 			equivalentGoFunc: func(foundValue interface{}) bool {
 				return strings.HasPrefix(foundValue.(string), value)
 			},
@@ -42,7 +42,7 @@ func newStringQueryWhereClause(columnName string, value string, queryModifiers .
 		if len(queryModifiers) == 1 {
 			return WhereClause{
 				Query:  fmt.Sprintf("NOT (%s ilike $$)", columnName),
-				Values: []interface{}{value + "%"},
+				Values: []interface{}{"%" + value + "%"},
 				equivalentGoFunc: func(foundValue interface{}) bool {
 					return !strings.HasPrefix(foundValue.(string), value)
 				},

--- a/tools/allowed-large-files
+++ b/tools/allowed-large-files
@@ -22,6 +22,7 @@ pkg/docker/types/types_easyjson.go
 pkg/fixtures/image.go
 pkg/mitre/files/mitre.json
 pkg/mocks/github.com/aws/aws-sdk-go/service/securityhub/securityhubiface/mocks/mocks.go
+pkg/search/postgres/index_test.go
 pkg/sliceutils/gen-builtins-generic.go
 proto/storage/proto.lock
 qa-tests-backend/artifacts/**/*


### PR DESCRIPTION
## Description
Change the string search from prefix matching to substring matching for all search labels. Due to analyzers that we use with bleve indexer, some fields are prefixed matched whereas others are substring matched (esp those with whitespaces). Make substring matching defacto string search technique and remove the inconsistency in Postgres.

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user-facing changes~

If any of these don't apply, please comment below.

## Testing Performed
Unit