### PR TITLE
[ROX-12313][Dackbox] Fill severity when reading out the records

### DIFF
--- a/central/cve/converter/utils/convert_utils.go
+++ b/central/cve/converter/utils/convert_utils.go
@@ -510,3 +510,15 @@ func GetFixedVersions(nvdCVE *schema.NVDCVEFeedJSON10DefCVEItem) []string {
 	}
 	return versions
 }
+
+// CVEScoreVersionToEmbeddedScoreVersion converts versions between cve protos.
+func CVEScoreVersionToEmbeddedScoreVersion(v storage.CVE_ScoreVersion) storage.EmbeddedVulnerability_ScoreVersion {
+	switch v {
+	case storage.CVE_V2:
+		return storage.EmbeddedVulnerability_V2
+	case storage.CVE_V3:
+		return storage.EmbeddedVulnerability_V3
+	default:
+		return storage.EmbeddedVulnerability_V2
+	}
+}

--- a/central/node/datastore/internal/store/common/parts_test.go
+++ b/central/node/datastore/internal/store/common/parts_test.go
@@ -25,7 +25,8 @@ func TestSplitAndMergeNode(t *testing.T) {
 			FixableCves: 2,
 		},
 		Scan: &storage.NodeScan{
-			ScanTime: ts,
+			ScanTime:        ts,
+			OperatingSystem: "rhel:8",
 			Components: []*storage.EmbeddedNodeScanComponent{
 				{
 					Name:    "comp1",
@@ -39,6 +40,7 @@ func TestSplitAndMergeNode(t *testing.T) {
 						{
 							Cve:               "cve1",
 							VulnerabilityType: storage.EmbeddedVulnerability_NODE_VULNERABILITY,
+							Severity:          storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
 						},
 						{
 							Cve:               "cve2",
@@ -46,6 +48,7 @@ func TestSplitAndMergeNode(t *testing.T) {
 							SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{
 								FixedBy: "ver3",
 							},
+							Severity: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
 						},
 					},
 				},
@@ -59,10 +62,12 @@ func TestSplitAndMergeNode(t *testing.T) {
 							SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{
 								FixedBy: "ver2",
 							},
+							Severity: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
 						},
 						{
 							Cve:               "cve2",
 							VulnerabilityType: storage.EmbeddedVulnerability_NODE_VULNERABILITY,
+							Severity:          storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
 						},
 					},
 				},
@@ -75,7 +80,8 @@ func TestSplitAndMergeNode(t *testing.T) {
 			Id:   "id",
 			Name: "name",
 			Scan: &storage.NodeScan{
-				ScanTime: ts,
+				ScanTime:        ts,
+				OperatingSystem: "rhel:8",
 			},
 			SetComponents: &storage.Node_Components{
 				Components: 3,
@@ -119,6 +125,11 @@ func TestSplitAndMergeNode(t *testing.T) {
 						CVE: &storage.CVE{
 							Id:   "cve1",
 							Type: storage.CVE_NODE_CVE,
+							DistroSpecifics: map[string]*storage.CVE_DistroSpecific{
+								"rhel:8": {
+									Severity: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+								},
+							},
 						},
 						Edge: &storage.ComponentCVEEdge{
 							Id:               edges.EdgeID{ParentID: scancomponent.ComponentID("comp1", "ver2", ""), ChildID: "cve1"}.ToString(),
@@ -130,6 +141,11 @@ func TestSplitAndMergeNode(t *testing.T) {
 						CVE: &storage.CVE{
 							Id:   "cve2",
 							Type: storage.CVE_NODE_CVE,
+							DistroSpecifics: map[string]*storage.CVE_DistroSpecific{
+								"rhel:8": {
+									Severity: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+								},
+							},
 						},
 						Edge: &storage.ComponentCVEEdge{
 							Id: edges.EdgeID{ParentID: scancomponent.ComponentID("comp1", "ver2", ""), ChildID: "cve2"}.ToString(),
@@ -160,6 +176,11 @@ func TestSplitAndMergeNode(t *testing.T) {
 						CVE: &storage.CVE{
 							Id:   "cve1",
 							Type: storage.CVE_NODE_CVE,
+							DistroSpecifics: map[string]*storage.CVE_DistroSpecific{
+								"rhel:8": {
+									Severity: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+								},
+							},
 						},
 						Edge: &storage.ComponentCVEEdge{
 							Id: edges.EdgeID{ParentID: scancomponent.ComponentID("comp2", "ver1", ""), ChildID: "cve1"}.ToString(),
@@ -175,6 +196,11 @@ func TestSplitAndMergeNode(t *testing.T) {
 						CVE: &storage.CVE{
 							Id:   "cve2",
 							Type: storage.CVE_NODE_CVE,
+							DistroSpecifics: map[string]*storage.CVE_DistroSpecific{
+								"rhel:8": {
+									Severity: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+								},
+							},
 						},
 						Edge: &storage.ComponentCVEEdge{
 							Id:               edges.EdgeID{ParentID: scancomponent.ComponentID("comp2", "ver1", ""), ChildID: "cve2"}.ToString(),

--- a/migrator/migrations/cvehelper/convert_utils.go
+++ b/migrator/migrations/cvehelper/convert_utils.go
@@ -518,3 +518,15 @@ func GetFixedVersions(nvdCVE *schema.NVDCVEFeedJSON10DefCVEItem) []string {
 	}
 	return versions
 }
+
+// CVEScoreVersionToEmbeddedScoreVersion converts versions between cve protos.
+func CVEScoreVersionToEmbeddedScoreVersion(v storage.CVE_ScoreVersion) storage.EmbeddedVulnerability_ScoreVersion {
+	switch v {
+	case storage.CVE_V2:
+		return storage.EmbeddedVulnerability_V2
+	case storage.CVE_V3:
+		return storage.EmbeddedVulnerability_V3
+	default:
+		return storage.EmbeddedVulnerability_V2
+	}
+}

--- a/migrator/migrations/n_35_to_n_36_postgres_nodes/common/merge.go
+++ b/migrator/migrations/n_35_to_n_36_postgres_nodes/common/merge.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"github.com/stackrox/rox/central/cve/converter/utils"
 	"github.com/stackrox/rox/generated/storage"
 	converter "github.com/stackrox/rox/migrator/migrations/cvehelper"
 	"github.com/stackrox/rox/pkg/dackbox/edges"
@@ -19,6 +20,7 @@ func mergeComponents(parts *NodeParts, node *storage.Node) {
 		return
 	}
 
+	os := node.GetScan().GetOperatingSystem()
 	// Use the edges to combine into the parent node.
 	for _, cp := range parts.Children {
 		// Parse the IDs of the edge.
@@ -33,11 +35,11 @@ func mergeComponents(parts *NodeParts, node *storage.Node) {
 		}
 
 		// Generate an embedded component for the edge and non-embedded version.
-		node.Scan.Components = append(node.Scan.Components, generateEmbeddedComponent(cp))
+		node.Scan.Components = append(node.Scan.Components, generateEmbeddedComponent(os, cp))
 	}
 }
 
-func generateEmbeddedComponent(cp *ComponentParts) *storage.EmbeddedNodeScanComponent {
+func generateEmbeddedComponent(os string, cp *ComponentParts) *storage.EmbeddedNodeScanComponent {
 	if cp.Component == nil || cp.Edge == nil {
 		return nil
 	}
@@ -54,12 +56,12 @@ func generateEmbeddedComponent(cp *ComponentParts) *storage.EmbeddedNodeScanComp
 
 	ret.Vulns = make([]*storage.EmbeddedVulnerability, 0, len(cp.Children))
 	for _, cve := range cp.Children {
-		ret.Vulns = append(ret.Vulns, generateEmbeddedCVE(cve))
+		ret.Vulns = append(ret.Vulns, generateEmbeddedCVE(os, cve))
 	}
 	return ret
 }
 
-func generateEmbeddedCVE(cp *CVEParts) *storage.EmbeddedVulnerability {
+func generateEmbeddedCVE(os string, cp *CVEParts) *storage.EmbeddedVulnerability {
 	if cp.CVE == nil || cp.Edge == nil {
 		return nil
 	}
@@ -74,6 +76,14 @@ func generateEmbeddedCVE(cp *CVEParts) *storage.EmbeddedVulnerability {
 	// Only legacy vuln snoozing feature affected node vulns state.
 	if ret.GetSuppressed() {
 		ret.State = storage.VulnerabilityState_DEFERRED
+	}
+
+	if distroSpecifics, ok := cp.CVE.GetDistroSpecifics()[os]; ok {
+		ret.Severity = distroSpecifics.GetSeverity()
+		ret.Cvss = distroSpecifics.GetCvss()
+		ret.CvssV2 = distroSpecifics.GetCvssV2()
+		ret.CvssV3 = distroSpecifics.GetCvssV3()
+		ret.ScoreVersion = utils.CVEScoreVersionToEmbeddedScoreVersion(distroSpecifics.GetScoreVersion())
 	}
 
 	// The `Suppressed` field is transferred to `State` field in `converter.ProtoCVEToEmbeddedCVE` and node cve deferral

--- a/migrator/migrations/n_35_to_n_36_postgres_nodes/common/merge.go
+++ b/migrator/migrations/n_35_to_n_36_postgres_nodes/common/merge.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"github.com/stackrox/rox/central/cve/converter/utils"
 	"github.com/stackrox/rox/generated/storage"
 	converter "github.com/stackrox/rox/migrator/migrations/cvehelper"
 	"github.com/stackrox/rox/pkg/dackbox/edges"
@@ -83,7 +82,7 @@ func generateEmbeddedCVE(os string, cp *CVEParts) *storage.EmbeddedVulnerability
 		ret.Cvss = distroSpecifics.GetCvss()
 		ret.CvssV2 = distroSpecifics.GetCvssV2()
 		ret.CvssV3 = distroSpecifics.GetCvssV3()
-		ret.ScoreVersion = utils.CVEScoreVersionToEmbeddedScoreVersion(distroSpecifics.GetScoreVersion())
+		ret.ScoreVersion = converter.CVEScoreVersionToEmbeddedScoreVersion(distroSpecifics.GetScoreVersion())
 	}
 
 	// The `Suppressed` field is transferred to `State` field in `converter.ProtoCVEToEmbeddedCVE` and node cve deferral


### PR DESCRIPTION
## Description

Ross is working on adding severity to node scan(https://issues.redhat.com/browse/ROX-12261). He noticed that despite doing the relevant changes in Scanner, the severity was always unset. 
In Dackbox, the node vulnerability severity was never set when the records were read out of the DB.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
Unit
