### PR TITLE
ROX-12010, ROX-12535: better release notes, prepare gosec scanner, finish-release automation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,16 @@
+# GitHub Actions
+
+## Upstream Release Automation
+
+### General Rules
+
+* **Ensure reentrancy**: expect a workflow to be re-run from failed state;
+* **Suggest the next step** if it is not automated: print `:arrow_right:` emoji
+  with the suggested action to `$GITHUB_STEP_SUMMARY` or post a message to Slack;
+* **Highlight major things**: print to stdout with `::error::`, `::warning::` or
+  `::notice::` prefix to higlight important status. Markdown is not supported;
+* **Log minor things**: print to `$GITHUB_STEP_SUMMARY` with markdown to describe
+  the executed actions and suggest the next step;
+* **Support dry-run**: use the `DRY_RUN` environment variable to check for dry-run,
+  it holds `true` or `false` values.
+* **Extract large scripts**: look in the `scripts` folder for examples;

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,5 +12,5 @@
 * **Log minor things**: print to `$GITHUB_STEP_SUMMARY` with markdown to describe
   the executed actions and suggest the next step;
 * **Support dry-run**: use the `DRY_RUN` environment variable to check for dry-run,
-  it holds `true` or `false` values.
+  it holds `true` or `false` values;
 * **Extract large scripts**: look in the `scripts` folder for examples;

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -219,7 +219,7 @@ jobs:
             tag-rc \
             "${{needs.variables.outputs.milestone}}"
 
-          echo "::set-output name=report-file-name::gosec-$(git rev-parse --short HEAD).output"
+          # echo "::set-output name=report-file-name::gosec-$(git rev-parse --short HEAD).output"
 
       - name: Create next milestone
         if: env.DRY_RUN == 'false'
@@ -242,18 +242,18 @@ jobs:
             echo ":arrow_right: Close the newly created milestone [${{needs.variables.outputs.next-milestone}}](${{github.event.milestone.html_url}}) when ready." >> $GITHUB_STEP_SUMMARY
           fi
 
-      - name: Run Gosec security scanner
-        uses: securego/gosec@master
-        with:
-          args: "-no-fail -out ${{ steps.tag.outputs.report-file-name }} ./..."
-      - run: |
-          cat <<EOF >> $GITHUB_STEP_SUMMARY
-          # gosec Report
+      # - name: Run Gosec security scanner
+      #   uses: securego/gosec@master
+      #   with:
+      #     args: "-no-fail -out ${{ steps.tag.outputs.report-file-name }} ./..."
+      # - run: |
+      #     cat <<EOF >> $GITHUB_STEP_SUMMARY
+      #     # gosec Report
 
-          \`\`\`
-          EOF
-          cat "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+      #     \`\`\`
+      #     EOF
+      #     cat "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}" >> $GITHUB_STEP_SUMMARY
+      #     echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Create GitHub Pre-release
         id: pre-release
@@ -273,14 +273,14 @@ jobs:
             --target "${{ needs.variables.outputs.branch }}")
           echo "::set-output name=url::$URL"
 
-      - name: Attach gosec report
-        if: env.DRY_RUN == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
-        run: |
-          gh release upload "${{ needs.variables.outputs.milestone }}" \
-            --repo "${{ github.repository }}" \
-            "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}"
+      # - name: Attach gosec report
+      #   if: env.DRY_RUN == 'false'
+      #   env:
+      #     GH_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
+      #   run: |
+      #     gh release upload "${{ needs.variables.outputs.milestone }}" \
+      #       --repo "${{ github.repository }}" \
+      #       "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}"
 
       - run: |
           echo "Created GitHub pre-release [${{needs.variables.outputs.milestone}}](${{steps.pre-release.outputs.url}})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -219,8 +219,6 @@ jobs:
             tag-rc \
             "${{needs.variables.outputs.milestone}}"
 
-          # echo "::set-output name=report-file-name::gosec-$(git rev-parse --short HEAD).output"
-
       - name: Create next milestone
         if: env.DRY_RUN == 'false'
         env:
@@ -242,19 +240,6 @@ jobs:
             echo ":arrow_right: Close the newly created milestone [${{needs.variables.outputs.next-milestone}}](${{github.event.milestone.html_url}}) when ready." >> $GITHUB_STEP_SUMMARY
           fi
 
-      # - name: Run Gosec security scanner
-      #   uses: securego/gosec@master
-      #   with:
-      #     args: "-no-fail -out ${{ steps.tag.outputs.report-file-name }} ./..."
-      # - run: |
-      #     cat <<EOF >> $GITHUB_STEP_SUMMARY
-      #     # gosec Report
-
-      #     \`\`\`
-      #     EOF
-      #     cat "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}" >> $GITHUB_STEP_SUMMARY
-      #     echo '```' >> $GITHUB_STEP_SUMMARY
-
       - name: Create GitHub Pre-release
         id: pre-release
         if: env.DRY_RUN == 'false'
@@ -273,15 +258,6 @@ jobs:
             --repo "${{ github.repository }}" \
             --target "${{ needs.variables.outputs.branch }}")
           echo "::set-output name=url::$URL"
-
-      # - name: Attach gosec report
-      #   if: env.DRY_RUN == 'false'
-      #   env:
-      #     GH_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
-      #   run: |
-      #     gh release upload "${{ needs.variables.outputs.milestone }}" \
-      #       --repo "${{ github.repository }}" \
-      #       "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}"
 
       - run: |
           echo "Created GitHub pre-release [${{needs.variables.outputs.milestone}}](${{steps.pre-release.outputs.url}})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -36,7 +36,8 @@ env:
   main_branch: ${{github.event.repository.default_branch}}
   docs_repository: openshift/openshift-docs
   jira_projects: ROX, RS, RTOOLS
-  slack_channel: C03KSV3N6N8 #test-release-automation
+  #eng-release (CMH5M8MHN) for real runs or #test-release-automation (C03KSV3N6N8) for testing:
+  slack_channel: ${{ fromJSON('["CMH5M8MHN", "C03KSV3N6N8"]')[ github.repository != 'stackrox/stackrox' || github.event.inputs.dry-run == 'true'] }}
   script_url: /repos/${{ github.repository }}/contents/.github/workflows/scripts/common.sh?ref=${{ github.ref_name }}
   DRY_RUN: ${{ fromJSON('["true", "false"]')[github.event.inputs.dry-run != 'true'] }}
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
@@ -142,15 +143,16 @@ jobs:
             echo "PR $PR has been moved to milestone ${{needs.variables.outputs.next-milestone}}." >> $GITHUB_STEP_SUMMARY
           done
 
-  check-merged-prs:
-    name: Cherry-pick from PRs
-    needs: [variables, postpone-prs]
+  cut-rc:
+    name: Tag RC for milestone ${{needs.variables.outputs.milestone}}
     runs-on: ubuntu-latest
+    needs: [variables, postpone-prs, check-jira]
     steps:
       - name: Check out code
         uses: actions/checkout@v3
         with:
           ref: ${{needs.variables.outputs.branch}}
+          token: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
       - name: Initialize mandatory git config
         run: |
           git config user.name "${{github.event.sender.login}}"
@@ -168,7 +170,7 @@ jobs:
             "${{needs.variables.outputs.branch}}" \
             "${{needs.variables.outputs.release-patch}}"
 
-      - name: Post to Slack
+      - name: Post to Slack about picked cherries
         if: failure() && steps.cherry-pick.outputs.bad-cherries != ''
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -198,19 +200,6 @@ jobs:
             Workflow: <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>" }}
             ]}
 
-  cut-rc:
-    name: Tag RC for milestone ${{needs.variables.outputs.milestone}}
-    runs-on: ubuntu-latest
-    needs: [variables, check-merged-prs, check-jira]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: "${{needs.variables.outputs.branch}}"
-          token: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
-      - name: Initialize mandatory git config
-        run: |
-          git config user.name "${{github.event.sender.login}}"
-          git config user.email noreply@github.com
       - name: Update docs submodule
         run: |
           git submodule update --init --remote -- docs/content
@@ -219,14 +208,23 @@ jobs:
             git commit -m "Update docs submodule for milestone ${{needs.variables.outputs.milestone}}"
             echo "Documentation submodule has been updated" >> $GITHUB_STEP_SUMMARY
           fi
+
       - name: Tag release branch with "${{needs.variables.outputs.milestone}}"
+        id: tag
+        env:
+          GH_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
         run: |
           set -uo pipefail
           gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
             tag-rc \
             "${{needs.variables.outputs.milestone}}"
+
+          echo "::set-output name=report-file-name::gosec-$(git rev-parse --short HEAD).output"
+
       - name: Create next milestone
         if: env.DRY_RUN == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
         run: |
           set -u
           if ! http_code=$(gh api --silent -X POST \
@@ -244,22 +242,46 @@ jobs:
             echo ":arrow_right: Close the newly created milestone [${{needs.variables.outputs.next-milestone}}](${{github.event.milestone.html_url}}) when ready." >> $GITHUB_STEP_SUMMARY
           fi
 
-  pre-release:
-    name: Publish a GitHub pre-release
-    needs: [variables, cut-rc]
-    runs-on: ubuntu-latest
-    steps:
+      - name: Run Gosec security scanner
+        uses: securego/gosec@master
+        with:
+          args: "-no-fail -out ${{ steps.tag.outputs.report-file-name }} ./..."
+      - run: |
+          cat <<EOF >> $GITHUB_STEP_SUMMARY
+          # gosec Report
+
+          \`\`\`
+          EOF
+          cat "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
       - name: Create GitHub Pre-release
         id: pre-release
         if: env.DRY_RUN == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
         run: |
-          _MD_SECTION="${{needs.variables.outputs.release-patch}}"
+          set -uo pipefail
+          gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
+            draft-release-notes \
+            "${{ needs.variables.outputs.release-patch }}" \
+            "${{ needs.variables.outputs.branch }}"
           URL=$(gh release create "${{needs.variables.outputs.milestone}}" \
             --prerelease \
-            --notes "**Changelog**: ${{github.repository}}/blob/master/CHANGELOG.md#${_MD_SECTION//./}" \
-            --repo "${{github.repository}}" \
-            --target "${{needs.variables.outputs.branch}}")
+            --notes-file RELEASE_NOTES_GENERATED.md \
+            --repo "${{ github.repository }}" \
+            --target "${{ needs.variables.outputs.branch }}")
           echo "::set-output name=url::$URL"
+
+      - name: Attach gosec report
+        if: env.DRY_RUN == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ needs.variables.outputs.milestone }}" \
+            --repo "${{ github.repository }}" \
+            "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}"
+
       - run: |
           echo "Created GitHub pre-release [${{needs.variables.outputs.milestone}}](${{steps.pre-release.outputs.url}})" >> $GITHUB_STEP_SUMMARY
       - name: Post to Slack
@@ -278,13 +300,10 @@ jobs:
             { "type": "divider" },
 
             { "type": "section", "text": { "type": "mrkdwn", "text":
-            ":white_check_mark: Once all checks pass, convert it to the final release
-            with:\n\n```gh release edit
-            \"${{needs.variables.outputs.milestone}}\"
-            --prerelease=false
-            --tag \"${{needs.variables.outputs.release-patch}}\"
-            --title \"${{needs.variables.outputs.release-patch}}\"```\nOtherwise
-            create next milestone `${{needs.variables.outputs.next-milestone}}`." }}
+            ":arrow_right: Once all checks pass and you're ready for release,
+            run the <${{ github.server_url }}/${{ github.repository }}/actions/workflows/finish-release.yml|Finish Release>
+            workflow and delete the `${{ needs.variables.outputs.next-milestone }}`
+            milestone to avoid confusion." }}
             ]}
 
   wait-for-images:

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -265,7 +265,8 @@ jobs:
           gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
             draft-release-notes \
             "${{ needs.variables.outputs.release-patch }}" \
-            "${{ needs.variables.outputs.branch }}"
+            "${{ needs.variables.outputs.branch }}" \
+            "RELEASE_NOTES_GENERATED.md"
           URL=$(gh release create "${{needs.variables.outputs.milestone}}" \
             --prerelease \
             --notes-file RELEASE_NOTES_GENERATED.md \

--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -100,7 +100,8 @@ jobs:
           gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
             draft-release-notes \
             "${{ needs.variables.outputs.release-patch }}" \
-            "${{ needs.variables.outputs.branch }}"
+            "${{ needs.variables.outputs.branch }}" \
+            "RELEASE_NOTES_GENERATED.md"
           URL=$(gh release create "${{ needs.variables.outputs.release-patch }}" \
             --notes-file RELEASE_NOTES_GENERATED.md \
             --repo "${{ github.repository }}" \

--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -75,21 +75,6 @@ jobs:
             tag-rc \
             "${{ needs.variables.outputs.release-patch }}"
 
-          # echo "::set-output name=report-file-name::gosec-$(git rev-parse --short HEAD).output"
-
-      # - name: Run Gosec security scanner
-      #   uses: securego/gosec@master
-      #   with:
-      #     args: "-no-fail -out ${{ steps.tag.outputs.report-file-name }} ./..."
-      # - run: |
-      #     cat <<EOF >> $GITHUB_STEP_SUMMARY
-      #     # gosec Report
-
-      #     \`\`\`
-      #     EOF
-      #     cat "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}" >> $GITHUB_STEP_SUMMARY
-      #     echo '```' >> $GITHUB_STEP_SUMMARY
-
       - name: Create GitHub Release
         id: release
         if: env.DRY_RUN == 'false'
@@ -107,15 +92,6 @@ jobs:
             --repo "${{ github.repository }}" \
             --target "${{ needs.variables.outputs.branch }}")
           echo "::set-output name=url::$URL"
-
-      # - name: Attach gosec report
-      #   if: env.DRY_RUN == 'false'
-      #   env:
-      #     GH_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
-      #   run: |
-      #     gh release upload "${{ needs.variables.outputs.release-patch }}" \
-      #       --repo "${{ github.repository }}" \
-      #       "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}"
 
       - run: |
           echo "Created GitHub release [${{ needs.variables.outputs.release-patch }}](${{ steps.release.outputs.url }})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -1,16 +1,124 @@
 name: Finish Release
 on:
-  release:
-    types: [released]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version (A.B.C[-N])
+        required: true
+        default: 0.0.0-test
+        type: string
+      dry-run:
+        description: Dry-run
+        required: false
+        default: true
+        type: boolean
 
 env:
-  slack_channel: C03KSV3N6N8 #test-release-automation
+  main_branch: ${{ github.event.repository.default_branch }}
+  #eng-release (CMH5M8MHN) for real runs or #test-release-automation (C03KSV3N6N8) for testing:
+  slack_channel: ${{ fromJSON('["CMH5M8MHN", "C03KSV3N6N8"]')[ github.repository != 'stackrox/stackrox' || github.event.inputs.dry-run == 'true'] }}
+  script_url: /repos/${{ github.repository }}/contents/.github/workflows/scripts/common.sh?ref=${{ github.ref_name }}
+  DRY_RUN: ${{ fromJSON('["true", "false"]')[inputs.dry-run != true] }}
+  ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
+  GH_TOKEN: ${{ github.token }}
+  GH_NO_UPDATE_NOTIFIER: 1
+
+# Ensure that only a single release automation workflow can run at a time.
+concurrency: Release automation
 
 jobs:
-  notify:
-    name: Notify about ${{github.event.release.title}}
+  run-parameters:
+    if: github.event_name == 'workflow_dispatch'
+    name: Run parameters
     runs-on: ubuntu-latest
     steps:
+      - run: |
+          [ "$DRY_RUN" = "true" ] && echo "::warning::This is a dry run"
+          echo "Event: ${{ github.event_name }}" >>"$GITHUB_STEP_SUMMARY"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            cat <<EOF >>"$GITHUB_STEP_SUMMARY"
+          \`\`\`
+          ${{ toJSON(inputs) }}
+          \`\`\`
+          EOF
+          fi
+
+  variables:
+    if: github.event_name == 'workflow_dispatch'
+    name: Setup variables
+    uses: ./.github/workflows/variables.yml
+    with:
+      version: ${{ inputs.version }}
+
+  publish-release:
+    name: Tag Release ${{ needs.variables.outputs.release-patch }}
+    runs-on: ubuntu-latest
+    needs: [variables]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.variables.outputs.branch }}
+          token: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "${{ github.event.sender.login }}"
+          git config user.email noreply@github.com
+
+      - name: Tag release branch with "${{ needs.variables.outputs.release-patch }}"
+        id: tag
+        env:
+          GH_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          gh api -H "$ACCEPT_RAW" "${{ env.script_url }}" | bash -s -- \
+            tag-rc \
+            "${{ needs.variables.outputs.release-patch }}"
+
+          echo "::set-output name=report-file-name::gosec-$(git rev-parse --short HEAD).output"
+
+      - name: Run Gosec security scanner
+        uses: securego/gosec@master
+        with:
+          args: "-no-fail -out ${{ steps.tag.outputs.report-file-name }} ./..."
+      - run: |
+          cat <<EOF >> $GITHUB_STEP_SUMMARY
+          # gosec Report
+
+          \`\`\`
+          EOF
+          cat "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Create GitHub Release
+        id: release
+        if: env.DRY_RUN == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
+            draft-release-notes \
+            "${{ needs.variables.outputs.release-patch }}" \
+            "${{ needs.variables.outputs.branch }}"
+          URL=$(gh release create "${{ needs.variables.outputs.release-patch }}" \
+            --notes-file RELEASE_NOTES_GENERATED.md \
+            --repo "${{ github.repository }}" \
+            --target "${{ needs.variables.outputs.branch }}")
+          echo "::set-output name=url::$URL"
+
+      - name: Attach gosec report
+        if: env.DRY_RUN == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ needs.variables.outputs.release-patch }}" \
+            --repo "${{ github.repository }}" \
+            "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}"
+
+      - run: |
+          echo "Created GitHub release [${{ needs.variables.outputs.release-patch }}](${{ steps.release.outputs.url }})" >> $GITHUB_STEP_SUMMARY
+
       - name: Post to Slack
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -21,10 +129,10 @@ jobs:
             { "blocks": [
 
             { "type": "section", "text": { "type": "mrkdwn", "text":
-            ":white_check_mark: *<${{github.event.release.url}} | ${{github.event.release.name}}> has been published on GitHub.*" }},
+            ":white_check_mark: *<${{ steps.release.outputs.url }} | ${{ inputs.version }}> has been published on GitHub.*" }},
 
             { "type": "section", "text": { "type": "mrkdwn", "text":
             ":arrow_right: Look for a CI generated PR created in `stackrox/release-artifacts` repository
-            and confirm that members of the `@release-publishers` Slack group got notified about
-            it.\n\n":arrow_right: Let's trigger the downstream release!" }}
+            and confirm that members of the @release-publishers Slack group got notified about
+            it.\n\n:arrow_right: Let's trigger the downstream release!" }}
             ]}

--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -75,20 +75,20 @@ jobs:
             tag-rc \
             "${{ needs.variables.outputs.release-patch }}"
 
-          echo "::set-output name=report-file-name::gosec-$(git rev-parse --short HEAD).output"
+          # echo "::set-output name=report-file-name::gosec-$(git rev-parse --short HEAD).output"
 
-      - name: Run Gosec security scanner
-        uses: securego/gosec@master
-        with:
-          args: "-no-fail -out ${{ steps.tag.outputs.report-file-name }} ./..."
-      - run: |
-          cat <<EOF >> $GITHUB_STEP_SUMMARY
-          # gosec Report
+      # - name: Run Gosec security scanner
+      #   uses: securego/gosec@master
+      #   with:
+      #     args: "-no-fail -out ${{ steps.tag.outputs.report-file-name }} ./..."
+      # - run: |
+      #     cat <<EOF >> $GITHUB_STEP_SUMMARY
+      #     # gosec Report
 
-          \`\`\`
-          EOF
-          cat "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+      #     \`\`\`
+      #     EOF
+      #     cat "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}" >> $GITHUB_STEP_SUMMARY
+      #     echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Create GitHub Release
         id: release
@@ -107,14 +107,14 @@ jobs:
             --target "${{ needs.variables.outputs.branch }}")
           echo "::set-output name=url::$URL"
 
-      - name: Attach gosec report
-        if: env.DRY_RUN == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
-        run: |
-          gh release upload "${{ needs.variables.outputs.release-patch }}" \
-            --repo "${{ github.repository }}" \
-            "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}"
+      # - name: Attach gosec report
+      #   if: env.DRY_RUN == 'false'
+      #   env:
+      #     GH_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
+      #   run: |
+      #     gh release upload "${{ needs.variables.outputs.release-patch }}" \
+      #       --repo "${{ github.repository }}" \
+      #       "$GITHUB_WORKSPACE/${{ steps.tag.outputs.report-file-name }}"
 
       - run: |
           echo "Created GitHub release [${{ needs.variables.outputs.release-patch }}](${{ steps.release.outputs.url }})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/scripts/check-jira-issues.sh
+++ b/.github/workflows/scripts/check-jira-issues.sh
@@ -102,10 +102,12 @@ echo
 echo "Open issues:"
 echo "$OPEN_ISSUES"
 
-if [ "$DRY_RUN" = "false" ]; then
+REPO_NAME="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+
+if [ "$DRY_RUN" = "false" ] && [ "$REPO_NAME" = "stackrox/stackrox" ]; then
     while read -r KEY; do
         comment_issue "$KEY"
-    done <<<"$OPEN_ISSUES"
+    done < <(cut -d " " -f 1 <<< "$OPEN_ISSUES")
 else
     exit 0
 fi

--- a/.github/workflows/scripts/cherry-pick.sh
+++ b/.github/workflows/scripts/cherry-pick.sh
@@ -92,13 +92,6 @@ if [ -n "$PR_COMMITS" ]; then
     while read -r PR_COMMIT; do
         cherry_pick "$PR_COMMIT"
     done <<<"$PR_COMMITS"
-
-    if [ "$PICKED" -gt 0 ]; then
-        [ "$DRY_RUN" = "false" ] &&
-            git push
-
-        gh_summary "Cherry-picked commits have been pushed to the release branch."
-    fi
 fi
 
 # Replace % with %25, escape \n and " to pass as step output to Slack message.

--- a/.github/workflows/scripts/create-cluster.sh
+++ b/.github/workflows/scripts/create-cluster.sh
@@ -38,12 +38,17 @@ function infra_status_summary() {
     gh_summary <<EOF
 *$2*
 Infra status for '$1':
-\`\`\`$(cluster_info "$1")\`\`\`
+\`\`\`
+$(cluster_info "$1")
+\`\`\`
 
 EOF
 }
 
 case $(cluster_status "$CNAME") in
+"")
+    gh_summary "Cluster $CNAME doesn't exist."
+    ;;
 1)
     # Don't wait for the cluster being created, as another workflow could be
     # waiting for it.
@@ -75,7 +80,7 @@ case $(cluster_status "$CNAME") in
 esac
 
 # Creating a cluster
-echo "Will attempt to create the cluster"
+echo "Will attempt to create the cluster."
 
 OPTIONS=()
 if [ "$WAIT" = "true" ]; then

--- a/.github/workflows/scripts/draft-release-notes.sh
+++ b/.github/workflows/scripts/draft-release-notes.sh
@@ -7,10 +7,12 @@ set -euo pipefail
 
 VERSION="$1"
 RELEASE_BRANCH="$2"
+OUTPUT="${3:-RELEASE_NOTES_GENERATED.md}"
 
 check_not_empty \
     VERSION \
-    RELEASE_BRANCH
+    RELEASE_BRANCH \
+    OUTPUT
 
 get_current_release_changelog() {
     gh api \
@@ -20,10 +22,10 @@ get_current_release_changelog() {
 }
 
 create_release_notes() {
-    sed -n "/^## \[$ESCAPED_VERSION]$/,/^## \[/p" CHANGELOG.md | sed '1d;$d' > RELEASE_NOTES_GENERATED.md
-    if [ $(wc -m RELEASE_NOTES_GENERATED.md | awk '{ print $1 }') -gt 150000 ]; then
+    sed -n "/^## \[$ESCAPED_VERSION]$/,/^## \[/p" CHANGELOG.md | sed '1d;$d' > "$OUTPUT"
+    if [ $(wc -m "$OUTPUT" | awk '{ print $1 }') -gt 150000 ]; then
         PREVIOUS_VERSION=$(sed -n "/^## \[$ESCAPED_VERSION]$/,/^## \[/p" CHANGELOG.md | tail -n 1 | tr -d '#[] ')
-        echo "**Full Changelog**: https://github.com/${REPO_NAME}/compare/${PREVIOUS_VERSION}...${VERSION}" > RELEASE_NOTES_GENERATED.md
+        echo "**Full Changelog**: https://github.com/${REPO_NAME}/compare/${PREVIOUS_VERSION}...${VERSION}" > "$OUTPUT"
     fi
 }
 

--- a/.github/workflows/scripts/draft-release-notes.sh
+++ b/.github/workflows/scripts/draft-release-notes.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Drafts release notes from CHANGELOG for the current
+# release, uses link to previous tag as fallback.
+#
+set -euo pipefail
+
+VERSION="$1"
+RELEASE_BRANCH="$2"
+
+check_not_empty \
+    VERSION \
+    RELEASE_BRANCH
+
+get_current_release_changelog() {
+    gh api \
+        -H "Accept: application/vnd.github.v3.raw" \
+        "/repos/${REPO_NAME}/contents/CHANGELOG.md?ref=${RELEASE_BRANCH}" \
+    > CHANGELOG.md
+}
+
+create_release_notes() {
+    sed -n "/^## \[$ESCAPED_VERSION]$/,/^## \[/p" CHANGELOG.md | sed '1d;$d' > RELEASE_NOTES_GENERATED.md
+    if [ $(wc -m RELEASE_NOTES_GENERATED.md | awk '{ print $1 }') -gt 150000 ]; then
+        PREVIOUS_VERSION=$(sed -n "/^## \[$ESCAPED_VERSION]$/,/^## \[/p" CHANGELOG.md | tail -n 1 | tr -d '#[] ')
+        echo "**Full Changelog**: https://github.com/${REPO_NAME}/compare/${PREVIOUS_VERSION}...${VERSION}" > RELEASE_NOTES_GENERATED.md
+    fi
+}
+
+REPO_NAME="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+ESCAPED_VERSION="${VERSION//./\.}"
+get_current_release_changelog
+create_release_notes

--- a/.github/workflows/scripts/local-env.sh
+++ b/.github/workflows/scripts/local-env.sh
@@ -12,13 +12,17 @@ export GITHUB_ACTOR
 export GITHUB_REPOSITORY=stackrox/stackrox
 export GITHUB_SERVER_URL=https://github.com
 
-export main_branch=master
+main_branch="$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)"
+export main_branch
 
 if [ -z "$DRY_RUN" ]; then
     export DRY_RUN=true
 fi
 
 SCRIPTS_ROOT="$(git rev-parse --show-toplevel)/.github/workflows/scripts"
+
+CI="false" # true if running in GitHub context
+export CI
 
 # Supress shellcheck false warning:
 # shellcheck source=/dev/null

--- a/.github/workflows/scripts/tag-rc.sh
+++ b/.github/workflows/scripts/tag-rc.sh
@@ -17,8 +17,13 @@ check_not_empty \
     DRY_RUN
 
 if [ "$(git tag "$TAG" --points-at HEAD)" = "$TAG" ]; then
-    git push --delete origin "$TAG"
+    if [ "$DRY_RUN" = "false" ]; then
+        git push --delete origin "$TAG"
+    fi
     gh_log warning "Existing tag '$TAG' has been deleted."
+elif [ "$(git tag --list "$TAG")" = "$TAG" ]; then
+    gh_log error "Tag $TAG exists and is not on the head."
+    exit 1
 fi
 
 git commit --allow-empty --message "Empty commit to trigger CI"

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -10,7 +10,7 @@ on:
       ref:
         description: Release base ref (for non-patch releases)
         required: false
-        default: master
+        default: HEAD
         type: string
       dry-run:
         description: Dry-run
@@ -20,7 +20,8 @@ on:
 
 env:
   docs_repository: openshift/openshift-docs
-  slack_channel: C03KSV3N6N8 #test-release-automation
+  #eng-release (CMH5M8MHN) for real runs or #test-release-automation (C03KSV3N6N8) for testing:
+  slack_channel: ${{ fromJSON('["CMH5M8MHN", "C03KSV3N6N8"]')[ github.repository != 'stackrox/stackrox' || github.event.inputs.dry-run == 'true'] }}
   main_branch: ${{github.event.repository.default_branch}}
   jira_project: ROX
   script_url: /repos/${{ github.repository }}/contents/.github/workflows/scripts/common.sh?ref=${{ github.ref_name }}


### PR DESCRIPTION
## Description

**Added:**
* README for GitHub actions
* prepare gosec scanner to cut-rc & finish-release workflows -> it is disabled until the teething problems are resolved.
* automate finish-release automation to create the final tag + release

**Changes:**
* send Slack messages to different channels based on run wetness
* improve re-tagging logic in cut-rc for reentry / idempotence
* build release notes based on CHANGELOG
* improve local / non-CI execution 

## Checklist
- ~[ ] Investigated and inspected CI test results~ -> tested in private test repository
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

-> changes developed & tested in private test repository 
