### PR TITLE
Support multi-arch binaries

### DIFF
--- a/.openshift-ci/build/build-main-and-bundle.sh
+++ b/.openshift-ci/build/build-main-and-bundle.sh
@@ -135,7 +135,7 @@ build_main_and_bundles() {
     info "Copying binaries for image/"
     mkdir -p image/bin
     make copy-binaries-to-image-dir
-    cp bin/linux/roxctl image/roxctl/roxctl-linux
+    cp bin/linux_amd64/roxctl image/roxctl/roxctl-linux-amd64
 
     info "Building docs"
     make -C docs

--- a/Makefile
+++ b/Makefile
@@ -343,35 +343,39 @@ endif
 
 .PHONY: build-prep
 build-prep: deps
-	mkdir -p bin/{darwin,linux,windows}
+	mkdir -p bin/{darwin_amd64,linux_amd64,linux_ppc64le,linux_s390x,windows_amd64}
 
 .PHONY: cli-build
 cli-build: build-prep
 	RACE=0 CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) ./roxctl
 	RACE=0 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) ./roxctl
+	RACE=0 CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le $(GOBUILD) ./roxctl
+	RACE=0 CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(GOBUILD) ./roxctl
 ifdef CI
-	RACE=0 CGO_ENABLED=0 GOOS=windows $(GOBUILD) ./roxctl
+	RACE=0 CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GOBUILD) ./roxctl
 endif
 
 .PHONY: cli
 cli: cli-build
 	# Copy the user's specific OS into gopath
-	cp bin/$(HOST_OS)/roxctl $(GOPATH)/bin/roxctl
+	cp bin/$(HOST_OS)_$(GOARCH)/roxctl $(GOPATH)/bin/roxctl
 	chmod u+w $(GOPATH)/bin/roxctl
 
 cli-linux: build-prep
 	RACE=0 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) ./roxctl
+	RACE=0 CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le $(GOBUILD) ./roxctl
+	RACE=0 CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(GOBUILD) ./roxctl
 
 cli-darwin: build-prep
 	RACE=0 CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) ./roxctl
 
-upgrader: bin/$(HOST_OS)/upgrader
+upgrader: bin/$(HOST_OS)_$(GOARCH)/upgrader
 
-bin/%/upgrader: build-prep
-	GOOS=$* $(GOBUILD) ./sensor/upgrader
+bin/$(HOST_OS)_$(GOARCH)/upgrader: build-prep
+	GOOS=$(HOST_OS) GOARCH=$(GOARCH) $(GOBUILD) ./sensor/upgrader
 
-bin/%/admission-control: build-prep
-	GOOS=$* $(GOBUILD) ./sensor/admission-control
+bin/$(HOST_OS)_$(GOARCH)/admission-control: build-prep
+	GOOS=$(HOST_OS) GOARCH=$(GOARCH) $(GOBUILD) ./sensor/admission-control
 
 .PHONY: build-volumes
 build-volumes:
@@ -572,7 +576,7 @@ docker-build-data-image: docs-image
 
 .PHONY: docker-build-roxctl-image
 docker-build-roxctl-image:
-	cp -f bin/linux/roxctl image/roxctl/roxctl-linux
+	cp -f bin/linux_$(GOARCH)/roxctl image/roxctl/roxctl
 	docker build \
 		-t stackrox/roxctl:$(TAG) \
 		-t $(DEFAULT_IMAGE_REGISTRY)/roxctl:$(TAG) \
@@ -582,22 +586,24 @@ docker-build-roxctl-image:
 
 .PHONY: copy-go-binaries-to-image-dir
 copy-go-binaries-to-image-dir:
-	cp bin/linux/central image/bin/central
+	cp bin/linux_$(GOARCH)/central image/bin/central
 ifdef CI
-	cp bin/linux/roxctl image/bin/roxctl-linux
-	cp bin/darwin/roxctl image/bin/roxctl-darwin
-	cp bin/windows/roxctl.exe image/bin/roxctl-windows.exe
+	cp bin/linux_amd64/roxctl image/bin/roxctl-linux-amd64
+	cp bin/linux_ppc64le/roxctl image/bin/roxctl-linux-ppc64le
+	cp bin/linux_s390x/roxctl image/bin/roxctl-linux-s390x
+	cp bin/darwin_amd64/roxctl image/bin/roxctl-darwin-amd64
+	cp bin/windows_amd64/roxctl.exe image/bin/roxctl-windows-amd64.exe
 else
 ifneq ($(HOST_OS),linux)
-	cp bin/linux/roxctl image/bin/roxctl-linux
+	cp bin/linux_$(GOARCH)/roxctl image/bin/roxctl-linux-$(GOARCH)
 endif
-	cp bin/$(HOST_OS)/roxctl image/bin/roxctl-$(HOST_OS)
+	cp bin/$(HOST_OS)_amd64/roxctl image/bin/roxctl-$(HOST_OS)-amd64
 endif
-	cp bin/linux/migrator image/bin/migrator
-	cp bin/linux/kubernetes        image/bin/kubernetes-sensor
-	cp bin/linux/upgrader          image/bin/sensor-upgrader
-	cp bin/linux/admission-control image/bin/admission-control
-	cp bin/linux/collection        image/bin/compliance
+	cp bin/linux_$(GOARCH)/migrator image/bin/migrator
+	cp bin/linux_$(GOARCH)/kubernetes        image/bin/kubernetes-sensor
+	cp bin/linux_$(GOARCH)/upgrader          image/bin/sensor-upgrader
+	cp bin/linux_$(GOARCH)/admission-control image/bin/admission-control
+	cp bin/linux_$(GOARCH)/collection        image/bin/compliance
 	# Workaround to bug in lima: https://github.com/lima-vm/lima/issues/602
 	find image/bin -not -path "*/.*" -type f -exec chmod +x {} \;
 
@@ -614,10 +620,10 @@ endif
 
 .PHONY: scale-image
 scale-image: scale-build clean-image
-	cp bin/linux/mocksensor scale/image/bin/mocksensor
-	cp bin/linux/mockcollector scale/image/bin/mockcollector
-	cp bin/linux/profiler scale/image/bin/profiler
-	cp bin/linux/chaos scale/image/bin/chaos
+	cp bin/linux_$(GOARCH)/mocksensor scale/image/bin/mocksensor
+	cp bin/linux_$(GOARCH)/mockcollector scale/image/bin/mockcollector
+	cp bin/linux_$(GOARCH)/profiler scale/image/bin/profiler
+	cp bin/linux_$(GOARCH)/chaos scale/image/bin/chaos
 	chmod +w scale/image/bin/*
 	docker build \
 		-t stackrox/scale:$(TAG) \
@@ -626,7 +632,7 @@ scale-image: scale-build clean-image
 
 webhookserver-image: webhookserver-build
 	-mkdir webhookserver/bin
-	cp bin/linux/webhookserver webhookserver/bin/webhookserver
+	cp bin/linux_$(GOARCH)/webhookserver webhookserver/bin/webhookserver
 	chmod +w webhookserver/bin/webhookserver
 	docker build \
 		-t stackrox/webhookserver:1.2 \
@@ -635,7 +641,7 @@ webhookserver-image: webhookserver-build
 
 .PHONY: mock-grpc-server-image
 mock-grpc-server-image: mock-grpc-server-build clean-image
-	cp bin/linux/mock-grpc-server integration-tests/mock-grpc-server/image/bin/mock-grpc-server
+	cp bin/linux_$(GOARCH)/mock-grpc-server integration-tests/mock-grpc-server/image/bin/mock-grpc-server
 	docker build \
 		-t stackrox/grpc-server:$(TAG) \
 		-t quay.io/rhacs-eng/grpc-server:$(TAG) \

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -54,7 +54,7 @@ function hotload_binary {
   echo "**********"
   echo
 
-  binary_path=$(realpath "$(git rev-parse --show-toplevel)/bin/linux/${local_name}")
+  binary_path=$(realpath "$(git rev-parse --show-toplevel)/bin/linux_amd64/${local_name}")
   kubectl -n stackrox patch "deploy/${deployment}" -p '{"spec":{"template":{"spec":{"containers":[{"name":"'${deployment}'","volumeMounts":[{"mountPath":"/stackrox/'${binary_name}'","name":"'binary-${local_name}'"}]}],"volumes":[{"hostPath":{"path":"'${binary_path}'","type":""},"name":"'binary-${local_name}'"}]}}}}'
   kubectl -n stackrox set env "deploy/$deployment" "ROX_HOTRELOAD=true"
 }

--- a/dev-tools/roxctl.sh
+++ b/dev-tools/roxctl.sh
@@ -21,9 +21,9 @@ is_operator_on_openshift() {
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-roxctl_bin="$DIR/../bin/linux/roxctl"
+roxctl_bin="$DIR/../bin/linux_amd64/roxctl"
 if [[ "$(uname)" == "Darwin"* ]]; then
-  roxctl_bin="$DIR/../bin/darwin/roxctl"
+  roxctl_bin="$DIR/../bin/darwin_amd64/roxctl"
 fi
 
 cache=""

--- a/image/rhel/Dockerfile.envsubst
+++ b/image/rhel/Dockerfile.envsubst
@@ -43,7 +43,7 @@ RUN ln -s entrypoint-wrapper.sh /stackrox/admission-control && \
     ln -s entrypoint-wrapper.sh /stackrox/compliance && \
     ln -s entrypoint-wrapper.sh /stackrox/kubernetes-sensor && \
     ln -s entrypoint-wrapper.sh /stackrox/sensor-upgrader && \
-    ln -s /assets/downloads/cli/roxctl-linux /stackrox/roxctl && \
+    ln -s /assets/downloads/cli/roxctl-linux-amd64 /stackrox/roxctl && \
     rpm --import RPM-GPG-KEY-CentOS-Official && \
     microdnf upgrade && \
     rpm -i /tmp/snappy.rpm && \
@@ -72,6 +72,6 @@ EXPOSE 8443
 
 USER 4000:4000
 
-ENTRYPOINT ["/assets/downloads/cli/roxctl-linux"]
+ENTRYPOINT ["/stackrox/roxctl"]
 
 HEALTHCHECK CMD curl --insecure --fail https://127.0.0.1:8443/v1/ping

--- a/image/roxctl/Dockerfile
+++ b/image/roxctl/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8-minimal:latest AS certs
 
 FROM scratch
-COPY ./roxctl-linux /roxctl
+COPY ./roxctl /roxctl
 COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
 ENV ROX_ROXCTL_IN_MAIN_IMAGE="true"
 

--- a/image/templates/README.md
+++ b/image/templates/README.md
@@ -48,7 +48,7 @@ $ cdrox
 
 # Receive the rendered helm chart from roxctl
 # To use a custom template path use the `--debug-path=</path/to/templates>` argument.
-$ ./bin/darwin/roxctl helm output central-services --image-defaults=development_build --debug
+$ ./bin/darwin_amd64/roxctl helm output central-services --image-defaults=development_build --debug
 
 # Install the helm chart
 $ helm upgrade --install -n stackrox stackrox-central-services --create-namespace  ./stackrox-central-services-chart \

--- a/make/env.mk
+++ b/make/env.mk
@@ -19,6 +19,10 @@ ifeq ($(shell uname -ms),Darwin arm64)
 	GOARCH := arm64
 else ifeq ($(shell uname -ms),Linux aarch64)
 	GOARCH := arm64
+else ifeq ($(shell uname -ms),Linux ppc64le)
+	GOARCH := ppc64le
+else ifeq ($(shell uname -ms),Linux s390x)
+	GOARCH := s390x
 else
 	GOARCH := amd64
 endif

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -58,9 +58,9 @@ COPY operator/build/status.sh status.sh
 RUN git init && git add .
 
 # Build the operator binary.
-RUN GOOS=$(go env GOOS) scripts/go-build.sh operator
+RUN GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) scripts/go-build.sh operator
 # Copy the operator binary to a location from where it will be taken into the final image.
-RUN cp -a bin/$(go env GOOS)/operator stackrox-operator
+RUN cp -a bin/$(go env GOOS)_$(go env GOARCH)/operator stackrox-operator
 
 FROM registry.access.redhat.com/ubi8-micro:8.6
 

--- a/qa-tests-backend/local-test-example/step1-setup-macos.sh
+++ b/qa-tests-backend/local-test-example/step1-setup-macos.sh
@@ -88,9 +88,9 @@ function setup_roxctl {
   local target url
   target="$GOPATH/bin/roxctl"
   if is_linux; then
-    url="https://mirror.openshift.com/pub/rhacs/assets/$MAIN_IMAGE_TAG/bin/linux/roxctl"
+    url="https://mirror.openshift.com/pub/rhacs/assets/$MAIN_IMAGE_TAG/bin/linux_amd64/roxctl"
   elif is_darwin; then
-    url="https://mirror.openshift.com/pub/rhacs/assets/$MAIN_IMAGE_TAG/bin/darwin/roxctl"
+    url="https://mirror.openshift.com/pub/rhacs/assets/$MAIN_IMAGE_TAG/bin/darwin_amd64/roxctl"
   else
     error "Unknown OS [$(uname)]"
   fi

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -78,7 +78,7 @@ setup_deployment_env() {
 install_built_roxctl_in_gopath() {
     require_environment "GOPATH"
 
-    local bin_os
+    local bin_os bin_platform
     if is_darwin; then
         bin_os="darwin"
     elif is_linux; then
@@ -87,7 +87,15 @@ install_built_roxctl_in_gopath() {
         die "Only linux or darwin are supported for this test"
     fi
 
-    local roxctl="$SCRIPTS_ROOT/bin/$bin_os/roxctl"
+    case "$(uname -m)" in
+        x86_64) bin_platform="${bin_os}_amd64" ;;
+        aarch64) bin_platform="${bin_os}_arm64" ;;
+        ppc64le) bin_platform="${bin_os}_ppc64le" ;;
+        s390x) bin_platform="${bin_os}_s390x" ;;
+        *) die "Unknown architecture" ;;
+    esac
+
+    local roxctl="$SCRIPTS_ROOT/bin/${bin_platform}/roxctl"
 
     require_executable "$roxctl" "roxctl should be built"
 

--- a/scripts/ci/roxctl-publish/prepare.sh
+++ b/scripts/ci/roxctl-publish/prepare.sh
@@ -20,6 +20,7 @@ target_dir="${2:-}"
 
 mkdir "${target_dir}/bin"
 
+# x86_64; directory names without architecture for compatibility
 for platform in Linux Darwin Windows; do
   platform_lower="$(echo "$platform" | tr A-Z a-z)"
 
@@ -30,8 +31,8 @@ for platform in Linux Darwin Windows; do
   if [[ "${platform}" == "Windows" ]]; then
     roxctl_bin="roxctl.exe"
   fi
-  cp "${source_dir}/bin/${platform_lower}/${roxctl_bin}" "${target_dir}/bin/${platform}/${roxctl_bin}"
-  cp "${source_dir}/bin/${platform_lower}/${roxctl_bin}" "${target_dir}/bin/${platform_lower}/${roxctl_bin}"
+  cp "${source_dir}/bin/${platform_lower}_amd64/${roxctl_bin}" "${target_dir}/bin/${platform}/${roxctl_bin}"
+  cp "${source_dir}/bin/${platform_lower}_amd64/${roxctl_bin}" "${target_dir}/bin/${platform_lower}/${roxctl_bin}"
 done
 
 # Create sha256sum.txt checksum files

--- a/scripts/go-tool.sh
+++ b/scripts/go-tool.sh
@@ -74,13 +74,14 @@ function invoke_go() {
 function go_build() (
   export GOOS="${GOOS:-${DEFAULT_GOOS}}"
   [[ -n "$GOOS" ]] || die "GOOS must be set"
+  [[ -n "$GOARCH" ]] || die "GOARCH must be set"
 
   for main_srcdir in "$@"; do
     if ! [[ "${main_srcdir}" =~ ^\.?/ ]]; then
       main_srcdir="./${main_srcdir}"
     fi
     bin_name="$(basename "$main_srcdir")"
-    output_file="bin/${GOOS}/${bin_name}"
+    output_file="bin/${GOOS}_${GOARCH}/${bin_name}"
     if [[ "$GOOS" == "windows" ]]; then
       output_file="${output_file}.exe"
     fi

--- a/tests/roxctl/bats-tests/helpers.bash
+++ b/tests/roxctl/bats-tests/helpers.bash
@@ -25,7 +25,7 @@ roxctl-development-cmd() {
     _uname="$(luname)"
     mkdir -p "$tmp_roxctl"
     make -s "cli-${_uname}" GOTAGS='' 2>&3
-    mv "bin/${_uname}/roxctl" "${tmp_roxctl}/roxctl-dev"
+    mv "bin/${_uname}_amd64/roxctl" "${tmp_roxctl}/roxctl-dev"
   fi
   echo "${tmp_roxctl}/roxctl-dev"
 }
@@ -41,7 +41,7 @@ roxctl-release-cmd() {
     _uname="$(luname)"
     mkdir -p "$tmp_roxctl"
     make -s "cli-${_uname}" GOTAGS='release' 2>&3
-    mv "bin/${_uname}/roxctl" "${tmp_roxctl}/roxctl-release"
+    mv "bin/${_uname}_amd64/roxctl" "${tmp_roxctl}/roxctl-release"
   fi
   echo "${tmp_roxctl}/roxctl-release"
 }

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -71,16 +71,25 @@ test_upgrade() {
 preamble() {
     info "Starting test preamble"
 
+    local host_os
     if is_darwin; then
-        TEST_HOST_OS="darwin"
+        host_os="darwin"
     elif is_linux; then
-        TEST_HOST_OS="linux"
+        host_os="linux"
     else
         die "Only linux or darwin are supported for this test"
     fi
 
-    require_executable "$TEST_ROOT/bin/$TEST_HOST_OS/roxctl"
-    require_executable "$TEST_ROOT/bin/$TEST_HOST_OS/upgrader"
+    case "$(uname -m)" in
+        x86_64) TEST_HOST_PLATFORM="${host_os}_amd64" ;;
+        aarch64) TEST_HOST_PLATFORM="${host_os}_arm64" ;;
+        ppc64le) TEST_HOST_PLATFORM="${host_os}_ppc64le" ;;
+        s390x) TEST_HOST_PLATFORM="${host_os}_s390x" ;;
+        *) die "Unknown architecture" ;;
+    esac
+
+    require_executable "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/roxctl"
+    require_executable "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/upgrader"
 
     info "Will clone or update a clean copy of the rox repo for test at $REPO_FOR_TIME_TRAVEL"
     if [[ -d "$REPO_FOR_TIME_TRAVEL" ]]; then
@@ -116,7 +125,7 @@ validate_sensor_bundle_via_upgrader() {
     sleep 5
 
     KUBECONFIG="$TEST_ROOT/scripts/ci/kube-api-proxy/config.yml" \
-        "$TEST_ROOT/bin/$TEST_HOST_OS/upgrader" \
+        "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/upgrader" \
         -kube-config kubectl \
         -local-bundle "$deploy_dir/sensor-deploy" \
         -workflow validate-bundle
@@ -128,7 +137,7 @@ test_sensor_bundle() {
     info "Testing the sensor bundle"
 
     rm -rf sensor-remote
-    "$TEST_ROOT/bin/$TEST_HOST_OS/roxctl" -e "$API_ENDPOINT" -p "$ROX_PASSWORD" sensor get-bundle remote
+    "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/roxctl" -e "$API_ENDPOINT" -p "$ROX_PASSWORD" sensor get-bundle remote
     [[ -d sensor-remote ]]
 
     ./sensor-remote/sensor.sh
@@ -149,7 +158,7 @@ test_upgrader() {
     info "Creating a 'sensor-remote-new' cluster"
 
     rm -rf sensor-remote-new
-    "$TEST_ROOT/bin/$TEST_HOST_OS/roxctl" -e "$API_ENDPOINT" -p "$ROX_PASSWORD" sensor generate k8s \
+    "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/roxctl" -e "$API_ENDPOINT" -p "$ROX_PASSWORD" sensor generate k8s \
         --main-image-repository "${MAIN_IMAGE_REPO:-$REGISTRY/main}" \
         --collector-image-repository "${COLLECTOR_IMAGE_REPO:-$REGISTRY/collector}" \
         --name remote-new \
@@ -281,7 +290,7 @@ deploy_sensor_via_upgrader() {
         ROX_MTLS_CERT_FILE="$TEST_ROOT/sensor-remote-new/sensor-cert.pem" \
         ROX_MTLS_KEY_FILE="$TEST_ROOT/sensor-remote-new/sensor-key.pem" \
         KUBECONFIG="$TEST_ROOT/scripts/ci/kube-api-proxy/config.yml" \
-        "$TEST_ROOT/bin/$TEST_HOST_OS/upgrader" -workflow roll-forward -local-bundle sensor-remote-new -kube-config kubectl
+        "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/upgrader" -workflow roll-forward -local-bundle sensor-remote-new -kube-config kubectl
 
     kill "$proxy_pid"
 
@@ -307,7 +316,7 @@ rollback_sensor_via_upgrader() {
         ROX_MTLS_CERT_FILE="$TEST_ROOT/sensor-remote-new/sensor-cert.pem" \
         ROX_MTLS_KEY_FILE="$TEST_ROOT/sensor-remote-new/sensor-key.pem" \
         KUBECONFIG="$TEST_ROOT/scripts/ci/kube-api-proxy/config.yml" \
-        "$TEST_ROOT/bin/$TEST_HOST_OS/upgrader" -workflow roll-back -kube-config kubectl
+        "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/upgrader" -workflow roll-back -kube-config kubectl
 
     kill "$proxy_pid"
 }
@@ -375,7 +384,7 @@ test_upgrade_paths() {
 
     info "Fetching a sensor bundle for cluster 'remote'"
     rm -rf sensor-remote
-    "$TEST_ROOT/bin/$TEST_HOST_OS/roxctl" -e "$API_ENDPOINT" -p "$ROX_PASSWORD" sensor get-bundle remote
+    "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/roxctl" -e "$API_ENDPOINT" -p "$ROX_PASSWORD" sensor get-bundle remote
     [[ -d sensor-remote ]]
 
     info "Installing sensor"
@@ -400,12 +409,12 @@ test_upgrade_paths() {
 deploy_earlier_central() {
     info "Deploying: $EARLIER_TAG..."
 
-    mkdir -p "bin/$TEST_HOST_OS"
-    gsutil cp "gs://stackrox-ci/roxctl-$EARLIER_TAG" "bin/$TEST_HOST_OS/roxctl"
-    chmod +x "bin/$TEST_HOST_OS/roxctl"
-    PATH="bin/$TEST_HOST_OS:$PATH" command -v roxctl
-    PATH="bin/$TEST_HOST_OS:$PATH" roxctl version
-    PATH="bin/$TEST_HOST_OS:$PATH" \
+    mkdir -p "bin/${TEST_HOST_PLATFORM}"
+    gsutil cp "gs://stackrox-ci/roxctl-$EARLIER_TAG" "bin/${TEST_HOST_PLATFORM}/roxctl"
+    chmod +x "bin/${TEST_HOST_PLATFORM}/roxctl"
+    PATH="bin/${TEST_HOST_PLATFORM}:$PATH" command -v roxctl
+    PATH="bin/${TEST_HOST_PLATFORM}:$PATH" roxctl version
+    PATH="bin/${TEST_HOST_PLATFORM}:$PATH" \
     MAIN_IMAGE_TAG="$EARLIER_TAG" \
     SCANNER_IMAGE="$REGISTRY/scanner:$(cat SCANNER_VERSION)" \
     SCANNER_DB_IMAGE="$REGISTRY/scanner-db:$(cat SCANNER_VERSION)" \

--- a/ui/apps/platform/src/Containers/MainPage/Header/CLIDownloadMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/CLIDownloadMenu.tsx
@@ -37,25 +37,25 @@ function CLIDownloadMenu({ addToast, removeToast }: CLIDownloadMenuProps): React
 
     const appLauncherItems = [
         <ApplicationLauncherItem
-            key="app-launcher-item-cli-mac"
+            key="app-launcher-item-cli-mac-amd64"
             component="button"
-            onClick={handleDownloadCLI('darwin')}
+            onClick={handleDownloadCLI('darwin-amd64')}
         >
-            Mac 64-bit
+            Mac x86_64
         </ApplicationLauncherItem>,
         <ApplicationLauncherItem
-            key="app-launcher-item-cli-linux"
+            key="app-launcher-item-cli-linux-amd64"
             component="button"
-            onClick={handleDownloadCLI('linux')}
+            onClick={handleDownloadCLI('linux-amd64')}
         >
-            Linux 64-bit
+            Linux x86_64
         </ApplicationLauncherItem>,
         <ApplicationLauncherItem
-            key="app-launcher-item-cli-windows"
+            key="app-launcher-item-cli-windows-amd64"
             component="button"
-            onClick={handleDownloadCLI('windows')}
+            onClick={handleDownloadCLI('windows-amd64')}
         >
-            Windows 64-bit
+            Windows x86_64
         </ApplicationLauncherItem>,
     ];
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/DownloadCLIDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/DownloadCLIDropdown.tsx
@@ -40,14 +40,14 @@ function DownloadCLIDropdown({ hasBuild }) {
             isOpen={isCLIDropdownOpen}
             onSelect={handleDownloadCLI}
             dropdownItems={[
-                <DropdownItem value="darwin" component="button">
-                    Mac 64-bit
+                <DropdownItem value="darwin-amd64" component="button">
+                    Mac x86_64
                 </DropdownItem>,
-                <DropdownItem value="linux" component="button">
-                    Linux 64-bit
+                <DropdownItem value="linux-amd64" component="button">
+                    Linux x86_64
                 </DropdownItem>,
-                <DropdownItem value="windows" component="button">
-                    Windows 64-bit
+                <DropdownItem value="windows-amd64" component="button">
+                    Windows x86_64
                 </DropdownItem>,
             ]}
         />

--- a/ui/apps/platform/src/services/CLIService.js
+++ b/ui/apps/platform/src/services/CLIService.js
@@ -8,9 +8,9 @@ import { saveFile } from 'services/DownloadService';
 export default function downloadCLI(type) {
     let name = 'roxctl';
     let suffix = type;
-    if (type === 'windows') {
+    if (type.startsWith('windows-')) {
         name = 'roxctl.exe';
-        suffix = 'windows.exe';
+        suffix += '.exe';
     }
     return saveFile({
         method: 'get',


### PR DESCRIPTION
## Description

Make all binary paths and names contain both OS and ARCH, as a prerequisite of multi-architecture enablement.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Relying on CI to verify.
