### PR TITLE
Replace assertions about DOM elements in risk sort priority integration test

### DIFF
--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -22,59 +22,45 @@ describe('Risk page', () => {
 
             const priorityColumnHeadingSelector = `${RiskPageSelectors.table.columnHeaders}:contains("Priority")`;
 
-            /*
-             * Because risk table displays all deployments on only one page in integration testing environment,
-             * sort descending just reverses the rows so first becomes last, and last becomes first.
-             */
-            cy.get(`${RiskPageSelectors.table.dataRows} .rt-td:nth-child(5)`).then(
-                ($priorityCells) => {
-                    const priorityFirst = $priorityCells.eq(0).text();
-                    const priorityLast = $priorityCells.eq($priorityCells.length - 1).text();
+            // Initial table state is not sorted by priority.
+            cy.get(priorityColumnHeadingSelector)
+                .should('not.have.class', '-sort-asc')
+                .should('not.have.class', '-sort-desc');
 
-                    // Initial table state is not sorted by priority.
-                    cy.get(priorityColumnHeadingSelector)
-                        .should('not.have.class', '-sort-asc')
-                        .should('not.have.class', '-sort-desc');
-
-                    // Sort ascending by priority.
-                    cy.get(priorityColumnHeadingSelector).click();
-                    cy.location('search').should(
-                        'eq',
-                        '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=false'
-                    );
-                    // There is no request because response is sorted ascending.
-
-                    // Sort descending by priority.
-                    cy.get(priorityColumnHeadingSelector).click();
-                    cy.location('search').should(
-                        'eq',
-                        '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=true'
-                    );
-                    // There is a request because of change in sorting.
-                    cy.get(priorityColumnHeadingSelector).should('have.class', '-sort-desc');
-                    cy.get(
-                        `.rt-tr-group:first-child .rt-tr .rt-td:nth-child(5):contains("${priorityLast}")`
-                    );
-                    cy.get(
-                        `.rt-tr-group:last-child .rt-tr .rt-td:nth-child(5):contains("${priorityFirst}")`
-                    );
-
-                    // Sort ascending by priority.
-                    cy.get(priorityColumnHeadingSelector).click();
-                    cy.location('search').should(
-                        'eq',
-                        '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=false'
-                    );
-                    // There is a request because of change in sorting.
-                    cy.get(priorityColumnHeadingSelector).should('have.class', '-sort-asc');
-                    cy.get(
-                        `.rt-tr-group:first-child .rt-tr .rt-td:nth-child(5):contains("${priorityFirst}")`
-                    );
-                    cy.get(
-                        `.rt-tr-group:last-child .rt-tr .rt-td:nth-child(5):contains("${priorityLast}")`
-                    );
-                }
+            // Sort ascending by priority.
+            cy.get(priorityColumnHeadingSelector).click();
+            cy.location('search').should(
+                'eq',
+                '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=false'
             );
+            // There is no request because response is sorted ascending.
+            // TODO If possible, replace TableV2 with Table element in RiskTable component.
+
+            // Sort descending by priority.
+            cy.get(priorityColumnHeadingSelector).click();
+            cy.location('search').should(
+                'eq',
+                '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=true'
+            );
+            // There is a request because of change in sorting.
+            cy.wait('@deploymentswithprocessinfo') // alias from visitRiskDeployments
+                .its('request.url')
+                .should('include', 'sortOption.field=Deployment%20Risk%20Priority')
+                .should('include', 'sortOption.reversed=true');
+            cy.get(priorityColumnHeadingSelector).should('have.class', '-sort-desc');
+
+            // Sort ascending by priority.
+            cy.get(priorityColumnHeadingSelector).click();
+            cy.location('search').should(
+                'eq',
+                '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=false'
+            );
+            // There is a request because of change in sorting.
+            cy.wait('@deploymentswithprocessinfo') // alias from visitRiskDeployments
+                .its('request.url')
+                .should('include', 'sortOption.field=Deployment%20Risk%20Priority')
+                .should('include', 'sortOption.reversed=false');
+            cy.get(priorityColumnHeadingSelector).should('have.class', '-sort-asc');
         });
 
         it('should open side panel for deployment', () => {

--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -22,7 +22,8 @@ describe('Risk page', () => {
 
             const priorityColumnHeadingSelector = `${RiskPageSelectors.table.columnHeaders}:contains("Priority")`;
 
-            // Initial table state is not sorted by priority.
+            // Initial table state does not indicate that it is sorted ascending by priority.
+            // TODO If possible, replace TableV2 with Table element in RiskTable component.
             cy.get(priorityColumnHeadingSelector)
                 .should('not.have.class', '-sort-asc')
                 .should('not.have.class', '-sort-desc');
@@ -34,7 +35,6 @@ describe('Risk page', () => {
                 '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=false'
             );
             // There is no request because response is sorted ascending.
-            // TODO If possible, replace TableV2 with Table element in RiskTable component.
 
             // Sort descending by priority.
             cy.get(priorityColumnHeadingSelector).click();


### PR DESCRIPTION
## Description

### Test failure

> should sort priority in the table: Risk page without mock API should sort priority in the table

> Timed out retrying after 4000ms: Expected to find element: `.rt-tr-group:first-child .rt-tr .rt-td:nth-child(5):contains("6")`, but never found it.

cypress/integration/risk/risk.test.js

* 1564197760603787264 from master build for #2854 on 2022-08-29

Here is the screenshot for the test failure in which **collector** has **Priority** of 7:
![prow](https://user-images.githubusercontent.com/11862657/187476914-c14b25e3-d018-4d54-8f11-f816594b675b.png)

Here is a frame from the video for the preceding test in which **collector** has **Priority** of 6:
<img width="1280" alt="frame" src="https://user-images.githubusercontent.com/11862657/187476856-f472b949-39a8-4240-acd0-68fb3d6790a1.png">

### Analysis

The test assumes that the priorities of deployments remains the same:
* first request which is sorted ascending (get values of first and last row)
* second request which is sorted descending (assert expected values of first and last row)
* third request which is sorted ascending (assert expected values of first and last row, but value of first row has changed)

### Solution

Replace assertions about DOM elements with assertions about requests: include expected search parameters for ascending or descending sort.

### Residue

1. While investigating why **Priority** table cell heading does not display the initial state of ascending sort:
    * `TableV2` component does not have `defaultSorted` prop like `Table` component.
    * This is the only use of `TableV2` component.
    * There is no use of `CheckboxTableV2` component.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed

For local deployment: ran test individually before and after the change