### PR TITLE
Wait 40m for quay images

### DIFF
--- a/.github/workflows/scripts/wait-for-image.sh
+++ b/.github/workflows/scripts/wait-for-image.sh
@@ -22,7 +22,7 @@ find_tag() {
 }
 
 # Seconds:
-TIME_LIMIT=1200
+TIME_LIMIT=2400
 INTERVAL=30
 
 # bash built-in variable


### PR DESCRIPTION
20m seems to be too little

## Description

See [failure](https://github.com/stackrox/stackrox/actions/runs/3024598991) and the [CI build](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-release-3.72-images/1569284663506112512)

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- None
