### PR TITLE
Postgres end-to-end tests - Fix VulnScanWithGraphQLTest GraphQL queries

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
@@ -130,6 +130,7 @@ class GraphQLService {
         private Response parseResponse(HttpResponse response)  {
             def bsa = new ByteArrayOutputStream()
             response.getEntity().writeTo(bsa)
+            log.info "GraphQL response: " + bsa.toString()
             def returnedValue = new JsonSlurper().parseText(bsa.toString())
             return new Response(response.getStatusLine().getStatusCode(), returnedValue.data, returnedValue.errors)
         }
@@ -158,6 +159,7 @@ class GraphQLService {
                 httpPost.addHeader(header.getFirst(), header.getSecond())
             }
             def jsonContent = new JsonOutput().toJson(content)
+            log.info "GraphQL query: " + jsonContent
             httpPost.setEntity(new StringEntity(jsonContent))
             return httpPost
         }

--- a/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
@@ -130,7 +130,7 @@ class GraphQLService {
         private Response parseResponse(HttpResponse response)  {
             def bsa = new ByteArrayOutputStream()
             response.getEntity().writeTo(bsa)
-            log.info "GraphQL response: " + bsa.toString()
+            log.info "GraphQL response: " + bsa
             def returnedValue = new JsonSlurper().parseText(bsa.toString())
             return new Response(response.getStatusLine().getStatusCode(), returnedValue.data, returnedValue.errors)
         }

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -382,6 +382,10 @@ class BaseSpecification extends Specification {
         orchestrator.deleteSecret("gcr-image-pull-secret", Constants.ORCHESTRATOR_NAMESPACE)
     }
 
+    static Boolean isPostgresRun() {
+        return Env.CI_JOBNAME.contains("postgres")
+    }
+
     static Boolean isRaceBuild() {
         return Env.get("IS_RACE_BUILD", null) == "true" || Env.CI_JOBNAME == "race-condition-tests"
     }


### PR DESCRIPTION
## Description

With the re-design of the dackbox graph for the postgres migration, some graphQL queries in the end-to-end tests need to be adapted.
Here, the focus is on the VulnScanWithGraphQLTest.groovy test file.

In order to make debugging easier, additional logs were added to the GraphQL service, and a minor framework adjustment was also introduced (add a function to tell whether the current run is a Postgres run or not).

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Test code fixes, CI run should be sufficient.