### PR TITLE
ROX-12032: Don't show edges for other deployments if Network Policy CIDR block is in public range

### DIFF
--- a/central/compliance/checks/common/insecure_registries.go
+++ b/central/compliance/checks/common/insecure_registries.go
@@ -8,17 +8,6 @@ import (
 	"github.com/stackrox/rox/pkg/netutil"
 )
 
-var (
-	privateSubnets = []*net.IPNet{
-		netutil.MustParseCIDR("127.0.0.0/8"),    // IPv4 localhost
-		netutil.MustParseCIDR("10.0.0.0/8"),     // class A
-		netutil.MustParseCIDR("172.16.0.0/12"),  // class B
-		netutil.MustParseCIDR("192.168.0.0/16"), // class C
-		netutil.MustParseCIDR("::1/128"),        // IPv6 localhost
-		netutil.MustParseCIDR("fd00::/8"),       // IPv6 ULA
-	}
-)
-
 func insecureRegistries(ctx framework.ComplianceContext, info *compliance.ContainerRuntimeInfo) {
 	if info == nil {
 		framework.Fail(ctx, "No container runtime information is available to determine insecure registry configs")
@@ -30,8 +19,8 @@ func insecureRegistries(ctx framework.ComplianceContext, info *compliance.Contai
 		_, cidr, _ := net.ParseCIDR(cidrStr)
 		isPrivate := false
 		if cidr != nil {
-			for _, privateSubnets := range privateSubnets {
-				if netutil.IsIPNetSubset(privateSubnets, cidr) {
+			for _, privateSubnet := range netutil.GetPrivateSubnets() {
+				if netutil.IsIPNetSubset(privateSubnet, cidr) {
 					isPrivate = true
 					break
 				}

--- a/central/networkpolicies/graph/evaluator_test.go
+++ b/central/networkpolicies/graph/evaluator_test.go
@@ -59,6 +59,22 @@ spec:
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
+  name: allow-only-egress-to-public-ipblock
+  namespace: default
+spec:
+  policyTypes:
+  - Egress
+  - Ingress
+  podSelector: {}
+  egress:
+  - to:
+    - ipblock:
+        cidr: 142.20.0.0/16
+`,
+	`
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
   name: allow-traffic-from-apps-using-multiple-selectors
   namespace: default
 spec:
@@ -1267,7 +1283,7 @@ func TestEvaluateClusters(t *testing.T) {
 			),
 		},
 		{
-			name: "test customer issue",
+			name: "public egress cidr block shouldn't show edges to other deployments in cluster",
 			deployments: []*storage.Deployment{
 				{
 					Id:          "d1",
@@ -1279,19 +1295,25 @@ func TestEvaluateClusters(t *testing.T) {
 					Namespace:   "qa",
 					NamespaceId: "qa",
 				},
+				{
+					Id:          "d3",
+					Namespace:   "qa",
+					NamespaceId: "qa",
+				},
+
 			},
 			networkTree: t1,
 			nps: []*storage.NetworkPolicy{
-				getExamplePolicy("allow-only-egress-to-ipblock"),
+				getExamplePolicy("allow-only-egress-to-public-ipblock"),
 			},
 			nodes: []*v1.NetworkNode{
-				mockNode("d1", "default", true, false, false, true, "allow-only-egress-to-ipblock"),
+				mockNode("d1", "default", true, false, false, true, "allow-only-egress-to-public-ipblock"),
 				mockNode("d2", "qa", true, true, true, true),
+				mockNode("d3", "qa", true, true, true, true),
 				mockInternetNode(),
-				mockExternalNode("es1", "172.17.0.0/24"),
 			},
 			edges: flattenEdges(
-				egressEdges("d1", "es1", networkgraph.InternetExternalSourceID),
+				egressEdges("d1", networkgraph.InternetExternalSourceID),
 			),
 		},
 		{
@@ -1339,7 +1361,7 @@ func TestEvaluateClusters(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			graph := g.GetGraph("", nil, testCase.deployments, testCase.networkTree, testCase.nps, false)
 			nodes := graph.GetNodes()
-			assert.Len(t, nodes, len(testCase.nodes))
+			require.Len(t, nodes, len(testCase.nodes))
 			for idx, expected := range testCase.nodes {
 				assert.Equalf(t, expected, nodes[idx], "node in pos %d and ID %d doesn't match expected", idx, expected.Entity.Id)
 			}

--- a/central/networkpolicies/graph/evaluator_test.go
+++ b/central/networkpolicies/graph/evaluator_test.go
@@ -1300,7 +1300,6 @@ func TestEvaluateClusters(t *testing.T) {
 					Namespace:   "qa",
 					NamespaceId: "qa",
 				},
-
 			},
 			networkTree: t1,
 			nps: []*storage.NetworkPolicy{

--- a/central/networkpolicies/graph/graph_builder.go
+++ b/central/networkpolicies/graph/graph_builder.go
@@ -9,6 +9,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/labels"
+	"github.com/stackrox/rox/pkg/netutil"
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/networkgraph/tree"
 	"github.com/stackrox/rox/pkg/set"
@@ -112,11 +113,16 @@ func (b *graphBuilder) evaluatePeers(currentNS *storage.NamespaceMetadata, peers
 
 func (b *graphBuilder) evaluatePeer(currentNS *storage.NamespaceMetadata, peer *storage.NetworkPolicyPeer) []*node {
 	if peer.GetIpBlock() != nil {
-		// TODO(ROX-5370): We assume all CIDR blocks always match all deployments and overlapping external CIDRs.
-		//  This is probably wrong, but we don't really have a good way of determining otherwise. Except for maybe
-		//  look at Pod IPs. Which we actually could.
-		allNodes := make([]*node, 0, len(b.allDeployments)+1)
-		allNodes = append(allNodes, b.allDeployments...)
+		var allNodes []*node
+		// If the IP is in the private range, we add edges to other deployments in the cluster.
+		// This is still not the perfect approach, but it solves user issues where edges were being
+		// shown on *every* deployment with a Network Policy that uses CIDR block matchers. By
+		// limiting to private ranges only, the set of edges in the graph is likely more accurate, but
+		// still not the reality. There is an epic created to tackle this further and come up with a
+		// more elaborate logic for this: ROX-12120
+		if netutil.IsCIDRBlockInPrivateSubnet(peer.GetIpBlock().GetCidr()) {
+			allNodes = append(allNodes, b.allDeployments...)
+		}
 		allNodes = append(allNodes, b.evaluateExternalPeer(peer.GetIpBlock())...)
 		return allNodes
 	}

--- a/central/networkpolicies/graph/graph_builder.go
+++ b/central/networkpolicies/graph/graph_builder.go
@@ -127,7 +127,7 @@ func (b *graphBuilder) evaluatePeer(currentNS *storage.NamespaceMetadata, peer *
 		// limiting to private ranges only, the set of edges in the graph is likely more accurate, but
 		// still not the reality. There is an epic created to tackle this further and come up with a
 		// more elaborate logic for this: ROX-12120
-		if netutil.IsIPSubNetOverlapingPrivateRange(ipNet) {
+		if netutil.IsIPNetOverlapingPrivateRange(ipNet) {
 			allNodes = append(allNodes, b.allDeployments...)
 		}
 

--- a/central/networkpolicies/graph/graph_builder_test.go
+++ b/central/networkpolicies/graph/graph_builder_test.go
@@ -19,7 +19,7 @@ func TestMatchPolicyPeer(t *testing.T) {
 			Desc: &storage.NetworkEntityInfo_ExternalSource_{
 				ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
 					Source: &storage.NetworkEntityInfo_ExternalSource_Cidr{
-						Cidr: "192.16.0.0/16",
+						Cidr: "192.168.0.0/16",
 					},
 				},
 			},
@@ -33,7 +33,7 @@ func TestMatchPolicyPeer(t *testing.T) {
 			Desc: &storage.NetworkEntityInfo_ExternalSource_{
 				ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
 					Source: &storage.NetworkEntityInfo_ExternalSource_Cidr{
-						Cidr: "192.16.0.0/32",
+						Cidr: "192.168.0.0/32",
 					},
 				},
 			},
@@ -47,7 +47,7 @@ func TestMatchPolicyPeer(t *testing.T) {
 			Desc: &storage.NetworkEntityInfo_ExternalSource_{
 				ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
 					Source: &storage.NetworkEntityInfo_ExternalSource_Cidr{
-						Cidr: "192.16.10.0/24",
+						Cidr: "192.168.10.0/24",
 					},
 				},
 			},
@@ -58,7 +58,7 @@ func TestMatchPolicyPeer(t *testing.T) {
 			Desc: &storage.NetworkEntityInfo_ExternalSource_{
 				ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
 					Source: &storage.NetworkEntityInfo_ExternalSource_Cidr{
-						Cidr: "192.16.15.0/24",
+						Cidr: "192.168.15.0/24",
 					},
 				},
 			},
@@ -154,7 +154,7 @@ func TestMatchPolicyPeer(t *testing.T) {
 			networkTree: t1,
 			peer: &storage.NetworkPolicyPeer{
 				IpBlock: &storage.IPBlock{
-					Cidr: "192.16.0.0/24",
+					Cidr: "192.168.0.0/24",
 				},
 			},
 			expectedMatches: []expectedMatch{
@@ -167,7 +167,7 @@ func TestMatchPolicyPeer(t *testing.T) {
 			networkTree: t1,
 			peer: &storage.NetworkPolicyPeer{
 				IpBlock: &storage.IPBlock{
-					Cidr: "192.16.0.0/24",
+					Cidr: "192.168.0.0/24",
 				},
 			},
 			expectedMatches: []expectedMatch{
@@ -185,7 +185,7 @@ func TestMatchPolicyPeer(t *testing.T) {
 			networkTree: t2,
 			peer: &storage.NetworkPolicyPeer{
 				IpBlock: &storage.IPBlock{
-					Cidr: "192.16.0.0/24",
+					Cidr: "192.168.0.0/24",
 				},
 			},
 			expectedMatches: []expectedMatch{
@@ -199,8 +199,8 @@ func TestMatchPolicyPeer(t *testing.T) {
 			networkTree: t3,
 			peer: &storage.NetworkPolicyPeer{
 				IpBlock: &storage.IPBlock{
-					Cidr:   "192.16.0.0/16",
-					Except: []string{"192.16.15.0/22"},
+					Cidr:   "192.168.0.0/16",
+					Except: []string{"192.168.15.0/22"},
 				},
 			},
 			expectedMatches: []expectedMatch{

--- a/central/networkpolicies/graph/graph_builder_test.go
+++ b/central/networkpolicies/graph/graph_builder_test.go
@@ -78,6 +78,7 @@ func TestMatchPolicyPeer(t *testing.T) {
 			},
 		},
 	})
+	assert.NoError(t, err)
 
 	_, _, _, _ = t1, t2, t3, t4
 

--- a/central/networkpolicies/graph/graph_builder_test.go
+++ b/central/networkpolicies/graph/graph_builder_test.go
@@ -80,8 +80,6 @@ func TestMatchPolicyPeer(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	_, _, _, _ = t1, t2, t3, t4
-
 	type expectedMatch struct {
 		id        string
 		matchType storage.NetworkEntityInfo_Type

--- a/pkg/compliance/checks/common/insecure_registries.go
+++ b/pkg/compliance/checks/common/insecure_registries.go
@@ -9,17 +9,6 @@ import (
 	"github.com/stackrox/rox/pkg/netutil"
 )
 
-var (
-	privateSubnets = []*net.IPNet{
-		netutil.MustParseCIDR("127.0.0.0/8"),    // IPv4 localhost
-		netutil.MustParseCIDR("10.0.0.0/8"),     // class A
-		netutil.MustParseCIDR("172.16.0.0/12"),  // class B
-		netutil.MustParseCIDR("192.168.0.0/16"), // class C
-		netutil.MustParseCIDR("::1/128"),        // IPv6 localhost
-		netutil.MustParseCIDR("fd00::/8"),       // IPv6 ULA
-	}
-)
-
 func insecureRegistries(info *compliance.ContainerRuntimeInfo) []*storage.ComplianceResultValue_Evidence {
 	if info == nil {
 		return FailList("No container runtime information is available to determine insecure registry configs")
@@ -31,7 +20,7 @@ func insecureRegistries(info *compliance.ContainerRuntimeInfo) []*storage.Compli
 		_, cidr, _ := net.ParseCIDR(cidrStr)
 		isPrivate := false
 		if cidr != nil {
-			for _, privateSubnets := range privateSubnets {
+			for _, privateSubnets := range netutil.GetPrivateSubnets() {
 				if netutil.IsIPNetSubset(privateSubnets, cidr) {
 					isPrivate = true
 					break

--- a/pkg/compliance/checks/common/insecure_registries.go
+++ b/pkg/compliance/checks/common/insecure_registries.go
@@ -20,8 +20,8 @@ func insecureRegistries(info *compliance.ContainerRuntimeInfo) []*storage.Compli
 		_, cidr, _ := net.ParseCIDR(cidrStr)
 		isPrivate := false
 		if cidr != nil {
-			for _, privateSubnets := range netutil.GetPrivateSubnets() {
-				if netutil.IsIPNetSubset(privateSubnets, cidr) {
+			for _, privateSubnet := range netutil.GetPrivateSubnets() {
+				if netutil.IsIPNetSubset(privateSubnet, cidr) {
 					isPrivate = true
 					break
 				}

--- a/pkg/net/addr.go
+++ b/pkg/net/addr.go
@@ -19,35 +19,6 @@ const (
 	IPv6
 )
 
-var (
-	ipV4PrivateNetworks = []*net.IPNet{
-		// private networks per RFC1918
-		netutil.MustParseCIDR("10.0.0.0/8"),
-		netutil.MustParseCIDR("172.16.0.0/12"),
-		netutil.MustParseCIDR("192.168.0.0/16"),
-
-		// Other reserved ranges
-		netutil.MustParseCIDR("100.64.0.0/10"),
-		netutil.MustParseCIDR("169.254.0.0/16"),
-	}
-
-	ipV6PrivateNetworks = []*net.IPNet{
-		// Unique Local Addresses (ULA)
-		netutil.MustParseCIDR("fd00::/8"),
-
-		// IPv4-mapped IPv6 for private networks per RFC1918
-		netutil.MustParseCIDR("::ffff:10.0.0.0/104"),
-		netutil.MustParseCIDR("::ffff:172.16.0.0/108"),
-		netutil.MustParseCIDR("::ffff:192.168.0.0/112"),
-
-		// Other reserved IPv4 ranges
-		netutil.MustParseCIDR("::ffff:100.64.0.0/106"),
-		netutil.MustParseCIDR("::ffff:169.254.0.0/112"),
-	}
-
-	ipV4MappedIPv6Loopback = netutil.MustParseCIDR("::ffff:127.0.0.1/104")
-)
-
 // String returns a string representation of the family
 func (f Family) String() string {
 	switch f {
@@ -95,7 +66,7 @@ func (d ipv4data) isLoopback() bool {
 
 func (d ipv4data) isPublic() bool {
 	netIP := net.IP(d.bytes())
-	for _, privateIPNet := range ipV4PrivateNetworks {
+	for _, privateIPNet := range netutil.IPV4PrivateNetworks {
 		if privateIPNet.Contains(netIP) {
 			return false
 		}
@@ -116,7 +87,7 @@ func (d ipv6data) bytes() []byte {
 	return d[:]
 }
 func (d ipv6data) isLoopback() bool {
-	if ipV4MappedIPv6Loopback.Contains(net.IP(d.bytes())) {
+	if netutil.IPV4MappedIPv6Loopback.Contains(net.IP(d.bytes())) {
 		return true
 	}
 
@@ -133,7 +104,7 @@ func (d ipv6data) isLoopback() bool {
 
 func (d ipv6data) isPublic() bool {
 	netIP := net.IP(d.bytes())
-	for _, privateIPNet := range ipV6PrivateNetworks {
+	for _, privateIPNet := range netutil.IPV6PrivateNetworks {
 		if privateIPNet.Contains(netIP) {
 			return false
 		}

--- a/pkg/net/addr.go
+++ b/pkg/net/addr.go
@@ -66,7 +66,7 @@ func (d ipv4data) isLoopback() bool {
 
 func (d ipv4data) isPublic() bool {
 	netIP := net.IP(d.bytes())
-	for _, privateIPNet := range netutil.IPV4PrivateNetworks {
+	for _, privateIPNet := range netutil.IPv4PrivateNetworks {
 		if privateIPNet.Contains(netIP) {
 			return false
 		}
@@ -87,7 +87,7 @@ func (d ipv6data) bytes() []byte {
 	return d[:]
 }
 func (d ipv6data) isLoopback() bool {
-	if netutil.IPV4MappedIPv6Loopback.Contains(net.IP(d.bytes())) {
+	if netutil.IPv4MappedIPv6Loopback.Contains(net.IP(d.bytes())) {
 		return true
 	}
 
@@ -104,7 +104,7 @@ func (d ipv6data) isLoopback() bool {
 
 func (d ipv6data) isPublic() bool {
 	netIP := net.IP(d.bytes())
-	for _, privateIPNet := range netutil.IPV6PrivateNetworks {
+	for _, privateIPNet := range netutil.IPv6PrivateNetworks {
 		if privateIPNet.Contains(netIP) {
 			return false
 		}

--- a/pkg/netutil/cidr.go
+++ b/pkg/netutil/cidr.go
@@ -3,6 +3,7 @@ package netutil
 import (
 	"net"
 
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
@@ -15,12 +16,16 @@ var (
 		MustParseCIDR("::1/128"),        // IPv6 localhost
 		MustParseCIDR("fd00::/8"),       // IPv6 ULA
 	}
+	log = logging.LoggerForModule()
 )
 
 // IsCIDRBlockInPrivateSubnet parses cidrStr and checks if it falls under the RFC 1819 private IP range
 func IsCIDRBlockInPrivateSubnet(cidrStr string) bool {
 	_, cidr, err := net.ParseCIDR(cidrStr)
-	utils.CrashOnError(err)
+	if err != nil {
+		log.Warnf("Parsing incorrect CIDR block string (%s) as CIDR %s", cidrStr, err)
+		return false
+	}
 	for _, subnet := range privateSubnets {
 		if IsIPNetSubset(subnet, cidr) {
 			return true

--- a/pkg/netutil/cidr.go
+++ b/pkg/netutil/cidr.go
@@ -19,27 +19,17 @@ var (
 	log = logging.LoggerForModule()
 )
 
-// IsCIDRBlockInPrivateSubnet parses cidrStr and checks if it falls under the RFC 1819 private IP range
-func IsCIDRBlockInPrivateSubnet(cidrStr string) bool {
-	_, cidr, err := net.ParseCIDR(cidrStr)
-	if err != nil {
-		log.Warnf("Parsing incorrect CIDR block string (%s) as CIDR %s", cidrStr, err)
-		return false
-	}
-	for _, subnet := range privateSubnets {
-		if IsIPNetSubset(subnet, cidr) {
-			return true
-		}
-	}
-	return false
-}
-
 // MustParseCIDR parses the given CIDR string and returns the corresponding IPNet. If the string is invalid, this
 // function panics.
 func MustParseCIDR(cidr string) *net.IPNet {
 	_, ipNet, err := net.ParseCIDR(cidr)
 	utils.CrashOnError(err)
 	return ipNet
+}
+
+// IsCIDRBlockInPrivateSubnet parses cidrStr and checks if it falls under the RFC 1819 private IP range
+func IsIPSubNetOverlapingPrivateRange(ipNet *net.IPNet) bool {
+	return AnyOverlap(ipNet, privateSubnets)
 }
 
 // IsIPNetSubset checks if maybeSubset is fully contained within ipNet.
@@ -76,3 +66,4 @@ func AnyOverlap(n1 *net.IPNet, ns []*net.IPNet) bool {
 	}
 	return false
 }
+

--- a/pkg/netutil/cidr.go
+++ b/pkg/netutil/cidr.go
@@ -29,7 +29,6 @@ func IsCIDRBlockInPrivateSubnet(cidrStr string) bool {
 	return false
 }
 
-
 // MustParseCIDR parses the given CIDR string and returns the corresponding IPNet. If the string is invalid, this
 // function panics.
 func MustParseCIDR(cidr string) *net.IPNet {

--- a/pkg/netutil/cidr.go
+++ b/pkg/netutil/cidr.go
@@ -6,6 +6,30 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 )
 
+var (
+	privateSubnets = []*net.IPNet{
+		MustParseCIDR("127.0.0.0/8"),    // IPv4 localhost
+		MustParseCIDR("10.0.0.0/8"),     // class A
+		MustParseCIDR("172.16.0.0/12"),  // class B
+		MustParseCIDR("192.168.0.0/16"), // class C
+		MustParseCIDR("::1/128"),        // IPv6 localhost
+		MustParseCIDR("fd00::/8"),       // IPv6 ULA
+	}
+)
+
+// IsCIDRBlockInPrivateSubnet parses cidrStr and checks if it falls under the RFC 1819 private IP range
+func IsCIDRBlockInPrivateSubnet(cidrStr string) bool {
+	_, cidr, err := net.ParseCIDR(cidrStr)
+	utils.CrashOnError(err)
+	for _, subnet := range privateSubnets {
+		if IsIPNetSubset(subnet, cidr) {
+			return true
+		}
+	}
+	return false
+}
+
+
 // MustParseCIDR parses the given CIDR string and returns the corresponding IPNet. If the string is invalid, this
 // function panics.
 func MustParseCIDR(cidr string) *net.IPNet {

--- a/pkg/netutil/cidr.go
+++ b/pkg/netutil/cidr.go
@@ -8,14 +8,6 @@ import (
 )
 
 var (
-	privateSubnets = []*net.IPNet{
-		MustParseCIDR("127.0.0.0/8"),    // IPv4 localhost
-		MustParseCIDR("10.0.0.0/8"),     // class A
-		MustParseCIDR("172.16.0.0/12"),  // class B
-		MustParseCIDR("192.168.0.0/16"), // class C
-		MustParseCIDR("::1/128"),        // IPv6 localhost
-		MustParseCIDR("fd00::/8"),       // IPv6 ULA
-	}
 	log = logging.LoggerForModule()
 )
 
@@ -27,8 +19,11 @@ func MustParseCIDR(cidr string) *net.IPNet {
 	return ipNet
 }
 
-// IsCIDRBlockInPrivateSubnet parses cidrStr and checks if it falls under the RFC 1819 private IP range
-func IsIPSubNetOverlapingPrivateRange(ipNet *net.IPNet) bool {
+// IsIPNetOverlapingPrivateRange checks if network overlaps with private subnets
+func IsIPNetOverlapingPrivateRange(ipNet *net.IPNet) bool {
+	var privateSubnets []*net.IPNet
+	privateSubnets = append(privateSubnets, IPV4PrivateNetworks...)
+	privateSubnets = append(privateSubnets, IPV6PrivateNetworks...)
 	return AnyOverlap(ipNet, privateSubnets)
 }
 
@@ -66,4 +61,3 @@ func AnyOverlap(n1 *net.IPNet, ns []*net.IPNet) bool {
 	}
 	return false
 }
-

--- a/pkg/netutil/cidr.go
+++ b/pkg/netutil/cidr.go
@@ -22,8 +22,8 @@ func MustParseCIDR(cidr string) *net.IPNet {
 // IsIPNetOverlapingPrivateRange checks if network overlaps with private subnets
 func IsIPNetOverlapingPrivateRange(ipNet *net.IPNet) bool {
 	var privateSubnets []*net.IPNet
-	privateSubnets = append(privateSubnets, IPV4PrivateNetworks...)
-	privateSubnets = append(privateSubnets, IPV6PrivateNetworks...)
+	privateSubnets = append(privateSubnets, IPv4PrivateNetworks...)
+	privateSubnets = append(privateSubnets, IPv6PrivateNetworks...)
 	return AnyOverlap(ipNet, privateSubnets)
 }
 

--- a/pkg/netutil/private_subnet.go
+++ b/pkg/netutil/private_subnet.go
@@ -1,0 +1,51 @@
+package netutil
+
+import "net"
+
+var (
+	// IPV4PrivateNetworks holds RFC1918 addresses plus other reserved IPv4 ranges.
+	IPV4PrivateNetworks = []*net.IPNet{
+		// private networks per RFC1918
+		MustParseCIDR("10.0.0.0/8"),
+		MustParseCIDR("172.16.0.0/12"),
+		MustParseCIDR("192.168.0.0/16"),
+
+		// Other reserved ranges
+		MustParseCIDR("100.64.0.0/10"),
+		MustParseCIDR("169.254.0.0/16"),
+	}
+
+	// IPV4LocalHost is the local host IP range 127.0.0.0/8.
+	IPV4LocalHost = MustParseCIDR("127.0.0.0/8")
+
+	// IPV6PrivateNetworks holds IPv6 private range and IPv4-mapped private addresses in IPv6 range.
+	IPV6PrivateNetworks = []*net.IPNet{
+		// Unique Local Addresses (ULA)
+		MustParseCIDR("fd00::/8"),
+
+		// IPv4-mapped IPv6 for private networks per RFC1918.
+		MustParseCIDR("::ffff:10.0.0.0/104"),
+		MustParseCIDR("::ffff:172.16.0.0/108"),
+		MustParseCIDR("::ffff:192.168.0.0/112"),
+
+		// Other reserved IPv4 ranges
+		MustParseCIDR("::ffff:100.64.0.0/106"),
+		MustParseCIDR("::ffff:169.254.0.0/112"),
+	}
+
+	// IPV6LocalHost is the local host IP range ::1/128.
+	IPV6LocalHost = MustParseCIDR("::1/128")
+
+	// IPV4MappedIPv6Loopback is the IPv4 loopback address mapped in IPv6 range.
+	IPV4MappedIPv6Loopback = MustParseCIDR("::ffff:127.0.0.1/104")
+)
+
+// GetPrivateSubnets returns a slice of IPv4 and IPv6 addresses considered as private ranges including localhost addresses.
+func GetPrivateSubnets() []*net.IPNet {
+	var subnets []*net.IPNet
+	subnets = append(subnets, IPV4PrivateNetworks...)
+	subnets = append(subnets, IPV4LocalHost)
+	subnets = append(subnets, IPV6PrivateNetworks...)
+	subnets = append(subnets, IPV6LocalHost)
+	return subnets
+}

--- a/pkg/netutil/private_subnet.go
+++ b/pkg/netutil/private_subnet.go
@@ -3,8 +3,8 @@ package netutil
 import "net"
 
 var (
-	// IPV4PrivateNetworks holds RFC1918 addresses plus other reserved IPv4 ranges.
-	IPV4PrivateNetworks = []*net.IPNet{
+	// IPv4PrivateNetworks holds RFC1918 addresses plus other reserved IPv4 ranges.
+	IPv4PrivateNetworks = []*net.IPNet{
 		// private networks per RFC1918
 		MustParseCIDR("10.0.0.0/8"),
 		MustParseCIDR("172.16.0.0/12"),
@@ -15,11 +15,11 @@ var (
 		MustParseCIDR("169.254.0.0/16"),
 	}
 
-	// IPV4LocalHost is the local host IP range 127.0.0.0/8.
-	IPV4LocalHost = MustParseCIDR("127.0.0.0/8")
+	// IPv4LocalHost is the local host IP range 127.0.0.0/8.
+	IPv4LocalHost = MustParseCIDR("127.0.0.0/8")
 
-	// IPV6PrivateNetworks holds IPv6 private range and IPv4-mapped private addresses in IPv6 range.
-	IPV6PrivateNetworks = []*net.IPNet{
+	// IPv6PrivateNetworks holds IPv6 private range and IPv4-mapped private addresses in IPv6 range.
+	IPv6PrivateNetworks = []*net.IPNet{
 		// Unique Local Addresses (ULA)
 		MustParseCIDR("fd00::/8"),
 
@@ -33,19 +33,20 @@ var (
 		MustParseCIDR("::ffff:169.254.0.0/112"),
 	}
 
-	// IPV6LocalHost is the local host IP range ::1/128.
-	IPV6LocalHost = MustParseCIDR("::1/128")
+	// IPv6LocalHost is the local host IP range ::1/128.
+	IPv6LocalHost = MustParseCIDR("::1/128")
 
-	// IPV4MappedIPv6Loopback is the IPv4 loopback address mapped in IPv6 range.
-	IPV4MappedIPv6Loopback = MustParseCIDR("::ffff:127.0.0.1/104")
+	// IPv4MappedIPv6Loopback is the IPv4 loopback address mapped in IPv6 range.
+	IPv4MappedIPv6Loopback = MustParseCIDR("::ffff:127.0.0.1/104")
 )
 
 // GetPrivateSubnets returns a slice of IPv4 and IPv6 addresses considered as private ranges including localhost addresses.
 func GetPrivateSubnets() []*net.IPNet {
 	var subnets []*net.IPNet
-	subnets = append(subnets, IPV4PrivateNetworks...)
-	subnets = append(subnets, IPV4LocalHost)
-	subnets = append(subnets, IPV6PrivateNetworks...)
-	subnets = append(subnets, IPV6LocalHost)
+	subnets = append(subnets, IPv4PrivateNetworks...)
+	subnets = append(subnets, IPv4LocalHost)
+	subnets = append(subnets, IPv6PrivateNetworks...)
+	subnets = append(subnets, IPv6LocalHost)
+	subnets = append(subnets, IPv4MappedIPv6Loopback)
 	return subnets
 }


### PR DESCRIPTION
## Description

This is a proposal of how to mitigate a Network Graph issue related to showing allowed edges between deployments if the egress Network Policy associated with a deployment uses public CIDR blocks. More info about the problem can be found [in this doc](https://docs.google.com/document/d/1W27OxPRr32kYzi77JsP0WmO-IgmB8_cjfOGhs5GM0uA/edit?usp=sharing).

The proposed change is: **Don't show allowed edges if Network Policy's CIDR block is in public range**. 

Some considerations:
- Deployments are scheduled within private CIDR blocks, so a public CIDR range network policy won't match.
- Deployments could be behind a service with a public IP. This could be considered as an allowed edge, but we're ignoring this case for now.

The proposal in this PR doesn't solve all problems. The set of allowed edges might not be accurate for CIDR block, but it limits the cases where they are added. 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] ~~Determined and documented upgrade steps~~
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

It's likely that we should add note in the docs and/or README about this change.

## Testing Performed

- New unit tests for this case

**Note for reviewers:** I had to change existing unit tests in `graph_builder_test` to use private IP range for external entities in the network tree wrapper. Because the graph builder should act the same way as before, but _only_ for private IPs. I've added two additional tests to cover the changed behavior. 

- Manual testing using the yaml files that exemplify the issue found [here](https://github.com/stackrox/yaml-examples/tree/main/network-graph-cidr-egress) 

Prior to this change, an edge between `ns3` and `ns2` would be shown. 

![image](https://user-images.githubusercontent.com/6811076/188400457-fd623205-b1ef-4995-95a6-d8b47640d715.png)

