### PR TITLE
Add type password for Robot password input box for Quay integration

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/QuayIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/QuayIntegrationForm.tsx
@@ -312,7 +312,7 @@ function QuayIntegrationForm({
                                     errors={errors}
                                 >
                                     <TextInput
-                                        type="text"
+                                        type="password"
                                         id="config.quay.registryRobotCredentials.password"
                                         value={
                                             values.config.quay.registryRobotCredentials?.password ??


### PR DESCRIPTION
## Description

Solve problem found by Nakul.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

With incorrect `type="text"` prop: display password.
![before-displays](https://user-images.githubusercontent.com/11862657/188896582-eed23587-0241-4e77-b09e-e691c738ccb2.png)

With correct `type="password"` prop: hide password.
![after-hides](https://user-images.githubusercontent.com/11862657/188896343-dc5159d6-5563-4244-9ae0-6d22ee2b872e.png)
