### PR TITLE
ROX-12692: Remove pods/attach resource from admission controller resources, and fail open on unsupported request kinds/api verbs

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -247,7 +247,6 @@ webhooks:
         - CONNECT
         resources:
           - pods
-          - pods/attach
           - pods/exec
           - pods/portforward
     failurePolicy: Ignore


### PR DESCRIPTION
## Description

The admission controller configuration specifies that we want to listen on `pods/attach` resource access. However, [we don't actually handle that](https://github.com/stackrox/stackrox/blob/master/pkg/kubernetes/event.go#L45).

This PR does two things: first, it removes the `pods/attach` resource from the admission controller configuration. This will not cause anything to break, as we're not handling pod attach events anyway, but it will ensure customers `kubectl attach` calls will not break when they have configured enforcement for K8s events. Second, it makes sure we simply log an error and fail open if we receive a request that we should not receive (per `ValidatingWebhookConfiguration`), instead of blocking the request.
 
## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] Determined and documented upgrade steps: https://docs.engineering.redhat.com/display/StackRox/Upgrade+to+73.0
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

TBD