### PR TITLE
Fix incorrect counts in Postgres Vuln Mgmt

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Clusters/VulnMgmtListClusters.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Clusters/VulnMgmtListClusters.js
@@ -32,7 +32,7 @@ export const defaultClusterSort = [
     },
 ];
 
-const VulnMgmtClusters = ({ selectedRowId, search, sort, page, data }) => {
+const VulnMgmtClusters = ({ selectedRowId, search, sort, page, data, totalResults }) => {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isFrontendVMUpdatesEnabled = isFeatureFlagEnabled('ROX_FRONTEND_VM_UPDATES');
 
@@ -310,6 +310,7 @@ const VulnMgmtClusters = ({ selectedRowId, search, sort, page, data }) => {
     return (
         <WorkflowListPage
             data={data}
+            totalResults={totalResults}
             query={query}
             queryOptions={queryOptions}
             entityListType={entityTypes.CLUSTER}

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Nodes/VulnMgmtListNodes.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Nodes/VulnMgmtListNodes.js
@@ -35,7 +35,7 @@ const nodeListUpdatedQuery = gql`
         results: nodes(query: $query, pagination: $pagination) {
             ...nodeFields
         }
-        count: nodeVulnerabilityCount(query: $query)
+        count: nodeCount(query: $query)
     }
     ${NODE_LIST_FRAGMENT_UPDATED}
 `;


### PR DESCRIPTION
## Description

1. Cluster count on Cluster CVEs > individual CVE > Clusters: Mark found this one while fixing an unrelated test flake (Another one he noticed on last week's stagingdb instance has already been fixed separately.)
2. Node count on Nodes: I saw this one while debugging the other issue.

## Checklist
- [x] Investigated and inspected CI test results (test failure is a flake where auth failed)


## Testing Performed

### Cluster count on Cluster CVEs > individual CVE > Clusters
Before (0 == 1)
![Screen Shot 2022-09-13 at 5 21 21 PM](https://user-images.githubusercontent.com/715729/190019694-99b331af-04f9-4d69-8ab3-9c890454cbec.png)

After (1 == 1)
![Screen Shot 2022-09-13 at 5 21 30 PM](https://user-images.githubusercontent.com/715729/190019701-8c41ffe7-b6b0-4ec0-acd4-8fa22f7414cd.png)

### Node count on Nodes
Before (54 == 3)
![Screen Shot 2022-09-13 at 4 20 53 PM](https://user-images.githubusercontent.com/715729/190019817-cec47b13-205b-420b-81a7-43be9fbc4fc7.png)

After (3 == 3)
![Screen Shot 2022-09-13 at 4 20 27 PM](https://user-images.githubusercontent.com/715729/190019827-a183a625-eeb4-486c-a638-898a077c2dd1.png)
