### PR TITLE
ROX-12428: [refactor] Limit scope of the `edit` role and move the control over SCCs to a separate role

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-rbac.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-rbac.yaml
@@ -53,6 +53,8 @@ roleRef:
   name: stackrox:view-cluster
   apiGroup: rbac.authorization.k8s.io
 ---
+# Role edit has all verbs but 'use' to disallow using any SCCs (resources: *).
+# The permission to 'use' SCCs should be defined at finer granularity in other roles.
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-rbac.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-rbac.yaml
@@ -69,7 +69,14 @@ rules:
   resources:
   - '*'
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+  - deletecollection
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -1,7 +1,7 @@
 {{- include "srox.init" . -}}
 
 {{- if and ._rox.env.openshift ._rox.system.createSCCs }}
-
+---
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
@@ -40,6 +40,8 @@ volumes:
   - downwardAPI
   - emptyDir
   - secret
+
+---
 
 {{- end }}
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -61,7 +61,7 @@ rules:
   resources:
   - securitycontextconstraints
   resourceNames:
-{{- if and ._rox.env.openshift ._rox.system.createSCCs }}
+{{- if ._rox.system.createSCCs }}
   - stackrox-sensor
 {{- end }}
   - nonroot-v2

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -63,9 +63,7 @@ rules:
 {{- if and ._rox.env.openshift ._rox.system.createSCCs }}
   - stackrox-sensor
 {{- end }}
-{{- if eq ._rox.env.openshift 4 }}
   - nonroot-v2
-{{- end }}
   - nonroot
   - anyuid
   verbs:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -61,7 +61,9 @@ rules:
 {{- if and ._rox.env.openshift ._rox.system.createSCCs }}
   - stackrox-sensor
 {{- end }}
+{{- if eq ._rox.env.openshift 4 }}
   - nonroot-v2
+{{- end }}
   - nonroot
   - anyuid
   verbs:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -13,6 +13,11 @@ metadata:
   annotations:
     {{- include "srox.annotations" (list . "securitycontextconstraints" "stackrox-sensor") | nindent 4 }}
     kubernetes.io/description: stackrox-sensor is the security constraint for the sensor
+{{- if eq ._rox.env.openshift 3 }}
+users:
+  - system:serviceaccount:{{ ._rox._namespace }}:sensor
+  - system:serviceaccount:{{ ._rox._namespace }}:sensor-upgrader
+{{- end }}
 priority: 0
 runAsUser:
   type: RunAsAny

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -65,9 +65,6 @@ rules:
   resources:
   - securitycontextconstraints
   resourceNames:
-{{- if ._rox.system.createSCCs }}
-  - stackrox-sensor
-{{- end }}
   - nonroot-v2
   - nonroot
   - anyuid

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -13,11 +13,9 @@ metadata:
   annotations:
     {{- include "srox.annotations" (list . "securitycontextconstraints" "stackrox-sensor") | nindent 4 }}
     kubernetes.io/description: stackrox-sensor is the security constraint for the sensor
-{{- if eq ._rox.env.openshift 3 }}
 users:
   - system:serviceaccount:{{ ._rox._namespace }}:sensor
   - system:serviceaccount:{{ ._rox._namespace }}:sensor-upgrader
-{{- end }}
 priority: 0
 runAsUser:
   type: RunAsAny

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -71,14 +71,33 @@ rules:
   - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: Role
 metadata:
-  name: sensor-use-scc
+  name: use-stackrox-sensor-scc
   namespace: {{ ._rox._namespace }}
   labels:
-    {{- include "srox.labels" (list . "rolebinding" "sensor-use-scc") | nindent 4 }}
+    {{- include "srox.labels" (list . "role" "use-stackrox-sensor-scc") | nindent 4 }}
   annotations:
-    {{- include "srox.annotations" (list . "rolebinding" "sensor-use-scc") | nindent 4 }}
+    {{- include "srox.annotations" (list . "role" "use-stackrox-sensor-scc") | nindent 4 }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - stackrox-sensor
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sensor-use-anyuid-scc
+  namespace: {{ ._rox._namespace }}
+  labels:
+    {{- include "srox.labels" (list . "rolebinding" "sensor-use-anyuid-scc") | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "rolebinding" "sensor-use-anyuid-scc") | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -90,5 +109,25 @@ subjects:
 - kind: ServiceAccount
   name: sensor-upgrader
   namespace: {{ ._rox._namespace }}
-
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sensor-use-stackrox-sensor-scc
+  namespace: {{ ._rox._namespace }}
+  labels:
+    {{- include "srox.labels" (list . "rolebinding" "sensor-use-stackrox-sensor-scc") | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "rolebinding" "sensor-use-stackrox-sensor-scc") | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: use-stackrox-sensor-scc
+subjects:
+- kind: ServiceAccount
+  name: sensor
+  namespace: {{ ._rox._namespace }}
+- kind: ServiceAccount
+  name: sensor-upgrader
+  namespace: {{ ._rox._namespace }}
 {{- end }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -53,6 +53,7 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "role" "use-anyuid-scc") | nindent 4 }}
+    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "role" "use-anyuid-scc") | nindent 4 }}
 rules:
@@ -77,6 +78,7 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "rolebinding" "sensor-use-scc") | nindent 4 }}
+    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "rolebinding" "sensor-use-scc") | nindent 4 }}
 roleRef:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -1,6 +1,7 @@
 {{- include "srox.init" . -}}
 
-{{- if and ._rox.env.openshift ._rox.system.createSCCs }}
+{{- if ._rox.env.openshift }}
+{{- if ._rox.system.createSCCs }}
 ---
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
@@ -89,3 +90,5 @@ subjects:
 - kind: ServiceAccount
   name: sensor-upgrader
   namespace: {{ ._rox._namespace }}
+
+{{- end }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -12,9 +12,6 @@ metadata:
   annotations:
     {{- include "srox.annotations" (list . "securitycontextconstraints" "stackrox-sensor") | nindent 4 }}
     kubernetes.io/description: stackrox-sensor is the security constraint for the sensor
-users:
-  - system:serviceaccount:{{ ._rox._namespace }}:sensor
-  - system:serviceaccount:{{ ._rox._namespace }}:sensor-upgrader
 priority: 0
 runAsUser:
   type: RunAsAny

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -49,12 +49,12 @@ volumes:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: use-sccs-for-sensor
+  name: use-anyuid-scc
   namespace: {{ ._rox._namespace }}
   labels:
-    {{- include "srox.labels" (list . "role" "use-sccs-for-sensor") | nindent 4 }}
+    {{- include "srox.labels" (list . "role" "use-anyuid-scc") | nindent 4 }}
   annotations:
-    {{- include "srox.annotations" (list . "role" "use-sccs-for-sensor") | nindent 4 }}
+    {{- include "srox.annotations" (list . "role" "use-anyuid-scc") | nindent 4 }}
 rules:
 - apiGroups:
   - security.openshift.io
@@ -73,16 +73,16 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: sensor-use-sccs-for-sensor
+  name: sensor-use-scc
   namespace: {{ ._rox._namespace }}
   labels:
-    {{- include "srox.labels" (list . "rolebinding" "sensor-use-stackrox-sensor-scc") | nindent 4 }}
+    {{- include "srox.labels" (list . "rolebinding" "sensor-use-scc") | nindent 4 }}
   annotations:
-    {{- include "srox.annotations" (list . "rolebinding" "sensor-use-stackrox-sensor-scc") | nindent 4 }}
+    {{- include "srox.annotations" (list . "rolebinding" "sensor-use-scc") | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: use-sccs-for-sensor
+  name: use-anyuid-scc
 subjects:
 - kind: ServiceAccount
   name: sensor

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -2,7 +2,7 @@
 
 {{- if ._rox.env.openshift }}
 {{- if ._rox.system.createSCCs }}
----
+
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-scc.yaml
@@ -44,76 +44,36 @@ volumes:
   - emptyDir
   - secret
 
-{{- else if eq ._rox.env.openshift 4 }}
-
-{{- if false }}
-# "fake" document separator to aid GVK extraction heuristic
----
 {{- end }}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: use-anyuid-scc
+  name: use-sccs-for-sensor
   namespace: {{ ._rox._namespace }}
   labels:
-    {{- include "srox.labels" (list . "role" "use-anyuid-scc") | nindent 4 }}
+    {{- include "srox.labels" (list . "role" "use-sccs-for-sensor") | nindent 4 }}
   annotations:
-    {{- include "srox.annotations" (list . "role" "use-anyuid-scc") | nindent 4 }}
+    {{- include "srox.annotations" (list . "role" "use-sccs-for-sensor") | nindent 4 }}
 rules:
 - apiGroups:
   - security.openshift.io
   resources:
   - securitycontextconstraints
   resourceNames:
+{{- if and ._rox.env.openshift ._rox.system.createSCCs }}
+  - stackrox-sensor
+{{- end }}
+  - nonroot-v2
+  - nonroot
   - anyuid
   verbs:
   - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: use-stackrox-sensor-scc
-  namespace: {{ ._rox._namespace }}
-  labels:
-    {{- include "srox.labels" (list . "role" "use-stackrox-sensor-scc") | nindent 4 }}
-  annotations:
-    {{- include "srox.annotations" (list . "role" "use-stackrox-sensor-scc") | nindent 4 }}
-rules:
-- apiGroups:
-  - security.openshift.io
-  resources:
-  - securitycontextconstraints
-  resourceNames:
-  - stackrox-sensor
-  verbs:
-  - use
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: sensor-use-anyuid-scc
-  namespace: {{ ._rox._namespace }}
-  labels:
-    {{- include "srox.labels" (list . "rolebinding" "sensor-use-anyuid-scc") | nindent 4 }}
-  annotations:
-    {{- include "srox.annotations" (list . "rolebinding" "sensor-use-anyuid-scc") | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: use-anyuid-scc
-subjects:
-- kind: ServiceAccount
-  name: sensor
-  namespace: {{ ._rox._namespace }}
-- kind: ServiceAccount
-  name: sensor-upgrader
-  namespace: {{ ._rox._namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: sensor-use-stackrox-sensor-scc
+  name: sensor-use-sccs-for-sensor
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "rolebinding" "sensor-use-stackrox-sensor-scc") | nindent 4 }}
@@ -122,7 +82,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: use-stackrox-sensor-scc
+  name: use-sccs-for-sensor
 subjects:
 - kind: ServiceAccount
   name: sensor
@@ -130,4 +90,3 @@ subjects:
 - kind: ServiceAccount
   name: sensor-upgrader
   namespace: {{ ._rox._namespace }}
-{{- end }}

--- a/operator/tests/common/delete-securedcluster-errors.yaml
+++ b/operator/tests/common/delete-securedcluster-errors.yaml
@@ -293,7 +293,7 @@ metadata:
 apiVersion: authorization.openshift.io/v1
 kind: RoleBinding
 metadata:
-  name: sensor-use-sccs-for-sensor
+  name: sensor-use-scc
 ---
 apiVersion: authorization.openshift.io/v1
 kind: RoleBinding
@@ -318,7 +318,7 @@ metadata:
 apiVersion: authorization.openshift.io/v1
 kind: Role
 metadata:
-  name: use-sccs-for-sensor
+  name: use-anyuid-scc
 ---
 apiVersion: authorization.openshift.io/v1
 kind: Role
@@ -373,7 +373,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: sensor-use-sccs-for-sensor
+  name: sensor-use-scc
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -398,7 +398,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: use-sccs-for-sensor
+  name: use-anyuid-scc
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/operator/tests/common/delete-securedcluster-errors.yaml
+++ b/operator/tests/common/delete-securedcluster-errors.yaml
@@ -373,6 +373,11 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: sensor-use-sccs-for-sensor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: stackrox-admission-control-psp
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/operator/tests/common/delete-securedcluster-errors.yaml
+++ b/operator/tests/common/delete-securedcluster-errors.yaml
@@ -293,7 +293,12 @@ metadata:
 apiVersion: authorization.openshift.io/v1
 kind: RoleBinding
 metadata:
-  name: sensor-use-scc
+  name: sensor-use-stackrox-sensor-scc
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: sensor-use-anyuid-scc
 ---
 apiVersion: authorization.openshift.io/v1
 kind: RoleBinding
@@ -373,7 +378,12 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: sensor-use-scc
+  name: sensor-use-stackrox-sensor-scc
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sensor-use-anyuid-scc
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operator/tests/common/delete-securedcluster-errors.yaml
+++ b/operator/tests/common/delete-securedcluster-errors.yaml
@@ -293,12 +293,7 @@ metadata:
 apiVersion: authorization.openshift.io/v1
 kind: RoleBinding
 metadata:
-  name: sensor-use-stackrox-sensor-scc
----
-apiVersion: authorization.openshift.io/v1
-kind: RoleBinding
-metadata:
-  name: sensor-use-anyuid-scc
+  name: sensor-use-sccs-for-sensor
 ---
 apiVersion: authorization.openshift.io/v1
 kind: RoleBinding
@@ -323,7 +318,7 @@ metadata:
 apiVersion: authorization.openshift.io/v1
 kind: Role
 metadata:
-  name: use-anyuid-scc
+  name: use-sccs-for-sensor
 ---
 apiVersion: authorization.openshift.io/v1
 kind: Role
@@ -378,16 +373,6 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: sensor-use-stackrox-sensor-scc
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: sensor-use-anyuid-scc
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
   name: stackrox-admission-control-psp
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -408,7 +393,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: use-anyuid-scc
+  name: use-sccs-for-sensor
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
## Description

This PR creates a separate RBAC role to control the `use` verb for sensor.
Before, sensor was affected by the `use` setting from the `edit` role.

SCC `stackrox-sensor` is no longer assigned using the `users:` field. Instead the permission to use the SCCs is provided by the role `use-sccs-for-sensor` and role binding `sensor-use-sccs-for-sensor`.

Note that this PR is mainly refactoring as sensor can still run under `anyuid` SCC.
A PR to change this will be opened as a follow-up (or added here if reviewers wish so).

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

I have not added any additional tests for the SCCs, but we may investigate such possibility in a follow-up.

## Testing Performed

- [x] Manually OCP 4.11, install with helm, `--set=system.createSCCs=false` -> uses SCCs in the following order: `anyuid`  > `nonroot-v2` > `nonroot` 
- [x] Manually OCP 4.11, install with helm, `--set=system.createSCCs=true` -> uses SCCs in the following order: `anyuid`  > `stackrox-sensor` > `nonroot-v2`  > `nonroot` 
- [x] Manually on K8s with and without `createSCCs` - expect to see no errors (SCCs should be ignored)