### PR TITLE
Fix turbo-build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,7 +102,7 @@ jobs:
         run: make build-prep main-build-nodeps
 
       - name: Bundle the build to preserve permissions
-        run: tar -cvzf go-binaries-build.tgz bin/linux
+        run: tar -cvzf go-binaries-build.tgz bin/linux_amd64
 
       - uses: actions/upload-artifact@v3
         with: 


### PR DESCRIPTION
## Description

In https://github.com/stackrox/stackrox/pull/2946 we introduced new layout of output dir switiching from `bin/$GOOS` to `bin/$GOOS_$GOARCH`. This change was not reflected in `turbo-build`. This PR fixes this problem.

## Testing Performed

CI