### PR TITLE
ROX-12436: Updating CVE CSV export endpoints

### DIFF
--- a/ui/apps/platform/src/Components/ExportButton.js
+++ b/ui/apps/platform/src/Components/ExportButton.js
@@ -21,7 +21,13 @@ const queryParamMap = {
 const complianceDownloadUrl = '/api/compliance/export/csv';
 
 function checkVulnMgmtSupport(page, type) {
-    return page === useCaseTypes.VULN_MANAGEMENT && type === entityTypes.CVE;
+    return (
+        page === useCaseTypes.VULN_MANAGEMENT &&
+        (type === entityTypes.CVE ||
+            type === entityTypes.IMAGE_CVE ||
+            type === entityTypes.NODE_CVE ||
+            type === entityTypes.CLUSTER_CVE)
+    );
 }
 
 function checkComplianceSupport(page, type) {

--- a/ui/apps/platform/src/Containers/Workflow/WorkflowListPageLayout.js
+++ b/ui/apps/platform/src/Containers/Workflow/WorkflowListPageLayout.js
@@ -45,10 +45,6 @@ const WorkflowListPageLayout = ({ location }) => {
     // set up cache-busting system that either the list or sidepanel can use to trigger list refresh
     const [refreshTrigger, setRefreshTrigger] = useState(0);
 
-    function customCsvExportHandler(fileName) {
-        return exportCvesAsCsv(fileName, workflowState);
-    }
-
     // Get the list / entity components
     const ListComponent = ListComponentMap[useCase];
     const EntityComponent = EntityComponentMap[useCase];
@@ -70,6 +66,10 @@ const WorkflowListPageLayout = ({ location }) => {
     const header = pluralize(entityLabels[pageListType]);
     const exportFilename = `${useCaseLabels[useCase]} ${pluralize(startCase(header))} Report`;
     const entityContext = {};
+
+    function customCsvExportHandler(fileName) {
+        return exportCvesAsCsv(fileName, workflowState, pageListType);
+    }
 
     if (selectedRow) {
         const { entityType, entityId } = selectedRow;

--- a/ui/apps/platform/src/services/VulnerabilitiesService.js
+++ b/ui/apps/platform/src/services/VulnerabilitiesService.js
@@ -15,6 +15,7 @@ function getCSVExportUrl(cveType) {
     if (cveType === entityTypes.IMAGE_CVE) {
         return '/api/export/csv/image/cve';
     }
+    // @TODO: Remove this URL when we remove feature flagging for ROX_VM_FRONTEND_UPDATES
     return '/api/vm/export/csv';
 }
 

--- a/ui/apps/platform/src/services/VulnerabilitiesService.js
+++ b/ui/apps/platform/src/services/VulnerabilitiesService.js
@@ -5,7 +5,18 @@ import queryService from 'utils/queryService';
 import entityTypes from 'constants/entityTypes';
 import axios from './instance';
 
-const csvUrl = '/api/vm/export/csv';
+function getCSVExportUrl(cveType) {
+    if (cveType === entityTypes.CLUSTER_CVE) {
+        return '/api/export/csv/cluster/cve';
+    }
+    if (cveType === entityTypes.NODE_CVE) {
+        return '/api/export/csv/node/cve';
+    }
+    if (cveType === entityTypes.IMAGE_CVE) {
+        return '/api/export/csv/image/cve';
+    }
+    return '/api/vm/export/csv';
+}
 
 function getBaseCveUrl(cveType) {
     if (cveType === entityTypes.CLUSTER_CVE) {
@@ -44,12 +55,14 @@ export function unsuppressVulns(cveType, cveNames) {
 }
 
 export function getCvesInCsvFormat(
+    cveType,
     fileName,
     query,
     sortOption = { field: cveSortFields.CVSS_SCORE, reversed: true },
     page = 0,
     pageSize = 0
 ) {
+    const csvUrl = getCSVExportUrl(cveType);
     const offset = page * pageSize;
     const params = queryString.stringify(
         {
@@ -73,7 +86,7 @@ export function getCvesInCsvFormat(
     });
 }
 
-export function exportCvesAsCsv(fileName, workflowState) {
+export function exportCvesAsCsv(fileName, workflowState, cveType) {
     const fullEntityContext = workflowState.getEntityContext();
     const lastEntityCtx = Object.keys(fullEntityContext).reduce((acc, key) => {
         return { ...{ [key]: fullEntityContext[key] } };
@@ -87,5 +100,5 @@ export function exportCvesAsCsv(fileName, workflowState) {
     let sortOption = workflowState.getCurrentSortState()[0];
     sortOption = sortOption && { field: sortOption.id, reversed: sortOption.desc };
 
-    return getCvesInCsvFormat(fileName, query, sortOption);
+    return getCvesInCsvFormat(cveType, fileName, query, sortOption);
 }


### PR DESCRIPTION
## Description

The following PR updates the endpoints used for exporting Platform/Image/Node CVEs as CSV 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

Example output for CSV

[StackRox_Vulnerability Management Platform CVES Report-09_12_2022.csv](https://github.com/stackrox/stackrox/files/9551890/StackRox_Vulnerability.Management.Platform.CVES.Report-09_12_2022.csv)
[StackRox_Vulnerability Management Node CVES Report-09_12_2022.csv](https://github.com/stackrox/stackrox/files/9551889/StackRox_Vulnerability.Management.Node.CVES.Report-09_12_2022.csv)
[StackRox_Vulnerability Management Image CVES Report-09_12_2022.csv](https://github.com/stackrox/stackrox/files/9551888/StackRox_Vulnerability.Management.Image.CVES.Report-09_12_2022.csv)


