### PR TITLE
ROX-11592: Remove support to retrieve groups without ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Technical Changes
 - ROX-11937: The Splunk integration now processes all additional standards of the compliance operator (ocp4-cis & ocp4-cis-node) correctly.
 
+### Removed Features
+- ROX-6194: `ROX_WHITELIST_GENERATION_DURATION` env var is removed in favor of `ROX_BASELINE_GENERATION_DURATION`;
+  `DeploymentWithProcessInfo` items in `/v1/deploymentswithprocessinfo` endpoint response do not include
+  `whitelist_statuses` anymore.
+- ROX-11592: Support to Get / Update / Mutate / Remove of groups via the `props` field and without the `props.id` field
+  being set in the `/v1/groups` endpoint have been removed.
+
 ## [3.72.0]
 
 ### Removed Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,18 +22,13 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - K8sRoleBinding | Label | Role Binding Label
   - K8sRoleAnnotation | Annotation | Role Binding Annotation
 - `ids` field in `/v1/cves/suppress` and `/v1/cves/unsuppress` API payload renamed to `cves`.
+- ROX-11592: Support to Get / Update / Mutate / Remove of groups via the `props` field and without the `props.id` field
+  being set in the `/v1/groups` endpoint have been removed.
 
 ### Deprecated Features
 
 ### Technical Changes
 - ROX-11937: The Splunk integration now processes all additional standards of the compliance operator (ocp4-cis & ocp4-cis-node) correctly.
-
-### Removed Features
-- ROX-6194: `ROX_WHITELIST_GENERATION_DURATION` env var is removed in favor of `ROX_BASELINE_GENERATION_DURATION`;
-  `DeploymentWithProcessInfo` items in `/v1/deploymentswithprocessinfo` endpoint response do not include
-  `whitelist_statuses` anymore.
-- ROX-11592: Support to Get / Update / Mutate / Remove of groups via the `props` field and without the `props.id` field
-  being set in the `/v1/groups` endpoint have been removed.
 
 ## [3.72.0]
 

--- a/central/group/datastore/datastore_impl.go
+++ b/central/group/datastore/datastore_impl.go
@@ -30,11 +30,6 @@ func (ds *dataStoreImpl) Get(ctx context.Context, props *storage.GroupProperties
 		return nil, nil
 	}
 
-	// TODO(ROX-11592): This can be removed once retrieving the group by its properties is fully deprecated.
-	if props.GetId() == "" {
-		return ds.getByProps(ctx, props)
-	}
-
 	group, _, err := ds.storage.Get(ctx, props.GetId())
 	return group, err
 }
@@ -161,7 +156,7 @@ func (ds *dataStoreImpl) Mutate(ctx context.Context, remove, update, add []*stor
 
 	var idsToRemove []string
 	for _, group := range remove {
-		if err := ValidateGroup(group); err != nil {
+		if err := ValidateGroup(group, true); err != nil {
 			return errox.InvalidArgs.CausedBy(err)
 		}
 		groupID, err := ds.validateAndPrepGroupForDeleteNoLock(ctx, group.GetProps(), force)
@@ -214,7 +209,7 @@ func (ds *dataStoreImpl) RemoveAllWithAuthProviderID(ctx context.Context, authPr
 // Validate if the group is allowed to be added and prep the group before it is added to the db.
 // NOTE: This function assumes that the call to this function is already behind a lock.
 func (ds *dataStoreImpl) validateAndPrepGroupForAddNoLock(ctx context.Context, group *storage.Group) error {
-	if err := ValidateGroup(group); err != nil {
+	if err := ValidateGroup(group, false); err != nil {
 		return errox.InvalidArgs.CausedBy(err)
 	}
 
@@ -239,19 +234,8 @@ func (ds *dataStoreImpl) validateAndPrepGroupForAddNoLock(ctx context.Context, g
 // NOTE: This function assumes that the call to this function is already behind a lock.
 func (ds *dataStoreImpl) validateAndPrepGroupForUpdateNoLock(ctx context.Context, group *storage.Group,
 	force bool) error {
-	if err := ValidateGroup(group); err != nil {
+	if err := ValidateGroup(group, true); err != nil {
 		return errox.InvalidArgs.CausedBy(err)
-	}
-
-	// TODO(ROX-11592): Once the deprecation of retrieving groups by their properties is fully deprecated, this condition
-	// can be removed and groups shall only be retrievable via their id.
-	if group.GetProps().GetId() == "" {
-		id, err := ds.findGroupIDByProps(ctx, group.GetProps())
-		if err != nil {
-			return err
-		}
-		// Use the id of the retrieved group to update
-		group.GetProps().Id = id
 	}
 
 	err := ds.validateMutableGroupIDNoLock(ctx, group.GetProps().GetId(), force)
@@ -276,22 +260,11 @@ func (ds *dataStoreImpl) validateAndPrepGroupForUpdateNoLock(ctx context.Context
 // NOTE: This function assumes that the call to this function is already behind a lock.
 func (ds *dataStoreImpl) validateAndPrepGroupForDeleteNoLock(ctx context.Context, props *storage.GroupProperties,
 	force bool) (string, error) {
-	if err := ValidateProps(props); err != nil {
+	if err := ValidateProps(props, true); err != nil {
 		return "", errox.InvalidArgs.CausedBy(err)
 	}
 
 	propsID := props.GetId()
-
-	// TODO(ROX-11592): Once the deprecation of retrieving groups by their properties is fully deprecated, this condition
-	// can be removed and groups shall only be retrievable via their id.
-	if propsID == "" {
-		id, err := ds.findGroupIDByProps(ctx, props)
-		if err != nil {
-			return "", err
-		}
-		// Use the id of the retrieved group to delete
-		propsID = id
-	}
 
 	if err := ds.validateMutableGroupIDNoLock(ctx, propsID, force); err != nil {
 		return "", err
@@ -343,7 +316,6 @@ func isDefaultGroup(props *storage.GroupProperties) bool {
 
 // getByProps returns a group matching the given properties if it exists from the store.
 // If more than one group is found matching the properties, an error will be returned.
-// TODO(ROX-11592): This can be removed once retrieving the group by its properties is fully deprecated.
 func (ds *dataStoreImpl) getByProps(ctx context.Context, props *storage.GroupProperties) (*storage.Group, error) {
 	groups, err := ds.GetFiltered(ctx, func(p *storage.GroupProperties) bool {
 		return propertiesMatch(p, props)
@@ -363,21 +335,6 @@ func (ds *dataStoreImpl) getByProps(ctx context.Context, props *storage.GroupPro
 	}
 
 	return groups[0], nil
-}
-
-// TODO(ROX-11592): Once the deprecation of retrieving groups by their properties is fully deprecated, this condition
-// can be removed and groups shall only be retrievable via their id.
-func (ds *dataStoreImpl) findGroupIDByProps(ctx context.Context, props *storage.GroupProperties) (string, error) {
-	group, err := ds.getByProps(ctx, props)
-	if err != nil {
-		return "", err
-	}
-	if group == nil {
-		return "", errox.NotFound.Newf("group config for (auth provider id=%s, key=%s, value=%s) does not exist",
-			props.GetAuthProviderId(), props.GetKey(), props.GetValue())
-	}
-
-	return group.GetProps().GetId(), nil
 }
 
 // getDefaultGroupForProps will check if the given properties are a default group and, if they are, search the

--- a/central/group/datastore/datastore_impl.go
+++ b/central/group/datastore/datastore_impl.go
@@ -30,6 +30,10 @@ func (ds *dataStoreImpl) Get(ctx context.Context, props *storage.GroupProperties
 		return nil, nil
 	}
 
+	if err := ValidateProps(props, true); err != nil {
+		return nil, errox.InvalidArgs.CausedBy(err)
+	}
+
 	group, _, err := ds.storage.Get(ctx, props.GetId())
 	return group, err
 }

--- a/central/group/datastore/validate.go
+++ b/central/group/datastore/validate.go
@@ -16,11 +16,11 @@ const groupIDPrefix = "io.stackrox.authz.group."
 // A group must fulfill the following:
 //	- have valid properties (validated via ValidateProps).
 //	- have a role name set.
-func ValidateGroup(group *storage.Group) error {
+func ValidateGroup(group *storage.Group, requireID bool) error {
 	if group.GetProps() == nil {
 		return errors.New("group properties must be set")
 	}
-	if err := ValidateProps(group.GetProps()); err != nil {
+	if err := ValidateProps(group.GetProps(), requireID); err != nil {
 		return errors.Wrap(err, "invalid group properties")
 	}
 	if group.GetRoleName() == "" {
@@ -33,8 +33,10 @@ func ValidateGroup(group *storage.Group) error {
 // A property must fulfill the following:
 //	- have an auth provider ID.
 // 	- if no key is given, no value shall be given.
-func ValidateProps(props *storage.GroupProperties) error {
-	// TODO(ROX-11592): Once retrieving properties by their ID is fully deprecated, require IDs and validate this here.
+func ValidateProps(props *storage.GroupProperties, requireID bool) error {
+	if requireID && props.GetId() == "" {
+		return errors.Errorf("group ID must be set in {%s}", proto.MarshalTextString(props))
+	}
 	if props.GetAuthProviderId() == "" {
 		return errors.Errorf("authprovider ID must be set in {%s}", proto.MarshalTextString(props))
 	}

--- a/central/group/datastore/validate_test.go
+++ b/central/group/datastore/validate_test.go
@@ -19,6 +19,7 @@ func TestValidate(t *testing.T) {
 					AuthProviderId: "Sentinel",
 					Key:            "le mot",
 					Value:          "tous a la Bastille!",
+					Id:             "id",
 				},
 				RoleName: "",
 			},
@@ -33,7 +34,7 @@ func TestValidate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Group.props.id must not be set",
+			name: "Group.props.id must be set",
 			group: &storage.Group{
 				Props: &storage.GroupProperties{
 					AuthProviderId: "Sentinel",
@@ -42,7 +43,7 @@ func TestValidate(t *testing.T) {
 				},
 				RoleName: "insurge",
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "Group.props.auth_provider_id must be set",
@@ -50,6 +51,7 @@ func TestValidate(t *testing.T) {
 				Props: &storage.GroupProperties{
 					Key:   "le mot",
 					Value: "tous a la Bastille!",
+					Id:    "id",
 				},
 				RoleName: "insurge",
 			},
@@ -61,6 +63,7 @@ func TestValidate(t *testing.T) {
 				Props: &storage.GroupProperties{
 					AuthProviderId: "Sentinel",
 					Value:          "tous a la Bastille!",
+					Id:             "id",
 				},
 				RoleName: "insurge",
 			},
@@ -105,7 +108,7 @@ func TestValidate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := ValidateGroup(tt.group); (err != nil) != tt.wantErr {
+			if err := ValidateGroup(tt.group, true); (err != nil) != tt.wantErr {
 				t.Errorf("validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/central/group/service/service_impl.go
+++ b/central/group/service/service_impl.go
@@ -105,12 +105,12 @@ func (s *serviceImpl) GetGroup(ctx context.Context, props *storage.GroupProperti
 
 func (s *serviceImpl) BatchUpdate(ctx context.Context, req *v1.GroupBatchUpdateRequest) (*v1.Empty, error) {
 	for _, group := range req.GetPreviousGroups() {
-		if err := datastore.ValidateGroup(group); err != nil {
+		if err := datastore.ValidateGroup(group, true); err != nil {
 			return nil, errox.InvalidArgs.CausedBy(err)
 		}
 	}
 	for _, group := range req.GetRequiredGroups() {
-		if err := datastore.ValidateGroup(group); err != nil {
+		if err := datastore.ValidateGroup(group, false); err != nil {
 			return nil, errox.InvalidArgs.CausedBy(err)
 		}
 	}


### PR DESCRIPTION
## Description

Remove support to retrieve groups without specifying an ID.

This was kept previously to not introduce a breaking change when re-working the groups API. Previously, groups where identified via a composite key of `auth provider ID, key, value`.
With the 3.71 release, a new field was introduced within the group properties called `id` which aims to uniquely identify a group.

Since the grace period has been reached, we can now remove the existing code that allowed retrieving the groups without specifying the id field.

## Testing Performed

- see unit tests and E2E tests passing.
