### PR TITLE
ROX-12182: Do not enable OpenShift Auth provider for managed centrals

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -439,12 +439,7 @@ func startGRPCServer() {
 	// env.EnableOpenShiftAuth signals the desire but does not guarantee Central
 	// is configured correctly to talk to the OpenShift's OAuth server. If this
 	// is the case, we can be setting up an auth providers which won't work.
-	//
-	// Additionally, env.ManagedCentral signals whether this is a managed instance
-	// of central running within an OSD cluster. For these instances, we do not want
-	// the OpenShift auth provider to be visible, as this would essentially disclose
-	// information about the underlying infrastructure.
-	if env.EnableOpenShiftAuth.BooleanSetting() && !env.ManagedCentral.BooleanSetting() {
+	if env.EnableOpenShiftAuth.BooleanSetting() {
 		authProviderBackendFactories[openshift.TypeName] = openshift.NewFactory
 	}
 

--- a/central/main.go
+++ b/central/main.go
@@ -439,6 +439,7 @@ func startGRPCServer() {
 	// env.EnableOpenShiftAuth signals the desire but does not guarantee Central
 	// is configured correctly to talk to the OpenShift's OAuth server. If this
 	// is the case, we can be setting up an auth providers which won't work.
+	//
 	// Additionally, env.ManagedCentral signals whether this is a managed instance
 	// of central running within an OSD cluster. For these instances, we do not want
 	// the OpenShift auth provider to be visible, as this would essentially disclose

--- a/central/main.go
+++ b/central/main.go
@@ -439,7 +439,11 @@ func startGRPCServer() {
 	// env.EnableOpenShiftAuth signals the desire but does not guarantee Central
 	// is configured correctly to talk to the OpenShift's OAuth server. If this
 	// is the case, we can be setting up an auth providers which won't work.
-	if env.EnableOpenShiftAuth.BooleanSetting() {
+	// Additionally, env.ManagedCentral signals whether this is a managed instance
+	// of central running within an OSD cluster. For these instances, we do not want
+	// the OpenShift auth provider to be visible, as this would essentially disclose
+	// information about the underlying infrastructure.
+	if env.EnableOpenShiftAuth.BooleanSetting() && !env.ManagedCentral.BooleanSetting() {
 		authProviderBackendFactories[openshift.TypeName] = openshift.NewFactory
 	}
 

--- a/deploy/common/env.sh
+++ b/deploy/common/env.sh
@@ -60,6 +60,9 @@ echo "ROX_DEV_AUTH0_CLIENT_SECRET is set to ${ROX_DEV_AUTH0_CLIENT_SECRET}"
 export ROX_HOTRELOAD="${HOTRELOAD:-false}"
 echo "ROX_HOTRELOAD is set to ${ROX_HOTRELOAD}"
 
+export ROX_MANAGED_CENTRAL="${ROX_MANAGED_CENTRAL:-false}"
+echo "ROX_MANAGED_CENTRAL is set to ${ROX_MANAGED_CENTRAL}"
+
 export TRUSTED_CA_FILE="${TRUSTED_CA_FILE:-}"
 if [[ -n "${TRUSTED_CA_FILE}" ]]; then
   [[ -f "${TRUSTED_CA_FILE}" ]] || { echo "Trusted CA file ${TRUSTED_CA_FILE} not found"; return 1; }

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -341,6 +341,11 @@ function launch_central {
         ${ORCH_CMD} -n stackrox set env deploy/central MODULE_LOGLEVELS="${MODULE_LOGLEVELS}"
       fi
 
+      if [[ "$ROX_MANAGED_CENTRAL" == "true" ]]; then
+        echo "ROX_MANAGED_CENTRAL=true is only supported in conjunction with OUTPUT_FORMAT=helm"
+        exit 1
+      fi
+
       if [[ "$SCANNER_SUPPORT" == "true" ]]; then
           echo "Deploying Scanner..."
           if [[ -n "${REGISTRY_USERNAME}" ]]; then

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -304,7 +304,7 @@ function launch_central {
 
       if [[ "$ROX_MANAGED_CENTRAL" == "true" ]]; then
         helm_args+=(
-          --set customize.central.envVars.ROX_MANAGED_CENTRAL="${ROX_MANAGED_CENTRAL}"
+          --set env.managedServices=true
         )
       fi
 
@@ -339,10 +339,6 @@ function launch_central {
       fi
       if [[ -n $MODULE_LOGLEVELS ]]; then
         ${ORCH_CMD} -n stackrox set env deploy/central MODULE_LOGLEVELS="${MODULE_LOGLEVELS}"
-      fi
-
-      if [[ "$ROX_MANAGED_CENTRAL" == "true" ]]; then
-        ${ORCH_CMD} -n stackrox set env deploy/central ROX_MANAGED_CENTRAL="${ROX_MANAGED_CENTRAL}"
       fi
 
       if [[ "$SCANNER_SUPPORT" == "true" ]]; then

--- a/image/templates/helm/stackrox-central/templates/01-central-00-serviceaccount.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-00-serviceaccount.yaml
@@ -8,11 +8,11 @@ metadata:
   labels:
     {{- include "srox.labels" (list . "serviceaccount" "central") | nindent 4 }}
   annotations:
+    {{- include "srox.annotations" (list . "serviceaccount" "central") | nindent 4 }}
     {{- if and (eq ._rox.env.openshift 4) (not ._rox.env.managedServices) }}
     serviceaccounts.openshift.io/oauth-redirectreference.main: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"central"}}'
     serviceaccounts.openshift.io/oauth-redirecturi.main: "sso/providers/openshift/callback"
     {{- end }}
-    {{- include "srox.annotations" (list . "serviceaccount" "central") | nindent 4 }}
 imagePullSecrets:
 {{- range $secretName := ._rox.imagePullSecrets._names }}
 - name: {{ quote $secretName }}

--- a/image/templates/helm/stackrox-central/templates/01-central-00-serviceaccount.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-00-serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "srox.labels" (list . "serviceaccount" "central") | nindent 4 }}
   annotations:
-    {{- if and (eq ._rox.env.openshift 4) (not (hasKey ._rox.customize.central.envVars "ROX_MANAGED_CENTRAL" )) }}
+    {{- if and (eq ._rox.env.openshift 4) (not ._rox.env.managedServices) }}
     serviceaccounts.openshift.io/oauth-redirectreference.main: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"central"}}'
     serviceaccounts.openshift.io/oauth-redirecturi.main: "sso/providers/openshift/callback"
     {{- end }}

--- a/image/templates/helm/stackrox-central/templates/01-central-00-serviceaccount.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-00-serviceaccount.yaml
@@ -8,9 +8,11 @@ metadata:
   labels:
     {{- include "srox.labels" (list . "serviceaccount" "central") | nindent 4 }}
   annotations:
-    {{- include "srox.annotations" (list . "serviceaccount" "central") | nindent 4 }}
+    {{- if and (eq ._rox.env.openshift 4) (not (hasKey ._rox.customize.central.envVars "ROX_MANAGED_CENTRAL" )) }}
     serviceaccounts.openshift.io/oauth-redirectreference.main: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"central"}}'
     serviceaccounts.openshift.io/oauth-redirecturi.main: "sso/providers/openshift/callback"
+    {{- end }}
+    {{- include "srox.annotations" (list . "serviceaccount" "central") | nindent 4 }}
 imagePullSecrets:
 {{- range $secretName := ._rox.imagePullSecrets._names }}
 - name: {{ quote $secretName }}

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -100,7 +100,7 @@ spec:
           value: {{ ._rox.central.disableTelemetry | not | quote }}
         - name: ROX_OFFLINE_MODE
           value: {{ ._rox.env.offlineMode | quote }}
-        {{- if and (eq ._rox.env.openshift 4) (not (hasKey ._rox.customize.central.envVars "ROX_MANAGED_CENTRAL" )) }}
+        {{- if eq ._rox.env.openshift 4 }}
         - name: ROX_ENABLE_OPENSHIFT_AUTH
           value: "true"
         {{- end }}

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -100,8 +100,12 @@ spec:
           value: {{ ._rox.central.disableTelemetry | not | quote }}
         - name: ROX_OFFLINE_MODE
           value: {{ ._rox.env.offlineMode | quote }}
-        {{- if eq ._rox.env.openshift 4 }}
+        {{- if and (eq ._rox.env.openshift 4) (not ._rox.env.managedServices) }}
         - name: ROX_ENABLE_OPENSHIFT_AUTH
+          value: "true"
+        {{- end }}
+        {{- if ._rox.env.managedServices }}
+        - name: ROX_MANAGED_CENTRAL
           value: "true"
         {{- end }}
         {{- include "srox.envVars" (list . "deployment" "central" "central") | nindent 8 }}

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -100,7 +100,7 @@ spec:
           value: {{ ._rox.central.disableTelemetry | not | quote }}
         - name: ROX_OFFLINE_MODE
           value: {{ ._rox.env.offlineMode | quote }}
-        {{- if eq ._rox.env.openshift 4 }}
+        {{- if and (eq ._rox.env.openshift 4) (not (hasKey ._rox.customize.central.envVars "ROX_MANAGED_CENTRAL" )) }}
         - name: ROX_ENABLE_OPENSHIFT_AUTH
           value: "true"
         {{- end }}

--- a/operator/pkg/central/values/translation/translation.go
+++ b/operator/pkg/central/values/translation/translation.go
@@ -103,10 +103,11 @@ func getEnv(c platform.Central) *translation.ValuesBuilder {
 	}
 
 	if annotations != nil {
-		if annotation, ok := annotations[managedServicesAnnotation]; ok {
-			managedServices, err := strconv.ParseBool(annotation)
+		if annotationValue, ok := annotations[managedServicesAnnotation]; ok {
+			managedServices, err := strconv.ParseBool(annotationValue)
 			if err != nil {
-				return env.SetError(fmt.Errorf("invalid annotation.%s %q", managedServicesAnnotation, annotation))
+				return env.SetError(fmt.Errorf("invalid annotation value %q for annotation %s",
+					annotationValue, managedServicesAnnotation))
 			}
 			if managedServices {
 				env.SetBoolValue("managedServices", true)

--- a/operator/pkg/central/values/translation/translation.go
+++ b/operator/pkg/central/values/translation/translation.go
@@ -3,6 +3,7 @@ package translation
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	// Required for the usage of go:embed below.
 	_ "embed"
@@ -20,6 +21,10 @@ import (
 var (
 	//go:embed base-values.yaml
 	baseValuesYAML []byte
+)
+
+const (
+	managedServicesAnnotation = "platform.stackrox.io/managed-services"
 )
 
 // Translator translates and enriches helm values
@@ -55,7 +60,7 @@ func translate(c platform.Central) (chartutil.Values, error) {
 	v := translation.NewValuesBuilder()
 
 	v.AddAllFrom(translation.GetImagePullSecrets(c.Spec.ImagePullSecrets))
-	v.AddAllFrom(getEnv(c.Spec.Egress))
+	v.AddAllFrom(getEnv(c))
 	v.AddAllFrom(translation.GetTLSConfigValues(c.Spec.TLS))
 
 	customize := translation.NewValuesBuilder()
@@ -78,8 +83,12 @@ func translate(c platform.Central) (chartutil.Values, error) {
 	return v.Build()
 }
 
-func getEnv(egress *platform.Egress) *translation.ValuesBuilder {
+func getEnv(c platform.Central) *translation.ValuesBuilder {
 	env := translation.NewValuesBuilder()
+
+	egress := c.Spec.Egress
+	annotations := c.GetAnnotations()
+
 	if egress != nil {
 		if egress.ConnectivityPolicy != nil {
 			switch *egress.ConnectivityPolicy {
@@ -92,6 +101,19 @@ func getEnv(egress *platform.Egress) *translation.ValuesBuilder {
 			}
 		}
 	}
+
+	if annotations != nil {
+		if annotation, ok := annotations[managedServicesAnnotation]; ok {
+			managedServices, err := strconv.ParseBool(annotation)
+			if err != nil {
+				return env.SetError(fmt.Errorf("invalid annotation.%s %q", managedServicesAnnotation, annotation))
+			}
+			if managedServices {
+				env.SetBoolValue("managedServices", true)
+			}
+		}
+	}
+
 	ret := translation.NewValuesBuilder()
 	ret.AddChild("env", &env)
 	return &ret

--- a/operator/pkg/central/values/translation/translation_test.go
+++ b/operator/pkg/central/values/translation/translation_test.go
@@ -465,6 +465,27 @@ func TestTranslate(t *testing.T) {
 				},
 			},
 		},
+
+		"add managed service setting": {
+			args: args{
+				c: platform.Central{
+					ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{managedServicesAnnotation: "true"}},
+				},
+			},
+			want: chartutil.Values{
+				"central": map[string]interface{}{
+					"exposeMonitoring": false,
+					"persistence": map[string]interface{}{
+						"persistentVolumeClaim": map[string]interface{}{
+							"createClaim": false,
+						},
+					},
+				},
+				"env": map[string]interface{}{
+					"managedServices": true,
+				},
+			},
+		},
 	}
 
 	for name, tt := range tests {

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-auth.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-auth.yaml
@@ -31,6 +31,5 @@ tests:
         envVars:
           ROX_MANAGED_CENTRAL: true
   expect: |
-    envVars(.deployments.central; "central")| assertThat(has("ROX_ENABLE_OPENSHIFT_AUTH") == false)
     .serviceaccounts.central.metadata.annotations | ."serviceaccounts.openshift.io/oauth-redirectreference.main" | assertThat(. == null)
     .serviceaccounts.central.metadata.annotations | ."serviceaccounts.openshift.io/oauth-redirecturi.main" | assertThat(. == null)

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-auth.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-auth.yaml
@@ -1,0 +1,36 @@
+defs: |
+  def container(obj; name):
+  obj.spec.template.spec.containers[] | select(.name == name);
+
+  def envVars(obj; container):
+  container(obj; container) | .env | from_entries;
+
+server:
+  availableSchemas:
+  - openshift-4.1.0
+tests:
+- name: OpenShift Auth should be disabled by default
+  expect: |
+    envVars(.deployments.central; "central")| assertThat(has("ROX_ENABLE_OPENSHIFT_AUTH") == false)
+    .serviceaccounts.central.metadata.annotations | ."serviceaccounts.openshift.io/oauth-redirectreference.main" | assertThat(. == null)
+    .serviceaccounts.central.metadata.annotations | ."serviceaccounts.openshift.io/oauth-redirecturi.main" | assertThat(. == null)
+
+- name: OpenShift Auth should be enabled when OpenShift 4 is detected
+  set:
+    env.openshift: 4
+  expect: |
+    envVars(.deployments.central; "central")| assertThat(has("ROX_ENABLE_OPENSHIFT_AUTH") == true)
+    .serviceaccounts.central.metadata.annotations | ."serviceaccounts.openshift.io/oauth-redirectreference.main" | assertThat(. != null)
+    .serviceaccounts.central.metadata.annotations | ."serviceaccounts.openshift.io/oauth-redirecturi.main" | assertThat(. != null)
+
+- name: OpenShift Auth should be disabled when ROX_MANAGED_CENTRAL is set irrespective of OpenShift 4 being set
+  set:
+    env.openshift: 4
+    customize:
+      central:
+        envVars:
+          ROX_MANAGED_CENTRAL: true
+  expect: |
+    envVars(.deployments.central; "central")| assertThat(has("ROX_ENABLE_OPENSHIFT_AUTH") == false)
+    .serviceaccounts.central.metadata.annotations | ."serviceaccounts.openshift.io/oauth-redirectreference.main" | assertThat(. == null)
+    .serviceaccounts.central.metadata.annotations | ."serviceaccounts.openshift.io/oauth-redirecturi.main" | assertThat(. == null)

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-auth.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-auth.yaml
@@ -26,10 +26,7 @@ tests:
 - name: OpenShift Auth should be disabled when ROX_MANAGED_CENTRAL is set irrespective of OpenShift 4 being set
   set:
     env.openshift: 4
-    customize:
-      central:
-        envVars:
-          ROX_MANAGED_CENTRAL: true
+    env.managedServices: true
   expect: |
     .serviceaccounts.central.metadata.annotations | ."serviceaccounts.openshift.io/oauth-redirectreference.main" | assertThat(. == null)
     .serviceaccounts.central.metadata.annotations | ."serviceaccounts.openshift.io/oauth-redirecturi.main" | assertThat(. == null)

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-auth.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-auth.yaml
@@ -23,10 +23,11 @@ tests:
     .serviceaccounts.central.metadata.annotations | ."serviceaccounts.openshift.io/oauth-redirectreference.main" | assertThat(. != null)
     .serviceaccounts.central.metadata.annotations | ."serviceaccounts.openshift.io/oauth-redirecturi.main" | assertThat(. != null)
 
-- name: OpenShift Auth should be disabled when ROX_MANAGED_CENTRAL is set irrespective of OpenShift 4 being set
+- name: OpenShift Auth should be disabled when env.managedServices is set irrespective of OpenShift 4 being set
   set:
     env.openshift: 4
     env.managedServices: true
   expect: |
+    envVars(.deployments.central; "central")| assertThat(has("ROX_ENABLE_OPENSHIFT_AUTH") == false)
     .serviceaccounts.central.metadata.annotations | ."serviceaccounts.openshift.io/oauth-redirectreference.main" | assertThat(. == null)
     .serviceaccounts.central.metadata.annotations | ."serviceaccounts.openshift.io/oauth-redirecturi.main" | assertThat(. == null)


### PR DESCRIPTION
## Description

Within the managed service context, the instances will run on a OpenShift Dedicated Cluster (OSD). This cluster will be, as the name suggests, use Openshift.
Specifically, OpenShift > 4.X.

Since the operator is auto-sensing during installation and setting the variable `env.openshift=4`, this means the OpenShift Auth provider is enabled.

This means that customers actually have the possibility to create an OpenShift Auth provider using the cluster their instance is hosted upon.
We definitely do not want to give this possibility to the customer and disclose such information.

We already have the environment variable `ROX_MANAGED_CENTRAL` highlighting whether we are running in "managed central" mode. 

Within the helm chart, a new setting `env.managedServices` has been added. If this variable is set, the Openshift auth provider will not be enabled (irrespective of whether the `env.openshift` variable is set).
The operator will inject this variable if the annotation `platform.stackrox.io/managed-services` is set to true.

What's left to do is to adjust the central creation in fleetshard synchronize to include this annotation, making sure the Openshift auth provider is disabled and `ROX_MANAGED_CENTRAL` is set.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI, added unit tests for the Helm chart itself.
- manual test:
  - create a central CR with annotation.
  - verify ROX_MANAGED_CENTRAL is set and Openshift auth provider is disabled.


