### PR TITLE
ROX-11937: Splunk TA not receiving ocp4-cis-node data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Entries in this file should be limited to:
 Please avoid adding duplicate information across this changelog and JIRA/doc input pages.
 
 ## [NEXT RELEASE]
+### Removed Features
+
+### Deprecated Features
+
+### Technical Changes
+- ROX-11937: The Splunk integration now processes all additional compliance standards of the compliance operator correctly.
+
 
 ## [3.72.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Deprecated Features
 
 ### Technical Changes
-- ROX-11937: The Splunk integration now processes all additional compliance standards of the compliance operator correctly.
+- ROX-11937: The Splunk integration now processes all additional standards of the compliance operator (ocp4-cis & ocp4-cis-node) correctly.
 
 
 ## [3.72.0]

--- a/central/splunk/compliance.go
+++ b/central/splunk/compliance.go
@@ -27,6 +27,21 @@ var (
 	}
 
 	log = logging.LoggerForModule()
+
+	getClusterIDs = func(ctx context.Context) ([]string, error) {
+		clusterDS := clusterDatastore.Singleton()
+
+		clusters, err := clusterDS.GetClusters(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		clusterIDs := make([]string, len(clusters))
+		for i, cluster := range clusters {
+			clusterIDs[i] = cluster.GetId()
+		}
+		return clusterIDs, nil
+	}
 )
 
 type splunkComplianceResult struct {
@@ -188,19 +203,4 @@ func NewComplianceHandler(complianceDS datastore.DataStore) http.HandlerFunc {
 			return
 		}
 	}
-}
-
-func getClusterIDs(ctx context.Context) ([]string, error) {
-	clusterDS := clusterDatastore.Singleton()
-
-	clusters, err := clusterDS.GetClusters(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	clusterIDs := make([]string, len(clusters))
-	for i, cluster := range clusters {
-		clusterIDs[i] = cluster.GetId()
-	}
-	return clusterIDs, nil
 }

--- a/central/splunk/compliance.go
+++ b/central/splunk/compliance.go
@@ -107,6 +107,8 @@ func NewComplianceHandler(complianceDS datastore.DataStore) http.HandlerFunc {
 							State:      stateToString(clusterValue.OverallState),
 							Evidence:   getMessageLines(clusterValue.GetEvidence()),
 						}
+						fmt.Print("Cluster Results")
+						fmt.Printf("%v\n", res)
 						if err := arrayWriter.WriteObject(res); err != nil {
 							httputil.WriteError(w, err)
 							return
@@ -130,6 +132,8 @@ func NewComplianceHandler(complianceDS datastore.DataStore) http.HandlerFunc {
 								State:      stateToString(result.OverallState),
 								Evidence:   getMessageLines(result.GetEvidence()),
 							}
+							fmt.Print("Deployment Results\n")
+							fmt.Printf("%v\n", res)
 							if err := arrayWriter.WriteObject(res); err != nil {
 								httputil.WriteError(w, err)
 								return
@@ -152,6 +156,8 @@ func NewComplianceHandler(complianceDS datastore.DataStore) http.HandlerFunc {
 								State:      stateToString(result.OverallState),
 								Evidence:   getMessageLines(result.GetEvidence()),
 							}
+							fmt.Print("Node Results")
+							fmt.Printf("%v\n", res)
 							if err := arrayWriter.WriteObject(res); err != nil {
 								httputil.WriteError(w, err)
 								return

--- a/central/splunk/compliance.go
+++ b/central/splunk/compliance.go
@@ -66,6 +66,7 @@ func NewComplianceHandler(complianceDS datastore.DataStore) http.HandlerFunc {
 		}
 
 		standardIDs := standards.GetSupportedStandards()
+		fmt.Printf("Iterating over standards: %v", standardIDs)
 		clusterIDs, err := getClusterIDs(r.Context())
 		if err != nil {
 			httputil.WriteError(w, err)
@@ -107,8 +108,6 @@ func NewComplianceHandler(complianceDS datastore.DataStore) http.HandlerFunc {
 							State:      stateToString(clusterValue.OverallState),
 							Evidence:   getMessageLines(clusterValue.GetEvidence()),
 						}
-						fmt.Print("Cluster Results")
-						fmt.Printf("%v\n", res)
 						if err := arrayWriter.WriteObject(res); err != nil {
 							httputil.WriteError(w, err)
 							return
@@ -132,8 +131,6 @@ func NewComplianceHandler(complianceDS datastore.DataStore) http.HandlerFunc {
 								State:      stateToString(result.OverallState),
 								Evidence:   getMessageLines(result.GetEvidence()),
 							}
-							fmt.Print("Deployment Results\n")
-							fmt.Printf("%v\n", res)
 							if err := arrayWriter.WriteObject(res); err != nil {
 								httputil.WriteError(w, err)
 								return
@@ -156,8 +153,6 @@ func NewComplianceHandler(complianceDS datastore.DataStore) http.HandlerFunc {
 								State:      stateToString(result.OverallState),
 								Evidence:   getMessageLines(result.GetEvidence()),
 							}
-							fmt.Print("Node Results")
-							fmt.Printf("%v\n", res)
 							if err := arrayWriter.WriteObject(res); err != nil {
 								httputil.WriteError(w, err)
 								return

--- a/central/splunk/compliance_test.go
+++ b/central/splunk/compliance_test.go
@@ -179,7 +179,7 @@ func (s *splunkComplianceAPITestSuite) TestComplianceAPIResults() {
 	}
 
 	for _, result := range expectedCompliance {
-		//s.Contains(responseBody, result.expectedResult, "Response did not contain expected results", result.name)
+		// s.Contains(responseBody, result.expectedResult, "Response did not contain expected results", result.name)
 		s.Run(result.name, func() {
 			s.Contains(responseBody, result.expectedResult, "Response did not contain expected results")
 		})

--- a/central/splunk/compliance_test.go
+++ b/central/splunk/compliance_test.go
@@ -152,15 +152,36 @@ func (s *splunkComplianceAPITestSuite) TestComplianceAPIResults() {
 	}
 	handler.ServeHTTP(responseRecorder, req)
 
-	expectedResults := []string{
-		"{\"standard\":\"CIS Docker v1.2.0\",\"cluster\":\"compliance-test-id\",\"namespace\":\"\",\"objectType\":\"Cluster\",\"objectName\":\"compliance-test-id\",\"control\":\"HIPAA_164:310_a_1\",\"state\":\"Pass\",\"evidence\":\"(Pass) Cluster has an image scanner in use\"}",
-		"{\"standard\":\"CIS Docker v1.2.0\",\"cluster\":\"compliance-test-id\",\"namespace\":\"dep-ns1\",\"objectType\":\"Deployment\",\"objectName\":\"deployment1\",\"control\":\"5.6\",\"state\":\"Pass\",\"evidence\":\"(Pass) Container has no ssh process running\"}",
-		"{\"standard\":\"CIS Docker v1.2.0\",\"cluster\":\"compliance-test-id\",\"namespace\":\"\",\"objectType\":\"Node\",\"objectName\":\"node1\",\"control\":\"1.1.2\",\"state\":\"N/A\",\"evidence\":\"(N/A) Node does not use Docker container runtime\"}",
-		"{\"standard\":\"CIS Docker v1.2.0\",\"cluster\":\"compliance-test-id\",\"namespace\":\"\",\"objectType\":\"Machine Config\",\"objectName\":\"ocp4-cis-node-master\",\"control\":\"ocp4-cis-node:file-owner-worker-kubeconfig\",\"state\":\"Pass\",\"evidence\":\"(Pass) Pass for ocp4-cis-node-master-file-owner-worker-kubeconfig.\"}",
+	responseBody := responseRecorder.Body.String()
+
+	// Primarily, we want to ensure that all RunResults are handed to the SplunkAPI results.
+	// By testing the return format, we additionally ensure that the returned data is complete and well formatted.
+	expectedCompliance := []struct {
+		name           string
+		expectedResult string
+	}{
+		{
+			name:           "Cluster Results",
+			expectedResult: "{\"standard\":\"CIS Docker v1.2.0\",\"cluster\":\"compliance-test-id\",\"namespace\":\"\",\"objectType\":\"Cluster\",\"objectName\":\"compliance-test-id\",\"control\":\"HIPAA_164:310_a_1\",\"state\":\"Pass\",\"evidence\":\"(Pass) Cluster has an image scanner in use\"}",
+		},
+		{
+			name:           "Deployment Results",
+			expectedResult: "{\"standard\":\"CIS Docker v1.2.0\",\"cluster\":\"compliance-test-id\",\"namespace\":\"dep-ns1\",\"objectType\":\"Deployment\",\"objectName\":\"deployment1\",\"control\":\"5.6\",\"state\":\"Pass\",\"evidence\":\"(Pass) Container has no ssh process running\"}",
+		},
+		{
+			name:           "Node Results",
+			expectedResult: "{\"standard\":\"CIS Docker v1.2.0\",\"cluster\":\"compliance-test-id\",\"namespace\":\"\",\"objectType\":\"Node\",\"objectName\":\"node1\",\"control\":\"1.1.2\",\"state\":\"N/A\",\"evidence\":\"(N/A) Node does not use Docker container runtime\"}",
+		},
+		{
+			name:           "Machine Config Results",
+			expectedResult: "{\"standard\":\"CIS Docker v1.2.0\",\"cluster\":\"compliance-test-id\",\"namespace\":\"\",\"objectType\":\"Machine Config\",\"objectName\":\"ocp4-cis-node-master\",\"control\":\"ocp4-cis-node:file-owner-worker-kubeconfig\",\"state\":\"Pass\",\"evidence\":\"(Pass) Pass for ocp4-cis-node-master-file-owner-worker-kubeconfig.\"}",
+		},
 	}
 
-	for _, expResult := range expectedResults {
-		s.Contains(responseRecorder.Body.String(), expResult)
+	for _, result := range expectedCompliance {
+		//s.Contains(responseBody, result.expectedResult, "Response did not contain expected results", result.name)
+		s.Run(result.name, func() {
+			s.Contains(responseBody, result.expectedResult, "Response did not contain expected results")
+		})
 	}
-
 }

--- a/central/splunk/compliance_test.go
+++ b/central/splunk/compliance_test.go
@@ -179,7 +179,6 @@ func (s *splunkComplianceAPITestSuite) TestComplianceAPIResults() {
 	}
 
 	for _, result := range expectedCompliance {
-		// s.Contains(responseBody, result.expectedResult, "Response did not contain expected results", result.name)
 		s.Run(result.name, func() {
 			s.Contains(responseBody, result.expectedResult, "Response did not contain expected results")
 		})

--- a/central/splunk/compliance_test.go
+++ b/central/splunk/compliance_test.go
@@ -1,0 +1,80 @@
+package splunk
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stackrox/rox/central/compliance"
+	"github.com/stackrox/rox/central/compliance/datastore/mocks"
+	"github.com/stackrox/rox/central/compliance/datastore/types"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// This file contains tests for the /compliance endpoint
+
+func TestSplunkComplianceAPI(t *testing.T) {
+	//t.Parallel()
+	suite.Run(t, &splunkComplianceAPITestSuite{})
+}
+
+type splunkComplianceAPITestSuite struct {
+	suite.Suite
+
+	hasReadCtx  context.Context
+	hasWriteCtx context.Context
+
+	mockCtrl *gomock.Controller
+	mockDS   *mocks.MockDataStore
+}
+
+func (s *splunkComplianceAPITestSuite) SetupTest() {
+	s.hasReadCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Compliance)))
+	s.mockCtrl = gomock.NewController(s.T())
+	s.mockDS = mocks.NewMockDataStore(s.mockCtrl)
+}
+
+func (s *splunkComplianceAPITestSuite) TearDownTest() {
+	s.mockCtrl.Finish()
+}
+
+func (s *splunkComplianceAPITestSuite) TestCISDockerResults() {
+	// set up http mocks
+	req, err := http.NewRequest("GET", "/api/splunk/ta/compliance", nil)
+	require.NoError(s.T(), err)
+	rr := httptest.NewRecorder()
+
+	// configure storage mocks
+	clusterIDs := []string{"testcluster"}
+	standardIDs := []string{"CIS_Docker_v1_2_0"}
+	csPair := compliance.ClusterStandardPair{
+		ClusterID:  "testcluster",
+		StandardID: "CIS_Docker_v1_2_0",
+	}
+	latestRunResultBatch := map[compliance.ClusterStandardPair]types.ResultsWithStatus{
+		csPair: {
+			LastSuccessfulResults: &storage.ComplianceRunResults{
+				DeploymentResults: map[string]*storage.ComplianceRunResults_EntityResults{
+					"deployment1": {},
+				},
+			},
+		},
+	}
+
+	s.mockDS.EXPECT().GetLatestRunResultsBatch(s.hasReadCtx, clusterIDs, standardIDs, types.WithMessageStrings).Return(latestRunResultBatch, nil)
+
+	handler := NewComplianceHandler(s.mockDS)
+	handler.ServeHTTP(rr, req)
+
+	s.Equal(rr.Body.String(), "")
+
+}


### PR DESCRIPTION
## Description

Debug and fix missing data in the Splunk API.
When the Compliance Operator is installed in an OpenShift 4 environment, additional standards become available in the Compliance view of StackRox, namely `ocp4-cis` and `ocp4-cis-node`.
The latter of these never showed up in Splunk API exports, therefore never finding its way into Splunk.

This was due to the information for `ocp4-cis-node` being stored in a different structure of the datastore than the rest of the compliance data.
This PR updates the internal Splunk API compliance handler to also include this additional information.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
- Deploy OS4 infra cluster
- Install Compliance Operator
- Deploy StackRox
- Run Compliance scan
- Observe ocp4* standards showing up in the Compliance WebUI
- Query Splunk API directly: `roxcurl https://localhost:8443/api/splunk/ta/compliance | grep -i standard\":\"ocp4-cis-node`
- Observe results from the Splunk API including `ocp4-cis-node`

### Additional Testing Performed
I have sucessfully tested E2E by deploying a Splunk instance, installing the StackRox TA and then pulling compliance data out of an OS4 cluster that has the compliance-operator installed.
Steps to reproduce: 
- Start with empty OS4 cluster 
- [Install and set up compliance operator](https://docs.google.com/document/d/1I88LUsDwviixecXSFL4yq7oZOgUnlOESqf6Qmt5karM/edit)
- [Deploy Splunk](https://github.com/srcporter/splunk-operator-ocp) (without setting up the HTTP event collector)
- Follow our [docs instructions ](https://docs.openshift.com/acs/3.71/integration/integrate-with-splunk.html#integrate-splunk-add-on)how to install and set up the StackRox TA
- Set up compliance input to be ingested in Splunk
- Open search in Splunk, observe all four types of data being ingested, including all compliance standards (including ocp4-cis-node)

![image](https://user-images.githubusercontent.com/8026915/191311808-164162f8-57b3-4835-bd45-ca8cfc9e0052.png)
![image](https://user-images.githubusercontent.com/8026915/191311864-cd8a837f-202b-413d-a139-656e90b1e9d6.png)
