### PR TITLE
ROX-12336: Harden SCCs for sensor to prevent running as root or privilege escalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ authentication is still required for an email notifier, but the user can now cho
 - ROX-11181: Any clusters that have been unhealthy (defined as central being unable to reach sensor running on those clusters) for a configured period of time will be automatically removed. The number of days after which an 'unhealthy' cluster is removed can be configured in the System Configuration page or using the cluster API.
   - Any cluster that is expected to be unavailable for a period of time (e.g. clusters used in disaster recovery), can be tagged with a customizable label. Clusters with those labels will never be removed automatically.
   - By default, this unhealthy cluster removal is disabled (number of days set to 0)
-- ROX-12336: If sensor is installed with the optional `SecurityContextConstraint`s (SCC), they now explicitly disallow now running as root and priviledges escalation.
+- ROX-12336: If sensor is installed with the optional `SecurityContextConstraint`s (SCC), they now explicitly disallow: running as root and priviledges escalation.
 
 ## [3.71.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Entries in this file should be limited to:
 Please avoid adding duplicate information across this changelog and JIRA/doc input pages.
 
 ## [NEXT RELEASE]
-- ROX-11348: The email notifier now allows for unauthenticated SMTP. By default, 
+- ROX-11348: The email notifier now allows for unauthenticated SMTP. By default,
 authentication is still required for an email notifier, but the user can now choose to turn it off.
 
 ### Removed Features
@@ -17,6 +17,7 @@ authentication is still required for an email notifier, but the user can now cho
 - ROX-11181: Any clusters that have been unhealthy (defined as central being unable to reach sensor running on those clusters) for a configured period of time will be automatically removed. The number of days after which an 'unhealthy' cluster is removed can be configured in the System Configuration page or using the cluster API.
   - Any cluster that is expected to be unavailable for a period of time (e.g. clusters used in disaster recovery), can be tagged with a customizable label. Clusters with those labels will never be removed automatically.
   - By default, this unhealthy cluster removal is disabled (number of days set to 0)
+- ROX-12336: If sensor is installed with the optional `SecurityContextConstraint`s (SCC), they now explicitly disallow now running as root and priviledges escalation.
 
 ## [3.71.0]
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -54,19 +54,19 @@ volumes:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: use-nonroot-scc
+  name: use-anyuid-scc
   namespace: {{ ._rox._namespace }}
   labels:
-    {{- include "srox.labels" (list . "role" "use-nonroot-scc") | nindent 4 }}
+    {{- include "srox.labels" (list . "role" "use-anyuid-scc") | nindent 4 }}
   annotations:
-    {{- include "srox.annotations" (list . "role" "use-nonroot-scc") | nindent 4 }}
+    {{- include "srox.annotations" (list . "role" "use-anyuid-scc") | nindent 4 }}
 rules:
 - apiGroups:
   - security.openshift.io
   resources:
   - securitycontextconstraints
   resourceNames:
-  - nonroot
+  - anyuid
   verbs:
   - use
 ---
@@ -82,7 +82,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: use-nonroot-scc
+  name: use-anyuid-scc
 subjects:
 - kind: ServiceAccount
   name: sensor

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -17,7 +17,7 @@ users:
   - system:serviceaccount:{{ ._rox._namespace }}:sensor-upgrader
 priority: 0
 runAsUser:
-  type: RunAsAny
+  type: MustRunAsNonRoot
 seLinuxContext:
   type: RunAsAny
 seccompProfiles:
@@ -33,7 +33,7 @@ allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
-allowPrivilegeEscalation: true
+allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
 allowedCapabilities: []
 defaultAddCapabilities: []

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -54,19 +54,19 @@ volumes:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: use-anyuid-scc
+  name: use-nonroot-scc
   namespace: {{ ._rox._namespace }}
   labels:
-    {{- include "srox.labels" (list . "role" "use-anyuid-scc") | nindent 4 }}
+    {{- include "srox.labels" (list . "role" "use-nonroot-scc") | nindent 4 }}
   annotations:
-    {{- include "srox.annotations" (list . "role" "use-anyuid-scc") | nindent 4 }}
+    {{- include "srox.annotations" (list . "role" "use-nonroot-scc") | nindent 4 }}
 rules:
 - apiGroups:
   - security.openshift.io
   resources:
   - securitycontextconstraints
   resourceNames:
-  - anyuid
+  - nonroot
   verbs:
   - use
 ---
@@ -82,7 +82,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: use-anyuid-scc
+  name: use-nonroot-scc
 subjects:
 - kind: ServiceAccount
   name: sensor


### PR DESCRIPTION
## Description

This PR hardens the security for sensor.
Based on the sensor-SCCs (that are optional in the installation), sensor was allowed to escalate the privileges from user 4000 (default) to 0 (root).
By changing this, we would most probably pass the validation that runs for `restricted-v2` SCC as defined [here](https://docs.openshift.com/container-platform/4.11/authentication/managing-security-context-constraints.html#default-sccs_configuring-internal-oauth).

The SCC being changed here was introduced [in this PR](https://github.com/stackrox/rox/pull/5129) most probably based on linter suggestions.
Creation of SCC resources was made optional in https://github.com/stackrox/rox/pull/8686.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

- [x] Manually changing SCC on OpenShift 4.11, recreating the pod and verifying that sensor still works
- [x] CI
