### PR TITLE
ROX-12005: Remove UI validation for Watched Image name

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Images/WatchedImagesDialog.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Images/WatchedImagesDialog.tsx
@@ -129,12 +129,7 @@ const WatchedImagesDialog = ({ closeDialog }: WatchedImagesDialogProps): ReactEl
                 <Formik
                     initialValues={{ imageTag: '' }}
                     validationSchema={Yup.object({
-                        imageTag: Yup.string()
-                            .matches(
-                                /([a-z.]+\/)([a-z0-9-]+\/)?([a-z0-9-@./]+)(?::[0-9a-z\-.]+)?/,
-                                'Must be a valid path to a container image'
-                            )
-                            .required('Required'),
+                        imageTag: Yup.string().required('Required'),
                     })}
                     onSubmit={addToWatch}
                     // }}


### PR DESCRIPTION
## Description

_Res ipsa loquitur_

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Before, UI validates based on regex
<img width="1552" alt="Screen Shot 2022-09-01 at 10 25 01 AM" src="https://user-images.githubusercontent.com/715729/187939295-0092a19a-a5fd-4010-b6be-c18850f9a17c.png">

After this change, UI does not validate actual value of image name
<img width="1552" alt="Screen Shot 2022-09-01 at 10 25 17 AM" src="https://user-images.githubusercontent.com/715729/187939392-7841fca3-63ac-4af1-a62e-8397e8821fd6.png">

UI still validates that _something_ is present in the image name input
<img width="1552" alt="Screen Shot 2022-09-01 at 10 25 22 AM" src="https://user-images.githubusercontent.com/715729/187939491-e5712c37-0848-4668-9524-880d7acdaf59.png">
