### PR TITLE
[ROX-12563][FE][PERFORMANCE] Optimize list image graphQL query

### DIFF
--- a/central/graphql/resolvers/image_scan_benchmark_test.go
+++ b/central/graphql/resolvers/image_scan_benchmark_test.go
@@ -54,6 +54,22 @@ const (
 					}
 				}
 			}}`
+
+	imageWithTopLevelScanTimeQuery = `
+		query getImages($query: String, $pagination: Pagination) {
+			images(query: $query, pagination: $pagination) { 
+				id
+				scanTime
+			}}`
+
+	imageWithNestedScanTimeQuery = `
+		query getImages($query: String, $pagination: Pagination) {
+			images(query: $query, pagination: $pagination) { 
+				id
+				scan {
+					scanTime
+				}
+			}}`
 )
 
 func BenchmarkImageResolver(b *testing.B) {
@@ -163,6 +179,36 @@ func BenchmarkImageResolver(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			response := schema.Exec(ctx,
 				imageWithCountsQuery,
+				"getImages",
+				map[string]interface{}{
+					"pagination": map[string]interface{}{
+						"limit": 25,
+					},
+				},
+			)
+			require.Len(b, response.Errors, 0)
+		}
+	})
+
+	b.Run("GetImageScanTimeTopLevel", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			response := schema.Exec(ctx,
+				imageWithTopLevelScanTimeQuery,
+				"getImages",
+				map[string]interface{}{
+					"pagination": map[string]interface{}{
+						"limit": 25,
+					},
+				},
+			)
+			require.Len(b, response.Errors, 0)
+		}
+	})
+
+	b.Run("GetImageScanTimeNested", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			response := schema.Exec(ctx,
+				imageWithNestedScanTimeQuery,
 				"getImages",
 				map[string]interface{}{
 					"pagination": map[string]interface{}{

--- a/ui/apps/platform/src/Components/CVEStackedPill/CVEStackedPill.js
+++ b/ui/apps/platform/src/Components/CVEStackedPill/CVEStackedPill.js
@@ -42,7 +42,7 @@ const CVEStackedPill = ({
     scanMessage,
 }) => {
     const hasCounts = vulnCounter?.all?.total > 0;
-    const hasScan = !scanTime;
+    const hasScan = !!scanTime;
     const hasScanMessage = !!scanMessage?.header;
 
     const pillTooltip = showTooltip
@@ -56,7 +56,7 @@ const CVEStackedPill = ({
 
     return (
         <div className="flex items-center w-full">
-            {!hasScan && <span>{entityName} not scanned</span>}
+            {hasScan && <span>{entityName} not scanned</span>}
             {!hasCounts && <span>No CVEs</span>}
             {hasCounts && (
                 <>

--- a/ui/apps/platform/src/Components/CVEStackedPill/CVEStackedPill.js
+++ b/ui/apps/platform/src/Components/CVEStackedPill/CVEStackedPill.js
@@ -56,7 +56,7 @@ const CVEStackedPill = ({
 
     return (
         <div className="flex items-center w-full">
-            {hasScan && <span>{entityName} not scanned</span>}
+            {!hasScan && <span>{entityName} not scanned</span>}
             {!hasCounts && <span>No CVEs</span>}
             {hasCounts && (
                 <>

--- a/ui/apps/platform/src/Components/CVEStackedPill/CVEStackedPill.js
+++ b/ui/apps/platform/src/Components/CVEStackedPill/CVEStackedPill.js
@@ -38,12 +38,11 @@ const CVEStackedPill = ({
     fixableUrl,
     showTooltip,
     entityName,
-    scan,
+    scanTime,
     scanMessage,
 }) => {
     const hasCounts = vulnCounter?.all?.total > 0;
-    const useScan = !!scan;
-    const hasScan = !!scan?.scanTime;
+    const hasScan = !scanTime;
     const hasScanMessage = !!scanMessage?.header;
 
     const pillTooltip = showTooltip
@@ -57,7 +56,7 @@ const CVEStackedPill = ({
 
     return (
         <div className="flex items-center w-full">
-            {useScan && !hasScan && <span>{entityName} not scanned</span>}
+            {!hasScan && <span>{entityName} not scanned</span>}
             {!hasCounts && <span>No CVEs</span>}
             {hasCounts && (
                 <>
@@ -133,10 +132,7 @@ CVEStackedPill.propTypes = {
     fixableUrl: PropTypes.string,
     showTooltip: PropTypes.bool,
     entityName: PropTypes.string,
-    scan: PropTypes.shape({
-        scanTime: PropTypes.string,
-        notes: PropTypes.arrayOf(PropTypes.string),
-    }),
+    scanTime: PropTypes.string,
     scanMessage: PropTypes.shape({
         header: PropTypes.string,
         body: PropTypes.string,
@@ -150,7 +146,7 @@ CVEStackedPill.defaultProps = {
     fixableUrl: '',
     showTooltip: true,
     entityName: '',
-    scan: null,
+    scanTime: '',
     scanMessage: null,
 };
 

--- a/ui/apps/platform/src/Components/CVEStackedPill/CVEStackedPill.js
+++ b/ui/apps/platform/src/Components/CVEStackedPill/CVEStackedPill.js
@@ -42,6 +42,7 @@ const CVEStackedPill = ({
     scanMessage,
 }) => {
     const hasCounts = vulnCounter?.all?.total > 0;
+    const useScan = scanTime !== '-';
     const hasScan = !!scanTime;
     const hasScanMessage = !!scanMessage?.header;
 
@@ -56,7 +57,7 @@ const CVEStackedPill = ({
 
     return (
         <div className="flex items-center w-full">
-            {!hasScan && <span>{entityName} not scanned</span>}
+            {useScan && !hasScan && <span>{entityName} not scanned</span>}
             {!hasCounts && <span>No CVEs</span>}
             {hasCounts && (
                 <>
@@ -146,7 +147,7 @@ CVEStackedPill.defaultProps = {
     fixableUrl: '',
     showTooltip: true,
     entityName: '',
-    scanTime: '',
+    scanTime: '-',
     scanMessage: null,
 };
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.js
@@ -63,7 +63,7 @@ export function getCurriedImageTableColumns(watchedImagesTrigger, isFeatureFlagE
                 headerClassName: `w-1/6 ${defaultHeaderClassName}`,
                 className: `w-1/6 ${defaultColumnClassName}`,
                 Cell: ({ original, pdf }) => {
-                    const { vulnCounter, id, scan, notes } = original;
+                    const { vulnCounter, id, scanTime, scanNotes, notes } = original;
 
                     const newState = workflowState
                         .pushListItem(id)
@@ -80,8 +80,8 @@ export function getCurriedImageTableColumns(watchedImagesTrigger, isFeatureFlagE
                             fixableUrl={fixableUrl}
                             entityName="Image"
                             hideLink={pdf}
-                            scan={scan}
-                            scanMessage={getImageScanMessage(notes || [], scan?.notes || [])}
+                            scanTime={scanTime}
+                            scanMessage={getImageScanMessage(notes || [], scanNotes || [])}
                         />
                     );
                 },
@@ -129,14 +129,14 @@ export function getCurriedImageTableColumns(watchedImagesTrigger, isFeatureFlagE
                 headerClassName: `w-1/12 ${defaultHeaderClassName}`,
                 className: `w-1/12 ${defaultColumnClassName}`,
                 Cell: ({ original, pdf }) => {
-                    const { scan } = original;
-                    if (!scan) {
+                    const { scanTime } = original;
+                    if (!scanTime) {
                         return '–';
                     }
-                    return <DateTimeField date={scan.scanTime} asString={pdf} />;
+                    return <DateTimeField date={scanTime} asString={pdf} />;
                 },
                 id: imageSortFields.SCAN_TIME,
-                accessor: 'scan.scanTime',
+                accessor: 'scanTime',
                 sortField: imageSortFields.SCAN_TIME,
             },
             {
@@ -144,14 +144,14 @@ export function getCurriedImageTableColumns(watchedImagesTrigger, isFeatureFlagE
                 headerClassName: `w-1/12 ${defaultHeaderClassName}`,
                 className: `w-1/12 ${defaultColumnClassName}`,
                 Cell: ({ original }) => {
-                    const { scan } = original;
-                    if (!scan?.operatingSystem) {
+                    const { operatingSystem } = original;
+                    if (!operatingSystem) {
                         return '–';
                     }
-                    return <span>{scan.operatingSystem}</span>;
+                    return <span>{operatingSystem}</span>;
                 },
                 id: imageSortFields.IMAGE_OS,
-                accessor: 'scan.operatingSystem',
+                accessor: 'operatingSystem',
                 sortField: imageSortFields.IMAGE_OS,
             },
             {

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.fragments.js
@@ -664,11 +664,9 @@ export const OLD_IMAGE_LIST_FRAGMENT = gql`
         }
         componentCount(query: $query)
         notes
-        scan {
-            scanTime
-            operatingSystem
-            notes
-        }
+        scanTime
+        operatingSystem
+        scanNotes
         vulnCounter {
             all {
                 total
@@ -714,11 +712,9 @@ export const IMAGE_LIST_FRAGMENT = gql`
         }
         componentCount: imageComponentCount(query: $query)
         notes
-        scan {
-            scanTime
-            operatingSystem
-            notes
-        }
+        scanTime
+        operatingSystem
+        scanNotes
         vulnCounter: imageVulnerabilityCounter {
             all {
                 total


### PR DESCRIPTION
## Description

The nested image `scan` graphQL query pulls are components and vulns. Therefore, use the top-level `operatingSystem`, `scanTime` when components and vulns are not required.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

```

BenchmarkImageResolver/GetImageScanTimeTopLevel-8                                     	    1879	    599140 ns/op
BenchmarkImageResolver/GetImageScanTimeNested
BenchmarkImageResolver/GetImageScanTimeNested-8                                       	    1344	    776117 ns/op
```

<img width="1428" alt="image" src="https://user-images.githubusercontent.com/9895898/189729808-c4244196-cc23-43b9-918c-e42546fe97c6.png">

<img width="1428" alt="image" src="https://user-images.githubusercontent.com/9895898/189729873-5a758050-7580-40a6-ab8c-a94e85ce77c1.png">
