### PR TITLE
ROX-11284: Map ClusterCVE to Cluster resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ authentication is still required for an email notifier, but the user can now cho
   `v1/policycategories` endpoint have been removed.
 - Support for violation tags and process tags has been removed.
 ### Deprecated Features
+- ROX-11284: Permission `ClusterCVE` is deprecated and will be superseded by the existing permission `Cluster`.
 ### Technical Changes
 - ROX-11181: Any clusters that have been unhealthy (defined as central being unable to reach sensor running on those clusters) for a configured period of time will be automatically removed. The number of days after which an 'unhealthy' cluster is removed can be configured in the System Configuration page or using the cluster API.
   - Any cluster that is expected to be unavailable for a period of time (e.g. clusters used in disaster recovery), can be tagged with a customizable label. Clusters with those labels will never be removed automatically.

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -43,7 +43,7 @@ const (
 var (
 	log            = logging.LoggerForModule()
 	schema         = pkgSchema.ClusterCvesSchema
-	targetResource = resources.ClusterCVE
+	targetResource = resources.Cluster
 )
 
 type Store interface {

--- a/central/role/resources/list.go
+++ b/central/role/resources/list.go
@@ -28,18 +28,14 @@ var (
 	// Administration is the new resource grouping all administration-like resources.
 	Administration = newResourceMetadata("Administration", permissions.GlobalScope)
 	Alert          = newResourceMetadata("Alert", permissions.NamespaceScope)
-	// SAC check is not performed directly on CVE resource. It exists here for postgres sac generation to pass.
-	CVE     = newResourceMetadata("CVE", permissions.NamespaceScope)
-	Cluster = newResourceMetadata("Cluster", permissions.ClusterScope)
-	// SAC check is not performed directly on ClusterCVE resource. It exists here for postgres sac generation to pass.
-	ClusterCVE = newResourceMetadata("ClusterCVE", permissions.ClusterScope)
-	Compliance = newResourceMetadata("Compliance", permissions.ClusterScope)
-	Deployment = newResourceMetadata("Deployment", permissions.NamespaceScope)
+	CVE            = newResourceMetadata("CVE", permissions.NamespaceScope)
+	Cluster        = newResourceMetadata("Cluster", permissions.ClusterScope)
+	Compliance     = newResourceMetadata("Compliance", permissions.ClusterScope)
+	Deployment     = newResourceMetadata("Deployment", permissions.NamespaceScope)
 	// DeploymentExtension is the new resource grouping all deployment extending resources.
 	DeploymentExtension = newResourceMetadata("DeploymentExtension", permissions.NamespaceScope)
 	Detection           = newResourceMetadata("Detection", permissions.GlobalScope)
 	Image               = newResourceMetadata("Image", permissions.NamespaceScope)
-
 	// Integration is the new  resource grouping all integration resources.
 	Integration                      = newResourceMetadata("Integration", permissions.GlobalScope)
 	K8sRole                          = newResourceMetadata("K8sRole", permissions.NamespaceScope)
@@ -69,6 +65,7 @@ var (
 		Access)
 	BackupPlugins = newDeprecatedResourceMetadata("BackupPlugins", permissions.GlobalScope,
 		Integration)
+	ClusterCVE     = newDeprecatedResourceMetadata("ClusterCVE", permissions.ClusterScope, Cluster)
 	ComplianceRuns = newDeprecatedResourceMetadata("ComplianceRuns", permissions.ClusterScope,
 		Compliance)
 	ComplianceRunSchedule = newDeprecatedResourceMetadata("ComplianceRunSchedule",

--- a/tools/generate-helpers/pg-table-bindings/list.go
+++ b/tools/generate-helpers/pg-table-bindings/list.go
@@ -18,6 +18,7 @@ func init() {
 	for s, r := range map[proto.Message]permissions.ResourceHandle{
 		&storage.ActiveComponent{}:                              resources.Deployment,
 		&storage.ClusterHealthStatus{}:                          resources.Cluster,
+		&storage.ClusterCVE{}:                                   resources.Cluster,
 		&storage.ClusterCVEEdge{}:                               resources.Cluster,
 		&storage.ComplianceControlResult{}:                      resources.Compliance,
 		&storage.ComplianceDomain{}:                             resources.Compliance,


### PR DESCRIPTION
## Description

The `ClusterCVE` resource was added during the dackbox re-design for postgres in order to allow the store code generation to work.
Technically, the access scope for cluster-related vulnerabilities should be driven by the `Cluster` resource. This is being addressed by the current change

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI run should be enough.
Additional tests will be introduced through a dedicated task as part of the datastore SAC test coverage effort.