### PR TITLE
ROX-12375: Disable sort on Images count until after Postgres launch

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtEntityNodeComponent.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtEntityNodeComponent.js
@@ -18,7 +18,7 @@ import {
 export const nodeComponentCountKeyMap = {
     ...defaultCountKeyMap,
     [entityTypes.CVE]: 'vulnCount: nodeVulnerabilityCount',
-    [entityTypes.NODE_CVE]: 'vulnCount: nodeVulnerabilityCount',
+    [entityTypes.NODE_CVE]: 'nodeVulnerabilityCount',
 };
 
 const VulnMgmtEntityNodeComponent = ({

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Components/ListComponents.utils.test.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Components/ListComponents.utils.test.js
@@ -150,7 +150,9 @@ function getComponentTableColumns(workflowState) {
             className: `w-1/8`,
             accessor: 'imageCount',
             Cell: ({ original }) => original.imageCount,
-            sortField: componentSortFields.IMAGES,
+            // TODO: restore sorting on this field, see https://issues.redhat.com/browse/ROX-12548 for context
+            // sortField: componentSortFields.IMAGES,
+            sortable: false,
         },
         {
             Header: `Deployments`,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Components/VulnMgmtListComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Components/VulnMgmtListComponents.js
@@ -157,7 +157,7 @@ export function getComponentTableColumns(workflowState) {
         {
             Header: `Images`,
             entityType: entityTypes.IMAGE,
-            headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+            headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
             id: componentSortFields.IMAGE_COUNT,
             accessor: 'imageCount',
@@ -169,7 +169,9 @@ export function getComponentTableColumns(workflowState) {
                     selectedRowId={original.id}
                 />
             ),
-            sortField: componentSortFields.IMAGE_COUNT,
+            // TODO: restore sorting on this field, see https://issues.redhat.com/browse/ROX-12548 for context
+            // sortField: componentSortFields.IMAGES,
+            sortable: false,
         },
         {
             Header: `Deployments`,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Deployments/VulnMgmtListDeployments.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Deployments/VulnMgmtListDeployments.js
@@ -229,7 +229,7 @@ export function getCurriedDeploymentTableColumns(isFeatureFlagEnabled) {
             },
             {
                 Header: `Images`,
-                headerClassName: `w-1/10 ${defaultHeaderClassName}`,
+                headerClassName: `w-1/10 ${nonSortableHeaderClassName}`,
                 className: `w-1/10 ${defaultColumnClassName}`,
                 Cell: ({ original, pdf }) => (
                     <TableCountLink
@@ -241,7 +241,9 @@ export function getCurriedDeploymentTableColumns(isFeatureFlagEnabled) {
                 ),
                 id: deploymentSortFields.IMAGE_COUNT,
                 accessor: 'imageCount',
-                sortField: deploymentSortFields.IMAGE_COUNT,
+                // TODO: restore sorting on this field, see https://issues.redhat.com/browse/ROX-12548 for context
+                // sortField: componentSortFields.IMAGES,
+                sortable: false,
             },
             {
                 Header: `Risk Priority`,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/ListImageComponents.utils.test.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/ListImageComponents.utils.test.js
@@ -150,7 +150,9 @@ function getComponentTableColumns(workflowState) {
             className: `w-1/8`,
             accessor: 'imageCount',
             Cell: ({ original }) => original.imageCount,
-            sortField: componentSortFields.IMAGES,
+            // TODO: restore sorting on this field, see https://issues.redhat.com/browse/ROX-12548 for context
+            // sortField: componentSortFields.IMAGES,
+            sortable: false,
         },
         {
             Header: `Deployments`,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.js
@@ -170,7 +170,7 @@ export function getComponentTableColumns(showVMUpdates) {
             {
                 Header: `Images`,
                 entityType: entityTypes.IMAGE,
-                headerClassName: `w-1/8 ${defaultHeaderClassName}`,
+                headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
                 className: `w-1/8 ${defaultColumnClassName}`,
                 id: componentSortFields.IMAGE_COUNT,
                 accessor: 'imageCount',
@@ -182,7 +182,9 @@ export function getComponentTableColumns(showVMUpdates) {
                         selectedRowId={original.id}
                     />
                 ),
-                sortField: componentSortFields.IMAGE_COUNT,
+                // TODO: restore sorting on this field, see https://issues.redhat.com/browse/ROX-12548 for context
+                // sortField: componentSortFields.IMAGES,
+                sortable: false,
             },
             {
                 Header: `Deployments`,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Namespaces/VulnMgmtListNamespaces.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Namespaces/VulnMgmtListNamespaces.js
@@ -171,7 +171,8 @@ const VulnMgmtNamespaces = ({ selectedRowId, search, sort, page, data, totalResu
                 ),
                 id: namespaceSortFields.IMAGES,
                 accessor: 'imageCount',
-                sortField: namespaceSortFields.IMAGES,
+                // TODO: restore sorting on this field, see https://issues.redhat.com/browse/ROX-12548 for context
+                // sortField: componentSortFields.IMAGES,
                 sortable: false,
             },
             // @TODD, restore the Policy Counts column once its performance is improved,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/ListNodeComponents.utils.test.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/ListNodeComponents.utils.test.js
@@ -150,7 +150,9 @@ function getComponentTableColumns(workflowState) {
             className: `w-1/8`,
             accessor: 'imageCount',
             Cell: ({ original }) => original.imageCount,
-            sortField: componentSortFields.IMAGES,
+            // TODO: restore sorting on this field, see https://issues.redhat.com/browse/ROX-12548 for context
+            // sortField: componentSortFields.IMAGES,
+            sortable: false,
         },
         {
             Header: `Deployments`,


### PR DESCRIPTION
## Description

Sorting is not working, FE is sending proper pagination

Per comment in related bug ticket, fixing this issue is tricky. In order to de-risk the release of the Postgres, we disabled sort by image count on all pages.


## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Verified that all Image count columns are not clickable to sort
<img width="1817" alt="Screen Shot 2022-09-09 at 4 21 15 PM" src="https://user-images.githubusercontent.com/715729/189446746-005a2e47-3bc1-43a1-badb-936c2a5d07f4.png">
<img width="1817" alt="Screen Shot 2022-09-09 at 4 22 04 PM" src="https://user-images.githubusercontent.com/715729/189446750-94c6c118-d441-4489-98ea-6a2d43aa7e51.png">
<img width="1817" alt="Screen Shot 2022-09-09 at 4 21 41 PM" src="https://user-images.githubusercontent.com/715729/189446753-09794007-5bc8-4a05-ac03-3d0a6e3cdbdc.png">
