### PR TITLE
Add basic shell and header for main collections page

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionsPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsPage.tsx
@@ -1,17 +1,11 @@
 import React from 'react';
 
-import NotFoundMessage from 'Components/NotFoundMessage';
 import CollectionsTablePage from './CollectionsTablePage';
 
 function CollectionsPage() {
     // TODO Implement permissions once https://issues.redhat.com/browse/ROX-12619 is merged
-    // const { hasReadAccess, hasReadWriteAccess } = usePermissions();
-    const hasReadAccessForCollections = true; // hasReadAccess('TODO');
-    const hasWriteAccessForCollections = true; // hasReadWriteAccess('TODO');
-
-    if (!hasReadAccessForCollections) {
-        return <NotFoundMessage title="404: We couldn't find that page" />;
-    }
+    // const { hasWriteAccess } = usePermissions();
+    const hasWriteAccessForCollections = true; // hasWriteAccess('TODO');
 
     return <CollectionsTablePage hasWriteAccessForCollections={hasWriteAccessForCollections} />;
 }

--- a/ui/apps/platform/src/Containers/Collections/CollectionsPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsPage.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import NotFoundMessage from 'Components/NotFoundMessage';
+import CollectionsTablePage from './CollectionsTablePage';
+
+function CollectionsPage() {
+    // TODO Implement permissions once https://issues.redhat.com/browse/ROX-12619 is merged
+    // const { hasReadAccess, hasReadWriteAccess } = usePermissions();
+    const hasReadAccessForCollections = true; // hasReadAccess('TODO');
+    const hasWriteAccessForCollections = true; // hasReadWriteAccess('TODO');
+
+    if (!hasReadAccessForCollections) {
+        return <NotFoundMessage title="404: We couldn't find that page" />;
+    }
+
+    return <CollectionsTablePage hasWriteAccessForCollections={hasWriteAccessForCollections} />;
+}
+
+export default CollectionsPage;

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {
+    PageSection,
+    Title,
+    Text,
+    Button,
+    Flex,
+    FlexItem,
+    ButtonVariant,
+} from '@patternfly/react-core';
+
+import PageTitle from 'Components/PageTitle';
+import LinkShim from 'Components/PatternFly/LinkShim';
+import { collectionsPath } from 'routePaths';
+
+type CollectionsTablePageProps = {
+    hasWriteAccessForCollections: boolean;
+};
+
+function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTablePageProps) {
+    return (
+        <>
+            <PageTitle title="Collections" />
+            <PageSection variant="light">
+                <Flex alignItems={{ default: 'alignItemsCenter' }}>
+                    <FlexItem flex={{ default: 'flex_1' }}>
+                        <Title headingLevel="h1">Collections</Title>
+                        <Text>
+                            Configure deployment collections to associate with other workflows
+                        </Text>
+                    </FlexItem>
+                    {hasWriteAccessForCollections && (
+                        <FlexItem align={{ default: 'alignRight' }}>
+                            <Button
+                                variant={ButtonVariant.primary}
+                                component={LinkShim}
+                                href={`${collectionsPath}?action=create`}
+                            >
+                                Create collection
+                            </Button>
+                        </FlexItem>
+                    )}
+                </Flex>
+            </PageSection>
+        </>
+    );
+}
+
+export default CollectionsTablePage;

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -61,6 +61,8 @@ const AsyncPolicyManagementPage = asyncComponent(
     () => import('Containers/PolicyManagement/PolicyManagementPage')
 );
 
+const AsyncCollectionsPage = asyncComponent(() => import('Containers/Collections/CollectionsPage'));
+
 const AsyncCompliancePage = asyncComponent(() => import('Containers/Compliance/Page'));
 const AsyncRiskPage = asyncComponent(() => import('Containers/Risk/RiskPage'));
 const AsyncAccessControlPageV2 = asyncComponent(
@@ -115,7 +117,9 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     <Route path={policyManagementBasePath} component={AsyncPolicyManagementPage} />
                     {/* Make sure the following Redirect element works after react-router-dom upgrade */}
                     <Redirect exact from={deprecatedPoliciesPath} to={policiesPath} />
-                    {isCollectionsEnabled && <Route path={collectionsPath} component={() => ''} />}
+                    {isCollectionsEnabled && (
+                        <Route path={collectionsPath} component={AsyncCollectionsPage} />
+                    )}
                     <Route path={riskPath} component={AsyncRiskPage} />
                     <Route path={accessControlPathV2} component={AsyncAccessControlPageV2} />
                     {isSearchPageEnabled && <Route path={searchPath} component={AsyncSearchPage} />}

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -98,6 +98,8 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
     const isCollectionsEnabled = isFeatureFlagEnabled('ROX_OBJECT_COLLECTIONS');
 
     const hasVulnerabilityReportsPermission = hasReadAccess('VulnerabilityReports');
+    // TODO Implement permissions once https://issues.redhat.com/browse/ROX-12619 is merged
+    const hasCollectionsPermission = true; // hasReadAccess('TODO');
 
     return (
         <div
@@ -117,7 +119,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     <Route path={policyManagementBasePath} component={AsyncPolicyManagementPage} />
                     {/* Make sure the following Redirect element works after react-router-dom upgrade */}
                     <Redirect exact from={deprecatedPoliciesPath} to={policiesPath} />
-                    {isCollectionsEnabled && (
+                    {isCollectionsEnabled && hasCollectionsPermission && (
                         <Route path={collectionsPath} component={AsyncCollectionsPage} />
                     )}
                     <Route path={riskPath} component={AsyncRiskPage} />


### PR DESCRIPTION
## Description

Adds the top level CollectionsPage component shell and header. This also stubs out permission props for the upcoming SAC role for "Workflow Administration". TODOs and Jira links are in the code as a reminder.


## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Visit the collections page from the sidebar, default behavior:
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/1292638/190716064-3254b57d-28d5-4e75-853c-70a51a5c8f26.png">

Visit the collection page with `hasReadAccessForCollections` manually set to `false`:
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/1292638/190716167-144a042e-708a-4c43-96c1-b6c645a93830.png">

Visit the collection page with `hasWriteAccessForCollections` manually set to `false`:
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/1292638/190716280-d43223c7-77a0-4220-9da6-ee85dbb5b8cf.png">

Click the 'Create collection' button and ensure the URL changes to the "create" page. (No change in rendered components at this point.)
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/1292638/190716403-d0e020a6-230b-4bf5-ba42-1ce322662251.png">

