### PR TITLE
Dashrews/ROX-11730 add Rocks to Postgres upgrade and rollback tests

### DIFF
--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -49,6 +49,22 @@ class UpgradeTest(BaseTest):
             post_start_hook=set_dirs_after_start,
         )
 
+class PostgresUpgradeTest(BaseTest):
+    TEST_TIMEOUT = 60 * 60
+    TEST_OUTPUT_DIR = "/tmp/postgres-upgrade-test-logs"
+
+    def run(self):
+        print("Executing the Postgres Upgrade Test")
+
+        def set_dirs_after_start():
+            # let post test know where logs are
+            self.test_outputs = [PostgresUpgradeTest.TEST_OUTPUT_DIR]
+
+        self.run_with_graceful_kill(
+            ["tests/upgrade/postgres_run.sh", PostgresUpgradeTest.TEST_OUTPUT_DIR],
+            PostgresUpgradeTest.TEST_TIMEOUT,
+            post_start_hook=set_dirs_after_start,
+        )
 
 class OperatorE2eTest(BaseTest):
     # TODO(ROX-12348): adjust these timeouts once we know average run times

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -25,7 +25,7 @@ ci_export CI_JOB_NAME "$ci_job"
 gate_job "$ci_job"
 
 case "$ci_job" in
-    gke*qa-e2e-tests|gke-nongroovy-e2e-tests|gke-upgrade-tests|gke-ui-e2e-tests|\
+    gke*qa-e2e-tests|gke-nongroovy-e2e-tests|gke*upgrade-tests|gke-ui-e2e-tests|\
     eks-qa-e2e-tests|osd*qa-e2e-tests)
         openshift_ci_e2e_mods
         ;;

--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -19,6 +19,16 @@ class UpgradesTest extends BaseSpecification {
     private final static String POLICIES_JSON_PATH =
             Env.get("POLICIES_JSON_RELATIVE_PATH", "../pkg/defaults/policies/files")
 
+    private static final String VULNERABILITY_RESOURCE_TYPE =
+        isPostgresRun() ?
+            "nodeVulnerabilities" :
+            "vulnerabilities"
+
+    private static final String COMPONENT_RESOURCE_TYPE =
+        isPostgresRun() ?
+            "nodeComponents" :
+            "components"
+
     private static final COMPLIANCE_QUERY = """query getAggregatedResults(
         \$groupBy: [ComplianceAggregation_Scope!],
         \$unit: ComplianceAggregation_Scope!,
@@ -89,8 +99,8 @@ class UpgradesTest extends BaseSpecification {
         "secrets"         | "Cluster ID:${CLUSTERID}" | 1
         "deployments"     | "Cluster ID:${CLUSTERID}" | 1
         "images"          | "Cluster ID:${CLUSTERID}" | 1
-        "components"      | "Cluster ID:${CLUSTERID}" | 1
-        "vulnerabilities" | "Cluster ID:${CLUSTERID}" | 1
+        COMPONENT_RESOURCE_TYPE      | "Cluster ID:${CLUSTERID}" | 1
+        VULNERABILITY_RESOURCE_TYPE | "Cluster ID:${CLUSTERID}" | 1
     }
 
     static getQuery(resourceType) {

--- a/scripts/ci/jobs/gke-postgres-upgrade-tests.sh
+++ b/scripts/ci/jobs/gke-postgres-upgrade-tests.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/bash
-
-echo "A stub for a yet to be implemented test"

--- a/scripts/ci/jobs/gke_postgres_upgrade_tests.py
+++ b/scripts/ci/jobs/gke_postgres_upgrade_tests.py
@@ -10,9 +10,6 @@ from pre_tests import PreSystemTests
 from ci_tests import PostgresUpgradeTest
 from post_tests import PostClusterTest, FinalPost
 
-# Start with Postgres off so we can begin with RocksDB and upgrade to Postgres
-os.environ["ROX_POSTGRES_DATASTORE"] = "false"
-
 ClusterTestRunner(
     cluster=GKECluster("upgrade-test"),
     pre_test=PreSystemTests(),

--- a/scripts/ci/jobs/gke_postgres_upgrade_tests.py
+++ b/scripts/ci/jobs/gke_postgres_upgrade_tests.py
@@ -10,6 +10,9 @@ from pre_tests import PreSystemTests
 from ci_tests import PostgresUpgradeTest
 from post_tests import PostClusterTest, FinalPost
 
+# Start with Postgres off so we can begin with RocksDB and upgrade to Postgres
+os.environ["ROX_POSTGRES_DATASTORE"] = "false"
+
 ClusterTestRunner(
     cluster=GKECluster("upgrade-test"),
     pre_test=PreSystemTests(),

--- a/scripts/ci/jobs/gke_postgres_upgrade_tests.py
+++ b/scripts/ci/jobs/gke_postgres_upgrade_tests.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run the upgrade test in a GKE cluster
+"""
+import os
+from runners import ClusterTestRunner
+from clusters import GKECluster
+from pre_tests import PreSystemTests
+from ci_tests import PostgresUpgradeTest
+from post_tests import PostClusterTest, FinalPost
+
+ClusterTestRunner(
+    cluster=GKECluster("upgrade-test"),
+    pre_test=PreSystemTests(),
+    test=PostgresUpgradeTest(),
+    post_test=PostClusterTest(),
+    final_post=FinalPost(
+        store_qa_test_debug_logs=True,
+        store_qa_spock_results=True,
+    ),
+).run()

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -100,6 +100,16 @@ test_gt_non_silent() {
   fi
 }
 
+test_empty_non_silent() {
+  if [[ "$#" -lt 1 ]]; then
+    die "usage: test_empty_non_silent <arg1>"
+  fi
+
+  if [[ -n "$1" ]]; then
+    die "Comparison failed: \"$1\" is not empty"
+  fi
+}
+
 require_environment() {
     if [[ "$#" -lt 1 ]]; then
         die "usage: require_environment NAME [reason]"

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -62,7 +62,7 @@ validate_upgrade() {
 
     if [[ -n "${API_TOKEN:-}" ]]; then
         info "Verifying API token generated can access the central"
-        echo "$API_TOKEN" | "$TEST_ROOT/bin/$TEST_HOST_OS/roxctl" --insecure-skip-tls-verify --insecure -e "$API_ENDPOINT" --token-file /dev/stdin central whoami > /dev/null
+        echo "${API_TOKEN}" | "${TEST_ROOT}/bin/${TEST_HOST_PLATFORM}/roxctl" --insecure-skip-tls-verify --insecure -e "${API_ENDPOINT}" --token-file /dev/stdin central whoami > /dev/null
     fi
 
     info "Validating the upgrade with upgrade tests: $stage_description"
@@ -79,4 +79,53 @@ function roxcurl() {
   local url="$1"
   shift
   curl -u "admin:${ROX_PASSWORD}" -k "https://${API_ENDPOINT}${url}" "$@"
+}
+
+deploy_earlier_central() {
+    info "Deploying: $EARLIER_TAG..."
+
+    mkdir -p "bin/$TEST_HOST_PLATFORM"
+    if is_CI; then
+        gsutil cp "gs://stackrox-ci/roxctl-$EARLIER_TAG" "bin/$TEST_HOST_PLATFORM/roxctl"
+    else
+        make cli
+    fi
+    chmod +x "bin/$TEST_HOST_PLATFORM/roxctl"
+    PATH="bin/$TEST_HOST_PLATFORM:$PATH" command -v roxctl
+    PATH="bin/$TEST_HOST_PLATFORM:$PATH" roxctl version
+    PATH="bin/$TEST_HOST_PLATFORM:$PATH" \
+    MAIN_IMAGE_TAG="$EARLIER_TAG" \
+    SCANNER_IMAGE="$REGISTRY/scanner:$(cat SCANNER_VERSION)" \
+    SCANNER_DB_IMAGE="$REGISTRY/scanner-db:$(cat SCANNER_VERSION)" \
+    ./deploy/k8s/central.sh
+
+    get_central_basic_auth_creds
+}
+
+restore_backup_test() {
+    info "Restoring a 56.1 backup into a newer central"
+
+    restore_56_1_backup
+}
+
+force_rollback() {
+    info "Forcing a rollback to $FORCE_ROLLBACK_VERSION"
+
+    local upgradeStatus
+    upgradeStatus=$(curl -sSk -X GET -u "admin:${ROX_PASSWORD}" https://"${API_ENDPOINT}"/v1/centralhealth/upgradestatus)
+    echo "upgrade status: ${upgradeStatus}"
+    test_equals_non_silent "$(echo "$upgradeStatus" | jq '.upgradeStatus.version' -r)" "$(make --quiet tag)"
+    test_equals_non_silent "$(echo "$upgradeStatus" | jq '.upgradeStatus.forceRollbackTo' -r)" "$FORCE_ROLLBACK_VERSION"
+    test_equals_non_silent "$(echo "$upgradeStatus" | jq '.upgradeStatus.canRollbackAfterUpgrade' -r)" "true"
+    test_gt_non_silent "$(echo "$upgradeStatus" | jq '.upgradeStatus.spaceAvailableForRollbackAfterUpgrade' -r)" "$(echo "$upgradeStatus" | jq '.upgradeStatus.spaceRequiredForRollbackAfterUpgrade' -r)"
+
+    kubectl -n stackrox get configmap/central-config -o yaml | yq e '{"data": .data}' - >/tmp/force_rollback_patch
+    local central_config
+    central_config=$(yq e '.data["central-config.yaml"]' /tmp/force_rollback_patch | yq e ".maintenance.forceRollbackVersion = \"$FORCE_ROLLBACK_VERSION\"" -)
+    local config_patch
+    config_patch=$(yq e ".data[\"central-config.yaml\"] |= \"$central_config\"" /tmp/force_rollback_patch)
+    echo "config patch: $config_patch"
+
+    kubectl -n stackrox patch configmap/central-config -p "$config_patch"
+    kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:$FORCE_ROLLBACK_VERSION"
 }

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -18,6 +18,10 @@ source "$TEST_ROOT/tests/upgrade/validation.sh"
 test_upgrade() {
     info "Starting Rocks to Postgres upgrade test"
 
+    # Need to push the flag to ci so that is where it needs to be for the part
+    # of the test.  We start this test with RocksDB
+    ci_export ROX_POSTGRES_DATASTORE "false"
+
     if [[ "$#" -ne 1 ]]; then
         die "missing args. usage: test_upgrade <log-output-dir>"
     fi

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -13,9 +13,10 @@ source "$TEST_ROOT/scripts/ci/sensor-wait.sh"
 source "$TEST_ROOT/tests/scripts/setup-certs.sh"
 source "$TEST_ROOT/tests/e2e/lib.sh"
 source "$TEST_ROOT/tests/upgrade/lib.sh"
+source "$TEST_ROOT/tests/upgrade/validation.sh"
 
 test_upgrade() {
-    info "Starting Postgres upgrade test"
+    info "Starting Rocks to Postgres upgrade test"
 
     if [[ "$#" -ne 1 ]]; then
         die "missing args. usage: test_upgrade <log-output-dir>"
@@ -36,8 +37,8 @@ test_upgrade() {
     export STORAGE="pvc"
     export CLUSTER_TYPE_FOR_TEST=K8S
 
-    export ROXCTL_IMAGE_REPO="quay.io/$QUAY_REPO/roxctl"
     if is_CI; then
+        export ROXCTL_IMAGE_REPO="quay.io/$QUAY_REPO/roxctl"
         require_environment "LONGTERM_LICENSE"
         export ROX_LICENSE_KEY="${LONGTERM_LICENSE}"
     fi
@@ -45,21 +46,32 @@ test_upgrade() {
     preamble
     setup_deployment_env false false
     remove_existing_stackrox_resources
+
     test_upgrade_paths "$log_output_dir"
 }
 
 preamble() {
     info "Starting test preamble"
 
+    local host_os
     if is_darwin; then
-        TEST_HOST_OS="darwin"
+        host_os="darwin"
     elif is_linux; then
-        TEST_HOST_OS="linux"
+        host_os="linux"
     else
         die "Only linux or darwin are supported for this test"
     fi
 
-    require_executable "$TEST_ROOT/bin/$TEST_HOST_OS/roxctl"
+    case "$(uname -m)" in
+        x86_64) TEST_HOST_PLATFORM="${host_os}_amd64" ;;
+        aarch64) TEST_HOST_PLATFORM="${host_os}_arm64" ;;
+        arm64) TEST_HOST_PLATFORM="${host_os}_arm64" ;;
+        ppc64le) TEST_HOST_PLATFORM="${host_os}_ppc64le" ;;
+        s390x) TEST_HOST_PLATFORM="${host_os}_s390x" ;;
+        *) die "Unknown architecture" ;;
+    esac
+
+    require_executable "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/roxctl"
 
     info "Will clone or update a clean copy of the rox repo for test at $REPO_FOR_TIME_TRAVEL"
     if [[ -d "$REPO_FOR_TIME_TRAVEL" ]]; then
@@ -99,30 +111,81 @@ test_upgrade_paths() {
 
     deploy_earlier_central
     wait_for_api
+    setup_client_TLS_certs
+    restore_backup_test
+    wait_for_api
+
+    # Add some access scopes and see that they survive the upgrade and rollback process
+    createRocksDBScopes
+    checkForRocksAccessScopes
 
     export API_TOKEN="$(roxcurl /v1/apitokens/generate -d '{"name": "helm-upgrade-test", "role": "Admin"}' | jq -r '.token')"
 
     cd "$TEST_ROOT"
+
     helm_upgrade_to_current_with_postgres
     wait_for_api
-
-    info "Waiting for scanner to be ready"
     wait_for_scanner_to_be_ready
 
+    # Upgraded to Postgres via helm.  Validate the upgrade.
     validate_upgrade "00_upgrade" "central upgrade to postgres" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
 
+    # Ensure the access scopes added to rocks still exist after the upgrade
+    checkForRocksAccessScopes
+
     collect_and_check_stackrox_logs "$log_output_dir" "00_initial_check"
+
+    # Add some Postgres Access Scopes.  These should not survive a rollback.
+    createPostgresScopes
+    checkForPostgresAccessScopes
+
+    force_rollback
+    wait_for_api
+    wait_for_scanner_to_be_ready
+
+    # We have rolled back, make sure access scopes added to Rocks still exist
+    checkForRocksAccessScopes
+    # The scopes added after the initial upgrade to Postgres should no longer exist.
+    verifyNoPostgresAccessScopes
+
+    # Now go back up to Postgres
+    kubectl -n stackrox set env deploy/central ROX_POSTGRES_DATASTORE=true
+    kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:$(make --quiet tag)"
+    wait_for_api
+    wait_for_scanner_to_be_ready
+
+    # Ensure we still have the access scopes added to Rocks
+    checkForRocksAccessScopes
+    # The scopes added after the initial upgrade to Postgres should no longer exist.
+    verifyNoPostgresAccessScopes
+
+    # Add the Postgres access scopes back in
+    createPostgresScopes
 
     info "Bouncing central"
     kubectl -n stackrox delete po "$(kubectl -n stackrox get po -l app=central -o=jsonpath='{.items[0].metadata.name}')" --grace-period=0
     wait_for_api
 
+    checkForRocksAccessScopes
+    checkForPostgresAccessScopes
+
     validate_upgrade "01-bounce-after-upgrade" "bounce after postgres upgrade" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
     collect_and_check_stackrox_logs "$log_output_dir" "01_post_bounce"
 
+# TODO ROX-12999 Add in case for restarting central-db
+#    info "Bouncing central-db"
+#    kubectl -n stackrox delete po "$(kubectl -n stackrox get po -l app=central-db -o=jsonpath='{.items[0].metadata.name}')" --grace-period=0
+#    wait_for_api
+#
+#    checkForRocksAccessScopes
+#    checkForPostgresAccessScopes
+#
+#    validate_upgrade "01-bounce-db-after-upgrade" "bounce central db after postgres upgrade" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
+#    collect_and_check_stackrox_logs "$log_output_dir" "01_post_bounce-db"
+
     info "Fetching a sensor bundle for cluster 'remote'"
     rm -rf sensor-remote
-    "$TEST_ROOT/bin/$TEST_HOST_OS/roxctl" -e "$API_ENDPOINT" -p "$ROX_PASSWORD" sensor get-bundle remote
+    "$TEST_ROOT/bin/$TEST_HOST_PLATFORM/roxctl" -e "$API_ENDPOINT" -p "$ROX_PASSWORD" sensor get-bundle remote
     [[ -d sensor-remote ]]
 
     info "Installing sensor"
@@ -144,33 +207,15 @@ test_upgrade_paths() {
     collect_and_check_stackrox_logs "$log_output_dir" "03_final"
 }
 
-# Need to move some of the functions to a lib if no change of course
-deploy_earlier_central() {
-    info "Deploying: $EARLIER_TAG..."
-
-    mkdir -p "bin/$TEST_HOST_OS"
-    if is_CI; then
-        gsutil cp "gs://stackrox-ci/roxctl-$EARLIER_TAG" "bin/$TEST_HOST_OS/roxctl"
-    else
-        make cli
-    fi
-    chmod +x "bin/$TEST_HOST_OS/roxctl"
-    PATH="bin/$TEST_HOST_OS:$PATH" command -v roxctl
-    PATH="bin/$TEST_HOST_OS:$PATH" roxctl version
-    PATH="bin/$TEST_HOST_OS:$PATH" \
-    MAIN_IMAGE_TAG="$EARLIER_TAG" \
-    SCANNER_IMAGE="$REGISTRY/scanner:$(cat SCANNER_VERSION)" \
-    SCANNER_DB_IMAGE="$REGISTRY/scanner-db:$(cat SCANNER_VERSION)" \
-    ./deploy/k8s/central.sh
-
-    get_central_basic_auth_creds
-}
-
 helm_upgrade_to_current_with_postgres() {
     info "Helm upgrade to current"
 
     # use postgres
     export ROX_POSTGRES_DATASTORE="true"
+    # Need to push the flag to ci so that the collect scripts pull from
+    # Postgres and not Rocks
+    ci_export ROX_POSTGRES_DATASTORE "true"
+    export CLUSTER="remote"
 
     # Get opensource charts and convert to development_build to support release builds
     if is_CI; then
@@ -187,11 +232,8 @@ helm_upgrade_to_current_with_postgres() {
     kubectl -n stackrox create secret generic central-db-password --from-literal=password=$password
     kubectl -n stackrox apply -f $TEST_ROOT/tests/upgrade/pvc.yaml
     create_db_tls_secret
-    kubectl -n stackrox set env deploy/central ROX_POSTGRES_DATASTORE=true
 
-    helm upgrade -n stackrox stackrox-central-services /tmp/stackrox-central-services-chart --set central.db.enabled=true
-
-    kubectl -n stackrox get deploy -o wide
+    helm upgrade -n stackrox stackrox-central-services /tmp/stackrox-central-services-chart --set central.db.enabled=true --set central.exposure.loadBalancer.enabled=true --force
 }
 
 create_db_tls_secret() {
@@ -199,8 +241,8 @@ create_db_tls_secret() {
 
     cert_dir="$(mktemp -d)"
     # get root ca
-    kubectl -n stackrox exec -it deployment/central -- cat /run/secrets/stackrox.io/certs/ca.pem > $cert_dir/ca.pem
-    kubectl -n stackrox exec -it deployment/central -- cat /run/secrets/stackrox.io/certs/ca-key.pem > $cert_dir/ca.key
+    kubectl -n stackrox exec -i deployment/central -- cat /run/secrets/stackrox.io/certs/ca.pem > $cert_dir/ca.pem
+    kubectl -n stackrox exec -i deployment/central -- cat /run/secrets/stackrox.io/certs/ca-key.pem > $cert_dir/ca.key
     # generate central-db certs
     openssl genrsa -out $cert_dir/key.pem 4096
     openssl req -new -key $cert_dir/key.pem -subj "/CN=CENTRAL_DB_SERVICE: Central DB" > $cert_dir/newreq

--- a/tests/upgrade/validation.sh
+++ b/tests/upgrade/validation.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+
+set -euo pipefail
+
+# Test validation functions for upgrades
+
+createRocksDBScopes() {
+    local scopes=(
+    '{"id":"","name":"RocksScope1","description":"Testing access scope","rules":{"includedClusters":["remote"],"includedNamespaces":[{"clusterName":"remote","namespaceName":"kube-public"},{"clusterName":"remote","namespaceName":"default"}],"clusterLabelSelectors":[],"namespaceLabelSelectors":[]}}'
+    '{"id":"","name":"RocksScope2","description":"Testing access scope","rules":{"includedClusters":["remote"],"includedNamespaces":[{"clusterName":"remote","namespaceName":"kube-public"},{"clusterName":"remote","namespaceName":"default"}],"clusterLabelSelectors":[],"namespaceLabelSelectors":[]}}'
+    '{"id":"","name":"RocksScope3","description":"Testing access scope","rules":{"includedClusters":["remote"],"includedNamespaces":[{"clusterName":"remote","namespaceName":"kube-public"},{"clusterName":"remote","namespaceName":"default"}],"clusterLabelSelectors":[],"namespaceLabelSelectors":[]}}'
+    )
+
+    for scopeJSON in "${scopes[@]}"
+    do
+      tmpOutput=$(mktemp)
+      status=$(curl -k -u "admin:${ROX_PASSWORD}" -X POST \
+        -d "${scopeJSON}" \
+        -o "${tmpOutput}" \
+        -w "%{http_code}\n" \
+        https://"${API_ENDPOINT}"/v1/simpleaccessscopes )
+
+      if [ "${status}" != "200" ] && [ "${status}" != "429" ] && [ "${status}" != "409" ]; then
+        cat "$tmpOutput"
+        exit 1
+      fi
+    done
+}
+
+checkForRocksAccessScopes() {
+    info "checkForRocksAccessScopes"
+    local accessScopes
+    accessScopes=$(curl -sSk -X GET -u "admin:${ROX_PASSWORD}" https://"${API_ENDPOINT}"/v1/simpleaccessscopes)
+    echo "access scopes: ${accessScopes}"
+    test_equals_non_silent "$(echo "$accessScopes" | jq '.accessScopes[] | select(.name == "RocksScope1") | .name' -r)" "RocksScope1"
+    test_equals_non_silent "$(echo "$accessScopes" | jq '.accessScopes[] | select(.name == "RocksScope2") | .name' -r)" "RocksScope2"
+}
+
+createPostgresScopes() {
+    local scopes=(
+    '{"id":"","name":"PostgresScope1","description":"Testing access scope","rules":{"includedClusters":["remote"],"includedNamespaces":[{"clusterName":"remote","namespaceName":"kube-public"},{"clusterName":"remote","namespaceName":"default"}],"clusterLabelSelectors":[],"namespaceLabelSelectors":[]}}'
+    '{"id":"","name":"PostgresScope2","description":"Testing access scope","rules":{"includedClusters":["remote"],"includedNamespaces":[{"clusterName":"remote","namespaceName":"kube-public"},{"clusterName":"remote","namespaceName":"default"}],"clusterLabelSelectors":[],"namespaceLabelSelectors":[]}}'
+    '{"id":"","name":"PostgresScope3","description":"Testing access scope","rules":{"includedClusters":["remote"],"includedNamespaces":[{"clusterName":"remote","namespaceName":"kube-public"},{"clusterName":"remote","namespaceName":"default"}],"clusterLabelSelectors":[],"namespaceLabelSelectors":[]}}'
+        )
+
+        for scopeJSON in "${scopes[@]}"
+        do
+          tmpOutput=$(mktemp)
+          status=$(curl -k -u "admin:${ROX_PASSWORD}" -X POST \
+            -d "${scopeJSON}" \
+            -o "$tmpOutput" \
+            -w "%{http_code}\n" \
+            https://"${API_ENDPOINT}"/v1/simpleaccessscopes )
+
+          if [ "${status}" != "200" ] && [ "${status}" != "429" ] && [ "${status}" != "409" ]; then
+            cat "$tmpOutput"
+            exit 1
+          fi
+        done
+}
+
+checkForPostgresAccessScopes() {
+    info "checkForPostgresAccessScopes"
+    local accessScopes
+    accessScopes=$(curl -sSk -X GET -u "admin:${ROX_PASSWORD}" https://"${API_ENDPOINT}"/v1/simpleaccessscopes)
+    echo "access scopes: ${accessScopes}"
+    test_equals_non_silent "$(echo "$accessScopes" | jq '.accessScopes[] | select(.name == "PostgresScope1") | .name' -r)" "PostgresScope1"
+    test_equals_non_silent "$(echo "$accessScopes" | jq '.accessScopes[] | select(.name == "PostgresScope2") | .name' -r)" "PostgresScope2"
+}
+
+verifyNoPostgresAccessScopes() {
+    info "verifyNoPostgresAccessScopes"
+    local accessScopes
+    accessScopes=$(curl -sSk -X GET -u "admin:${ROX_PASSWORD}" https://"${API_ENDPOINT}"/v1/simpleaccessscopes)
+    echo "access scopes: ${accessScopes}"
+    test_empty_non_silent "$(echo "$accessScopes" | jq '.accessScopes[] | select(.name == "PostgresScope1") | .name' -r)"
+    test_empty_non_silent "$(echo "$accessScopes" | jq '.accessScopes[] | select(.name == "PostgresScope2") | .name' -r)"
+}


### PR DESCRIPTION
## Description

Created a version of the upgrade tests that will start with Rocks DB.  It will then do an upgrade to Postgres.  Then it goes back to Rocks before finally going back to Postgres for good.  Along the way I inserted some objects and checks to make sure they exist or don't exist depending on if we upgraded or rolled back.

For instance, Initially I add some access scopes to the Rocks version.  When I upgrade to Postgres, I ensure that those access scopes were migrated over.  Similarly after I upgrade to Postgres I create some additional access scopes.  When the rollback from Postgres to Rocks occurs, a check is made to ensure that those access scopes add after the move to Postgres are no longer there BUT that the ones added initially to Rocks are still present.

Along the way there are various executions of the groovy Upgrades tests and at the end the smoke tests are executed to ensure that everything is functional.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

This is the test.
