### PR TITLE
ROX-12309: Substitute ROX_IMAGE_FLAVOR based on ROX_PRODUCT_BRANDING.

### DIFF
--- a/.openshift-ci/build/build-operator-artifacts.sh
+++ b/.openshift-ci/build/build-operator-artifacts.sh
@@ -24,9 +24,9 @@ build_operator_bundle_and_binary() {
     # Otherwise we get the cryptic "Missing value for flag: -I" error when running protoc.
     go mod download
 
-    info "Preparing bundle sources and smuggled status.sh file"
+    info "Preparing build/Dockerfile.gen, bundle sources and smuggled status.sh file"
     # TODO(ROX-11889): get rid of the SILENT= once we gain some confidence (after release 3.72?)
-    make -C operator bundle bundle-post-process smuggled-status-sh SILENT=
+    make -C operator build/Dockerfile.gen bundle bundle-post-process smuggled-status-sh SILENT=
 
     info "Making a copy of the built bundle sources in a magically named directory that will be used instead of the bundle image."
     # The hacked opm tool will first see if a directory named as the reference exists, and if so, use its content as if it's an unpacked image of that name.

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -330,12 +330,14 @@ check-expected-go-version:
 	actual=$$(grep '^FROM golang' Dockerfile | awk '{print $$2}' | cut -d: -f2); \
 	[ "$${expected}" = "$${actual}" ] || { echo "../EXPECTED_GO_VERSION $${expected}, Dockerfile $${actual}; please update to match"; exit 1; }
 
+build/Dockerfile.gen: Dockerfile
+	sed -e 's,$${ROX_IMAGE_FLAVOR},$(ROX_IMAGE_FLAVOR),g' < $< > $@
+
 .PHONY: docker-build
-docker-build: check-expected-go-version test smuggled-status-sh ## Build docker image with the operator.
+docker-build: build/Dockerfile.gen check-expected-go-version test smuggled-status-sh ## Build docker image with the operator.
 	DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain docker build \
 		-t ${IMG} \
-		--build-arg ROX_IMAGE_FLAVOR=$(ROX_IMAGE_FLAVOR) \
-		-f Dockerfile \
+		-f $< \
 		..
 
 ##@ Deployment

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -331,6 +331,7 @@ check-expected-go-version:
 	[ "$${expected}" = "$${actual}" ] || { echo "../EXPECTED_GO_VERSION $${expected}, Dockerfile $${actual}; please update to match"; exit 1; }
 
 build/Dockerfile.gen: Dockerfile
+	mkdir -p build/
 	sed -e 's,$${ROX_IMAGE_FLAVOR},$(ROX_IMAGE_FLAVOR),g' < $< > $@
 
 .PHONY: docker-build

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -330,6 +330,8 @@ check-expected-go-version:
 	actual=$$(grep '^FROM golang' Dockerfile | awk '{print $$2}' | cut -d: -f2); \
 	[ "$${expected}" = "$${actual}" ] || { echo "../EXPECTED_GO_VERSION $${expected}, Dockerfile $${actual}; please update to match"; exit 1; }
 
+# Force re-building the file to make sure the current environment is correctly reflected.
+.PHONY: build/Dockerfile.gen
 build/Dockerfile.gen: Dockerfile
 	mkdir -p build/
 	sed -e 's,$${ROX_IMAGE_FLAVOR},$(ROX_IMAGE_FLAVOR),g' < $< > $@


### PR DESCRIPTION
## Description

This is so that we can get rid of the `ROX_IMAGE_FLAVOR` variable in the CI definition file.

In CI building the `Dockerfile.gen` will happen during the operator artifacts build.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

1. Tested locally that `make -C operator docker-build` works, both with clean anv and with `ROX_PRODUCT_BRANDING=RHACS_BRANDING` and that the resulting `Env` shown by `docker image inspect` is as expected.
2. Relying on CI to ensure nothing broken. Note that the path to the original `Dockerfile` is still used at the moment. The `build/Dockerfile.gen` will start getting used after [a change](https://github.com/openshift/release/pull/31762) to `openshift/release` which will be rehearsed separately.