### PR TITLE
ROX-12365: Remove FixedIn column from NODE COMPONENTS list

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/componentsListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/componentsListPages.test.js
@@ -57,7 +57,7 @@ describe('Components list Page and its entity detail page, (related entities) su
             }
         });
 
-        it('should display all the columns expected in components list page', () => {
+        it('should display all the columns expected in image components list page', () => {
             visitVulnerabilityManagementEntities('image-components');
             hasExpectedHeaderColumns([
                 'Component',
@@ -82,6 +82,36 @@ describe('Components list Page and its entity detail page, (related entities) su
                     allFixableCheck(url.list.components); */
                 if (columnValue !== 'no cves' && columnValue.includes('cve')) {
                     allCVECheck(url.list['image-components']);
+                }
+            });
+            //  TBD to be fixed after back end sorting is fixed
+            //  validateSort(selectors.componentsRiskScoreCol);
+        });
+
+        it('should display all the columns expected in node components list page', () => {
+            visitVulnerabilityManagementEntities('node-components');
+            hasExpectedHeaderColumns([
+                'Component',
+                'Operating System',
+                'CVEs',
+                'Top CVSS',
+                'Images',
+                'Deployments',
+                'Risk Priority',
+            ]);
+            cy.get(selectors.tableBodyColumn).each(($el) => {
+                const columnValue = $el.text().toLowerCase();
+                // TODO: uncomment after API fixes deploymentCount return value in this context
+                // if (columnValue !== 'no deployments' && columnValue.includes('deployment')) {
+                //     allChecksForEntities(url.list['node-components'], 'Deployment');
+                // }
+                if (columnValue !== 'no nodes' && columnValue.includes('node')) {
+                    allChecksForEntities(url.list['node-components'], 'Node');
+                }
+                /* TBD - uncomment later - if (columnValue !== 'no cves' && columnValue.includes('fixable'))
+                    allFixableCheck(url.list.components); */
+                if (columnValue !== 'no cves' && columnValue.includes('cve')) {
+                    allCVECheck(url.list['node-components']);
                 }
             });
             //  TBD to be fixed after back end sorting is fixed

--- a/ui/apps/platform/cypress/integration/vulnmanagement/componentsListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/componentsListPages.test.js
@@ -95,8 +95,7 @@ describe('Components list Page and its entity detail page, (related entities) su
                 'Operating System',
                 'CVEs',
                 'Top CVSS',
-                'Images',
-                'Deployments',
+                'Nodes',
                 'Risk Priority',
             ]);
             cy.get(selectors.tableBodyColumn).each(($el) => {

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.js
@@ -119,18 +119,6 @@ export function getComponentTableColumns(showVMUpdates) {
                 sortable: false,
             },
             {
-                Header: `Fixed In`,
-                headerClassName: `w-1/12 ${defaultHeaderClassName}`,
-                className: `w-1/12 word-break-all ${defaultColumnClassName}`,
-                Cell: ({ original }) =>
-                    original.fixedIn ||
-                    (original.vulnCounter.all.total === 0 ? 'N/A' : 'Not Fixable'),
-                id: componentSortFields.FIXEDIN,
-                accessor: 'fixedIn',
-                sortField: componentSortFields.FIXEDIN,
-                sortable: false,
-            },
-            {
                 Header: `Top CVSS`,
                 headerClassName: `w-1/10 text-center ${defaultHeaderClassName}`,
                 className: `w-1/10 ${defaultColumnClassName}`,
@@ -208,7 +196,7 @@ const VulnMgmtNodeComponents = ({ selectedRowId, search, sort, page, data, total
     const showVMUpdates = isFeatureFlagEnabled('ROX_FRONTEND_VM_UPDATES');
 
     const query = gql`
-        query getComponents($query: String, $pagination: Pagination) {
+        query getNodeComponents($query: String, $pagination: Pagination) {
             results: nodeComponents(query: $query, pagination: $pagination) {
                 ...nodeComponentFields
             }

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
@@ -792,7 +792,6 @@ export const VULN_NODE_COMPONENT_LIST_FRAGMENT = gql`
         version
         location
         source
-        fixedIn
         vulnCounter: nodeVulnerabilityCounter {
             all {
                 total


### PR DESCRIPTION
## Description

Fulfilling requirement:
> This attribute is not supported for node components, and adding it is at least medium effort because it involves Scanner work as well as Central work. Without the split it was not very evident but not anymore.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added


## Testing Performed

Node components top-level list
![Screen Shot 2022-08-31 at 11 24 49 AM](https://user-images.githubusercontent.com/715729/187725959-c9a7408a-3056-41da-8a82-1d39be21c889.png)

Node components list under Node
![Screen Shot 2022-08-31 at 11 25 07 AM](https://user-images.githubusercontent.com/715729/187727331-97ca6162-1194-4fc1-88a6-7cc6f1df997e.png)

Node components list under Cluster
![Screen Shot 2022-08-31 at 11 25 21 AM](https://user-images.githubusercontent.com/715729/187727363-63e9b4ec-0044-46af-bc64-4356313587fc.png)
