### PR TITLE
Remove 'Fixable' search field from query to IsFixable sub-resolver in post-postgres csv export handlers

### DIFF
--- a/central/cve/cluster/csv/handler.go
+++ b/central/cve/cluster/csv/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/parser"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -134,7 +135,9 @@ func ClusterCVECSVHandler() http.HandlerFunc {
 			dataRow := clusterCveRow{}
 			dataRow.cve = d.CVE(ctx)
 			dataRow.cveTypes = strings.Join(d.VulnerabilityTypes(), " ")
-			isFixable, err := d.IsFixable(ctx, rawQuery)
+			// query to IsFixable should not have Fixable field
+			rawQueryWithoutFixable := resolvers.FilterFieldFromRawQuery(rawQuery, search.Fixable)
+			isFixable, err := d.IsFixable(ctx, rawQueryWithoutFixable)
 			if err != nil {
 				errorList.AddError(err)
 			}

--- a/central/cve/image/csv/handler.go
+++ b/central/cve/image/csv/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/parser"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -139,7 +140,9 @@ func ImageCVECSVHandler() http.HandlerFunc {
 			var errorList errorhelpers.ErrorList
 			dataRow := imageCveRow{}
 			dataRow.cve = d.CVE(ctx)
-			isFixable, err := d.IsFixable(ctx, rawQuery)
+			// query to IsFixable should not have Fixable field
+			rawQueryWithoutFixable := resolvers.FilterFieldFromRawQuery(rawQuery, search.Fixable)
+			isFixable, err := d.IsFixable(ctx, rawQueryWithoutFixable)
 			if err != nil {
 				errorList.AddError(err)
 			}

--- a/central/cve/node/csv/handler.go
+++ b/central/cve/node/csv/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/parser"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -134,7 +135,9 @@ func NodeCVECSVHandler() http.HandlerFunc {
 			var errorList errorhelpers.ErrorList
 			dataRow := nodeCveRow{}
 			dataRow.cve = d.CVE(ctx)
-			isFixable, err := d.IsFixable(ctx, rawQuery)
+			// query to IsFixable should not have Fixable field
+			rawQueryWithoutFixable := resolvers.FilterFieldFromRawQuery(rawQuery, search.Fixable)
+			isFixable, err := d.IsFixable(ctx, rawQueryWithoutFixable)
 			if err != nil {
 				errorList.AddError(err)
 			}

--- a/central/graphql/resolvers/utils.go
+++ b/central/graphql/resolvers/utils.go
@@ -400,3 +400,13 @@ func imageComponentsToNodeComponents(comps []*storage.ImageComponent) ([]*storag
 	}
 	return ret, nil
 }
+
+// FilterFieldFromRawQuery removes the given field from RawQuery
+func FilterFieldFromRawQuery(rq RawQuery, label search.FieldLabel) RawQuery {
+	return RawQuery{
+		Query: pointers.String(search.FilterFields(rq.String(), func(field string) bool {
+			return label.String() == field
+		})),
+		ScopeQuery: rq.ScopeQuery,
+	}
+}


### PR DESCRIPTION
ImageVulnerability, NodeVulnerability and ClusterVulneraility GraphQL errors out if `IsFixable` sub-resolver is called with a query that has `Fixable` search field present in the query. CSV export endpoints take only one query and use the same query to query both top level `vulnerabilities` and `isFixable` within each vuln. If the query has `Fixable`  field, CSV export would error out while resolving `IsFixable` . To avoid that, this fix filters out the fixable field before calling `IsFixable` resolver in CSV export handlers.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
