### PR TITLE
Wait on all requests for main dashboard in integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -2,24 +2,67 @@ import * as api from '../constants/apiEndpoints';
 import { url } from '../constants/DashboardPage';
 import navSelectors from '../selectors/navigation';
 
+import { interactAndWaitForResponses } from './request';
 import { visit } from './visit';
+
+/*
+ * Import relevant alias constants in test files that call visitMainDashboard function
+ * with staticResponseMap argument to provide mock data for a widget.
+ */
+export const mostRecentAlertsAlias = 'mostRecentAlerts';
+export const getImagesAlias = 'getImages';
+export const deploymentswithprocessinfoAlias = 'deploymentswithprocessinfo';
+export const agingImagesQueryAlias = 'agingImagesQuery';
+export const alertsSummaryCountsAlias = 'alerts/summary/counts';
+export const getAggregatedResultsAlias = 'getAggregatedResults';
+
+const requestConfig = {
+    routeMatcherMap: {
+        // ViolationsByPolicySeverity
+        [mostRecentAlertsAlias]: {
+            method: 'POST',
+            url: api.graphql('mostRecentAlerts'),
+        },
+        // ImagesAtMostRisk
+        [getImagesAlias]: {
+            method: 'POST',
+            url: api.graphql('getImages'),
+        },
+        // DeploymentsAtMostRisk
+        [deploymentswithprocessinfoAlias]: {
+            method: 'GET',
+            url: api.risks.riskyDeployments,
+        },
+        // AgingImages
+        [agingImagesQueryAlias]: {
+            method: 'POST',
+            url: api.graphql('agingImagesQuery'),
+        },
+        // ViolationsByPolicySeverity ViolationsByPolicyCategory
+        [alertsSummaryCountsAlias]: {
+            method: 'GET',
+            url: api.alerts.countsByCategory,
+        },
+        // ComplianceLevelsByStandard
+        [getAggregatedResultsAlias]: {
+            method: 'POST',
+            url: api.graphql('getAggregatedResults'),
+        },
+    },
+};
 
 // visit helpers
 
 export function visitMainDashboardFromLeftNav() {
-    cy.intercept('GET', api.risks.riskyDeployments).as('deploymentswithprocessinfo');
+    interactAndWaitForResponses(() => {
+        cy.get(`${navSelectors.navLinks}:contains("Dashboard")`).click();
+    }, requestConfig);
 
-    cy.get(`${navSelectors.navLinks}:contains("Dashboard")`).click();
-
-    cy.wait('@deploymentswithprocessinfo');
     cy.get('h1:contains("Dashboard")');
 }
 
-export function visitMainDashboard(requestConfig, staticResponseMap) {
-    cy.intercept('GET', api.risks.riskyDeployments).as('deploymentswithprocessinfo');
-
+export function visitMainDashboard(staticResponseMap) {
     visit(url, requestConfig, staticResponseMap);
 
-    cy.wait('@deploymentswithprocessinfo');
     cy.get('h1:contains("Dashboard")');
 }


### PR DESCRIPTION
## Description

Follow up after removal of route for classic main dashboard in #3057

Alias constant is the “foreign key” to join:
* `method` and `url` in `routeMatcherMap` object
    `RouteMatcher` see https://docs.cypress.io/api/commands/intercept#Matching-method
* `{ fixture: fixtureFilePath }` or `{ body: data }` in optional `staticResponseMap` argument to provide mock data
    `StaticResponse` see https://docs.cypress.io/api/commands/intercept#StaticResponse-objects

Deleted `requestConfig` argument from `visitMainDashboard` because it was a temporary kludge in case tests needed to provide classic versus PatternFly requests.

### Objectives

* Negative problem to prevent: Prevent timing problems between adjacent tests, each of which might have assertions which succeed while slower requests are still in progress. Based on experience with clusters tests, the timing problem is worse when adjacent tests mock some requests, but do not wait on all requests.
* Postive improvement to achieve: Be able to mock only the relevant requests to test a widget.

This is a recommended pattern to follow in helper files for containers.

See a systemConfig test wait for requests:
* **generic** requests to render any page: always intercepted by `visit` function in visit.js
* **specific** requests to render tested page: intercepted by `visit` function because of `requestConfig` argument in its call from `visitMainDashboard` function
<img width="1440" alt="visitMainDashboard" src="https://user-images.githubusercontent.com/11862657/190449190-5b6ab51f-5ce0-44ba-a305-b4a948999e49.png">

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

* clusters/clusters
* policies/policiesTable
* systemHealth/systemHealthGeneral
* violations/violations
* certexpiration
* systemConfig