### PR TITLE
Dashrews/ROX-11357 process baseline issue with failure on slow environments

### DIFF
--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -115,12 +115,6 @@ class ProcessBaselinesTest extends BaseSpecification {
         orchestrator.execInContainer(deployment, "ls")
 
         String containerName = deployment.getName()
-//         ProcessBaselineOuterClass.ProcessBaseline baseline = ProcessBaselineService.
-//                     getProcessBaseline(clusterId, deployment, containerName)
-//         assert (baseline != null)
-//         assert ((baseline.key.deploymentId.equalsIgnoreCase(deploymentId)) &&
-//                     (baseline.key.containerName.equalsIgnoreCase(containerName)))
-//         assert baseline.elementsList.find { it.element.processName == processName } != null
 
         // wait for baseline to come out of observation
         ProcessBaselineOuterClass.ProcessBaseline baseline = evaluateWithRetry(10, 10) {

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -109,20 +109,21 @@ class ProcessBaselinesTest extends BaseSpecification {
         def deployment = DEPLOYMENTS.find { it.name == deploymentName }
         assert deployment != null
         orchestrator.createDeployment(deployment)
+        assert Services.waitForDeployment(deployment)
         String deploymentId = deployment.getDeploymentUid()
         assert deploymentId != null
         orchestrator.execInContainer(deployment, "ls")
 
         String containerName = deployment.getName()
-        ProcessBaselineOuterClass.ProcessBaseline baseline = ProcessBaselineService.
-                    getProcessBaseline(clusterId, deployment, containerName)
-        assert (baseline != null)
-        assert ((baseline.key.deploymentId.equalsIgnoreCase(deploymentId)) &&
-                    (baseline.key.containerName.equalsIgnoreCase(containerName)))
-        assert baseline.elementsList.find { it.element.processName == processName } != null
+//         ProcessBaselineOuterClass.ProcessBaseline baseline = ProcessBaselineService.
+//                     getProcessBaseline(clusterId, deployment, containerName)
+//         assert (baseline != null)
+//         assert ((baseline.key.deploymentId.equalsIgnoreCase(deploymentId)) &&
+//                     (baseline.key.containerName.equalsIgnoreCase(containerName)))
+//         assert baseline.elementsList.find { it.element.processName == processName } != null
 
         // wait for baseline to come out of observation
-        baseline = evaluateWithRetry(10, 10) {
+        ProcessBaselineOuterClass.ProcessBaseline baseline = evaluateWithRetry(10, 10) {
             def tmpBaseline = ProcessBaselineService.getProcessBaseline(clusterId, deployment, containerName)
             def now = System.currentTimeSeconds()
             if (tmpBaseline.getStackRoxLockedTimestamp().getSeconds() > now) {
@@ -133,6 +134,9 @@ class ProcessBaselinesTest extends BaseSpecification {
             return tmpBaseline
         }
         assert baseline
+        assert ((baseline.key.deploymentId.equalsIgnoreCase(deploymentId)) &&
+                    (baseline.key.containerName.equalsIgnoreCase(containerName)))
+        assert baseline.elementsList.find { it.element.processName == processName } != null
 
         log.info "Baseline Before after observation: ${baseline}"
 


### PR DESCRIPTION
## Description

The crux of the problem here appears to be speed.  Looks like the orchestrator is trying to execute the ls before the deployment is ready.  So I made a couple of adjustments.  

1. utilize the waitForDeployment call to hopefully ensure the deployment is ready before the exec call.
2. Move the validation of the container name being in the baseline until after the baseline is out of observation.  that just buys a little more time for the process indicator to come in and get processed.  And really, moving it simplifies the test as we were waiting on it to come out of observation anyway.

## Checklist
~- [ ] Investigated and inspected CI test results~
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

It is a test.  CI is sufficient.
