### PR TITLE
Wait for 3 more generic requests in visit helper functions for integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -2,6 +2,36 @@ import * as api from '../constants/apiEndpoints';
 
 import { interceptRequests, waitForResponses } from './request';
 
+// generic requests to render the MainPage component
+const requestConfigGeneric = {
+    routeMatcherMap: {
+        featureflags: {
+            method: 'GET',
+            url: api.featureFlags,
+        }, // sagas/featureFlagSagas
+        mypermissions: {
+            method: 'GET',
+            url: api.roles.mypermissions,
+        }, // sagas/authSagas
+        'config/public': {
+            method: 'GET',
+            url: api.system.configPublic,
+        }, // sagas/systemConfig
+        'auth/status': {
+            method: 'GET',
+            url: api.auth.authStatus,
+        }, // sagas/authSagas
+        credentialexpiry_CENTRAL: {
+            method: 'GET',
+            url: api.certExpiry.central,
+        }, // MainPage/CredentialExpiryService
+        credentialexpiry_SCANNER: {
+            method: 'GET',
+            url: api.certExpiry.scanner,
+        }, // MainPage/CredentialExpiryService
+    },
+};
+
 /*
  * Wait for prerequisite requests to render container components.
  *
@@ -24,14 +54,12 @@ import { interceptRequests, waitForResponses } from './request';
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
 export function visit(pageUrl, requestConfig, staticResponseMap) {
-    cy.intercept('GET', api.featureFlags).as('featureflags');
-    cy.intercept('GET', api.roles.mypermissions).as('mypermissions');
-    cy.intercept('GET', api.system.configPublic).as('config/public');
+    interceptRequests(requestConfigGeneric);
     interceptRequests(requestConfig, staticResponseMap);
 
     cy.visit(pageUrl);
 
-    cy.wait(['@featureflags', '@mypermissions', '@config/public']);
+    waitForResponses(requestConfigGeneric);
     waitForResponses(requestConfig);
 }
 
@@ -52,13 +80,11 @@ export function visitWithPermissions(
     requestConfig,
     staticResponseMap
 ) {
-    cy.intercept('GET', api.featureFlags).as('featureflags');
-    cy.intercept('GET', api.roles.mypermissions, permissionsStaticResponse).as('mypermissions');
-    cy.intercept('GET', api.system.configPublic).as('config/public');
+    interceptRequests(requestConfigGeneric);
     interceptRequests(requestConfig, staticResponseMap);
 
     cy.visit(pageUrl);
 
-    cy.wait(['@featureflags', '@mypermissions', '@config/public']);
+    waitForResponses(requestConfigGeneric);
     waitForResponses(requestConfig);
 }

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -8,15 +8,15 @@ const requestConfigGeneric = {
         featureflags: {
             method: 'GET',
             url: api.featureFlags,
-        }, // sagas/featureFlagSagas
+        }, // reducers/featureFlags and sagas/featureFlagSagas
         mypermissions: {
             method: 'GET',
             url: api.roles.mypermissions,
-        }, // sagas/authSagas
+        }, // hooks/usePermissions and reducers/roles and sagas/authSagas
         'config/public': {
             method: 'GET',
             url: api.system.configPublic,
-        }, // sagas/systemConfig
+        }, // reducers/systemConfig and sagas/systemConfig
         'auth/status': {
             method: 'GET',
             url: api.auth.authStatus,

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -80,7 +80,10 @@ export function visitWithPermissions(
     requestConfig,
     staticResponseMap
 ) {
-    interceptRequests(requestConfigGeneric);
+    const staticResponseMapGeneric = {
+        mypermissions: permissionsStaticResponse,
+    };
+    interceptRequests(requestConfigGeneric, staticResponseMapGeneric);
     interceptRequests(requestConfig, staticResponseMap);
 
     cy.visit(pageUrl);

--- a/ui/apps/platform/cypress/integration/general.test.js
+++ b/ui/apps/platform/cypress/integration/general.test.js
@@ -7,6 +7,7 @@ import { visitComplianceDashboard, visitComplianceEntities } from '../helpers/co
 import { visitMainDashboard, visitMainDashboardFromLeftNav } from '../helpers/main';
 import { visitNetworkGraph } from '../helpers/networkGraph';
 import { visitViolations, visitViolationsWithUncaughtException } from '../helpers/violations';
+import { visit } from '../helpers/visit';
 
 //
 // Sanity / general checks for UI being up and running

--- a/ui/apps/platform/cypress/integration/general.test.js
+++ b/ui/apps/platform/cypress/integration/general.test.js
@@ -6,7 +6,6 @@ import withAuth from '../helpers/basicAuth';
 import { visitComplianceDashboard, visitComplianceEntities } from '../helpers/compliance';
 import { visitMainDashboard, visitMainDashboardFromLeftNav } from '../helpers/main';
 import { visitNetworkGraph } from '../helpers/networkGraph';
-import { visit } from '../helpers/visit';
 import { visitViolations, visitViolationsWithUncaughtException } from '../helpers/violations';
 
 //

--- a/ui/apps/platform/cypress/integration/general.test.js
+++ b/ui/apps/platform/cypress/integration/general.test.js
@@ -6,6 +6,7 @@ import withAuth from '../helpers/basicAuth';
 import { visitComplianceDashboard, visitComplianceEntities } from '../helpers/compliance';
 import { visitMainDashboard, visitMainDashboardFromLeftNav } from '../helpers/main';
 import { visitNetworkGraph } from '../helpers/networkGraph';
+import { visit } from '../helpers/visit';
 import { visitViolations, visitViolationsWithUncaughtException } from '../helpers/violations';
 
 //
@@ -51,10 +52,7 @@ describe('General sanity checks', () => {
         });
 
         it('for User Profile', () => {
-            cy.intercept('GET', api.roles.mypermissions).as('mypermissions');
-            cy.intercept('GET', api.auth.authStatus).as('authStatus');
-            cy.visit(userUrl);
-            cy.wait(['@mypermissions', '@authStatus']);
+            visit(userUrl);
 
             cy.title().should('match', new RegExp(`User Profile | ${productNameRegExp}`));
         });
@@ -62,8 +60,8 @@ describe('General sanity checks', () => {
         it('for API Docs', () => {
             // User Profile test often failed when preceded by this test, so move to last place.
             cy.intercept('GET', api.apiDocs.docs).as('apiDocs');
-            cy.visit(apidocsUrl);
-            cy.wait('@apiDocs', { timeout: 10000 }); // api docs are sloooooow
+            visit(apidocsUrl);
+            cy.wait('@apiDocs', { responseTimeout: 10000 }); // api docs are sloooooow
 
             cy.title().should('match', new RegExp(`API Reference | ${productNameRegExp}`));
         });


### PR DESCRIPTION
## Description

### Test failure

> for API Docs: General sanity checks should have correct page titles based on URL for API Docs

> Timed out retrying after 10000ms: `cy.wait()` timed out waiting `10000ms` for the 1st response to the route: `apiDocs`. No response ever occurred.

cypress/integration/general.test.js
![prow](https://user-images.githubusercontent.com/11862657/187278542-6b4ecae9-c94b-472d-af61-998128957748.png)

* 1563129461082165248 from master build for #2775 on 2022-08-26
* 1564401364421840896 from master build for #2825 on 2022-08-29
* 1564522511587086336 from master build for #2883 on 2022-08-30

### Analysis

* /v1/api/docs/swagger request has green indicator at lower left of the picture.
* This test might some of the time interval on prerequisite requests. Fix that problem now. Only if it fails in the future, increase the timeout.

### Changed files

1. Edit helpers/visit.js
    * Factor out `requestConfigGeneric` object and add comments about code files which make requests.
    * Add requests to `visit` and `visitWithPermissions` functions: /v1/auth/status and /v1/credentialexpiry for CENTRAL and SCANNER.

1. Edit integration/general.test.js
    * Replace `cy.visit` with `visit` helper function which waits for generic prerequisite requests before time interval begins for test-specific responses.
    * Replace `timeout` with `responseTimeout` key to be more precise.

### Residue

1. Rewrite the classic test for API Docs and then unskip it. Because it is slow, combine the tests.
2. Investigate double pair of credentialexpiry requests.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

For local deployment: ran tests individually before and after the change