### PR TITLE
Dashrews/ROX-12256 remove connections before create db

### DIFF
--- a/migrator/postgreshelper/load.go
+++ b/migrator/postgreshelper/load.go
@@ -46,7 +46,7 @@ func Load(conf *config.Config, databaseName string) (*pgxpool.Pool, *gorm.DB, er
 		}
 		// Create the central database if necessary
 		if !pgadmin.CheckIfDBExists(adminConfig, databaseName) {
-			err = pgadmin.CreateDB(sourceMap, adminConfig, pgadmin.AdminDB, databaseName)
+			err = pgadmin.CreateDB(sourceMap, adminConfig, pgadmin.EmptyDB, databaseName)
 			if err != nil {
 				log.WriteToStderrf("Could not create central database: %v", err)
 				return

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -190,7 +190,7 @@ func AnalyzeDatabase(config *pgxpool.Config, dbName string) error {
 
 // terminateConnection - terminates connections to the specified database
 func terminateConnection(config *pgxpool.Config, dbName string) error {
-	log.Infof("terminateConnection - %q", dbName)
+	log.Debugf("terminateConnection - %q", dbName)
 
 	// Connect to different database for admin functions
 	connectPool := GetAdminPool(config)
@@ -199,7 +199,7 @@ func terminateConnection(config *pgxpool.Config, dbName string) error {
 
 	_, err := connectPool.Exec(context.Background(), terminateConnectionStmt, dbName)
 
-	log.Info("terminateConnection done")
+	log.Debug("terminateConnection done")
 	return err
 }
 

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -32,6 +32,12 @@ const (
 	postgresTimeBetweenRetries = 10 * time.Second
 
 	getCloneStmt = "SELECT datname FROM pg_catalog.pg_database WHERE datname ~ '^%s_.*'"
+
+	// terminateConnectionStmt - terminates connections to the specified database
+	terminateConnectionStmt = "SELECT pg_terminate_backend(pg_stat_activity.pid) " +
+		"FROM pg_stat_activity " +
+		"WHERE datname = $1 " +
+		" AND pid <> pg_backend_pid();"
 )
 
 // DropDB - drops a database.
@@ -76,6 +82,13 @@ func CreateDB(sourceMap map[string]string, adminConfig *pgxpool.Config, dbTempla
 
 	SetPostgresCmdEnv(cmd, sourceMap, adminConfig)
 
+	// terminate connections to the source database.  You cannot copy from a database if
+	// there are open connections to it.
+	err := terminateConnection(adminConfig, dbTemplate)
+	if err != nil {
+		return err
+	}
+
 	log.Infof("%q has been created", dbName)
 	return ExecutePostgresCmd(cmd)
 }
@@ -86,9 +99,16 @@ func RenameDB(adminPool *pgxpool.Pool, originalDB, newDB string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), postgresQueryTimeout)
 	defer cancel()
 
+	// terminate connections to the source database.  You cannot move a database if
+	// there are open connections to it.
+	err := terminateConnection(adminPool.Config(), originalDB)
+	if err != nil {
+		return err
+	}
+
 	sqlStmt := fmt.Sprintf("ALTER DATABASE %s RENAME TO %s", originalDB, newDB)
 
-	_, err := adminPool.Exec(ctx, sqlStmt)
+	_, err = adminPool.Exec(ctx, sqlStmt)
 
 	return err
 }
@@ -165,6 +185,21 @@ func AnalyzeDatabase(config *pgxpool.Config, dbName string) error {
 	_, err := connectPool.Exec(context.Background(), "ANALYZE")
 
 	log.Debug("Anaylze done")
+	return err
+}
+
+// terminateConnection - terminates connections to the specified database
+func terminateConnection(config *pgxpool.Config, dbName string) error {
+	log.Infof("terminateConnection - %q", dbName)
+
+	// Connect to different database for admin functions
+	connectPool := GetAdminPool(config)
+	// Close the admin connection pool
+	defer connectPool.Close()
+
+	_, err := connectPool.Exec(context.Background(), terminateConnectionStmt, dbName)
+
+	log.Info("terminateConnection done")
 	return err
 }
 

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -37,7 +37,7 @@ const (
 	terminateConnectionStmt = "SELECT pg_terminate_backend(pg_stat_activity.pid) " +
 		"FROM pg_stat_activity " +
 		"WHERE datname = $1 " +
-		" AND pid <> pg_backend_pid();"
+		"AND pid <> pg_backend_pid();"
 )
 
 // DropDB - drops a database.

--- a/pkg/postgres/pgadmin/admin_utils_test.go
+++ b/pkg/postgres/pgadmin/admin_utils_test.go
@@ -64,14 +64,14 @@ func (s *PostgresRestoreSuite) SetupTest() {
 }
 
 func (s *PostgresRestoreSuite) TearDownTest() {
-	// Clean up
-	s.Nil(DropDB(s.sourceMap, s.config, restoreDB))
-	s.Nil(DropDB(s.sourceMap, s.config, activeDB))
-	s.Nil(DropDB(s.sourceMap, s.config, tempDB))
-
 	if s.pool != nil {
+		// Clean up
+		s.Nil(DropDB(s.sourceMap, s.config, restoreDB))
+		s.Nil(DropDB(s.sourceMap, s.config, activeDB))
+		s.Nil(DropDB(s.sourceMap, s.config, tempDB))
 		s.pool.Close()
 	}
+
 	s.envIsolator.RestoreAll()
 }
 

--- a/pkg/postgres/pgadmin/admin_utils_test.go
+++ b/pkg/postgres/pgadmin/admin_utils_test.go
@@ -64,7 +64,7 @@ func (s *PostgresRestoreSuite) SetupTest() {
 }
 
 func (s *PostgresRestoreSuite) TearDownTest() {
-	//Clean up
+	// Clean up
 	s.Nil(DropDB(s.sourceMap, s.config, restoreDB))
 	s.Nil(DropDB(s.sourceMap, s.config, activeDB))
 	s.Nil(DropDB(s.sourceMap, s.config, tempDB))

--- a/pkg/postgres/pgadmin/admin_utils_test.go
+++ b/pkg/postgres/pgadmin/admin_utils_test.go
@@ -65,10 +65,9 @@ func (s *PostgresRestoreSuite) SetupTest() {
 
 func (s *PostgresRestoreSuite) TearDownTest() {
 	//Clean up
-	err := DropDB(s.sourceMap, s.config, restoreDB)
-	s.Nil(err)
-	err = DropDB(s.sourceMap, s.config, activeDB)
-	s.Nil(err)
+	s.Nil(DropDB(s.sourceMap, s.config, restoreDB))
+	s.Nil(DropDB(s.sourceMap, s.config, activeDB))
+	s.Nil(DropDB(s.sourceMap, s.config, tempDB))
 
 	if s.pool != nil {
 		s.pool.Close()
@@ -128,5 +127,6 @@ func (s *PostgresRestoreSuite) TestUtilities() {
 	// Successfully drop the restore DB
 	err = DropDB(s.sourceMap, s.config, restoreDB)
 	s.Nil(err)
+	// Make sure the connection to the restore db was terminated
 	s.NotNil(restorePool.Ping(s.ctx))
 }


### PR DESCRIPTION
## Description

In Postgres you cannot copy (via a create_db with a template) or rename a database if there are open connections on the source database.  Since those operations are being performed throughout the migration process, it is not really valid to be connected to those database at this time.  This PR will terminate any open connections on a source database before we try to copy it or move it.  

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Moved a test file and renamed it to be admin_utils_test.go.  Then expanded it to cover cases to ensure connections were being terminated prior to copy and rename functions being completed.
