### PR TITLE
Remove import of classic policies selectors from violations integration test

### DIFF
--- a/ui/apps/platform/cypress/integration/violations/violations.test.js
+++ b/ui/apps/platform/cypress/integration/violations/violations.test.js
@@ -1,5 +1,4 @@
 import { selectors } from '../../constants/ViolationsPage';
-import { selectors as PoliciesPageSelectors } from '../../constants/PoliciesPage';
 import withAuth from '../../helpers/basicAuth';
 import {
     clickDeploymentTabWithFixture,
@@ -153,7 +152,10 @@ describe('Violations page', () => {
         visitViolationWithFixture('alerts/alertFirstInAlerts.json');
 
         cy.get(selectors.details.policyTab).click();
-        cy.get(PoliciesPageSelectors.policyDetailsPanel.detailsSection);
+        cy.get('h3:contains("Policy overview")');
+        cy.get('h3:contains("Policy behavior")');
+        cy.get('h3:contains("Policy criteria")');
+        // Conditionally rendered: Policy scope
     });
 
     it('should sort violations when clicking on a table header', () => {


### PR DESCRIPTION
## Description

Limit the changed files to policies folder in a future contribution which removes the classic selectors.

Prefer assertions about what what users see to assertion about `data-testid` attribute.

Although this damp readable rewrite might require changes to a few similar assertions in violations and policies tests, if there are changes to the reusable `PolicyDetailContent` component, there is no guarantee that a dry abstract rewrite would avoid the possibility of changes.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed

For local deployment: run the test individually, and then run all tests in the file.