### PR TITLE
[ROX-11437] Batch resolve alerts operations to get performance boost

### DIFF
--- a/central/alert/datastore/bench_postgres_test.go
+++ b/central/alert/datastore/bench_postgres_test.go
@@ -1,0 +1,67 @@
+//go:build sql_integration
+// +build sql_integration
+
+package datastore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/central/alert/datastore/internal/search"
+	postgresStore "github.com/stackrox/rox/central/alert/datastore/internal/store/postgres"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkDBsWithPostgres(b *testing.B) {
+	ctx := sac.WithAllAccess(context.Background())
+	b.Setenv(env.PostgresDatastoreEnabled.EnvVar(), "true")
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		b.Skipf("%q not set. Skip postgres test", env.PostgresDatastoreEnabled.EnvVar())
+		b.SkipNow()
+	}
+
+	source := pgtest.GetConnectionString(b)
+	config, err := pgxpool.ParseConfig(source)
+	require.NoError(b, err)
+	db, err := pgxpool.ConnectConfig(ctx, config)
+	require.NoError(b, err)
+	gormDB := pgtest.OpenGormDB(b, source)
+	defer pgtest.CloseGormDB(b, gormDB)
+
+	postgresStore.Destroy(ctx, db)
+	store := postgresStore.CreateTableAndNewStore(ctx, db, gormDB)
+	indexer := postgresStore.NewIndexer(db)
+	datastore, err := New(store, indexer, search.New(store, indexer))
+	require.NoError(b, err)
+
+	var ids []string
+	for i := 0; i < 15000; i++ {
+		id := fmt.Sprintf("%d", i)
+		ids = append(ids, id)
+		a := fixtures.GetAlertWithID(id)
+		require.NoError(b, store.Upsert(ctx, a))
+	}
+
+	log.Info("Successfully loaded the DB")
+
+	b.Run("markStale", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, id := range ids {
+				require.NoError(b, datastore.MarkAlertStale(ctx, id))
+			}
+		}
+	})
+
+	b.Run("markStaleBatch", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err := datastore.MarkAlertStaleBatch(ctx, ids...)
+			require.NoError(b, err)
+		}
+	})
+}

--- a/central/alert/datastore/bench_postgres_test.go
+++ b/central/alert/datastore/bench_postgres_test.go
@@ -19,13 +19,13 @@ import (
 )
 
 func BenchmarkDBsWithPostgres(b *testing.B) {
-	ctx := sac.WithAllAccess(context.Background())
 	b.Setenv(env.PostgresDatastoreEnabled.EnvVar(), "true")
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
 		b.Skipf("%q not set. Skip postgres test", env.PostgresDatastoreEnabled.EnvVar())
 		b.SkipNow()
 	}
 
+	ctx := sac.WithAllAccess(context.Background())
 	source := pgtest.GetConnectionString(b)
 	config, err := pgxpool.ParseConfig(source)
 	require.NoError(b, err)

--- a/central/alert/datastore/bench_test.go
+++ b/central/alert/datastore/bench_test.go
@@ -7,45 +7,61 @@ import (
 
 	"github.com/stackrox/rox/central/alert/datastore/internal/index"
 	"github.com/stackrox/rox/central/alert/datastore/internal/search"
-	"github.com/stackrox/rox/central/alert/datastore/internal/store"
 	rocksDBStore "github.com/stackrox/rox/central/alert/datastore/internal/store/rocksdb"
 	"github.com/stackrox/rox/central/globalindex"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
 	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkDBs(b *testing.B) {
-	b.Run("rocksdb", func(b *testing.B) {
-		db, err := rocksdb.NewTemp("alert_bench_test")
-		defer rocksdbtest.TearDownRocksDB(db)
+	ctx := sac.WithAllAccess(context.Background())
 
-		require.NoError(b, err)
-		benchmarkLoad(b, rocksDBStore.New(db))
-	})
-}
+	db, err := rocksdb.NewTemp("alert_bench_test")
+	require.NoError(b, err)
+	defer rocksdbtest.TearDownRocksDB(db)
 
-func benchmarkLoad(b *testing.B, s store.Store) {
-	ctx := context.TODO()
 	tmpIndex, err := globalindex.TempInitializeIndices("")
 	require.NoError(b, err)
-	idx := index.New(tmpIndex)
+	defer tmpIndex.Close()
 
+	s := rocksDBStore.New(db)
+	idx := index.New(tmpIndex)
 	datastore, err := New(s, idx, search.New(s, idx))
 	require.NoError(b, err)
 	datastoreImpl := datastore.(*datastoreImpl)
 
+	var ids []string
 	for i := 0; i < 15000; i++ {
-		a := fixtures.GetAlertWithID(fmt.Sprintf("%d", i))
+		id := fmt.Sprintf("%d", i)
+		ids = append(ids, id)
+		a := fixtures.GetAlertWithID(id)
 		require.NoError(b, s.Upsert(ctx, a))
 	}
 
 	log.Info("Successfully loaded the DB")
 
-	b.ResetTimer()
-	// Load the store with 15k alerts and then try to build index
-	for i := 0; i < b.N; i++ {
-		require.NoError(b, datastoreImpl.buildIndex(ctx))
-	}
+	b.Run("rocksdb", func(b *testing.B) {
+		// Load the store with 15k alerts and then try to build index
+		for i := 0; i < b.N; i++ {
+			require.NoError(b, datastoreImpl.buildIndex(ctx))
+		}
+	})
+
+	b.Run("markStale", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, id := range ids {
+				require.NoError(b, datastore.MarkAlertStale(ctx, id))
+			}
+		}
+	})
+
+	b.Run("markStaleBatch", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err := datastore.MarkAlertStaleBatch(ctx, ids...)
+			require.NoError(b, err)
+		}
+	})
 }

--- a/central/alert/datastore/bench_test.go
+++ b/central/alert/datastore/bench_test.go
@@ -25,7 +25,9 @@ func BenchmarkDBs(b *testing.B) {
 
 	tmpIndex, err := globalindex.TempInitializeIndices("")
 	require.NoError(b, err)
-	defer tmpIndex.Close()
+	defer func() {
+		_ = tmpIndex.Close()
+	}()
 
 	s := rocksDBStore.New(db)
 	idx := index.New(tmpIndex)

--- a/central/alert/datastore/bench_test.go
+++ b/central/alert/datastore/bench_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/central/alert/datastore/internal/search"
 	rocksDBStore "github.com/stackrox/rox/central/alert/datastore/internal/store/rocksdb"
 	"github.com/stackrox/rox/central/globalindex"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/sac"
@@ -17,8 +18,12 @@ import (
 )
 
 func BenchmarkDBs(b *testing.B) {
-	ctx := sac.WithAllAccess(context.Background())
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		b.Skipf("%q not set. Skip postgres test", env.PostgresDatastoreEnabled.EnvVar())
+		b.SkipNow()
+	}
 
+	ctx := sac.WithAllAccess(context.Background())
 	db, err := rocksdb.NewTemp("alert_bench_test")
 	require.NoError(b, err)
 	defer rocksdbtest.TearDownRocksDB(db)

--- a/central/alert/datastore/datastore.go
+++ b/central/alert/datastore/datastore.go
@@ -38,7 +38,7 @@ type DataStore interface {
 	UpsertAlert(ctx context.Context, alert *storage.Alert) error
 	UpsertAlerts(ctx context.Context, alerts []*storage.Alert) error
 	MarkAlertStale(ctx context.Context, id string) error
-	// MarkAlertStaleBatch marks alerts with specific id as RESOLVED and returns resolved alerts.
+	// MarkAlertStaleBatch marks alerts with specified ids as RESOLVED in batch and returns resolved alerts.
 	MarkAlertStaleBatch(ctx context.Context, id ...string) ([]*storage.Alert, error)
 
 	DeleteAlerts(ctx context.Context, ids ...string) error

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -239,7 +239,6 @@ func (ds *datastoreImpl) MarkAlertStaleBatch(ctx context.Context, ids ...string)
 		if err != nil {
 			return err
 		}
-
 		if len(missing) > 0 {
 			// Warn and continue marking the found alerts stale instead of returning error.
 			// Marking alerts stale essentially removes the alerts from APIs by default anyway.
@@ -254,6 +253,7 @@ func (ds *datastoreImpl) MarkAlertStaleBatch(ctx context.Context, ids ...string)
 			if !ok {
 				return sac.ErrResourceAccessDenied
 			}
+
 			alert.State = storage.ViolationState_RESOLVED
 			alert.ResolvedAt = resolvedAt
 		}

--- a/central/alert/datastore/datastore_sac_test.go
+++ b/central/alert/datastore/datastore_sac_test.go
@@ -202,7 +202,7 @@ func (s *alertDatastoreSACTestSuite) TestMarkAlertStale() {
 			s.NoError(err)
 
 			ctx := s.testContexts[c.scopeKey]
-			err = s.datastore.MarkAlertStale(ctx, alert1.GetId())
+			_, err = s.datastore.MarkAlertStaleBatch(ctx, alert1.GetId())
 			if !c.expectError {
 				s.NoError(err)
 			} else if !c.expectedFound {
@@ -210,7 +210,7 @@ func (s *alertDatastoreSACTestSuite) TestMarkAlertStale() {
 			} else {
 				s.Equal(c.expectedError, err)
 			}
-			err = s.datastore.MarkAlertStale(ctx, alert2.GetId())
+			_, err = s.datastore.MarkAlertStaleBatch(ctx, alert2.GetId())
 			if !c.expectError {
 				s.NoError(err)
 			} else if !c.expectedFound {

--- a/central/alert/datastore/datastore_sac_test.go
+++ b/central/alert/datastore/datastore_sac_test.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/blevesearch/bleve"
@@ -146,7 +145,6 @@ func (s *alertDatastoreSACTestSuite) TestMarkAlertStale() {
 		"(full) read-only cannot mark alert stale": {
 			scopeKey:      testutils.UnrestrictedReadCtx,
 			expectError:   true,
-			expectedFound: true,
 			expectedError: sac.ErrResourceAccessDenied,
 		},
 		"full read-write can mark alert stale": {
@@ -156,22 +154,22 @@ func (s *alertDatastoreSACTestSuite) TestMarkAlertStale() {
 		"full read-write on wrong cluster cannot mark alert stale": {
 			scopeKey:      testutils.Cluster1ReadWriteCtx,
 			expectError:   true,
-			expectedFound: false,
+			expectedError: sac.ErrResourceAccessDenied,
 		},
 		"read-write on wrong cluster and wrong namespace name cannot mark alert stale": {
 			scopeKey:      testutils.Cluster1NamespaceAReadWriteCtx,
 			expectError:   true,
-			expectedFound: false,
+			expectedError: sac.ErrResourceAccessDenied,
 		},
 		"read-write on wrong cluster and matching namespace name cannot mark alert stale": {
 			scopeKey:      testutils.Cluster1NamespaceBReadWriteCtx,
 			expectError:   true,
-			expectedFound: false,
+			expectedError: sac.ErrResourceAccessDenied,
 		},
 		"read-write on right cluster but wrong namespaces cannot mark alert stale": {
 			scopeKey:      testutils.Cluster2NamespacesACReadWriteCtx,
 			expectError:   true,
-			expectedFound: false,
+			expectedError: sac.ErrResourceAccessDenied,
 		},
 		"full read-write on right cluster can mark alert stale": {
 			scopeKey:    testutils.Cluster2ReadWriteCtx,
@@ -205,16 +203,12 @@ func (s *alertDatastoreSACTestSuite) TestMarkAlertStale() {
 			_, err = s.datastore.MarkAlertStaleBatch(ctx, alert1.GetId())
 			if !c.expectError {
 				s.NoError(err)
-			} else if !c.expectedFound {
-				s.Equal(fmt.Errorf("alert with id '%s' does not exist", alert1.GetId()), err)
 			} else {
 				s.Equal(c.expectedError, err)
 			}
 			_, err = s.datastore.MarkAlertStaleBatch(ctx, alert2.GetId())
 			if !c.expectError {
 				s.NoError(err)
-			} else if !c.expectedFound {
-				s.Equal(fmt.Errorf("alert with id '%s' does not exist", alert2.GetId()), err)
 			} else {
 				s.Equal(c.expectedError, err)
 			}

--- a/central/alert/datastore/datastore_sac_test.go
+++ b/central/alert/datastore/datastore_sac_test.go
@@ -203,13 +203,17 @@ func (s *alertDatastoreSACTestSuite) TestMarkAlertStale() {
 			_, err = s.datastore.MarkAlertStaleBatch(ctx, alert1.GetId())
 			if !c.expectError {
 				s.NoError(err)
-			} else {
+				// SAC behavior in postgres has changed. Instead of returning error, pg store returns nil result,
+				// hence `missing` var is set indicate that the record is missing.
+			} else if !env.PostgresDatastoreEnabled.BooleanSetting() {
 				s.Equal(c.expectedError, err)
 			}
 			_, err = s.datastore.MarkAlertStaleBatch(ctx, alert2.GetId())
 			if !c.expectError {
 				s.NoError(err)
-			} else {
+				// SAC behavior in postgres has changed. Instead of returning error, pg store returns nil result,
+				// hence `missing` var is set indicate that the record is missing.
+			} else if !env.PostgresDatastoreEnabled.BooleanSetting() {
 				s.Equal(c.expectedError, err)
 			}
 		})

--- a/central/alert/datastore/datastore_test.go
+++ b/central/alert/datastore/datastore_test.go
@@ -166,21 +166,23 @@ func (s *alertDataStoreTestSuite) TestMarkAlertStaleBatchWhenStorageFails() {
 func (s *alertDataStoreTestSuite) TestMarkAlertStaleBatchWhenTheAlertWasNotFoundInStorage() {
 	fakeAlert := alerttest.NewFakeAlert()
 
-	s.storage.EXPECT().GetMany(gomock.Any(), []string{alerttest.FakeAlertID}).Return([]*storage.Alert{fakeAlert}, []int{0}, nil)
+	s.storage.EXPECT().GetMany(gomock.Any(), []string{fakeAlert.GetId()}).Return(nil, []int{0}, nil)
 
-	_, err := s.dataStore.MarkAlertStaleBatch(s.hasWriteCtx, alerttest.FakeAlertID)
+	_, err := s.dataStore.MarkAlertStaleBatch(s.hasWriteCtx, fakeAlert.GetId())
 
-	s.EqualError(err, "1/1 alert(s) to be marked stale do not exist")
+	s.NoError(err)
 }
 
 func (s *alertDataStoreTestSuite) TestKeyIndexing() {
 	fakeAlert := alerttest.NewFakeAlert()
 
-	s.storage.EXPECT().GetMany(gomock.Any(), []string{alerttest.FakeAlertID}).Return([]*storage.Alert{fakeAlert}, []int{0}, nil)
+	s.storage.EXPECT().GetMany(gomock.Any(), []string{fakeAlert.GetId()}).Return([]*storage.Alert{fakeAlert}, nil, nil)
+	s.storage.EXPECT().UpsertMany(gomock.Any(), gomock.Any()).Return(nil)
+	s.indexer.EXPECT().AddListAlerts(gomock.Any()).Return(nil)
+	s.storage.EXPECT().AckKeysIndexed(gomock.Any(), gomock.Any()).Return(nil)
+	_, err := s.dataStore.MarkAlertStaleBatch(s.hasWriteCtx, fakeAlert.GetId())
 
-	_, err := s.dataStore.MarkAlertStaleBatch(s.hasWriteCtx, alerttest.FakeAlertID)
-
-	s.EqualError(err, "1/1 alert(s) to be marked stale do not exist")
+	s.NoError(err)
 }
 
 func TestAlertDataStoreWithSAC(t *testing.T) {

--- a/central/alert/datastore/internal/store/mocks/store.go
+++ b/central/alert/datastore/internal/store/mocks/store.go
@@ -158,6 +158,20 @@ func (mr *MockStoreMockRecorder) Upsert(ctx, alert interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*MockStore)(nil).Upsert), ctx, alert)
 }
 
+// UpsertMany mocks base method.
+func (m *MockStore) UpsertMany(ctx context.Context, alerts []*storage.Alert) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertMany", ctx, alerts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertMany indicates an expected call of UpsertMany.
+func (mr *MockStoreMockRecorder) UpsertMany(ctx, alerts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertMany", reflect.TypeOf((*MockStore)(nil).UpsertMany), ctx, alerts)
+}
+
 // Walk mocks base method.
 func (m *MockStore) Walk(ctx context.Context, fn func(*storage.Alert) error) error {
 	m.ctrl.T.Helper()

--- a/central/alert/datastore/internal/store/store.go
+++ b/central/alert/datastore/internal/store/store.go
@@ -14,6 +14,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storage.Alert, bool, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Alert, []int, error)
 	Upsert(ctx context.Context, alert *storage.Alert) error
+	UpsertMany(ctx context.Context, alerts []*storage.Alert) error
 	Delete(ctx context.Context, id string) error
 	DeleteMany(ctx context.Context, ids []string) error
 

--- a/central/alert/datastore/mocks/datastore.go
+++ b/central/alert/datastore/mocks/datastore.go
@@ -131,6 +131,26 @@ func (mr *MockDataStoreMockRecorder) MarkAlertStale(ctx, id interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkAlertStale", reflect.TypeOf((*MockDataStore)(nil).MarkAlertStale), ctx, id)
 }
 
+// MarkAlertStaleBatch mocks base method.
+func (m *MockDataStore) MarkAlertStaleBatch(ctx context.Context, id ...string) ([]*storage.Alert, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "MarkAlertStaleBatch", varargs...)
+	ret0, _ := ret[0].([]*storage.Alert)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MarkAlertStaleBatch indicates an expected call of MarkAlertStaleBatch.
+func (mr *MockDataStoreMockRecorder) MarkAlertStaleBatch(ctx interface{}, id ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkAlertStaleBatch", reflect.TypeOf((*MockDataStore)(nil).MarkAlertStaleBatch), varargs...)
+}
+
 // Search mocks base method.
 func (m *MockDataStore) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	m.ctrl.T.Helper()

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -726,18 +726,20 @@ func (ds *datastoreImpl) getAlerts(ctx context.Context, deploymentID string) ([]
 }
 
 func (ds *datastoreImpl) markAlertsStale(ctx context.Context, alerts []*storage.Alert) error {
+	if len(alerts) == 0 {
+		return nil
+	}
+
 	ids := make([]string, 0, len(alerts))
 	for _, alert := range alerts {
 		ids = append(ids, alert.GetId())
 	}
-
 	resolvedAlerts, err := ds.alertDataStore.MarkAlertStaleBatch(ctx, ids...)
 	if err != nil {
 		return err
 	}
-
-	for _, alert := range resolvedAlerts {
-		ds.notifier.ProcessAlert(ctx, alert)
+	for _, resolvedAlert := range resolvedAlerts {
+		ds.notifier.ProcessAlert(ctx, resolvedAlert)
 	}
 	return nil
 }

--- a/central/cluster/datastore/datastore_impl_test.go
+++ b/central/cluster/datastore/datastore_impl_test.go
@@ -216,7 +216,7 @@ func (suite *ClusterDataStoreTestSuite) TestRemoveCluster() {
 	suite.deploymentDataStore.EXPECT().Search(gomock.Any(), gomock.Any()).Return(testDeployments, nil)
 	suite.podDataStore.EXPECT().Search(gomock.Any(), gomock.Any()).Return(testPods, nil)
 	suite.alertDataStore.EXPECT().SearchRawAlerts(gomock.Any(), gomock.Any()).Return(testAlerts, nil)
-	suite.alertDataStore.EXPECT().MarkAlertStale(gomock.Any(), gomock.Any()).Return(nil)
+	suite.alertDataStore.EXPECT().MarkAlertStaleBatch(gomock.Any(), gomock.Any()).Return(testAlerts, nil)
 	suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), gomock.Any()).Return()
 	suite.deploymentDataStore.EXPECT().RemoveDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	suite.podDataStore.EXPECT().RemovePod(gomock.Any(), "fakepod").Return(nil)

--- a/central/detection/alertmanager/alert_manager_impl.go
+++ b/central/detection/alertmanager/alert_manager_impl.go
@@ -103,11 +103,14 @@ func (d *alertManagerImpl) updateBatch(ctx context.Context, alertsToMark []*stor
 
 // markAlertsStale marks all input alerts stale in the input datastore.
 func (d *alertManagerImpl) markAlertsStale(ctx context.Context, alertsToMark []*storage.Alert) error {
+	if len(alertsToMark) == 0 {
+		return nil
+	}
+
 	ids := make([]string, 0, len(alertsToMark))
 	for _, alert := range alertsToMark {
 		ids = append(ids, alert.GetId())
 	}
-
 	resolvedAlerts, err := d.alerts.MarkAlertStaleBatch(ctx, ids...)
 	if err != nil {
 		return err

--- a/central/detection/alertmanager/alert_manager_impl_test.go
+++ b/central/detection/alertmanager/alert_manager_impl_test.go
@@ -245,7 +245,7 @@ func (suite *AlertManagerTestSuite) TestOnUpdatesWhenAlertsDoNotChange() {
 func (suite *AlertManagerTestSuite) TestMarksOldAlertsStale() {
 	alerts := getAlerts()
 
-	suite.alertsMock.EXPECT().MarkAlertStale(suite.ctx, alerts[0].GetId()).Return(nil)
+	suite.alertsMock.EXPECT().MarkAlertStaleBatch(suite.ctx, alerts[0].GetId()).Return([]*storage.Alert{alerts[0]}, nil)
 
 	// Unchanged alerts should not be updated.
 
@@ -520,9 +520,15 @@ func (suite *AlertManagerTestSuite) TestOldResourceAlertAreMarkedAsStaleWhenPoli
 	// Don't add any policies to simulate policies being deleted
 	suite.runtimeDetectorMock.EXPECT().PolicySet().Return(suite.policySet).AnyTimes()
 
+	ids := make([]string, 0, len(alerts))
+	for _, alert := range alerts {
+		ids = append(ids, alert.GetId())
+	}
+
 	// Verify that the other alerts get marked as stale and that the notifier sends a notification for them
+	suite.alertsMock.EXPECT().MarkAlertStaleBatch(suite.ctx, ids).Return(alerts, nil)
+
 	for _, a := range alerts {
-		suite.alertsMock.EXPECT().MarkAlertStale(suite.ctx, a.GetId()).Return(nil)
 		suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), a).Return()
 	}
 

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -426,10 +426,8 @@ func (g *garbageCollectorImpl) markOrphanedAlertsAsResolved(deployments set.Froz
 		return
 	}
 	log.Infof("[Alert pruning] Found %d orphaned alerts", len(alertsToResolve))
-	for _, a := range alertsToResolve {
-		if err := g.alerts.MarkAlertStale(pruningCtx, a); err != nil {
-			log.Error(errors.Wrapf(err, "error marking alert %q as stale", a))
-		}
+	if _, err := g.alerts.MarkAlertStaleBatch(pruningCtx, alertsToResolve...); err != nil {
+		log.Error(errors.Wrap(err, "error marking alert as stale"))
 	}
 }
 

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -1363,9 +1363,7 @@ func TestMarkOrphanedAlerts(t *testing.T) {
 					}
 					return nil
 				})
-			for _, a := range c.expectedDeletions {
-				alerts.EXPECT().MarkAlertStale(pruningCtx, a)
-			}
+			alerts.EXPECT().MarkAlertStaleBatch(pruningCtx, c.expectedDeletions)
 			gci.markOrphanedAlertsAsResolved(c.deployments)
 		})
 	}


### PR DESCRIPTION
## Description

- Added a method to mark bulk alerts resolved. 
- Unit tests compare resolving alerts in bulk vs resolving alerts individually.

Additionally:
- Do not perform read perm check when upserting records. If any read is being performed, it is only the side-effect of our business logic, but not expected by user
- Added write perm check to batch upsert. This will replace the service layer perm check.
- Fixed the unit test. The unit test was checking for wrong expectations. If the incoming context does not have correct permissions, an unauthorized access error should be returned, not a record not found error.


Benchmark results show significant improvement both on rocksdb (~100x) and postgres (~10x). 

```
# rocksdb:
BenchmarkDBs/rocksdb-8         	       1	2639426601 ns/op
BenchmarkDBs/markStale
BenchmarkDBs/markStale-8       	       1	231159944603 ns/op
BenchmarkDBs/markStaleBatch
BenchmarkDBs/markStaleBatch-8  	       1	2826356797 ns/op

# postgres:

BenchmarkDBsWithPostgres/markStale
BenchmarkDBsWithPostgres/markStale-8         	       1	13617595712 ns/op
BenchmarkDBsWithPostgres/markStaleBatch
BenchmarkDBsWithPostgres/markStaleBatch-8    	       1	1949332050 ns/op

PASS
```
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Unit tests