### PR TITLE
Bump kuttl to new upstream release.

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -182,9 +182,8 @@ operator-sdk: ## Download operator-sdk necessary for scaffolding and bundling.
 	$(GET_GITHUB_RELEASE_FN); \
 	get_github_release $(OPERATOR_SDK) $${OPERATOR_SDK_URL}
 
-# TODO(porridge): change back to kudobuilder release once https://github.com/kudobuilder/kuttl/issues/371 is fixed
-KUTTL_VERSION = 0.11.0-verbose-resource
-KUTTL_UPSTREAM = porridge
+KUTTL_VERSION = 0.13.0
+KUTTL_UPSTREAM = kudobuilder
 KUTTL ?= $(PROJECT_DIR)/bin/kubectl-kuttl-$(KUTTL_VERSION)
 .PHONY: kuttl
 kuttl: ## Download kuttl.


### PR DESCRIPTION
## Description

The issue was fixed upstream, so we can go back to using the upstream release.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Relying on CI.