### PR TITLE
ROX-12356: Add dockerfile line to each affected component in Image Overview

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
@@ -150,8 +150,8 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
                 ...targetComponent,
                 dockerfileLine: {
                     line: line + 1, // findIndex returns 0-based index number
-                    instruction: layers[line]?.instruction || '(no instruction)',
-                    value: layers[line]?.value || '',
+                    instruction: layers[line]?.instruction || '-',
+                    value: layers[line]?.value || '-',
                 },
             };
         });

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
@@ -49,6 +49,7 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
     const { activeKeyTab, onSelectTab } = useTabs({
         defaultTab: 'OBSERVED_CVES',
     });
+    const [selectedCveName, setSelectedCveName] = useState('');
     const [selectedComponents, setSelectedComponents] = useState([]);
     const { isModalOpen, openModal, closeModal } = useModal();
 
@@ -129,10 +130,8 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
         );
     }
 
-    function showComponentDetails(components) {
+    function showComponentDetails(components, cveName) {
         const augmentedComponents = components.map((targetComponent) => {
-            console.log({ targetComponent });
-            console.log({ layers });
             const line = layers.findIndex((layer) => {
                 return layer.components.some((layerComponent) => {
                     return (
@@ -141,11 +140,7 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
                     );
                 });
             });
-            console.log({ line });
 
-            if (line !== -1) {
-                console.log(`${line + 1} ${layers[line]?.instruction} ${layers[line]?.value}`);
-            }
             return {
                 ...targetComponent,
                 dockerfileLine: {
@@ -155,6 +150,7 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
                 },
             };
         });
+        setSelectedCveName(cveName);
         setSelectedComponents(augmentedComponents);
         openModal();
     }
@@ -209,6 +205,7 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
                             Observed, Deferred, and False Postive CVEs tables */}
                         <div className="w-full">
                             <AffectedComponentsModal
+                                cveName={selectedCveName}
                                 isOpen={isModalOpen}
                                 components={selectedComponents}
                                 onClose={closeModal}

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
@@ -51,10 +51,6 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
     });
     const [selectedComponents, setSelectedComponents] = useState([]);
     const { isModalOpen, openModal, closeModal } = useModal();
-    function showComponentDetails(components) {
-        setSelectedComponents(components);
-        openModal();
-    }
 
     // guard against incomplete GraphQL-cached data
     const safeData = { ...emptyImage, ...data };
@@ -132,6 +128,37 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
             />
         );
     }
+
+    function showComponentDetails(components) {
+        const augmentedComponents = components.map((targetComponent) => {
+            console.log({ targetComponent });
+            console.log({ layers });
+            const line = layers.findIndex((layer) => {
+                return layer.components.some((layerComponent) => {
+                    return (
+                        layerComponent.name === targetComponent.name &&
+                        layerComponent.version === targetComponent.version
+                    );
+                });
+            });
+            console.log({ line });
+
+            if (line !== -1) {
+                console.log(`${line + 1} ${layers[line]?.instruction} ${layers[line]?.value}`);
+            }
+            return {
+                ...targetComponent,
+                dockerfileLine: {
+                    line: line + 1, // findIndex returns 0-based index number
+                    instruction: layers[line]?.instruction || '(no instruction)',
+                    value: layers[line]?.value || '',
+                },
+            };
+        });
+        setSelectedComponents(augmentedComponents);
+        openModal();
+    }
+
     const currentEntity = { [entityTypes.IMAGE]: data.id };
     const newEntityContext = { ...entityContext, ...currentEntity };
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
@@ -23,12 +23,14 @@ import workflowStateContext from 'Containers/workflowStateContext';
 import { EmbeddedImageScanComponent } from '../imageVulnerabilities.graphql';
 
 export type AffectedComponentsModalProps = {
+    cveName: string;
     isOpen: boolean;
     components: EmbeddedImageScanComponent[];
     onClose: () => void;
 };
 
 function AffectedComponentsModal({
+    cveName = 'Unknown CVE',
     isOpen,
     components,
     onClose,
@@ -61,7 +63,7 @@ function AffectedComponentsModal({
     return (
         <Modal
             variant={ModalVariant.small}
-            title="Affected Components"
+            title={`Components affected by ${cveName}`}
             isOpen={isOpen}
             onClose={onCloseHandler}
         >

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
@@ -14,7 +14,7 @@ import { EmbeddedImageScanComponent } from '../imageVulnerabilities.graphql';
 
 type DeferredCVEsProps = {
     imageId: string;
-    showComponentDetails: (components: EmbeddedImageScanComponent[]) => void;
+    showComponentDetails: (components: EmbeddedImageScanComponent[], cveName: string) => void;
 };
 
 const sortFields = ['Severity'];

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
@@ -44,7 +44,7 @@ export type DeferredCVEsTableProps = {
     searchFilter: SearchFilter;
     setSearchFilter: React.Dispatch<React.SetStateAction<SearchFilter>>;
     getSortParams: GetSortParams;
-    showComponentDetails: (components: EmbeddedImageScanComponent[]) => void;
+    showComponentDetails: (components: EmbeddedImageScanComponent[], cveName: string) => void;
 } & UsePaginationResult;
 
 function DeferredCVEsTable({
@@ -245,7 +245,7 @@ function DeferredCVEsTable({
                                             variant={ButtonVariant.link}
                                             isInline
                                             onClick={() => {
-                                                showComponentDetails(row.components);
+                                                showComponentDetails(row.components, row.cve);
                                             }}
                                         >
                                             {row.components.length} components

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
@@ -14,7 +14,7 @@ import { EmbeddedImageScanComponent } from '../imageVulnerabilities.graphql';
 
 type FalsePositiveCVEsProps = {
     imageId: string;
-    showComponentDetails: (components: EmbeddedImageScanComponent[]) => void;
+    showComponentDetails: (components: EmbeddedImageScanComponent[], cveName: string) => void;
 };
 
 const sortFields = ['Severity'];

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
@@ -43,7 +43,7 @@ export type FalsePositiveCVEsTableProps = {
     searchFilter: SearchFilter;
     setSearchFilter: React.Dispatch<React.SetStateAction<SearchFilter>>;
     getSortParams: GetSortParams;
-    showComponentDetails: (components: EmbeddedImageScanComponent[]) => void;
+    showComponentDetails: (components: EmbeddedImageScanComponent[], cveName: string) => void;
 } & UsePaginationResult;
 
 function FalsePositiveCVEsTable({
@@ -230,7 +230,7 @@ function FalsePositiveCVEsTable({
                                             variant={ButtonVariant.link}
                                             isInline
                                             onClick={() => {
-                                                showComponentDetails(row.components);
+                                                showComponentDetails(row.components, row.cve);
                                             }}
                                         >
                                             {row.components.length} components

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
@@ -10,10 +10,11 @@ import useTableSort from 'hooks/patternfly/useTableSort';
 import { SortOption } from 'types/table';
 import ObservedCVEsTable from './ObservedCVEsTable';
 import useImageVulnerabilities from '../useImageVulnerabilities';
+import { EmbeddedImageScanComponent } from '../imageVulnerabilities.graphql';
 
 type ObservedCVEsProps = {
     imageId: string;
-    showComponentDetails: () => void;
+    showComponentDetails: (components: EmbeddedImageScanComponent[], cveName: string) => void;
 };
 
 const sortFields = ['Severity', 'CVSS', 'Discovered'];

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
@@ -56,7 +56,7 @@ export type ObservedCVEsTableProps = {
     searchFilter: SearchFilter;
     setSearchFilter: React.Dispatch<React.SetStateAction<SearchFilter>>;
     getSortParams: GetSortParams;
-    showComponentDetails: (components: EmbeddedImageScanComponent[]) => void;
+    showComponentDetails: (components: EmbeddedImageScanComponent[], cveName: string) => void;
 } & UsePaginationResult;
 
 function ObservedCVEsTable({
@@ -286,7 +286,7 @@ function ObservedCVEsTable({
                                             variant={ButtonVariant.link}
                                             isInline
                                             onClick={() => {
-                                                showComponentDetails(row.components);
+                                                showComponentDetails(row.components, row.cve);
                                             }}
                                         >
                                             {row.components.length} components

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/imageVulnerabilities.graphql.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/imageVulnerabilities.graphql.ts
@@ -39,6 +39,11 @@ export type EmbeddedImageScanComponent = {
     name: string;
     version: string;
     fixedIn: string;
+    dockerfileLine?: {
+        line: number;
+        instruction: string;
+        value: string;
+    };
 };
 
 export type GetImageVulnerabilitiesData = {


### PR DESCRIPTION
## Description

I broke this work into three (3) iterative commits, to make it easier to follow the progression of work.
1. [Add dockerfile line info to Affected Components modal data](https://github.com/stackrox/stackrox/commit/d39fb2c9ce820e8f9ab501d247a5bdfbd5c0632d)
2. [Add expandable table rows for dockerfile lines to Affected Components](https://github.com/stackrox/stackrox/commit/d39a2abfb35552dd44f8daa8b73d011986916aa8)
3. [Add CVE name to Affected Components modal title](https://github.com/stackrox/stackrox/commit/59dc3fb06e10216467d3da7cfbf87ccf603e3892)

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

### "Before" screenshots
<img width="557" alt="old_1_component" src="https://user-images.githubusercontent.com/715729/187548345-8a0ceb8a-344d-4b8d-b7d1-f67299f8ecdf.png">
<img width="553" alt="old_2_components" src="https://user-images.githubusercontent.com/715729/187548348-25cab48f-c488-4f3f-88f8-96938a6a0ced.png">

### "After" screenshots

#### One component
Collapsed
<img width="1516" alt="Screen Shot 2022-08-30 at 4 56 57 PM" src="https://user-images.githubusercontent.com/715729/187548499-0de5dd67-7829-4772-86e4-69528ecc2208.png">
Expanded
<img width="1516" alt="Screen Shot 2022-08-30 at 4 57 03 PM" src="https://user-images.githubusercontent.com/715729/187548502-1fc5f51b-fd73-44be-8357-bfa0f11dcfe0.png">



#### Two components
One of two rows expanded
<img width="1516" alt="Screen Shot 2022-08-30 at 4 57 14 PM" src="https://user-images.githubusercontent.com/715729/187548580-34bd99b8-7071-4f77-8ab0-ff178a75926b.png">
All two of two rows expanded
<img width="1516" alt="Screen Shot 2022-08-30 at 4 57 17 PM" src="https://user-images.githubusercontent.com/715729/187548583-219cc706-8b6a-4c4c-bcd4-5b55cc8728cc.png">

