### PR TITLE
Document the need to mirror golang image.

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -3,8 +3,15 @@ ARG roxpath=/workspace/src/github.com/stackrox/rox
 
 # NOTE 1: the following version needs to be in sync with the ../EXPECTED_GO_VERSION file.
 FROM golang:1.17.12 as builder
-# NOTE 2: Also, to keep CI from flakes, the above image needs to be mirrored into openshift CI registry
-# and the CI configured to use the mirrored image. See example PRs for how to achieve this:
+# NOTE 2: Also, to keep CI from flakes, the above image needs to be mirrored into openshift CI registry and the CI
+# configured to use the mirrored image instead of the specification above.
+# This is because pulling from docker.io/library/... (which is what happens with a bare image specification above) is
+# subject to rate limits that our CI tends to hit, causing intermittent build failres.
+#
+# Ideally, the mirroring and overrides for new image should be put in place first, and then once the above line is
+# updated, the old ones removed. But with some luck, doing it post-facto might also be possible without causing too
+# many failures, depending on the load.
+# See example PRs for how to achieve that:
 # - https://github.com/openshift/release/pull/31790/files
 # - https://github.com/openshift/release/pull/31791/files
 

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,8 +1,12 @@
 # We have to emulate directory layout as in the repo so that imports in go files work fine.
 ARG roxpath=/workspace/src/github.com/stackrox/rox
 
-# Note: the following version needs to be in sync with the ../EXPECTED_GO_VERSION file.
+# NOTE 1: the following version needs to be in sync with the ../EXPECTED_GO_VERSION file.
 FROM golang:1.17.12 as builder
+# NOTE 2: Also, to keep CI from flakes, the above image needs to be mirrored into openshift CI registry
+# and the CI configured to use the mirrored image. See example PRs for how to achieve this:
+# - https://github.com/openshift/release/pull/31790/files
+# - https://github.com/openshift/release/pull/31791/files
 
 # Build the manager binary
 ARG roxpath


### PR DESCRIPTION
## Description

Luckily with operator jobs not running by default, we didn't seem to get many flakes after https://github.com/stackrox/stackrox/pull/2762

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

The approach is being verified as we speak.