### PR TITLE
Add info about not using DockerHub images in QA tests

### DIFF
--- a/qa-tests-backend/README.md
+++ b/qa-tests-backend/README.md
@@ -116,3 +116,14 @@ You will need to start another proxy:
  Or use the script provided by the deployment script:
 
 `deploy/{k8s,openshift}/central-deploy/central/scripts/port-forward.sh 8000`
+
+## When image pulls from docker.io get throttled
+
+You shouldn't use images from DockerHub in tests.
+We don't use a paid account there and so image pulls get throttled, and
+tests that use such images fail.
+
+If you need a specific image from DockerHub, pull it, retag as
+`quay.io/rhacs-eng/qa:<your-tag-here>` and push. 
+Then consume the new image from `quay.io/rhacs-eng/qa:<your-tag-here>`
+in tests. Such pulls shouldn't get throttled.


### PR DESCRIPTION
## Description

See https://srox.slack.com/archives/CELUQKESC/p1661461149989649?thread_ts=1661443773.120269&cid=CELUQKESC

## Checklist
- [x] Investigated and inspected CI test results

None of these needed:
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

None.