### PR TITLE
CI: run the test job despite error with retrieving PR details

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -884,7 +884,10 @@ gate_job() {
     elif [[ "$exitstatus" == "1" ]]; then
         gate_merge_job "$job_config"
     else
-        die "Could not determine if this is a PR versus a merge"
+        echo "ERROR: Could not determine if this is a PR versus a merge: $exitstatus"
+        echo "DEBUG: PR details: ${_PR_DETAILS}"
+        info "$job will run despite this error"
+        return
     fi
 }
 


### PR DESCRIPTION
## Description

`get_pr_details()` has started to fail for some hard to diagnose reason. It would be more prudent to run the test job than error in this case. Note: there is a downside to this in that more GKE clusters will run per commit when this failure is hit. I will follow up with a PR to switch e2e tests to prow native job gating.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient