### PR TITLE
Add rows retrieved to query tracer

### DIFF
--- a/central/graphql/handler/handler.go
+++ b/central/graphql/handler/handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
@@ -84,7 +85,8 @@ func (h *relayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if queryTracerEnabled && time.Since(startTime) > graphQLQueryThreshold {
-		postgres.LogTracef(ctx, log, "GraphQL Op %s took %d ms: %s %+v", params.OperationName, time.Since(startTime).Milliseconds(), params.Query, params.Variables)
+		singleLineQuery := strings.ReplaceAll(params.Query, "\n", " ")
+		postgres.LogTracef(ctx, log, "GraphQL Op %s took %d ms: %s vars=%+v", params.OperationName, time.Since(startTime).Milliseconds(), singleLineQuery, params.Variables)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = w.Write(responseJSON)


### PR DESCRIPTION
## Description

Adds the number of rows retrieved and cleans up some formatting

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

```
ks logs deploy/central -f | grep 2e6a41d0-54ea-483a-8812-a47834e05d3e

graphql/handler: 2022/09/06 21:07:35.891158 postgres.go:67: Info: trace=2e6a41d0-54ea-483a-8812-a47834e05d3e: GraphQL Op getImages took 23 ms: query getImages($query: String) {   images(     query: $query     pagination: {limit: 6, sortOption: {field: "Image Risk Priority", reversed: false}}   ) {     id     name {       remote       fullName       __typename     }     priority     imageVulnerabilityCounter {       important {         total         fixable         __typename       }       critical {         total         fixable         __typename       }       __typename     }     __typename   } }  vars=map[query:]

graphql/handler: 2022/09/06 21:07:35.891210 postgres.go:78: Info: trace=2e6a41d0-54ea-483a-8812-a47834e05d3e: returned 3 rows and took(5 ms): select images.Id from images order by images.RiskScore desc LIMIT 6 [[[]]]

graphql/handler: 2022/09/06 21:07:35.891217 postgres.go:78: Info: trace=2e6a41d0-54ea-483a-8812-a47834e05d3e: returned 0 rows and took(6 ms): select distinct(image_cves.Id) from image_cves inner join image_component_cve_edges on image_cves.Id = image_component_cve_edges.ImageCveId inner join image_cve_edges on image_cves.Id = image_cve_edges.ImageCveId inner join images on image_cve_edges.ImageId = images.Id where ((image_cves.Snoozed = $1 and image_component_cve_edges.IsFixable = $2) and images.Id = $3) [[[false true sha256:f8d7e72d657e8a4cac33561e0537ab0de3d24c5c5a83d66bce71ec5ca8006d01]]]

graphql/handler: 2022/09/06 21:07:35.891221 postgres.go:78: Info: trace=2e6a41d0-54ea-483a-8812-a47834e05d3e: returned 0 rows and took(6 ms): select distinct(image_cves.Id) from image_cves inner join image_component_cve_edges on image_cves.Id = image_component_cve_edges.ImageCveId inner join image_cve_edges on image_cves.Id = image_cve_edges.ImageCveId inner join images on image_cve_edges.ImageId = images.Id where ((image_cves.Snoozed = $1 and image_component_cve_edges.IsFixable = $2) and images.Id = $3) [[[false true sha256:bf1fe8cd48da57bde9ff157cbdba78e32bb3fac4234a0fcb7a2da1cc0e2a8754]]]

graphql/handler: 2022/09/06 21:07:35.891226 postgres.go:78: Info: trace=2e6a41d0-54ea-483a-8812-a47834e05d3e: returned 0 rows and took(5 ms): select distinct(image_cves.Id) from image_cves inner join image_component_cve_edges on image_cves.Id = image_component_cve_edges.ImageCveId inner join image_cve_edges on image_cves.Id = image_cve_edges.ImageCveId inner join images on image_cve_edges.ImageId = images.Id where ((image_cves.Snoozed = $1 and image_component_cve_edges.IsFixable = $2) and images.Id = $3) [[[false false sha256:0c92ad587f619c2eee35a1247e5ed1aa0734552c74d1f830592546caa8d63e4c]]]
```