### PR TITLE
Update TypeScript 4.8.2 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -164,7 +164,7 @@
         "redux-immutable-state-invariant": "^2.1.0",
         "redux-saga-test-plan": "^3.7.0",
         "tailwindcss": "^2.0.3",
-        "typescript": "^4.7.4"
+        "typescript": "^4.8.2"
     },
     "browserslist": [
         ">0.2%",

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/useIntegrationForm.ts
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/useIntegrationForm.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useFormik, FormikProps } from 'formik';
+import { useFormik, FormikProps, FormikValues } from 'formik';
 import { Schema } from 'yup';
 
 import { IntegrationOptions } from 'services/IntegrationsService';
@@ -20,7 +20,7 @@ export type UseIntegrationFormResult<T> = FormikProps<T> & {
     message: FormResponseMessage;
 };
 
-function useIntegrationForm<T>({
+function useIntegrationForm<T extends FormikValues>({
     initialValues,
     validationSchema,
 }: UseIntegrationForm<T>): UseIntegrationFormResult<T> {

--- a/ui/apps/platform/src/hooks/patternfly/useFormModal.ts
+++ b/ui/apps/platform/src/hooks/patternfly/useFormModal.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { FormikProps, useFormik } from 'formik';
+import { FormikProps, FormikValues, useFormik } from 'formik';
 
 import { FormResponseMessage } from 'Components/PatternFly/FormMessage';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -19,7 +19,7 @@ type UseFormModalResults<T> = {
     onHandleCancel: () => void;
 };
 
-function useFormModal<T>({
+function useFormModal<T extends FormikValues>({
     initialValues,
     validationSchema,
     onSendRequest,

--- a/ui/apps/platform/src/hooks/useWidgetConfig.ts
+++ b/ui/apps/platform/src/hooks/useWidgetConfig.ts
@@ -29,7 +29,11 @@ function loadConfigs(): WidgetConfigStorage {
 //
 // This is not an exhaustive type check (won't check array length, union types, ...) but
 // should cover most possible error states.
-function loadSafeConfig<T>(widgetId: string, routeId: string, defaultConfig: T): T {
+function loadSafeConfig<T extends WidgetConfig>(
+    widgetId: string,
+    routeId: string,
+    defaultConfig: T
+): T {
     const rootConfigs = loadConfigs();
     const parsedConfig = rootConfigs[widgetId]?.[routeId] ?? {};
     const configObject = isPlainObject(parsedConfig) ? parsedConfig : {};

--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -84,6 +84,6 @@
         "react-is": "^17.0.2",
         "tailwindcss": "^2.0.3",
         "ts-jest": "^26.5.6",
-        "typescript": "^4.7.4"
+        "typescript": "^4.8.2"
     }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -18629,10 +18629,10 @@ typeface-open-sans@^1.1.13:
   resolved "https://registry.yarnpkg.com/typeface-open-sans/-/typeface-open-sans-1.1.13.tgz#32a09ebd7df59601e01ad81216f98ce641eeafd1"
   integrity sha512-lVGVHvYl7UJDFB9vN8r7NHw3sVm7Rjeow6b9AeABc/J+2mDaCkmcdVtw3QZnsJW39P+xm5zeggIj9gLHYGn9Iw==
 
-typescript@^4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@^4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
+  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
 
 ua-parser-js@^0.7.18:
   version "0.7.28"


### PR DESCRIPTION
## Description

TypeScript releases a minor update every quarter.

Although TypeScript is brave to release late on Thursday, we will merge early on Monday.

https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/

### Overview

* Improved Intersection Reduction, Union Compatibility, and Narrowing
    https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#improved-intersection-reduction-union-compatibility-and-narrowing

* `--build`, `--watch`, and `--incremental` Performance Improvements

    https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#build-watch-and-incremental-performance-improvements

    This deserves investigation in case stackrox/ui does not but could take advantage of these command line options.

* Errors When Comparing Object and Array Literals

    https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#errors-when-comparing-object-and-array-literals

* File-Watching Fixes (Especially Across `git checkout`s)

    https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#file-watching-fixes-especially-across-git-checkouts

    > Sometimes the symptoms are stale or inaccurate errors that might show up that require restarting `tsc` or VS Code.
    This sounds familiar when swapping branches in git: restarting VS Code.

    Ironically, even after restarting, I did not see the following errors in the **Problems** pane when I opened each of the 3 files.

* Find-All-References Performance Improvements

    https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#find-all-references-performance-improvements

* Unconstrained Generics No Longer Assignable to `{}`

    https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#unconstrained-generics-no-longer-assignable-to

    > In TypeScript 4.8, for projects with `strictNullChecks` enabled, TypeScript will now correctly issue an error when an unconstrained type parameter is used in a position where `null` or `undefined` are not legal values. That will include any type that expects `{}`, `object`, or an object type with all-optional properties.

    For more info, see **How do I fix this?** in https://github.com/microsoft/TypeScript/issues/49489

    > Note that adding a constraint to `foo` might cause new errors to appear in callers of `foo`. You may have to repeat this process a few times to fix all call chains in your program.

    Because the changes below did not cause new errors: although the calling code was correct, TypeScript now will report as errors some incorrect calls which it would have missed in the past.

### Errors

TypeScript 4.8.2 reported 3 errors for the breaking change described above.

Because `yarn build` reports only the first error, and not even the name of the file:

1. `yarn tsc` in ui/apps/platform
    * src/Containers/Integrations/IntegrationForm/useIntegrationForm.ts:35

        error TS2344: Type 'T' does not satisfy the constraint 'FormikValues'.
        `const formik = useFormik<T>({`

        `function useIntegrationForm<T>({`
        This type parameter might need an `extends FormikValues` constraint.

    * src/hooks/patternfly/useFormModal.ts:30

        error TS2344: Type 'T' does not satisfy the constraint 'FormikValues'.
        `const formik = useFormik<T>({`

        `function useFormModal<T>({`
        This type parameter might need an `extends FormikValues` constraint.

    * src/hooks/useWidgetConfig.ts:37

        Overload 1 of 2, '(o: { [s: string]: unknown; } | ArrayLike<unknown>): [string, unknown][]', gave the following error.
        Argument of type 'T' is not assignable to parameter of type '{ [s: string]: unknown; } | ArrayLike<unknown>'.
        Type 'T' is not assignable to type 'ArrayLike<unknown>'.
        Overload 2 of 2, '(o: {}): [string, any][]', gave the following error.
        Argument of type 'T' is not assignable to parameter of type '{}'.
        `Object.entries(defaultConfig).forEach(([defaultKey, defaultValue]) => {`

        `function loadSafeConfig<T>(widgetId: string, routeId: string, defaultConfig: T): T {`
        This type parameter might need an `extends ArrayLike<unknown>` constraint.
        This type parameter might need an `extends { [s: string]: unknown; } | ArrayLike<unknown>` constraint.
        This type parameter might need an `extends {}` constraint.

2. `yarn tsc` in ui/packages/ui-components

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn build` in ui
2. `wc build/static/js/*.chunk.js` in ui
    * branch - master: 0 = 6013871 - 6013871 which makes sense for changes only to types
3. `yarn start` in ui