### PR TITLE
ROX-12341: Add support for creating resolver instance with context

### DIFF
--- a/central/graphql/resolvers/cluster_vulnerabilities.go
+++ b/central/graphql/resolvers/cluster_vulnerabilities.go
@@ -391,11 +391,8 @@ func (resolver *clusterCVEResolver) EnvImpact(ctx context.Context) (float64, err
 
 func (resolver *clusterCVEResolver) FixedByVersion(_ context.Context) (string, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ClusterCVEs, "FixedByVersion")
-	scope, hasScope := scoped.GetScope(resolver.ctx)
+	scope, hasScope := scoped.GetScopeAtLevel(resolver.ctx, v1.SearchCategory_CLUSTERS)
 	if !hasScope {
-		return "", nil
-	}
-	if scope.Level != v1.SearchCategory_CLUSTERS {
 		return "", nil
 	}
 

--- a/central/graphql/resolvers/cluster_vulnerabilities.go
+++ b/central/graphql/resolvers/cluster_vulnerabilities.go
@@ -73,11 +73,7 @@ func (resolver *Resolver) ClusterVulnerability(ctx context.Context, args IDQuery
 	}
 
 	ret, err := loader.FromID(ctx, string(*args.ID))
-	vulnResolver, err := resolver.wrapClusterCVEWithContext(ctx, ret, true, err)
-	if err != nil {
-		return nil, err
-	}
-	return vulnResolver, nil
+	return resolver.wrapClusterCVEWithContext(ctx, ret, true, err)
 }
 
 // ClusterVulnerabilities resolves a set of image vulnerabilities for the input query

--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -149,7 +149,8 @@ func (resolver *Resolver) Cluster(ctx context.Context, args struct{ graphql.ID }
 	if err := readClusters(ctx); err != nil {
 		return nil, err
 	}
-	return resolver.wrapCluster(resolver.ClusterDataStore.GetCluster(ctx, string(args.ID)))
+	cluster, ok, err := resolver.ClusterDataStore.GetCluster(ctx, string(args.ID))
+	return resolver.wrapClusterWithContext(ctx, cluster, ok, err)
 }
 
 // Clusters returns GraphQL resolvers for all clusters
@@ -163,7 +164,8 @@ func (resolver *Resolver) Clusters(ctx context.Context, args PaginatedQuery) ([]
 		return nil, err
 	}
 
-	return resolver.wrapClusters(resolver.ClusterDataStore.SearchRawClusters(ctx, query))
+	clusters, err := resolver.ClusterDataStore.SearchRawClusters(ctx, query)
+	return resolver.wrapClustersWithContext(ctx, clusters, err)
 }
 
 // ClusterCount returns count of all clusters across infrastructure
@@ -232,104 +234,55 @@ func (resolver *clusterResolver) FailingPolicyCounter(ctx context.Context, args 
 }
 
 // Deployments returns GraphQL resolvers for all deployments in this cluster
-func (resolver *clusterResolver) Deployments(ctx context.Context, args PaginatedQuery) ([]*deploymentResolver, error) {
+func (resolver *clusterResolver) Deployments(_ context.Context, args PaginatedQuery) ([]*deploymentResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "Deployments")
-
-	if err := readDeployments(ctx); err != nil {
-		return nil, err
-	}
-
-	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
-
-	return resolver.root.Deployments(ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
+	return resolver.root.Deployments(resolver.clusterScopeContext(), args)
 }
 
 // DeploymentCount returns count of all deployments in this cluster
-func (resolver *clusterResolver) DeploymentCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *clusterResolver) DeploymentCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "DeploymentCount")
-	if err := readDeployments(ctx); err != nil {
-		return 0, err
-	}
-
-	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
-
-	return resolver.root.DeploymentCount(ctx, RawQuery{Query: &query})
+	return resolver.root.DeploymentCount(resolver.clusterScopeContext(), args)
 }
 
 // Nodes returns all nodes on the cluster
-func (resolver *clusterResolver) Nodes(ctx context.Context, args PaginatedQuery) ([]*nodeResolver, error) {
+func (resolver *clusterResolver) Nodes(_ context.Context, args PaginatedQuery) ([]*nodeResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "Nodes")
-
-	if err := readNodes(ctx); err != nil {
-		return nil, err
-	}
-
-	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
-
-	return resolver.root.Nodes(ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
+	return resolver.root.Nodes(resolver.clusterScopeContext(), args)
 }
 
 // NodeCount returns count of all nodes on the cluster
-func (resolver *clusterResolver) NodeCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *clusterResolver) NodeCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "NodeCount")
-
-	if err := readNodes(ctx); err != nil {
-		return 0, err
-	}
-
-	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
-
-	return resolver.root.NodeCount(ctx, RawQuery{Query: &query})
+	return resolver.root.NodeCount(resolver.clusterScopeContext(), args)
 }
 
 // Node returns a given node on a cluster
-func (resolver *clusterResolver) Node(ctx context.Context, args struct{ Node graphql.ID }) (*nodeResolver, error) {
+func (resolver *clusterResolver) Node(_ context.Context, args struct{ Node graphql.ID }) (*nodeResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "Node")
-
-	if err := readNodes(ctx); err != nil {
-		return nil, err
-	}
-	store, err := resolver.root.NodeGlobalDataStore.GetClusterNodeStore(ctx, resolver.data.GetId(), false)
-	if err != nil {
-		return nil, err
-	}
-	node, err := store.GetNode(string(args.Node))
-	return resolver.root.wrapNode(node, node != nil, err)
+	return resolver.root.Node(resolver.ctx, struct{ graphql.ID }{args.Node})
 }
 
 // Namespaces returns the namespaces in a cluster.
-func (resolver *clusterResolver) Namespaces(ctx context.Context, args PaginatedQuery) ([]*namespaceResolver, error) {
+func (resolver *clusterResolver) Namespaces(_ context.Context, args PaginatedQuery) ([]*namespaceResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "Namespaces")
-
-	if err := readNamespaces(ctx); err != nil {
-		return nil, err
-	}
-
-	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
-
-	return resolver.root.Namespaces(ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
+	return resolver.root.Namespaces(resolver.clusterScopeContext(), args)
 }
 
 // Namespace returns a given namespace in a cluster.
-func (resolver *clusterResolver) Namespace(ctx context.Context, args struct{ Name string }) (*namespaceResolver, error) {
+func (resolver *clusterResolver) Namespace(_ context.Context, args struct{ Name string }) (*namespaceResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "Namespace")
 
-	return resolver.root.NamespaceByClusterIDAndName(ctx, clusterIDAndNameQuery{
+	return resolver.root.NamespaceByClusterIDAndName(resolver.ctx, clusterIDAndNameQuery{
 		ClusterID: graphql.ID(resolver.data.GetId()),
 		Name:      args.Name,
 	})
 }
 
 // NamespaceCount returns counts of namespaces on a cluster.
-func (resolver *clusterResolver) NamespaceCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *clusterResolver) NamespaceCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "NamespaceCount")
-	if err := readNamespaces(ctx); err != nil {
-		return 0, err
-	}
-
-	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
-
-	return resolver.root.NamespaceCount(ctx, RawQuery{Query: &query})
+	return resolver.root.NamespaceCount(resolver.clusterScopeContext(), args)
 }
 
 func (resolver *clusterResolver) ComplianceResults(ctx context.Context, args RawQuery) ([]*controlResultResolver, error) {
@@ -538,20 +491,14 @@ func (resolver *clusterResolver) Subject(ctx context.Context, args struct{ Name 
 	return resolver.root.wrapSubject(k8srbac.GetSubject(subjectName, bindings))
 }
 
-func (resolver *clusterResolver) Images(ctx context.Context, args PaginatedQuery) ([]*imageResolver, error) {
+func (resolver *clusterResolver) Images(_ context.Context, args PaginatedQuery) ([]*imageResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "Images")
-
-	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
-
-	return resolver.root.Images(ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
+	return resolver.root.Images(resolver.clusterScopeContext(), args)
 }
 
-func (resolver *clusterResolver) ImageCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *clusterResolver) ImageCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ImageCount")
-
-	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
-
-	return resolver.root.ImageCount(ctx, RawQuery{Query: &query})
+	return resolver.root.ImageCount(resolver.clusterScopeContext(), args)
 }
 
 func (resolver *clusterResolver) Components(ctx context.Context, args PaginatedQuery) ([]ComponentResolver, error) {
@@ -570,26 +517,26 @@ func (resolver *clusterResolver) ComponentCount(ctx context.Context, args RawQue
 	return resolver.root.ComponentCount(ctx, RawQuery{Query: &query})
 }
 
-func (resolver *clusterResolver) ImageComponents(ctx context.Context, args PaginatedQuery) ([]ImageComponentResolver, error) {
+func (resolver *clusterResolver) ImageComponents(_ context.Context, args PaginatedQuery) ([]ImageComponentResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ImageComponents")
-	return resolver.root.ImageComponents(resolver.withClusterScope(ctx), args)
+	return resolver.root.ImageComponents(resolver.clusterScopeContext(), args)
 }
 
-func (resolver *clusterResolver) ImageComponentCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *clusterResolver) ImageComponentCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ImageComponentCount")
-	return resolver.root.ImageComponentCount(resolver.withClusterScope(ctx), args)
+	return resolver.root.ImageComponentCount(resolver.clusterScopeContext(), args)
 }
 
 // NodeComponents returns the node components in the cluster.
-func (resolver *clusterResolver) NodeComponents(ctx context.Context, args PaginatedQuery) ([]NodeComponentResolver, error) {
+func (resolver *clusterResolver) NodeComponents(_ context.Context, args PaginatedQuery) ([]NodeComponentResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "NodeComponents")
-	return resolver.root.NodeComponents(resolver.withClusterScope(ctx), args)
+	return resolver.root.NodeComponents(resolver.clusterScopeContext(), args)
 }
 
 // NodeComponentCount returns the number of node components in the cluster
-func (resolver *clusterResolver) NodeComponentCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *clusterResolver) NodeComponentCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "NodeComponentCount")
-	return resolver.root.NodeComponentCount(resolver.withClusterScope(ctx), args)
+	return resolver.root.NodeComponentCount(resolver.clusterScopeContext(), args)
 }
 
 func (resolver *clusterResolver) Vulns(ctx context.Context, args PaginatedQuery) ([]VulnerabilityResolver, error) {
@@ -643,71 +590,71 @@ func (resolver *clusterResolver) NodeVulnerabilityCounter(ctx context.Context, a
 	return resolver.root.NodeVulnerabilityCounter(ctx, RawQuery{Query: &query})
 }
 
-func (resolver *clusterResolver) withClusterScope(ctx context.Context) context.Context {
-	return scoped.Context(ctx, scoped.Scope{
+func (resolver *clusterResolver) clusterScopeContext() context.Context {
+	return scoped.Context(resolver.ctx, scoped.Scope{
 		Level: v1.SearchCategory_CLUSTERS,
 		ID:    resolver.data.GetId(),
 	})
 }
 
-func (resolver *clusterResolver) ImageVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ImageVulnerabilityResolver, error) {
+func (resolver *clusterResolver) ImageVulnerabilities(_ context.Context, args PaginatedQuery) ([]ImageVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ImageVulnerabilities")
-	return resolver.root.ImageVulnerabilities(resolver.withClusterScope(ctx), args)
+	return resolver.root.ImageVulnerabilities(resolver.clusterScopeContext(), args)
 }
 
-func (resolver *clusterResolver) ImageVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *clusterResolver) ImageVulnerabilityCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ImageVulnerabilityCount")
-	return resolver.root.ImageVulnerabilityCount(resolver.withClusterScope(ctx), args)
+	return resolver.root.ImageVulnerabilityCount(resolver.clusterScopeContext(), args)
 }
 
-func (resolver *clusterResolver) ImageVulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
+func (resolver *clusterResolver) ImageVulnerabilityCounter(_ context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ImageVulnerabilityCounter")
-	return resolver.root.ImageVulnerabilityCounter(resolver.withClusterScope(ctx), args)
+	return resolver.root.ImageVulnerabilityCounter(resolver.clusterScopeContext(), args)
 }
 
-func (resolver *clusterResolver) ClusterVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
+func (resolver *clusterResolver) ClusterVulnerabilities(_ context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ClusterVulnerabilities")
-	return resolver.root.ClusterVulnerabilities(resolver.withClusterScope(ctx), args)
+	return resolver.root.ClusterVulnerabilities(resolver.clusterScopeContext(), args)
 }
 
-func (resolver *clusterResolver) ClusterVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *clusterResolver) ClusterVulnerabilityCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ClusterVulnerabilityCount")
-	return resolver.root.ClusterVulnerabilityCount(resolver.withClusterScope(ctx), args)
+	return resolver.root.ClusterVulnerabilityCount(resolver.clusterScopeContext(), args)
 }
 
-func (resolver *clusterResolver) ClusterVulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
+func (resolver *clusterResolver) ClusterVulnerabilityCounter(_ context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ClusterVulnerabilityCounter")
-	return resolver.root.ClusterVulnerabilityCounter(resolver.withClusterScope(ctx), args)
+	return resolver.root.ClusterVulnerabilityCounter(resolver.clusterScopeContext(), args)
 }
 
-func (resolver *clusterResolver) K8sClusterVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
+func (resolver *clusterResolver) K8sClusterVulnerabilities(_ context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "K8sClusterVulnerabilities")
-	return resolver.root.K8sClusterVulnerabilities(resolver.withClusterScope(ctx), args)
+	return resolver.root.K8sClusterVulnerabilities(resolver.clusterScopeContext(), args)
 }
 
-func (resolver *clusterResolver) K8sClusterVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *clusterResolver) K8sClusterVulnerabilityCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "K8sClusterVulnerabilityCount")
-	return resolver.root.K8sClusterVulnerabilityCount(resolver.withClusterScope(ctx), args)
+	return resolver.root.K8sClusterVulnerabilityCount(resolver.clusterScopeContext(), args)
 }
 
-func (resolver *clusterResolver) IstioClusterVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
+func (resolver *clusterResolver) IstioClusterVulnerabilities(_ context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "IstioClusterVulnerabilities")
-	return resolver.root.IstioClusterVulnerabilities(resolver.withClusterScope(ctx), args)
+	return resolver.root.IstioClusterVulnerabilities(resolver.clusterScopeContext(), args)
 }
 
-func (resolver *clusterResolver) IstioClusterVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *clusterResolver) IstioClusterVulnerabilityCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "IstioClusterVulnerabilityCount")
-	return resolver.root.IstioClusterVulnerabilityCount(resolver.withClusterScope(ctx), args)
+	return resolver.root.IstioClusterVulnerabilityCount(resolver.clusterScopeContext(), args)
 }
 
-func (resolver *clusterResolver) OpenShiftClusterVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
+func (resolver *clusterResolver) OpenShiftClusterVulnerabilities(_ context.Context, args PaginatedQuery) ([]ClusterVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "OpenShiftClusterVulnerabilities")
-	return resolver.root.OpenShiftClusterVulnerabilities(resolver.withClusterScope(ctx), args)
+	return resolver.root.OpenShiftClusterVulnerabilities(resolver.clusterScopeContext(), args)
 }
 
-func (resolver *clusterResolver) OpenShiftClusterVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *clusterResolver) OpenShiftClusterVulnerabilityCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "OpenShiftClusterVulnerabilityCount")
-	return resolver.root.OpenShiftClusterVulnerabilityCount(resolver.withClusterScope(ctx), args)
+	return resolver.root.OpenShiftClusterVulnerabilityCount(resolver.clusterScopeContext(), args)
 }
 
 func (resolver *clusterResolver) K8sVulns(ctx context.Context, args PaginatedQuery) ([]VulnerabilityResolver, error) {
@@ -1113,12 +1060,12 @@ func (resolver *clusterResolver) PlottedNodeVulnerabilities(ctx context.Context,
 }
 
 // PlottedImageVulnerabilities returns the data required by top risky entity scatter-plot on vuln mgmt dashboard
-func (resolver *clusterResolver) PlottedImageVulnerabilities(ctx context.Context, args RawQuery) (*PlottedImageVulnerabilitiesResolver, error) {
+func (resolver *clusterResolver) PlottedImageVulnerabilities(_ context.Context, args RawQuery) (*PlottedImageVulnerabilitiesResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "PlottedImageVulnerabilities")
-	return resolver.root.PlottedImageVulnerabilities(resolver.withClusterScope(ctx), args)
+	return resolver.root.PlottedImageVulnerabilities(resolver.clusterScopeContext(), args)
 }
 
-func (resolver *clusterResolver) UnusedVarSink(ctx context.Context, args RawQuery) *int32 {
+func (resolver *clusterResolver) UnusedVarSink(_ context.Context, _ RawQuery) *int32 {
 	return nil
 }
 

--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -237,12 +237,20 @@ func (resolver *clusterResolver) FailingPolicyCounter(ctx context.Context, args 
 // Deployments returns GraphQL resolvers for all deployments in this cluster
 func (resolver *clusterResolver) Deployments(_ context.Context, args PaginatedQuery) ([]*deploymentResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "Deployments")
+	if !features.PostgresDatastore.Enabled() {
+		query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
+		return resolver.root.Deployments(resolver.ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
+	}
 	return resolver.root.Deployments(resolver.clusterScopeContext(), args)
 }
 
 // DeploymentCount returns count of all deployments in this cluster
 func (resolver *clusterResolver) DeploymentCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "DeploymentCount")
+	if !features.PostgresDatastore.Enabled() {
+		query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
+		return resolver.root.DeploymentCount(resolver.ctx, RawQuery{Query: &query})
+	}
 	return resolver.root.DeploymentCount(resolver.clusterScopeContext(), args)
 }
 
@@ -278,12 +286,23 @@ func (resolver *clusterResolver) Node(_ context.Context, args struct{ Node graph
 // Namespaces returns the namespaces in a cluster.
 func (resolver *clusterResolver) Namespaces(_ context.Context, args PaginatedQuery) ([]*namespaceResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "Namespaces")
+	if !features.PostgresDatastore.Enabled() {
+		query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
+		return resolver.root.Namespaces(resolver.ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
+	}
 	return resolver.root.Namespaces(resolver.clusterScopeContext(), args)
 }
 
 // Namespace returns a given namespace in a cluster.
 func (resolver *clusterResolver) Namespace(_ context.Context, args struct{ Name string }) (*namespaceResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "Namespace")
+
+	if !features.PostgresDatastore.Enabled() {
+		return resolver.root.NamespaceByClusterIDAndName(resolver.ctx, clusterIDAndNameQuery{
+			ClusterID: graphql.ID(resolver.data.GetId()),
+			Name:      args.Name,
+		})
+	}
 
 	return resolver.root.NamespaceByClusterIDAndName(resolver.clusterScopeContext(), clusterIDAndNameQuery{
 		ClusterID: graphql.ID(resolver.data.GetId()),
@@ -294,6 +313,10 @@ func (resolver *clusterResolver) Namespace(_ context.Context, args struct{ Name 
 // NamespaceCount returns counts of namespaces on a cluster.
 func (resolver *clusterResolver) NamespaceCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "NamespaceCount")
+	if !features.PostgresDatastore.Enabled() {
+		query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
+		return resolver.root.NamespaceCount(resolver.ctx, RawQuery{Query: &query})
+	}
 	return resolver.root.NamespaceCount(resolver.clusterScopeContext(), args)
 }
 
@@ -505,11 +528,19 @@ func (resolver *clusterResolver) Subject(ctx context.Context, args struct{ Name 
 
 func (resolver *clusterResolver) Images(_ context.Context, args PaginatedQuery) ([]*imageResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "Images")
+	if !features.PostgresDatastore.Enabled() {
+		query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
+		return resolver.root.Images(resolver.ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
+	}
 	return resolver.root.Images(resolver.clusterScopeContext(), args)
 }
 
 func (resolver *clusterResolver) ImageCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Cluster, "ImageCount")
+	if !features.PostgresDatastore.Enabled() {
+		query := search.AddRawQueriesAsConjunction(args.String(), resolver.getClusterRawQuery())
+		return resolver.root.ImageCount(resolver.ctx, RawQuery{Query: &query})
+	}
 	return resolver.root.ImageCount(resolver.clusterScopeContext(), args)
 }
 

--- a/central/graphql/resolvers/components_v2.go
+++ b/central/graphql/resolvers/components_v2.go
@@ -292,13 +292,6 @@ func (eicr *imageComponentResolver) VulnCounter(ctx context.Context, args RawQue
 	return mapCVEsToVulnerabilityCounter(cveToVulnerabilityWithSeverity(fixableVulns), cveToVulnerabilityWithSeverity(unFixableCVEs)), nil
 }
 
-func (eicr *imageComponentResolver) imageComponentScopeContext() context.Context {
-	return scoped.Context(eicr.ctx, scoped.Scope{
-		Level: v1.SearchCategory_IMAGE_COMPONENTS,
-		ID:    eicr.data.GetId(),
-	})
-}
-
 // Nodes are the nodes that contain the Component.
 func (eicr *imageComponentResolver) Nodes(ctx context.Context, args PaginatedQuery) ([]*nodeResolver, error) {
 	if err := readNodes(ctx); err != nil {

--- a/central/graphql/resolvers/deployments.go
+++ b/central/graphql/resolvers/deployments.go
@@ -85,7 +85,8 @@ func (resolver *Resolver) Deployment(ctx context.Context, args struct{ *graphql.
 	if err := readDeployments(ctx); err != nil {
 		return nil, err
 	}
-	return resolver.wrapDeployment(resolver.DeploymentDataStore.GetDeployment(ctx, string(*args.ID)))
+	deployment, ok, err := resolver.DeploymentDataStore.GetDeployment(ctx, string(*args.ID))
+	return resolver.wrapDeploymentWithContext(ctx, deployment, ok, err)
 }
 
 // Deployments returns GraphQL resolvers all deployments
@@ -98,8 +99,8 @@ func (resolver *Resolver) Deployments(ctx context.Context, args PaginatedQuery) 
 	if err != nil {
 		return nil, err
 	}
-	return resolver.wrapDeployments(
-		resolver.DeploymentDataStore.SearchRawDeployments(ctx, q))
+	deployments, err := resolver.DeploymentDataStore.SearchRawDeployments(ctx, q)
+	return resolver.wrapDeploymentsWithContext(ctx, deployments, err)
 }
 
 // DeploymentCount returns count all deployments across infrastructure
@@ -120,25 +121,15 @@ func (resolver *Resolver) DeploymentCount(ctx context.Context, args RawQuery) (i
 }
 
 // Cluster returns a GraphQL resolver for the cluster where this deployment runs
-func (resolver *deploymentResolver) Cluster(ctx context.Context) (*clusterResolver, error) {
+func (resolver *deploymentResolver) Cluster(_ context.Context) (*clusterResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "Cluster")
-	if err := readClusters(ctx); err != nil {
-		return nil, err
-	}
-
-	clusterID := graphql.ID(resolver.data.GetClusterId())
-	return resolver.root.Cluster(ctx, struct{ graphql.ID }{clusterID})
+	return resolver.root.Cluster(resolver.deploymentScopeContext(), struct{ graphql.ID }{graphql.ID(resolver.data.GetClusterId())})
 }
 
 // NamespaceObject returns a GraphQL resolver for the namespace where this deployment runs
-func (resolver *deploymentResolver) NamespaceObject(ctx context.Context) (*namespaceResolver, error) {
+func (resolver *deploymentResolver) NamespaceObject(_ context.Context) (*namespaceResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "NamespaceObject")
-
-	if err := readNamespaces(ctx); err != nil {
-		return nil, err
-	}
-	namespaceID := graphql.ID(resolver.data.GetNamespaceId())
-	return resolver.root.Namespace(ctx, struct{ graphql.ID }{namespaceID})
+	return resolver.root.Namespace(resolver.deploymentScopeContext(), struct{ graphql.ID }{graphql.ID(resolver.data.GetNamespaceId())})
 }
 
 // ServiceAccountObject returns a GraphQL resolver for the service account associated with this deployment
@@ -533,25 +524,17 @@ func (resolver *deploymentResolver) ServiceAccountID(ctx context.Context) (strin
 	return results[0].ID, nil
 }
 
-func (resolver *deploymentResolver) Images(ctx context.Context, args PaginatedQuery) ([]*imageResolver, error) {
+func (resolver *deploymentResolver) Images(_ context.Context, args PaginatedQuery) ([]*imageResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "Images")
-	if err := readImages(ctx); err != nil {
-		return nil, err
-	}
 	if !resolver.hasImages() {
 		return nil, nil
 	}
-
-	return resolver.root.Images(resolver.withDeploymentScope(ctx), PaginatedQuery{Query: args.Query, Pagination: args.Pagination})
+	return resolver.root.Images(resolver.deploymentScopeContext(), args)
 }
 
-func (resolver *deploymentResolver) ImageCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *deploymentResolver) ImageCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "ImageCount")
-	if err := readImages(ctx); err != nil {
-		return 0, err
-	}
-
-	return resolver.root.ImageCount(resolver.withDeploymentScope(ctx), RawQuery{Query: args.Query})
+	return resolver.root.ImageCount(resolver.deploymentScopeContext(), args)
 }
 
 func (resolver *deploymentResolver) Components(ctx context.Context, args PaginatedQuery) ([]ComponentResolver, error) {
@@ -577,33 +560,33 @@ func (resolver *deploymentResolver) ComponentCount(ctx context.Context, args Raw
 	}), RawQuery{Query: &query})
 }
 
-func (resolver *deploymentResolver) ImageComponents(ctx context.Context, args PaginatedQuery) ([]ImageComponentResolver, error) {
+func (resolver *deploymentResolver) ImageComponents(_ context.Context, args PaginatedQuery) ([]ImageComponentResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "ImageComponents")
-	return resolver.root.ImageComponents(resolver.withDeploymentScope(ctx), args)
+	return resolver.root.ImageComponents(resolver.deploymentScopeContext(), args)
 }
 
-func (resolver *deploymentResolver) ImageComponentCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *deploymentResolver) ImageComponentCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "ImageComponentCount")
-	return resolver.root.ImageComponentCount(resolver.withDeploymentScope(ctx), args)
+	return resolver.root.ImageComponentCount(resolver.deploymentScopeContext(), args)
 }
 
-func (resolver *deploymentResolver) ImageVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ImageVulnerabilityResolver, error) {
+func (resolver *deploymentResolver) ImageVulnerabilities(_ context.Context, args PaginatedQuery) ([]ImageVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "ImageVulnerabilities")
-	return resolver.root.ImageVulnerabilities(resolver.withDeploymentScope(ctx), args)
+	return resolver.root.ImageVulnerabilities(resolver.deploymentScopeContext(), args)
 }
 
-func (resolver *deploymentResolver) ImageVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *deploymentResolver) ImageVulnerabilityCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "ImageVulnerabilityCount")
-	return resolver.root.ImageVulnerabilityCount(resolver.withDeploymentScope(ctx), args)
+	return resolver.root.ImageVulnerabilityCount(resolver.deploymentScopeContext(), args)
 }
 
-func (resolver *deploymentResolver) ImageVulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
+func (resolver *deploymentResolver) ImageVulnerabilityCounter(_ context.Context, args RawQuery) (*VulnerabilityCounterResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "ImageVulnerabilityCounter")
-	return resolver.root.ImageVulnerabilityCounter(resolver.withDeploymentScope(ctx), args)
+	return resolver.root.ImageVulnerabilityCounter(resolver.deploymentScopeContext(), args)
 }
 
-func (resolver *deploymentResolver) withDeploymentScope(ctx context.Context) context.Context {
-	return scoped.Context(ctx, scoped.Scope{
+func (resolver *deploymentResolver) deploymentScopeContext() context.Context {
+	return scoped.Context(resolver.ctx, scoped.Scope{
 		Level: v1.SearchCategory_DEPLOYMENTS,
 		ID:    resolver.data.GetId(),
 	})
@@ -803,11 +786,11 @@ func (resolver *deploymentResolver) PlottedVulns(ctx context.Context, args RawQu
 }
 
 // PlottedImageVulnerabilities returns the data required by top risky entity scatter-plot on vuln mgmt dashboard
-func (resolver *deploymentResolver) PlottedImageVulnerabilities(ctx context.Context, args RawQuery) (*PlottedImageVulnerabilitiesResolver, error) {
+func (resolver *deploymentResolver) PlottedImageVulnerabilities(_ context.Context, args RawQuery) (*PlottedImageVulnerabilitiesResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "PlottedImageVulnerabilities")
-	return resolver.root.PlottedImageVulnerabilities(resolver.withDeploymentScope(ctx), args)
+	return resolver.root.PlottedImageVulnerabilities(resolver.deploymentScopeContext(), args)
 }
 
-func (resolver *deploymentResolver) UnusedVarSink(ctx context.Context, args RawQuery) *int32 {
+func (resolver *deploymentResolver) UnusedVarSink(_ context.Context, _ RawQuery) *int32 {
 	return nil
 }

--- a/central/graphql/resolvers/image_components.go
+++ b/central/graphql/resolvers/image_components.go
@@ -108,11 +108,7 @@ func (resolver *Resolver) ImageComponent(ctx context.Context, args IDQuery) (Ima
 	}
 
 	ret, err := loader.FromID(ctx, string(*args.ID))
-	res, err := resolver.wrapImageComponentWithContext(ctx, ret, true, err)
-	if err != nil {
-		return nil, err
-	}
-	return res, nil
+	return resolver.wrapImageComponentWithContext(ctx, ret, true, err)
 }
 
 // ImageComponents returns image components that match the input query.

--- a/central/graphql/resolvers/image_vulnerabilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities.go
@@ -80,11 +80,10 @@ func (resolver *Resolver) ImageVulnerability(ctx context.Context, args IDQuery) 
 	}
 
 	ret, err := loader.FromID(ctx, string(*args.ID))
-	vulnResolver, err := resolver.wrapImageCVE(ret, true, err)
+	vulnResolver, err := resolver.wrapImageCVEWithContext(ctx, ret, true, err)
 	if err != nil {
 		return nil, err
 	}
-	vulnResolver.ctx = ctx
 	return vulnResolver, nil
 }
 
@@ -115,7 +114,8 @@ func (resolver *Resolver) ImageVulnerabilities(ctx context.Context, q PaginatedQ
 
 	// get values
 	query = tryUnsuppressedQuery(query)
-	cveResolvers, err := resolver.wrapImageCVEs(loader.FromQuery(ctx, query))
+	vulns, err := loader.FromQuery(ctx, query)
+	cveResolvers, err := resolver.wrapImageCVEsWithContext(ctx, vulns, err)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,6 @@ func (resolver *Resolver) ImageVulnerabilities(ctx context.Context, q PaginatedQ
 	// cast as return type
 	ret := make([]ImageVulnerabilityResolver, 0, len(cveResolvers))
 	for _, res := range cveResolvers {
-		res.ctx = ctx
 		ret = append(ret, res)
 	}
 	return ret, nil
@@ -252,11 +251,10 @@ func (resolver *Resolver) TopImageVulnerability(ctx context.Context, args RawQue
 		return nil, errors.New("TopImageVulnerability query returned more than one vulnerabilities")
 	}
 
-	res, err := resolver.wrapImageCVE(topVuln[0], true, nil)
+	res, err := resolver.wrapImageCVEWithContext(ctx, topVuln[0], true, nil)
 	if err != nil {
 		return nil, err
 	}
-	res.ctx = ctx
 	return res, nil
 }
 
@@ -272,14 +270,14 @@ func imageCveToVulnerabilityWithSeverity(in []*storage.ImageCVE) []Vulnerability
 	return ret
 }
 
-func (resolver *imageCVEResolver) withImageVulnerabilityScope(ctx context.Context) context.Context {
+func (resolver *imageCVEResolver) imageVulnerabilityScopeContext() context.Context {
 	if features.PostgresDatastore.Enabled() {
-		return scoped.Context(ctx, scoped.Scope{
+		return scoped.Context(resolver.ctx, scoped.Scope{
 			ID:    resolver.data.GetId(),
 			Level: v1.SearchCategory_IMAGE_VULNERABILITIES,
 		})
 	}
-	return scoped.Context(ctx, scoped.Scope{
+	return scoped.Context(resolver.ctx, scoped.Scope{
 		ID:    resolver.data.GetId(),
 		Level: v1.SearchCategory_VULNERABILITIES,
 	})
@@ -304,13 +302,13 @@ func withImageCveTypeFiltering(q string) string {
 Sub Resolver Functions
 */
 
-func (resolver *imageCVEResolver) EnvImpact(ctx context.Context) (float64, error) {
+func (resolver *imageCVEResolver) EnvImpact(_ context.Context) (float64, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "EnvImpact")
-	allCount, err := resolver.root.DeploymentCount(ctx, RawQuery{})
+	allCount, err := resolver.root.DeploymentCount(resolver.ctx, RawQuery{})
 	if err != nil || allCount == 0 {
 		return 0, err
 	}
-	scopedCount, err := resolver.root.DeploymentCount(resolver.withImageVulnerabilityScope(ctx), RawQuery{})
+	scopedCount, err := resolver.root.DeploymentCount(resolver.imageVulnerabilityScopeContext(), RawQuery{})
 	if err != nil {
 		return 0, err
 	}
@@ -375,7 +373,7 @@ func (resolver *imageCVEResolver) IsFixable(_ context.Context, args RawQuery) (b
 	return count != 0, nil
 }
 
-func (resolver *imageCVEResolver) LastScanned(ctx context.Context) (*graphql.Time, error) {
+func (resolver *imageCVEResolver) LastScanned(_ context.Context) (*graphql.Time, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "LastScanned")
 
 	// Short path. Full image is embedded when image scan resolver is called.
@@ -383,7 +381,7 @@ func (resolver *imageCVEResolver) LastScanned(ctx context.Context) (*graphql.Tim
 		return timestamp(scanTime)
 	}
 
-	imageLoader, err := loaders.GetImageLoader(ctx)
+	imageLoader, err := loaders.GetImageLoader(resolver.ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -400,7 +398,7 @@ func (resolver *imageCVEResolver) LastScanned(ctx context.Context) (*graphql.Tim
 		},
 	}
 
-	images, err := imageLoader.FromQuery(resolver.withImageVulnerabilityScope(ctx), q)
+	images, err := imageLoader.FromQuery(resolver.imageVulnerabilityScopeContext(), q)
 	if err != nil || len(images) == 0 {
 		return nil, err
 	} else if len(images) > 1 {
@@ -425,7 +423,7 @@ func (resolver *imageCVEResolver) Vectors() *EmbeddedVulnerabilityVectorsResolve
 	return nil
 }
 
-func (resolver *imageCVEResolver) VulnerabilityState(ctx context.Context) string {
+func (resolver *imageCVEResolver) VulnerabilityState(_ context.Context) string {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "VulnerabilityState")
 
 	// Short path. Full image is embedded when image scan resolver is called.
@@ -447,12 +445,12 @@ func (resolver *imageCVEResolver) VulnerabilityState(ctx context.Context) string
 		return ""
 	}
 
-	imageLoader, err := loaders.GetImageLoader(ctx)
+	imageLoader, err := loaders.GetImageLoader(resolver.ctx)
 	if err != nil {
 		log.Error(errors.Wrap(err, "getting image loader"))
 		return ""
 	}
-	img, err := imageLoader.FromID(ctx, imageID)
+	img, err := imageLoader.FromID(resolver.ctx, imageID)
 	if err != nil {
 		log.Error(errors.Wrapf(err, "fetching image with id %s", imageID))
 		return ""
@@ -487,7 +485,7 @@ func (resolver *imageCVEResolver) ActiveState(ctx context.Context, args RawQuery
 	}
 	// We only support OS level component. The active state is not determined if there is no OS level component associate with this vuln.
 	query := search.NewQueryBuilder().AddExactMatches(search.CVEID, resolver.data.GetId()).AddStrings(search.ComponentSource, storage.SourceType_OS.String()).ProtoQuery()
-	osLevelComponents, err := resolver.root.ImageComponentDataStore.Count(ctx, query)
+	osLevelComponents, err := resolver.root.ImageComponentDataStore.Count(resolver.ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -502,7 +500,7 @@ func (resolver *imageCVEResolver) ActiveState(ctx context.Context, args RawQuery
 	}
 	query = search.ConjunctionQuery(resolver.getImageCVEQuery(), qb.ProtoQuery())
 
-	results, err := resolver.root.ActiveComponent.Search(ctx, query)
+	results, err := resolver.root.ActiveComponent.Search(resolver.ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +512,7 @@ func (resolver *imageCVEResolver) ActiveState(ctx context.Context, args RawQuery
 	return &activeStateResolver{root: resolver.root, state: state, activeComponentIDs: ids, imageScope: imageID}, nil
 }
 
-func (resolver *imageCVEResolver) EffectiveVulnerabilityRequest(ctx context.Context) (*VulnerabilityRequestResolver, error) {
+func (resolver *imageCVEResolver) EffectiveVulnerabilityRequest(_ context.Context) (*VulnerabilityRequestResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "EffectiveVulnerabilityRequest")
 	var imageID string
 	scope, hasScope := scoped.GetScopeAtLevel(resolver.ctx, v1.SearchCategory_IMAGES)
@@ -525,17 +523,17 @@ func (resolver *imageCVEResolver) EffectiveVulnerabilityRequest(ctx context.Cont
 	if imageID == "" {
 		return nil, errors.Errorf("image scope must be provided for determining effective vulnerability request for cve %s", resolver.data.GetId())
 	}
-	imageLoader, err := loaders.GetImageLoader(ctx)
+	imageLoader, err := loaders.GetImageLoader(resolver.ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting image loader")
 	}
-	img, err := imageLoader.FromID(ctx, imageID)
+	img, err := imageLoader.FromID(resolver.ctx, imageID)
 	if err != nil {
 		log.Error(errors.Wrapf(err, "fetching image with id %s", imageID))
 		return nil, nil
 	}
 
-	req, err := resolver.root.vulnReqQueryMgr.EffectiveVulnReq(ctx, resolver.data.GetCveBaseInfo().GetCve(),
+	req, err := resolver.root.vulnReqQueryMgr.EffectiveVulnReq(resolver.ctx, resolver.data.GetCveBaseInfo().GetCve(),
 		common.VulnReqScope{
 			Registry: img.GetName().GetRegistry(),
 			Remote:   img.GetName().GetRemote(),
@@ -547,14 +545,14 @@ func (resolver *imageCVEResolver) EffectiveVulnerabilityRequest(ctx context.Cont
 	return resolver.root.wrapVulnerabilityRequest(req, nil)
 }
 
-func (resolver *imageCVEResolver) DeploymentCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *imageCVEResolver) DeploymentCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "DeploymentCount")
-	return resolver.root.DeploymentCount(resolver.withImageVulnerabilityScope(ctx), args)
+	return resolver.root.DeploymentCount(resolver.imageVulnerabilityScopeContext(), args)
 }
 
-func (resolver *imageCVEResolver) Deployments(ctx context.Context, args PaginatedQuery) ([]*deploymentResolver, error) {
+func (resolver *imageCVEResolver) Deployments(_ context.Context, args PaginatedQuery) ([]*deploymentResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "Deployments")
-	return resolver.root.Deployments(resolver.withImageVulnerabilityScope(ctx), args)
+	return resolver.root.Deployments(resolver.imageVulnerabilityScopeContext(), args)
 }
 
 func (resolver *imageCVEResolver) DiscoveredAtImage(_ context.Context, args RawQuery) (*graphql.Time, error) {
@@ -589,24 +587,24 @@ func (resolver *imageCVEResolver) DiscoveredAtImage(_ context.Context, args RawQ
 	return timestamp(edges[0].GetFirstImageOccurrence())
 }
 
-func (resolver *imageCVEResolver) ImageComponents(ctx context.Context, args PaginatedQuery) ([]ImageComponentResolver, error) {
+func (resolver *imageCVEResolver) ImageComponents(_ context.Context, args PaginatedQuery) ([]ImageComponentResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "ImageComponents")
-	return resolver.root.ImageComponents(resolver.withImageVulnerabilityScope(ctx), args)
+	return resolver.root.ImageComponents(resolver.imageVulnerabilityScopeContext(), args)
 }
 
-func (resolver *imageCVEResolver) ImageComponentCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *imageCVEResolver) ImageComponentCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "ImageComponentCount")
-	return resolver.root.ImageComponentCount(resolver.withImageVulnerabilityScope(ctx), args)
+	return resolver.root.ImageComponentCount(resolver.imageVulnerabilityScopeContext(), args)
 }
 
-func (resolver *imageCVEResolver) ImageCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *imageCVEResolver) ImageCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "ImageCount")
-	return resolver.root.ImageCount(resolver.withImageVulnerabilityScope(ctx), args)
+	return resolver.root.ImageCount(resolver.imageVulnerabilityScopeContext(), args)
 }
 
-func (resolver *imageCVEResolver) Images(ctx context.Context, args PaginatedQuery) ([]*imageResolver, error) {
+func (resolver *imageCVEResolver) Images(_ context.Context, args PaginatedQuery) ([]*imageResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "Images")
-	return resolver.root.Images(resolver.withImageVulnerabilityScope(ctx), args)
+	return resolver.root.Images(resolver.imageVulnerabilityScopeContext(), args)
 }
 
 func (resolver *imageCVEResolver) UnusedVarSink(_ context.Context, _ RawQuery) *int32 {

--- a/central/graphql/resolvers/image_vulnerabilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities.go
@@ -81,11 +81,7 @@ func (resolver *Resolver) ImageVulnerability(ctx context.Context, args IDQuery) 
 	}
 
 	ret, err := loader.FromID(ctx, string(*args.ID))
-	vulnResolver, err := resolver.wrapImageCVEWithContext(ctx, ret, true, err)
-	if err != nil {
-		return nil, err
-	}
-	return vulnResolver, nil
+	return resolver.wrapImageCVEWithContext(ctx, ret, true, err)
 }
 
 // ImageVulnerabilities resolves a set of image vulnerabilities for the input query

--- a/central/graphql/resolvers/node_components.go
+++ b/central/graphql/resolvers/node_components.go
@@ -84,11 +84,7 @@ func (resolver *Resolver) NodeComponent(ctx context.Context, args IDQuery) (Node
 	}
 
 	ret, err := loader.FromID(ctx, string(*args.ID))
-	res, err := resolver.wrapNodeComponentWithContext(ctx, ret, true, err)
-	if err != nil {
-		return nil, err
-	}
-	return res, nil
+	return resolver.wrapNodeComponentWithContext(ctx, ret, true, err)
 }
 
 // NodeComponents returns node components that match the input query.

--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -63,11 +63,10 @@ func (resolver *Resolver) NodeVulnerability(ctx context.Context, args IDQuery) (
 		return nil, err
 	}
 	vuln, err := vulnLoader.FromID(ctx, string(*args.ID))
-	vulnResolver, err := resolver.wrapNodeCVE(vuln, true, err)
+	vulnResolver, err := resolver.wrapNodeCVEWithContext(ctx, vuln, true, err)
 	if err != nil {
 		return nil, err
 	}
-	vulnResolver.ctx = ctx
 	return vulnResolver, nil
 }
 
@@ -94,7 +93,7 @@ func (resolver *Resolver) NodeVulnerabilities(ctx context.Context, args Paginate
 
 	query = tryUnsuppressedQuery(query)
 	vulns, err := vulnLoader.FromQuery(ctx, query)
-	vulnResolvers, err := resolver.wrapNodeCVEs(vulns, err)
+	vulnResolvers, err := resolver.wrapNodeCVEsWithContext(ctx, vulns, err)
 
 	if err != nil {
 		return nil, err
@@ -102,7 +101,6 @@ func (resolver *Resolver) NodeVulnerabilities(ctx context.Context, args Paginate
 
 	ret := make([]NodeVulnerabilityResolver, 0, len(vulnResolvers))
 	for _, res := range vulnResolvers {
-		res.ctx = ctx
 		ret = append(ret, res)
 	}
 	return ret, nil
@@ -219,11 +217,10 @@ func (resolver *Resolver) TopNodeVulnerability(ctx context.Context, args RawQuer
 		return nil, errors.New("multiple vulnerabilities matched for top node vulnerability")
 	}
 
-	res, err := resolver.wrapNodeCVE(vulns[0], true, nil)
+	res, err := resolver.wrapNodeCVEWithContext(ctx, vulns[0], true, nil)
 	if err != nil {
 		return nil, err
 	}
-	res.ctx = ctx
 	return res, nil
 }
 
@@ -253,14 +250,14 @@ func withNodeCveTypeFiltering(q string) string {
 		search.NewQueryBuilder().AddExactMatches(search.CVEType, storage.CVE_NODE_CVE.String()).Query())
 }
 
-func (resolver *nodeCVEResolver) withNodeVulnerabilityScope(ctx context.Context) context.Context {
+func (resolver *nodeCVEResolver) withNodeVulnerabilityScope() context.Context {
 	if features.PostgresDatastore.Enabled() {
-		return scoped.Context(ctx, scoped.Scope{
+		return scoped.Context(resolver.ctx, scoped.Scope{
 			ID:    resolver.data.GetId(),
 			Level: v1.SearchCategory_NODE_VULNERABILITIES,
 		})
 	}
-	return scoped.Context(ctx, scoped.Scope{
+	return scoped.Context(resolver.ctx, scoped.Scope{
 		ID:    resolver.data.GetId(),
 		Level: v1.SearchCategory_VULNERABILITIES,
 	})
@@ -271,20 +268,20 @@ Sub Resolver Functions
 */
 
 // EnvImpact is the fraction of nodes that contain the nodeCVE
-func (resolver *nodeCVEResolver) EnvImpact(ctx context.Context) (float64, error) {
+func (resolver *nodeCVEResolver) EnvImpact(_ context.Context) (float64, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "EnvImpact")
 
-	nodeLoader, err := loaders.GetNodeLoader(ctx)
+	nodeLoader, err := loaders.GetNodeLoader(resolver.ctx)
 	if err != nil {
 		return 0, err
 	}
-	numNodes, err := nodeLoader.CountAll(ctx)
+	numNodes, err := nodeLoader.CountAll(resolver.ctx)
 	if err != nil || numNodes == 0 {
 		return 0, err
 	}
 
 	query := resolver.getNodeCVEQuery()
-	numNodesWithCVE, err := nodeLoader.CountFromQuery(ctx, query)
+	numNodesWithCVE, err := nodeLoader.CountFromQuery(resolver.ctx, query)
 	if err != nil || numNodesWithCVE == 0 {
 		return 0, err
 	}
@@ -341,10 +338,10 @@ func (resolver *nodeCVEResolver) IsFixable(_ context.Context, args RawQuery) (bo
 }
 
 // LastScanned is the last time this node CVE was last scanned in a node
-func (resolver *nodeCVEResolver) LastScanned(ctx context.Context) (*graphql.Time, error) {
+func (resolver *nodeCVEResolver) LastScanned(_ context.Context) (*graphql.Time, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "LastScanned")
 
-	nodeLoader, err := loaders.GetNodeLoader(ctx)
+	nodeLoader, err := loaders.GetNodeLoader(resolver.ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -361,7 +358,7 @@ func (resolver *nodeCVEResolver) LastScanned(ctx context.Context) (*graphql.Time
 		},
 	}
 
-	nodes, err := nodeLoader.FromQuery(ctx, q)
+	nodes, err := nodeLoader.FromQuery(resolver.ctx, q)
 	if err != nil || len(nodes) == 0 {
 		return nil, err
 	} else if len(nodes) > 1 {
@@ -372,7 +369,7 @@ func (resolver *nodeCVEResolver) LastScanned(ctx context.Context) (*graphql.Time
 }
 
 // UnusedVarSink represents a query sink
-func (resolver *nodeCVEResolver) UnusedVarSink(ctx context.Context, args RawQuery) *int32 {
+func (resolver *nodeCVEResolver) UnusedVarSink(_ context.Context, _ RawQuery) *int32 {
 	return nil
 }
 
@@ -394,94 +391,94 @@ func (resolver *nodeCVEResolver) Vectors() *EmbeddedVulnerabilityVectorsResolver
 }
 
 // NodeComponentCount is the number of node components that contain the node CVE.
-func (resolver *nodeCVEResolver) NodeComponentCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *nodeCVEResolver) NodeComponentCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "NodeComponentCount")
-	return resolver.root.NodeComponentCount(resolver.withNodeVulnerabilityScope(ctx), args)
+	return resolver.root.NodeComponentCount(resolver.withNodeVulnerabilityScope(), args)
 }
 
 // NodeComponents are the node components that contain the node CVE.
-func (resolver *nodeCVEResolver) NodeComponents(ctx context.Context, args PaginatedQuery) ([]NodeComponentResolver, error) {
+func (resolver *nodeCVEResolver) NodeComponents(_ context.Context, args PaginatedQuery) ([]NodeComponentResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "NodeComponents")
-	return resolver.root.NodeComponents(resolver.withNodeVulnerabilityScope(ctx), args)
+	return resolver.root.NodeComponents(resolver.withNodeVulnerabilityScope(), args)
 }
 
 // NodeCount is the number of nodes that contain the node CVE
-func (resolver *nodeCVEResolver) NodeCount(ctx context.Context, args RawQuery) (int32, error) {
+func (resolver *nodeCVEResolver) NodeCount(_ context.Context, args RawQuery) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "NodeCount")
-	return resolver.root.NodeCount(resolver.withNodeVulnerabilityScope(ctx), args)
+	return resolver.root.NodeCount(resolver.withNodeVulnerabilityScope(), args)
 }
 
 // Nodes are the nodes that contain the node CVE
-func (resolver *nodeCVEResolver) Nodes(ctx context.Context, args PaginatedQuery) ([]*nodeResolver, error) {
+func (resolver *nodeCVEResolver) Nodes(_ context.Context, args PaginatedQuery) ([]*nodeResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "Nodes")
-	return resolver.root.Nodes(resolver.withNodeVulnerabilityScope(ctx), args)
+	return resolver.root.Nodes(resolver.withNodeVulnerabilityScope(), args)
 }
 
 // Follows are functions that return information that is nested in the CVEInfo object
 // or are convenience functions to allow time for UI to migrate to new naming schemes
 
 // ID of the node CVE
-func (resolver *nodeCVEResolver) ID(ctx context.Context) graphql.ID {
+func (resolver *nodeCVEResolver) ID(_ context.Context) graphql.ID {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "ID")
 	return graphql.ID(resolver.data.GetId())
 }
 
 // CreatedAt is the time a node CVE first seen in the system
-func (resolver *nodeCVEResolver) CreatedAt(ctx context.Context) (*graphql.Time, error) {
+func (resolver *nodeCVEResolver) CreatedAt(_ context.Context) (*graphql.Time, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "CreatedAt")
 	return timestamp(resolver.data.GetCveBaseInfo().GetCreatedAt())
 }
 
 // CVE name of the node CVE
-func (resolver *nodeCVEResolver) CVE(ctx context.Context) string {
+func (resolver *nodeCVEResolver) CVE(_ context.Context) string {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "CVE")
 	return resolver.data.GetCveBaseInfo().GetCve()
 }
 
 // LastModified is the time this node CVE was last modified in the system
-func (resolver *nodeCVEResolver) LastModified(ctx context.Context) (*graphql.Time, error) {
+func (resolver *nodeCVEResolver) LastModified(_ context.Context) (*graphql.Time, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "LastModified")
 	return timestamp(resolver.data.GetCveBaseInfo().GetLastModified())
 }
 
 // Link to the node CVE
-func (resolver *nodeCVEResolver) Link(ctx context.Context) string {
+func (resolver *nodeCVEResolver) Link(_ context.Context) string {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "Link")
 	return resolver.data.GetCveBaseInfo().GetLink()
 }
 
 // PublishedOn is date and time when this node CVE was first published in the cve feeds
-func (resolver *nodeCVEResolver) PublishedOn(ctx context.Context) (*graphql.Time, error) {
+func (resolver *nodeCVEResolver) PublishedOn(_ context.Context) (*graphql.Time, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "PublishedOn")
 	return timestamp(resolver.data.GetCveBaseInfo().GetPublishedOn())
 }
 
 // ScoreVersion of the node CVE
-func (resolver *nodeCVEResolver) ScoreVersion(ctx context.Context) string {
+func (resolver *nodeCVEResolver) ScoreVersion(_ context.Context) string {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "ScoreVersion")
 	return resolver.data.GetCveBaseInfo().GetScoreVersion().String()
 }
 
 // Summary of the node CVE
-func (resolver *nodeCVEResolver) Summary(ctx context.Context) string {
+func (resolver *nodeCVEResolver) Summary(_ context.Context) string {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "Summary")
 	return resolver.data.GetCveBaseInfo().GetSummary()
 }
 
 // SuppressActivation returns the snooze start timestamp of the node CVE
-func (resolver *nodeCVEResolver) SuppressActivation(ctx context.Context) (*graphql.Time, error) {
+func (resolver *nodeCVEResolver) SuppressActivation(_ context.Context) (*graphql.Time, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "SuppressActivation")
 	return timestamp(resolver.data.GetSnoozeStart())
 }
 
 // SuppressExpiry returns the snooze expiration timestamp of the node CVE
-func (resolver *nodeCVEResolver) SuppressExpiry(ctx context.Context) (*graphql.Time, error) {
+func (resolver *nodeCVEResolver) SuppressExpiry(_ context.Context) (*graphql.Time, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "SuppressExpiry")
 	return timestamp(resolver.data.GetSnoozeExpiry())
 }
 
 // Suppressed returns true if the node CVE is snoozed
-func (resolver *nodeCVEResolver) Suppressed(ctx context.Context) bool {
+func (resolver *nodeCVEResolver) Suppressed(_ context.Context) bool {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "Suppressed")
 	return resolver.data.GetSnoozed()
 }

--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -64,11 +64,7 @@ func (resolver *Resolver) NodeVulnerability(ctx context.Context, args IDQuery) (
 		return nil, err
 	}
 	vuln, err := vulnLoader.FromID(ctx, string(*args.ID))
-	vulnResolver, err := resolver.wrapNodeCVEWithContext(ctx, vuln, true, err)
-	if err != nil {
-		return nil, err
-	}
-	return vulnResolver, nil
+	return resolver.wrapNodeCVEWithContext(ctx, vuln, true, err)
 }
 
 // NodeVulnerabilities resolves a set of vulnerabilities based on a query.

--- a/central/graphql/resolvers/nodes.go
+++ b/central/graphql/resolvers/nodes.go
@@ -443,7 +443,7 @@ func (resolver *nodeResolver) Vulns(ctx context.Context, args PaginatedQuery) ([
 	}
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getNodeRawQuery())
 
-	return resolver.root.vulnerabilitiesV2(resolver.nodeScopeContext(), PaginatedQuery{Query: &query, Pagination: args.Pagination})
+	return resolver.root.vulnerabilitiesV2(ctx, PaginatedQuery{Query: &query, Pagination: args.Pagination})
 }
 
 // VulnCount returns the number of vulnerabilities the node has.
@@ -454,7 +454,7 @@ func (resolver *nodeResolver) VulnCount(ctx context.Context, args RawQuery) (int
 	}
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getNodeRawQuery())
 
-	return resolver.root.vulnerabilityCountV2(resolver.nodeScopeContext(), RawQuery{Query: &query})
+	return resolver.root.vulnerabilityCountV2(ctx, RawQuery{Query: &query})
 }
 
 // VulnCounter resolves the number of different types of vulnerabilities contained in a node.
@@ -465,7 +465,7 @@ func (resolver *nodeResolver) VulnCounter(ctx context.Context, args RawQuery) (*
 	}
 	query := search.AddRawQueriesAsConjunction(args.String(), resolver.getNodeRawQuery())
 
-	return resolver.root.vulnCounterV2(resolver.nodeScopeContext(), RawQuery{Query: &query})
+	return resolver.root.vulnCounterV2(ctx, RawQuery{Query: &query})
 }
 
 // NodeVulnerabilities returns the vulnerabilities in the node.


### PR DESCRIPTION
## Description

Pass resolver context to sub resolver for usage and ensure sub resolvers use parent context.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

Manually verified some graphql endpoints to ensure nested objects resolve as anticipated.