### PR TITLE
Disable updates for patch releases updates for aws-sdk-go

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -45,7 +45,7 @@ updates:
     open-pull-requests-limit: 3
     reviewers:
       - "stackrox/backend-dep-updaters"
-   ignore:
+    ignore:
       - dependency-name: "github.com/aws/aws-sdk-go"
         update-types: ["version-update:semver-patch"]
 

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -45,6 +45,9 @@ updates:
     open-pull-requests-limit: 3
     reviewers:
       - "stackrox/backend-dep-updaters"
+   ignore:
+      - dependency-name: "github.com/aws/aws-sdk-go"
+        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: 'gomod'
     directory: '/tools/linters/'


### PR DESCRIPTION
## Description

aws-sdk-go has many patch releases that are noisy. Let's update only on security updates and minor and major releases.

Refs: https://github.com/stackrox/stackrox/pull/2854#issuecomment-1230096187

## Testing Performed

CI