### PR TITLE
ROX-12318: QA compatibility test parameterized sensor version

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -499,6 +499,7 @@ function launch_sensor {
         --set "clusterName=${CLUSTER}"
         --set "centralEndpoint=${CLUSTER_API_ENDPOINT}"
         --set "image.main.repository=${MAIN_IMAGE_REPO}"
+        --set "image.main.tag=${MAIN_IMAGE_TAG}"
         --set "collector.collectionMethod=$(echo "$COLLECTION_METHOD" | tr '[:lower:]' '[:upper:]')"
         --set "env.openshift=$([[ "$ORCH" == "openshift" ]] && echo "true" || echo "false")"
       )

--- a/qa-tests-backend/Makefile
+++ b/qa-tests-backend/Makefile
@@ -67,7 +67,6 @@ compatibility-test: compile
 	@echo "+ $@"
 	$(GRADLE) test $(GRADLE_TEST_ARGS) -Dgroups=SMOKE
 
-
 .PHONY: runtime-test
 runtime-test: compile
 	@echo "+ $@"

--- a/qa-tests-backend/Makefile
+++ b/qa-tests-backend/Makefile
@@ -62,6 +62,12 @@ smoke-test: compile
 	@echo "+ $@"
 	$(GRADLE) test $(GRADLE_TEST_ARGS) -Dgroups=SMOKE
 
+.PHONY: compatibility-test
+compatibility-test: compile
+	@echo "+ $@"
+	$(GRADLE) test $(GRADLE_TEST_ARGS) -Dgroups=SMOKE
+
+
 .PHONY: runtime-test
 runtime-test: compile
 	@echo "+ $@"

--- a/qa-tests-backend/scripts/lib.sh
+++ b/qa-tests-backend/scripts/lib.sh
@@ -1,0 +1,23 @@
+deploy_default_psp() {
+    info "Deploy Default PSP for stackrox namespace"
+    "${ROOT}/scripts/ci/create-default-psp.sh"
+}
+
+deploy_webhook_server() {
+    info "Deploy Webhook server"
+
+    local certs_dir
+    certs_dir="$(mktemp -d)"
+    "${ROOT}/scripts/ci/create-webhookserver.sh" "${certs_dir}"
+    ci_export GENERIC_WEBHOOK_SERVER_CA_CONTENTS "$(cat "${certs_dir}/ca.crt")"
+}
+
+get_ECR_docker_pull_password() {
+    info "Get AWS ECR Docker Pull Password"
+
+    aws --version
+    local pass
+    pass="$(aws --region="${AWS_ECR_REGISTRY_REGION}" ecr get-login-password)"
+    ci_export AWS_ECR_DOCKER_PULL_PASSWORD "${pass}"
+}
+

--- a/qa-tests-backend/scripts/lib.sh
+++ b/qa-tests-backend/scripts/lib.sh
@@ -1,3 +1,9 @@
+#!/usr/bin/env bash
+
+# Common functions for deploying a cluster for QA tests
+
+set -euo pipefail
+
 deploy_default_psp() {
     info "Deploy Default PSP for stackrox namespace"
     "${ROOT}/scripts/ci/create-default-psp.sh"

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -52,8 +52,6 @@ compatibility_test() {
 
     store_qa_test_results "compatibility-test-sensor-$SENSOR_IMAGE_TAG"
     [[ ! -f FAIL ]] || die "compatibility-test-sensor-$SENSOR_IMAGE_TAG"
-
-	run_compatibility_test
 }
 
 

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -45,10 +45,9 @@ compatibility_test() {
         oc get scc qatest-anyuid || oc create -f "${ROOT}/qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
     fi
 
-    # export CLUSTER=$(echo $ORCHESTRATOR_FLAVOR | tr '[:upper:]')
-    export CLUSTER="$(echo $ORCHESTRATOR_FLAVOR | tr '[:lower:]' '[:upper:]')"
+    export CLUSTER="${ORCHESTRATOR_FLAVOR^^}"
 
-	# TODO(ROX-12320): Update the list of tests we want to run during "compatibility tests"
+    # TODO(ROX-12320): Update the list of tests we want to run during "compatibility tests"
     make -C qa-tests-backend compatibility-test || touch FAIL
 
     store_qa_test_results "compatibility-test-sensor-$SENSOR_IMAGE_TAG"

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Compatibility test installation of ACS using MAIN_IMAGE_TAG for central SENSOR_IMAGE_TAG for secured cluster
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+source "$ROOT/scripts/ci/gcp.sh"
+source "$ROOT/scripts/ci/lib.sh"
+source "$ROOT/scripts/ci/sensor-wait.sh"
+source "$ROOT/tests/e2e/lib.sh"
+source "$ROOT/tests/scripts/setup-certs.sh"
+source "$ROOT/qa-tests-backend/scripts/lib.sh"
+
+set -euo pipefail
+
+compatibility_test() {
+    info "Starting test (sensor compatibility test $SENSOR_IMAGE_TAG)"
+
+    require_environment "ORCHESTRATOR_FLAVOR"
+    require_environment "KUBECONFIG"
+
+    export_test_environment
+
+    if [[ "${SKIP_DEPLOY:-false}" = "false" ]]; then
+        if [[ "${CI:-false}" = "true" ]]; then
+            setup_gcp
+        else
+            info "Not running on CI: skipping cluster setup make sure cluster is already available"
+        fi
+
+        setup_deployment_env false false
+        remove_existing_stackrox_resources
+        setup_default_TLS_certs
+
+        deploy_stackrox
+        echo "Stackrox deployed"
+
+        deploy_default_psp
+        deploy_webhook_server
+        get_ECR_docker_pull_password
+    fi
+
+    info "Running compatibility tests"
+
+    if [[ "${ORCHESTRATOR_FLAVOR}" == "openshift" ]]; then
+        oc get scc qatest-anyuid || oc create -f "${ROOT}/qa-tests-backend/src/k8s/scc-qatest-anyuid.yaml"
+    fi
+
+    # export CLUSTER=$(echo $ORCHESTRATOR_FLAVOR | tr '[:upper:]')
+    export CLUSTER="$(echo $ORCHESTRATOR_FLAVOR | tr '[:lower:]' '[:upper:]')"
+
+	# TODO(ROX-12320): Update the list of tests we want to run during "compatibility tests"
+    make -C qa-tests-backend compatibility-test || touch FAIL
+
+    store_qa_test_results "compatibility-test-sensor-$SENSOR_IMAGE_TAG"
+    [[ ! -f FAIL ]] || die "compatibility-test-sensor-$SENSOR_IMAGE_TAG"
+
+	run_compatibility_test
+}
+
+
+compatibility_test

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -33,29 +33,6 @@ test_part_1() {
     run_tests_part_1
 }
 
-deploy_default_psp() {
-    info "Deploy Default PSP for stackrox namespace"
-    "${ROOT}/scripts/ci/create-default-psp.sh"
-}
-
-deploy_webhook_server() {
-    info "Deploy Webhook server"
-
-    local certs_dir
-    certs_dir="$(mktemp -d)"
-    "${ROOT}/scripts/ci/create-webhookserver.sh" "${certs_dir}"
-    ci_export GENERIC_WEBHOOK_SERVER_CA_CONTENTS "$(cat "${certs_dir}/ca.crt")"
-}
-
-get_ECR_docker_pull_password() {
-    info "Get AWS ECR Docker Pull Password"
-
-    aws --version
-    local pass
-    pass="$(aws --region="${AWS_ECR_REGISTRY_REGION}" ecr get-login-password)"
-    ci_export AWS_ECR_DOCKER_PULL_PASSWORD "${pass}"
-}
-
 run_tests_part_1() {
     info "QA Automation Platform Part 1"
 

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -8,6 +8,7 @@ source "$ROOT/scripts/ci/lib.sh"
 source "$ROOT/scripts/ci/sensor-wait.sh"
 source "$ROOT/tests/e2e/lib.sh"
 source "$ROOT/tests/scripts/setup-certs.sh"
+source "$ROOT/qa-tests-backend/scripts/lib.sh"
 
 set -euo pipefail
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -20,10 +20,11 @@ deploy_stackrox() {
     wait_for_api
     setup_client_TLS_certs
 
-    if [ ! -z $SENSOR_IMAGE_TAG ]; then
+	SENSOR_IMAGE_TAG=${SENSOR_IMAGE_TAG:-$MAIN_IMAGE_TAG}
+    if [ $SENSOR_IMAGE_TAG != $MAIN_IMAGE_TAG ]; then
         echo "Deploying sensor with custom image: $SENSOR_IMAGE_TAG"
     fi
-    MAIN_IMAGE_TAG=${SENSOR_IMAGE_TAG:-$MAIN_IMAGE_TAG} deploy_sensor
+    MAIN_IMAGE_TAG=$SENSOR_IMAGE_TAG deploy_sensor
     echo "Sensor deployed. Waiting for sensor to be up"
     sensor_wait
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -20,11 +20,11 @@ deploy_stackrox() {
     wait_for_api
     setup_client_TLS_certs
 
-	SENSOR_IMAGE_TAG=${SENSOR_IMAGE_TAG:-$MAIN_IMAGE_TAG}
-    if [ $SENSOR_IMAGE_TAG != $MAIN_IMAGE_TAG ]; then
+    SENSOR_IMAGE_TAG=${SENSOR_IMAGE_TAG:-$MAIN_IMAGE_TAG}
+    if [ "$SENSOR_IMAGE_TAG" != "$MAIN_IMAGE_TAG" ]; then
         echo "Deploying sensor with custom image: $SENSOR_IMAGE_TAG"
     fi
-    MAIN_IMAGE_TAG=$SENSOR_IMAGE_TAG deploy_sensor
+    MAIN_IMAGE_TAG="$SENSOR_IMAGE_TAG" deploy_sensor
     echo "Sensor deployed. Waiting for sensor to be up"
     sensor_wait
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -20,7 +20,11 @@ deploy_stackrox() {
     wait_for_api
     setup_client_TLS_certs
 
-    deploy_sensor
+    if [ ! -z $SENSOR_IMAGE_TAG ]; then
+        echo "Deploying sensor with custom image: $SENSOR_IMAGE_TAG"
+    fi
+    MAIN_IMAGE_TAG=${SENSOR_IMAGE_TAG:-$MAIN_IMAGE_TAG} deploy_sensor
+    echo "Sensor deployed. Waiting for sensor to be up"
     sensor_wait
 
     # Bounce collectors to avoid restarts on initial module pull


### PR DESCRIPTION
## Description

This PR enables groovy tests to be run with a different sensor version than central. Test can use both `MAIN_IMAGE_TAG` (traditionally used to set both sensor and central versions) in conjunction to `SENSOR_IMAGE_TAG`, which will override the sensor image *only*. 

This doesn't add the tests to CI yet. This is only and intermediate step to parameterize QA scripts and allow different central/sensor versions. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~


## Testing Performed

Run locally: 
```
USE_LOCAL_ROXCTL="true" MAIN_IMAGE_TAG="3.71.0" SENSOR_IMAGE_TAG="3.70.0" ./qa-tests-backend/scripts/run-compatibility.sh
```

The command above will deploy an environment with central using image `3.71` and sensor using `3.70`. The tests ran (for now) are the groovy tests tagged with `SMOKE`. This is only a placeholder for now and we'll decide later which tests should we run. 
