### PR TITLE
Delete spec.relatedImages from operator CSV

### DIFF
--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -75,6 +75,8 @@ def patch_csv(csv_doc, version, operator_image, first_version, no_related_images
         else:
             csv_doc["spec"]["replaces"] = f'{raw_name}.v{x}.{y}.{z-1}'
 
+    # We don't know what this does or why it is there, but it breaks downstream builds.
+    del csv_doc['spec']['relatedImages']
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Patch StackRox Operator ClusterServiceVersion file')


### PR DESCRIPTION
## Description

Since [recently upgrading to a newer operator-sdk version](https://github.com/stackrox/stackrox/pull/2749), the generation of the ClusterServiceVersion included an [empty `relatedImages` entry](https://github.com/stackrox/stackrox/pull/2749/files#diff-31342b68c83ec8bf58029a16b4c4047c13b714cdb2b245a94d1ef2ea89d4b076R918-R920). We don't know why this was added, but it breaks the downstream image pinning logic, where we set the `RELATED_IMAGE_` environment variables and the relevant pipeline stage cannot handle presence of both the env vars and the `spec.relatedImages` field.

Since the value of the new entry is unclear and it doesn't seem to affect upstream builds, let's remove it in post-processing.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- Ran generation locally, observed that entry was gone