### PR TITLE
ROX-12368: Post query pagination for clusters/namespaces for correctness and performance

### DIFF
--- a/central/cluster/datastore/internal/search/searcher_impl_v2.go
+++ b/central/cluster/datastore/internal/search/searcher_impl_v2.go
@@ -34,7 +34,8 @@ func NewV2(storage store.Store, indexer index.Indexer, clusterRanker *ranking.Ra
 func formatSearcherV2(unsafeSearcher blevesearch.UnsafeSearcher, clusterRanker *ranking.Ranker) search.Searcher {
 	scopedSearcher := postgres.WithScoping(sacHelper.FilteredSearcher(unsafeSearcher))
 	prioritySortedSearcher := sorted.Searcher(scopedSearcher, search.ClusterPriority, clusterRanker)
-	return paginated.WithDefaultSortOption(prioritySortedSearcher, defaultSortOption)
+	paginatedSearcher := paginated.Paginated(prioritySortedSearcher)
+	return paginated.WithDefaultSortOption(paginatedSearcher, defaultSortOption)
 }
 
 type searcherImplV2 struct {

--- a/central/namespace/datastore/datastore.go
+++ b/central/namespace/datastore/datastore.go
@@ -314,7 +314,9 @@ func (b *datastoreImpl) updateNamespacePriority(nss ...*storage.NamespaceMetadat
 func formatSearcherV2(unsafeSearcher blevesearch.UnsafeSearcher, namespaceRanker *ranking.Ranker) search.Searcher {
 	scopedSearcher := pkgPostgres.WithScoping(namespaceSACPostgresSearchHelper.FilteredSearcher(unsafeSearcher))
 	prioritySortedSearcher := sorted.Searcher(scopedSearcher, search.NamespacePriority, namespaceRanker)
-	return paginated.WithDefaultSortOption(prioritySortedSearcher, defaultSortOption)
+	// This is currently required due to the priority searcher
+	paginatedSearcher := paginated.Paginated(prioritySortedSearcher)
+	return paginated.WithDefaultSortOption(paginatedSearcher, defaultSortOption)
 }
 
 func formatSearcher(unsafeSearcher blevesearch.UnsafeSearcher, graphProvider graph.Provider, namespaceRanker *ranking.Ranker) search.Searcher {


### PR DESCRIPTION
## Description

Due to the priority sorted searcher, we need to post paginate. 

Filed ROX-12401 to roll this back eventually, but we'll need to determine how to handle the risk priorities

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Run on a cluster with more than 25 namespaces and only 25 results appear