### PR TITLE
ROX-12487: Fix handling of proxy-related environment variables in the operator

### DIFF
--- a/operator/pkg/proxy/translation_test.go
+++ b/operator/pkg/proxy/translation_test.go
@@ -1,13 +1,18 @@
 package proxy
 
 import (
+	"context"
 	"testing"
 
+	"github.com/operator-framework/helm-operator-plugins/pkg/values"
 	platform "github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/chartutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var (
@@ -20,31 +25,70 @@ var (
 			Name: "test-central",
 		},
 	}
+
+	testObjUnstructured = func() *unstructured.Unstructured {
+		obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(testObj)
+		utils.CrashOnError(err)
+		return &unstructured.Unstructured{
+			Object: obj,
+		}
+	}
 )
 
-func TestGetProxyConfigHelmValues_EmptyEnv(t *testing.T) {
-	vals, err := getProxyConfigHelmValues(testObj, nil)
+func TestGetProxyConfigEnvVars_EmptyEnv(t *testing.T) {
+	vals, err := getProxyConfigEnvVars(testObj, nil)
 	assert.NoError(t, err)
 	assert.Empty(t, vals)
 }
 
-func TestGetProxyConfigHelmValues_WithValues(t *testing.T) {
+func TestGetProxyConfigEnvVars_WithValues(t *testing.T) {
 	env := map[string]string{
 		"http_proxy": "http://my.proxy",
 		"NO_PROXY":   "127.0.0.1/8",
 	}
 
-	vals, err := getProxyConfigHelmValues(testObj, env)
+	vals, err := getProxyConfigEnvVars(testObj, env)
 	assert.NoError(t, err)
 
 	expectedVals, err := chartutil.ReadValues([]byte(`
+http_proxy:
+  valueFrom:
+    secretKeyRef:
+      name: central-test-central-proxy-env
+      key: http_proxy
+NO_PROXY:
+  valueFrom:
+    secretKeyRef:
+      name: central-test-central-proxy-env
+      key: NO_PROXY`))
+
+	require.NoError(t, err)
+	assert.EqualValues(t, expectedVals, vals)
+}
+
+func TestInjectProxyEnvVars(t *testing.T) {
+	env := map[string]string{
+		"http_proxy": "http://my.proxy",
+		"NO_PROXY":   "127.0.0.1/8",
+	}
+
+	vals, err := InjectProxyEnvVars(values.TranslatorFunc(func(_ context.Context, _ *unstructured.Unstructured) (chartutil.Values, error) {
+		return chartutil.ReadValues([]byte(`
+foo:
+  bar: baz`))
+	}), env).Translate(context.Background(), testObjUnstructured())
+	assert.NoError(t, err)
+
+	expectedVals, err := chartutil.ReadValues([]byte(`
+foo:
+  bar: baz
 customize:
   envVars:
     http_proxy:
       valueFrom:
-       secretKeyRef:
-         name: central-test-central-proxy-env
-         key: http_proxy
+        secretKeyRef:
+          name: central-test-central-proxy-env
+          key: http_proxy
     NO_PROXY:
       valueFrom:
         secretKeyRef:
@@ -52,5 +96,85 @@ customize:
           key: NO_PROXY`))
 
 	require.NoError(t, err)
-	assert.Equal(t, expectedVals, vals)
+	assert.EqualValues(t, expectedVals, vals)
+}
+
+func TestInjectProxyEnvVars_NoConflict(t *testing.T) {
+	env := map[string]string{
+		"http_proxy": "http://my.proxy",
+		"NO_PROXY":   "127.0.0.1/8",
+	}
+
+	vals, err := InjectProxyEnvVars(values.TranslatorFunc(func(_ context.Context, _ *unstructured.Unstructured) (chartutil.Values, error) {
+		return chartutil.ReadValues([]byte(`
+foo:
+  bar: baz
+customize:
+  envVars:
+    SOME_VAR: foo
+    ANOTHER_VAR:
+      value: bar`))
+	}), env).Translate(context.Background(), testObjUnstructured())
+	assert.NoError(t, err)
+
+	expectedVals, err := chartutil.ReadValues([]byte(`
+foo:
+  bar: baz
+customize:
+  envVars:
+    SOME_VAR: foo
+    ANOTHER_VAR:
+      value: bar
+    http_proxy:
+      valueFrom:
+        secretKeyRef:
+          name: central-test-central-proxy-env
+          key: http_proxy
+    NO_PROXY:
+      valueFrom:
+        secretKeyRef:
+          name: central-test-central-proxy-env
+          key: NO_PROXY`))
+
+	require.NoError(t, err)
+	assert.EqualValues(t, expectedVals, vals)
+}
+
+func TestInjectProxyEnvVars_WithConflict(t *testing.T) {
+	env := map[string]string{
+		"http_proxy": "http://my.proxy",
+		"NO_PROXY":   "127.0.0.1/8",
+		"ALL_PROXY":  "http://my.other.proxy",
+	}
+
+	vals, err := InjectProxyEnvVars(values.TranslatorFunc(func(_ context.Context, _ *unstructured.Unstructured) (chartutil.Values, error) {
+		return chartutil.ReadValues([]byte(`
+foo:
+  bar: baz
+customize:
+  envVars:
+    SOME_VAR: foo
+    http_proxy:
+      value: bar
+    NO_PROXY: baz`))
+	}), env).Translate(context.Background(), testObjUnstructured())
+	assert.NoError(t, err)
+
+	expectedVals, err := chartutil.ReadValues([]byte(`
+foo:
+  bar: baz
+customize:
+  envVars:
+    SOME_VAR: foo
+    http_proxy:
+      value: bar
+    NO_PROXY: baz
+    ALL_PROXY:
+      valueFrom:
+        secretKeyRef:
+          name: central-test-central-proxy-env
+          key: ALL_PROXY`))
+
+	require.NoError(t, err)
+	assert.EqualValues(t, expectedVals, vals)
 }


### PR DESCRIPTION
## Description

See bug for a more detailed description of the issue.

This PR changes the proxy-related environment variable injection logic to always give precedence to environment variables specified in the CR in the customize section, ignoring the respective values from the Operator's environment if both are set.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- Unit tests
- CI (tbd)