### PR TITLE
Fix variable unbound in upgrade

### DIFF
--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -60,7 +60,7 @@ validate_upgrade() {
     local upgrade_cluster_id="$3"
     local policies_dir="../pkg/defaults/policies/files"
 
-    if [[ -n ${API_TOKEN:-} ]]; then
+    if [[ -n "${API_TOKEN:-}" ]]; then
         info "Verifying API token generated can access the central"
         echo $API_TOKEN | $TEST_ROOT/bin/$TEST_HOST_OS/roxctl --insecure-skip-tls-verify --insecure -e "$API_ENDPOINT" --token-file /dev/stdin central whoami > /dev/null
     fi

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -62,7 +62,7 @@ validate_upgrade() {
 
     if [[ -n "${API_TOKEN:-}" ]]; then
         info "Verifying API token generated can access the central"
-        echo $API_TOKEN | $TEST_ROOT/bin/$TEST_HOST_OS/roxctl --insecure-skip-tls-verify --insecure -e "$API_ENDPOINT" --token-file /dev/stdin central whoami > /dev/null
+        echo "$API_TOKEN" | "$TEST_ROOT/bin/$TEST_HOST_OS/roxctl" --insecure-skip-tls-verify --insecure -e "$API_ENDPOINT" --token-file /dev/stdin central whoami > /dev/null
     fi
 
     info "Validating the upgrade with upgrade tests: $stage_description"

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -60,7 +60,7 @@ validate_upgrade() {
     local upgrade_cluster_id="$3"
     local policies_dir="../pkg/defaults/policies/files"
 
-    if [ -n $API_TOKEN ]; then
+    if [[ -n ${API_TOKEN:-} ]]; then
         info "Verifying API token generated can access the central"
         echo $API_TOKEN | $TEST_ROOT/bin/$TEST_HOST_OS/roxctl --insecure-skip-tls-verify --insecure -e "$API_ENDPOINT" --token-file /dev/stdin central whoami > /dev/null
     fi


### PR DESCRIPTION
## Description

Fix a break to the gke-upgrade test in variable unbond.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed
Run existing tests.
