### PR TITLE
Make syslog and openshift auth integration proxy-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ## [NEXT RELEASE]
 - ROX-11348: The email notifier now allows for unauthenticated SMTP. By default, 
 authentication is still required for an email notifier, but the user can now choose to turn it off.
+- Previously, the syslog integration did not respect a configured TCP proxy. This is now fixed.
 
 ### Removed Features
 - ROX-11784: The `RenamePolicyCategory` and `DeletePolicyCategory` methods in the

--- a/pkg/auth/authproviders/openshift/internal/dexconnector/openshift.go
+++ b/pkg/auth/authproviders/openshift/internal/dexconnector/openshift.go
@@ -41,6 +41,7 @@ import (
 //   * add validation for connectivity to OAuth2 endpoints                    //
 //   * extract fetching user info into identity() function                    //
 //   * deduce redirect URI's host and scheme via MakeRedirectURI() function   //
+//   * use our custom proxy configuration mechanism                           //
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -333,7 +334,7 @@ func newHTTPClient(certPool *x509.CertPool) (*http.Client, error) {
 	return &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{RootCAs: certPool},
-			Proxy:           http.ProxyFromEnvironment,
+			Proxy:           proxy.FromConfig(),
 			DialContext: (&net.Dialer{
 				Timeout:   30 * time.Second,
 				KeepAlive: 30 * time.Second,


### PR DESCRIPTION
## Description

Syslog integration was using a raw `net.Dialer`/`tls.Dialer`, that might bypass proxy configuration.

Also use our custom proxy configuration library for OpenShfit auth, rather than the default Golang proxy library.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required
- [x] ~Determined and documented upgrade steps
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- CI
- Manual test (see below)

### Test steps
- Deploy StackRox on remote cluster (OSD)
- Run squid container (`openshift4/ose-egress-http-proxy`) with a permissive configuration on local machine via `docker run --net 3128:3128 ...`
- Expose local port 3128 via ngrok
- Modify `central` deployment to set `http_proxy`, `https_proxy`, `all_proxy` to point to the ngrok port
- Run `socat TCP-LISTEN:5050 -` in an ubuntu container on localhost
- Create a syslog integration, using `<ubuntu container ip>:5050` as the endpoint
- Test the syslog integration, observe `socat` output `254 <135>1 2022-08-31T12:41:00Z central stackRoxKubernetesSecurityPlatform 1 stackroxKubernetesSecurityPlatformIntegrationTest - CEF:0|StackRox|Kubernetes Security Platform|3.71.x-433-g765238180d|Test|0|Test|stackroxKubernetesSecurityPlatformTestMessage=test`

This proves that the integration is getting proxied, because Central running in an OSD cluster could otherwise not access a container on my laptop that is _not_ exposed via ngrok (only the proxy is).