### PR TITLE
Fix hotreload script by deriving arch

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -54,7 +54,7 @@ function hotload_binary {
   echo "**********"
   echo
 
-  binary_path=$(realpath "$(git rev-parse --show-toplevel)/bin/linux_amd64/${local_name}")
+  binary_path=$(realpath "$(git rev-parse --show-toplevel)/bin/linux_$(uname -m)/${local_name}")
   kubectl -n stackrox patch "deploy/${deployment}" -p '{"spec":{"template":{"spec":{"containers":[{"name":"'${deployment}'","volumeMounts":[{"mountPath":"/stackrox/'${binary_name}'","name":"'binary-${local_name}'"}]}],"volumes":[{"hostPath":{"path":"'${binary_path}'","type":""},"name":"'binary-${local_name}'"}]}}}}'
   kubectl -n stackrox set env "deploy/$deployment" "ROX_HOTRELOAD=true"
 }

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -54,7 +54,12 @@ function hotload_binary {
   echo "**********"
   echo
 
-  binary_path=$(realpath "$(git rev-parse --show-toplevel)/bin/linux_$(uname -m)/${local_name}")
+  arch="amd64"
+  if [[ "$(uname -m)" == "arm64" ]]; then
+    arch="arm64"
+  fi
+
+  binary_path=$(realpath "$(git rev-parse --show-toplevel)/bin/linux_${arch}/${local_name}")
   kubectl -n stackrox patch "deploy/${deployment}" -p '{"spec":{"template":{"spec":{"containers":[{"name":"'${deployment}'","volumeMounts":[{"mountPath":"/stackrox/'${binary_name}'","name":"'binary-${local_name}'"}]}],"volumes":[{"hostPath":{"path":"'${binary_path}'","type":""},"name":"'binary-${local_name}'"}]}}}}'
   kubectl -n stackrox set env "deploy/$deployment" "ROX_HOTRELOAD=true"
 }


### PR DESCRIPTION
## Description

Can't always be amd64 for hotreload

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran on my mac
