### PR TITLE
ROX-10986-ROX-11033: Prevent checkbox crashes on Image Overview CVEs tables

### DIFF
--- a/ui/apps/platform/src/hooks/useTableSelection.ts
+++ b/ui/apps/platform/src/hooks/useTableSelection.ts
@@ -55,7 +55,7 @@ function useTableSelection<T extends Base>(
     function getSelectedIds() {
         const ids: string[] = [];
         for (let i = 0; i < selected.length; i += 1) {
-            if (selected[i]) {
+            if (selected[i] && data[i]?.id) {
                 ids.push(data[i].id);
             }
         }


### PR DESCRIPTION
## Description

* Considered refactoring useTableSelection hook, and its usage, but rejected as too risky at this time.
* Created [draft brute-force fix](https://github.com/stackrox/stackrox/pull/2938) of clearing selections before every action that changed the tables in question
* This PR's simpler solution: check and short-circuit where crash occurred before during component update cycle (suggested by @dvail in [comment to draft PR](https://github.com/stackrox/stackrox/pull/2938#pullrequestreview-1099250127))


## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Existing crash when changing view of table (paging, filtering) after selecting one or more checkboxes.
<img width="1552" alt="Screen Shot 2022-09-09 at 3 12 20 PM" src="https://user-images.githubusercontent.com/715729/189429179-a50adca3-6fb6-42ca-9863-d4a951275bac.png">


After this code change,
select one or more checkboxes
<img width="1552" alt="Screen Shot 2022-09-09 at 3 12 43 PM" src="https://user-images.githubusercontent.com/715729/189429381-24e4b9d1-e5a2-4f71-b7ca-4d0bb5fdd35a.png">

then page or filter--and page behaves as expected (does not crash)
<img width="1552" alt="Screen Shot 2022-09-09 at 3 12 48 PM" src="https://user-images.githubusercontent.com/715729/189429411-0529ad97-7aec-4ba4-81b1-0bf253e3b62e.png">
