### PR TITLE
Add a visual indicator to dashboard option menus when the defaults have changed

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.tsx
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-core';
 import { useQuery, gql } from '@apollo/client';
 import cloneDeep from 'lodash/cloneDeep';
+import isEqual from 'lodash/isEqual';
 import pluralize from 'pluralize';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
@@ -33,6 +34,7 @@ import AgingImagesChart, {
 import isResourceScoped from '../utils';
 import NoDataEmptyState from './NoDataEmptyState';
 import WidgetOptionsMenu from './WidgetOptionsMenu';
+import WidgetOptionsResetButton from './WidgetOptionsResetButton';
 
 export const imageCountQuery = gql`
     query agingImagesQuery($query0: String, $query1: String, $query2: String, $query3: String) {
@@ -115,6 +117,9 @@ type TimeRangeAction =
           type: 'update';
           index: TimeRangeTupleIndex;
           value: number;
+      }
+    | {
+          type: 'reset';
       };
 
 function timeRangeReducer(state: Config, action: TimeRangeAction): Config {
@@ -128,6 +133,8 @@ function timeRangeReducer(state: Config, action: TimeRangeAction): Config {
         case 'update':
             timeRanges[action.index].value = action.value;
             return nextState;
+        case 'reset':
+            return defaultConfig;
         default:
             return nextState;
     }
@@ -178,6 +185,8 @@ function AgingImages() {
             (value, index) => !timeRanges[index].enabled || value === 0
         );
 
+    const isOptionsChanged = !isEqual(timeRanges, defaultConfig.timeRanges);
+
     let inputError: Error | undefined;
     let errorTitle: string | undefined;
     let errorMessage: string | undefined;
@@ -205,6 +214,9 @@ function AgingImages() {
                         </Title>
                     </FlexItem>
                     <FlexItem>
+                        {isOptionsChanged && (
+                            <WidgetOptionsResetButton onClick={() => dispatch({ type: 'reset' })} />
+                        )}
                         <WidgetOptionsMenu
                             bodyContent={
                                 <Form>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
@@ -129,7 +129,7 @@ describe('Compliance levels by standard dashboard widget', () => {
         });
 
         // Sort by descending
-        await user.click(screen.getByText('Options'));
+        await user.click(screen.getByLabelText('Options'));
         await user.click(screen.getByText('Descending'));
 
         await waitFor(async () => {
@@ -160,5 +160,30 @@ describe('Compliance levels by standard dashboard widget', () => {
         expect(history.location.search).toBe(
             `?s[Cluster]=%2A&s[standard]=${encodeURIComponent(standard)}`
         );
+    });
+
+    it('should contain a button that resets the widget options to default', async () => {
+        const { user } = setup();
+
+        await user.click(await screen.findByLabelText('Options'));
+        const [asc, desc] = await screen.findAllByRole('button', {
+            name: /Ascending|Descending/,
+        });
+
+        // Defaults
+        expect(asc).toHaveAttribute('aria-pressed', 'true');
+        expect(desc).toHaveAttribute('aria-pressed', 'false');
+
+        await user.click(desc);
+
+        expect(asc).toHaveAttribute('aria-pressed', 'false');
+        expect(desc).toHaveAttribute('aria-pressed', 'true');
+
+        const resetButton = await screen.findByLabelText('Revert to default options');
+        await user.click(resetButton);
+        await user.unhover(resetButton); // Avoid displaying the tooltip, which leads to React errors on test exit
+
+        expect(asc).toHaveAttribute('aria-pressed', 'true');
+        expect(desc).toHaveAttribute('aria-pressed', 'false');
     });
 });

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.tsx
@@ -16,7 +16,8 @@ import {
 } from '@patternfly/react-core';
 import { SyncIcon } from '@patternfly/react-icons';
 import { useQuery } from '@apollo/client';
-import { sortBy } from 'lodash';
+import isEqual from 'lodash/isEqual';
+import sortBy from 'lodash/sortBy';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
 import useURLSearch from 'hooks/useURLSearch';
@@ -38,6 +39,7 @@ import { standardLabels } from 'messages/standards';
 import ComplianceLevelsByStandardChart, { ComplianceData } from './ComplianceLevelsByStandardChart';
 import WidgetCard from './WidgetCard';
 import WidgetOptionsMenu from './WidgetOptionsMenu';
+import WidgetOptionsResetButton from './WidgetOptionsResetButton';
 
 const fieldIdPrefix = 'compliance-levels-by-standard';
 
@@ -151,6 +153,8 @@ function ComplianceLevelsByStandard() {
         [searchFilter, sortDataBy, data, previousData]
     );
 
+    const isOptionsChanged = !isEqual(sortDataBy, defaultConfig.sortDataBy);
+
     return (
         <WidgetCard
             isLoading={loading && !complianceData}
@@ -161,6 +165,9 @@ function ComplianceLevelsByStandard() {
                         <Title headingLevel="h2">Compliance by standard</Title>
                     </FlexItem>
                     <FlexItem>
+                        {isOptionsChanged && (
+                            <WidgetOptionsResetButton onClick={() => updateConfig(defaultConfig)} />
+                        )}
                         <WidgetOptionsMenu
                             bodyContent={
                                 <Form>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
@@ -94,7 +94,7 @@ describe('Images at most risk dashboard widget', () => {
         expect(await screen.findByText('Images at most risk')).toBeInTheDocument();
 
         // Change to display only active images
-        await user.click(await screen.findByText('Options'));
+        await user.click(await screen.findByLabelText('Options'));
         await user.click(await screen.findByText('Active images'));
 
         expect(await screen.findByText('Active images at most risk')).toBeInTheDocument();
@@ -115,7 +115,7 @@ describe('Images at most risk dashboard widget', () => {
         );
 
         // Switch to show total CVEs
-        await user.click(await screen.findByText('Options'));
+        await user.click(await screen.findByLabelText('Options'));
         await user.click(await screen.findByText('All CVEs'));
 
         expect(await screen.findAllByText(`${totalCritical} CVEs`)).toHaveLength(mockImages.length);
@@ -143,5 +143,41 @@ describe('Images at most risk dashboard widget', () => {
 
         await user.click(screen.getByText('View all'));
         expect(history.location.pathname).toBe(`${vulnManagementImagesPath}`);
+    });
+
+    it('should contain a button that resets the widget options to default', async () => {
+        const { user } = setup();
+
+        await user.click(await screen.findByLabelText('Options'));
+        const [fixableCves, allCves, activeImages, allImages] = await screen.findAllByRole(
+            'button',
+            {
+                name: /Fixable CVEs|All CVEs|Active images|All images/,
+            }
+        );
+
+        // Defaults
+        expect(fixableCves).toHaveAttribute('aria-pressed', 'true');
+        expect(allCves).toHaveAttribute('aria-pressed', 'false');
+        expect(activeImages).toHaveAttribute('aria-pressed', 'false');
+        expect(allImages).toHaveAttribute('aria-pressed', 'true');
+
+        // Change some options
+        await user.click(allCves);
+        await user.click(activeImages);
+
+        expect(fixableCves).toHaveAttribute('aria-pressed', 'false');
+        expect(allCves).toHaveAttribute('aria-pressed', 'true');
+        expect(activeImages).toHaveAttribute('aria-pressed', 'true');
+        expect(allImages).toHaveAttribute('aria-pressed', 'false');
+
+        const resetButton = await screen.findByLabelText('Revert to default options');
+        await user.click(resetButton);
+        await user.unhover(resetButton); // Avoid displaying the tooltip, which leads to React errors on test exit
+
+        expect(fixableCves).toHaveAttribute('aria-pressed', 'true');
+        expect(allCves).toHaveAttribute('aria-pressed', 'false');
+        expect(activeImages).toHaveAttribute('aria-pressed', 'false');
+        expect(allImages).toHaveAttribute('aria-pressed', 'true');
     });
 });

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.tsx
@@ -11,6 +11,7 @@ import {
     ToggleGroup,
     ToggleGroupItem,
 } from '@patternfly/react-core';
+import isEqual from 'lodash/isEqual';
 
 import { vulnManagementImagesPath } from 'routePaths';
 import useFeatureFlags from 'hooks/useFeatureFlags';
@@ -26,6 +27,7 @@ import ImagesAtMostRiskTable, { CveStatusOption, ImageData } from './ImagesAtMos
 import isResourceScoped from '../utils';
 import NoDataEmptyState from './NoDataEmptyState';
 import WidgetOptionsMenu from './WidgetOptionsMenu';
+import WidgetOptionsResetButton from './WidgetOptionsResetButton';
 
 function getTitle(searchFilter: SearchFilter, imageStatusOption: ImageStatusOption) {
     return imageStatusOption === 'Active' || isResourceScoped(searchFilter)
@@ -101,11 +103,12 @@ function ImagesAtMostRisk() {
     const { searchFilter } = useURLSearch();
     const { pathname } = useLocation();
 
-    const [{ cveStatus, imageStatus }, updateConfig] = useWidgetConfig<Config>(
+    const [config, updateConfig] = useWidgetConfig<Config>(
         'ImagesAtMostRisk',
         pathname,
         defaultConfig
     );
+    const { cveStatus, imageStatus } = config;
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
 
@@ -117,6 +120,7 @@ function ImagesAtMostRisk() {
 
     const imageData = data || previousData;
     const isScopeApplied = isResourceScoped(searchFilter);
+    const isOptionsChanged = !isEqual(config, defaultConfig);
 
     return (
         <WidgetCard
@@ -128,6 +132,9 @@ function ImagesAtMostRisk() {
                         <Title headingLevel="h2">{getTitle(searchFilter, imageStatus)}</Title>
                     </FlexItem>
                     <FlexItem>
+                        {isOptionsChanged && (
+                            <WidgetOptionsResetButton onClick={() => updateConfig(defaultConfig)} />
+                        )}
                         <WidgetOptionsMenu
                             bodyContent={
                                 <Form>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
@@ -86,9 +86,9 @@ describe('Violations by policy category widget', () => {
         ]);
 
         // Switch to sort-by-volume, which orders the chart by total violations per category
-        await user.click(await screen.findByText('Options'));
+        await user.click(await screen.findByLabelText('Options'));
         await user.click(await screen.findByText('Total'));
-        await user.click(await screen.findByText('Options'));
+        await user.click(await screen.findByLabelText('Options'));
 
         await waitForAxisLinksToBe([
             'Security Best Practices',
@@ -105,9 +105,9 @@ describe('Violations by policy category widget', () => {
         expect(await screen.findByText('Anomalous Activity')).toBeInTheDocument();
 
         // Sort by volume, so that enabling lower severity bars changes the order of the chart
-        await user.click(await screen.findByText('Options'));
+        await user.click(await screen.findByLabelText('Options'));
         await user.click(await screen.findByText('Total'));
-        await user.click(await screen.findByText('Options'));
+        await user.click(await screen.findByLabelText('Options'));
 
         // Toggle on low and medium violations, which are disabled by default
         await user.click(await screen.findByText('Low'));
@@ -120,5 +120,41 @@ describe('Violations by policy category widget', () => {
             'Docker CIS',
             'Anomalous Activity',
         ]);
+    });
+
+    it('should contain a button that resets the widget options to default', async () => {
+        const { user } = setup();
+
+        await user.click(await screen.findByLabelText('Options'));
+        const [severity, total, all, deploy, runtime] = await screen.findAllByRole('button', {
+            name: /Severity|Total|All|Deploy|Runtime/,
+        });
+
+        // Defaults
+        expect(severity).toHaveAttribute('aria-pressed', 'true');
+        expect(total).toHaveAttribute('aria-pressed', 'false');
+        expect(all).toHaveAttribute('aria-pressed', 'true');
+        expect(deploy).toHaveAttribute('aria-pressed', 'false');
+        expect(runtime).toHaveAttribute('aria-pressed', 'false');
+
+        // Change some options
+        await user.click(total);
+        await user.click(runtime);
+
+        expect(severity).toHaveAttribute('aria-pressed', 'false');
+        expect(total).toHaveAttribute('aria-pressed', 'true');
+        expect(all).toHaveAttribute('aria-pressed', 'false');
+        expect(deploy).toHaveAttribute('aria-pressed', 'false');
+        expect(runtime).toHaveAttribute('aria-pressed', 'true');
+
+        const resetButton = await screen.findByLabelText('Revert to default options');
+        await user.click(resetButton);
+        await user.unhover(resetButton); // Avoid displaying the tooltip, which leads to React errors on test exit
+
+        expect(severity).toHaveAttribute('aria-pressed', 'true');
+        expect(total).toHaveAttribute('aria-pressed', 'false');
+        expect(all).toHaveAttribute('aria-pressed', 'true');
+        expect(deploy).toHaveAttribute('aria-pressed', 'false');
+        expect(runtime).toHaveAttribute('aria-pressed', 'false');
     });
 });

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.tsx
@@ -9,6 +9,7 @@ import {
     ToggleGroup,
     ToggleGroupItem,
 } from '@patternfly/react-core';
+import xor from 'lodash/xor';
 
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import useURLSearch from 'hooks/useURLSearch';
@@ -21,10 +22,11 @@ import WidgetCard from './WidgetCard';
 import NoDataEmptyState from './NoDataEmptyState';
 import ViolationsByPolicyCategoryChart, { Config } from './ViolationsByPolicyCategoryChart';
 import WidgetOptionsMenu from './WidgetOptionsMenu';
+import WidgetOptionsResetButton from './WidgetOptionsResetButton';
 
 const fieldIdPrefix = 'policy-category-violations';
 
-const defaultHiddenSeverities = ['MEDIUM_SEVERITY', 'LOW_SEVERITY'] as const;
+const defaultHiddenSeverities = ['LOW_SEVERITY', 'MEDIUM_SEVERITY'] as const;
 
 const defaultConfig = {
     sortType: 'Severity',
@@ -59,6 +61,12 @@ function ViolationsByPolicyCategory() {
     const query = getRequestQueryStringForSearchFilter(queryFilter);
     const { data: alertGroups, loading, error } = useAlertGroups(query, 'CATEGORY');
 
+    const isOptionsChanged =
+        lifecycle !== defaultConfig.lifecycle ||
+        sortType !== defaultConfig.sortType ||
+        // Compares the arrays and ensures the contain the same items, in any order
+        xor(hiddenSeverities, defaultConfig.hiddenSeverities).length !== 0;
+
     return (
         <WidgetCard
             isLoading={loading}
@@ -69,6 +77,9 @@ function ViolationsByPolicyCategory() {
                         <Title headingLevel="h2">Policy violations by category</Title>
                     </FlexItem>
                     <FlexItem>
+                        {isOptionsChanged && (
+                            <WidgetOptionsResetButton onClick={() => updateConfig(defaultConfig)} />
+                        )}
                         <WidgetOptionsMenu
                             bodyContent={
                                 <Form>

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetOptionsMenu.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetOptionsMenu.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
-import { CaretDownIcon } from '@patternfly/react-icons';
+import { CaretDownIcon, CogIcon } from '@patternfly/react-icons';
 
 import './WidgetOptionsMenu.css';
 
@@ -18,12 +18,13 @@ function WidgetOptionsMenu({ bodyContent }: OptionsMenuProps) {
             bodyContent={bodyContent}
         >
             <Button
+                aria-label="Options"
                 variant="secondary"
                 className="pf-u-mr-sm"
                 icon={<CaretDownIcon />}
                 iconPosition="right"
             >
-                Options
+                <CogIcon className="pf-u-display-inline" />
             </Button>
         </Popover>
     );

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetOptionsResetButton.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/WidgetOptionsResetButton.tsx
@@ -1,0 +1,25 @@
+import React, { MouseEventHandler } from 'react';
+import { Button, Tooltip } from '@patternfly/react-core';
+
+import { UndoIcon } from '@patternfly/react-icons';
+
+export type WidgetOptionsResetButtonProps = {
+    onClick: MouseEventHandler<HTMLButtonElement>;
+};
+
+const buttonLabel = 'Revert to default options';
+
+function WidgetOptionsResetButton({ onClick }: WidgetOptionsResetButtonProps) {
+    return (
+        <Tooltip content={buttonLabel}>
+            <Button
+                aria-label={buttonLabel}
+                variant="plain"
+                icon={<UndoIcon />}
+                onClick={onClick}
+            />
+        </Tooltip>
+    );
+}
+
+export default WidgetOptionsResetButton;


### PR DESCRIPTION
## Description

This adds a visual indication that default widget options have changed, as well as a reset button to restore the defaults.

Changes:

- The "Options" text in the dropdown has been changed to a standard "Cog" icon.
- The cog icon will be displayed as grey when the options are equal to their defaults, and blue when the default options have changed.
- A reset icon will appear next to the options dropdown that when clicked will restore the default options.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

For each of the four widgets with options:
- Load the main dashboard and see that the cog is grey and the reset icon is not visible
- Change each individual option in the widget, observing that the cog turns blue and the reset icon appears (for the Violations by policy category widget, also show/hide non-default severities)
- Manually revert the options to the defaults, observing that the cog turns grey and the rest icon disappears
- Change an option to a non-default option and hover over the reset icon, displaying the icon's tooltip
- Click the reset icon to restore the widget options to the default
- Ensure that non-default options that are stored in local storage correctly display the cog and reset icon on page load

For the sake of brevity, screenshots for only a single widget are below.

Page load:
<img width="655" alt="image" src="https://user-images.githubusercontent.com/1292638/188913018-26647ee7-fa43-4078-ad07-27e42d6ec3a0.png">

Default option changed:
<img width="655" alt="image" src="https://user-images.githubusercontent.com/1292638/188913253-871e2907-617e-494f-b475-2e78458be1d6.png">
<img width="655" alt="image" src="https://user-images.githubusercontent.com/1292638/188913300-ecaa5e4b-829e-4709-925e-796ca81d60cc.png">

Reset icon hover:
<img width="672" alt="image" src="https://user-images.githubusercontent.com/1292638/188913394-b12f77dd-42e0-4a84-b75a-4744a603ec1c.png">

Clicking the reset icon:
<img width="672" alt="image" src="https://user-images.githubusercontent.com/1292638/188913476-c63d8e9f-7aab-44cc-941c-02674bdecd65.png">


