### PR TITLE
ROX-12672: Fix auth providers shown as immutable

### DIFF
--- a/ui/apps/platform/cypress/fixtures/auth/authProviders-id1.json
+++ b/ui/apps/platform/cypress/fixtures/auth/authProviders-id1.json
@@ -13,9 +13,7 @@
             "loginUrl": "irrelevant",
             "validated": false,
             "active": false,
-            "traits": {
-                "mutabilityMode": "ALLOW_MUTATE"
-            }
+            "traits": null
         }
     ]
 }

--- a/ui/apps/platform/cypress/fixtures/auth/authProvidersWithClientSecret.json
+++ b/ui/apps/platform/cypress/fixtures/auth/authProvidersWithClientSecret.json
@@ -16,9 +16,7 @@
             "type": "oidc",
             "uiEndpoint": "localhost:3000",
             "validated": false,
-            "traits": {
-                "mutabilityMode": "ALLOW_MUTATE"
-            }
+            "traits": null
         }
     ]
 }

--- a/ui/apps/platform/cypress/fixtures/auth/groupsWithClientSecret.json
+++ b/ui/apps/platform/cypress/fixtures/auth/groupsWithClientSecret.json
@@ -4,7 +4,8 @@
             "props": {
                 "authProviderId": "auth-provider-1",
                 "key": "",
-                "value": ""
+                "value": "",
+                "traits": null
             },
             "roleName":"Admin"
         }

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
@@ -63,6 +63,7 @@ function RuleGroups({
             (group &&
                 'props' in group &&
                 'traits' in group.props &&
+                group?.props?.traits != null &&
                 group?.props?.traits?.mutabilityMode !== 'ALLOW_MUTATE')
         );
     }

--- a/ui/apps/platform/src/services/AuthService/AuthService.ts
+++ b/ui/apps/platform/src/services/AuthService/AuthService.ts
@@ -415,5 +415,9 @@ export function addAuthInterceptors(authHttpErrorHandler): void {
  * @return {boolean} indicating whether the auth provider is immutable.
  */
 export function getIsAuthProviderImmutable(authProvider: AuthProvider): boolean {
-    return 'traits' in authProvider && authProvider.traits?.mutabilityMode !== 'ALLOW_MUTATE';
+    return (
+        'traits' in authProvider &&
+        authProvider.traits != null &&
+        authProvider.traits?.mutabilityMode !== 'ALLOW_MUTATE'
+    );
 }


### PR DESCRIPTION
## Description

When creating auth providers via API instead of within UI, the field `traits` is set to `null` instead of omitted.

This lead to the auth provider being incorrectly shown as immutable, although the traits field was null.

It's due to the way we check for immutability. We should also check, if the traits field exists, whether its != null (this way checking if the value is either `null` or `undefined`).

This PR will add those additional checks (for both the auth provider and groups) and additionally changes the E2E tests to use `traits: null` as value, so we have this covered in the future.

## Testing Performed

- see E2E tests.
