### PR TITLE
Update TypeScript 4.8.3 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -163,7 +163,7 @@
         "redux-immutable-state-invariant": "^2.1.0",
         "redux-saga-test-plan": "^3.7.0",
         "tailwindcss": "^2.0.3",
-        "typescript": "^4.8.2"
+        "typescript": "^4.8.3"
     },
     "browserslist": [
         ">0.2%",

--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -83,6 +83,6 @@
         "react-is": "^17.0.2",
         "tailwindcss": "^2.0.3",
         "ts-jest": "^26.5.6",
-        "typescript": "^4.8.2"
+        "typescript": "^4.8.3"
     }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -18629,10 +18629,10 @@ typeface-open-sans@^1.1.13:
   resolved "https://registry.yarnpkg.com/typeface-open-sans/-/typeface-open-sans-1.1.13.tgz#32a09ebd7df59601e01ad81216f98ce641eeafd1"
   integrity sha512-lVGVHvYl7UJDFB9vN8r7NHw3sVm7Rjeow6b9AeABc/J+2mDaCkmcdVtw3QZnsJW39P+xm5zeggIj9gLHYGn9Iw==
 
-typescript@^4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
-  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
+typescript@^4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
+  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
 
 ua-parser-js@^0.7.18:
   version "0.7.28"


### PR DESCRIPTION
## Description

Patch release fixes some bugs related to type narrowing.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui
3. `wc build/static/js/*.chunk.js` in ui before and after build
    * branch - master: 0 = 5553068 - 5553068 which makes sense for a patch release which does not report any new problems
4. `yarn deploy-local` in ui
5. `yarn start` in ui and visit several pages