### PR TITLE
CI: Do not fail the build if the PR comment fails

### DIFF
--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -67,7 +67,9 @@ push_images() {
     fi
 
     if is_in_PR_context && [[ "$brand" == "STACKROX_BRANDING" ]] && [[ -n "${MAIN_IMAGE}" ]]; then
-        add_build_comment_to_pr
+        add_build_comment_to_pr || {
+            info "Could not add a comment to the PR"
+        }
     fi
 }
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1350,13 +1350,23 @@ EOF
 add_build_comment_to_pr() {
     info "Adding a comment with the build tag to the PR"
 
+    local pr_details
+    local exitstatus=0
+    pr_details="$(get_pr_details)" || exitstatus="$?"
+    if [[ "$exitstatus" != "0" ]]; then
+        echo "DEBUG: Unable to get the PR details from GitHub: $exitstatus"
+        echo "DEBUG: PR details: ${pr_details}"
+        info "Will continue without commenting on the PR"
+        return
+    fi
+
     # hub-comment is tied to Circle CI env
     local url
-    url=$(get_pr_details | jq -r '.html_url')
+    url=$(jq -r '.html_url' <<<"$pr_details")
     export CIRCLE_PULL_REQUEST="$url"
 
     local sha
-    sha=$(get_pr_details | jq -r '.head.sha')
+    sha=$(jq -r '.head.sha' <<<"$pr_details")
     sha=${sha:0:7}
     export _SHA="$sha"
 


### PR DESCRIPTION
## Description

This will no longer fail the build if a comment cannot be added to the PR. As the build is a required job and commenting on the PR is a non critical feature. This is motivated by recent github API limits but is a better approach in any case.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient