### PR TITLE
ROX-12288: Collect pod logs AFTER we are done talking to them.

### DIFF
--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -119,12 +119,12 @@ class PostClusterTest(StoreArtifacts):
         self.collect_central_artifacts = collect_central_artifacts
 
     def run(self, test_outputs=None):
-        self.collect_service_logs()
         self.collect_collector_metrics()
         if self.collect_central_artifacts and self.wait_for_central_api():
             self.get_central_debug_dump()
             self.get_central_diagnostics()
             self.grab_central_data()
+        self.collect_service_logs()
         if self._check_stackrox_logs:
             self.check_stackrox_logs()
         self.store_artifacts(test_outputs)


### PR DESCRIPTION
## Description

The referenced ticket is about failed attempt to fetch debug metrics dump.
It looks like the cause would be logged by central, but unfortunately the logs we have were fetched BEFORE the failure.

Reordering the steps should make it possible to investigate similar things in the future.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Relying on CI.