### PR TITLE
Disabling hovering on user events in flaky dashboard tests

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/AgingImages.test.tsx
@@ -156,9 +156,9 @@ describe('AgingImages dashboard widget', () => {
         expect(history.location.search).toContain('s[Image Created Time]=30d-180d');
     });
 
-    // Disabled due to React state updates on unmounted components from PatternFly/Tooltip
-    it.skip('should contain a button that resets the widget options to default', async () => {
-        const { user } = setup();
+    it('should contain a button that resets the widget options to default', async () => {
+        setup();
+        const user = userEvent.setup({ skipHover: true });
 
         await user.click(await screen.findByLabelText('Options'));
         const checkboxes = await screen.findAllByLabelText('Toggle image time range');
@@ -188,7 +188,6 @@ describe('AgingImages dashboard widget', () => {
 
         const resetButton = await screen.findByLabelText('Revert to default options');
         await user.click(resetButton);
-        await user.unhover(resetButton); // Avoid displaying the tooltip, which leads to React errors on test exit
 
         checkboxes.forEach((cb) => expect(cb).toBeChecked());
         expect(inputs.map(({ value }) => parseInt(value, 10))).toEqual(

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ComplianceLevelsByStandard.test.tsx
@@ -148,9 +148,9 @@ describe('Compliance levels by standard dashboard widget', () => {
         );
     });
 
-    // Disabled due to React state updates on unmounted components from PatternFly/Tooltip
-    it.skip('should contain a button that resets the widget options to default', async () => {
-        const { user } = setup();
+    it('should contain a button that resets the widget options to default', async () => {
+        setup();
+        const user = userEvent.setup({ skipHover: true });
 
         await user.click(await screen.findByLabelText('Options'));
         const [asc, desc] = await screen.findAllByRole('button', {
@@ -168,7 +168,6 @@ describe('Compliance levels by standard dashboard widget', () => {
 
         const resetButton = await screen.findByLabelText('Revert to default options');
         await user.click(resetButton);
-        await user.unhover(resetButton); // Avoid displaying the tooltip, which leads to React errors on test exit
 
         expect(asc).toHaveAttribute('aria-pressed', 'true');
         expect(desc).toHaveAttribute('aria-pressed', 'false');

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ImagesAtMostRisk.test.tsx
@@ -145,9 +145,9 @@ describe('Images at most risk dashboard widget', () => {
         expect(history.location.pathname).toBe(`${vulnManagementImagesPath}`);
     });
 
-    // Disabled due to React state updates on unmounted components from PatternFly/Tooltip
-    it.skip('should contain a button that resets the widget options to default', async () => {
-        const { user } = setup();
+    it('should contain a button that resets the widget options to default', async () => {
+        setup();
+        const user = userEvent.setup({ skipHover: true });
 
         await user.click(await screen.findByLabelText('Options'));
         const [fixableCves, allCves, activeImages, allImages] = await screen.findAllByRole(
@@ -174,7 +174,6 @@ describe('Images at most risk dashboard widget', () => {
 
         const resetButton = await screen.findByLabelText('Revert to default options');
         await user.click(resetButton);
-        await user.unhover(resetButton); // Avoid displaying the tooltip, which leads to React errors on test exit
 
         expect(fixableCves).toHaveAttribute('aria-pressed', 'true');
         expect(allCves).toHaveAttribute('aria-pressed', 'false');

--- a/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/PatternFly/Widgets/ViolationsByPolicyCategory.test.tsx
@@ -122,9 +122,9 @@ describe('Violations by policy category widget', () => {
         ]);
     });
 
-    // Disabled due to React state updates on unmounted components from PatternFly/Tooltip
-    it.skip('should contain a button that resets the widget options to default', async () => {
-        const { user } = setup();
+    it('should contain a button that resets the widget options to default', async () => {
+        setup();
+        const user = userEvent.setup({ skipHover: true });
 
         await user.click(await screen.findByLabelText('Options'));
         const [severity, total, all, deploy, runtime] = await screen.findAllByRole('button', {
@@ -150,7 +150,6 @@ describe('Violations by policy category widget', () => {
 
         const resetButton = await screen.findByLabelText('Revert to default options');
         await user.click(resetButton);
-        await user.unhover(resetButton); // Avoid displaying the tooltip, which leads to React errors on test exit
 
         expect(severity).toHaveAttribute('aria-pressed', 'true');
         expect(total).toHaveAttribute('aria-pressed', 'false');


### PR DESCRIPTION
## Description

**Re-enables flaky tests, with hovering disabled during the click events.**

These tests would fail with the occasional `Warning: Can't perform a React state update on an unmounted component.` error during CI runs.

This was determined to be due to two things:

1. The fact that we spy on `console.error` and automatically fail any test that calls it, regardless of passing assertions.
2. PatternFly's `Tooltip` component having a 300ms fade in/fade out effect that is called by `setTimeout`.

These errors originally started due to the call to `user-event`'s
```typescript
        await user.click(resetButton);
```
which in order to better simulate a real user, dispatches a `hover`event internally before the `click` event. Since the element was being hovered, this would cause the Tooltip to display after 300ms via a `setTimeout` and `setState`, which throws an error due to the state update after the test exits.

A fix was merged that immediately unhovered the element after clicking in an attempt to prevent the tooltip from rendering:
```typescript
        await user.click(resetButton);
        await user.unhover(resetButton);
```

This mostly worked, but would still cause occasional flakes. My theory is that CI slow downs were taking long enough that the implicit `hover` was causing the tooltip to display before the `unhover` event was applied. I was able to replicate this reliably locally with:

```typescript
        await user.click(resetButton);
        await new Promise((res) => setTimeout(res, 300));
        // always calls `console.error`
        await user.unhover(resetButton);
```

The solution in this PR disables the automatic `hover` event entirely for these tests, instead of having to deal with the timing of intermediate tooltip renders.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

`yarn test` locally

Manually executing `/test ui-unit-tests` twice

