### PR TITLE
ROX-12566: Proof-of-concept URL-driven network graph

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -6,6 +6,7 @@ import {
     mainPath,
     dashboardPath,
     networkPath,
+    networkPathPF,
     violationsPath,
     compliancePath,
     clustersPathWithParam,
@@ -50,6 +51,9 @@ const AsyncSearchPage = asyncComponent(() => import('Containers/Search/SearchPag
 const AsyncApiDocsPage = asyncComponent(() => import('Containers/Docs/ApiPage'));
 const AsyncDashboardPage = asyncComponent(() => import('Containers/Dashboard/DashboardPage'));
 const AsyncNetworkPage = asyncComponent(() => import('Containers/Network/Page'));
+const AsyncNetworkGraphPage = asyncComponent(
+    () => import('Containers/NetworkGraph/NetworkGraphPage')
+);
 const AsyncClustersPage = asyncComponent(() => import('Containers/Clusters/ClustersPage'));
 const AsyncPFClustersPage = asyncComponent(() => import('Containers/Clusters/PF/ClustersPage'));
 const AsyncIntegrationsPage = asyncComponent(
@@ -109,6 +113,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     <Route path={mainPath} exact render={() => <Redirect to={dashboardPath} />} />
                     <Route path={dashboardPath} component={AsyncDashboardPage} />
                     <Route path={networkPath} component={AsyncNetworkPage} />
+                    <Route path={networkPathPF} component={AsyncNetworkGraphPage} />
                     <Route path={violationsPath} component={AsyncViolationsPage} />
                     <Route path={compliancePath} component={AsyncCompliancePage} />
                     <Route path={integrationsPath} component={AsyncIntegrationsPage} />

--- a/ui/apps/platform/src/Containers/NetworkGraph/ClusterSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/ClusterSelect.tsx
@@ -1,0 +1,47 @@
+import React, { ReactElement } from 'react';
+import { Select, SelectOption } from '@patternfly/react-core';
+
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { Cluster } from 'types/cluster.proto';
+
+type ClusterSelectProps = {
+    id?: string;
+    setSelectedClusterId: (clusterId: string) => void;
+    clusters: Cluster[];
+    selectedClusterId?: string;
+    isDisabled?: boolean;
+};
+
+const ClusterSelect = ({
+    id,
+    setSelectedClusterId,
+    clusters,
+    selectedClusterId = '',
+    isDisabled = false,
+}: ClusterSelectProps): ReactElement => {
+    const { closeSelect, isOpen, onToggle } = useSelectToggle();
+    function changeCluster(_e, clusterId) {
+        setSelectedClusterId(clusterId);
+        closeSelect();
+    }
+
+    return (
+        <Select
+            id={id}
+            isOpen={isOpen}
+            onToggle={onToggle}
+            isDisabled={isDisabled || !clusters.length}
+            selections={selectedClusterId}
+            placeholderText="Select a cluster"
+            onSelect={changeCluster}
+        >
+            {clusters.map(({ id: clusterId, name }) => (
+                <SelectOption key={clusterId} value={clusterId}>
+                    {name}
+                </SelectOption>
+            ))}
+        </Select>
+    );
+};
+
+export default ClusterSelect;

--- a/ui/apps/platform/src/Containers/NetworkGraph/ClusterSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/ClusterSelect.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Select, SelectOption } from '@patternfly/react-core';
+import { Select, SelectOption, Spinner } from '@patternfly/react-core';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { Cluster } from 'types/cluster.proto';
@@ -10,6 +10,8 @@ type ClusterSelectProps = {
     clusters: Cluster[];
     selectedClusterId?: string;
     isDisabled?: boolean;
+    isLoading?: boolean;
+    error?: string;
 };
 
 const ClusterSelect = ({
@@ -18,6 +20,8 @@ const ClusterSelect = ({
     clusters,
     selectedClusterId = '',
     isDisabled = false,
+    isLoading = false,
+    error = '',
 }: ClusterSelectProps): ReactElement => {
     const { closeSelect, isOpen, onToggle } = useSelectToggle();
     function changeCluster(_e, clusterId) {
@@ -30,9 +34,15 @@ const ClusterSelect = ({
             id={id}
             isOpen={isOpen}
             onToggle={onToggle}
-            isDisabled={isDisabled || !clusters.length}
+            isDisabled={isDisabled || !!error || !clusters.length}
             selections={selectedClusterId}
-            placeholderText="Select a cluster"
+            placeholderText={
+                isLoading ? (
+                    <Spinner isSVG size="sm" aria-label="Contents of the small example" />
+                ) : (
+                    'Select a cluster'
+                )
+            }
             onSelect={changeCluster}
         >
             {clusters.map(({ id: clusterId, name }) => (

--- a/ui/apps/platform/src/Containers/NetworkGraph/EntityBreadcrumbs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/EntityBreadcrumbs.tsx
@@ -1,0 +1,110 @@
+import React, { ReactElement } from 'react';
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    BreadcrumbHeading,
+    Dropdown,
+    BadgeToggle,
+    DropdownItem,
+    Select,
+    SelectOption,
+    Spinner,
+} from '@patternfly/react-core';
+import { AngleLeftIcon } from '@patternfly/react-icons';
+
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { Cluster } from 'types/cluster.proto';
+
+type EntityBreadcrumbsProps = {
+    id?: string;
+    setSelectedClusterId: (clusterId: string) => void;
+    clusters: Cluster[];
+    selectedClusterId?: string;
+    isDisabled?: boolean;
+    isLoading?: boolean;
+    error?: string;
+};
+
+const EntityBreadcrumbs = ({
+    id,
+    setSelectedClusterId,
+    clusters,
+    selectedClusterId = '',
+    isDisabled = false,
+    isLoading = false,
+    error = '',
+}: EntityBreadcrumbsProps): ReactElement => {
+    // const { closeSelect, isOpen, onToggle } = useSelectToggle();
+    // function changeCluster(_e, clusterId) {
+    //     setSelectedClusterId(clusterId);
+    //     closeSelect();
+    // }
+
+    const dropdownItems: JSX.Element[] = [
+        <DropdownItem key="edit" component="button" icon={<AngleLeftIcon />}>
+            Edit
+        </DropdownItem>,
+        <DropdownItem key="action" component="button" icon={<AngleLeftIcon />}>
+            Deployment
+        </DropdownItem>,
+        <DropdownItem key="apps" component="button" icon={<AngleLeftIcon />}>
+            Applications
+        </DropdownItem>,
+    ];
+    const [isOpen, setIsOpen] = React.useState(false);
+    const badgeToggleRef = React.useRef<HTMLButtonElement>(null);
+
+    const onToggle = (isOpen: boolean) => setIsOpen(isOpen);
+
+    const onSelect = () => {
+        setIsOpen((prevIsOpen: boolean) => !prevIsOpen);
+        if (badgeToggleRef?.current) {
+            badgeToggleRef.current.focus();
+        }
+    };
+
+    return (
+        <Breadcrumb>
+            <BreadcrumbItem component="button">Section home</BreadcrumbItem>
+            <BreadcrumbItem isDropdown>
+                <Dropdown
+                    onSelect={onSelect}
+                    toggle={
+                        <BadgeToggle ref={badgeToggleRef} onToggle={onToggle}>
+                            {dropdownItems.length}
+                        </BadgeToggle>
+                    }
+                    isOpen={isOpen}
+                    dropdownItems={dropdownItems}
+                />
+            </BreadcrumbItem>
+            <BreadcrumbHeading component="button">Section title</BreadcrumbHeading>
+        </Breadcrumb>
+    );
+
+    // return (
+    //     <Select
+    //         id={id}
+    //         isOpen={isOpen}
+    //         onToggle={onToggle}
+    //         isDisabled={isDisabled || !!error || !clusters.length}
+    //         selections={selectedClusterId}
+    //         placeholderText={
+    //             isLoading ? (
+    //                 <Spinner isSVG size="sm" aria-label="Contents of the small example" />
+    //             ) : (
+    //                 'Select a cluster'
+    //             )
+    //         }
+    //         onSelect={changeCluster}
+    //     >
+    //         {clusters.map(({ id: clusterId, name }) => (
+    //             <SelectOption key={clusterId} value={clusterId}>
+    //                 {name}
+    //             </SelectOption>
+    //         ))}
+    //     </Select>
+    // );
+};
+
+export default EntityBreadcrumbs;

--- a/ui/apps/platform/src/Containers/NetworkGraph/NamespaceSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NamespaceSelect.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, ChangeEvent } from 'react';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import useNamespaceFilters from './useNamespaceFilters';
+// import useNamespaceFilters from './useNamespaceFilters';
 
 function filterElementsWithValueProp(
     filterValue: string,
@@ -17,24 +17,24 @@ function filterElementsWithValueProp(
     );
 }
 interface NamespaceSelectProps {
+    namespaces: any[];
     id?: string;
     isDisabled?: boolean;
     className?: string;
-    selectedClusterId?: string;
     selectedNamespaces: string[];
     setSelectedNamespaces: (namespaces: string[]) => void;
 }
 
 function NamespaceSelect({
+    namespaces = [],
     id = '',
     className = '',
     isDisabled = false,
-    selectedClusterId = '',
     selectedNamespaces,
     setSelectedNamespaces,
 }: NamespaceSelectProps) {
     const { isOpen, onToggle } = useSelectToggle();
-    const { loading, error, availableNamespaceFilters } = useNamespaceFilters(selectedClusterId);
+    // const { loading, error, availableNamespaceFilters } = useNamespaceFilters(selectedClusterId);
 
     function onSelect(e, selected) {
         const newSelection = selectedNamespaces.find((nsFilter) => nsFilter === selected)
@@ -47,11 +47,9 @@ function NamespaceSelect({
         (e: ChangeEvent<HTMLInputElement> | null, filterValue: string) =>
             filterElementsWithValueProp(
                 filterValue,
-                availableNamespaceFilters.map((nsFilter) => (
-                    <SelectOption key={nsFilter} value={nsFilter} />
-                ))
+                namespaces.map((nsFilter) => <SelectOption key={nsFilter} value={nsFilter} />)
             ),
-        [availableNamespaceFilters]
+        [namespaces]
     );
 
     // TODO Is there a more reliable way to set maxHeight here instead of hard coded px values?
@@ -64,13 +62,13 @@ function NamespaceSelect({
             onFilter={onFilter}
             className={`namespace-select ${className}`}
             placeholderText="Namespaces"
-            isDisabled={isDisabled || loading || Boolean(error)}
+            isDisabled={isDisabled}
             selections={selectedNamespaces}
             variant={SelectVariant.checkbox}
             maxHeight="275px"
             hasInlineFilter
         >
-            {availableNamespaceFilters.map((nsFilter) => (
+            {namespaces.map((nsFilter) => (
                 <SelectOption key={nsFilter} value={nsFilter} />
             ))}
         </Select>

--- a/ui/apps/platform/src/Containers/NetworkGraph/NamespaceSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NamespaceSelect.tsx
@@ -1,0 +1,80 @@
+import React, { useCallback, ChangeEvent } from 'react';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import useNamespaceFilters from './useNamespaceFilters';
+
+function filterElementsWithValueProp(
+    filterValue: string,
+    elements: React.ReactElement[] | undefined
+): React.ReactElement[] | undefined {
+    if (filterValue === '' || elements === undefined) {
+        return elements;
+    }
+
+    return elements.filter((reactElement) =>
+        reactElement.props.value?.toLowerCase().includes(filterValue.toLowerCase())
+    );
+}
+interface NamespaceSelectProps {
+    id?: string;
+    isDisabled?: boolean;
+    className?: string;
+    selectedClusterId?: string;
+    selectedNamespaces: string[];
+    setSelectedNamespaces: (namespaces: string[]) => void;
+}
+
+function NamespaceSelect({
+    id = '',
+    className = '',
+    isDisabled = false,
+    selectedClusterId = '',
+    selectedNamespaces,
+    setSelectedNamespaces,
+}: NamespaceSelectProps) {
+    const { isOpen, onToggle } = useSelectToggle();
+    const { loading, error, availableNamespaceFilters } = useNamespaceFilters(selectedClusterId);
+
+    function onSelect(e, selected) {
+        const newSelection = selectedNamespaces.find((nsFilter) => nsFilter === selected)
+            ? selectedNamespaces.filter((nsFilter) => nsFilter !== selected)
+            : selectedNamespaces.concat(selected);
+        setSelectedNamespaces(newSelection);
+    }
+
+    const onFilter = useCallback(
+        (e: ChangeEvent<HTMLInputElement> | null, filterValue: string) =>
+            filterElementsWithValueProp(
+                filterValue,
+                availableNamespaceFilters.map((nsFilter) => (
+                    <SelectOption key={nsFilter} value={nsFilter} />
+                ))
+            ),
+        [availableNamespaceFilters]
+    );
+
+    // TODO Is there a more reliable way to set maxHeight here instead of hard coded px values?
+    return (
+        <Select
+            id={id}
+            isOpen={isOpen}
+            onToggle={onToggle}
+            onSelect={onSelect}
+            onFilter={onFilter}
+            className={`namespace-select ${className}`}
+            placeholderText="Namespaces"
+            isDisabled={isDisabled || loading || Boolean(error)}
+            selections={selectedNamespaces}
+            variant={SelectVariant.checkbox}
+            maxHeight="275px"
+            hasInlineFilter
+        >
+            {availableNamespaceFilters.map((nsFilter) => (
+                <SelectOption key={nsFilter} value={nsFilter} />
+            ))}
+        </Select>
+    );
+}
+
+export default NamespaceSelect;

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { Flex, FlexItem, PageSection } from '@patternfly/react-core';
 
 import useURLSearch from 'hooks/useURLSearch';
-import { fetchClustersAsArray } from 'services/ClustersService';
-import { Cluster } from 'types/cluster.proto';
+import useClusters from './useClusters';
+import useNamespaces from './useNamespaces';
 import ClusterSelect from './ClusterSelect';
 import NamespaceSelect from './NamespaceSelect';
 
@@ -15,20 +15,16 @@ export type Namespace = {
 };
 
 function NetworkGraphPage() {
-    const [clusters, setClusters] = React.useState<Cluster[]>([]);
     const { searchFilter, setSearchFilter } = useURLSearch();
     const selectedClusterId = (searchFilter.Cluster as string) || '';
     const selectedNamespaces = (searchFilter.Namespace as string[]) || [];
 
-    React.useEffect(() => {
-        fetchClustersAsArray()
-            .then((data) => {
-                setClusters(data as Cluster[]);
-            })
-            .catch(() => {
-                // TODO
-            });
-    }, []);
+    const { clusters, error: clusterError, isLoading: isLoadingCluster } = useClusters();
+    const {
+        namespaces,
+        error: namespaceError,
+        loading: isLoadingNamespace,
+    } = useNamespaces(selectedClusterId);
 
     function updateSelectedClusterId(selection) {
         const newSearchFiliter = { ...searchFilter, Cluster: selection };
@@ -49,11 +45,13 @@ function NetworkGraphPage() {
                         clusters={clusters}
                         selectedClusterId={selectedClusterId}
                         setSelectedClusterId={updateSelectedClusterId}
+                        isLoading={isLoadingCluster}
+                        error={clusterError}
                     />
                 </FlexItem>
                 <FlexItem>
                     <NamespaceSelect
-                        selectedClusterId={selectedClusterId}
+                        namespaces={namespaces}
                         selectedNamespaces={selectedNamespaces}
                         setSelectedNamespaces={updateSelectedNamespaces}
                     />

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+
+import parseURL from 'utils/URLParser';
+
+function NetworkGraphPage() {
+    const location = useLocation();
+    const { pathname, search } = location.pathname;
+
+    const workflowState = parseURL({ pathname, search });
+    return (
+        <div>
+            <h1>Network Graph</h1>
+        </div>
+    );
+}
+
+export default NetworkGraphPage;

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -5,6 +5,7 @@ import useURLSearch from 'hooks/useURLSearch';
 import useClusters from './useClusters';
 import useNamespaces from './useNamespaces';
 import ClusterSelect from './ClusterSelect';
+import EntityBreadcrumbs from './EntityBreadcrumbs';
 import NamespaceSelect from './NamespaceSelect';
 
 export type Namespace = {
@@ -38,6 +39,13 @@ function NetworkGraphPage() {
 
     return (
         <PageSection variant="light" isFilled id="policies-table-loading">
+            <EntityBreadcrumbs
+                clusters={clusters}
+                selectedClusterId={selectedClusterId}
+                setSelectedClusterId={updateSelectedClusterId}
+                isLoading={isLoadingCluster}
+                error={clusterError}
+            />
             <h1>Network Graph</h1>
             <Flex>
                 <FlexItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/useClusters.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/useClusters.ts
@@ -1,0 +1,49 @@
+import { useState, useEffect } from 'react';
+
+import { fetchClustersAsArray } from 'services/ClustersService';
+import { Cluster } from 'types/cluster.proto';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+type Result = {
+    isLoading: boolean;
+    clusters: Cluster[];
+    error: string;
+};
+
+function useClusters(): Result {
+    const defaultResultState = {
+        clusters: [],
+        error: '',
+        isLoading: true,
+    };
+
+    const [result, setResult] = useState<Result>(defaultResultState);
+
+    useEffect(() => {
+        setResult(defaultResultState);
+
+        fetchClustersAsArray()
+            .then((data) => {
+                setResult({
+                    clusters: (data as Cluster[]) || [],
+                    error: '',
+                    isLoading: false,
+                });
+            })
+            .catch((error) => {
+                const message = getAxiosErrorMessage(error);
+                const errorMessage =
+                    message || 'An unknown error occurred while getting the list of clusters';
+
+                setResult({
+                    clusters: [],
+                    error: errorMessage,
+                    isLoading: false,
+                });
+            });
+    }, []);
+
+    return result;
+}
+
+export default useClusters;

--- a/ui/apps/platform/src/Containers/NetworkGraph/useNamespaceFilters.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/useNamespaceFilters.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react';
+import { gql, useQuery } from '@apollo/client';
+
+type NamespaceMetadataResp = {
+    id: string;
+    results: {
+        namespaces: {
+            metadata: {
+                name: string;
+            };
+        }[];
+    };
+};
+
+export const NAMESPACES_FOR_CLUSTER_QUERY = gql`
+    query getClusterNamespaceNames($id: ID!) {
+        results: cluster(id: $id) {
+            id
+            namespaces {
+                metadata {
+                    name
+                }
+            }
+        }
+    }
+`;
+
+function useNamespaceFilters(selectedClusterId) {
+    const [availableNamespaceFilters, setAvailableNamespaceFilters] = useState<string[]>([]);
+    // If the selectedClusterId has not been set yet, do not run the gql query
+    const queryOptions = selectedClusterId
+        ? { variables: { id: selectedClusterId } }
+        : { skip: true };
+
+    const { loading, error, data } = useQuery<NamespaceMetadataResp, { id: string }>(
+        NAMESPACES_FOR_CLUSTER_QUERY,
+        queryOptions
+    );
+
+    useEffect(() => {
+        if (!data || !data.results) {
+            return;
+        }
+
+        const namespaces = data.results.namespaces.map(({ metadata }) => metadata.name);
+
+        setAvailableNamespaceFilters(namespaces);
+    }, [data]);
+
+    return {
+        loading,
+        error,
+        availableNamespaceFilters,
+    };
+}
+
+export default useNamespaceFilters;

--- a/ui/apps/platform/src/Containers/NetworkGraph/useNamespaces.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/useNamespaces.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react';
+import { gql, useQuery } from '@apollo/client';
+
+type NamespaceMetadataResp = {
+    id: string;
+    results: {
+        namespaces: {
+            metadata: {
+                name: string;
+            };
+        }[];
+    };
+};
+
+export const NAMESPACES_FOR_CLUSTER_QUERY = gql`
+    query getClusterNamespaceNames($id: ID!) {
+        results: cluster(id: $id) {
+            id
+            namespaces {
+                metadata {
+                    name
+                }
+            }
+        }
+    }
+`;
+
+function useNamespaces(selectedClusterId) {
+    const [availableNamespace, setAvailableNamespace] = useState<string[]>([]);
+    // If the selectedClusterId has not been set yet, do not run the gql query
+    const queryOptions = selectedClusterId
+        ? { variables: { id: selectedClusterId } }
+        : { skip: true };
+
+    const { loading, error, data } = useQuery<NamespaceMetadataResp, { id: string }>(
+        NAMESPACES_FOR_CLUSTER_QUERY,
+        queryOptions
+    );
+
+    useEffect(() => {
+        if (!data || !data.results) {
+            return;
+        }
+
+        const namespaces = data.results.namespaces.map(({ metadata }) => metadata.name);
+
+        setAvailableNamespace(namespaces);
+    }, [data]);
+
+    return {
+        loading,
+        error,
+        namespaces: availableNamespace,
+    };
+}
+
+export default useNamespaces;

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -12,6 +12,7 @@ export const authResponsePrefix = '/auth/response/';
 export const dashboardPath = `${mainPath}/dashboard`;
 export const networkBasePath = `${mainPath}/network`;
 export const networkPath = `${networkBasePath}/:deploymentId?/:externalType?`;
+export const networkPathPF = `${mainPath}/network-graph`;
 export const violationsBasePath = `${mainPath}/violations`;
 export const violationsPath = `${violationsBasePath}/:alertId?`;
 export const clustersBasePath = `${mainPath}/clusters`;


### PR DESCRIPTION
## Description

****_Never merge!_****

Reduced test case for StackRox "classic" Search query as cluster/namespace selectors for Network Graph

To try out, deploy and visit `<hostname>//main/network-graph`

1. On first load, Cluster Select is populated with clusters names, none selected
2. On first load, Namespace Select is empty
3. Select a Cluster, and its ID will appear as part of the search string in the URL, and its namespaces will be loaded as options in the Namespace Select
4. Select one or more namespaces, and those selected names will be added to the search string in the URL
5. With cluster and namespace options in the URL, refresh the page and watch the controls pre-populate with those selections

<img width="1379" alt="Screen Shot 2022-09-16 at 6 27 07 PM" src="https://user-images.githubusercontent.com/715729/190827262-9e043722-6786-44ba-a465-c5b1b4c570f1.png">

<img width="1379" alt="Screen Shot 2022-09-16 at 6 27 15 PM" src="https://user-images.githubusercontent.com/715729/190827273-08755584-ecc8-4922-bb93-2ac8647e6c0e.png">

<img width="1379" alt="Screen Shot 2022-09-16 at 6 27 27 PM" src="https://user-images.githubusercontent.com/715729/190827286-c064fe9e-289c-49c8-80ad-7c7cfdd023cb.png">

<img width="1601" alt="Screen Shot 2022-09-16 at 6 27 36 PM" src="https://user-images.githubusercontent.com/715729/190827290-9b1de445-9581-4f89-9bf1-558acd130001.png">
