### PR TITLE
ROX-12611: Add support to Postgres store generator for ON DELETE RESTRICT

### DIFF
--- a/pkg/postgres/walker/schema.go
+++ b/pkg/postgres/walker/schema.go
@@ -66,8 +66,8 @@ type SchemaRelationship struct {
 	// level by a foreign key constraint.
 	NoConstraint bool
 
-	// DeleteRestrict indicates that this relationship should restrict deletion
-	DeleteRestrict bool
+	// RestrictDelete indicates that this relationship should restrict deletion rather than cascade
+	RestrictDelete bool
 }
 
 // ThisSchemaColumnNames generates the sequence of column names for this schema
@@ -345,9 +345,9 @@ func (s *Schema) ResolveReferences(schemaProvider func(messageTypeName string) *
 		fieldRef.OtherSchema = otherTable
 		fieldRef.ColumnName = columnNameInOtherSchema
 
-		addColumnPairToRelationshipsSlice(&s.References, s, otherTable, f.ColumnName, columnNameInOtherSchema, fieldRef.NoConstraint, fieldRef.DeleteRestriction)
+		addColumnPairToRelationshipsSlice(&s.References, s, otherTable, f.ColumnName, columnNameInOtherSchema, fieldRef.NoConstraint, fieldRef.RestrictDelete)
 		if !fieldRef.Directional {
-			addColumnPairToRelationshipsSlice(&otherTable.ReferencedBy, otherTable, s, columnNameInOtherSchema, f.ColumnName, fieldRef.NoConstraint, fieldRef.DeleteRestriction)
+			addColumnPairToRelationshipsSlice(&otherTable.ReferencedBy, otherTable, s, columnNameInOtherSchema, f.ColumnName, fieldRef.NoConstraint, fieldRef.RestrictDelete)
 		}
 	}
 
@@ -356,7 +356,7 @@ func (s *Schema) ResolveReferences(schemaProvider func(messageTypeName string) *
 	}
 }
 
-func addColumnPairToRelationshipsSlice(relationshipsSlice *[]SchemaRelationship, thisSchema, otherSchema *Schema, columnNameInThisSchema, columnNameInOtherSchema string, noConstraint bool, deleteRestrict bool) {
+func addColumnPairToRelationshipsSlice(relationshipsSlice *[]SchemaRelationship, thisSchema, otherSchema *Schema, columnNameInThisSchema, columnNameInOtherSchema string, noConstraint bool, restrictDelete bool) {
 	refIdxToModify := -1
 	for i, ref := range *relationshipsSlice {
 		if ref.OtherSchema == otherSchema {
@@ -370,7 +370,7 @@ func addColumnPairToRelationshipsSlice(relationshipsSlice *[]SchemaRelationship,
 	}
 	// This is the first column mapping for this particular schema.
 	if refIdxToModify == -1 {
-		*relationshipsSlice = append(*relationshipsSlice, SchemaRelationship{OtherSchema: otherSchema, NoConstraint: noConstraint, DeleteRestrict: deleteRestrict})
+		*relationshipsSlice = append(*relationshipsSlice, SchemaRelationship{OtherSchema: otherSchema, NoConstraint: noConstraint, RestrictDelete: restrictDelete})
 		refIdxToModify = len(*relationshipsSlice) - 1
 	}
 	(*relationshipsSlice)[refIdxToModify].MappedColumnNames = append((*relationshipsSlice)[refIdxToModify].MappedColumnNames, ColumnNamePair{
@@ -417,7 +417,7 @@ type foreignKeyRef struct {
 	NoConstraint bool
 
 	// If true, the constraint on this foreign key reference should restrict deletion
-	DeleteRestriction bool
+	RestrictDelete bool
 
 	// If true, this means that we only want to create a graph edge out from this field and not have it be bi-directional
 	Directional bool

--- a/pkg/postgres/walker/walker.go
+++ b/pkg/postgres/walker/walker.go
@@ -202,6 +202,14 @@ func getPostgresOptions(tag string, topLevel bool, ignorePK, ignoreUnique, ignor
 				opts.Reference = &foreignKeyRef{}
 			}
 			opts.Reference.NoConstraint = true
+		case field == "delete-restrict":
+			if ignoreFKs {
+				continue
+			}
+			if opts.Reference == nil {
+				opts.Reference = &foreignKeyRef{}
+			}
+			opts.Reference.DeleteRestriction = true
 		case field == "directional":
 			if ignoreFKs {
 				continue

--- a/pkg/postgres/walker/walker.go
+++ b/pkg/postgres/walker/walker.go
@@ -202,14 +202,14 @@ func getPostgresOptions(tag string, topLevel bool, ignorePK, ignoreUnique, ignor
 				opts.Reference = &foreignKeyRef{}
 			}
 			opts.Reference.NoConstraint = true
-		case field == "delete-restrict":
+		case field == "restrict-delete":
 			if ignoreFKs {
 				continue
 			}
 			if opts.Reference == nil {
 				opts.Reference = &foreignKeyRef{}
 			}
-			opts.Reference.DeleteRestriction = true
+			opts.Reference.RestrictDelete = true
 		case field == "directional":
 			if ignoreFKs {
 				continue

--- a/tools/generate-helpers/pg-table-bindings/schema.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/schema.go.tpl
@@ -79,7 +79,7 @@ var (
         {{$field.ColumnName|upperCamelCase}} {{$field.ModelType}} `gorm:"column:{{$field.ColumnName|lowerCase}};type:{{$field.SQLType}}{{if $field.Options.Unique}};unique{{end}}{{if $field.Options.PrimaryKey}};primaryKey{{end}}{{if $field.Options.Index}};index:{{$schema.Table|lowerCamelCase|lowerCase}}_{{$field.ColumnName|lowerCase}},type:{{$field.Options.Index}}{{end}}"`
     {{- end}}
     {{- range $idx, $rel := $schema.RelationshipsToDefineAsForeignKeys }}
-        {{$rel.OtherSchema.Table|upperCamelCase}}Ref {{$rel.OtherSchema.Table|upperCamelCase}} `gorm:"foreignKey:{{ (concatWith $rel.ThisSchemaColumnNames ",") | lowerCase}};references:{{ (concatWith $rel.OtherSchemaColumnNames ",")|lowerCase}};belongsTo;constraint:OnDelete:CASCADE"`
+        {{$rel.OtherSchema.Table|upperCamelCase}}Ref {{$rel.OtherSchema.Table|upperCamelCase}} `gorm:"foreignKey:{{ (concatWith $rel.ThisSchemaColumnNames ",") | lowerCase}};references:{{ (concatWith $rel.OtherSchemaColumnNames ",")|lowerCase}};belongsTo;constraint:OnDelete:{{$rel.DeleteRestrict]]RESTRICT{{else}}CASCADE{{end}}"`
     {{- end}}
     }
     {{- range $idx, $child := $schema.Children }}

--- a/tools/generate-helpers/pg-table-bindings/schema.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/schema.go.tpl
@@ -79,7 +79,7 @@ var (
         {{$field.ColumnName|upperCamelCase}} {{$field.ModelType}} `gorm:"column:{{$field.ColumnName|lowerCase}};type:{{$field.SQLType}}{{if $field.Options.Unique}};unique{{end}}{{if $field.Options.PrimaryKey}};primaryKey{{end}}{{if $field.Options.Index}};index:{{$schema.Table|lowerCamelCase|lowerCase}}_{{$field.ColumnName|lowerCase}},type:{{$field.Options.Index}}{{end}}"`
     {{- end}}
     {{- range $idx, $rel := $schema.RelationshipsToDefineAsForeignKeys }}
-        {{$rel.OtherSchema.Table|upperCamelCase}}Ref {{$rel.OtherSchema.Table|upperCamelCase}} `gorm:"foreignKey:{{ (concatWith $rel.ThisSchemaColumnNames ",") | lowerCase}};references:{{ (concatWith $rel.OtherSchemaColumnNames ",")|lowerCase}};belongsTo;constraint:OnDelete:{{ if $rel.DeleteRestrict }}RESTRICT{{ else }}CASCADE{{ end }}"`
+        {{$rel.OtherSchema.Table|upperCamelCase}}Ref {{$rel.OtherSchema.Table|upperCamelCase}} `gorm:"foreignKey:{{ (concatWith $rel.ThisSchemaColumnNames ",") | lowerCase}};references:{{ (concatWith $rel.OtherSchemaColumnNames ",")|lowerCase}};belongsTo;constraint:OnDelete:{{ if $rel.RestrictDelete }}RESTRICT{{ else }}CASCADE{{ end }}"`
     {{- end}}
     }
     {{- range $idx, $child := $schema.Children }}

--- a/tools/generate-helpers/pg-table-bindings/schema.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/schema.go.tpl
@@ -79,7 +79,7 @@ var (
         {{$field.ColumnName|upperCamelCase}} {{$field.ModelType}} `gorm:"column:{{$field.ColumnName|lowerCase}};type:{{$field.SQLType}}{{if $field.Options.Unique}};unique{{end}}{{if $field.Options.PrimaryKey}};primaryKey{{end}}{{if $field.Options.Index}};index:{{$schema.Table|lowerCamelCase|lowerCase}}_{{$field.ColumnName|lowerCase}},type:{{$field.Options.Index}}{{end}}"`
     {{- end}}
     {{- range $idx, $rel := $schema.RelationshipsToDefineAsForeignKeys }}
-        {{$rel.OtherSchema.Table|upperCamelCase}}Ref {{$rel.OtherSchema.Table|upperCamelCase}} `gorm:"foreignKey:{{ (concatWith $rel.ThisSchemaColumnNames ",") | lowerCase}};references:{{ (concatWith $rel.OtherSchemaColumnNames ",")|lowerCase}};belongsTo;constraint:OnDelete:{{$rel.DeleteRestrict]]RESTRICT{{else}}CASCADE{{end}}"`
+        {{$rel.OtherSchema.Table|upperCamelCase}}Ref {{$rel.OtherSchema.Table|upperCamelCase}} `gorm:"foreignKey:{{ (concatWith $rel.ThisSchemaColumnNames ",") | lowerCase}};references:{{ (concatWith $rel.OtherSchemaColumnNames ",")|lowerCase}};belongsTo;constraint:OnDelete:{{ if $rel.DeleteRestrict }}RESTRICT{{ else }}CASCADE{{ end }}"`
     {{- end}}
     }
     {{- range $idx, $child := $schema.Children }}


### PR DESCRIPTION
## Description

Add support to the postgres store generator to support a protobuf tag denoting a delete restriction for foreign key references.

This is necessary due to the fact that collections can have references to other collections and we want to prevent the deletion of nested collections that are in use. Errors encountered by attempted deletions will be percolated up to the UI to inform users that a given collection is a dependency of another collection.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added


## Testing Performed

Locally added the flag to a proto definition, built an image, and verified that the table had the correct configuration.
