### PR TITLE
Call assertSortedItems in policies and risk integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/policiesPatternFly.js
+++ b/ui/apps/platform/cypress/helpers/policiesPatternFly.js
@@ -5,16 +5,20 @@ import { visit } from './visit';
 
 // Navigation
 
+export const notifiersAlias = 'notifiers';
+export const searchMetadataOptionsAlias = 'search/metadata/options';
+export const policiesAlias = 'policies';
+
 const routeMatcherMap = {
-    notifiers: {
+    [notifiersAlias]: {
         method: 'GET',
         url: api.integrations.notifiers,
     },
-    'search/metadata/options': {
+    [searchMetadataOptionsAlias]: {
         method: 'GET',
         url: api.search.optionsCategories('POLICIES'),
     },
-    policies: {
+    [policiesAlias]: {
         method: 'GET',
         // Include empty search query to distinguish from intercept with search query.
         url: `${api.policies.policies}?query=`,
@@ -69,7 +73,7 @@ export function changePolicyStatusInTable({ policyName, statusPrev, actionText, 
     cy.intercept('PATCH', api.policies.policy).as('PATCH_policies/id');
     doPolicyRowAction(trSelector, actionText);
     cy.wait('@PATCH_policies/id');
-    cy.wait('@policies'); // assume alias from visitPolicies function call
+    cy.wait(`@${policiesAlias}`); // assume visitPolicies as a prerequisite
     cy.get(`${trSelector} td[data-label="Status"]:contains("${statusNext}")`);
 }
 
@@ -80,7 +84,7 @@ export function deletePolicyInTable({ policyName, actionText }) {
     doPolicyRowAction(trSelector, actionText);
     cy.get('[role="dialog"][aria-label="Confirm delete"] button:contains("Delete")').click();
     cy.wait('@DELETE_policies/id');
-    cy.wait('@policies'); // assume alias from visitPolicies function call
+    cy.wait(`@${policiesAlias}`); // assume visitPolicies as a prerequisite
 }
 
 export function searchPolicies(category, value) {

--- a/ui/apps/platform/cypress/helpers/risk.js
+++ b/ui/apps/platform/cypress/helpers/risk.js
@@ -6,16 +6,20 @@ import { visit } from './visit';
 
 // visit
 
+export const deploymentswithprocessinfoAlias = 'deploymentswithprocessinfo';
+export const deploymentscountAlias = 'deploymentscount';
+export const searchOptionsAlias = 'searchOptions';
+
 const routeMatcherMap = {
-    deploymentswithprocessinfo: {
+    [deploymentswithprocessinfoAlias]: {
         method: 'GET',
         url: api.risks.riskyDeployments,
     },
-    deploymentscount: {
+    [deploymentscountAlias]: {
         method: 'GET',
         url: api.risks.deploymentsCount,
     },
-    searchOptions: {
+    [searchOptionsAlias]: {
         method: 'POST',
         url: api.graphql('searchOptions'),
     },

--- a/ui/apps/platform/cypress/helpers/sort.js
+++ b/ui/apps/platform/cypress/helpers/sort.js
@@ -1,7 +1,7 @@
 /*
  * Assert that each pair of adjacent items are in sorted order.
  * items might be DOM elements from cy.get(…) call.
- * callbackForPairOfSortedItems(itemA, itemB) is returned from create higher-order function below.
+ * callbackForPairOfSortedItems(itemA, itemB) is returned from higher-order function below.
  */
 export function assertSortedItems(items, callbackForPairOfSortedItems) {
     for (let indexB = 1; indexB < items.length; indexB += 1) {

--- a/ui/apps/platform/cypress/helpers/sort.js
+++ b/ui/apps/platform/cypress/helpers/sort.js
@@ -1,0 +1,120 @@
+/*
+ * Assert that each pair of adjacent items are in sorted order.
+ * items might be DOM elements from cy.get(…) call.
+ * callbackForPairOfSortedItems(itemA, itemB) is returned from create higher-order function below.
+ */
+export function assertSortedItems(items, callbackForPairOfSortedItems) {
+    for (let indexB = 1; indexB < items.length; indexB += 1) {
+        const itemA = items[indexB - 1];
+        const itemB = items[indexB];
+        const result = callbackForPairOfSortedItems(itemA, itemB);
+
+        // No news is good news. One incorrect result is enough bad news.
+        if (result !== '') {
+            expect(result).to.equal('');
+            break;
+        }
+    }
+}
+
+/*
+ * Create callback function for assertSortedItems function above.
+ * notValidDescription looks like a function name
+ * - Its prefix is not.
+ * - Its root is a description in PascalCase of valid and sorted values from items.
+ * getValueFromItem encapsulates access like item?.innerText property.
+ * isValidValue encapsulates expected type of value like string.
+ * isPairOfSortedValues encapsulates comparison like ascending or descending.
+ *
+ * Return empty string for a pair of valid and sorted values.
+ * Return non-empty string which looks like a function call for a pair of invalid or unsorted values.
+ */
+export function createCallbackForPairOfSortedItems(
+    notValidDescription,
+    getValueFromItem,
+    isValidValue,
+    isPairOfSortedValues
+) {
+    return function callbackForPairOfItems(itemA, itemB) {
+        const valueA = getValueFromItem(itemA);
+        const valueB = getValueFromItem(itemB);
+
+        if (isValidValue(valueA) && isValidValue(valueB) && isPairOfSortedValues(valueA, valueB)) {
+            return ''; // return empty string for correctly sorted pair
+        }
+
+        return `${notValidDescription}(${valueA}, ${valueB})`;
+    };
+}
+
+export function getNumberValueFromElement(element) {
+    return Number(element?.innerText);
+}
+
+export function isValidNumberValue(value) {
+    return typeof value === 'number' && !Number.isNaN(value);
+}
+
+// Compare either number or string values.
+export function isPairOfAscendingValues(valueA, valueB) {
+    return valueA <= valueB;
+}
+
+// Compare either number or string values.
+export function isPairOfDescendingValues(valueA, valueB) {
+    return valueA >= valueB;
+}
+
+export const callbackForPairOfAscendingNumberValuesFromElements =
+    createCallbackForPairOfSortedItems(
+        'notAscendingNumberValuesFromElements',
+        getNumberValueFromElement,
+        isValidNumberValue,
+        isPairOfAscendingValues
+    );
+
+export const callbackForPairOfDescendingNumberValuesFromElements =
+    createCallbackForPairOfSortedItems(
+        'notDescendingNumberValuesFromElements',
+        getNumberValueFromElement,
+        isValidNumberValue,
+        isPairOfDescendingValues
+    );
+
+export function getStringValueFromElement(element) {
+    return element?.innerText;
+}
+
+const severityValues = ['Low', 'Medium', 'High', 'Critical'];
+
+export function isValidSeverityValue(value) {
+    return typeof value === 'string' && severityValues.includes(value);
+}
+
+export function isPairOfAscendingSeverityValues(valueA, valueB) {
+    const indexA = severityValues.indexOf(valueA);
+    const indexB = severityValues.indexOf(valueB);
+    return indexA !== -1 && indexA <= indexB;
+}
+
+export function isPairOfDescendingSeverityValues(valueA, valueB) {
+    const indexA = severityValues.indexOf(valueA);
+    const indexB = severityValues.indexOf(valueB);
+    return indexA >= indexB && indexB !== -1;
+}
+
+export const callbackForPairOfAscendingSeverityValuesFromElements =
+    createCallbackForPairOfSortedItems(
+        'notAscendingSeverityValuesFromElements',
+        getStringValueFromElement,
+        isValidSeverityValue,
+        isPairOfAscendingSeverityValues
+    );
+
+export const callbackForPairOfDescendingSeverityValuesFromElements =
+    createCallbackForPairOfSortedItems(
+        'notDescendingSeverityValuesFromElements',
+        getStringValueFromElement,
+        isValidSeverityValue,
+        isPairOfDescendingSeverityValues
+    );

--- a/ui/apps/platform/cypress/integration/policies/policiesTable.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policiesTable.test.js
@@ -11,6 +11,11 @@ import {
     visitPolicies,
     visitPoliciesFromLeftNav,
 } from '../../helpers/policiesPatternFly';
+import {
+    assertSortedItems,
+    callbackForPairOfAscendingSeverityValuesFromElements,
+    callbackForPairOfDescendingSeverityValuesFromElements,
+} from '../../helpers/sort';
 import { visit } from '../../helpers/visit';
 import navSelectors from '../../selectors/navigation';
 
@@ -57,7 +62,7 @@ describe('Policies table', () => {
         );
     });
 
-    it('table should have columns', () => {
+    it('should have columns', () => {
         visitPolicies();
 
         cy.get('th[scope="col"]:contains("Policy")');
@@ -66,6 +71,64 @@ describe('Policies table', () => {
         cy.get('th[scope="col"]:contains("Notifiers")');
         cy.get('th[scope="col"]:contains("Severity")');
         cy.get('th[scope="col"]:contains("Lifecycle")');
+    });
+
+    it('should sort the Severity column', () => {
+        visitPolicies();
+
+        const thSelector = 'th[scope="col"]:contains("Severity")';
+        const tdSelector = 'td[data-label="Severity"]';
+
+        // 0. Initial table state is sorted by the Policy column.
+        cy.get(thSelector).should('have.attr', 'aria-sort', 'none');
+
+        // 1. Sort ascending by the Severity column.
+        cy.get(thSelector).click();
+        // TODO Move sort order from invisible page state to visible query parameters in page address.
+        /*
+        cy.location('search').should('eq', '?sort[id]=Severity&sort[desc]=false');
+        */
+
+        // There is no request because front-end sorting.
+        cy.wait(1000);
+
+        cy.get(thSelector).should('have.attr', 'aria-sort', 'ascending');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfAscendingSeverityValuesFromElements);
+        });
+
+        // 2. Sort descending by the Severity column.
+        cy.get(thSelector).click();
+        // TODO Move sort order from invisible page state to visible query parameters in page address.
+        /*
+        cy.location('search').should(
+            'eq',
+            '?sort[id]=Severity&sort[desc]=true'
+        );
+        */
+
+        // There is no request because front-end sorting.
+        cy.wait(1000);
+
+        cy.get(thSelector).should('have.attr', 'aria-sort', 'descending');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfDescendingSeverityValuesFromElements);
+        });
+
+        // 3. Sort ascending by the Severity column.
+        cy.get(thSelector).click();
+        // TODO Move sort order from invisible page state to visible query parameters in page address.
+        /*
+        cy.location('search').should('eq', '?sort[id]=Severity&sort[desc]=false');
+        */
+
+        // There is no request because front-end sorting.
+        cy.wait(1000);
+
+        cy.get(thSelector).should('have.attr', 'aria-sort', 'ascending');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfAscendingSeverityValuesFromElements);
+        });
     });
 
     it('should have expected status values', () => {


### PR DESCRIPTION
## Description

Follow up on comment by Dave

> I can still see value in testing that the items in the table are in sorted order though, e.g. that each item is >= or <= the following one in the table depending on the sort order. It might be something worth adding in the future if we revisit this test.

### History

1. The original test sometimes failed because of timing problems: get element too soon.
2. The simplified test has intercept-wait and assertions for search query and column heading indicator. I deleted the contains assertion, because the risk priority can change between the initial state and the sorted state.
3. The strengthened test depends on wait and assertions to get column elements in sorted state and assert the order.

### Overview

1. Write `assertSortedItems` function whose arguments are `items` array of unknown type and corresponding `callbackForPairOfSortedItems` function which returns a non-empty string if a comparison fails.

2. Write `createCallbackForPairOfSortedItems` higher-order function which returns a callback function from reusable functions:

    * `getValueFromItem`
    * `isValidValue`
    * `isPairOfSortedValues`

3. Export generic callback functions for tests in multiple containers:

    * `callbackForPairOfAscendingNumberValuesFromElements`
    * `callbackForPairOfDescendingNumberValuesFromElements`
    * `callbackForPairOfAscendingSeverityValuesFromElements`
    * `callbackForPairOfDescendingSeverityValuesFromElements`

Because backend sorting algorithm for strings might differ from JavaScript comparison operators or methods, especially considering possible effect of locale, it seems better not to test that arbitrary string values are sorted.

Here is an example of an artificial test failure when I temporarily edited sort.js to replace  `<=` with `<` in the `isPairOfAscendingSeverityValues` function.
<img width="1440" alt="policiesTable" src="https://user-images.githubusercontent.com/11862657/190502418-283630d1-e0eb-4056-b22e-c3df32acd6e6.png">

Here is an example of an artificial test failure when I temporarily edited risk.test.js to replace `callbackForPairOfAscendingNumberValuesFromElements` with `callbackForPairOfDescendingNumberValuesFromElements` in the test as if get got ahead of re-rendering the table. Which happened during development before I added wait for /v1/deploymentscount request.
<img width="1440" alt="risk" src="https://user-images.githubusercontent.com/11862657/190502399-7044c068-e7ac-4725-9aec-b07350b183c2.png">

### Changed files

1. Edit cypress/helpers/risk.js
    * Export whateverAlias constants.

2. Edit cypress/helpers/policiesPatternFly.js
    * Export whateverAlias constants.

3. Add cypress/helpers/sort.js

4. Edit cypress/integration/policies/policiesTable.test.js

5. Edit cypress/integration/risk/risk.test.js
    * Add `'should have table columns'` test.
    * Edit `'should sort the Priority column'` test:
        * Define `thSelector` and `tdSelector` constants to reduce the chance of copy-paste-edit errors when applying the pattern in other containers.
        * Wait for /v1/deploymentscount request to reduce the risk to get elements before the table has been re-rendered.
        * Call `assertSortedItems` helper function.

### Residue

1. Delete redundant `describe` blocks in risk.test.js file. Respect the changed files diff to review this pull request.
2. Call `assertSortedItems` in vulnmamagement integration tests.
    * Several tables have **Risk Priority** column.
    * Although some tables have **Severity** column, it looks like backend does not sort it yet. For now, write tests for **CVSS Score** decimal number value.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

* policies/policiesTable.test.js
* risk.test.js