### PR TITLE
ROX-12512: Use operator framework version without memory leak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -434,7 +434,7 @@ replace (
 
 	// github.com/stackrox/helm-operator is a modified fork of github.com/operator-framework/helm-operator-plugins that
 	// we currently depend on.
-	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.8-0.20220804162433-be98f831243c
+	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.10-0.20220908144520-9d1614a2a007
 	// github.com/sigstore/rekor is a transitive dep pulled in by cosign. The version pulled in by cosign is using
 	// a vulnerable go-tuf version
 	// (https://github.com/theupdateframework/go-tuf/security/advisories/GHSA-66x3-6cw3-v5gj).

--- a/go.sum
+++ b/go.sum
@@ -2757,8 +2757,8 @@ github.com/stackrox/dotnet-scraper v0.0.0-20201023051640-72ef543323dd h1:vEjp7Q6
 github.com/stackrox/dotnet-scraper v0.0.0-20201023051640-72ef543323dd/go.mod h1:HILeV3i/EyJz844GcrC3+oU7oZONhjfujaIYBMJ/bZE=
 github.com/stackrox/external-network-pusher v0.0.0-20210419192707-074af92bbfa7 h1:F4Gq3G5G07HQ/ECrg/+EQxFBmCTcq9ZDyLPI5LaDUKI=
 github.com/stackrox/external-network-pusher v0.0.0-20210419192707-074af92bbfa7/go.mod h1:faUw9vx/mA7ql41Ftlst5MYar2DT3nnS6oK94lbaW0g=
-github.com/stackrox/helm-operator v0.0.8-0.20220804162433-be98f831243c h1:mP6VDc8pG6IAFzxyufwdFFGMZ3hdzbxhnsMYHvkGp7A=
-github.com/stackrox/helm-operator v0.0.8-0.20220804162433-be98f831243c/go.mod h1:w+aTtmogp/HRpQcRouVHeNGHn80IrDMiWkWzmIOdcGE=
+github.com/stackrox/helm-operator v0.0.10-0.20220908144520-9d1614a2a007 h1:8tVrEtgwja7q91xcFGwD8A/CgkURWHjCRgZJzS5QztM=
+github.com/stackrox/helm-operator v0.0.10-0.20220908144520-9d1614a2a007/go.mod h1:uHQPYB600zyk6/e9/V781Kg5LOincTYWdkVzBiuX77I=
 github.com/stackrox/helmtest v0.0.0-20220118100812-1ad97c4de347 h1:ByiXbT2lnhWmUlrpUCeQlk8hRZTFr6CPtTtpd7XlOGY=
 github.com/stackrox/helmtest v0.0.0-20220118100812-1ad97c4de347/go.mod h1:vWZFszN4CfxMWzzMI/XfrcG4kkoDIPdwfDry76nYIbo=
 github.com/stackrox/k8s-cves v0.0.0-20201110001126-cc333981eaab h1:77xJmm1YkqbgrQzHI3C4MyPckWL+PYRLWakQRC6Mzj8=


### PR DESCRIPTION
## Description

This uses the `helm-operator` version where the memory leak issue is fixed. See https://github.com/stackrox/helm-operator/pull/30 for more details.

I'd like to decouple reducing the operator container resources from this, as it will require some more detailed investigation/load testing to see how bad the usage can become in a busy cluster with several CRDs, and this PR on its own represents a sufficient improvement.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- CI (tbd)