### PR TITLE
Change AddStrings queries to AddExactMatches where possible

### DIFF
--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -116,7 +116,7 @@ func (ds *datastoreImpl) GetAlert(ctx context.Context, id string) (*storage.Aler
 
 // CountAlerts returns the number of alerts that are active
 func (ds *datastoreImpl) CountAlerts(ctx context.Context) (int, error) {
-	activeQuery := searchCommon.NewQueryBuilder().AddStrings(searchCommon.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery()
+	activeQuery := searchCommon.NewQueryBuilder().AddExactMatches(searchCommon.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery()
 	return ds.Count(ctx, activeQuery)
 }
 

--- a/central/alert/datastore/datastore_test.go
+++ b/central/alert/datastore/datastore_test.go
@@ -99,7 +99,7 @@ func (s *alertDataStoreTestSuite) TestSearchListAlerts() {
 }
 
 func (s *alertDataStoreTestSuite) TestCountAlerts_Success() {
-	expectedQ := search.NewQueryBuilder().AddStrings(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery()
+	expectedQ := search.NewQueryBuilder().AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery()
 	s.searcher.EXPECT().Count(s.hasReadCtx, expectedQ).Return(1, nil)
 
 	result, err := s.dataStore.CountAlerts(s.hasReadCtx)
@@ -109,7 +109,7 @@ func (s *alertDataStoreTestSuite) TestCountAlerts_Success() {
 }
 
 func (s *alertDataStoreTestSuite) TestCountAlerts_Error() {
-	expectedQ := search.NewQueryBuilder().AddStrings(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery()
+	expectedQ := search.NewQueryBuilder().AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery()
 	s.searcher.EXPECT().Count(s.hasReadCtx, expectedQ).Return(0, errFake)
 
 	_, err := s.dataStore.CountAlerts(s.hasReadCtx)

--- a/central/alert/datastore/internal/search/searcher_impl.go
+++ b/central/alert/datastore/internal/search/searcher_impl.go
@@ -176,7 +176,7 @@ func (ds *defaultViolationStateSearcher) Search(ctx context.Context, q *v1.Query
 
 	// By default, set stale to false.
 	if !querySpecifiesStateField {
-		cq := search.ConjunctionQuery(q, search.NewQueryBuilder().AddStrings(
+		cq := search.ConjunctionQuery(q, search.NewQueryBuilder().AddExactMatches(
 			search.ViolationState,
 			storage.ViolationState_ACTIVE.String(),
 			storage.ViolationState_ATTEMPTED.String()).ProtoQuery())
@@ -201,7 +201,7 @@ func (ds *defaultViolationStateSearcher) Count(ctx context.Context, q *v1.Query)
 
 	// By default, set stale to false.
 	if !querySpecifiesStateField {
-		cq := search.ConjunctionQuery(q, search.NewQueryBuilder().AddStrings(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery())
+		cq := search.ConjunctionQuery(q, search.NewQueryBuilder().AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery())
 		cq.Pagination = q.GetPagination()
 		q = cq
 	}

--- a/central/alert/service/service_impl.go
+++ b/central/alert/service/service_impl.go
@@ -257,7 +257,7 @@ func (s *serviceImpl) ResolveAlerts(ctx context.Context, req *v1.ResolveAlertsRe
 		log.Error(err)
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
-	runtimeQuery := search.NewQueryBuilder().AddStrings(search.LifecycleStage, storage.LifecycleStage_RUNTIME.String()).ProtoQuery()
+	runtimeQuery := search.NewQueryBuilder().AddExactMatches(search.LifecycleStage, storage.LifecycleStage_RUNTIME.String()).ProtoQuery()
 	cq := search.ConjunctionQuery(query, runtimeQuery)
 	alerts, err := s.dataStore.SearchRawAlerts(ctx, cq)
 	if err != nil {

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -722,7 +722,7 @@ func (ds *datastoreImpl) getSecrets(ctx context.Context, cluster *storage.Cluste
 
 func (ds *datastoreImpl) getAlerts(ctx context.Context, deploymentID string) ([]*storage.Alert, error) {
 	q := pkgSearch.NewQueryBuilder().
-		AddStrings(pkgSearch.ViolationState, storage.ViolationState_ACTIVE.String()).
+		AddExactMatches(pkgSearch.ViolationState, storage.ViolationState_ACTIVE.String()).
 		AddExactMatches(pkgSearch.DeploymentID, deploymentID).ProtoQuery()
 	return ds.alertDataStore.SearchRawAlerts(ctx, q)
 }

--- a/central/compliance/data/repository.go
+++ b/central/compliance/data/repository.go
@@ -288,7 +288,7 @@ func (r *repository) init(ctx context.Context, domain framework.ComplianceDomain
 
 	alertQuery := search.ConjunctionQuery(
 		clusterQuery,
-		search.NewQueryBuilder().AddStrings(search.ViolationState, storage.ViolationState_ACTIVE.String(), storage.ViolationState_SNOOZED.String()).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String(), storage.ViolationState_SNOOZED.String()).ProtoQuery(),
 	)
 	alertQuery.Pagination = infPagination
 	r.unresolvedAlerts, err = f.alertStore.SearchListAlerts(ctx, alertQuery)

--- a/central/compliance/manager/manager_impl.go
+++ b/central/compliance/manager/manager_impl.go
@@ -155,13 +155,13 @@ func (m *manager) createDomain(ctx context.Context, clusterID string) (framework
 		return nil, errors.Wrapf(err, "listing nodes for cluster %s", clusterID)
 	}
 
-	query := search.NewQueryBuilder().AddStrings(search.ClusterID, clusterID).ProtoQuery()
+	query := search.NewQueryBuilder().AddExactMatches(search.ClusterID, clusterID).ProtoQuery()
 	deployments, err := m.deploymentStore.SearchRawDeployments(ctx, query)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get deployments for cluster %s", clusterID)
 	}
 
-	query = search.NewQueryBuilder().AddStrings(search.ClusterID, clusterID).ProtoQuery()
+	query = search.NewQueryBuilder().AddExactMatches(search.ClusterID, clusterID).ProtoQuery()
 	pods, err := m.podStore.SearchRawPods(ctx, query)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get pods for cluster %s", clusterID)

--- a/central/detection/alertmanager/alert_manager_impl.go
+++ b/central/detection/alertmanager/alert_manager_impl.go
@@ -133,7 +133,7 @@ func (d *alertManagerImpl) shouldDebounceNotification(ctx context.Context, alert
 	q := search.NewQueryBuilder().
 		AddExactMatches(search.DeploymentID, alert.GetDeployment().GetId()).
 		AddExactMatches(search.PolicyID, alert.GetPolicy().GetId()).
-		AddStrings(search.ViolationState, storage.ViolationState_RESOLVED.String()).
+		AddExactMatches(search.ViolationState, storage.ViolationState_RESOLVED.String()).
 		ProtoQuery()
 	resolvedAlerts, err := d.alerts.SearchRawAlerts(ctx, q)
 	if err != nil {
@@ -291,7 +291,7 @@ func (d *alertManagerImpl) mergeManyAlerts(
 	incomingAlerts []*storage.Alert,
 	oldAlertFilters ...AlertFilterOption,
 ) (newAlerts, updatedAlerts, staleAlerts []*storage.Alert, err error) {
-	qb := search.NewQueryBuilder().AddStrings(
+	qb := search.NewQueryBuilder().AddExactMatches(
 		search.ViolationState,
 		storage.ViolationState_ACTIVE.String(),
 		storage.ViolationState_ATTEMPTED.String())

--- a/central/detection/alertmanager/filter_options.go
+++ b/central/detection/alertmanager/filter_options.go
@@ -66,7 +66,7 @@ func WithClusterID(clusterID string) AlertFilterOption {
 func WithoutResourceType(resourceType storage.ListAlert_ResourceType) AlertFilterOption {
 	return &alertFilterOptionImpl{
 		applyFunc: func(qb *search.QueryBuilder) {
-			qb.AddStrings(search.ResourceType, search.NegateQueryString(resourceType.String()))
+			qb.AddExactMatches(search.ResourceType, search.NegateQueryString(resourceType.String()))
 		},
 	}
 }
@@ -75,7 +75,7 @@ func WithoutResourceType(resourceType storage.ListAlert_ResourceType) AlertFilte
 func WithLifecycleStage(lifecycleStage storage.LifecycleStage) AlertFilterOption {
 	return &alertFilterOptionImpl{
 		applyFunc: func(qb *search.QueryBuilder) {
-			qb.AddStrings(search.LifecycleStage, lifecycleStage.String())
+			qb.AddExactMatches(search.LifecycleStage, lifecycleStage.String())
 		},
 	}
 }

--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -1016,8 +1016,8 @@ func (resolver *clusterResolver) getActiveDeployAlerts(ctx context.Context, q *v
 	return resolver.root.ViolationsDataStore.SearchListAlerts(ctx,
 		search.ConjunctionQuery(q,
 			search.NewQueryBuilder().AddExactMatches(search.ClusterID, cluster.GetId()).
-				AddStrings(search.ViolationState, storage.ViolationState_ACTIVE.String()).
-				AddStrings(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).ProtoQuery()))
+				AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).
+				AddExactMatches(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).ProtoQuery()))
 }
 
 func (resolver *clusterResolver) Risk(ctx context.Context) (*riskResolver, error) {

--- a/central/graphql/resolvers/deployments.go
+++ b/central/graphql/resolvers/deployments.go
@@ -167,7 +167,7 @@ func (resolver *deploymentResolver) GroupedProcesses(ctx context.Context) ([]*pr
 	if err := readIndicators(ctx); err != nil {
 		return nil, err
 	}
-	query := search.NewQueryBuilder().AddStrings(search.DeploymentID, resolver.data.GetId()).ProtoQuery()
+	query := search.NewQueryBuilder().AddExactMatches(search.DeploymentID, resolver.data.GetId()).ProtoQuery()
 	indicators, err := resolver.root.ProcessIndicatorStore.SearchRawProcessIndicators(ctx, query)
 	return resolver.root.wrapProcessNameGroups(service.IndicatorsToGroupedResponses(indicators), err)
 }
@@ -468,7 +468,7 @@ func (resolver *deploymentResolver) getDeploymentSecrets(ctx context.Context, q 
 	psr := search.NewQueryBuilder().
 		AddExactMatches(search.ClusterID, deployment.GetClusterId()).
 		AddExactMatches(search.Namespace, deployment.GetNamespace()).
-		AddStrings(search.SecretName, secretSet.AsSlice()...).
+		AddExactMatches(search.SecretName, secretSet.AsSlice()...).
 		ProtoQuery()
 	secrets, err := resolver.root.SecretsDataStore.SearchRawSecrets(ctx, psr)
 	if err != nil {
@@ -674,7 +674,7 @@ func (resolver *deploymentResolver) ProcessActivityCount(ctx context.Context) (i
 	if err := readIndicators(ctx); err != nil {
 		return 0, err
 	}
-	query := search.NewQueryBuilder().AddStrings(search.DeploymentID, resolver.data.GetId()).ProtoQuery()
+	query := search.NewQueryBuilder().AddExactMatches(search.DeploymentID, resolver.data.GetId()).ProtoQuery()
 	indicators, err := resolver.root.ProcessIndicatorStore.Search(ctx, query)
 	if err != nil {
 		return 0, err

--- a/central/graphql/resolvers/namespaces.go
+++ b/central/graphql/resolvers/namespaces.go
@@ -473,7 +473,7 @@ func (resolver *namespaceResolver) PolicyStatusOnly(ctx context.Context, args Ra
 		search.ConjunctionQuery(q,
 			search.NewQueryBuilder().AddExactMatches(search.ClusterID, resolver.data.GetMetadata().GetClusterId()).
 				AddExactMatches(search.Namespace, resolver.data.GetMetadata().GetName()).
-				AddStrings(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery()))
+				AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery()))
 	if err != nil {
 		return "", err
 	}
@@ -495,8 +495,8 @@ func (resolver *namespaceResolver) getActiveDeployAlerts(ctx context.Context, q 
 		search.ConjunctionQuery(q,
 			search.NewQueryBuilder().AddExactMatches(search.ClusterID, namespace.GetMetadata().GetClusterId()).
 				AddExactMatches(search.Namespace, namespace.GetMetadata().GetName()).
-				AddStrings(search.ViolationState, storage.ViolationState_ACTIVE.String()).
-				AddStrings(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).ProtoQuery()))
+				AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).
+				AddExactMatches(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).ProtoQuery()))
 }
 
 func (resolver *namespaceResolver) ImageComponents(ctx context.Context, args PaginatedQuery) ([]ImageComponentResolver, error) {

--- a/central/graphql/resolvers/violations.go
+++ b/central/graphql/resolvers/violations.go
@@ -109,8 +109,8 @@ func anyActiveDeployAlerts(ctx context.Context, root *Resolver, q *v1.Query) (bo
 		return false, err
 	}
 
-	alertsQuery := search.NewQueryBuilder().AddStrings(search.ViolationState, storage.ViolationState_ACTIVE.String()).
-		AddStrings(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).
+	alertsQuery := search.NewQueryBuilder().AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).
+		AddExactMatches(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).
 		ProtoQuery()
 
 	q, err := search.AddAsConjunction(q, alertsQuery)

--- a/central/graphql/resolvers/vulnerabilities_v1.go
+++ b/central/graphql/resolvers/vulnerabilities_v1.go
@@ -489,7 +489,7 @@ func (evr *EmbeddedVulnerabilityResolver) ActiveState(ctx context.Context, _ Raw
 	}
 
 	// We only support OS level component. The active state is not determined if there is no OS level component associate with this vuln.
-	query := search.NewQueryBuilder().AddExactMatches(search.CVE, evr.data.GetCve()).AddStrings(search.ComponentSource, storage.SourceType_OS.String()).ProtoQuery()
+	query := search.NewQueryBuilder().AddExactMatches(search.CVE, evr.data.GetCve()).AddExactMatches(search.ComponentSource, storage.SourceType_OS.String()).ProtoQuery()
 	osLevelComponents, err := evr.root.ImageComponentDataStore.Count(ctx, query)
 	if err != nil {
 		return nil, err

--- a/central/graphql/resolvers/vulnerabilities_v2.go
+++ b/central/graphql/resolvers/vulnerabilities_v2.go
@@ -1002,7 +1002,7 @@ func (resolver *cVEResolver) ActiveState(ctx context.Context, args RawQuery) (*a
 		return nil, nil
 	}
 	// We only support OS level component. The active state is not determined if there is no OS level component associate with this vuln.
-	query := search.NewQueryBuilder().AddExactMatches(search.CVE, resolver.data.GetId()).AddStrings(search.ComponentSource, storage.SourceType_OS.String()).ProtoQuery()
+	query := search.NewQueryBuilder().AddExactMatches(search.CVE, resolver.data.GetId()).AddExactMatches(search.ComponentSource, storage.SourceType_OS.String()).ProtoQuery()
 	osLevelComponents, err := resolver.root.ImageComponentDataStore.Count(ctx, query)
 	if err != nil {
 		return nil, err

--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -210,7 +210,7 @@ func (ds *datastoreImpl) GetImagesBatch(ctx context.Context, shas []string) ([]*
 			return nil, err
 		}
 	} else {
-		shasQuery := pkgSearch.NewQueryBuilder().AddStrings(pkgSearch.ImageSHA, shas...).ProtoQuery()
+		shasQuery := pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.ImageSHA, shas...).ProtoQuery()
 		imgs, err = ds.SearchRawImages(ctx, shasQuery)
 		if err != nil {
 			return nil, err

--- a/central/namespace/resolver.go
+++ b/central/namespace/resolver.go
@@ -69,7 +69,7 @@ func populateFromMetadataSlice(ctx context.Context, metadataSlice []*storage.Nam
 // ResolveByClusterIDAndName resolves a namespace given its cluster ID and its name.
 func ResolveByClusterIDAndName(ctx context.Context, clusterID string, name string, dataStore datastore.DataStore, deploymentDataStore deploymentDataStore.DataStore,
 	secretDataStore secretDataStore.DataStore, npStore npDS.DataStore) (*v1.Namespace, bool, error) {
-	q := search.NewQueryBuilder().AddExactMatches(search.Namespace, name).AddStrings(search.ClusterID, clusterID).ProtoQuery()
+	q := search.NewQueryBuilder().AddExactMatches(search.Namespace, name).AddExactMatches(search.ClusterID, clusterID).ProtoQuery()
 	namespaces, err := dataStore.SearchNamespaces(ctx, q)
 	if err != nil {
 		return nil, false, err

--- a/central/node/datastore/dackbox/datastore/datastore_impl.go
+++ b/central/node/datastore/dackbox/datastore/datastore_impl.go
@@ -158,7 +158,7 @@ func (ds *datastoreImpl) GetNodesBatch(ctx context.Context, ids []string) ([]*st
 			return nil, err
 		}
 	} else {
-		idsQuery := pkgSearch.NewQueryBuilder().AddStrings(pkgSearch.NodeID, ids...).ProtoQuery()
+		idsQuery := pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.NodeID, ids...).ProtoQuery()
 		nodes, err = ds.SearchRawNodes(ctx, idsQuery)
 		if err != nil {
 			return nil, err

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -602,7 +602,7 @@ func (g *garbageCollectorImpl) collectClusters(config *storage.PrivateConfig) {
 func (g *garbageCollectorImpl) checkIfClusterContainsCentral(cluster *storage.Cluster) (bool, error) {
 	// This query could be expensive, but it's a rare occurrence. It only happens if there is a cluster that has been unhealthy for a long time (configurable)
 	query := search.NewQueryBuilder().
-		AddStrings(search.ClusterID, cluster.GetId()).
+		AddExactMatches(search.ClusterID, cluster.GetId()).
 		AddExactMatches(search.DeploymentName, "central")
 	deploys, err := g.deployments.SearchRawDeployments(pruningCtx, query.ProtoQuery())
 	if err != nil {
@@ -657,8 +657,8 @@ func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
 
 	if pruneResolvedDeployAfter > 0 {
 		q := search.NewQueryBuilder().
-			AddStrings(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).
-			AddStrings(search.ViolationState, storage.ViolationState_RESOLVED.String()).
+			AddExactMatches(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).
+			AddExactMatches(search.ViolationState, storage.ViolationState_RESOLVED.String()).
 			AddDays(search.ViolationTime, int64(pruneResolvedDeployAfter)).
 			ProtoQuery()
 		queries = append(queries, q)
@@ -666,7 +666,7 @@ func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
 
 	if pruneAllRuntimeAfter > 0 {
 		q := search.NewQueryBuilder().
-			AddStrings(search.LifecycleStage, storage.LifecycleStage_RUNTIME.String()).
+			AddExactMatches(search.LifecycleStage, storage.LifecycleStage_RUNTIME.String()).
 			AddDays(search.ViolationTime, int64(pruneAllRuntimeAfter)).
 			ProtoQuery()
 		queries = append(queries, q)
@@ -674,7 +674,7 @@ func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
 
 	if pruneDeletedRuntimeAfter > 0 && pruneAllRuntimeAfter != pruneDeletedRuntimeAfter {
 		q := search.NewQueryBuilder().
-			AddStrings(search.LifecycleStage, storage.LifecycleStage_RUNTIME.String()).
+			AddExactMatches(search.LifecycleStage, storage.LifecycleStage_RUNTIME.String()).
 			AddDays(search.ViolationTime, int64(pruneDeletedRuntimeAfter)).
 			AddBools(search.Inactive, true).
 			ProtoQuery()
@@ -683,8 +683,8 @@ func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
 
 	if pruneAttemptedDeployAfter > 0 {
 		q := search.NewQueryBuilder().
-			AddStrings(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).
-			AddStrings(search.ViolationState, storage.ViolationState_ATTEMPTED.String()).
+			AddExactMatches(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).
+			AddExactMatches(search.ViolationState, storage.ViolationState_ATTEMPTED.String()).
 			AddDays(search.ViolationTime, int64(pruneAttemptedDeployAfter)).
 			ProtoQuery()
 		queries = append(queries, q)
@@ -692,8 +692,8 @@ func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
 
 	if pruneAttemptedRuntimeAfter > 0 {
 		q := search.NewQueryBuilder().
-			AddStrings(search.LifecycleStage, storage.LifecycleStage_RUNTIME.String()).
-			AddStrings(search.ViolationState, storage.ViolationState_ATTEMPTED.String()).
+			AddExactMatches(search.LifecycleStage, storage.LifecycleStage_RUNTIME.String()).
+			AddExactMatches(search.ViolationState, storage.ViolationState_ATTEMPTED.String()).
 			AddDays(search.ViolationTime, int64(pruneAttemptedRuntimeAfter)).
 			ProtoQuery()
 		queries = append(queries, q)

--- a/central/reports/common/query_builder.go
+++ b/central/reports/common/query_builder.go
@@ -63,9 +63,9 @@ func (q *queryBuilder) buildCVEAttributesQuery() (string, error) {
 	case storage.VulnerabilityReportFilters_BOTH:
 		break
 	case storage.VulnerabilityReportFilters_FIXABLE:
-		conjuncts = append(conjuncts, search.NewQueryBuilder().AddExactMatches(search.Fixable, "true").Query())
+		conjuncts = append(conjuncts, search.NewQueryBuilder().AddBools(search.Fixable, true).Query())
 	case storage.VulnerabilityReportFilters_NOT_FIXABLE:
-		conjuncts = append(conjuncts, search.NewQueryBuilder().AddExactMatches(search.Fixable, "false").Query())
+		conjuncts = append(conjuncts, search.NewQueryBuilder().AddBools(search.Fixable, false).Query())
 	}
 
 	severities := make([]string, 0, len(vulnReportFilters.GetSeverities()))

--- a/central/reports/common/query_builder.go
+++ b/central/reports/common/query_builder.go
@@ -63,9 +63,9 @@ func (q *queryBuilder) buildCVEAttributesQuery() (string, error) {
 	case storage.VulnerabilityReportFilters_BOTH:
 		break
 	case storage.VulnerabilityReportFilters_FIXABLE:
-		conjuncts = append(conjuncts, search.NewQueryBuilder().AddStrings(search.Fixable, "true").Query())
+		conjuncts = append(conjuncts, search.NewQueryBuilder().AddExactMatches(search.Fixable, "true").Query())
 	case storage.VulnerabilityReportFilters_NOT_FIXABLE:
-		conjuncts = append(conjuncts, search.NewQueryBuilder().AddStrings(search.Fixable, "false").Query())
+		conjuncts = append(conjuncts, search.NewQueryBuilder().AddExactMatches(search.Fixable, "false").Query())
 	}
 
 	severities := make([]string, 0, len(vulnReportFilters.GetSeverities()))
@@ -73,7 +73,7 @@ func (q *queryBuilder) buildCVEAttributesQuery() (string, error) {
 		severities = append(severities, severity.String())
 	}
 	if len(severities) > 0 {
-		conjuncts = append(conjuncts, search.NewQueryBuilder().AddStrings(search.Severity, severities...).Query())
+		conjuncts = append(conjuncts, search.NewQueryBuilder().AddExactMatches(search.Severity, severities...).Query())
 	}
 
 	if vulnReportFilters.SinceLastReport {

--- a/central/reports/common/query_builder_test.go
+++ b/central/reports/common/query_builder_test.go
@@ -71,5 +71,5 @@ func TestBuildQuery(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.ElementsMatch(t, []string{"Cluster:remote+Namespace:ns1", "Cluster:secured+Namespace:ns2"}, rq.ScopeQueries)
-	assert.Equal(t, "Fixable:true+Severity:CRITICAL_VULNERABILITY_SEVERITY,IMPORTANT_VULNERABILITY_SEVERITY", rq.CveFieldsQuery)
+	assert.Equal(t, "Fixable:\"true\"+Severity:\"CRITICAL_VULNERABILITY_SEVERITY\",\"IMPORTANT_VULNERABILITY_SEVERITY\"", rq.CveFieldsQuery)
 }

--- a/central/reports/common/query_builder_test.go
+++ b/central/reports/common/query_builder_test.go
@@ -71,5 +71,5 @@ func TestBuildQuery(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.ElementsMatch(t, []string{"Cluster:remote+Namespace:ns1", "Cluster:secured+Namespace:ns2"}, rq.ScopeQueries)
-	assert.Equal(t, "Fixable:\"true\"+Severity:\"CRITICAL_VULNERABILITY_SEVERITY\",\"IMPORTANT_VULNERABILITY_SEVERITY\"", rq.CveFieldsQuery)
+	assert.Equal(t, "Fixable:true+Severity:\"CRITICAL_VULNERABILITY_SEVERITY\",\"IMPORTANT_VULNERABILITY_SEVERITY\"", rq.CveFieldsQuery)
 }

--- a/central/reports/service/singleton.go
+++ b/central/reports/service/singleton.go
@@ -31,7 +31,7 @@ func initializeManager() manager.Manager {
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.VulnerabilityReports)))
 
-	query := search.NewQueryBuilder().AddStrings(search.ReportType, storage.ReportConfiguration_VULNERABILITY.String()).ProtoQuery()
+	query := search.NewQueryBuilder().AddExactMatches(search.ReportType, storage.ReportConfiguration_VULNERABILITY.String()).ProtoQuery()
 	reportConfigs, err := datastore.Singleton().GetReportConfigurations(ctx, query)
 	if err != nil {
 		panic(err)

--- a/central/risk/getters/alert_mock.go
+++ b/central/risk/getters/alert_mock.go
@@ -2,6 +2,7 @@ package getters
 
 import (
 	"context"
+	"strings"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
@@ -30,7 +31,7 @@ func (m MockAlertsGetter) ListAlerts(ctx context.Context, req *v1.ListAlertsRequ
 	})
 
 	for _, a := range m.Alerts {
-		if a.GetState().String() == state {
+		if a.GetState().String() == strings.Trim(state, "\"") {
 			alerts = append(alerts, a)
 		}
 	}

--- a/central/risk/multipliers/deployment/violations.go
+++ b/central/risk/multipliers/deployment/violations.go
@@ -45,7 +45,7 @@ func NewViolations(getter getters.AlertGetter) *ViolationsMultiplier {
 
 // Score takes a deployment and evaluates its risk based on policy violations.
 func (v *ViolationsMultiplier) Score(ctx context.Context, deployment *storage.Deployment, _ map[string][]*storage.Risk_Result) *storage.Risk_Result {
-	qb := search.NewQueryBuilder().AddExactMatches(search.DeploymentID, deployment.GetId()).AddStrings(search.ViolationState, storage.ViolationState_ACTIVE.String())
+	qb := search.NewQueryBuilder().AddExactMatches(search.DeploymentID, deployment.GetId()).AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String())
 
 	alerts, err := v.getter.ListAlerts(ctx, &v1.ListAlertsRequest{
 		Query: qb.Query(),


### PR DESCRIPTION
## Description

This PR is In prep for changing the string search from prefix to substring. We should replace the occurrences in the code that should be exact matches instead of prefix queries such as, enum queries, ID queries.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
CI