### PR TITLE
ROX-12588 Add collections sidebar link gated behind flag

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -26,6 +26,7 @@ import {
     vulnManagementReportsPath,
     configManagementPath,
     vulnManagementRiskAcceptancePath,
+    collectionsPath,
 } from 'routePaths';
 import { useTheme } from 'Containers/ThemeProvider';
 
@@ -92,6 +93,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
 
     const isSystemHealthPatternFlyEnabled = isFeatureFlagEnabled('ROX_SYSTEM_HEALTH_PF');
     const isSearchPageEnabled = isFeatureFlagEnabled('ROX_SEARCH_PAGE_UI');
+    const isCollectionsEnabled = isFeatureFlagEnabled('ROX_OBJECT_COLLECTIONS');
 
     const hasVulnerabilityReportsPermission = hasReadAccess('VulnerabilityReports');
 
@@ -113,6 +115,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     <Route path={policyManagementBasePath} component={AsyncPolicyManagementPage} />
                     {/* Make sure the following Redirect element works after react-router-dom upgrade */}
                     <Redirect exact from={deprecatedPoliciesPath} to={policiesPath} />
+                    {isCollectionsEnabled && <Route path={collectionsPath} component={() => ''} />}
                     <Route path={riskPath} component={AsyncRiskPage} />
                     <Route path={accessControlPathV2} component={AsyncAccessControlPageV2} />
                     {isSearchPageEnabled && <Route path={searchPath} component={AsyncSearchPage} />}

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -22,26 +22,20 @@ import {
     accessControlBasePathV2,
     systemConfigPath,
     systemHealthPath,
+    collectionsPath,
 } from 'routePaths';
 
 import LeftNavItem from './LeftNavItem';
 
-const platformConfigurationPaths = [
-    clustersBasePath,
-    policyManagementBasePath,
-    integrationsPath,
-    accessControlBasePathV2,
-    systemConfigPath,
-    systemHealthPath,
-];
-
 type NavigationSidebarProps = {
     hasReadAccess: HasReadAccess;
-    // eslint-disable-next-line react/no-unused-prop-types
     isFeatureFlagEnabled: IsFeatureFlagEnabled;
 };
 
-function NavigationSidebar({ hasReadAccess }: NavigationSidebarProps): ReactElement {
+function NavigationSidebar({
+    hasReadAccess,
+    isFeatureFlagEnabled,
+}: NavigationSidebarProps): ReactElement {
     const location: Location = useLocation();
 
     const vulnerabilityManagementPaths = [vulnManagementPath];
@@ -53,6 +47,27 @@ function NavigationSidebar({ hasReadAccess }: NavigationSidebarProps): ReactElem
     }
     if (hasReadAccess('VulnerabilityReports')) {
         vulnerabilityManagementPaths.push(vulnManagementReportsPath);
+    }
+
+    const platformConfigurationPaths = [
+        clustersBasePath,
+        policyManagementBasePath,
+        integrationsPath,
+        accessControlBasePathV2,
+        systemConfigPath,
+        systemHealthPath,
+    ];
+
+    // TODO
+    // - This must be restricted based on permissions once the BE is in place https://issues.redhat.com/browse/ROX-12695
+    // - See also https://issues.redhat.com/browse/ROX-12619
+    if (isFeatureFlagEnabled('ROX_OBJECT_COLLECTIONS')) {
+        // Insert 'Collections' after 'Policy Management'
+        platformConfigurationPaths.splice(
+            platformConfigurationPaths.indexOf(policyManagementBasePath) + 1,
+            0,
+            collectionsPath
+        );
     }
 
     const Navigation = (

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -44,6 +44,7 @@ export const compliancePath = `${mainPath}/:context(compliance)`;
 export const dataRetentionPath = `${mainPath}/retention`;
 export const systemHealthPath = `${mainPath}/system-health`;
 export const systemHealthPathPF = `${mainPath}/system-health-pf`;
+export const collectionsPath = `${mainPath}/collections`;
 export const productDocsPath = '/docs/product';
 
 // Configuration Management
@@ -156,6 +157,7 @@ export const basePathToLabelMap = {
     [policyManagementBasePath]: 'Policy Management',
     [policiesBasePath]: 'Policy Management',
     [policyCategoriesPath]: 'Policy Categories',
+    [collectionsPath]: 'Collections',
     [integrationsPath]: 'Integrations',
     [accessControlPath]: 'Access Control',
     [accessControlBasePathV2]: 'Access Control',


### PR DESCRIPTION
## Description

Adds 'Collection' navigation link to sidebar when feature flag is enabled. This currently will render an empty component/blank page.

## Follow up

This needs to be restricted based on user permissions once BE work is in place. There is a TODO and Jira link in the code where this needs to occur.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Open sidebar navigation with feature flag enabled:
<img width="1663" alt="image" src="https://user-images.githubusercontent.com/1292638/190693867-c0bbf09d-ecb0-44c6-a1dd-91ce2486907e.png">

Open sidebar navigation with feature flag disabled:
<img width="1663" alt="image" src="https://user-images.githubusercontent.com/1292638/190694712-1631bb88-56a9-40be-8396-ccf319b473ad.png">

Visit Collection URL directly when feature flag is disabled:
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/1292638/191029884-0302e2b9-ec5b-4cbe-9a84-b658548e759c.png">

