### PR TITLE
Dashrews/ROX-12289 cleanup rocks after postgres upgrade

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -673,13 +673,13 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 		customRoutes = append(customRoutes, routes.CustomRoute{
 			Route:         "/db/backup",
 			Authorizer:    dbAuthz.DBReadAccessAuthorizer(),
-			ServerHandler: notImplementedOnManagedServices(globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), globaldb.GetPostgres(), false)),
+			ServerHandler: notImplementedOnManagedServices(globaldbHandlers.BackupDB(nil, nil, globaldb.GetPostgres(), false)),
 			Compression:   true,
 		})
 		customRoutes = append(customRoutes, routes.CustomRoute{
 			Route:         "/api/extensions/backup",
 			Authorizer:    user.WithRole(role.Admin),
-			ServerHandler: notImplementedOnManagedServices(globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), globaldb.GetPostgres(), true)),
+			ServerHandler: notImplementedOnManagedServices(globaldbHandlers.BackupDB(nil, nil, globaldb.GetPostgres(), true)),
 			Compression:   true,
 		})
 		customRoutes = append(customRoutes, routes.CustomRoute{

--- a/migrator/clone/db_clone_manager_impl.go
+++ b/migrator/clone/db_clone_manager_impl.go
@@ -122,10 +122,11 @@ func (d *dbCloneManagerImpl) Persist(cloneName string, pgClone string, persistBo
 		if !persistBoth {
 			rocksVersion := d.dbmRocks.GetVersion(rocksdb.CurrentClone)
 			currentPostgresVersion := d.dbmPostgres.GetCurrentVersion()
+			log.Infof("Current PG => %v", currentPostgresVersion)
 
 			// If the versions do not match, we have updated another time with Postgres,
 			// so we can no longer roll back to RocksDB.
-			if rocksVersion == nil || rocksVersion.MainVersion != currentPostgresVersion.MainVersion {
+			if rocksVersion == nil || (currentPostgresVersion != nil && rocksVersion.MainVersion != currentPostgresVersion.MainVersion) {
 				d.dbmRocks.DecommissionRocksDB()
 			}
 		}

--- a/migrator/clone/db_clone_manager_impl.go
+++ b/migrator/clone/db_clone_manager_impl.go
@@ -118,7 +118,7 @@ func (d *dbCloneManagerImpl) Persist(cloneName string, pgClone string, persistBo
 			return err
 		}
 
-		// Now that updated Postgres was persisted we can decommission RocksDB if necessary
+		// Now that updated Postgres was persisted we can decommission RocksDB
 		if !persistBoth {
 			rocksVersion := d.dbmRocks.GetVersion(rocksdb.CurrentClone)
 			currentPostgresVersion := d.dbmPostgres.GetCurrentVersion()

--- a/migrator/clone/db_clone_manager_impl.go
+++ b/migrator/clone/db_clone_manager_impl.go
@@ -118,7 +118,7 @@ func (d *dbCloneManagerImpl) Persist(cloneName string, pgClone string, persistBo
 			return err
 		}
 
-		// Now that updated Postgres was persisted we can decommission RocksDB
+		// Now that updated Postgres was persisted we can decommission RocksDB if necessary
 		if !persistBoth {
 			rocksVersion := d.dbmRocks.GetVersion(rocksdb.CurrentClone)
 			currentPostgresVersion := d.dbmPostgres.GetCurrentVersion()

--- a/migrator/clone/postgres/db_clone_manager.go
+++ b/migrator/clone/postgres/db_clone_manager.go
@@ -39,4 +39,7 @@ type DBCloneManager interface {
 
 	// Persist -- moves the clone database to be the active database.
 	Persist(clone string) error
+
+	// GetCurrentVersion -- gets the version of the current clone
+	GetCurrentVersion() *migrations.MigrationVersion
 }

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -376,9 +376,19 @@ func (d *dbCloneManagerImpl) hasSpaceForRollback() bool {
 
 // GetCurrentVersion -- gets the version of the current clone
 func (d *dbCloneManagerImpl) GetCurrentVersion() *migrations.MigrationVersion {
-	clone, cloneExists := d.cloneMap[CurrentClone]
-	if cloneExists {
-		return clone.GetMigVersion()
+	// Get a short-lived connection for the purposes of checking the version of the clone.
+	pool := pgadmin.GetClonePool(d.adminConfig, CurrentClone)
+
+	ver, err := migrations.ReadVersionPostgres(pool)
+	if err != nil {
+		return nil
 	}
-	return nil
+	pool.Close()
+
+	return ver
+	//clone, cloneExists := d.cloneMap[CurrentClone]
+	//if cloneExists {
+	//	return clone.GetMigVersion()
+	//}
+	//return nil
 }

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -386,9 +386,4 @@ func (d *dbCloneManagerImpl) GetCurrentVersion() *migrations.MigrationVersion {
 	pool.Close()
 
 	return ver
-	//clone, cloneExists := d.cloneMap[CurrentClone]
-	//if cloneExists {
-	//	return clone.GetMigVersion()
-	//}
-	//return nil
 }

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -151,16 +151,21 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 	// If the current Postgres version is less than Rocks version then we need to migrate rocks to postgres
 	// If the versions are the same, but rocks has a more recent update then we need to migrate rocks to postgres
 	// Otherwise we roll with Postgres->Postgres
-	if rocksVersion != nil && !rocksVersion.LastPersisted.IsZero() {
-		log.Info("A previously used version of Rocks exists")
+	if d.rocksExists(rocksVersion) {
+		log.Infof("A previously used version of Rocks exists -- %v", rocksVersion)
 		// Rocks has been used but Postgres is fresh.  So just return current.
-		if !currExists || currClone.GetMigVersion() == nil || !d.rollbackEnabled() {
+		if !currExists || currClone.GetMigVersion() == nil {
 			return CurrentClone, true, nil
 		}
 
 		// Rocks more recently updated than Postgres so need to migrate from there.  Otherwise, Postgres is more recent
 		// so just fall through to the rest of the processing.
 		if currClone.GetMigVersion().LastPersisted.Before(rocksVersion.LastPersisted) {
+			// Rollback is not enabled, so process the Rocks -> Postgres migration on CurrentClone.
+			if !d.rollbackEnabled() {
+				return CurrentClone, true, nil
+			}
+
 			// Create a temp clone for processing of current
 			// Seed it from an empty database because we need to run migrations from Rocks to Postgres.
 			if !d.databaseExists(TempClone) {
@@ -220,6 +225,17 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 
 	log.Info("Fell through all checks to return current, meaning probably empty OR rollback disabled.")
 	return CurrentClone, false, nil
+}
+
+func (d *dbCloneManagerImpl) rocksExists(rocksVersion *migrations.MigrationVersion) bool {
+	if rocksVersion != nil &&
+		!rocksVersion.LastPersisted.IsZero() &&
+		rocksVersion.SeqNum != 0 &&
+		rocksVersion.MainVersion != "0" {
+		return true
+	}
+
+	return false
 }
 
 // Persist - replaces current clone with upgraded one.
@@ -356,4 +372,13 @@ func (d *dbCloneManagerImpl) rollbackEnabled() bool {
 func (d *dbCloneManagerImpl) hasSpaceForRollback() bool {
 	// TODO(ROX-12059):  Figure out what this means in the Postgres world.
 	return true
+}
+
+// GetCurrentVersion -- gets the version of the current clone
+func (d *dbCloneManagerImpl) GetCurrentVersion() *migrations.MigrationVersion {
+	clone, cloneExists := d.cloneMap[CurrentClone]
+	if cloneExists {
+		return clone.GetMigVersion()
+	}
+	return nil
 }

--- a/migrator/clone/rocksdb/db_clone_manager.go
+++ b/migrator/clone/rocksdb/db_clone_manager.go
@@ -57,4 +57,7 @@ type DBCloneManager interface {
 
 	// GetDirName - gets the directory name of the clone
 	GetDirName(cloneName string) string
+
+	// DecommissionRocksDB -- removes RocksDB from central
+	DecommissionRocksDB()
 }

--- a/pkg/migrations/paths.go
+++ b/pkg/migrations/paths.go
@@ -78,7 +78,9 @@ func GetRestoreClone() string {
 // If path is a symbolic link, remove it and the database it points to.
 func SafeRemoveDBWithSymbolicLink(path string) error {
 	currentDB, err := fileutils.ResolveIfSymlink(CurrentPath())
-	utils.CrashOnError(errors.Wrap(err, "no current database"))
+	if err != nil {
+		utils.CrashOnError(errors.Wrap(err, "no current database"))
+	}
 
 	switch path {
 	case CurrentPath(), currentDB:
@@ -92,9 +94,14 @@ func SafeRemoveDBWithSymbolicLink(path string) error {
 			if err != nil {
 				return err
 			}
+			log.Infof("Remove path = %q", path)
 			if err = os.RemoveAll(path); err != nil {
 				return err
 			}
+			// Remove any rocks database if in postgres mode
+			log.Infof("Remove linkTo = %q", linkTo)
+			return os.RemoveAll(linkTo)
+
 			// Remove linked database if it is not the current database
 			if linkTo != CurrentPath() && linkTo != currentDB {
 				return os.RemoveAll(linkTo)

--- a/pkg/migrations/paths.go
+++ b/pkg/migrations/paths.go
@@ -78,9 +78,7 @@ func GetRestoreClone() string {
 // If path is a symbolic link, remove it and the database it points to.
 func SafeRemoveDBWithSymbolicLink(path string) error {
 	currentDB, err := fileutils.ResolveIfSymlink(CurrentPath())
-	if err != nil {
-		utils.CrashOnError(errors.Wrap(err, "no current database"))
-	}
+	utils.CrashOnError(errors.Wrap(err, "no current database"))
 
 	switch path {
 	case CurrentPath(), currentDB:
@@ -94,14 +92,9 @@ func SafeRemoveDBWithSymbolicLink(path string) error {
 			if err != nil {
 				return err
 			}
-			log.Infof("Remove path = %q", path)
 			if err = os.RemoveAll(path); err != nil {
 				return err
 			}
-			// Remove any rocks database if in postgres mode
-			log.Infof("Remove linkTo = %q", linkTo)
-			return os.RemoveAll(linkTo)
-
 			// Remove linked database if it is not the current database
 			if linkTo != CurrentPath() && linkTo != currentDB {
 				return os.RemoveAll(linkTo)


### PR DESCRIPTION
## Description

From the perspective of the migrator, this will clear out Rocks after a Postgres has been used twice.  At that point we will no longer be able to rollback to Rocks and the data within rocks will be removed.  For the time being, central will add the current directory back to the PVC for things like bolt.  Clearing this out from a global perspective is a bit more work, so the focus here is from the perspective of the migrator.  The rest of it will be handled by such tickets as ROX-9882.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Did various levels of upgrades and such in manual testing.  Also added a multiple upgrade steps in the clone_test to drive this condition.
