### PR TITLE
Prefactor for fixes to autocomplete feature

### DIFF
--- a/central/imageintegration/store/postgres/gen.go
+++ b/central/imageintegration/store/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.ImageIntegration --get-all-func --migration-seq 23 --migrate-from boltdb
+//go:generate pg-table-bindings-wrapper --type=storage.ImageIntegration --search-category IMAGE_INTEGRATIONS --get-all-func --migration-seq 23 --migrate-from boltdb

--- a/central/serviceaccount/datastore/datastore_impl_test.go
+++ b/central/serviceaccount/datastore/datastore_impl_test.go
@@ -5,15 +5,19 @@ import (
 	"testing"
 
 	"github.com/blevesearch/bleve"
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/central/globalindex"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/central/serviceaccount/internal/index"
 	"github.com/stackrox/rox/central/serviceaccount/internal/store"
+	"github.com/stackrox/rox/central/serviceaccount/internal/store/postgres"
 	"github.com/stackrox/rox/central/serviceaccount/internal/store/rocksdb"
 	serviceAccountSearch "github.com/stackrox/rox/central/serviceaccount/search"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	rocksdbHelper "github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
@@ -28,6 +32,7 @@ func TestServiceAccountDataStore(t *testing.T) {
 type ServiceAccountDataStoreTestSuite struct {
 	suite.Suite
 
+	pool       *pgxpool.Pool
 	db         *rocksdbHelper.RocksDB
 	bleveIndex bleve.Index
 
@@ -41,16 +46,23 @@ type ServiceAccountDataStoreTestSuite struct {
 
 func (suite *ServiceAccountDataStoreTestSuite) SetupSuite() {
 	var err error
-	suite.bleveIndex, err = globalindex.TempInitializeIndices("")
-	suite.Require().NoError(err)
+	if features.PostgresDatastore.Enabled() {
+		pgtestbase := pgtest.ForT(suite.T())
+		suite.Require().NotNil(pgtestbase)
+		suite.pool = pgtestbase.Pool
+		suite.storage = postgres.New(suite.pool)
+		suite.indexer = postgres.NewIndexer(suite.pool)
+	} else {
+		suite.bleveIndex, err = globalindex.TempInitializeIndices("")
+		suite.Require().NoError(err)
 
-	db, err := rocksdbHelper.NewTemp(suite.T().Name())
-	suite.Require().NoError(err)
-	suite.db = db
+		suite.db, err := rocksdbHelper.NewTemp(suite.T().Name())
+		suite.Require().NoError(err)
 
-	suite.storage = rocksdb.New(db)
-	suite.Require().NoError(err)
-	suite.indexer = index.New(suite.bleveIndex)
+		suite.storage = rocksdb.New(suite.db)
+		suite.Require().NoError(err)
+		suite.indexer = index.New(suite.bleveIndex)
+	}
 	suite.searcher = serviceAccountSearch.New(suite.storage, suite.indexer)
 	suite.datastore, err = New(suite.storage, suite.indexer, suite.searcher)
 	suite.Require().NoError(err)
@@ -62,15 +74,19 @@ func (suite *ServiceAccountDataStoreTestSuite) SetupSuite() {
 }
 
 func (suite *ServiceAccountDataStoreTestSuite) TearDownSuite() {
-	rocksdbtest.TearDownRocksDB(suite.db)
-	suite.NoError(suite.bleveIndex.Close())
+	if features.PostgresDatastore.Enabled() {
+		suite.pool.Close()
+	} else {
+		rocksdbtest.TearDownRocksDB(suite.db)
+		suite.NoError(suite.bleveIndex.Close())
+	}
 }
 
 func (suite *ServiceAccountDataStoreTestSuite) assertSearchResults(q *v1.Query, s *storage.ServiceAccount) {
 	results, err := suite.datastore.SearchServiceAccounts(suite.ctx, q)
 	suite.Require().NoError(err)
 	if s != nil {
-		suite.Len(results, 1)
+		suite.Require().Len(results, 1)
 		suite.Equal(s.GetId(), results[0].GetId())
 	} else {
 		suite.Len(results, 0)

--- a/central/serviceaccount/datastore/datastore_impl_test.go
+++ b/central/serviceaccount/datastore/datastore_impl_test.go
@@ -56,7 +56,7 @@ func (suite *ServiceAccountDataStoreTestSuite) SetupSuite() {
 		suite.bleveIndex, err = globalindex.TempInitializeIndices("")
 		suite.Require().NoError(err)
 
-		suite.db, err := rocksdbHelper.NewTemp(suite.T().Name())
+		suite.db, err = rocksdbHelper.NewTemp(suite.T().Name())
 		suite.Require().NoError(err)
 
 		suite.storage = rocksdb.New(suite.db)

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
@@ -44,6 +44,7 @@ type Store interface {
 	Count(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.ImageIntegration, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ImageIntegration, error)
 	GetAll(ctx context.Context) ([]*storage.ImageIntegration, error)
 	Upsert(ctx context.Context, obj *storage.ImageIntegration) error
 	UpsertMany(ctx context.Context, objs []*storage.ImageIntegration) error
@@ -382,6 +383,33 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		}
 	}
 	return elems, missingIndices, nil
+}
+
+// GetByQuery returns the objects matching the query
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ImageIntegration, error) {
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []*storage.ImageIntegration
+	for _, data := range rows {
+		msg := &storage.ImageIntegration{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		results = append(results, msg)
+	}
+	return results, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/pkg/postgres/schema/image_integrations.go
+++ b/pkg/postgres/schema/image_integrations.go
@@ -5,9 +5,11 @@ package schema
 import (
 	"reflect"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/search"
 )
 
 var (
@@ -34,6 +36,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ImageIntegration)(nil)), "image_integrations")
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_IMAGE_INTEGRATIONS, "imageintegration", (*storage.ImageIntegration)(nil)))
 		RegisterTable(schema, CreateTableImageIntegrationsStmt)
 		return schema
 	}()


### PR DESCRIPTION
## Description

Preparing for the re-activation of autocomplete tests in postgres mode, some datastore-level adjustments were identified:
- imageintegration indexing was incomplete in postgres mode
- some datastore tests are running against rocksdb+bleve in postgres mode too

Image integration indexing is being fixed in the postgres code generation.
ProcessBaseline datastore test is altered to run against postgres too.
ServiceAccount datastore test is altered to run against postgres too.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI run should be sufficient.