### PR TITLE
ROX-12400: Do not use digest of imageID when image names do not match

### DIFF
--- a/sensor/kubernetes/listener/resources/convert_test.go
+++ b/sensor/kubernetes/listener/resources/convert_test.go
@@ -329,6 +329,27 @@ func TestPopulateImageMetadata(t *testing.T) {
 			},
 			isClusterLocal: true,
 		},
+		{
+			name: "Image and ImageID mismatch",
+			wrap: []wrapContainer{
+				{
+					image: "quay.io/nginx:1.23",
+				},
+			},
+			pods: []pod{
+				{
+					images: []string{"quay.io/nginx:1.23"},
+					imageIDsInStatus: []string{
+						"docker.io/nginx@sha256:89020cd33be2767f3f894484b8dd77bc2e5a1ccc864350b92c53262213257dfc",
+					},
+				},
+			},
+			expectedMetadata: []metadata{
+				{
+					expectedID: "",
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Description

Within detecting deployments, we use the `imageID` field to associate an image with a digest. This will help us potentially short-circuiting and using cached values for already existing images.

However, when using images that have been re-tagged, but are stored within different registries, it _may_ occur that the reference within the `imageID` field is for a different image.

As an example, when running two pods on the _same_ node with the following two images:
```bash
k run orig-img --image=docker.io/nginx:1.23

k run re-tagged-img --image=quay.io/dhaus/repro:1.23 # This is a retag of docker.io/nginx:1.23
```

You will observe the following within the output for kubectl describe:
```bash
k describe pod re-tagged-image
...
Containers:
  internal-image-signed:
    Container ID:   cri-o://3aaa27524519b64944721c91c89c73fd4c27eceb4efca435a5e47f7ab452cd67
    Image:          quay.io/dhaus/repro:1.23
    Image ID:       docker.io/nginx@sha256:89020cd33be2767f3f894484b8dd77bc2e5a1ccc864350b92c53262213257dfc
```

Although the repository digest _may_ be the valid for the quay.io/dhaus/repro repository, it is not guaranteed that it is.

Instead, we should skip setting the digest if the image name within the `imageID` field does not match with the image within the pod spec.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
- added unit tests.
