### PR TITLE
[NO MERGE] need quay.io/rhacs-eng/main image built by ci

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,12 @@
 	url = https://github.com/stackrox/docs-tools.git
 	branch = main
 	shallow = true
+[submodule "test/bats"]
+	path = test/bats
+	url = https://github.com/bats-core/bats-core.git
+[submodule "test/test_helper/bats-support"]
+	path = test/test_helper/bats-support
+	url = https://github.com/bats-core/bats-support.git
+[submodule "test/test_helper/bats-assert"]
+	path = test/test_helper/bats-assert
+	url = https://github.com/bats-core/bats-assert.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,12 +7,3 @@
 	url = https://github.com/stackrox/docs-tools.git
 	branch = main
 	shallow = true
-[submodule "test/bats"]
-	path = test/bats
-	url = https://github.com/bats-core/bats-core.git
-[submodule "test/test_helper/bats-support"]
-	path = test/test_helper/bats-support
-	url = https://github.com/bats-core/bats-support.git
-[submodule "test/test_helper/bats-assert"]
-	path = test/test_helper/bats-assert
-	url = https://github.com/bats-core/bats-assert.git

--- a/tests/roxctl/bats-runner.sh
+++ b/tests/roxctl/bats-runner.sh
@@ -23,5 +23,10 @@ else
 fi
 
 # Running all bats test suites found in the directory
-echo "Running Bats with parameters: " "${BATS_FLAGS[@]}"
+echo "BATS_FLAGS   : ${BATS_FLAGS[@]}"
+echo "BATS_TESTS   : ${BATS_TESTS}"
+echo "TESTS_OUTPUT : $TESTS_OUTPUT"
+echo "BATS_TESTS   : $BATS_TESTS"
+
+set -x
 bats "${BATS_FLAGS[@]}" "${BATS_TESTS}"

--- a/tests/roxctl/bats-runner.sh
+++ b/tests/roxctl/bats-runner.sh
@@ -23,10 +23,4 @@ else
 fi
 
 # Running all bats test suites found in the directory
-echo "BATS_FLAGS   : ${BATS_FLAGS[@]}"
-echo "BATS_TESTS   : ${BATS_TESTS}"
-echo "TESTS_OUTPUT : $TESTS_OUTPUT"
-echo "BATS_TESTS   : $BATS_TESTS"
-
-set -x
-bats "${BATS_FLAGS[@]}" "${BATS_TESTS}"
+(set -x; bats "${BATS_FLAGS[@]}" "${BATS_TESTS}")

--- a/tests/roxctl/bats-tests/README.md
+++ b/tests/roxctl/bats-tests/README.md
@@ -21,8 +21,11 @@ Installation:
 
 ```shell
 mkdir -p "$HOME/bats-core/"
+git -C "$HOME/bats-core/" clone --depth=1 https://github.com/bats-core/bats-core
 git -C "$HOME/bats-core/" clone --depth=1 https://github.com/bats-core/bats-assert
 git -C "$HOME/bats-core/" clone --depth=1 https://github.com/bats-core/bats-support
+(cd "$HOME/bats-core/bats-core" && sudo ./install.sh "/usr/local")
+bats --version
 ```
 
 The helpers are installed correctly if the following tests are passing:


### PR DESCRIPTION
I don't have permission to push to quay.io/rhacs-eng/main.

I need to run `tests/e2e/run.sh` locally, but it requires roxctl (binary) version to `match quay.io/rhacs-eng/main` (image) version, which only works if I'm building on mainline since the image was already built and pushed by CI. If I make a change locally, I can build but not push, so the GKE test cluster will fail to pull the image. There does not appear to be an image override, only the `MAIN_IMAGE_TAG` which is appended to `quay.io/rhacs-eng/main`. The image repo is hard-coded in many places so I suspect e2e testing was intended to be run only from CI environment. Maybe this PR will trigger a build and push? When I search for `MAIN_IMAGE_TAG` I see it assigned to `MAIN_TAG` and also lots of results for `main_tag` and used with many hard-coded `registry/repo:tag` definitions. So I'm trying to avoid going down that rabbit hole. Basically there is no easy way to override the registry and repo values.

https://quay.io/repository/rhacs-eng/main?tab=tags