### PR TITLE
Fix dashboard slicing of compliance data when there are more than 6 standards

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
@@ -90,7 +90,7 @@ function processData(
 
     const sorted = sortBy(modifiedData, [(datum) => datum.passing]);
 
-    if (sortDirection === 'asc') {
+    if (sortDirection === 'desc') {
         sorted.reverse();
     }
 
@@ -144,7 +144,10 @@ function ComplianceLevelsByStandard() {
     );
 
     const complianceData = useMemo(
-        () => processData(searchFilter, sortDataBy, data || previousData)?.slice(0, 6),
+        () =>
+            processData(searchFilter, sortDataBy, data || previousData)
+                ?.slice(0, 6)
+                ?.reverse(), // Reverse since Victory charts renders items from bottom to top
         [searchFilter, sortDataBy, data, previousData]
     );
 


### PR DESCRIPTION
## Description

As discussed in this [Slack thread](https://srox.slack.com/archives/C02TXEA9WKF/p1662034816902929), the display of compliance data on the dashboard when there are more than six standards is incorrect. The current implementation sorts the list of all standards either ascending or descending, and then takes the first six items. However, since the PF charts display data items from bottom to top this results in the ascending sort showing the _top_ six standards from lowest to highest, and the _bottom_ six standards from highest to lowest.

What makes more sense is effectively the opposite of this:

- “Sort by Ascending” shows the six _lowest_ standards by compliance percentage, ordered low to high (this is the default)
- “Sort by Descending” shows the six _highest_ standards by compliance percentage, ordered high to low

### Follow Up

Add test cases that cover situations where more than six standards are returned via the API. (e.g. when the openshift compliance operator is installed.)

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Against an OpenShift installation containing the compliance operator, which adds additional compliance standards, the default "ascending" view should show the _worst_ standards by compliance percentage, ordered from lowest to highest.
<img width="652" alt="image" src="https://user-images.githubusercontent.com/1292638/188734395-dc48d2bc-bc6e-4bc8-a53c-dc08ea1a521a.png">

Sorting the list by "descending" in turn displays the six _best_ standards by compliance percentage, ordered from highest to lowest. 
<img width="652" alt="image" src="https://user-images.githubusercontent.com/1292638/188734424-c1226a22-2838-4d2a-9f7f-99675d4e4fe5.png">

Note that in this instance there are 9 total standards and the middle 3 (ocp4-cis-node, CIS Kubernetes, HIPAA 164) are visible in the appropriate places in each chart.

