### PR TITLE
Use a `http.Server` with a timeout

### DIFF
--- a/webhookserver/server.go
+++ b/webhookserver/server.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -69,14 +70,24 @@ func rootHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func tlsServer() {
-	err := http.ListenAndServeTLS(":8443", "/tmp/certs/server.crt", "/tmp/certs/server.key", http.HandlerFunc(rootHandler))
+	server := &http.Server{
+		ReadHeaderTimeout: 5 * time.Second,
+		Addr:              ":8443",
+		Handler:           http.HandlerFunc(rootHandler),
+	}
+	err := server.ListenAndServeTLS("/tmp/certs/server.crt", "/tmp/certs/server.key")
 	if err != nil {
 		log.Fatal("ListenAndServe: ", err)
 	}
 }
 
 func nonTLSServer() {
-	if err := http.ListenAndServe(":8080", http.HandlerFunc(rootHandler)); err != nil {
+	server := &http.Server{
+		ReadHeaderTimeout: 5 * time.Second,
+		Addr:              ":8080",
+		Handler:           http.HandlerFunc(rootHandler),
+	}
+	if err := server.ListenAndServe(); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
## Description

`gosec` reports *G114: Use of net/http serve function that has no support for setting timeouts*.

(Some versions of `gosec` would actually crash trying to report that.)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed
```
$ gosec webhookserver
[gosec] 2022/09/20 10:32:51 Including rules: default
[gosec] 2022/09/20 10:32:51 Excluding rules: default
[gosec] 2022/09/20 10:32:51 Import directory: /home/mipetrov/go/src/github.com/stackrox/stackrox/webhookserver
[gosec] 2022/09/20 10:32:51 Checking package: main
[gosec] 2022/09/20 10:32:51 Checking file: /home/mipetrov/go/src/github.com/stackrox/stackrox/webhookserver/server.go
Results:


Summary:
  Gosec  : dev
  Files  : 1
  Lines  : 99
  Nosec  : 0
  Issues : 0
```