### PR TITLE
ROX-12562: enable running Github action scripts to run from non-main branch

### DIFF
--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -58,8 +58,7 @@ on:
 
 env:
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
-  script_url: /repos/${{github.repository}}/contents/.github/workflows/scripts/common.sh?ref=${{github.event.repository.default_branch}}
-  main_branch: ${{github.event.repository.default_branch}}
+  script_url: /repos/${{ github.repository }}/contents/.github/workflows/scripts/common.sh?ref=${{ github.ref_name }}
 
 jobs:
   infra:

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -37,7 +37,7 @@ env:
   docs_repository: openshift/openshift-docs
   jira_projects: ROX, RS, RTOOLS
   slack_channel: C03KSV3N6N8 #test-release-automation
-  script_url: /repos/${{github.repository}}/contents/.github/workflows/scripts/common.sh?ref=${{github.event.repository.default_branch}}
+  script_url: /repos/${{ github.repository }}/contents/.github/workflows/scripts/common.sh?ref=${{ github.ref_name }}
   DRY_RUN: ${{ fromJSON('["true", "false"]')[github.event.inputs.dry-run != 'true'] }}
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
   GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/scripts/common.sh
+++ b/.github/workflows/scripts/common.sh
@@ -55,7 +55,7 @@ if ! (return 0 2>/dev/null); then # called
     check_not_empty \
         SCRIPT \
         GITHUB_REPOSITORY \
-        main_branch
+        GITHUB_REF_NAME
     URL="/repos/$GITHUB_REPOSITORY/contents/.github/workflows/scripts/$SCRIPT.sh?ref=$main_branch"
     shift
     gh api -H "Accept: application/vnd.github.v3.raw" "$URL" | bash -s -- "$@"

--- a/.github/workflows/scripts/common.sh
+++ b/.github/workflows/scripts/common.sh
@@ -56,7 +56,7 @@ if ! (return 0 2>/dev/null); then # called
         SCRIPT \
         GITHUB_REPOSITORY \
         GITHUB_REF_NAME
-    URL="/repos/$GITHUB_REPOSITORY/contents/.github/workflows/scripts/$SCRIPT.sh?ref=$main_branch"
+    URL="/repos/$GITHUB_REPOSITORY/contents/.github/workflows/scripts/$SCRIPT.sh?ref=$GITHUB_REF_NAME"
     shift
     gh api -H "Accept: application/vnd.github.v3.raw" "$URL" | bash -s -- "$@"
 fi

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -23,7 +23,7 @@ env:
   slack_channel: C03KSV3N6N8 #test-release-automation
   main_branch: ${{github.event.repository.default_branch}}
   jira_project: ROX
-  script_url: /repos/${{github.repository}}/contents/.github/workflows/scripts/common.sh?ref=${{github.event.repository.default_branch}}
+  script_url: /repos/${{ github.repository }}/contents/.github/workflows/scripts/common.sh?ref=${{ github.ref_name }}
   DRY_RUN: ${{ fromJSON('["true", "false"]')[github.event.inputs.dry-run != 'true'] }}
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
   GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Description

Enable running Github action scripts from other branches than the main branch: 

![](https://user-images.githubusercontent.com/9576848/191033707-344315fd-1d68-46fe-9251-dc141a3ab1ae.png)

-> Github Actions will then take the `common.sh` and subsequent other scripts, like `cherry-pick.sh` from the specified branch/tag.

## Checklist
- ~[ ] Investigated and inspected CI test results~ -> already done in private test repo, another proof build here: https://github.com/stackrox/stackrox/actions/runs/3084356172/jobs/4986410971
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
