### PR TITLE
ROX-11537: workaround a race in admission controller test

### DIFF
--- a/sensor/admission-control/service/service_test.go
+++ b/sensor/admission-control/service/service_test.go
@@ -168,6 +168,9 @@ func (r serviceTestRun) execute() {
 	require.NotNil(r.t, r.mgr)
 	require.NotNil(r.t, r.handlerFunc)
 	require.True(r.t, r.mgr.IsReady(), "Manager is stopped or was not started")
+	// Wait for any events delivered to manager prior to this call to be processed.
+	// TODO(porridge): come up with a less hacky way to synchronize
+	time.Sleep(2 * time.Second)
 
 	s := service{
 		mgr: r.mgr,
@@ -186,7 +189,7 @@ func (r serviceTestRun) execute() {
 	assert.Equal(r.t, http.StatusOK, resp.Code)
 
 	select {
-	case <-time.After(30 * time.Second):
+	case <-time.After(3 * time.Second):
 		assert.Fail(r.t, "Did not receive any alerts before timeout expired, but expected some")
 	case alerts := <-r.mgr.Alerts():
 		r.assertionFunc(r.t, resp.Result(), alerts)

--- a/sensor/admission-control/service/service_test.go
+++ b/sensor/admission-control/service/service_test.go
@@ -162,6 +162,8 @@ type serviceTestRun struct {
 	t           *testing.T
 }
 
+// execute runs the review request through the handler and then
+// runs alerts from manager through the assertion function.
 func (r serviceTestRun) execute() {
 	require.NotNil(r.t, r.mgr)
 	require.NotNil(r.t, r.handlerFunc)


### PR DESCRIPTION
## Description

See [the ticket for a description](https://issues.redhat.com/browse/ROX-11537?focusedCommentId=20877231&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-20877231) of the root cause.

This is a stopgap solution to stop the pain, but we need to think of a better way to test this.
It also reminds me of a similar race (in sensor?) that @fredrb mentioned a while ago, where there was no way to tell whether all events had been processed.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Ran `go test . -test.v -test.run '^\QTestExecIntoPodNameEventPolicy\E$' -test.count=100` in `sensor/admission-control/service`.