### PR TITLE
Wait for more requests in helper function for Network Graph integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -57,6 +57,7 @@ export const general = {
 export const search = {
     results: '/v1/search?query=*',
     options: '/v1/search/metadata/options*',
+    optionsCategories: (categories) => `/v1/search/metadata/options?categories=${categories}`,
     autocomplete: 'v1/search/autocomplete*',
     autocompleteBySearch: (searchObj, category) =>
         `v1/search/autocomplete?query=${searchObjToQuery(searchObj)}&categories=${category}`,

--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -218,7 +218,7 @@ const requestConfigToVisitGraph = {
         },
         'search/metadata/options': {
             method: 'GET',
-            url: `/v1/search/metadata/options?categories=DEPLOYMENTS`,
+            url: api.search.optionsCategories('DEPLOYMENTS'),
         },
     },
 };

--- a/ui/apps/platform/cypress/helpers/policiesPatternFly.js
+++ b/ui/apps/platform/cypress/helpers/policiesPatternFly.js
@@ -12,7 +12,7 @@ const routeMatcherMap = {
     },
     'search/metadata/options': {
         method: 'GET',
-        url: `/v1/search/metadata/options?categories=POLICIES`,
+        url: api.search.optionsCategories('POLICIES'),
     },
     policies: {
         method: 'GET',


### PR DESCRIPTION
## Description

## Test failure

> Network Graph Search should filter to show only the deployments from the stackrox namespace and deployments connected to them

> Timed out retrying after 4000ms: Expected to find element: `h1:contains("Network Graph")`, but never found it.

at visitNetworkGraph
at visitNetworkGraphWithNamespaceFilter

cypress/integration/networkGraph/networkGraph.test.js

* 1564230427168739328 from master build for #2946 on 2022-08-29
![prow](https://user-images.githubusercontent.com/11862657/187934246-2e7f0010-36c6-4c88-8876-b83d48de56d0.png)

`visitNetworkGraph` helper function
* does wait on GET /v1/clusters request from src/sagas/networkSagas.js
    Brad, this is an example of unneeded use of global reducer which we will replace with a request within the Network container in the future.
* does not wait for POST /api/graphql?opname=getClusterNamespaceNames request from src/Containers/Network/Header/useNamespaceFilters.ts
    During manual exploratory testing, I notice that (unlike the following request) this request does not occur if I go to a different container, and then click the browser Back button.
    Because each integration test opens a new connection, I will include it with a comment.
* does not wait for GET /v1/search/metadata/options?categories=DEPLOYMENTS request from src/Containers/Network/Header/NetworkSearch.js

### Changed files

Brad, this is an example of an emerging composable convention for helper function arguments that was added in #2176

* `routeMatcherMap` property of request config object
    https://docs.cypress.io/api/commands/intercept#Matching-with-RouteMatcher
* `staticResponseMap` argument of `interactAndWaitForResponses` and `visit` functions
    https://docs.cypress.io/api/commands/intercept#StaticResponse-objects

1. Edit cypress/constants/apiEndpoint.js
    * Add `optionsCategories` function.

2. Edit cypress/helpers/networkGraph.js
    * Factor out repeated `intercept` and `wait` as request config and static response map objects.
    * Add prerequisite requests to visit.

3. Edit cypress/helpers/policiesPatternFly.js
    * Replace template literal with `optionsCategories` function call.

### Residue

1. Split network.test.js into separate test files with descriptive names and move into networkGraph folder. 

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test helper functions

## Testing Performed

Some tests fail in local deployment. Perhaps because collector is not running, or only one cluster, or both reasons.

* network.test.js
* networkGraph/networkGraph.test.js

Network Graph tests now wait on the additional search-related requests:
<img width="1440" alt="local" src="https://user-images.githubusercontent.com/11862657/187934160-b95373b6-f9fe-4354-9d47-f7b10f7e1e10.png">