### PR TITLE
ROX-12054: Poll for different images for different tests

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -439,7 +439,7 @@ poll_for_system_test_images() {
         *-operator-e2e-tests)
             reqd_images=("stackrox-operator-controller" "stackrox-operator-bundle" "stackrox-operator-bundle-index" "main")
             ;;
-        *-race-condition-qa-e2e-test)
+        *-race-condition-qa-e2e-tests)
             reqd_images=("main-rcd" "roxctl")
             ;;
         *-postgres-*)

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -437,7 +437,7 @@ poll_for_system_test_images() {
     # Require imagea based on the job
     case "$CI_JOB_NAME" in
         *-operator-e2e-tests)
-            reqd_images=("operator-controller" "operator-bundle" "operator-bundle-index" "main")
+            reqd_images=("stackrox-operator-controller" "stackrox-operator-bundle" "stackrox-operator-bundle-index" "main")
             ;;
         *-race-condition-qa-e2e-test)
             reqd_images=("main-rcd" "roxctl")
@@ -459,12 +459,16 @@ poll_for_system_test_images() {
 
     _image_exists() {
         local name="$1"
-        local url="https://quay.io/api/v1/repository/rhacs-eng/$name/tag?specificTag=$tag"
+        local v=""
+        if [[ "$name" =~ stackrox-operator-bundle ]]; then
+            v="v"
+        fi
+        local url="https://quay.io/api/v1/repository/rhacs-eng/$name/tag?specificTag=$v$tag"
         info "Checking for $name using $url"
         local check
         check=$(curl --location -sS -H "Authorization: Bearer ${QUAY_RHACS_ENG_BEARER_TOKEN}" "$url")
         echo "$check"
-        [[ "$(jq -r '.tags | first | .name' <<<"$check")" == "$tag" ]]
+        [[ "$(jq -r '.tags | first | .name' <<<"$check")" == "$v$tag" ]]
     }
 
     while true; do

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -437,7 +437,7 @@ poll_for_system_test_images() {
     # Require images based on the job
     case "$CI_JOB_NAME" in
         *-operator-e2e-tests)
-            reqd_images=("stackrox-operator-controller" "stackrox-operator-bundle" "stackrox-operator-bundle-index" "main")
+            reqd_images=("stackrox-operator" "stackrox-operator-bundle" "stackrox-operator-index" "main")
             ;;
         *-race-condition-qa-e2e-tests)
             reqd_images=("main-rcd" "roxctl")
@@ -483,7 +483,7 @@ check_rhacs_eng_image_exists() {
     local name="$1"
     local tag="$2"
 
-    if [[ "$name" =~ stackrox-operator-bundle ]]; then
+    if [[ "$name" =~ stackrox-operator-(bundle|index) ]]; then
         tag="v$tag"
     elif [[ "$name" == "main-rcd" ]]; then
         name="main"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -484,7 +484,9 @@ check_rhacs_eng_image_exists() {
     local tag="$2"
 
     if [[ "$name" =~ stackrox-operator-(bundle|index) ]]; then
-        tag="v$tag"
+        tag="$(echo "v${tag}" | sed 's,x,0,')"
+    elif [[ "$name" == "stackrox-operator" ]]; then
+        tag="$(echo "${tag}" | sed 's,x,0,')"
     elif [[ "$name" == "main-rcd" ]]; then
         name="main"
         tag="${tag}-rcd"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -434,7 +434,7 @@ poll_for_system_test_images() {
 
     require_environment "QUAY_RHACS_ENG_BEARER_TOKEN"
 
-    # Require imagea based on the job
+    # Require images based on the job
     case "$CI_JOB_NAME" in
         *-operator-e2e-tests)
             reqd_images=("stackrox-operator-controller" "stackrox-operator-bundle" "stackrox-operator-bundle-index" "main")

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -437,7 +437,7 @@ poll_for_system_test_images() {
     # Require imagea based on the job
     case "$CI_JOB_NAME" in
         *-operator-e2e-tests)
-            reqd_images=("operator-controller" "operator-bundle" "operator-bundle-index")
+            reqd_images=("operator-controller" "operator-bundle" "operator-bundle-index" "main")
             ;;
         *-race-condition-qa-e2e-test)
             reqd_images=("main-rcd" "roxctl")


### PR DESCRIPTION
## Description

Per title. Different e2e tests need different images and should not all poll for the main/central-db/roxctl ones. This change will be more useful in the future if we push images or image groups separately.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient