### PR TITLE
Create legacy symlink for roxctl

### DIFF
--- a/image/rhel/Dockerfile.envsubst
+++ b/image/rhel/Dockerfile.envsubst
@@ -44,6 +44,7 @@ RUN ln -s entrypoint-wrapper.sh /stackrox/admission-control && \
     ln -s entrypoint-wrapper.sh /stackrox/kubernetes-sensor && \
     ln -s entrypoint-wrapper.sh /stackrox/sensor-upgrader && \
     ln -s /assets/downloads/cli/roxctl-linux-amd64 /stackrox/roxctl && \
+    ln -s /assets/downloads/cli/roxctl-linux-amd64 /assets/downloads/cli/roxctl-linux && \
     rpm --import RPM-GPG-KEY-CentOS-Official && \
     microdnf upgrade && \
     rpm -i /tmp/snappy.rpm && \


### PR DESCRIPTION
## Description

With a recent change in preparation of multiarch, `roxctl` filenames in the `/assets/downloads/cli` directory were made architecture-specific (i.e., `roxctl-linux-amd64` instead of `roxctl-linux`).

Since apparently [some automation](https://srox.slack.com/archives/CELUQKESC/p1662669354128059) depends on the presence of `/assets/downloads/cli/roxctl-linux`, create a symlink for backwards compatibility.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- [ ] will check out that the old path works in the image once it's built