### PR TITLE
ROX-11717: GitHub workflow use proper gh env vars

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -229,7 +229,7 @@ jobs:
 
       - name: Comment on the PR
         env:
-          GITHUB_TOKEN: "${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}"
         run: |
             source ./scripts/ci/lib.sh
             add_build_comment_to_pr

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -229,7 +229,7 @@ jobs:
 
       - name: Comment on the PR
         env:
-          GH_TOKEN: "${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}"
         run: |
             source ./scripts/ci/lib.sh
             add_build_comment_to_pr

--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -79,7 +79,8 @@ jobs:
       - name: Create Cluster
         env:
           INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
-          GH_TOKEN: ${{github.token}}
+          GH_TOKEN: ${{ github.token }}
+          GH_NO_UPDATE_NOTIFIER: 1
         run: |
           set -uo pipefail
           gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \

--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Create Cluster
         env:
           INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
-          GITHUB_TOKEN: ${{github.token}}
+          GH_TOKEN: ${{github.token}}
         run: |
           set -uo pipefail
           gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -40,7 +40,7 @@ env:
   script_url: /repos/${{github.repository}}/contents/.github/workflows/scripts/common.sh?ref=${{github.event.repository.default_branch}}
   DRY_RUN: ${{ fromJSON('["true", "false"]')[github.event.inputs.dry-run != 'true'] }}
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 # Ensure that only a single release automation workflow can run at a time.
 concurrency: Release automation

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -40,7 +40,7 @@ env:
   script_url: /repos/${{github.repository}}/contents/.github/workflows/scripts/common.sh?ref=${{github.event.repository.default_branch}}
   DRY_RUN: ${{ fromJSON('["true", "false"]')[github.event.inputs.dry-run != 'true'] }}
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_TOKEN: ${{ github.token }}
 
 # Ensure that only a single release automation workflow can run at a time.
 concurrency: Release automation

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -41,6 +41,7 @@ env:
   DRY_RUN: ${{ fromJSON('["true", "false"]')[github.event.inputs.dry-run != 'true'] }}
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
   GH_TOKEN: ${{ github.token }}
+  GH_NO_UPDATE_NOTIFIER: 1
 
 # Ensure that only a single release automation workflow can run at a time.
 concurrency: Release automation

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -13,5 +13,5 @@ jobs:
     steps:
     - uses: actions/labeler@v3
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: "${{ github.token }}"
         sync-labels: ""

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -26,7 +26,7 @@ env:
   script_url: /repos/${{github.repository}}/contents/.github/workflows/scripts/common.sh?ref=${{github.event.repository.default_branch}}
   DRY_RUN: ${{ fromJSON('["true", "false"]')[github.event.inputs.dry-run != 'true'] }}
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_TOKEN: ${{ github.token }}
 
 # Ensure that only a single release automation workflow can run at a time.
 concurrency: Release automation

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -27,6 +27,7 @@ env:
   DRY_RUN: ${{ fromJSON('["true", "false"]')[github.event.inputs.dry-run != 'true'] }}
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
   GH_TOKEN: ${{ github.token }}
+  GH_NO_UPDATE_NOTIFIER: 1
 
 # Ensure that only a single release automation workflow can run at a time.
 concurrency: Release automation

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -26,7 +26,7 @@ env:
   script_url: /repos/${{github.repository}}/contents/.github/workflows/scripts/common.sh?ref=${{github.event.repository.default_branch}}
   DRY_RUN: ${{ fromJSON('["true", "false"]')[github.event.inputs.dry-run != 'true'] }}
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 # Ensure that only a single release automation workflow can run at a time.
 concurrency: Release automation


### PR DESCRIPTION
## Description

* replace `GITHUB_TOKEN` with `GH_TOKEN` (preferred by `gh` CLI) 
* replace `secrets.GITHUB_TOKEN` with `github.token`
* add `GH_NO_UPDATE_NOTIFIER` where required

See https://cli.github.com/manual/gh_help_environment for the details.

> GH_TOKEN, GITHUB_TOKEN (in order of precedence): an authentication token for github.com API requests. Setting this avoids being prompted to authenticate and takes precedence over previously stored credentials.

> GH_NO_UPDATE_NOTIFIER: set to any value to disable update notifications. By default, gh checks for new releases once every 24 hours and displays an upgrade notice on standard error if a newer version was found

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required
  - not required because CI change
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Tested in https://github.com/stackrox/test-gh-actions/pull/25. 