### PR TITLE
Increase golangci-lint timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 5m
+  timeout: 16m
   skip-dirs:
   - pkg/complianceoperator/api
   build-tags:

--- a/Makefile
+++ b/Makefile
@@ -166,11 +166,11 @@ ifdef CI
 	@echo 'The environment indicates we are in CI; running linters in check mode.'
 	@echo 'If this fails, run `make style`.'
 	@echo "Running with no tags..."
-	golangci-lint run --timeout 8m0s
+	golangci-lint run
 	@echo "Running with release tags..."
 	@# We use --tests=false because some unit tests don't compile with release tags,
 	@# since they use functions that we don't define in the release build. That's okay.
-	golangci-lint run --timeout 8m0s --build-tags "$(subst $(comma),$(space),$(RELEASE_GOTAGS))" --tests=false
+	golangci-lint run --build-tags "$(subst $(comma),$(space),$(RELEASE_GOTAGS))" --tests=false
 else
 	golangci-lint run --fix
 	golangci-lint run --fix --build-tags "$(subst $(comma),$(space),$(RELEASE_GOTAGS))" --tests=false


### PR DESCRIPTION
## Description

From time to time `style-checks` fails due to golangci-lint timeout. Let's increase it to prevent such failures as this check is required and fully predictable and repeatable hence should pass every time. 

## Testing Performed

CI