### PR TITLE
Fix local operator build/start

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -290,7 +290,7 @@ stackrox-image-pull-secret: ## Create default image pull secret for StackRox ima
 
 .PHONY: check-ci-setup
 check-ci-setup: ## Make sure this target is not started in CI environment.
-	$(SILENT)if [ -n "$$CI" ]; then echo "Setup error: operator should be installed and started by OLM." >&2; exit 1; fi
+	$(SILENT)if [ -n "$${CI:-}" ]; then echo "Setup error: operator should be installed and started by OLM." >&2; exit 1; fi
 
 .PHONY: run
 run: check-ci-setup manifests generate ensure-rox-main-image-exists fmt vet ## Run operator from your host without deploying it to a cluster.

--- a/operator/hack/ensure-rox-image-exist.sh
+++ b/operator/hack/ensure-rox-image-exist.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 git fetch origin
 
 root_dir="$(git rev-parse --show-toplevel)"
-image_registry="$(make --quiet -C "$root_dir" default-image-registry)"
-main_image_tag="${MAIN_IMAGE_TAG:-"$(make --quiet -C "$root_dir" tag)"}"
+image_registry="$(make --quiet --no-print-directory -C "$root_dir" default-image-registry)"
+main_image_tag="${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory -C "$root_dir" tag)"}"
 main_image="${image_registry}/main:${main_image_tag}"
 
 echo "Ensuring $main_image is available locally"
@@ -19,6 +19,12 @@ fi
 echo "Trying to pull $main_image"
 if ! docker pull "$main_image"; then
   echo "Could not pull $main_image, trying to build it."
+  # Check if building from the checked out tree would actually give us the image we want.
+  working_copy_tag="$(make --quiet --no-print-directory -C "$root_dir" tag)"
+  if [[ "${main_image_tag}" != "${working_copy_tag}" ]]; then
+    echo "I don't know how to build ${main_image} (currently checked out tree would result in tag ${working_copy_tag})"
+    exit 1
+  fi
   make -C "$root_dir" image
 fi
 


### PR DESCRIPTION
## Description

I tried to `make -C operator install run` yesterday, and this failed for several reasons:
- `.SHELLFLAGS` are set to `-u`, so the check for CI only works if the CI variable is defined (it not being defined is kind of the point of the check, though)
- `ensure_image_exists.sh` was working with a garbled `$main_image_tag` (it said `Ensuring quay.io/stackrox-io/main:make[1] Entering directory ...`). Tell `make` to really shut up by passing `--no-print-directory` in addition to `--quiet`.
- More of a related improvement, only try to build the image if the build would actually result in the desired image.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- Manual testing, it worked afterwards