### PR TITLE
CI: use helm for 4.10+ support

### DIFF
--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -62,6 +62,7 @@ import util.Timer
 import org.junit.Assume
 import org.junit.experimental.categories.Category
 import spock.lang.IgnoreIf
+import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Unroll
 
@@ -1071,12 +1072,11 @@ class ComplianceTest extends BaseSpecification {
 
     @Unroll
     @Category(BAT)
+    @Requires({ ClusterService.isOpenShift4() })
+    @IgnoreIf({ true }) // ROX-12461 The compliance operator tests are not working as expected
     def "Verify Compliance Operator aggregation results on OpenShift for machine configs #standard"() {
         given:
         "get compliance aggregation results"
-        Assume.assumeTrue(ClusterService.isOpenShift4())
-        Assume.assumeTrue(Env.CI_JOBNAME == "openshift-newest-qa-e2e-tests")
-
         log.info "Getting compliance results for ${standard}"
         ComplianceRunResults run = BASE_RESULTS.get(standard)
 
@@ -1109,14 +1109,12 @@ class ComplianceTest extends BaseSpecification {
     }
 
     @Category(BAT)
+    @Requires({ ClusterService.isOpenShift4() })
+    @IgnoreIf({ true }) // ROX-12461 The compliance operator tests are not working as expected
     def "Verify Tailored Profile does not have evidence for disabled rule"() {
         given:
         "get compliance aggregation results"
-        Assume.assumeTrue(ClusterService.isOpenShift4())
-
-        // https://issues.redhat.com/browse/ROX-9951 -- fails on OSD
-        Assume.assumeTrue(Env.CI_JOBNAME == "openshift-newest-qa-e2e-tests")
-
+        log.info "Getting compliance results for rhcos4-moderate-modified"
         ComplianceRunResults run = BASE_RESULTS.get("rhcos4-moderate-modified")
 
         expect:
@@ -1138,12 +1136,11 @@ class ComplianceTest extends BaseSpecification {
     }
 
     @Category(BAT)
+    @Requires({ ClusterService.isOpenShift4() })
+    @IgnoreIf({ true }) // ROX-12461 The compliance operator tests are not working as expected
     def "Verify Compliance Operator aggregation results on OpenShift for cluster results"() {
         given:
         "get compliance aggregation results"
-        Assume.assumeTrue(ClusterService.isOpenShift4())
-        Assume.assumeTrue(Env.CI_JOBNAME == "openshift-newest-qa-e2e-tests")
-
         log.info "Getting compliance results for ocp4-cis"
         ComplianceRunResults run = BASE_RESULTS.get("ocp4-cis")
 

--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -56,7 +56,6 @@ import services.NodeService
 import services.PolicyService
 import services.ProcessService
 import services.RoleService
-import util.Env
 import util.Timer
 
 import org.junit.Assume

--- a/scripts/ci/jobs/openshift_4_qa_e2e_tests.py
+++ b/scripts/ci/jobs/openshift_4_qa_e2e_tests.py
@@ -9,6 +9,7 @@ from clusters import NullCluster
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["OUTPUT_FORMAT"] = "helm"
 os.environ["OPENSHIFT_CI_CLUSTER_CLAIM"] = "openshift-4"
 
 make_qa_e2e_test_runner(cluster=NullCluster()).run()


### PR DESCRIPTION
## Description

The current openshift CI deploy mechanism (`roxctl central generate openshift`) generates 3.x compatible YAML which cannot be deployed to 4.10+.

```
error: unable to recognize "/go/src/github.com/stackrox/stackrox/deploy/openshift/sensor-deploy/admission-controller.yaml": no matches for kind "ValidatingWebhookConfiguration" in version "admissionregistration.k8s.io/v1beta1"
```

This PR changes the CI deploy mechanism to `helm` which correctly identifies that the cluster is 4.x and uses the appropriate ValidatingWebhookConfiguration version. This will allow us to try and use 4.11 etc. https://github.com/openshift/release/pull/31777

This PR also disables the compliance operator tests because due to the 3.x install approach these had been skipped (ROX-12461).

## Checklist
- [x] Investigated and inspected CI test results


## Testing Performed

/test openshift-newest-qa-e2e-tests