### PR TITLE
ROX-12291: add resource specs for ScannerDB's init-db

### DIFF
--- a/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
+++ b/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
@@ -252,6 +252,8 @@ spec:
           env:
             - name: POSTGRES_PASSWORD_FILE
               value: "/run/secrets/stackrox.io/secrets/password"
+          resources:
+            {{- ._rox.scanner._dbResources | nindent 10 }}
           volumeMounts:
             - name: scanner-db-data
               mountPath: /var/lib/postgresql/data


### PR DESCRIPTION
## Description

If a customer sets a resource quota for StackRox resources, then `scanner-db` will fail to run, as the `init-db` container does not specify any resources requests nor limits. This PR sets the resources to match the normal `db` container for `scanner-db`.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI
