### PR TITLE
ROX-11891: Add an empty commit when retagging

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -220,13 +220,10 @@ jobs:
           fi
       - name: Tag release branch with "${{needs.variables.outputs.milestone}}"
         run: |
-          git tag --annotate "${{needs.variables.outputs.milestone}}" --message ""
-      - name: Push
-        if: env.DRY_RUN == 'false'
-        run: |
-          git push --follow-tags
-      - run: |
-          echo "Release branch has been tagged with ${{needs.variables.outputs.milestone}}." >> $GITHUB_STEP_SUMMARY
+          set -uo pipefail
+          gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
+            tag-rc \
+            "${{needs.variables.outputs.milestone}}"
       - name: Create next milestone
         if: env.DRY_RUN == 'false'
         run: |

--- a/.github/workflows/scripts/local-env.sh
+++ b/.github/workflows/scripts/local-env.sh
@@ -14,7 +14,9 @@ export GITHUB_SERVER_URL=https://github.com
 
 export main_branch=master
 
-export DRY_RUN=true
+if [ -z "$DRY_RUN" ]; then
+    export DRY_RUN=true
+fi
 
 SCRIPTS_ROOT="$(git rev-parse --show-toplevel)/.github/workflows/scripts"
 

--- a/.github/workflows/scripts/tag-rc.sh
+++ b/.github/workflows/scripts/tag-rc.sh
@@ -18,7 +18,7 @@ check_not_empty \
 
 if [ "$(git tag "$TAG" --points-at HEAD)" = "$TAG" ]; then
     git push --delete origin "$TAG"
-    gh_log warning "Tag '$TAG' has been deleted."
+    gh_log warning "Existing tag '$TAG' has been deleted."
 fi
 
 git commit --allow-empty --message "Empty commit to trigger CI"

--- a/.github/workflows/scripts/tag-rc.sh
+++ b/.github/workflows/scripts/tag-rc.sh
@@ -3,6 +3,10 @@
 # Add an empty commit and delete the remote tag if the tag exists.
 # Tag and push the branch.
 #
+# Local wet run:
+#
+#   DRY_RUN=false bash local-env.sh tag-rc <tag>
+#
 set -euo pipefail
 
 TAG="$1"

--- a/.github/workflows/scripts/tag-rc.sh
+++ b/.github/workflows/scripts/tag-rc.sh
@@ -16,7 +16,7 @@ check_not_empty \
     \
     DRY_RUN
 
-if git ls-remote --tags --exit-code origin "$TAG"; then
+if [ "$(git tag "$TAG" --points-at HEAD)" = "$TAG" ]; then
     git push --delete origin "$TAG"
     git commit --allow-empty --message "Empty commit to trigger CI"
     gh_log warning "Tag '$TAG' has been deleted and an empty commit has been added to trigger CI."

--- a/.github/workflows/scripts/tag-rc.sh
+++ b/.github/workflows/scripts/tag-rc.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Add an empty commit and delete the remote tag if the tag exists.
+# Tag and push the branch.
+#
+set -euo pipefail
+
+TAG="$1"
+
+check_not_empty \
+    TAG \
+    \
+    DRY_RUN
+
+if git ls-remote --tags --exit-code origin "$TAG"; then
+    git push --delete origin "$TAG"
+    git commit --allow-empty --message "Empty commit to trigger CI"
+    gh_log warning "Tag '$TAG' has been deleted and an empty commit has been added to trigger CI."
+fi
+
+git tag --force --annotate "$TAG" --message "Upstream release automation"
+
+if [ "$DRY_RUN" = "false" ]; then
+    git push --follow-tags
+fi
+
+gh_summary "Release branch has been tagged with $TAG."

--- a/.github/workflows/scripts/tag-rc.sh
+++ b/.github/workflows/scripts/tag-rc.sh
@@ -18,10 +18,10 @@ check_not_empty \
 
 if [ "$(git tag "$TAG" --points-at HEAD)" = "$TAG" ]; then
     git push --delete origin "$TAG"
-    git commit --allow-empty --message "Empty commit to trigger CI"
-    gh_log warning "Tag '$TAG' has been deleted and an empty commit has been added to trigger CI."
+    gh_log warning "Tag '$TAG' has been deleted."
 fi
 
+git commit --allow-empty --message "Empty commit to trigger CI"
 git tag --force --annotate "$TAG" --message "Upstream release automation"
 
 if [ "$DRY_RUN" = "false" ]; then


### PR DESCRIPTION
## Description

Extraction of the `tag-rc.sh` script, which can also be used locally to retag a release branch if needed.

Allow running wet scripts locally by setting `DRY_RUN=false`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

TODO(replace-me)
