### PR TITLE
CI: allow push-images separation for main/-rcd/docs/operator

### DIFF
--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -22,7 +22,7 @@ push_images() {
     local tag
     tag="$(make --quiet tag)"
 
-    if [[ "$brand" == "STACKROX_BRANDING" ]]; then
+    if [[ "$brand" == "STACKROX_BRANDING" ]] && [[ -n "${MAIN_IMAGE}" ]]; then
         slack_build_notice "$tag"
     fi
 
@@ -44,11 +44,13 @@ push_images() {
         push_context="merge-to-master"
     fi
 
-    if is_OPENSHIFT_CI && is_in_PR_context && pr_has_label "turbo-build" && [[ "$brand" == "RHACS_BRANDING" ]]; then
-        info "Images were built and pushed elsewhere, skipping it here."
-    else
-        push_main_image_set "$push_context" "$brand"
-        push_matching_collector_scanner_images "$brand"
+    if [[ -n "${MAIN_IMAGE}" ]]; then
+        if is_OPENSHIFT_CI && is_in_PR_context && pr_has_label "turbo-build" && [[ "$brand" == "RHACS_BRANDING" ]]; then
+            info "Images were built and pushed elsewhere, skipping it here."
+        else
+            push_main_image_set "$push_context" "$brand"
+            push_matching_collector_scanner_images "$brand"
+        fi
     fi
     if [[ -n "${PIPELINE_DOCS_IMAGE:-}" ]]; then
         push_docs_image
@@ -56,7 +58,6 @@ push_images() {
     if [[ -n "${MAIN_RCD_IMAGE:-}" ]]; then
         push_race_condition_debug_image
     fi
-    # TODO(ROX-12041): make this unconditional once the openshift/release side is ready
     if [[ -n "${OPERATOR_IMAGE:-}" ]]; then
         if is_OPENSHIFT_CI && is_in_PR_context && pr_has_label "turbo-build"; then
             info "Operator images were built and pushed elsewhere, skipping it here."
@@ -65,7 +66,7 @@ push_images() {
         fi
     fi
 
-    if is_in_PR_context && [[ "$brand" == "STACKROX_BRANDING" ]]; then
+    if is_in_PR_context && [[ "$brand" == "STACKROX_BRANDING" ]] && [[ -n "${MAIN_IMAGE}" ]]; then
         add_build_comment_to_pr
     fi
 }

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -214,7 +214,10 @@ push_operator_image_set() {
 
     local operator_image_set=("stackrox-operator" "stackrox-operator-bundle" "stackrox-operator-index")
     if is_OPENSHIFT_CI; then
-        local operator_image_srcs=("$OPERATOR_IMAGE" "$OPERATOR_BUNDLE_IMAGE" "$OPERATOR_BUNDLE_INDEX_MAGE")
+        if [[ -n "${OPERATOR_BUNDLE_INDEX_MAGE:-}" ]]; then
+            OPERATOR_BUNDLE_INDEX_IMAGE="${OPERATOR_BUNDLE_INDEX_MAGE}"
+        fi
+        local operator_image_srcs=("$OPERATOR_IMAGE" "$OPERATOR_BUNDLE_IMAGE" "$OPERATOR_BUNDLE_INDEX_IMAGE")
         oc registry login
     fi
 


### PR DESCRIPTION
## Description

It would be useful to push the image in separate batches to allow some e2e tests to continue if some parts of the build flake.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Will test with an openshift/release PR after https://github.com/stackrox/stackrox/pull/2943