### PR TITLE
CI: Set openshift version for roxctl installs

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -198,6 +198,10 @@ function launch_central {
       add_args "--enable-pod-security-policies"
     fi
 
+    if [[ "$ORCH" == "openshift" && -n "${OPENSHIFT_VERSION}" ]]; then
+      add_args "--openshift-version=${OPENSHIFT_VERSION}"
+    fi
+
     local unzip_dir="${k8s_dir}/central-deploy/"
     rm -rf "${unzip_dir}"
     if ! (( use_docker )); then

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -198,7 +198,7 @@ function launch_central {
       add_args "--enable-pod-security-policies"
     fi
 
-    if [[ "$ORCH" == "openshift" && -n "${OPENSHIFT_VERSION}" ]]; then
+    if [[ "$ORCH" == "openshift" ]] && [[ -n "${OPENSHIFT_VERSION}" ]]; then
       add_args "--openshift-version=${OPENSHIFT_VERSION}"
     fi
 

--- a/scripts/ci/jobs/openshift_4_qa_e2e_tests.py
+++ b/scripts/ci/jobs/openshift_4_qa_e2e_tests.py
@@ -11,5 +11,6 @@ from clusters import NullCluster
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["OUTPUT_FORMAT"] = "helm"
 os.environ["OPENSHIFT_CI_CLUSTER_CLAIM"] = "openshift-4"
+os.environ["OPENSHIFT_VERSION"] = "4"
 
 make_qa_e2e_test_runner(cluster=NullCluster()).run()

--- a/scripts/ci/jobs/openshift_4_qa_e2e_tests.py
+++ b/scripts/ci/jobs/openshift_4_qa_e2e_tests.py
@@ -11,6 +11,5 @@ from clusters import NullCluster
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["OUTPUT_FORMAT"] = "helm"
 os.environ["OPENSHIFT_CI_CLUSTER_CLAIM"] = "openshift-4"
-os.environ["OPENSHIFT_VERSION"] = "4"
 
 make_qa_e2e_test_runner(cluster=NullCluster()).run()

--- a/scripts/ci/jobs/osd_aws_qa_e2e_tests.py
+++ b/scripts/ci/jobs/osd_aws_qa_e2e_tests.py
@@ -9,6 +9,7 @@ from clusters import AutomationFlavorsCluster
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["OPENSHIFT_VERSION"] = "4"
 os.environ["SENSOR_HELM_DEPLOY"] = "true"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/osd_gcp_qa_e2e_tests.py
+++ b/scripts/ci/jobs/osd_gcp_qa_e2e_tests.py
@@ -9,6 +9,7 @@ from clusters import AutomationFlavorsCluster
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["OPENSHIFT_VERSION"] = "4"
 os.environ["SENSOR_HELM_DEPLOY"] = "true"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()


### PR DESCRIPTION
## Description

OSD is currently deployed in 3.x compatibility mode which is not what I want.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.

/test openshift-newest-qa-e2e-tests 
/test osd-aws-qa-e2e-tests 
/test osd-gcp-qa-e2e-tests
