### PR TITLE
[ROX-13346] Add autocomplete option for new vulnerability search categories in graphQL

### DIFF
--- a/central/cve/cluster/datastore/datastore.go
+++ b/central/cve/cluster/datastore/datastore.go
@@ -21,7 +21,7 @@ import (
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)
-	SearchCVEs(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)
+	SearchClusterCVEs(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)
 	SearchRawCVEs(ctx context.Context, q *v1.Query) ([]*storage.ClusterCVE, error)
 
 	Exists(ctx context.Context, id string) (bool, error)

--- a/central/cve/cluster/datastore/datastore_impl.go
+++ b/central/cve/cluster/datastore/datastore_impl.go
@@ -66,7 +66,7 @@ func (ds *datastoreImpl) Search(ctx context.Context, q *v1.Query) ([]pkgSearch.R
 	return ds.searcher.Search(ctx, q)
 }
 
-func (ds *datastoreImpl) SearchCVEs(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
+func (ds *datastoreImpl) SearchClusterCVEs(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
 	return ds.searcher.SearchClusterCVEs(ctx, q)
 }
 

--- a/central/cve/cluster/datastore/mocks/datastore.go
+++ b/central/cve/cluster/datastore/mocks/datastore.go
@@ -129,19 +129,19 @@ func (mr *MockDataStoreMockRecorder) Search(ctx, q interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockDataStore)(nil).Search), ctx, q)
 }
 
-// SearchCVEs mocks base method.
-func (m *MockDataStore) SearchCVEs(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
+// SearchClusterCVEs mocks base method.
+func (m *MockDataStore) SearchClusterCVEs(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchCVEs", ctx, q)
+	ret := m.ctrl.Call(m, "SearchClusterCVEs", ctx, q)
 	ret0, _ := ret[0].([]*v1.SearchResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SearchCVEs indicates an expected call of SearchCVEs.
-func (mr *MockDataStoreMockRecorder) SearchCVEs(ctx, q interface{}) *gomock.Call {
+// SearchClusterCVEs indicates an expected call of SearchClusterCVEs.
+func (mr *MockDataStoreMockRecorder) SearchClusterCVEs(ctx, q interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchCVEs", reflect.TypeOf((*MockDataStore)(nil).SearchCVEs), ctx, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchClusterCVEs", reflect.TypeOf((*MockDataStore)(nil).SearchClusterCVEs), ctx, q)
 }
 
 // SearchRawCVEs mocks base method.

--- a/central/cve/datastoretest/datastore_sac_test.go
+++ b/central/cve/datastoretest/datastore_sac_test.go
@@ -964,7 +964,7 @@ func (s *cveDataStoreSACTestSuite) TestSACNodeCVESearchCVEs() {
 		s.Run(c.contextKey, func() {
 
 			testCtx := s.nodeTestContexts[c.contextKey]
-			results, err := s.nodeCVEStore.SearchCVEs(testCtx, nil)
+			results, err := s.nodeCVEStore.SearchNodeCVEs(testCtx, nil)
 			s.NoError(err)
 			expectedCVENames := make([]string, 0, len(c.expectedCVEFound))
 			for name, visible := range c.expectedCVEFound {

--- a/central/cve/datastoretest/node_cve_from_generic_cve_datastore.go
+++ b/central/cve/datastoretest/node_cve_from_generic_cve_datastore.go
@@ -31,7 +31,7 @@ func (s *nodeCVEDataStoreFromGenericStore) Search(ctx context.Context, q *v1.Que
 	return s.genericStore.Search(ctx, q)
 }
 
-func (s *nodeCVEDataStoreFromGenericStore) SearchCVEs(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
+func (s *nodeCVEDataStoreFromGenericStore) SearchNodeCVEs(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
 	return s.genericStore.SearchCVEs(ctx, q)
 }
 

--- a/central/cve/node/datastore/datastore.go
+++ b/central/cve/node/datastore/datastore.go
@@ -21,7 +21,7 @@ import (
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)
-	SearchCVEs(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)
+	SearchNodeCVEs(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)
 	SearchRawCVEs(ctx context.Context, q *v1.Query) ([]*storage.NodeCVE, error)
 
 	Exists(ctx context.Context, id string) (bool, error)

--- a/central/cve/node/datastore/datastore_impl.go
+++ b/central/cve/node/datastore/datastore_impl.go
@@ -60,7 +60,7 @@ func (ds *datastoreImpl) Search(ctx context.Context, q *v1.Query) ([]pkgSearch.R
 	return ds.searcher.Search(ctx, q)
 }
 
-func (ds *datastoreImpl) SearchCVEs(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
+func (ds *datastoreImpl) SearchNodeCVEs(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
 	return ds.searcher.SearchCVEs(ctx, q)
 }
 

--- a/central/cve/node/datastore/mocks/datastore.go
+++ b/central/cve/node/datastore/mocks/datastore.go
@@ -126,19 +126,19 @@ func (mr *MockDataStoreMockRecorder) Search(ctx, q interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockDataStore)(nil).Search), ctx, q)
 }
 
-// SearchCVEs mocks base method.
-func (m *MockDataStore) SearchCVEs(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
+// SearchNodeCVEs mocks base method.
+func (m *MockDataStore) SearchNodeCVEs(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchCVEs", ctx, q)
+	ret := m.ctrl.Call(m, "SearchNodeCVEs", ctx, q)
 	ret0, _ := ret[0].([]*v1.SearchResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SearchCVEs indicates an expected call of SearchCVEs.
-func (mr *MockDataStoreMockRecorder) SearchCVEs(ctx, q interface{}) *gomock.Call {
+// SearchNodeCVEs indicates an expected call of SearchNodeCVEs.
+func (mr *MockDataStoreMockRecorder) SearchNodeCVEs(ctx, q interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchCVEs", reflect.TypeOf((*MockDataStore)(nil).SearchCVEs), ctx, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchNodeCVEs", reflect.TypeOf((*MockDataStore)(nil).SearchNodeCVEs), ctx, q)
 }
 
 // SearchRawCVEs mocks base method.

--- a/central/graphql/resolvers/search.go
+++ b/central/graphql/resolvers/search.go
@@ -139,6 +139,11 @@ func (resolver *Resolver) getAutoCompleteSearchers() map[v1.SearchCategory]searc
 	}
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
 		searchers[v1.SearchCategory_VULNERABILITIES] = resolver.CVEDataStore
+	} else {
+		searchers[v1.SearchCategory_IMAGE_VULNERABILITIES] = resolver.ImageCVEDataStore
+		searchers[v1.SearchCategory_NODE_VULNERABILITIES] = resolver.NodeCVEDataStore
+		searchers[v1.SearchCategory_CLUSTER_VULNERABILITIES] = resolver.ClusterCVEDataStore
+		searchers[v1.SearchCategory_NODE_COMPONENTS] = resolver.NodeComponentDataStore
 	}
 
 	return searchers
@@ -163,6 +168,11 @@ func (resolver *Resolver) getSearchFuncs() map[v1.SearchCategory]searchService.S
 	}
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
 		searchfuncs[v1.SearchCategory_VULNERABILITIES] = resolver.CVEDataStore.SearchCVEs
+	} else {
+		searchfuncs[v1.SearchCategory_IMAGE_VULNERABILITIES] = resolver.ImageCVEDataStore.SearchImageCVEs
+		searchfuncs[v1.SearchCategory_NODE_VULNERABILITIES] = resolver.NodeCVEDataStore.SearchNodeCVEs
+		searchfuncs[v1.SearchCategory_CLUSTER_VULNERABILITIES] = resolver.ClusterCVEDataStore.SearchClusterCVEs
+		searchfuncs[v1.SearchCategory_NODE_COMPONENTS] = resolver.NodeComponentDataStore.SearchNodeComponents
 	}
 	return searchfuncs
 }


### PR DESCRIPTION
## Description

Apparently, graphQL and gRPC endpoints maintain separate implementations for auto-complete. This PR updates the graphQL autocomplete that was missed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

