### PR TITLE
Several related fixes for VM Postgres display

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.js
@@ -28,6 +28,10 @@ export function getFilteredCVEColumns(columns, workflowState) {
     const shouldKeepEntitiesColumn =
         !workflowState.isPrecedingSingle(entityTypes.COMPONENT) ||
         !workflowState.getSingleAncestorOfType(entityTypes.NODE);
+    // special case CLUSTER CVE under CLUSTER
+    const clusterCveUnderCluster =
+        workflowState.getSingleAncestorOfType(entityTypes.CLUSTER) &&
+        currentEntityType === entityTypes.CLUSTER_CVE;
 
     // TODO: remove this temporary conditional check, after generic CVE list is removed
     const shouldKeepCveType =
@@ -55,7 +59,7 @@ export function getFilteredCVEColumns(columns, workflowState) {
                 return shouldKeepDiscoveredAtImageColumn;
             }
             case 'entities': {
-                return shouldKeepEntitiesColumn;
+                return shouldKeepEntitiesColumn && !clusterCveUnderCluster;
             }
             case 'severity': {
                 return shouldKeepSeverity || shouldKeepDiscoveredAtImageColumn;

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
@@ -323,27 +323,40 @@ const getEntitiesByContext = (entityContext, showVmUpdates) => {
             });
         }
     } else {
-        if (entityContext === {} || !entityContext[entityTypes.NODE_COMPONENT]) {
+        if (
+            entityContext === {} ||
+            (!entityContext[entityTypes.NODE_COMPONENT] && !entityContext[entityTypes.IMAGE])
+        ) {
             entities.push({
                 label: 'Top Riskiest Node Components',
                 value: entityTypes.NODE_COMPONENT,
             });
         }
-        if (entityContext === {} || !entityContext[entityTypes.IMAGE_COMPONENT]) {
+        if (
+            entityContext === {} ||
+            (!entityContext[entityTypes.IMAGE_COMPONENT] && !entityContext[entityTypes.NODE])
+        ) {
             entities.push({
                 label: 'Top Riskiest Image Components',
                 value: entityTypes.IMAGE_COMPONENT,
             });
         }
     }
-    if (entityContext === {} || !entityContext[entityTypes.IMAGE] || entities.length === 0) {
+    if (
+        entityContext === {} ||
+        (!entityContext[entityTypes.IMAGE] && !entityContext[entityTypes.NODE]) ||
+        entities.length === 0
+    ) {
         // unshift so it sits at the front of the list (in case both entity types are added, image should come first)
         entities.unshift({
             label: 'Top Riskiest Images',
             value: entityTypes.IMAGE,
         });
     }
-    if (entityContext === {} || !entityContext[entityTypes.NODE]) {
+    if (
+        entityContext === {} ||
+        (!entityContext[entityTypes.NODE] && !entityContext[entityTypes.IMAGE])
+    ) {
         entities.push({
             label: 'Top Riskiest Nodes',
             value: entityTypes.NODE,

--- a/ui/apps/platform/src/utils/queryService.js
+++ b/ui/apps/platform/src/utils/queryService.js
@@ -72,12 +72,35 @@ function entityContextToQueryObject(entityContext) {
         const entityQueryObj = {};
         if (key === entityTypes.IMAGE) {
             entityQueryObj[`${key} SHA`] = entityContext[key];
-        } else if (key === entityTypes.COMPONENT) {
-            const parsedComponentID = entityContext[key].split(':').map(decodeBase64);
+        } else if (
+            key === entityTypes.COMPONENT ||
+            key === entityTypes.IMAGE_COMPONENT ||
+            key === entityTypes.NODE_COMPONENT
+        ) {
+            const parsedComponentID =
+                key === entityTypes.COMPONENT
+                    ? entityContext[key].split(':').map(decodeBase64)
+                    : entityContext[key].split('#');
             // eslint-disable-next-line dot-notation
-            [entityQueryObj['COMPONENT'], entityQueryObj[`COMPONENT VERSION`]] = parsedComponentID;
-        } else if (key === entityTypes.CVE) {
-            entityQueryObj[key] = entityContext[key];
+            [
+                entityQueryObj.COMPONENT,
+                entityQueryObj[`COMPONENT VERSION`],
+                entityQueryObj['COMPONENT OS'],
+            ] = parsedComponentID;
+            if (entityQueryObj['COMPONENT OS']) {
+                entityQueryObj[`COMPONENT VERSION`] = `${entityQueryObj[`COMPONENT VERSION`]}#${
+                    entityQueryObj[`COMPONENT OS`]
+                }`;
+
+                delete entityQueryObj[`COMPONENT OS`];
+            }
+        } else if (
+            key === entityTypes.CVE ||
+            key === entityTypes.IMAGE_CVE ||
+            key === entityTypes.NODE_CVE ||
+            key === entityTypes.CLUSTER_CVE
+        ) {
+            entityQueryObj.CVE = entityContext[key];
         } else {
             entityQueryObj[`${key} ID`] = entityContext[key];
         }

--- a/ui/apps/platform/src/utils/queryService.test.js
+++ b/ui/apps/platform/src/utils/queryService.test.js
@@ -61,5 +61,79 @@ describe('queryService.', () => {
                 'COMPONENT VERSION': '3.4.3-1ubuntu1~14.04.7',
             });
         });
+
+        it('returns the query object for an Image Component', () => {
+            const entityContext = {
+                IMAGE_COMPONENT: 'openssl#1.1.1d-0+deb10u7#debian:10',
+            };
+
+            const queryObject = queryService.entityContextToQueryObject(entityContext);
+
+            expect(queryObject).toEqual({
+                COMPONENT: 'openssl',
+                'COMPONENT VERSION': '1.1.1d-0+deb10u7#debian:10',
+            });
+        });
+
+        it('returns the query object for a Node Component', () => {
+            const entityContext = {
+                NODE_COMPONENT: 'linux-gke#5.4.0-1068#ubuntu:20.04',
+            };
+
+            const queryObject = queryService.entityContextToQueryObject(entityContext);
+
+            expect(queryObject).toEqual({
+                COMPONENT: 'linux-gke',
+                'COMPONENT VERSION': '5.4.0-1068#ubuntu:20.04',
+            });
+        });
+
+        it('returns the query object for a CVE', () => {
+            const entityContext = {
+                CVE: 'CVE-2022-2068',
+            };
+
+            const queryObject = queryService.entityContextToQueryObject(entityContext);
+
+            expect(queryObject).toEqual({
+                CVE: 'CVE-2022-2068',
+            });
+        });
+
+        it('returns the query object for an IMAGE CVE', () => {
+            const entityContext = {
+                CVE: 'CVE-2005-2541#debian:10',
+            };
+
+            const queryObject = queryService.entityContextToQueryObject(entityContext);
+
+            expect(queryObject).toEqual({
+                CVE: 'CVE-2005-2541#debian:10',
+            });
+        });
+
+        it('returns the query object for a NODE CVE', () => {
+            const entityContext = {
+                CVE: 'CVE-2022-27223#ubuntu:20.04',
+            };
+
+            const queryObject = queryService.entityContextToQueryObject(entityContext);
+
+            expect(queryObject).toEqual({
+                CVE: 'CVE-2022-27223#ubuntu:20.04',
+            });
+        });
+
+        it('returns the query object for a CLUSTER CVE', () => {
+            const entityContext = {
+                CVE: 'CVE-2020-8554#K8S_CVE',
+            };
+
+            const queryObject = queryService.entityContextToQueryObject(entityContext);
+
+            expect(queryObject).toEqual({
+                CVE: 'CVE-2020-8554#K8S_CVE',
+            });
+        });
     });
 });


### PR DESCRIPTION
## Description

Several related fixes for VM Postgres display
*  Use existing search terms for new split CVE and COMPONENT types _(see unit tests for examples)_
* Remove Entities column for cluster CVEs under a cluster (an empty column otherwise
* Fixed Top Riskiest Image Components widget for an image

## Checklist
- [x] Investigated and inspected CI test results (failure is unrelated flakey test suite, `ci/prow/openshift-newest-qa-e2e-tests`)
- [x] Unit test and regression tests added

## Testing Performed

Image Vulnerability search
<img width="1450" alt="image_vulnerability-search" src="https://user-images.githubusercontent.com/715729/186774503-26117933-2f50-40d0-9c2d-f6ff52f23807.png">

Node Vulnerability search
<img width="1450" alt="node_vulnerability-search" src="https://user-images.githubusercontent.com/715729/186774651-2f2a9b7b-3e8a-4203-8144-5166b6f32715.png">

Cluster Vulnerability search
<img width="1450" alt="cluster_vulnerability-search" src="https://user-images.githubusercontent.com/715729/186774627-6c74a8df-0bf7-4c03-b833-305c3dea6a04.png">

Image Component search
<img width="1450" alt="image_component-search" src="https://user-images.githubusercontent.com/715729/186774601-794ee97f-d2b5-4556-b9b9-85ee32dc3ffa.png">

Node Component search
<img width="1450" alt="node_component-search" src="https://user-images.githubusercontent.com/715729/186774485-b567594c-19ab-43e5-8d54-5a2b93e80f16.png">


Cluster > Cluster CVEs sub-list BEFORE, with empty entities column
![cluster- cluster-cves-BAD](https://user-images.githubusercontent.com/715729/186774457-fbcdefd5-af47-47c4-b2cc-dc562e474c0e.png)

Cluster > Cluster CVEs sub-list AFTER, with empty column removed
![cluster- cluster-cves-GOOD](https://user-images.githubusercontent.com/715729/186774449-96045ea5-b570-4075-afa6-e3c3ad3a8f19.png)


Top Riskiest <thing> widget now only shows Image Components when on a single Image overview page
![fixed-Top_Riskiest_Image_Components-for an Image](https://user-images.githubusercontent.com/715729/186774436-03201e56-f655-42cf-a1d8-c34bc902752f.png)


