### PR TITLE
Upstream automation: exclude managed services and feature requests from JIRA issues query

### DIFF
--- a/.github/workflows/scripts/check-jira-issues.sh
+++ b/.github/workflows/scripts/check-jira-issues.sh
@@ -22,10 +22,10 @@ check_not_empty \
 # TODO: Jira returns 400 if requested fixVersion does not exist. That means
 # the named release must exist on Jira, which is not given.
 JQL="project IN ($PROJECTS) \
-AND fixVersion IN (\"$RELEASE.$PATCH\") \
+AND fixVersion = \"$RELEASE.$PATCH\" \
 AND status != CLOSED \
-AND Component != Documentation \
-AND type != Epic \
+AND Component NOT IN (Documentation, \"ACS Managed Service\") \
+AND type NOT IN (Epic, \"Feature Request\") \
 ORDER BY assignee"
 
 get_issues() {
@@ -49,13 +49,13 @@ get_issues_summary() {
     read -r GH_MD_FORMAT_LINE <<EOF
 * [\(.key)](https://issues.redhat.com/browse/\(.key)): \
 **\(.fields.assignee.displayName // "unassigned")** \
-(\(.fields.status.name)) — _\(.fields.summary | gsub (" +$";""))_
+(\(.fields.issuetype.name), \(.fields.status.name)) — _\(.fields.summary | gsub (" +$";""))_
 EOF
     get_issues | jq -r ".issues[] | \"$GH_MD_FORMAT_LINE\"" | sort
 }
 
 get_open_issues() {
-    get_issues | jq -r '.issues[] | "\(.key) - \(.fields.assignee.displayName)"' | sort
+    get_issues | jq -r '.issues[] | "\(.key) - \(.fields.assignee.displayName // "unassigned")"' | sort
 }
 
 ISSUES=$(get_issues_summary)


### PR DESCRIPTION
## Description

This is to narrow the list of issues for which we want to warn people during a release.

## Testing Performed

Local testing:
```sh
$ bash local-env.sh check-jira-issues "ROX, RS, RTOOLS" 3.72 0 3.72.0
<GitHub step summary>
<GitHub job message>
<console log>
```

### GitHub step summary:

:red_circle: The following Jira issues are still open for release 3.72.0:

* [ROX-11296](https://issues.redhat.com/browse/ROX-11296): **Michaël Petrov** (Bug, In Progress) — _Configure OpenShift OAuth for more than one URI_
* [ROX-11575](https://issues.redhat.com/browse/ROX-11575): **Alan Roy** (Task, In Progress) — _Replace hovering functionality with clicking_
* [ROX-11578](https://issues.redhat.com/browse/ROX-11578): **Linda Song** (Bug, To Do) — _click on deployment in NW graph should not reset the view_
* [ROX-11613](https://issues.redhat.com/browse/ROX-11613): **unassigned** (Bug, To Do) — _Verify process visualization with replicas on apacheserverdeployment_
* [ROX-12356](https://issues.redhat.com/browse/ROX-12356): **Van Wilson** (Story, Review) — _Add dockerfile line to each component in Components modal_

:arrow_right: Contact the assignees to clarify the status.

### GitHub job message:

::error::There are non-closed Jira issues for version 3.72.0.

### console log:

Open issues:
ROX-11296 - Michaël Petrov
ROX-11575 - Alan Roy
ROX-11578 - Linda Song
ROX-11613 - unassigned
ROX-12356 - Van Wilson