### PR TITLE
ROX-11323: Local-Sensor resource consumption monitoring: recording pprof

### DIFF
--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -218,6 +218,7 @@ func registerHostKillSignals(startTime time.Time, fakeCentral *centralDebug.Fake
 	if writeMemProfile {
 		writeMemoryProfile()
 	}
+	pprof.StopCPUProfile()
 	allMessages := fakeCentral.GetAllMessages()
 	dumpMessages(allMessages, startTime, endTime, outfile, outputFormat)
 	os.Exit(0)
@@ -259,7 +260,6 @@ func main() {
 		if err := pprof.StartCPUProfile(f); err != nil {
 			log.Fatal("could not start CPU profile: ", err)
 		}
-		defer pprof.StopCPUProfile()
 	}
 
 	startTime := time.Now()

--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -382,19 +382,3 @@ func dumpMessages(messages []*central.MsgFromSensor, start, end time.Time, outfi
 	}
 	f(messages, start, end, outfile)
 }
-
-// PrintMemUsage outputs the current, total and OS memory being used. As well as the number
-// of garage collection cycles completed.
-func PrintMemUsage() {
-	var m runtime.MemStats
-	runtime.ReadMemStats(&m)
-	// For info on each, see: https://golang.org/pkg/runtime/#MemStats
-	fmt.Printf("Alloc = %v MiB", bToMb(m.Alloc))
-	fmt.Printf("\tTotalAlloc = %v MiB", bToMb(m.TotalAlloc))
-	fmt.Printf("\tSys = %v MiB", bToMb(m.Sys))
-	fmt.Printf("\tNumGC = %v\n", m.NumGC)
-}
-
-func bToMb(b uint64) uint64 {
-	return b / 1024 / 1024
-}


### PR DESCRIPTION
## Description

This PR adds automated recording of memory and CPU profile to `local-sensor`.
The feature is enabled by default and can be disabled by using flags: `--no-cpu-prof` and `--no-mem-prof`.

⚠️ This is one of potentially many PRs that will be needed to cover the scope of [ROX-11323](https://issues.redhat.com/browse/ROX-11323), but I wanted to deliver the features in small chunks.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

Changes apply to a tool used locally.

## Testing Performed

```shell
$ go run tools/local-sensor/main.go -replay -replay-in=sensor/tests/replay/data/safety-net-alerts-k8s-trace.jsonl -resync=10s -delay=0s -format=raw -central-out=/dev/null

$ ls -l local-sensor-*.prof
-rw-r--r--  1 prygiels  staff   7952 Sep 16 17:10 local-sensor-cpu-2022-09-16T15:10:01Z.prof
-rw-r--r--  1 prygiels  staff  24648 Sep 16 17:10 local-sensor-mem-2022-09-16T15:10:39Z.prof

$ go tool pprof local-sensor-cpu-2022-09-16T15:10:01Z.prof 
Type: cpu
Time: Sep 16, 2022 at 5:10pm (CEST)
Duration: 38.43s, Total samples = 380ms ( 0.99%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) web
(pprof) q

$ go tool pprof local-sensor-mem-2022-09-16T15:10:39Z.prof 
Type: alloc_space
Time: Sep 16, 2022 at 5:10pm (CEST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) web
(pprof) q
```
