### PR TITLE
ROX-12709: Use mirrored golang in CI and document mirroring.

### DIFF
--- a/.openshift-ci/build/build-operator-artifacts.sh
+++ b/.openshift-ci/build/build-operator-artifacts.sh
@@ -26,7 +26,7 @@ build_operator_bundle_and_binary() {
 
     info "Preparing build/Dockerfile.gen, bundle sources and smuggled status.sh file"
     # TODO(ROX-12346): get rid of the SILENT= once we gain some confidence (after release 3.72?)
-    make -C operator build/Dockerfile.gen bundle bundle-post-process smuggled-status-sh SILENT=
+    make -C operator build/Dockerfile.gen bundle bundle-post-process smuggled-status-sh SILENT= GOLANG_IMAGE_PREFIX=registry.ci.openshift.org/stackrox/
 
     info "Making a copy of the built bundle sources in a magically named directory that will be used instead of the bundle image."
     # The hacked opm tool will first see if a directory named as the reference exists, and if so, use its content as if it's an unpacked image of that name.

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -3,17 +3,24 @@ ARG roxpath=/workspace/src/github.com/stackrox/rox
 
 # NOTE 1: the following version needs to be in sync with the ../EXPECTED_GO_VERSION file.
 FROM golang:1.17.12 as builder
-# NOTE 2: Also, to keep CI from flakes, the above image needs to be mirrored into openshift CI registry and the CI
-# configured to use the mirrored image instead of the specification above.
-# This is because pulling from docker.io/library/... (which is what happens with a bare image specification above) is
-# subject to rate limits that our CI tends to hit, causing intermittent build failures.
+# NOTE 2: Also, the above image MUST be mirrored into openshift CI registry.
 #
-# Ideally, the mirroring and overrides for new image should be put in place first, and then once the above line is
-# updated, the old ones removed. But with some luck, doing it post-facto might also be possible without causing too
-# many failures, depending on the load.
-# See example PRs for how to achieve that:
-# - https://github.com/openshift/release/pull/31790/files
-# - https://github.com/openshift/release/pull/31791/files
+# Why?
+# This is because pulling from docker.io/library/... (which is what happens with a bare image specification above) is
+# subject to rate limits that our CI tends to hit, causing intermittent build failures. To prevent that, this file
+# processed in CI at build time to prefix the image specification with the CI registry.
+# See .openshift-ci/build/build-operator-artifacts.sh
+#
+# How?
+# The safe procedure is:
+# 1. Mirror docker.io/library/golang:x to quay.io/stackrox-io/ci:golang-x
+#    TODO(gavin-stackrox): how to do this?
+# 2. Set up supplemental ci image mirroring to mirror from quay.io/stackrox-io/ci:golang-x
+#    to registry.ci.openshift.org/stackrox/golang:x
+#    Example PR: https://github.com/openshift/release/pull/31790/files
+# 3. Wait for the image to actually get mirrored. See https://prow.ci.openshift.org/?job=*mirroring-supplemental-ci-images*
+# 4. Update the line above in this file.
+# 5. Clean up the old mirroring.
 
 # Build the manager binary
 ARG roxpath

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -328,7 +328,7 @@ check-expected-go-version:
 .PHONY: build/Dockerfile.gen
 build/Dockerfile.gen: Dockerfile
 	mkdir -p build/
-	sed -e 's,$${ROX_IMAGE_FLAVOR},$(ROX_IMAGE_FLAVOR),g' < $< > $@
+	sed -e 's,$${ROX_IMAGE_FLAVOR},$(ROX_IMAGE_FLAVOR),g; s,^FROM golang:,FROM $(GOLANG_IMAGE_PREFIX)golang:,' < $< > $@
 
 .PHONY: docker-build
 docker-build: build/Dockerfile.gen check-expected-go-version test smuggled-status-sh ## Build docker image with the operator.


### PR DESCRIPTION
## Description

[Turns out](https://coreos.slack.com/archives/CBN38N3MW/p1663231189451949) our hacks for overriding golang image didn't really work.
Use a different approach and mostly document the necessary steps for bumping golang image.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] Determined and documented upgrade steps
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Ran the `make build/Dockerfile.gen` command manually with and without the variable to make sure it behaves as expected.
Relying on CI otherwise.