### PR TITLE
release automation: add default PR search for start-release

### DIFF
--- a/.github/workflows/scripts/patch-changelog.sh
+++ b/.github/workflows/scripts/patch-changelog.sh
@@ -58,7 +58,7 @@ git add CHANGELOG.md
 if ! git diff-index --quiet HEAD; then
     git commit --message "Next version in changelog after $VERSION"
 
-    PR_URL=""
+    PR_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pulls?q=is%3Apr+is%3Aopen+head%3Aautomation%2Fchangelog"
     if [ "$DRY_RUN" = "false" ]; then
         git push --set-upstream origin "$CHANGELOG_BRANCH"
         PR_URL=$(create_pr)


### PR DESCRIPTION
## Description

start-release gave an empty `[PR]()` link
https://github.com/stackrox/stackrox/actions/runs/3016841701#summary-8254641794

I don't know why it was empty because it did create the PR (https://github.com/stackrox/stackrox/pull/3013). Could the script provide a search to find the PR if we do not get a PR link from creating it?