### PR TITLE
ROX-12302: indicate required field on runtime policies

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
@@ -195,6 +195,7 @@ function PolicyBehaviorForm() {
                     <FormGroup
                         fieldId="policy-event-source"
                         label="Event sources (Runtime lifecycle only)"
+                        isRequired={hasRuntime}
                     >
                         <Flex direction={{ default: 'row' }}>
                             <Radio


### PR DESCRIPTION
## Description

For a better user experience when creating policies we want to indicate that the event sources field is required if the "Runtime" lifecycle option is selected.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Manual testing

Deploy selected

![Screen Shot 2022-08-26 at 9 38 11 AM](https://user-images.githubusercontent.com/61400697/186940750-305154c7-d3da-419e-b77f-1b7d6beb184e.png)


Runtime selected

![Screen Shot 2022-08-26 at 9 38 59 AM](https://user-images.githubusercontent.com/61400697/186940720-641e37d1-7ec7-42aa-876e-82cf7ca712c5.png)
