### PR TITLE
ROX-11033: Clear selection to avoid table interaction crashes

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { TableComposable, Thead, ThProps, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import {
     Bullseye,
     Button,
@@ -90,6 +90,36 @@ function DeferredCVEsTable({
     const canApproveRequests = hasReadWriteAccess('VulnerabilityManagementApprovals');
     const canCreateRequests = hasReadWriteAccess('VulnerabilityManagementRequests');
 
+    function clearedSetSearchFilter(newFilters) {
+        onClearAll();
+        setSearchFilter(newFilters);
+    }
+
+    function clearedOnSetPage(e, newPage) {
+        onClearAll();
+        onSetPage(e, newPage);
+    }
+
+    function clearedOnPerPageSelect(e, newPerPage) {
+        onClearAll();
+        onPerPageSelect(e, newPerPage);
+    }
+
+    function clearedGetSortParams(newSortParam): ThProps['sort'] {
+        const baseSortResponse: ThProps['sort'] = getSortParams(newSortParam);
+
+        return {
+            sortBy: baseSortResponse?.sortBy || {},
+            onSort: (_event, _index, direction, extraData) => {
+                onClearAll();
+                if (baseSortResponse?.onSort) {
+                    baseSortResponse.onSort(_event, _index, direction, extraData);
+                }
+            },
+            columnIndex: baseSortResponse?.columnIndex || 0,
+        };
+    }
+
     const selectedIds = getSelectedIds();
     const selectedDeferralsToReobserve = rows
         .filter((row) => {
@@ -111,7 +141,7 @@ function DeferredCVEsTable({
                     <ToolbarItem>
                         <ImageVulnsSearchFilter
                             searchFilter={searchFilter}
-                            setSearchFilter={setSearchFilter}
+                            setSearchFilter={clearedSetSearchFilter}
                         />
                     </ToolbarItem>
                     <ToolbarItem variant="separator" />
@@ -137,9 +167,9 @@ function DeferredCVEsTable({
                         <Pagination
                             itemCount={itemCount}
                             page={page}
-                            onSetPage={onSetPage}
+                            onSetPage={clearedOnSetPage}
                             perPage={perPage}
-                            onPerPageSelect={onPerPageSelect}
+                            onPerPageSelect={clearedOnPerPageSelect}
                         />
                     </ToolbarItem>
                 </ToolbarContent>
@@ -168,7 +198,7 @@ function DeferredCVEsTable({
                         />
                         <Th>CVE</Th>
                         <Th>Fixable</Th>
-                        <Th sort={getSortParams('Severity')}>Severity</Th>
+                        <Th sort={clearedGetSortParams('Severity')}>Severity</Th>
                         <Th>Expires</Th>
                         <Th modifier="fitContent">Scope</Th>
                         <Th>Affected Components</Th>

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { TableComposable, Thead, ThProps, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import {
     Bullseye,
     Button,
@@ -89,6 +89,36 @@ function FalsePositiveCVEsTable({
     const canApproveRequests = hasReadWriteAccess('VulnerabilityManagementApprovals');
     const canCreateRequests = hasReadWriteAccess('VulnerabilityManagementRequests');
 
+    function clearedSetSearchFilter(newFilters) {
+        onClearAll();
+        setSearchFilter(newFilters);
+    }
+
+    function clearedOnSetPage(e, newPage) {
+        onClearAll();
+        onSetPage(e, newPage);
+    }
+
+    function clearedOnPerPageSelect(e, newPerPage) {
+        onClearAll();
+        onPerPageSelect(e, newPerPage);
+    }
+
+    function clearedGetSortParams(newSortParam): ThProps['sort'] {
+        const baseSortResponse: ThProps['sort'] = getSortParams(newSortParam);
+
+        return {
+            sortBy: baseSortResponse?.sortBy || {},
+            onSort: (_event, _index, direction, extraData) => {
+                onClearAll();
+                if (baseSortResponse?.onSort) {
+                    baseSortResponse.onSort(_event, _index, direction, extraData);
+                }
+            },
+            columnIndex: baseSortResponse?.columnIndex || 0,
+        };
+    }
+
     const selectedIds = getSelectedIds();
     const selectedFalsePositivesToReobserve = rows
         .filter((row) => {
@@ -110,7 +140,7 @@ function FalsePositiveCVEsTable({
                     <ToolbarItem>
                         <ImageVulnsSearchFilter
                             searchFilter={searchFilter}
-                            setSearchFilter={setSearchFilter}
+                            setSearchFilter={clearedSetSearchFilter}
                         />
                     </ToolbarItem>
                     <ToolbarItem variant="separator" />
@@ -136,9 +166,9 @@ function FalsePositiveCVEsTable({
                         <Pagination
                             itemCount={itemCount}
                             page={page}
-                            onSetPage={onSetPage}
+                            onSetPage={clearedOnSetPage}
                             perPage={perPage}
-                            onPerPageSelect={onPerPageSelect}
+                            onPerPageSelect={clearedOnPerPageSelect}
                         />
                     </ToolbarItem>
                 </ToolbarContent>
@@ -167,7 +197,7 @@ function FalsePositiveCVEsTable({
                         />
                         <Th>CVE</Th>
                         <Th>Fixable</Th>
-                        <Th sort={getSortParams('Severity')}>Severity</Th>
+                        <Th sort={clearedGetSortParams('Severity')}>Severity</Th>
                         <Th modifier="fitContent">Scope</Th>
                         <Th>Affected Components</Th>
                         <Th>Comments</Th>

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
@@ -1,7 +1,16 @@
 /* eslint-disable no-nested-ternary */
 /* eslint-disable react/no-array-index-key */
 import React, { ReactElement, useState } from 'react';
-import { TableComposable, Thead, Tbody, Tr, Th, Td, IActions } from '@patternfly/react-table';
+import {
+    TableComposable,
+    Thead,
+    ThProps,
+    Tbody,
+    Tr,
+    Th,
+    Td,
+    IActions,
+} from '@patternfly/react-table';
 import {
     Bullseye,
     Button,
@@ -112,6 +121,36 @@ function ObservedCVEsTable({
 
     const canCreateRequests = hasReadWriteAccess('VulnerabilityManagementRequests');
 
+    function clearedSetSearchFilter(newFilters) {
+        onClearAll();
+        setSearchFilter(newFilters);
+    }
+
+    function clearedOnSetPage(e, newPage) {
+        onClearAll();
+        onSetPage(e, newPage);
+    }
+
+    function clearedOnPerPageSelect(e, newPerPage) {
+        onClearAll();
+        onPerPageSelect(e, newPerPage);
+    }
+
+    function clearedGetSortParams(newSortParam): ThProps['sort'] {
+        const baseSortResponse: ThProps['sort'] = getSortParams(newSortParam);
+
+        return {
+            sortBy: baseSortResponse?.sortBy || {},
+            onSort: (_event, _index, direction, extraData) => {
+                onClearAll();
+                if (baseSortResponse?.onSort) {
+                    baseSortResponse.onSort(_event, _index, direction, extraData);
+                }
+            },
+            columnIndex: baseSortResponse?.columnIndex || 0,
+        };
+    }
+
     const selectedIds = getSelectedIds();
     const selectedVulnsToDeferOrMarkFalsePositive = canCreateRequests
         ? rows
@@ -128,7 +167,7 @@ function ObservedCVEsTable({
                     <ToolbarItem>
                         <ImageVulnsSearchFilter
                             searchFilter={searchFilter}
-                            setSearchFilter={setSearchFilter}
+                            setSearchFilter={clearedSetSearchFilter}
                         />
                     </ToolbarItem>
                     <ToolbarItem variant="separator" />
@@ -167,9 +206,9 @@ function ObservedCVEsTable({
                         <Pagination
                             itemCount={itemCount}
                             page={page}
-                            onSetPage={onSetPage}
+                            onSetPage={clearedOnSetPage}
                             perPage={perPage}
-                            onPerPageSelect={onPerPageSelect}
+                            onPerPageSelect={clearedOnPerPageSelect}
                         />
                     </ToolbarItem>
                 </ToolbarContent>
@@ -198,10 +237,10 @@ function ObservedCVEsTable({
                         />
                         <Th>CVE</Th>
                         <Th>Fixable</Th>
-                        <Th sort={getSortParams('Severity')}>Severity</Th>
-                        <Th sort={getSortParams('CVSS')}>CVSS score</Th>
+                        <Th sort={clearedGetSortParams('Severity')}>Severity</Th>
+                        <Th sort={clearedGetSortParams('CVSS')}>CVSS score</Th>
                         <Th>Affected components</Th>
-                        <Th sort={getSortParams('Discovered')}>Discovered</Th>
+                        <Th sort={clearedGetSortParams('Discovered')}>Discovered</Th>
                     </Tr>
                 </Thead>
                 <Tbody>


### PR DESCRIPTION
## Description

Brute-force fix for these crashes, rather than refactoring the several components/hooks involved, because we are going to be reworking all of vulnerability management.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Rather than provided screenshots of pages working-as-expected, I list the manual tests I did for each of the 3 tabbed tables on the Image Overview page: Observed CVEs, Deferred CVEs, and False Positive CVEs.

1. Visit VulnMgmt -> Images
2. Scroll down to the embedded PatternFly CVE list
3. Select one or more CVEs by clicking the checkboxes
4. Perform any of the following actions at the top of the table

- Change the table "page"
- Change the number of items per page
- Apply a search filter
- Click the top heading of a column