### PR TITLE
Generate JUnit report for sensor tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 DOCS_IMAGE = $(DEFAULT_IMAGE_REGISTRY)/docs:$(shell make --quiet --no-print-directory docs-tag)
 
 GOBUILD := $(CURDIR)/scripts/go-build.sh
-
+GO_TEST_OUTPUT_PATH=$(CURDIR)/test-output/test.log
 GOPATH_VOLUME_NAME := stackrox-rox-gopath
 GOCACHE_VOLUME_NAME := stackrox-rox-gocache
 
@@ -489,7 +489,7 @@ go-unit-tests: build-prep test-prep
 	set -o pipefail ; \
 	CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test scripts/go-test.sh -p 4 -race -cover -coverprofile test-output/coverage.out -v \
 		$(shell git ls-files -- '*_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
-		| tee test-output/test.log
+		| tee $(GO_TEST_OUTPUT_PATH)
 	# Exercise the logging package for all supported logging levels to make sure that initialization works properly
 	for encoding in console json; do \
 		for level in debug info warn error fatal panic; do \
@@ -500,9 +500,10 @@ go-unit-tests: build-prep test-prep
 .PHONE: sensor-integration-test
 sensor-integration-test: build-prep test-prep
 	set -eo pipefail ; \
+	rm -rf  $(GO_TEST_OUTPUT_PATH); \
 	for package in $(shell git ls-files ./sensor/tests | grep '_test.go' | xargs -n 1 dirname | uniq | sort | sed -e 's/sensor\/tests\///'); do \
 		CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test scripts/go-test.sh -p 4 -race -cover -coverprofile test-output/coverage.out -v ./sensor/tests/$$package \
-		| tee test-output/$$(echo $$package | sed -e 's/\//\_/').integration.log; \
+		| tee -a $(GO_TEST_OUTPUT_PATH); \
 	done \
 
 .PHONY: go-postgres-unit-tests
@@ -511,7 +512,7 @@ go-postgres-unit-tests: build-prep test-prep
 	set -o pipefail ; \
 	CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 ROX_POSTGRES_DATASTORE=true GOTAGS=$(GOTAGS),test,sql_integration scripts/go-test.sh -p 1 -race -cover -coverprofile test-output/coverage.out -v \
 		$(shell git ls-files -- '*postgres/*_test.go' '*postgres_test.go' '*datastore_sac_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
-		| tee test-output/test.log
+		| tee $(GO_TEST_OUTPUT_PATH)
 
 .PHONY: shell-unit-tests
 shell-unit-tests:
@@ -539,7 +540,7 @@ integration-unit-tests: build-prep test-prep
 	set -o pipefail ; \
 	GOTAGS=$(GOTAGS),test,integration scripts/go-test.sh -count=1 -v \
 		$(shell go list ./... | grep  "registries\|scanners\|notifiers") \
-		| tee test-output/test.log
+		| tee $(GO_TEST_OUTPUT_PATH)
 
 generate-junit-reports: $(GO_JUNIT_REPORT_BIN)
 	$(BASE_DIR)/scripts/generate-junit-reports.sh

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -45,7 +45,10 @@ test_e2e() {
 
     info "Sensor k8s integration tests"
     make sensor-integration-test || touch FAIL
-    store_test_results "test-output/sensor-integration.log" "sensor-integration"
+    info "Saving junit XML report"
+    make generate-junit-reports || touch FAIL
+    store_test_results junit-reports reports
+    store_test_results "test-output/test.log" "sensor-integration"
     [[ ! -f FAIL ]] || die "e2e tests failed"
 
     setup_proxy_tests "localhost"


### PR DESCRIPTION
## Description

Sensors tests are stored in different files then other go tests and junit report is not generated for them.
This PR stores all sensors tests output into a single file (the same as other tests) and generate junit report from it saving it in prow so it will be visible with lenses.

## Testing Performed
CI

## Refs
https://github.com/stackrox/stackrox/pull/2202