### PR TITLE
Add Postgres query tracer that logs the GraphQL query and the resulting queries

### DIFF
--- a/central/graphql/handler/handler.go
+++ b/central/graphql/handler/handler.go
@@ -22,7 +22,8 @@ import (
 var (
 	log = logging.LoggerForModule()
 
-	queryTracerEnabled = features.PostgresDatastore.Enabled() && env.PostgresQueryTracer.BooleanSetting()
+	queryTracerEnabled    = features.PostgresDatastore.Enabled() && env.PostgresQueryTracer.BooleanSetting()
+	graphQLQueryThreshold = env.PostgresQueryTracerGraphQLThreshold.DurationSetting()
 )
 
 type logger struct {
@@ -83,7 +84,7 @@ func (h *relayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if queryTracerEnabled {
+	if queryTracerEnabled && time.Since(startTime) > graphQLQueryThreshold {
 		postgres.LogTrace(log, ctx, fmt.Sprintf("GraphQL Op %s took %d ms: %s %+v", params.OperationName, time.Since(startTime).Milliseconds(), params.Query, params.Variables))
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/central/graphql/handler/handler.go
+++ b/central/graphql/handler/handler.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"runtime"
 	"time"
@@ -85,7 +84,7 @@ func (h *relayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if queryTracerEnabled && time.Since(startTime) > graphQLQueryThreshold {
-		postgres.LogTrace(log, ctx, fmt.Sprintf("GraphQL Op %s took %d ms: %s %+v", params.OperationName, time.Since(startTime).Milliseconds(), params.Query, params.Variables))
+		postgres.LogTracef(ctx, log, "GraphQL Op %s took %d ms: %s %+v", params.OperationName, time.Since(startTime).Milliseconds(), params.Query, params.Variables)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = w.Write(responseJSON)

--- a/pkg/env/postgres_query_tracer.go
+++ b/pkg/env/postgres_query_tracer.go
@@ -1,6 +1,14 @@
 package env
 
+import "time"
+
 var (
 	// PostgresQueryTracer toggles whether to trace Postgres queries and their timing
 	PostgresQueryTracer = RegisterBooleanSetting("ROX_POSTGRES_QUERY_TRACER", false)
+
+	// PostgresQueryTracerGraphQLThreshold sets a threshold for how long a GraphQL query must take to be logged
+	PostgresQueryTracerGraphQLThreshold = registerDurationSetting("ROX_POSTGRES_QUERY_TRACER_GRAPHQL_THRESHOLD", 1*time.Second)
+
+	// PostgresQueryTracerQueryThreshold sets a threshold for how long an individual Postgres query must take to be logged
+	PostgresQueryTracerQueryThreshold = registerDurationSetting("ROX_POSTGRES_QUERY_TRACER_QUERY_THRESHOLD", 200*time.Millisecond)
 )

--- a/pkg/env/postgres_query_tracer.go
+++ b/pkg/env/postgres_query_tracer.go
@@ -1,0 +1,6 @@
+package env
+
+var (
+	// PostgresQueryTracer toggles whether to trace Postgres queries and their timing
+	PostgresQueryTracer = RegisterBooleanSetting("ROX_POSTGRES_QUERY_TRACER", false)
+)

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -1,0 +1,76 @@
+package postgres
+
+import (
+	"context"
+	"runtime/debug"
+	"time"
+
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/uuid"
+)
+
+type queryTracerKey struct{}
+
+type queryEvent struct {
+	query    string
+	args     []interface{}
+	duration time.Duration
+	stack    []byte
+}
+
+type queryTracer struct {
+	lock   sync.Mutex
+	events []queryEvent
+	id     string
+}
+
+func (qt *queryTracer) AddEvent(start time.Time, query string, args ...interface{}) {
+	qt.lock.Lock()
+	defer qt.lock.Unlock()
+
+	qt.events = append(qt.events, queryEvent{
+		query:    query,
+		args:     args,
+		duration: time.Since(start),
+		stack:    debug.Stack(),
+	})
+}
+
+func LogTrace(logger *logging.Logger, ctx context.Context, contextString string) {
+	tracer := ctx.Value(queryTracerKey{}).(*queryTracer)
+
+	logger.Infof("%s: %s", tracer.id, contextString)
+	if len(tracer.events) == 0 {
+		logger.Infof("%s: no queries ran", tracer.id)
+		return
+	}
+	for _, e := range tracer.events {
+		logger.Infof("%s: took(%d ms): %s %+v", tracer.id, e.duration.Milliseconds(), e.query, e.args)
+	}
+}
+
+func WithTracerContext(ctx context.Context) context.Context {
+	if tracer := GetTracerFromContext(ctx); tracer != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, queryTracerKey{}, &queryTracer{
+		id: uuid.NewV4().String(),
+	})
+}
+
+func GetTracerFromContext(ctx context.Context) *queryTracer {
+	val, ok := ctx.Value(queryTracerKey{}).(*queryTracer)
+	if ok {
+		return val
+	}
+	return nil
+}
+
+func AddTracedQuery(ctx context.Context, start time.Time, sql string, args ...interface{}) {
+	tracer := GetTracerFromContext(ctx)
+	if tracer == nil {
+		return
+	}
+	tracer.AddEvent(start, sql, args)
+}

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/pointers"
+	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/random"
 	searchPkg "github.com/stackrox/rox/pkg/search"
@@ -516,6 +517,24 @@ func standardizeFieldNamesInQuery(q *v1.Query) {
 	}
 }
 
+func tracedQuery(ctx context.Context, pool *pgxpool.Pool, sql string, args ...interface{}) (pgx.Rows, error) {
+	if strings.Contains(sql, "select distinct(deployments.Id)") {
+		debug.PrintStack()
+	}
+	log.Infof("SQL: %v", sql)
+	t := time.Now()
+	rows, err := pool.Query(ctx, sql, args...)
+	postgres.AddTracedQuery(ctx, t, sql, args)
+	return rows, err
+}
+
+func tracedQueryRow(ctx context.Context, pool *pgxpool.Pool, sql string, args ...interface{}) pgx.Row {
+	t := time.Now()
+	row := pool.QueryRow(ctx, sql, args...)
+	postgres.AddTracedQuery(ctx, t, sql, args)
+	return row
+}
+
 // RunSearchRequest executes a request against the database for given category
 func RunSearchRequest(ctx context.Context, category v1.SearchCategory, q *v1.Query, db *pgxpool.Pool) ([]searchPkg.Result, error) {
 	schema := mapping.GetTableFromCategory(category)
@@ -551,7 +570,7 @@ func RunSearchRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1
 	}
 
 	queryStr := query.AsSQL()
-	rows, err := db.Query(ctx, queryStr, query.Data...)
+	rows, err := tracedQuery(ctx, db, queryStr, query.Data...)
 	if err != nil {
 		debug.PrintStack()
 		log.Errorf("Query issue: %s %+v: %v", queryStr, query.Data, err)
@@ -646,7 +665,7 @@ func RunCountRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1.
 
 	queryStr := query.AsSQL()
 	var count int
-	row := db.QueryRow(ctx, queryStr, query.Data...)
+	row := tracedQueryRow(ctx, db, queryStr, query.Data...)
 	if err := row.Scan(&count); err != nil {
 		debug.PrintStack()
 		log.Errorf("Query issue: %s %+v: %v", queryStr, query.Data, err)
@@ -666,7 +685,7 @@ func RunGetQueryForSchema(ctx context.Context, schema *walker.Schema, q *v1.Quer
 	}
 
 	queryStr := query.AsSQL()
-	row := db.QueryRow(ctx, queryStr, query.Data...)
+	row := tracedQueryRow(db, ctx, queryStr, query.Data...)
 
 	var data []byte
 	err = row.Scan(&data)
@@ -684,7 +703,7 @@ func RunGetManyQueryForSchema(ctx context.Context, schema *walker.Schema, q *v1.
 	}
 
 	queryStr := query.AsSQL()
-	rows, err := db.Query(ctx, queryStr, query.Data...)
+	rows, err := tracedQuery(db, ctx, queryStr, query.Data...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Adds a top level context value that will trace the run queries in order
Add threshold for graphql query to be logged and also for individual postgres queries to be logged

Future work:
- extend into grpc interceptor
- extend to include rows affected / rows returned watchdog

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Run with it on and check which queries are slow
