### PR TITLE
Set metadata when enriching local images.

### DIFF
--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -62,6 +62,11 @@ func EnrichLocalImage(ctx context.Context, centralClient v1.ImageServiceClient, 
 		return nil, errors.Wrapf(err, "fetching image metadata for image %q", imgName)
 	}
 
+	// Ensure the metadata is set on the image we pass to i.e. fetching signatures. If no V2 digest is available for the
+	// image, the signature will not be attempted to be fetched.
+	// We don't need to do anything on central side, as there the image will correctly have the metadata assigned.
+	image.Metadata = metadata
+
 	log.Debugf("Received metadata for image %q: %v", imgName, metadata)
 
 	// Scan the image via local scanner.


### PR DESCRIPTION
## Description

Within [2736](https://github.com/stackrox/stackrox/pull/2736) we have added a short-circuit when fetching 
image signatures. If no V2 digest is available within the image metadata, we skip trying to fetch 
signatures.
The reason for that is V1 digests / manifests are not supported by cosign.

Now, the metadata is getting fetched prior within all enrichment pipelines, but within the local image 
enrichment pipeline the metadata is not added to the image proto, which led to the signature fetching not 
being done.

There's no issue for customers, as the current change has not been released yet.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

## Testing Performed

see CI + added unit tests that ensure image metadata is set in the successful path.
