### PR TITLE
CI: Use prow job control

### DIFF
--- a/scripts/ci/gate-jobs-config.json
+++ b/scripts/ci/gate-jobs-config.json
@@ -1,114 +1,18 @@
 {
     "go-unit-tests": {
-        "run_with_labels": [],
-        "skip_with_label": "",
         "run_with_changed_path": "^.*$",
-        "changed_path_to_ignore": "^ui/",
-        "run_on_master": "true",
-        "run_on_tags": "true"
+        "changed_path_to_ignore": "^ui/"
     },
     "go-unit-tests-release": {
-        "run_with_labels": [],
-        "skip_with_label": "",
         "run_with_changed_path": "^.*$",
-        "changed_path_to_ignore": "^ui/",
-        "run_on_master": "true",
-        "run_on_tags": "true"
+        "changed_path_to_ignore": "^ui/"
     },
     "go-postgres-tests": {
-        "run_with_labels": [],
-        "skip_with_label": "",
         "run_with_changed_path": "^.*$",
-        "changed_path_to_ignore": "^ui/",
-        "run_on_master": "true",
-        "run_on_tags": "true"
-    },
-    "shell-unit-tests": {
-        "run_with_labels": [],
-        "skip_with_label": "",
-        "run_with_changed_path": "^.*$",
-        "changed_path_to_ignore": "^ui/",
-        "run_on_master": "true",
-        "run_on_tags": "true"
+        "changed_path_to_ignore": "^ui/"
     },
     "ui-unit-tests": {
-        "run_with_labels": [],
-        "skip_with_label": "",
         "run_with_changed_path": "^ui/",
-        "changed_path_to_ignore": "",
-        "run_on_master": "false",
-        "run_on_tags": "true"
-    },
-    "gke-qa-e2e-tests": {
-        "run_with_labels": [],
-        "skip_with_label": "ci-no-qa-tests",
-        "run_with_changed_path": "^.*$",
-        "changed_path_to_ignore": "^ui/",
-        "run_on_master": "true",
-        "run_on_tags": "true"
-    },
-    "gke-nongroovy-e2e-tests": {
-        "run_with_labels": [],
-        "skip_with_label": "ci-no-nongroovy-tests",
-        "run_with_changed_path": "^.*$",
-        "changed_path_to_ignore": "^ui/",
-        "run_on_master": "true",
-        "run_on_tags": "true"
-    },
-    "gke-kernel-qa-e2e-tests": {
-        "run_with_labels": ["ci-kernel-module-tests"],
-        "skip_with_label": "",
-        "run_with_changed_path": "",
-        "changed_path_to_ignore": "",
-        "run_on_master": "true",
-        "run_on_tags": "true"
-    },
-    "gke-postgres-qa-e2e-tests": {
-        "run_with_labels": ["ci-postgres-tests"],
-        "skip_with_label": "",
-        "run_with_changed_path": "^.*$",
-        "changed_path_to_ignore": "^ui/",
-        "run_on_master": "true",
-        "run_on_tags": "false"
-    },
-    "gke-upgrade-tests": {
-        "run_with_labels": ["ci-upgrade-tests"],
-        "skip_with_label": "ci-no-upgrade-tests",
-        "run_with_changed_path": "^migrator/.*$|^image/",
-        "changed_path_to_ignore": "",
-        "run_on_master": "true",
-        "run_on_tags": "true"
-    },
-    "gke-ui-e2e-tests": {
-        "run_with_labels": [],
-        "skip_with_label": "ci-no-ui-tests",
-        "run_with_changed_path": "^ui/",
-        "changed_path_to_ignore": "",
-        "run_on_master": "true",
-        "run_on_tags": "true"
-    },
-    "gke-race-condition-qa-e2e-tests": {
-        "run_with_labels": ["ci-race-condition-tests"],
-        "skip_with_label": "",
-        "run_with_changed_path": "",
-        "changed_path_to_ignore": "",
-        "run_on_master": "true",
-        "run_on_tags": "true"
-    },
-    "gke-scale-tests": {
-        "run_with_labels": ["ci-scale-tests"],
-        "skip_with_label": "",
-        "run_with_changed_path": "",
-        "changed_path_to_ignore": "",
-        "run_on_master": "false",
-        "run_on_tags": "true"
-    },
-    "gke-postgres-scale-tests": {
-        "run_with_labels": ["ci-postgres-scale-tests"],
-        "skip_with_label": "",
-        "run_with_changed_path": "",
-        "changed_path_to_ignore": "",
-        "run_on_master": "false",
-        "run_on_tags": "false"
+        "changed_path_to_ignore": ""
     }
 }

--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -102,13 +102,8 @@ slack_build_notice() {
         fi
     elif is_nightly_run; then
         build_url="https://prow.ci.openshift.org/?repo=stackrox%2Fstackrox&job=*stackrox*night*"
-        if is_in_PR_context && pr_has_label "simulate-nightly-run"; then
-            # send to #slack-test when testing nightlies
-            webhook_url="${SLACK_MAIN_WEBHOOK}"
-        else
-            # send to #nightly-ci-runs
-            webhook_url="${NIGHTLY_WORKFLOW_NOTIFY_WEBHOOK}"
-        fi
+        # send to #nightly-ci-runs
+        webhook_url="${NIGHTLY_WORKFLOW_NOTIFY_WEBHOOK}"
     else
         die "unexpected"
     fi


### PR DESCRIPTION
## Description

With the merge of https://github.com/openshift/release/pull/32294 CI job triggering can be simplified. By:
- removing the internal job gating except for triggering unit tests based on the files that change. 
- this preserves the status quo which avoid flakes in unrelated areas (UI versus everything else) being able to block PRs due to required CI jobs not passing.

This PR also removes calls to the GitHub API to help reduce rate limiting. By:
- removing the not currently used check for a `simulate-nightly-run` label by all jobs
- caching the PR details response to file so it can be reused between script invocations (e.g. QA e2e parts 1 & 2).

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient