### PR TITLE
Add junit output to golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,9 @@ run:
   build-tags:
   - sql_integration
 
+output:
+  format: "junit-xml:report.xml,colored-line-number"
+
 issues:
   exclude-use-default: false
 

--- a/scripts/ci/jobs/style-checks.sh
+++ b/scripts/ci/jobs/style-checks.sh
@@ -7,7 +7,14 @@ set -euo pipefail
 
 style_checks() {
     info "Starting style-checks"
-    make style
+    make style || touch FAIL
+
+    info "Saving junit XML report"
+    mkdir -p junit-reports
+    cp -a report.xml "junit-reports/" || true
+    store_test_results junit-reports reports
+
+    [[ ! -f FAIL ]] || die "Style checks failed"
 }
 
 style_checks "$@"


### PR DESCRIPTION
## Description

To make it easier to spot bugs in prow let's add junit output for golangci-lint.
https://github.com/janisz/release/blob/d2025ba662b735c46b87c867344146506526d59a/core-services/prow/02_config/_config.yaml#L79-L80

## Testing Performed

![image](https://user-images.githubusercontent.com/1616386/187288776-56d02238-f413-448e-8ad8-c15cb2167be2.png)
