### PR TITLE
Replace deprecated api usage

### DIFF
--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -20,7 +20,7 @@ def grpcVersion = '1.21.0'
 def protocVersion = '3.21.4'
 def protobufVersion = '3.21.4'
 def nettyTcNativeVersion = '2.0.45.Final'
-def fabric8Version = '5.12.2'
+def fabric8Version = '6.1.1'
 def jacksonVersion = '2.13.2'
 
 protobuf {

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
@@ -166,7 +166,7 @@ interface OrchestratorMain {
 
     //Misc
     def execInContainer(Deployment deployment, String cmd)
-    def execInContainerByPodName(String name, String namespace, String cmd, int retries)
+    boolean execInContainerByPodName(String name, String namespace, String cmd, int retries)
     String generateYaml(Object orchestratorObject)
     String getNameSpace()
     String getSensorContainerName()


### PR DESCRIPTION
## Description

> TtyExecErrorChannelable methods have been deprecated in favor of ExecWatch.exitCode and ExecListener.onExit.

Bumps `fabric8Version` from 5.12.2 to 6.1.1.
Updates `kubernetes-client` from 5.12.2 to 6.1.1
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/fabric8io/kubernetes-client/releases">kubernetes-client's releases</a>.</em></p>
<blockquote>
<h2>6.1.1 (2022-09-01)</h2>
<h4>Bugs</h4>
<p>fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4373">#4373</a>: NO_PROXY should allow URIs with hyphens (&quot;circleci-internal-outer-build-agent&quot;)</p>
<p><strong>Full Changelog</strong>: <a href="https://github.com/fabric8io/kubernetes-client/compare/v6.1.0...v6.1.1">https://github.com/fabric8io/kubernetes-client/compare/v6.1.0...v6.1.1</a></p>
<h2>6.1.0 (2022-08-31)</h2>
<h4>Bugs</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4109">#4109</a>: Templates with parameters can be retrieved from OpenShift</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4206">#4206</a>: KubernetesDeserializer can now handle any valid object. If the object lacks type information, it will be deserialized as a GenericKubernetesResource</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4247">#4247</a>: NO_PROXY with invalid entries throws exception</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4256">#4256</a>: crd-generator-apt pom.xml includes transitive dependencies</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4294">#4294</a>: crd-generator respects JsonIgnore annotations on enum properties</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4320">#4320</a>: corrected leader transitions field on leader election leases</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4360">#4360</a>: JUnit dependencies aren't leaked in child modules</li>
</ul>
<h4>Improvements</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/887">#887</a>: added KubernetesClient.visitResources to search and perform other operations across all resources.</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/3960">#3960</a>: adding a KubernetesMockServer.expectCustomResource helper method and additional mock crd support</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4041">#4041</a>: adding Quantity.getNumericalAmount with an explanation about bytes and cores.</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4241">#4241</a>: added more context to informer logs with the endpoint path</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4250">#4250</a>: allowing for deserialization of polymorphic unwrapped fields</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4254">#4254</a>: adding debug logging for exec stream messages</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4259">#4259</a>: Java Generator's CR should have Lombok's <code>@EqualsAndHashCode</code> with <code>callSuper = true</code></li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4287">#4287</a>: added WorkloadGroup for Istio v1alpha3 extension generator</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4318">#4318</a>: implemented LeaderElection releaseOnCancel</li>
</ul>
<h4>Dependency Upgrade</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/3967">#3967</a>: Update chaos-mesh extension to v2.1.3. Add PodHttpChaos, GCPChaos, BlockChaos and PhysicalMachineChaos.</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4352">#4352</a>: Update Knative model to v0.34.0</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4356">#4356</a>: Update Apache CamelK to v1.9.2</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4361">#4361</a>: Bump Cert-Manager to v1.9.0-beta.1.0.20220829113803-8465f1223efb</li>
</ul>
<h4>New Features</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/2271">#2271</a>: Support periodic refresh of access tokens before they expire</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4333">#4333</a>: Implement &quot;attach to pod&quot; functionality</li>
</ul>
<h4><em><strong>Note</strong></em>: Breaking changes in the API</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4206">#4206</a>: The Serialization utility class will throw an Exception, instead of returning null, if an untyped unmarshall method is used on something that lacks type information</li>
<li>In ChaosMesh Model, some types have been renamed. These are
<ul>
<li><code>io.fabric8.chaosmesh.v1alpha1.AwsChaos</code> =&gt; <code>io.fabric8.chaosmesh.v1alpha1.AWSChaos</code></li>
<li><code>io.fabric8.chaosmesh.v1alpha1.IoChaos</code> =&gt; <code>io.fabric8.chaosmesh.v1alpha1.IOChaos</code></li>
<li><code>io.fabric8.chaosmesh.v1alpha1.PodIoChaos</code> =&gt; <code>io.fabric8.chaosmesh.v1alpha1.PodIOChaos</code></li>
</ul>
</li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/fabric8io/kubernetes-client/compare/v6.0.0...v6.1.0">https://github.com/fabric8io/kubernetes-client/compare/v6.0.0...v6.1.0</a></p>
<h2>6.0.0 (2022-07-13)</h2>
<h4>Bugs</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/2811">#2811</a>: Approve/Reject CSR not supported in v1beta1 CertificateSigningRequest API</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md">kubernetes-client's changelog</a>.</em></p>
<blockquote>
<h3>6.1.1 (2022-09-01)</h3>
<h4>Bugs</h4>
<p>fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4373">#4373</a>: NO_PROXY should allow URIs with hyphens (&quot;circleci-internal-outer-build-agent&quot;)</p>
<h3>6.1.0 (2022-08-31)</h3>
<h4>Bugs</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4109">#4109</a>: Templates with parameters can be retrieved from OpenShift</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4206">#4206</a>: KubernetesDeserializer can now handle any valid object. If the object lacks type information, it will be deserialized as a GenericKubernetesResource</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4247">#4247</a>: NO_PROXY with invalid entries throws exception</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4256">#4256</a>: crd-generator-apt pom.xml includes transitive dependencies</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4294">#4294</a>: crd-generator respects JsonIgnore annotations on enum properties</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4320">#4320</a>: corrected leader transitions field on leader election leases</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4360">#4360</a>: JUnit dependencies aren't leaked in child modules</li>
</ul>
<h4>Improvements</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/887">#887</a>: added KubernetesClient.visitResources to search and perform other operations across all resources.</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/3960">#3960</a>: adding a KubernetesMockServer.expectCustomResource helper method and additional mock crd support</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4041">#4041</a>: adding Quantity.getNumericalAmount with an explanation about bytes and cores.</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4241">#4241</a>: added more context to informer logs with the endpoint path</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4250">#4250</a>: allowing for deserialization of polymorphic unwrapped fields</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4254">#4254</a>: adding debug logging for exec stream messages</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4259">#4259</a>: Java Generator's CR should have Lombok's <code>@EqualsAndHashCode</code> with <code>callSuper = true</code></li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4287">#4287</a>: added WorkloadGroup for Istio v1alpha3 extension generator</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4318">#4318</a>: implemented LeaderElection releaseOnCancel</li>
</ul>
<h4>Dependency Upgrade</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/3967">#3967</a>: Update chaos-mesh extension to v2.1.3. Add PodHttpChaos, GCPChaos, BlockChaos and PhysicalMachineChaos.</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4352">#4352</a>: Update Knative model to v0.34.0</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4356">#4356</a>: Update Apache CamelK to v1.9.2</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4361">#4361</a>: Bump Cert-Manager to v1.9.0-beta.1.0.20220829113803-8465f1223efb</li>
</ul>
<h4>New Features</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/2271">#2271</a>: Support periodic refresh of access tokens before they expire</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4333">#4333</a>: Implement &quot;attach to pod&quot; functionality</li>
</ul>
<h4><em><strong>Note</strong></em>: Breaking changes in the API</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4206">#4206</a>: The Serialization utility class will throw an Exception, instead of returning null, if an untyped unmarshall method is used on something that lacks type information</li>
<li>In ChaosMesh Model, some types have been renamed. These are
<ul>
<li><code>io.fabric8.chaosmesh.v1alpha1.AwsChaos</code> =&gt; <code>io.fabric8.chaosmesh.v1alpha1.AWSChaos</code></li>
<li><code>io.fabric8.chaosmesh.v1alpha1.IoChaos</code> =&gt; <code>io.fabric8.chaosmesh.v1alpha1.IOChaos</code></li>
<li><code>io.fabric8.chaosmesh.v1alpha1.PodIoChaos</code> =&gt; <code>io.fabric8.chaosmesh.v1alpha1.PodIOChaos</code></li>
</ul>
</li>
</ul>
<h3>5.12.3 (2022-07-27)</h3>
<h4>Bugs</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/3969">#3969</a>: relist will not trigger sync events</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4049">#4049</a>: properly populate exception metadata with resource information if available</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4222">#4222</a>: backport of <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4082">#4082</a> - to not process events until the cache is complete</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/d6e6cc35c689f5dd1920d95a73aa77174a645f43"><code>d6e6cc3</code></a> [RELEASE] Updated project version to v6.1.1</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/04aa2b8f34a1d0902567404dc40b3f12d04cf96f"><code>04aa2b8</code></a> fix: NO_PROXY should allow URIs with hyphens (&quot;circleci-internal-outer-build-...</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/acf6d264885ac415592da3181c8cfc6acd73d034"><code>acf6d26</code></a> [RELEASE] Prepare for next development iteration</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/ff81bd13a59d60aeea953f4e48d8d1ca8217efda"><code>ff81bd1</code></a> [RELEASE] Updated project version to v6.1.0</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/409af93a1b6685f1e933ed8ecabe7583252077cb"><code>409af93</code></a> chore: add missing references to changelog</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/45eb12ab7f52680da253c19a896f369352a19fa3"><code>45eb12a</code></a> test: temporary disable extra fields in Karaf deserializer test</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/1ff665bd343d1029c9c5647c7cc8747903c1707d"><code>1ff665b</code></a> fix (extensions/certmanager) : Update CertManager extension to latest version...</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/f5524268e410560cd44eb86c7bb8ee44327f7c39"><code>f552426</code></a> feat (kubernetes-model-generator) : Add Kubernetes Model Gateway API module</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/5a993d3baffe80733f1f62a271a1386ea5e113be"><code>5a993d3</code></a> test: refactor karaf deserialization tests to ensure GenericKuberentesResourc...</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/aef57f44a2b0670965880583dda6d878fec9effa"><code>aef57f4</code></a> fix: Configure dependency scope for junit dependencies at parent</li>
<li>Additional commits viewable in <a href="https://github.com/fabric8io/kubernetes-client/compare/v5.12.2...v6.1.1">compare view</a></li>
</ul>
</details>
<br />

Updates `openshift-client` from 5.12.2 to 6.1.1
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/fabric8io/kubernetes-client/releases">openshift-client's releases</a>.</em></p>
<blockquote>
<h2>6.1.1 (2022-09-01)</h2>
<h4>Bugs</h4>
<p>fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4373">#4373</a>: NO_PROXY should allow URIs with hyphens (&quot;circleci-internal-outer-build-agent&quot;)</p>
<p><strong>Full Changelog</strong>: <a href="https://github.com/fabric8io/kubernetes-client/compare/v6.1.0...v6.1.1">https://github.com/fabric8io/kubernetes-client/compare/v6.1.0...v6.1.1</a></p>
<h2>6.1.0 (2022-08-31)</h2>
<h4>Bugs</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4109">#4109</a>: Templates with parameters can be retrieved from OpenShift</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4206">#4206</a>: KubernetesDeserializer can now handle any valid object. If the object lacks type information, it will be deserialized as a GenericKubernetesResource</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4247">#4247</a>: NO_PROXY with invalid entries throws exception</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4256">#4256</a>: crd-generator-apt pom.xml includes transitive dependencies</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4294">#4294</a>: crd-generator respects JsonIgnore annotations on enum properties</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4320">#4320</a>: corrected leader transitions field on leader election leases</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4360">#4360</a>: JUnit dependencies aren't leaked in child modules</li>
</ul>
<h4>Improvements</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/887">#887</a>: added KubernetesClient.visitResources to search and perform other operations across all resources.</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/3960">#3960</a>: adding a KubernetesMockServer.expectCustomResource helper method and additional mock crd support</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4041">#4041</a>: adding Quantity.getNumericalAmount with an explanation about bytes and cores.</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4241">#4241</a>: added more context to informer logs with the endpoint path</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4250">#4250</a>: allowing for deserialization of polymorphic unwrapped fields</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4254">#4254</a>: adding debug logging for exec stream messages</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4259">#4259</a>: Java Generator's CR should have Lombok's <code>@EqualsAndHashCode</code> with <code>callSuper = true</code></li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4287">#4287</a>: added WorkloadGroup for Istio v1alpha3 extension generator</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4318">#4318</a>: implemented LeaderElection releaseOnCancel</li>
</ul>
<h4>Dependency Upgrade</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/3967">#3967</a>: Update chaos-mesh extension to v2.1.3. Add PodHttpChaos, GCPChaos, BlockChaos and PhysicalMachineChaos.</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4352">#4352</a>: Update Knative model to v0.34.0</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4356">#4356</a>: Update Apache CamelK to v1.9.2</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4361">#4361</a>: Bump Cert-Manager to v1.9.0-beta.1.0.20220829113803-8465f1223efb</li>
</ul>
<h4>New Features</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/2271">#2271</a>: Support periodic refresh of access tokens before they expire</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4333">#4333</a>: Implement &quot;attach to pod&quot; functionality</li>
</ul>
<h4><em><strong>Note</strong></em>: Breaking changes in the API</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4206">#4206</a>: The Serialization utility class will throw an Exception, instead of returning null, if an untyped unmarshall method is used on something that lacks type information</li>
<li>In ChaosMesh Model, some types have been renamed. These are
<ul>
<li><code>io.fabric8.chaosmesh.v1alpha1.AwsChaos</code> =&gt; <code>io.fabric8.chaosmesh.v1alpha1.AWSChaos</code></li>
<li><code>io.fabric8.chaosmesh.v1alpha1.IoChaos</code> =&gt; <code>io.fabric8.chaosmesh.v1alpha1.IOChaos</code></li>
<li><code>io.fabric8.chaosmesh.v1alpha1.PodIoChaos</code> =&gt; <code>io.fabric8.chaosmesh.v1alpha1.PodIOChaos</code></li>
</ul>
</li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/fabric8io/kubernetes-client/compare/v6.0.0...v6.1.0">https://github.com/fabric8io/kubernetes-client/compare/v6.0.0...v6.1.0</a></p>
<h2>6.0.0 (2022-07-13)</h2>
<h4>Bugs</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/2811">#2811</a>: Approve/Reject CSR not supported in v1beta1 CertificateSigningRequest API</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md">openshift-client's changelog</a>.</em></p>
<blockquote>
<h3>6.1.1 (2022-09-01)</h3>
<h4>Bugs</h4>
<p>fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4373">#4373</a>: NO_PROXY should allow URIs with hyphens (&quot;circleci-internal-outer-build-agent&quot;)</p>
<h3>6.1.0 (2022-08-31)</h3>
<h4>Bugs</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4109">#4109</a>: Templates with parameters can be retrieved from OpenShift</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4206">#4206</a>: KubernetesDeserializer can now handle any valid object. If the object lacks type information, it will be deserialized as a GenericKubernetesResource</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4247">#4247</a>: NO_PROXY with invalid entries throws exception</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4256">#4256</a>: crd-generator-apt pom.xml includes transitive dependencies</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4294">#4294</a>: crd-generator respects JsonIgnore annotations on enum properties</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4320">#4320</a>: corrected leader transitions field on leader election leases</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4360">#4360</a>: JUnit dependencies aren't leaked in child modules</li>
</ul>
<h4>Improvements</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/887">#887</a>: added KubernetesClient.visitResources to search and perform other operations across all resources.</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/3960">#3960</a>: adding a KubernetesMockServer.expectCustomResource helper method and additional mock crd support</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4041">#4041</a>: adding Quantity.getNumericalAmount with an explanation about bytes and cores.</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4241">#4241</a>: added more context to informer logs with the endpoint path</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4250">#4250</a>: allowing for deserialization of polymorphic unwrapped fields</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4254">#4254</a>: adding debug logging for exec stream messages</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4259">#4259</a>: Java Generator's CR should have Lombok's <code>@EqualsAndHashCode</code> with <code>callSuper = true</code></li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4287">#4287</a>: added WorkloadGroup for Istio v1alpha3 extension generator</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4318">#4318</a>: implemented LeaderElection releaseOnCancel</li>
</ul>
<h4>Dependency Upgrade</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/3967">#3967</a>: Update chaos-mesh extension to v2.1.3. Add PodHttpChaos, GCPChaos, BlockChaos and PhysicalMachineChaos.</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4352">#4352</a>: Update Knative model to v0.34.0</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4356">#4356</a>: Update Apache CamelK to v1.9.2</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4361">#4361</a>: Bump Cert-Manager to v1.9.0-beta.1.0.20220829113803-8465f1223efb</li>
</ul>
<h4>New Features</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/2271">#2271</a>: Support periodic refresh of access tokens before they expire</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4333">#4333</a>: Implement &quot;attach to pod&quot; functionality</li>
</ul>
<h4><em><strong>Note</strong></em>: Breaking changes in the API</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4206">#4206</a>: The Serialization utility class will throw an Exception, instead of returning null, if an untyped unmarshall method is used on something that lacks type information</li>
<li>In ChaosMesh Model, some types have been renamed. These are
<ul>
<li><code>io.fabric8.chaosmesh.v1alpha1.AwsChaos</code> =&gt; <code>io.fabric8.chaosmesh.v1alpha1.AWSChaos</code></li>
<li><code>io.fabric8.chaosmesh.v1alpha1.IoChaos</code> =&gt; <code>io.fabric8.chaosmesh.v1alpha1.IOChaos</code></li>
<li><code>io.fabric8.chaosmesh.v1alpha1.PodIoChaos</code> =&gt; <code>io.fabric8.chaosmesh.v1alpha1.PodIOChaos</code></li>
</ul>
</li>
</ul>
<h3>5.12.3 (2022-07-27)</h3>
<h4>Bugs</h4>
<ul>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/3969">#3969</a>: relist will not trigger sync events</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4049">#4049</a>: properly populate exception metadata with resource information if available</li>
<li>Fix <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4222">#4222</a>: backport of <a href="https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/4082">#4082</a> - to not process events until the cache is complete</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/d6e6cc35c689f5dd1920d95a73aa77174a645f43"><code>d6e6cc3</code></a> [RELEASE] Updated project version to v6.1.1</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/04aa2b8f34a1d0902567404dc40b3f12d04cf96f"><code>04aa2b8</code></a> fix: NO_PROXY should allow URIs with hyphens (&quot;circleci-internal-outer-build-...</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/acf6d264885ac415592da3181c8cfc6acd73d034"><code>acf6d26</code></a> [RELEASE] Prepare for next development iteration</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/ff81bd13a59d60aeea953f4e48d8d1ca8217efda"><code>ff81bd1</code></a> [RELEASE] Updated project version to v6.1.0</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/409af93a1b6685f1e933ed8ecabe7583252077cb"><code>409af93</code></a> chore: add missing references to changelog</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/45eb12ab7f52680da253c19a896f369352a19fa3"><code>45eb12a</code></a> test: temporary disable extra fields in Karaf deserializer test</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/1ff665bd343d1029c9c5647c7cc8747903c1707d"><code>1ff665b</code></a> fix (extensions/certmanager) : Update CertManager extension to latest version...</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/f5524268e410560cd44eb86c7bb8ee44327f7c39"><code>f552426</code></a> feat (kubernetes-model-generator) : Add Kubernetes Model Gateway API module</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/5a993d3baffe80733f1f62a271a1386ea5e113be"><code>5a993d3</code></a> test: refactor karaf deserialization tests to ensure GenericKuberentesResourc...</li>
<li><a href="https://github.com/fabric8io/kubernetes-client/commit/aef57f44a2b0670965880583dda6d878fec9effa"><code>aef57f4</code></a> fix: Configure dependency scope for junit dependencies at parent</li>
<li>Additional commits viewable in <a href="https://github.com/fabric8io/kubernetes-client/compare/v5.12.2...v6.1.1">compare view</a></li>
</ul>
</details>
<br />


</details>

## Testing Performed

CI
