### PR TITLE
Dashrews/ROX-12415 upgrade db copy fails

### DIFF
--- a/central/globaldb/v2backuprestore/restore/postgres.go
+++ b/central/globaldb/v2backuprestore/restore/postgres.go
@@ -84,33 +84,6 @@ func runRestoreStream(fileReader io.Reader, sourceMap map[string]string, config 
 	return nil
 }
 
-// SwitchToRestoredDB - switches the restore DB to be the active DB
-func SwitchToRestoredDB(sourceMap map[string]string, dbConfig *pgxpool.Config) error {
-	log.Info("Switching to restored database")
-
-	// Connect to different database for admin functions
-	connectPool := pgadmin.GetAdminPool(dbConfig)
-	// Close the admin connection pool
-	defer connectPool.Close()
-
-	// Restore succeeded to the separate DB, so we need to drop the original in order to rename
-	// the new one.
-	err := pgadmin.DropDB(sourceMap, dbConfig, pgconfig.GetActiveDB())
-	if err != nil {
-		log.Errorf("Could not drop the DB: %v", err)
-		return err
-	}
-
-	// rename central_restore to postgres
-	err = pgadmin.RenameDB(connectPool, getRestoreDBName(), pgconfig.GetActiveDB())
-	if err != nil {
-		log.Errorf("Could not rename the DB: %v", err)
-		return err
-	}
-
-	return nil
-}
-
 // CheckIfRestoreDBExists - checks to see if a restore database exists
 func CheckIfRestoreDBExists(dbConfig *pgxpool.Config) bool {
 	return pgadmin.CheckIfDBExists(dbConfig, getRestoreDBName())

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -326,8 +326,12 @@ func (d *dbCloneManagerImpl) moveClones(previousClone, updatedClone string) erro
 
 func (d *dbCloneManagerImpl) renameClone(ctx context.Context, tx pgx.Tx, srcClone, destClone string) error {
 	// Move the current to the previous clone
-	pgadmin.TerminateConnection(d.adminConfig, srcClone)
-	_, err := tx.Exec(ctx, fmt.Sprintf("ALTER DATABASE %s RENAME TO %s", srcClone, destClone))
+	err := pgadmin.TerminateConnection(d.adminConfig, srcClone)
+	if err != nil {
+		return err
+	}
+	
+	_, err = tx.Exec(ctx, fmt.Sprintf("ALTER DATABASE %s RENAME TO %s", srcClone, destClone))
 	if err != nil {
 		log.Errorf("Unable to switch to clone %q DB: %v", destClone, err)
 		if err := tx.Rollback(ctx); err != nil {

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -1,6 +1,10 @@
 package postgres
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/migrator/clone/metadata"
@@ -53,6 +57,8 @@ func (d *dbCloneManagerImpl) Scan() error {
 			d.cloneMap[name] = metadata.NewPostgres(ver, name)
 			log.Debugf("Closing the pool from scan %q", name)
 			pool.Close()
+		case name == TempClone:
+			clonesToRemove.Add(name)
 		}
 	}
 
@@ -163,7 +169,7 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 				// If for some reason, we cannot create a temp clone we will need to continue to upgrade
 				// with the current and thus no fallback.
 				if err != nil {
-					log.Errorf("Unable to create Temp database: %v", err)
+					log.Errorf("Unable to create temp clone: %v", err)
 				}
 			}
 			d.cloneMap[TempClone] = metadata.NewPostgres(d.cloneMap[CurrentClone].GetMigVersion(), TempClone)
@@ -194,7 +200,8 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 				// If for some reason, we cannot create a temp clone we will need to continue to upgrade
 				// with the current and thus no fallback.
 				if err != nil {
-					log.Errorf("Unable to create Temp database: %v", err)
+					log.Errorf("Unable to create temp clone, will use current clone: %v", err)
+					return CurrentClone, false, nil
 				}
 			}
 			d.cloneMap[TempClone] = metadata.NewPostgres(d.cloneMap[CurrentClone].GetMigVersion(), TempClone)
@@ -247,11 +254,6 @@ func (d *dbCloneManagerImpl) Persist(cloneName string) error {
 func (d *dbCloneManagerImpl) doPersist(cloneName string, prev string) error {
 	log.Infof("doPersist clone = %q, prev = %q", cloneName, prev)
 
-	// Connect to different database for admin functions
-	connectPool := pgadmin.GetAdminPool(d.adminConfig)
-	// Close the admin connection pool
-	defer connectPool.Close()
-
 	var moveCurrent string
 	// Remove prev clone if exist.
 	if prev != "" {
@@ -262,17 +264,9 @@ func (d *dbCloneManagerImpl) doPersist(cloneName string, prev string) error {
 		moveCurrent = TempClone
 	}
 
-	// Flip current to prev
-	err := pgadmin.RenameDB(connectPool, CurrentClone, moveCurrent)
+	err := d.moveClones(moveCurrent, cloneName)
 	if err != nil {
-		log.Errorf("Unable to switch to previous DB: %v", err)
-		return err
-	}
-
-	// Now flip the clone to be the primary DB
-	err = pgadmin.RenameDB(connectPool, cloneName, CurrentClone)
-	if err != nil {
-		log.Errorf("Unable to switch to clone DB: %v", err)
+		log.Errorf("unable to move clones: %v", err)
 		return err
 	}
 
@@ -284,6 +278,62 @@ func (d *dbCloneManagerImpl) doPersist(cloneName string, prev string) error {
 			log.Errorf("Unable to remove the temp DB (%s): %v", moveCurrent, err)
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (d *dbCloneManagerImpl) moveClones(previousClone, updatedClone string) error {
+	// Connect to different database for admin functions
+	connectPool := pgadmin.GetAdminPool(d.adminConfig)
+	// Close the admin connection pool
+	defer connectPool.Close()
+
+	// Wrap in a transaction so either both renames work or none work
+	ctx, cancel := context.WithTimeout(context.Background(), pgadmin.PostgresQueryTimeout)
+	defer cancel()
+	conn, err := connectPool.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Release()
+
+	// Start a transaction
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Move the current to the previous clone
+	err = d.renameClone(ctx, tx, CurrentClone, previousClone)
+	if err != nil {
+		return err
+	}
+
+	// Now flip the clone to be the primary DB
+	err = d.renameClone(ctx, tx, updatedClone, CurrentClone)
+	if err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		log.Info("Commit")
+		return err
+	}
+
+	return nil
+}
+
+func (d *dbCloneManagerImpl) renameClone(ctx context.Context, tx pgx.Tx, srcClone, destClone string) error {
+	// Move the current to the previous clone
+	pgadmin.TerminateConnection(d.adminConfig, srcClone)
+	_, err := tx.Exec(ctx, fmt.Sprintf("ALTER DATABASE %s RENAME TO %s", srcClone, destClone))
+	if err != nil {
+		log.Errorf("Unable to switch to clone %q DB: %v", destClone, err)
+		if err := tx.Rollback(ctx); err != nil {
+			return err
+		}
+		return err
 	}
 
 	return nil

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -330,7 +330,6 @@ func (d *dbCloneManagerImpl) renameClone(ctx context.Context, tx pgx.Tx, srcClon
 	if err != nil {
 		return err
 	}
-	
 	_, err = tx.Exec(ctx, fmt.Sprintf("ALTER DATABASE %s RENAME TO %s", srcClone, destClone))
 	if err != nil {
 		log.Errorf("Unable to switch to clone %q DB: %v", destClone, err)

--- a/migrator/clone/postgres/db_clone_manager_impl_test.go
+++ b/migrator/clone/postgres/db_clone_manager_impl_test.go
@@ -1,0 +1,398 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/migrator/clone/metadata"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/migrations"
+	migrationtestutils "github.com/stackrox/rox/pkg/migrations/testutils"
+	"github.com/stackrox/rox/pkg/postgres/pgadmin"
+	"github.com/stackrox/rox/pkg/postgres/pgconfig"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/testutils/envisolator"
+	"github.com/stackrox/rox/pkg/timestamp"
+	"github.com/stackrox/rox/pkg/version"
+	"github.com/stackrox/rox/pkg/version/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	tempDB = "central_temp"
+
+	// Database with no typical connections that will be used as a template in a create
+	adminDB = "template1"
+)
+
+var (
+	preHistoryVer = versionPair{version: "3.0.56.0", seqNum: 62}
+	preVer        = versionPair{version: "3.0.57.0", seqNum: 65}
+	currVer       = versionPair{version: "3.0.58.0", seqNum: 65}
+	futureVer     = versionPair{version: "10001.0.0.0", seqNum: 6533}
+
+	// Current versions
+	rcVer      = versionPair{version: "3.0.58.0-rc.1", seqNum: 65}
+	releaseVer = versionPair{version: "3.0.58.0", seqNum: 65}
+	devVer     = versionPair{version: "3.0.58.x-19-g6bd31dae22-dirty", seqNum: 65}
+	nightlyVer = versionPair{version: "3.0.58.x-nightly-20210407", seqNum: 65}
+
+	invalidClones = set.NewStringSet(tempDB, "central_123", "central_garbage")
+)
+
+type versionPair struct {
+	version string
+	seqNum  int
+}
+
+type PostgresCloneManagerSuite struct {
+	suite.Suite
+	envIsolator *envisolator.EnvIsolator
+	pool        *pgxpool.Pool
+	config      *pgxpool.Config
+	sourceMap   map[string]string
+	ctx         context.Context
+}
+
+func TestManagerSuite(t *testing.T) {
+	suite.Run(t, new(PostgresCloneManagerSuite))
+}
+
+func (s *PostgresCloneManagerSuite) SetupTest() {
+	s.envIsolator = envisolator.NewEnvIsolator(s.T())
+
+	if !features.PostgresDatastore.Enabled() {
+		s.T().Skip("Skip postgres store tests")
+		s.T().SkipNow()
+	}
+
+	s.envIsolator.Setenv(features.PostgresDatastore.EnvVar(), "true")
+
+	ctx := sac.WithAllAccess(context.Background())
+
+	source := pgtest.GetConnectionString(s.T())
+	config, err := pgxpool.ParseConfig(source)
+	s.Require().NoError(err)
+	pool, err := pgxpool.ConnectConfig(ctx, config)
+	s.Require().NoError(err)
+
+	s.ctx = ctx
+	s.pool = pool
+	s.config = config
+	s.sourceMap, err = pgconfig.ParseSource(source)
+	if err != nil {
+		log.Infof("Unable to parse source %q", source)
+	}
+
+	s.setVersion(s.T(), &currVer)
+}
+
+func (s *PostgresCloneManagerSuite) CreateClones() {
+	pgtest.CreateDatabase(s.T(), tempDB)
+
+	for clone := range knownClones {
+		pgtest.CreateDatabase(s.T(), clone)
+	}
+}
+
+func (s *PostgresCloneManagerSuite) DestroyClones() {
+	// Clean up databases
+	pgtest.DropDatabase(s.T(), tempDB)
+
+	for clone := range knownClones {
+		pgtest.DropDatabase(s.T(), clone)
+	}
+}
+
+func (s *PostgresCloneManagerSuite) TearDownTest() {
+	if s.pool != nil {
+		s.DestroyClones()
+
+		s.pool.Close()
+	}
+
+	s.envIsolator.RestoreAll()
+}
+
+func (s *PostgresCloneManagerSuite) setVersion(t *testing.T, ver *versionPair) {
+	log.Infof("setVersion => %v", ver)
+	testutils.SetMainVersion(t, ver.version)
+	migrationtestutils.SetCurrentDBSequenceNumber(t, ver.seqNum)
+}
+
+func (s *PostgresCloneManagerSuite) TestScan() {
+	s.CreateClones()
+
+	s.True(pgadmin.CheckIfDBExists(s.config, tempDB))
+
+	for clone := range knownClones {
+		s.True(pgadmin.CheckIfDBExists(s.config, clone))
+	}
+
+	dbm := New("", s.config, s.sourceMap)
+
+	// Scan the clones
+	s.Nil(dbm.Scan())
+
+	// Ensure known clones remain and temp clones are deleted
+	for clone := range knownClones {
+		s.True(pgadmin.CheckIfDBExists(s.config, clone))
+	}
+
+	s.False(pgadmin.CheckIfDBExists(s.config, tempDB))
+
+	// Clean up for the next test
+	s.DestroyClones()
+}
+
+func (s *PostgresCloneManagerSuite) TestScanCurrentPrevious() {
+	s.CreateClones()
+	pgtest.DropDatabase(s.T(), tempDB)
+	pgtest.DropDatabase(s.T(), migrations.RestoreDatabase)
+	pgtest.DropDatabase(s.T(), migrations.BackupDatabase)
+
+	dbm := New("", s.config, s.sourceMap)
+
+	// Set central_active in the future and have no previous
+	pool := pgadmin.GetClonePool(s.config, migrations.GetCurrentClone())
+	futureVersion := &storage.Version{
+		SeqNum:        int32(futureVer.seqNum),
+		Version:       futureVer.version,
+		LastPersisted: timestamp.Now().GogoProtobuf(),
+	}
+	migrations.SetVersionPostgres(pool, futureVersion)
+	pool.Close()
+
+	// Drop previous
+	pgtest.DropDatabase(s.T(), migrations.PreviousDatabase)
+
+	// Scan the clones
+	s.EqualError(dbm.Scan(), metadata.ErrNoPrevious)
+
+	// Create a previous and set its version to current one
+	pgtest.CreateDatabase(s.T(), migrations.PreviousDatabase)
+	pool = pgadmin.GetClonePool(s.config, migrations.PreviousDatabase)
+	verForPrevClone := &storage.Version{
+		SeqNum:        int32(currVer.seqNum),
+		Version:       currVer.version,
+		LastPersisted: timestamp.Now().GogoProtobuf(),
+	}
+	migrations.SetVersionPostgres(pool, verForPrevClone)
+	pool.Close()
+
+	// Scan the clones
+	s.EqualError(dbm.Scan(), metadata.ErrForceUpgradeDisabled)
+
+	// Set previous clone version so it doesn't match current sw version
+	pool = pgadmin.GetClonePool(s.config, migrations.PreviousDatabase)
+	verForPrevClone = &storage.Version{
+		SeqNum:        int32(currVer.seqNum),
+		Version:       preVer.version,
+		LastPersisted: timestamp.Now().GogoProtobuf(),
+	}
+	migrations.SetVersionPostgres(pool, verForPrevClone)
+	pool.Close()
+
+	// New manager with force rollback version set
+	dbm = New(currVer.version, s.config, s.sourceMap)
+	s.EqualError(dbm.Scan(), fmt.Sprintf(metadata.ErrPreviousMismatchWithVersions, verForPrevClone.GetVersion(), version.GetMainVersion()))
+
+	// Clean up for the next test
+	s.DestroyClones()
+}
+
+func (s *PostgresCloneManagerSuite) TestScanRestoreFromFuture() {
+	s.CreateClones()
+	pgtest.DropDatabase(s.T(), tempDB)
+	pgtest.DropDatabase(s.T(), migrations.PreviousDatabase)
+	pgtest.DropDatabase(s.T(), migrations.BackupDatabase)
+
+	dbm := New("", s.config, s.sourceMap)
+
+	// Set central_active in the future and have no previous
+	pool := pgadmin.GetClonePool(s.config, migrations.RestoreDatabase)
+	futureVersion := &storage.Version{
+		SeqNum:        int32(futureVer.seqNum),
+		Version:       futureVer.version,
+		LastPersisted: timestamp.Now().GogoProtobuf(),
+	}
+	migrations.SetVersionPostgres(pool, futureVersion)
+	pool.Close()
+
+	s.EqualError(dbm.Scan(), fmt.Sprintf(metadata.ErrUnableToRestore, futureVersion.GetVersion(), version.GetMainVersion()))
+
+	// Clean up for the next test
+	s.DestroyClones()
+}
+
+func (s *PostgresCloneManagerSuite) TestGetRestoreClone() {
+	s.CreateClones()
+
+	dbm := New("", s.config, s.sourceMap)
+
+	// Scan the clones
+	s.Nil(dbm.Scan())
+
+	clone, migrateRocks, err := dbm.GetCloneToMigrate(nil)
+	s.Equal(clone, migrations.RestoreDatabase)
+	s.False(migrateRocks)
+	s.Nil(err)
+
+	// Clean up for the next test
+	s.DestroyClones()
+}
+
+func (s *PostgresCloneManagerSuite) TestGetCloneMigrateRocks() {
+	s.CreateClones()
+	pgtest.DropDatabase(s.T(), tempDB)
+	pgtest.DropDatabase(s.T(), migrations.RestoreDatabase)
+	pgtest.DropDatabase(s.T(), migrations.BackupDatabase)
+
+	// Set central_active in the future and have no previous
+	pool := pgadmin.GetClonePool(s.config, migrations.GetCurrentClone())
+	currVersion := &storage.Version{
+		SeqNum:        int32(currVer.seqNum),
+		Version:       currVer.version,
+		LastPersisted: timestamp.Now().GogoProtobuf(),
+	}
+	migrations.SetVersionPostgres(pool, currVersion)
+	pool.Close()
+
+	dbm := New("", s.config, s.sourceMap)
+
+	// Scan the clones
+	s.Nil(dbm.Scan())
+
+	rocksVersion := &migrations.MigrationVersion{
+		SeqNum:        currVer.seqNum,
+		MainVersion:   currVer.version,
+		LastPersisted: time.Now(),
+	}
+
+	// Need to migrate from Rocks because Rocks is more current.
+	clone, migrateRocks, err := dbm.GetCloneToMigrate(rocksVersion)
+	s.Equal(clone, tempDB)
+	s.True(migrateRocks)
+	s.Nil(err)
+
+	rocksVersion = &migrations.MigrationVersion{
+		SeqNum:        currVer.seqNum,
+		MainVersion:   currVer.version,
+		LastPersisted: time.Now().Add(-time.Hour * 24),
+	}
+
+	// Need to migrate from Rocks because Rocks is more current.
+	clone, migrateRocks, err = dbm.GetCloneToMigrate(rocksVersion)
+	s.Equal(clone, CurrentClone)
+	s.False(migrateRocks)
+	s.Nil(err)
+
+	// Need to migrate from Rocks because it is newer.
+	rocksVersion = &migrations.MigrationVersion{
+		SeqNum:        currVer.seqNum,
+		MainVersion:   currVer.version,
+		LastPersisted: time.Now().Add(time.Hour * 24),
+	}
+	// Need to re-scan to get the clone deletion
+	s.Nil(dbm.Scan())
+	clone, migrateRocks, err = dbm.GetCloneToMigrate(rocksVersion)
+	s.Equal(clone, tempDB)
+	s.True(migrateRocks)
+	s.Nil(err)
+
+	// Clean up for the next test
+	s.DestroyClones()
+}
+
+func (s *PostgresCloneManagerSuite) TestGetCloneFreshCurrent() {
+	s.CreateClones()
+	pgtest.DropDatabase(s.T(), migrations.RestoreDatabase)
+	pgtest.DropDatabase(s.T(), migrations.BackupDatabase)
+
+	dbm := New("", s.config, s.sourceMap)
+
+	// Scan the clones
+	s.Nil(dbm.Scan())
+
+	clone, migrateRocks, err := dbm.GetCloneToMigrate(nil)
+	s.Equal(clone, CurrentClone)
+	s.False(migrateRocks)
+	s.Nil(err)
+
+	// Clean up for the next test
+	s.DestroyClones()
+}
+
+func (s *PostgresCloneManagerSuite) TestGetCloneCurrentCurrent() {
+	s.CreateClones()
+	pgtest.DropDatabase(s.T(), migrations.RestoreDatabase)
+	pgtest.DropDatabase(s.T(), migrations.BackupDatabase)
+
+	// Set central_active in the future and have no previous
+	pool := pgadmin.GetClonePool(s.config, migrations.GetCurrentClone())
+	currVersion := &storage.Version{
+		SeqNum:        int32(currVer.seqNum),
+		Version:       currVer.version,
+		LastPersisted: timestamp.Now().GogoProtobuf(),
+	}
+	migrations.SetVersionPostgres(pool, currVersion)
+	pool.Close()
+
+	dbm := New("", s.config, s.sourceMap)
+
+	// Scan the clones
+	s.Nil(dbm.Scan())
+
+	clone, migrateRocks, err := dbm.GetCloneToMigrate(nil)
+	s.Equal(clone, CurrentClone)
+	s.False(migrateRocks)
+	s.Nil(err)
+
+	// Clean up for the next test
+	s.DestroyClones()
+}
+
+func (s *PostgresCloneManagerSuite) TestGetClonePrevious() {
+	s.CreateClones()
+	pgtest.DropDatabase(s.T(), migrations.RestoreDatabase)
+	pgtest.DropDatabase(s.T(), migrations.BackupDatabase)
+
+	// Set central_active in the future and have no previous
+	pool := pgadmin.GetClonePool(s.config, migrations.GetCurrentClone())
+	futureVersion := &storage.Version{
+		SeqNum:        int32(futureVer.seqNum),
+		Version:       futureVer.version,
+		LastPersisted: timestamp.Now().GogoProtobuf(),
+	}
+	migrations.SetVersionPostgres(pool, futureVersion)
+	pool.Close()
+
+	// Set previous to the current version to simulate a rollback
+	pool = pgadmin.GetClonePool(s.config, migrations.PreviousDatabase)
+	currVersion := &storage.Version{
+		SeqNum:        int32(currVer.seqNum),
+		Version:       currVer.version,
+		LastPersisted: timestamp.Now().GogoProtobuf(),
+	}
+	migrations.SetVersionPostgres(pool, currVersion)
+	pool.Close()
+
+	dbm := New(currVer.version, s.config, s.sourceMap)
+
+	// Scan the clones
+	s.Nil(dbm.Scan())
+
+	clone, migrateRocks, err := dbm.GetCloneToMigrate(nil)
+	s.Equal(clone, PreviousClone)
+	s.False(migrateRocks)
+	s.Nil(err)
+
+	// Clean up for the next test
+	s.DestroyClones()
+}


### PR DESCRIPTION
## Description

Found an issue where if we failed to create a temp database we would return the temp clone anyway and thus it would create empty and cause all the data to be removed as the migration process continued.  While there discovered I could do renames of databases in a transaction so that we can prevent weird states where some clones were moved and others were not.  So that is the rationale behind the changes to doPersist so that we can wrap those calls in a transaction.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Added a unit test to drive some of the Postgres clone cases.
