### PR TITLE
CI: explain that build_root is defined elsewhere

### DIFF
--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -1,25 +1,24 @@
-# Changes to this file are not validated automatically by CI. That is because
-# the CI as defined in openshift/release runs against HEAD and uses the version
-# of this file found there.
+# This file is *not used* as the build_root in CI. Instead a mirrored image is
+# used for performance reasons. See the build_root: in:
+# https://github.com/openshift/release/blob/master/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master.yaml
 
-# In order to validate a change to this file i.e. a new version of the test environment:
-# - make the change on a stackrox/stackrox PR (do not use / in the branch name as it is
-#   not supported in openshift/release)
+# However this file can be used to validate proposed changes to
+# stackrox/rox-ci-image. And this is why the automation in that repo will update
+# this file when it creates dependent PRs and
+# `stackrox-update-ci-image-from-<rox-ci-image PR>` branches e.g.
+# https://github.com/stackrox/stackrox/pull/2762
+
+# In order to validate a new version of the test environment:
 # - open a PR in openshift/release (this is just for test. mark the PR with `/hold` and
 #   `/uncc` autoassigned reviewers to reduce noise)
-# - duplicate the main branch CI workflow to a workflow that tests the stackrox/stackrox
+# - rename the main branch CI workflow to a workflow that tests the stackrox/stackrox
 #   PR branch, specifically
-#   - clone `stackrox-stackrox-master.yaml` and `stackrox-stackrox-master__stackrox_branding.yaml`
+#   - git mv `stackrox-stackrox-master.yaml` to `stackrox-stackrox-stackrox-update-ci-image-from-<rox-ci-image PR number>.yaml`
 #     in `ci-operator/config/stackrox/stackrox/` folder
-#   - clone `stackrox-stackrox-master-postsubmits.yaml`
-#     in `ci-operator/jobs/stackrox/stackrox/` folder
-#   - name choice of the cloned files is important, "master" must be replaced by the name
-#     of the stackrox/stackrox PR branch you want to test, for example,
-#     `stackrox-update-ci-image-from-163`
-#   - replace all mentions of "master" branches with the stackrox/stackrox PR branch, for
-#     example, `stackrox-update-ci-image-from-163`
-#   - change the tags in both cloned files in the ci-operator/config/stackrox/stackrox/`
-#     folder from `latest` and `latest-stackrox-branding` to something else
+#   - change the zz_generated_metadata.branch to stackrox-update-ci-image-from-<rox-ci-image PR number>
+#   - change the build_root to:
+#     project_image:
+#       dockerfile_path: .openshift-ci/Dockerfile.build_root
 # - run openshift/release automation to generate the prow config, specifically
 #   - run `make update` locally, commit the results, and push them to the test PR in
 #     openshift/release you created earlier


### PR DESCRIPTION
## Description

Updates `.openshift-ci/Dockerfile.build_root` to explain its change in relevance. I've documented the build_root mirroring and update process elsewhere which is something of an art form / WIP: https://docs.engineering.redhat.com/pages/viewpage.action?pageId=306785028

## Checklist
n/a

## Testing Performed
n/a
