### PR TITLE
ROX-12219: use helm operator with pause reconcile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -443,7 +443,7 @@ replace (
 
 	// github.com/stackrox/helm-operator is a modified fork of github.com/operator-framework/helm-operator-plugins that
 	// we currently depend on.
-	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.10-0.20220908144520-9d1614a2a007
+	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.10-0.20220919075814-d1c8fe0fabdb
 	// github.com/sigstore/rekor is a transitive dep pulled in by cosign. The version pulled in by cosign is using
 	// a vulnerable go-tuf version
 	// (https://github.com/theupdateframework/go-tuf/security/advisories/GHSA-66x3-6cw3-v5gj).

--- a/go.mod
+++ b/go.mod
@@ -443,7 +443,7 @@ replace (
 
 	// github.com/stackrox/helm-operator is a modified fork of github.com/operator-framework/helm-operator-plugins that
 	// we currently depend on.
-	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.10-0.20220919075814-d1c8fe0fabdb
+	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.10-0.20220919093109-89f9785764c6
 	// github.com/sigstore/rekor is a transitive dep pulled in by cosign. The version pulled in by cosign is using
 	// a vulnerable go-tuf version
 	// (https://github.com/theupdateframework/go-tuf/security/advisories/GHSA-66x3-6cw3-v5gj).

--- a/go.sum
+++ b/go.sum
@@ -2569,8 +2569,8 @@ github.com/stackrox/dotnet-scraper v0.0.0-20201023051640-72ef543323dd h1:vEjp7Q6
 github.com/stackrox/dotnet-scraper v0.0.0-20201023051640-72ef543323dd/go.mod h1:HILeV3i/EyJz844GcrC3+oU7oZONhjfujaIYBMJ/bZE=
 github.com/stackrox/external-network-pusher v0.0.0-20210419192707-074af92bbfa7 h1:F4Gq3G5G07HQ/ECrg/+EQxFBmCTcq9ZDyLPI5LaDUKI=
 github.com/stackrox/external-network-pusher v0.0.0-20210419192707-074af92bbfa7/go.mod h1:faUw9vx/mA7ql41Ftlst5MYar2DT3nnS6oK94lbaW0g=
-github.com/stackrox/helm-operator v0.0.10-0.20220919075814-d1c8fe0fabdb h1:QMqxayO6iIZV38ZAX/54n0fgHYsP0/MeOPlxhJLGQ+o=
-github.com/stackrox/helm-operator v0.0.10-0.20220919075814-d1c8fe0fabdb/go.mod h1:uHQPYB600zyk6/e9/V781Kg5LOincTYWdkVzBiuX77I=
+github.com/stackrox/helm-operator v0.0.10-0.20220919093109-89f9785764c6 h1:WE9QerfdLyA2hxYx6KPITrCQmcGkl2k+qgw0i2ln18E=
+github.com/stackrox/helm-operator v0.0.10-0.20220919093109-89f9785764c6/go.mod h1:uHQPYB600zyk6/e9/V781Kg5LOincTYWdkVzBiuX77I=
 github.com/stackrox/helmtest v0.0.0-20220118100812-1ad97c4de347 h1:ByiXbT2lnhWmUlrpUCeQlk8hRZTFr6CPtTtpd7XlOGY=
 github.com/stackrox/helmtest v0.0.0-20220118100812-1ad97c4de347/go.mod h1:vWZFszN4CfxMWzzMI/XfrcG4kkoDIPdwfDry76nYIbo=
 github.com/stackrox/k8s-cves v0.0.0-20201110001126-cc333981eaab h1:77xJmm1YkqbgrQzHI3C4MyPckWL+PYRLWakQRC6Mzj8=

--- a/go.sum
+++ b/go.sum
@@ -2569,8 +2569,8 @@ github.com/stackrox/dotnet-scraper v0.0.0-20201023051640-72ef543323dd h1:vEjp7Q6
 github.com/stackrox/dotnet-scraper v0.0.0-20201023051640-72ef543323dd/go.mod h1:HILeV3i/EyJz844GcrC3+oU7oZONhjfujaIYBMJ/bZE=
 github.com/stackrox/external-network-pusher v0.0.0-20210419192707-074af92bbfa7 h1:F4Gq3G5G07HQ/ECrg/+EQxFBmCTcq9ZDyLPI5LaDUKI=
 github.com/stackrox/external-network-pusher v0.0.0-20210419192707-074af92bbfa7/go.mod h1:faUw9vx/mA7ql41Ftlst5MYar2DT3nnS6oK94lbaW0g=
-github.com/stackrox/helm-operator v0.0.10-0.20220908144520-9d1614a2a007 h1:8tVrEtgwja7q91xcFGwD8A/CgkURWHjCRgZJzS5QztM=
-github.com/stackrox/helm-operator v0.0.10-0.20220908144520-9d1614a2a007/go.mod h1:uHQPYB600zyk6/e9/V781Kg5LOincTYWdkVzBiuX77I=
+github.com/stackrox/helm-operator v0.0.10-0.20220919075814-d1c8fe0fabdb h1:QMqxayO6iIZV38ZAX/54n0fgHYsP0/MeOPlxhJLGQ+o=
+github.com/stackrox/helm-operator v0.0.10-0.20220919075814-d1c8fe0fabdb/go.mod h1:uHQPYB600zyk6/e9/V781Kg5LOincTYWdkVzBiuX77I=
 github.com/stackrox/helmtest v0.0.0-20220118100812-1ad97c4de347 h1:ByiXbT2lnhWmUlrpUCeQlk8hRZTFr6CPtTtpd7XlOGY=
 github.com/stackrox/helmtest v0.0.0-20220118100812-1ad97c4de347/go.mod h1:vWZFszN4CfxMWzzMI/XfrcG4kkoDIPdwfDry76nYIbo=
 github.com/stackrox/k8s-cves v0.0.0-20201110001126-cc333981eaab h1:77xJmm1YkqbgrQzHI3C4MyPckWL+PYRLWakQRC6Mzj8=

--- a/operator/pkg/central/reconciler/reconciler.go
+++ b/operator/pkg/central/reconciler/reconciler.go
@@ -35,5 +35,6 @@ func RegisterNewReconciler(mgr ctrl.Manager) error {
 		pkgReconciler.WithPreExtension(commonExtensions.CheckForbiddenNamespacesExtension(commonExtensions.IsSystemNamespace)),
 		pkgReconciler.WithPreExtension(commonExtensions.ReconcileProductVersionStatusExtension(version.GetMainVersion())),
 		pkgReconciler.WithReconcilePeriod(extensions.InitBundleReconcilePeriod),
+		pkgReconciler.WithPauseReconcileAnnotation("stackrox.io/pause-reconcile"),
 	)
 }


### PR DESCRIPTION
## Description

Enables support for stackrox.io/pause-reconcile annotations.
Replaces https://github.com/stackrox/stackrox/pull/2953.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Refresh once https://github.com/stackrox/helm-operator/pull/29 is merged
- [x] Unit test and regression tests added - in the dependency repo
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

We probably do not want to document this facility..

## Testing Performed

Relying on CI to check things are not broken.
