### PR TITLE
Add visitWithGenericResponses helper function for integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -114,6 +114,7 @@ export const images = {
 };
 
 export const auth = {
+    availableAuthProviders: '/v1/availableAuthProviders',
     loginAuthProviders: '/v1/login/authproviders',
     authProviders: '/v1/authProviders',
     authStatus: '/v1/auth/status',

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -3,8 +3,9 @@ import * as api from '../constants/apiEndpoints';
 import { interceptRequests, waitForResponses } from './request';
 
 // Import one or more alias constants in test files that call visitWithResponseMapGeneric function.
+export const availableAuthProvidersAlias = 'availableAuthProviders';
 export const featureflagsAlias = 'featureflags';
-export const loginAuthProviders = 'login/authproviders';
+export const loginAuthProvidersAlias = 'login/authproviders';
 export const mypermissionsAlias = 'mypermissions';
 export const configPublicAlias = 'config/public';
 export const authStatusAlias = 'auth/status';
@@ -14,11 +15,15 @@ export const credentialexpiryScannerAlias = 'credentialexpiry_SCANNER';
 // Generic requests to render the MainPage component (that is, prerequisite to test any page).
 const requestConfigGeneric = {
     routeMatcherMap: {
+        [availableAuthProvidersAlias]: {
+            method: 'GET',
+            url: api.auth.availableAuthProviders,
+        }, // reducers/auth and sagas/authSagas
         [featureflagsAlias]: {
             method: 'GET',
             url: api.featureFlags,
         }, // reducers/featureFlags and sagas/featureFlagSagas
-        [loginAuthProviders]: {
+        [loginAuthProvidersAlias]: {
             method: 'GET',
             url: api.auth.loginAuthProviders,
         }, // reducers/auth and sagas/authSagas

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -68,17 +68,17 @@ const requestConfigGeneric = {
  * Optionally wait for responses with waitOptions: { requestTimeout, responseTimeout }
  *
  * @param {string} pageUrl
- * @param {{ routeMatcherMap?: Record<string, { method: string, url: string }>, opnameAliasesMap?: Record<string, (request: Object) => boolean>, waitOptions?: { requestTimeout?: number, responseTimeout?: number } }} [requestConfig]
- * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ * @param {{ routeMatcherMap?: Record<string, { method: string, url: string }>, opnameAliasesMap?: Record<string, (request: Object) => boolean>, waitOptions?: { requestTimeout?: number, responseTimeout?: number } }} [requestConfigSpecific]
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMapSpecific]
  */
-export function visit(pageUrl, requestConfig, staticResponseMap) {
+export function visit(pageUrl, requestConfigSpecific, staticResponseMapSpecific) {
     interceptRequests(requestConfigGeneric);
-    interceptRequests(requestConfig, staticResponseMap);
+    interceptRequests(requestConfigSpecific, staticResponseMapSpecific);
 
     cy.visit(pageUrl);
 
     waitForResponses(requestConfigGeneric);
-    waitForResponses(requestConfig);
+    waitForResponses(requestConfigSpecific);
 }
 
 /*

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -6,7 +6,7 @@ import {
 import * as api from '../../constants/apiEndpoints';
 import sampleCert from '../../helpers/sampleCert';
 import { generateNameWithDate, getInputByLabel } from '../../helpers/formHelpers';
-import { visit, visitWithPermissions } from '../../helpers/visit';
+import { visit, visitWithPermissionsResponse } from '../../helpers/visit';
 import updateMinimumAccessRoleRequest from '../../fixtures/auth/updateMinimumAccessRole.json';
 
 import withAuth from '../../helpers/basicAuth';
@@ -47,10 +47,10 @@ describe('Access Control Auth providers', () => {
     withAuth();
 
     it('displays alert if no permission', () => {
-        const permissionsStaticResponse = {
+        const staticResponseForPermissions = {
             fixture: 'auth/mypermissionsMinimalAccess.json',
         };
-        visitWithPermissions(authProvidersUrl, permissionsStaticResponse);
+        visitWithPermissionsResponse(authProvidersUrl, staticResponseForPermissions);
 
         cy.get(`${selectors.h1}:contains("${h1}")`);
         cy.get(selectors.navLink).should('not.exist');

--- a/ui/apps/platform/cypress/integration/certexpiration.test.js
+++ b/ui/apps/platform/cypress/integration/certexpiration.test.js
@@ -1,71 +1,102 @@
 import dateFns from 'date-fns';
-import withAuth from '../helpers/basicAuth';
+
 import * as api from '../constants/apiEndpoints';
 import { selectors } from '../constants/CertExpiration';
-import { visitMainDashboard } from '../helpers/main';
+import { systemConfigUrl } from '../constants/SystemConfigPage';
+import withAuth from '../helpers/basicAuth';
+import {
+    credentialexpiryCentralAlias,
+    credentialexpiryScannerAlias,
+    mypermissionsAlias,
+    visitWithGenericResponses,
+} from '../helpers/visit';
+
+/*
+ * Visit System Configuration page for certificate expiration tests:
+ * It has a minimal number of page-specific requests.
+ * The credentialexpiry and mypermissions requests are generic for any page.
+ */
+function visitForCredentialExpiry(staticResponseMapGeneric) {
+    visitWithGenericResponses(systemConfigUrl, staticResponseMapGeneric, {
+        config: {
+            method: 'GET',
+            url: api.system.config,
+        },
+    });
+}
 
 describe('Cert Expiration Banner', () => {
     withAuth();
 
-    const mockCertExpiryAndVisitHomepage = (endpoint, expiry) => {
-        cy.intercept('GET', endpoint, {
-            body: { expiry },
-        }).as('certExpiry');
-        visitMainDashboard();
-        cy.wait('@certExpiry');
-    };
-
     describe('Central', () => {
         it('should not display banner if central cert is expiring more than 14 days later', () => {
             const expiry = dateFns.addHours(dateFns.addDays(new Date(), 15), 1);
-            mockCertExpiryAndVisitHomepage(api.certExpiry.central, expiry);
+            const staticResponseMapGeneric = {
+                [credentialexpiryCentralAlias]: {
+                    body: { expiry },
+                },
+            };
+            visitForCredentialExpiry(staticResponseMapGeneric);
 
             cy.get(selectors.centralCertExpiryBanner).should('not.exist');
         });
 
         it('should display banner without download button if user does not have the required permission', () => {
-            cy.intercept('GET', api.permissions.mypermissions, {
-                body: {
-                    globalAccess: 'READ_ACCESS',
-                    resourceToAccess: {
-                        VulnerabilityManagementRequests: 'READ_ACCESS',
-                        VulnerabilityManagementApprovals: 'READ_ACCESS',
-                    },
-                },
-            }).as('permissions');
             const expiry = dateFns.addMinutes(dateFns.addHours(new Date(), 23), 30);
-            mockCertExpiryAndVisitHomepage(api.certExpiry.central, expiry);
-            cy.wait('@permissions');
+            const staticResponseMapGeneric = {
+                [mypermissionsAlias]: {
+                    fixture: 'auth/mypermissionsMinimalAccess.json',
+                },
+                [credentialexpiryCentralAlias]: {
+                    body: { expiry },
+                },
+            };
+            visitForCredentialExpiry(staticResponseMapGeneric);
+
             cy.get(selectors.centralCertExpiryBanner)
                 .invoke('text')
                 .then((text) => {
                     expect(text).to.include('Central certificate expires in 23 hours');
                     expect(text).to.include('Contact your administrator');
                 });
-            cy.get(selectors.centralCertExpiryBanner).find('button').should('not.exist');
+            cy.get(`${selectors.centralCertExpiryBanner} button`).should('not.exist');
         });
 
         it('should show a warning banner if the expiry date is within 4-14 days', () => {
             const expiry = dateFns.addDays(new Date(), 10);
-            mockCertExpiryAndVisitHomepage(api.certExpiry.central, expiry);
+            const staticResponseMapGeneric = {
+                [credentialexpiryCentralAlias]: {
+                    body: { expiry },
+                },
+            };
+            visitForCredentialExpiry(staticResponseMapGeneric);
 
             cy.get(selectors.centralCertExpiryBanner).should('have.class', 'pf-m-warning');
         });
 
         it('should show a danger banner if the expiry date is less than or equal to 3 days', () => {
             const expiry = dateFns.addDays(new Date(), 2);
-            mockCertExpiryAndVisitHomepage(api.certExpiry.central, expiry);
+            const staticResponseMapGeneric = {
+                [credentialexpiryCentralAlias]: {
+                    body: { expiry },
+                },
+            };
+            visitForCredentialExpiry(staticResponseMapGeneric);
 
             cy.get(selectors.centralCertExpiryBanner).should('have.class', 'pf-m-danger');
         });
 
         it('should download the YAML', () => {
             const expiry = dateFns.addDays(new Date(), 1);
-            mockCertExpiryAndVisitHomepage(api.certExpiry.central, expiry);
+            const staticResponseMapGeneric = {
+                [credentialexpiryCentralAlias]: {
+                    body: { expiry },
+                },
+            };
+            visitForCredentialExpiry(staticResponseMapGeneric);
 
             cy.intercept('POST', api.certGen.central).as('download');
-            const downloadYAMLButton = cy.get(selectors.centralCertExpiryBanner).find('button');
-            downloadYAMLButton.click();
+            cy.get(`${selectors.centralCertExpiryBanner} button`).click();
             cy.wait('@download');
         });
     });
@@ -73,53 +104,72 @@ describe('Cert Expiration Banner', () => {
     describe('Scanner', () => {
         it('should not display banner if scanner cert is expiring more than 14 days later', () => {
             const expiry = dateFns.addHours(dateFns.addDays(new Date(), 15), 1);
-            mockCertExpiryAndVisitHomepage(api.certExpiry.scanner, expiry);
+            const staticResponseMapGeneric = {
+                [credentialexpiryScannerAlias]: {
+                    body: { expiry },
+                },
+            };
+            visitForCredentialExpiry(staticResponseMapGeneric);
+
             cy.get(selectors.centralCertExpiryBanner).should('not.exist');
         });
 
         it("should display banner without download button if user doesn't have the required permission", () => {
-            cy.intercept('GET', api.permissions.mypermissions, {
-                body: {
-                    globalAccess: 'READ_ACCESS',
-                    resourceToAccess: {
-                        VulnerabilityManagementRequests: 'READ_ACCESS',
-                        VulnerabilityManagementApprovals: 'READ_ACCESS',
-                    },
-                },
-            }).as('permissions');
             const expiry = dateFns.addMinutes(dateFns.addHours(new Date(), 23), 30);
-            mockCertExpiryAndVisitHomepage(api.certExpiry.scanner, expiry);
-            cy.wait('@permissions');
+            const staticResponseMapGeneric = {
+                [mypermissionsAlias]: {
+                    fixture: 'auth/mypermissionsMinimalAccess.json',
+                },
+                [credentialexpiryScannerAlias]: {
+                    body: { expiry },
+                },
+            };
+            visitForCredentialExpiry(staticResponseMapGeneric);
+
             cy.get(selectors.scannerCertExpiryBanner)
                 .invoke('text')
                 .then((text) => {
                     expect(text).to.include('Scanner certificate expires in 23 hours');
                     expect(text).to.include('Contact your administrator');
                 });
-            cy.get(selectors.scannerCertExpiryBanner).find('button').should('not.exist');
+            cy.get(`${selectors.scannerCertExpiryBanner} button`).should('not.exist');
         });
 
         it('should show a warning banner if the expiry date is within 4-14 days', () => {
             const expiry = dateFns.addDays(new Date(), 10);
-            mockCertExpiryAndVisitHomepage(api.certExpiry.scanner, expiry);
+            const staticResponseMapGeneric = {
+                [credentialexpiryScannerAlias]: {
+                    body: { expiry },
+                },
+            };
+            visitForCredentialExpiry(staticResponseMapGeneric);
 
             cy.get(selectors.scannerCertExpiryBanner).should('have.class', 'pf-m-warning');
         });
 
         it('should show a danger banner if the expiry date is greater than 14 days', () => {
             const expiry = dateFns.addDays(new Date(), 2);
-            mockCertExpiryAndVisitHomepage(api.certExpiry.scanner, expiry);
+            const staticResponseMapGeneric = {
+                [credentialexpiryScannerAlias]: {
+                    body: { expiry },
+                },
+            };
+            visitForCredentialExpiry(staticResponseMapGeneric);
 
             cy.get(selectors.scannerCertExpiryBanner).should('have.class', 'pf-m-danger');
         });
 
         it('should download the YAML', () => {
             const expiry = dateFns.addDays(new Date(), 1);
-            mockCertExpiryAndVisitHomepage(api.certExpiry.scanner, expiry);
+            const staticResponseMapGeneric = {
+                [credentialexpiryScannerAlias]: {
+                    body: { expiry },
+                },
+            };
+            visitForCredentialExpiry(staticResponseMapGeneric);
 
             cy.intercept('POST', api.certGen.scanner).as('download');
-            const downloadYAMLButton = cy.get(selectors.scannerCertExpiryBanner).find('button');
-            downloadYAMLButton.click();
+            cy.get(`${selectors.scannerCertExpiryBanner} button`).click();
             cy.wait('@download');
         });
     });


### PR DESCRIPTION
## Description

Extend and adjust naming convention for helper functions before presentation to the team.

### Changed files

1. Edit cypress/helpers/visit.js
    * Export alias constants for callers of `visitWithGenericResponses` function.
    * Add `availableAuthProviders` generic request for completeness.
    * Add `loginAuthProviders` generic request especially for auth tests.
    * Rename `visitWithPermissions` as `visitWithPermissionsResponse` function.
    * Add `visitWithGenericResponses` function.

2. Edit cypress/integration/accessControl/accessControlAuthProviders.test.js
    * Rename `visitWithPermissions` as `visitWithPermissionsResponse` function and also its argument.

3. Edit cypress/integration/certexpiration.test.js
    * Replace local helper with `requestConfig` and `staticResponseMap` arguments of `visitMainDashboard` function.

### Residue

1. ~Call `visitWithGenericResponses` function~ in auth.test.js file. Rewriting `stubAPIs` and `setupAuth` functions might be more subtle than that.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test and helper functions

## Testing Performed

* accessControl/accessControlAuthProviders.test.js: 1 request with fixture has open green circle
    <img width="1440" alt="accessControlAuthProviders" src="https://user-images.githubusercontent.com/11862657/188002222-6894e792-c488-4278-99e6-25c76b975a53.png">
* auth.test.js
* certexpiration.test.js: 2 requests with fixture and body have open green circle
    <img width="1440" alt="certexpiration" src="https://user-images.githubusercontent.com/11862657/188000744-25855980-9544-48e1-a0b7-61cdd7ab3b27.png">

* network.test.js
* networkGraph/networkGraph.test.js