### PR TITLE
CI: update submodules

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1040,6 +1040,7 @@ openshift_ci_mods() {
         if [[ -n "${sha:-}" ]] && [[ "$sha" != "null" ]]; then
             info "Will checkout SHA to match PR: $sha"
             git checkout "$sha"
+            git submodule update
         else
             echo "WARNING: Could not determine a SHA for this PR, ${sha:-}"
         fi


### PR DESCRIPTION
## Description

When we switch to the SHA of the PR for test, we should probably also update the submodules, which will hopefully resolve failures like: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/2991/pull-ci-stackrox-stackrox-master-grouped-static-checks/1568213389635751936

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient