### PR TITLE
ROX-10928: Deprecate release-tools scripts

### DIFF
--- a/scripts/release-tools/README.md
+++ b/scripts/release-tools/README.md
@@ -1,3 +1,7 @@
+# DEPRECATION NOTICE
+
+:warning: The scripts are deprecated and will be removed on October 10, 2022. The functionality is now implemented by GitHub Actions.
+
 # Upstream Release Tools
 
 This directory contains a selection of scripts that automate selected mundane manual steps (a.k.a toil) in the upstream release process.

--- a/scripts/release-tools/jira.sh
+++ b/scripts/release-tools/jira.sh
@@ -19,7 +19,9 @@ main() {
   fi
   RED='\033[0;31m'
   NC='\033[0m' # No Color
-  echo -e "${RED}WARNING:${NC} some of these scripts may be outdated, bleeding-edge, or not working. Read the code before you run them to be on the safe side."
+  echo -e "${RED}WARNING: this script is deprecated and will be removed on October 10, 2022.${NC}"
+  echo -e "${RED}WARNING: some of these scripts may be outdated, bleeding-edge, or not working. Read the code before you run them to be on the safe side.${NC}"
+
   select ans in "${MENU_OPTIONS[@]}"
   do
     exec_option "$ans"


### PR DESCRIPTION
## Description

The release-tools scripts are deprecated and will be removed on October 10, 2022. The functionality is now implemented by GitHub Actions.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* scripts run manually to check for warning output