### PR TITLE
Call assertSortedItems in vulnmanagement integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/sort.js
+++ b/ui/apps/platform/cypress/helpers/sort.js
@@ -85,36 +85,70 @@ export function getStringValueFromElement(element) {
     return element?.innerText;
 }
 
-const severityValues = ['Low', 'Medium', 'High', 'Critical'];
+const policySeverityValues = ['Low', 'Medium', 'High', 'Critical'];
 
-export function isValidSeverityValue(value) {
-    return typeof value === 'string' && severityValues.includes(value);
+export function isValidPolicySeverityValue(value) {
+    return typeof value === 'string' && policySeverityValues.includes(value);
 }
 
-export function isPairOfAscendingSeverityValues(valueA, valueB) {
-    const indexA = severityValues.indexOf(valueA);
-    const indexB = severityValues.indexOf(valueB);
+export function isPairOfAscendingPolicySeverityValues(valueA, valueB) {
+    const indexA = policySeverityValues.indexOf(valueA);
+    const indexB = policySeverityValues.indexOf(valueB);
     return indexA !== -1 && indexA <= indexB;
 }
 
-export function isPairOfDescendingSeverityValues(valueA, valueB) {
-    const indexA = severityValues.indexOf(valueA);
-    const indexB = severityValues.indexOf(valueB);
+export function isPairOfDescendingPolicySeverityValues(valueA, valueB) {
+    const indexA = policySeverityValues.indexOf(valueA);
+    const indexB = policySeverityValues.indexOf(valueB);
     return indexA >= indexB && indexB !== -1;
 }
 
-export const callbackForPairOfAscendingSeverityValuesFromElements =
+export const callbackForPairOfAscendingPolicySeverityValuesFromElements =
     createCallbackForPairOfSortedItems(
-        'notAscendingSeverityValuesFromElements',
+        'notAscendingPolicySeverityValuesFromElements',
         getStringValueFromElement,
-        isValidSeverityValue,
-        isPairOfAscendingSeverityValues
+        isValidPolicySeverityValue,
+        isPairOfAscendingPolicySeverityValues
     );
 
-export const callbackForPairOfDescendingSeverityValuesFromElements =
+export const callbackForPairOfDescendingPolicySeverityValuesFromElements =
     createCallbackForPairOfSortedItems(
-        'notDescendingSeverityValuesFromElements',
+        'notDescendingPolicySeverityValuesFromElements',
         getStringValueFromElement,
-        isValidSeverityValue,
-        isPairOfDescendingSeverityValues
+        isValidPolicySeverityValue,
+        isPairOfDescendingPolicySeverityValues
+    );
+
+const vulnerabilitySeverityValues = ['Low', 'Moderate', 'Important', 'Critical'];
+
+export function isValidVulnerabilitySeverityValue(value) {
+    return typeof value === 'string' && vulnerabilitySeverityValues.includes(value);
+}
+
+export function isPairOfAscendingVulnerabilitySeverityValues(valueA, valueB) {
+    const indexA = vulnerabilitySeverityValues.indexOf(valueA);
+    const indexB = vulnerabilitySeverityValues.indexOf(valueB);
+    return indexA !== -1 && indexA <= indexB;
+}
+
+export function isPairOfDescendingVulnerabilitySeverityValues(valueA, valueB) {
+    const indexA = vulnerabilitySeverityValues.indexOf(valueA);
+    const indexB = vulnerabilitySeverityValues.indexOf(valueB);
+    return indexA >= indexB && indexB !== -1;
+}
+
+export const callbackForPairOfAscendingVulnerabilitySeverityValuesFromElements =
+    createCallbackForPairOfSortedItems(
+        'notAscendingVulnerabilitySeverityValuesFromElements',
+        getStringValueFromElement,
+        isValidVulnerabilitySeverityValue,
+        isPairOfAscendingVulnerabilitySeverityValues
+    );
+
+export const callbackForPairOfDescendingVulnerabilitySeverityValuesFromElements =
+    createCallbackForPairOfSortedItems(
+        'notDescendingVulnerabilitySeverityValuesFromElements',
+        getStringValueFromElement,
+        isValidVulnerabilitySeverityValue,
+        isPairOfDescendingVulnerabilitySeverityValues
     );

--- a/ui/apps/platform/cypress/integration/policies/policiesTable.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policiesTable.test.js
@@ -13,8 +13,8 @@ import {
 } from '../../helpers/policiesPatternFly';
 import {
     assertSortedItems,
-    callbackForPairOfAscendingSeverityValuesFromElements,
-    callbackForPairOfDescendingSeverityValuesFromElements,
+    callbackForPairOfAscendingPolicySeverityValuesFromElements,
+    callbackForPairOfDescendingPolicySeverityValuesFromElements,
 } from '../../helpers/sort';
 import { visit } from '../../helpers/visit';
 import navSelectors from '../../selectors/navigation';
@@ -94,7 +94,7 @@ describe('Policies table', () => {
 
         cy.get(thSelector).should('have.attr', 'aria-sort', 'ascending');
         cy.get(tdSelector).then((items) => {
-            assertSortedItems(items, callbackForPairOfAscendingSeverityValuesFromElements);
+            assertSortedItems(items, callbackForPairOfAscendingPolicySeverityValuesFromElements);
         });
 
         // 2. Sort descending by the Severity column.
@@ -112,7 +112,7 @@ describe('Policies table', () => {
 
         cy.get(thSelector).should('have.attr', 'aria-sort', 'descending');
         cy.get(tdSelector).then((items) => {
-            assertSortedItems(items, callbackForPairOfDescendingSeverityValuesFromElements);
+            assertSortedItems(items, callbackForPairOfDescendingPolicySeverityValuesFromElements);
         });
 
         // 3. Sort ascending by the Severity column.
@@ -122,13 +122,7 @@ describe('Policies table', () => {
         cy.location('search').should('eq', '?sort[id]=Severity&sort[desc]=false');
         */
 
-        // There is no request because front-end sorting.
-        cy.wait(1000);
-
         cy.get(thSelector).should('have.attr', 'aria-sort', 'ascending');
-        cy.get(tdSelector).then((items) => {
-            assertSortedItems(items, callbackForPairOfAscendingSeverityValuesFromElements);
-        });
     });
 
     it('should have expected status values', () => {

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusterCvesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusterCvesListPages.test.js
@@ -1,8 +1,14 @@
 import { selectors } from '../../constants/VulnManagementPage';
 import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
+import {
+    assertSortedItems,
+    callbackForPairOfAscendingNumberValuesFromElements,
+    callbackForPairOfDescendingNumberValuesFromElements,
+} from '../../helpers/sort';
 import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
+    interactAndWaitForVulnerabilityManagementEntities,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
@@ -47,8 +53,38 @@ describe('Vulnerability Management Cluster (Platform) CVEs', () => {
         );
     });
 
-    // TODO to be fixed after back end sorting is fixed
-    // validateSortForCVE(selectors.cvesCvssScoreCol);
+    it('should sort the CVSS Score column', () => {
+        visitVulnerabilityManagementEntities(entitiesKey);
+
+        const thSelector = '.rt-th:contains("CVSS Score")';
+        const tdSelector = '.rt-td:nth-child(6) [data-testid="label-chip"]';
+
+        // 0. Initial table state indicates that the column is sorted descending.
+        cy.get(thSelector).should('have.class', '-sort-desc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfDescendingNumberValuesFromElements);
+        });
+
+        // 1. Sort ascending by the column.
+        interactAndWaitForVulnerabilityManagementEntities(() => {
+            cy.get(thSelector).click();
+        }, entitiesKey);
+        cy.location('search').should('eq', '?sort[0][id]=CVSS&sort[0][desc]=false');
+
+        cy.get(thSelector).should('have.class', '-sort-asc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfAscendingNumberValuesFromElements);
+        });
+
+        // 2. Sort descending by the column.
+        cy.get(thSelector).click(); // no request because initial response has been cached
+        cy.location('search').should('eq', '?sort[0][id]=CVSS&sort[0][desc]=true');
+
+        cy.get(thSelector).should('have.class', '-sort-desc');
+        // Do not assert because of potential timing problem: get td elements before table re-renders.
+    });
+
+    // Cluster (Platform) CVEs does not yet have Severity column.
 
     it('should display vulnerability descriptions', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clustersListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clustersListPages.test.js
@@ -1,9 +1,15 @@
 import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
+import {
+    assertSortedItems,
+    callbackForPairOfAscendingNumberValuesFromElements,
+    callbackForPairOfDescendingNumberValuesFromElements,
+} from '../../helpers/sort';
 import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
     getCountAndNounFromImageCVEsLinkResults,
     getCountAndNounFromNodeCVEsLinkResults,
+    interactAndWaitForVulnerabilityManagementEntities,
     verifyFilteredSecondaryEntitiesLink,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
@@ -42,6 +48,43 @@ describe('Vulnerability Management Clusters', () => {
             'Latest Violation',
             'Risk Priority',
         ]);
+    });
+
+    it('should sort the Risk Priority column', () => {
+        visitVulnerabilityManagementEntities(entitiesKey);
+
+        const thSelector = '.rt-th:contains("Risk Priority")';
+        const tdSelector = '.rt-td:nth-child(10)';
+
+        // 0. Initial table state indicates that the column is sorted ascending.
+        cy.get(thSelector).should('have.class', '-sort-asc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfAscendingNumberValuesFromElements);
+        });
+
+        // 1. Sort descending by the column.
+        interactAndWaitForVulnerabilityManagementEntities(() => {
+            cy.get(thSelector).click();
+        }, entitiesKey);
+        cy.location('search').should(
+            'eq',
+            '?sort[0][id]=Cluster%20Risk%20Priority&sort[0][desc]=true'
+        );
+
+        cy.get(thSelector).should('have.class', '-sort-desc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfDescendingNumberValuesFromElements);
+        });
+
+        // 2. Sort ascending by the column.
+        cy.get(thSelector).click(); // no request because initial response has been cached
+        cy.location('search').should(
+            'eq',
+            '?sort[0][id]=Cluster%20Risk%20Priority&sort[0][desc]=false'
+        );
+
+        cy.get(thSelector).should('have.class', '-sort-asc');
+        // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
     // Argument 3 in verify functions is one-based index of column which has the links.

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsListPages.test.js
@@ -2,6 +2,11 @@ import { url, selectors } from '../../constants/VulnManagementPage';
 import { hasFeatureFlag } from '../../helpers/features';
 import withAuth from '../../helpers/basicAuth';
 import {
+    assertSortedItems,
+    callbackForPairOfAscendingNumberValuesFromElements,
+    callbackForPairOfDescendingNumberValuesFromElements,
+} from '../../helpers/sort';
+import {
     hasExpectedHeaderColumns,
     allChecksForEntities,
     allCVECheck,
@@ -9,6 +14,7 @@ import {
 } from '../../helpers/vmWorkflowUtils';
 import {
     getCountAndNounFromImageCVEsLinkResults,
+    interactAndWaitForVulnerabilityManagementEntities,
     verifyFilteredSecondaryEntitiesLink,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
@@ -79,8 +85,42 @@ describe('Vulnerability Management Deployments', () => {
             ]);
         });
 
-        //  TBD to be fixed after back end sorting is fixed
-        //  validateSort(selectors.riskScoreCol);
+        it('should sort the Risk Priority column', () => {
+            visitVulnerabilityManagementEntities(entitiesKey);
+
+            const thSelector = '.rt-th:contains("Risk Priority")';
+            const tdSelector = '.rt-td:nth-child(9)';
+
+            // 0. Initial table state indicates that the column is sorted ascending.
+            cy.get(thSelector).should('have.class', '-sort-asc');
+            cy.get(tdSelector).then((items) => {
+                assertSortedItems(items, callbackForPairOfAscendingNumberValuesFromElements);
+            });
+
+            // 1. Sort descending by the column.
+            interactAndWaitForVulnerabilityManagementEntities(() => {
+                cy.get(thSelector).click();
+            }, entitiesKey);
+            cy.location('search').should(
+                'eq',
+                '?sort[0][id]=Deployment%20Risk%20Priority&sort[0][desc]=true'
+            );
+
+            cy.get(thSelector).should('have.class', '-sort-desc');
+            cy.get(tdSelector).then((items) => {
+                assertSortedItems(items, callbackForPairOfDescendingNumberValuesFromElements);
+            });
+
+            // 2. Sort ascending by the column.
+            cy.get(thSelector).click(); // no request because initial response has been cached
+            cy.location('search').should(
+                'eq',
+                '?sort[0][id]=Deployment%20Risk%20Priority&sort[0][desc]=false'
+            );
+
+            cy.get(thSelector).should('have.class', '-sort-asc');
+            // Do not assert because of potential timing problem: get td elements before table re-renders.
+        });
 
         // Argument 3 in verify functions is one-based index of column which has the links.
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageComponentsListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageComponentsListPages.test.js
@@ -1,8 +1,14 @@
 import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
+import {
+    assertSortedItems,
+    callbackForPairOfAscendingNumberValuesFromElements,
+    callbackForPairOfDescendingNumberValuesFromElements,
+} from '../../helpers/sort';
 import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
     getCountAndNounFromImageCVEsLinkResults,
+    interactAndWaitForVulnerabilityManagementEntities,
     verifyFilteredSecondaryEntitiesLink,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
@@ -34,8 +40,82 @@ describe('Vulnerability Management Image Components', () => {
         ]);
     });
 
-    //  TBD to be fixed after back end sorting is fixed
-    //  validateSort(selectors.componentsRiskScoreCol);
+    it('should sort the Risk Priority column', () => {
+        visitVulnerabilityManagementEntities(entitiesKey);
+
+        const thSelector = '.rt-th:contains("Risk Priority")';
+        const tdSelector = '.rt-td:nth-child(9)';
+
+        // 0. Initial table state indicates that the column is sorted ascending.
+        cy.get(thSelector).should('have.class', '-sort-asc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfAscendingNumberValuesFromElements);
+        });
+
+        // 1. Sort descending by the column.
+        interactAndWaitForVulnerabilityManagementEntities(() => {
+            cy.get(thSelector).click();
+        }, entitiesKey);
+        cy.location('search').should(
+            'eq',
+            '?sort[0][id]=Component%20Risk%20Priority&sort[0][desc]=true'
+        );
+
+        cy.get(thSelector).should('have.class', '-sort-desc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfDescendingNumberValuesFromElements);
+        });
+
+        // 2. Sort ascending by the column.
+        cy.get(thSelector).click(); // no request because initial response has been cached
+        cy.location('search').should(
+            'eq',
+            '?sort[0][id]=Component%20Risk%20Priority&sort[0][desc]=false'
+        );
+
+        cy.get(thSelector).should('have.class', '-sort-asc');
+        // Do not assert because of potential timing problem: get td elements before table re-renders.
+    });
+
+    it('should sort the Top CVSS column', () => {
+        visitVulnerabilityManagementEntities(entitiesKey);
+
+        const thSelector = '.rt-th:contains("Top CVSS")';
+        const tdSelector = '.rt-td:nth-child(6) [data-testid="label-chip"]';
+
+        // 0. Initial table state indicates that the column is not sorted.
+        cy.get(thSelector)
+            .should('not.have.class', '-sort-asc')
+            .should('not.have.class', '-sort-desc');
+
+        // 1. Sort ascending by the column.
+        interactAndWaitForVulnerabilityManagementEntities(() => {
+            cy.get(thSelector).click();
+        }, entitiesKey);
+        cy.location('search').should(
+            'eq',
+            '?sort[0][id]=Component%20Top%20CVSS&sort[0][desc]=false'
+        );
+
+        cy.get(thSelector).should('have.class', '-sort-asc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfAscendingNumberValuesFromElements);
+        });
+
+        // 2. Sort descending by the column.
+        interactAndWaitForVulnerabilityManagementEntities(() => {
+            cy.get(thSelector).click();
+        }, entitiesKey);
+        cy.location('search').should(
+            'eq',
+            '?sort[0][id]=Component%20Top%20CVSS&sort[0][desc]=true'
+        );
+
+        cy.get(thSelector).should('have.class', '-sort-desc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfDescendingNumberValuesFromElements);
+        });
+    });
 
     // Argument 3 in verify functions is one-based index of column which has the links.
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageComponentsListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageComponentsListPages.test.js
@@ -77,7 +77,8 @@ describe('Vulnerability Management Image Components', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    it('should sort the Top CVSS column', () => {
+    // TODO Investigate whether not yet supported or incorrect field in payload.
+    it.skip('should sort the Top CVSS column', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
         const thSelector = '.rt-th:contains("Top CVSS")';

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageCvesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageCvesListPages.test.js
@@ -1,8 +1,16 @@
 import { selectors } from '../../constants/VulnManagementPage';
 import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
+import {
+    assertSortedItems,
+    callbackForPairOfAscendingNumberValuesFromElements,
+    callbackForPairOfAscendingVulnerabilitySeverityValuesFromElements,
+    callbackForPairOfDescendingNumberValuesFromElements,
+    callbackForPairOfDescendingVulnerabilitySeverityValuesFromElements,
+} from '../../helpers/sort';
 import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
+    interactAndWaitForVulnerabilityManagementEntities,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
@@ -38,8 +46,77 @@ describe('Vulnerability Management Image CVEs', () => {
         );
     });
 
-    // TODO to be fixed after back end sorting is fixed
-    // validateSortForCVE(selectors.cvesCvssScoreCol);
+    it('should sort the CVSS Score column', () => {
+        visitVulnerabilityManagementEntities(entitiesKey);
+
+        const thSelector = '.rt-th:contains("CVSS Score")';
+        const tdSelector = '.rt-td:nth-child(7) [data-testid="label-chip"]';
+
+        // 0. Initial table state indicates that the column is sorted descending.
+        cy.get(thSelector).should('have.class', '-sort-desc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfDescendingNumberValuesFromElements);
+        });
+
+        // 1. Sort ascending by the column.
+        interactAndWaitForVulnerabilityManagementEntities(() => {
+            cy.get(thSelector).click();
+        }, entitiesKey);
+        cy.location('search').should('eq', '?sort[0][id]=CVSS&sort[0][desc]=false');
+
+        cy.get(thSelector).should('have.class', '-sort-asc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfAscendingNumberValuesFromElements);
+        });
+
+        // 2. Sort descending by the column.
+        cy.get(thSelector).click(); // no request because initial response has been cached
+        cy.location('search').should('eq', '?sort[0][id]=CVSS&sort[0][desc]=true');
+
+        cy.get(thSelector).should('have.class', '-sort-desc');
+        // Do not assert because of potential timing problem: get td elements before table re-renders.
+    });
+
+    // TODO Investigate whether not yet supported or incorrect field in payload.
+    it.skip('should sort the Severity column', () => {
+        visitVulnerabilityManagementEntities(entitiesKey);
+
+        const thSelector = '.rt-th:contains("Severity")';
+        const tdSelector = '.rt-td:nth-child(6)';
+
+        // 0. Initial table state indicates that the column is not sorted.
+        cy.get(thSelector)
+            .should('not.have.class', '-sort-asc')
+            .should('not.have.class', '-sort-desc');
+
+        // 1. Sort ascending by the column.
+        interactAndWaitForVulnerabilityManagementEntities(() => {
+            cy.get(thSelector).click();
+        }, entitiesKey);
+        cy.location('search').should('eq', '?sort[0][id]=Severity&sort[0][desc]=false');
+
+        cy.get(thSelector).should('have.class', '-sort-asc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(
+                items,
+                callbackForPairOfAscendingVulnerabilitySeverityValuesFromElements
+            );
+        });
+
+        // 2. Sort descending by the column.
+        interactAndWaitForVulnerabilityManagementEntities(() => {
+            cy.get(thSelector).click();
+        }, entitiesKey);
+        cy.location('search').should('eq', '?sort[0][id]=Severity&sort[0][desc]=true');
+
+        cy.get(thSelector).should('have.class', '-sort-desc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(
+                items,
+                callbackForPairOfDescendingVulnerabilitySeverityValuesFromElements
+            );
+        });
+    });
 
     it('should display vulnerability descriptions', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imagesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imagesListPages.test.js
@@ -79,7 +79,8 @@ describe('Vulnerability Management Images', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    it('should sort the Top CVSS column', () => {
+    // TODO Investigate whether not yet supported or incorrect field in payload.
+    it.skip('should sort the Top CVSS column', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
         const thSelector = '.rt-th:contains("Top CVSS")';

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespacesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespacesListPages.test.js
@@ -2,6 +2,11 @@ import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
 import { url, selectors } from '../../constants/VulnManagementPage';
 import {
+    assertSortedItems,
+    callbackForPairOfAscendingNumberValuesFromElements,
+    callbackForPairOfDescendingNumberValuesFromElements,
+} from '../../helpers/sort';
+import {
     hasExpectedHeaderColumns,
     allChecksForEntities,
     allCVECheck,
@@ -9,6 +14,7 @@ import {
 } from '../../helpers/vmWorkflowUtils';
 import {
     getCountAndNounFromImageCVEsLinkResults,
+    interactAndWaitForVulnerabilityManagementEntities,
     verifyFilteredSecondaryEntitiesLink,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
@@ -83,8 +89,42 @@ describe('Vulnerability Management Namespaces', () => {
             ]);
         });
 
-        //  TBD to be fixed after back end sorting is fixed
-        //  validateSort(selectors.riskScoreCol);
+        it('should sort the Risk Priority column', () => {
+            visitVulnerabilityManagementEntities(entitiesKey);
+
+            const thSelector = '.rt-th:contains("Risk Priority")';
+            const tdSelector = '.rt-td:nth-child(9)';
+
+            // 0. Initial table state indicates that the column is sorted ascending.
+            cy.get(thSelector).should('have.class', '-sort-asc');
+            cy.get(tdSelector).then((items) => {
+                assertSortedItems(items, callbackForPairOfAscendingNumberValuesFromElements);
+            });
+
+            // 1. Sort descending by the column.
+            interactAndWaitForVulnerabilityManagementEntities(() => {
+                cy.get(thSelector).click();
+            }, entitiesKey);
+            cy.location('search').should(
+                'eq',
+                '?sort[0][id]=Namespace%20Risk%20Priority&sort[0][desc]=true'
+            );
+
+            cy.get(thSelector).should('have.class', '-sort-desc');
+            cy.get(tdSelector).then((items) => {
+                assertSortedItems(items, callbackForPairOfDescendingNumberValuesFromElements);
+            });
+
+            // 2. Sort ascending by the column.
+            cy.get(thSelector).click(); // no request because initial response has been cached
+            cy.location('search').should(
+                'eq',
+                '?sort[0][id]=Namespace%20Risk%20Priority&sort[0][desc]=false'
+            );
+
+            cy.get(thSelector).should('have.class', '-sort-asc');
+            // Do not assert because of potential timing problem: get td elements before table re-renders.
+        });
 
         // Argument 3 in verify functions is one-based index of column which has the links.
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponentsListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponentsListPages.test.js
@@ -75,7 +75,8 @@ describe('Vulnerability Management Node Components', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    it('should sort the Top CVSS column', () => {
+    // TODO Investigate whether not yet supported or incorrect field in payload.
+    it.skip('should sort the Top CVSS column', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
         const thSelector = '.rt-th:contains("Top CVSS")';

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponentsListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponentsListPages.test.js
@@ -1,8 +1,14 @@
 import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
+import {
+    assertSortedItems,
+    callbackForPairOfAscendingNumberValuesFromElements,
+    callbackForPairOfDescendingNumberValuesFromElements,
+} from '../../helpers/sort';
 import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
     getCountAndNounFromNodeCVEsLinkResults,
+    interactAndWaitForVulnerabilityManagementEntities,
     verifyFilteredSecondaryEntitiesLink,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
@@ -32,8 +38,82 @@ describe('Vulnerability Management Node Components', () => {
         ]);
     });
 
-    //  TBD to be fixed after back end sorting is fixed
-    //  validateSort(selectors.componentsRiskScoreCol);
+    it('should sort the Risk Priority column', () => {
+        visitVulnerabilityManagementEntities(entitiesKey);
+
+        const thSelector = '.rt-th:contains("Risk Priority")';
+        const tdSelector = '.rt-td:nth-child(7)';
+
+        // 0. Initial table state indicates that the column is sorted ascending.
+        cy.get(thSelector).should('have.class', '-sort-asc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfAscendingNumberValuesFromElements);
+        });
+
+        // 1. Sort descending by the column.
+        interactAndWaitForVulnerabilityManagementEntities(() => {
+            cy.get(thSelector).click();
+        }, entitiesKey);
+        cy.location('search').should(
+            'eq',
+            '?sort[0][id]=Component%20Risk%20Priority&sort[0][desc]=true'
+        );
+
+        cy.get(thSelector).should('have.class', '-sort-desc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfDescendingNumberValuesFromElements);
+        });
+
+        // 2. Sort ascending by the column.
+        cy.get(thSelector).click(); // no request because initial response has been cached
+        cy.location('search').should(
+            'eq',
+            '?sort[0][id]=Component%20Risk%20Priority&sort[0][desc]=false'
+        );
+
+        cy.get(thSelector).should('have.class', '-sort-asc');
+        // Do not assert because of potential timing problem: get td elements before table re-renders.
+    });
+
+    it('should sort the Top CVSS column', () => {
+        visitVulnerabilityManagementEntities(entitiesKey);
+
+        const thSelector = '.rt-th:contains("Top CVSS")';
+        const tdSelector = '.rt-td:nth-child(5) [data-testid="label-chip"]';
+
+        // 0. Initial table state indicates that the column is not sorted.
+        cy.get(thSelector)
+            .should('not.have.class', '-sort-asc')
+            .should('not.have.class', '-sort-desc');
+
+        // 1. Sort ascending by the column.
+        interactAndWaitForVulnerabilityManagementEntities(() => {
+            cy.get(thSelector).click();
+        }, entitiesKey);
+        cy.location('search').should(
+            'eq',
+            '?sort[0][id]=Component%20Top%20CVSS&sort[0][desc]=false'
+        );
+
+        cy.get(thSelector).should('have.class', '-sort-asc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfAscendingNumberValuesFromElements);
+        });
+
+        // 2. Sort descending by the column.
+        interactAndWaitForVulnerabilityManagementEntities(() => {
+            cy.get(thSelector).click();
+        }, entitiesKey);
+        cy.location('search').should(
+            'eq',
+            '?sort[0][id]=Component%20Top%20CVSS&sort[0][desc]=true'
+        );
+
+        cy.get(thSelector).should('have.class', '-sort-desc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfDescendingNumberValuesFromElements);
+        });
+    });
 
     // Argument 3 in verify functions is one-based index of column which has the links.
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeCvesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeCvesListPages.test.js
@@ -1,8 +1,16 @@
 import { selectors } from '../../constants/VulnManagementPage';
 import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
+import {
+    assertSortedItems,
+    callbackForPairOfAscendingNumberValuesFromElements,
+    callbackForPairOfAscendingVulnerabilitySeverityValuesFromElements,
+    callbackForPairOfDescendingNumberValuesFromElements,
+    callbackForPairOfDescendingVulnerabilitySeverityValuesFromElements,
+} from '../../helpers/sort';
 import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
+    interactAndWaitForVulnerabilityManagementEntities,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
@@ -38,8 +46,77 @@ describe('Vulnerability Management Node CVEs', () => {
         );
     });
 
-    // TODO to be fixed after back end sorting is fixed
-    // validateSortForCVE(selectors.cvesCvssScoreCol);
+    it('should sort the CVSS Score column', () => {
+        visitVulnerabilityManagementEntities(entitiesKey);
+
+        const thSelector = '.rt-th:contains("CVSS Score")';
+        const tdSelector = '.rt-td:nth-child(7) [data-testid="label-chip"]';
+
+        // 0. Initial table state indicates that the column is sorted descending.
+        cy.get(thSelector).should('have.class', '-sort-desc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfDescendingNumberValuesFromElements);
+        });
+
+        // 1. Sort ascending by the column.
+        interactAndWaitForVulnerabilityManagementEntities(() => {
+            cy.get(thSelector).click();
+        }, entitiesKey);
+        cy.location('search').should('eq', '?sort[0][id]=CVSS&sort[0][desc]=false');
+
+        cy.get(thSelector).should('have.class', '-sort-asc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfAscendingNumberValuesFromElements);
+        });
+
+        // 2. Sort descending by the column.
+        cy.get(thSelector).click(); // no request because initial response has been cached
+        cy.location('search').should('eq', '?sort[0][id]=CVSS&sort[0][desc]=true');
+
+        cy.get(thSelector).should('have.class', '-sort-desc');
+        // Do not assert because of potential timing problem: get td elements before table re-renders.
+    });
+
+    // TODO Investigate whether not yet supported or incorrect field in payload.
+    it.skip('should sort the Severity column', () => {
+        visitVulnerabilityManagementEntities(entitiesKey);
+
+        const thSelector = '.rt-th:contains("Severity")';
+        const tdSelector = '.rt-td:nth-child(6)';
+
+        // 0. Initial table state indicates that the column is not sorted.
+        cy.get(thSelector)
+            .should('not.have.class', '-sort-asc')
+            .should('not.have.class', '-sort-desc');
+
+        // 1. Sort ascending by the column.
+        interactAndWaitForVulnerabilityManagementEntities(() => {
+            cy.get(thSelector).click();
+        }, entitiesKey);
+        cy.location('search').should('eq', '?sort[0][id]=Severity&sort[0][desc]=false');
+
+        cy.get(thSelector).should('have.class', '-sort-asc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(
+                items,
+                callbackForPairOfAscendingVulnerabilitySeverityValuesFromElements
+            );
+        });
+
+        // 2. Sort descending by the column.
+        interactAndWaitForVulnerabilityManagementEntities(() => {
+            cy.get(thSelector).click();
+        }, entitiesKey);
+        cy.location('search').should('eq', '?sort[0][id]=Severity&sort[0][desc]=true');
+
+        cy.get(thSelector).should('have.class', '-sort-desc');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(
+                items,
+                callbackForPairOfDescendingVulnerabilitySeverityValuesFromElements
+            );
+        });
+    });
 
     it('should display vulnerability descriptions', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodesListPages.test.js
@@ -75,7 +75,8 @@ describe('Vulnerability Management Nodes', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    it('should sort the Top CVSS column', () => {
+    // TODO Investigate whether not yet supported or incorrect field in payload.
+    it.skip('should sort the Top CVSS column', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
         const thSelector = '.rt-th:contains("Top CVSS")';

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodesListPages.test.js
@@ -1,4 +1,3 @@
-import { selectors } from '../../constants/VulnManagementPage';
 import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
 import {
@@ -8,16 +7,13 @@ import {
 } from '../../helpers/sort';
 import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
-    getCountAndNounFromImageCVEsLinkResults,
     interactAndWaitForVulnerabilityManagementEntities,
-    verifyFixableCVEsLinkAndRiskAcceptanceTabs,
-    verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
 
-const entitiesKey = 'images';
+const entitiesKey = 'nodes';
 
-describe('Vulnerability Management Images', () => {
+describe('Vulnerability Management Nodes', () => {
     withAuth();
 
     before(function beforeHook() {
@@ -30,14 +26,14 @@ describe('Vulnerability Management Images', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
         hasExpectedHeaderColumns([
-            'Image',
-            'CVEs',
+            'Node',
+            'Node CVEs',
             'Top CVSS',
-            'Created',
+            'Cluster',
+            'Operating System',
+            'Container Runtime',
+            'Join Time',
             'Scan Time',
-            'Image OS',
-            'Image Status',
-            'Entities',
             'Risk Priority',
         ]);
     });
@@ -60,7 +56,7 @@ describe('Vulnerability Management Images', () => {
         }, entitiesKey);
         cy.location('search').should(
             'eq',
-            '?sort[0][id]=Image%20Risk%20Priority&sort[0][desc]=true'
+            '?sort[0][id]=Node%20Risk%20Priority&sort[0][desc]=true'
         );
 
         cy.get(thSelector).should('have.class', '-sort-desc');
@@ -72,7 +68,7 @@ describe('Vulnerability Management Images', () => {
         cy.get(thSelector).click(); // no request because initial response has been cached
         cy.location('search').should(
             'eq',
-            '?sort[0][id]=Image%20Risk%20Priority&sort[0][desc]=false'
+            '?sort[0][id]=Node%20Risk%20Priority&sort[0][desc]=false'
         );
 
         cy.get(thSelector).should('have.class', '-sort-asc');
@@ -94,7 +90,7 @@ describe('Vulnerability Management Images', () => {
         interactAndWaitForVulnerabilityManagementEntities(() => {
             cy.get(thSelector).click();
         }, entitiesKey);
-        cy.location('search').should('eq', '?sort[0][id]=Image%20Top%20CVSS&sort[0][desc]=false');
+        cy.location('search').should('eq', '?sort[0][id]=Node%20Top%20CVSS&sort[0][desc]=false');
 
         cy.get(thSelector).should('have.class', '-sort-asc');
         cy.get(tdSelector).then((items) => {
@@ -105,56 +101,11 @@ describe('Vulnerability Management Images', () => {
         interactAndWaitForVulnerabilityManagementEntities(() => {
             cy.get(thSelector).click();
         }, entitiesKey);
-        cy.location('search').should('eq', '?sort[0][id]=Image%20Top%20CVSS&sort[0][desc]=true');
+        cy.location('search').should('eq', '?sort[0][id]=Node%20Top%20CVSS&sort[0][desc]=true');
 
         cy.get(thSelector).should('have.class', '-sort-desc');
         cy.get(tdSelector).then((items) => {
             assertSortedItems(items, callbackForPairOfDescendingNumberValuesFromElements);
         });
-    });
-
-    // Argument 3 in verify functions is one-based index of column which has the links.
-
-    // Some tests might fail in local deployment.
-
-    it('should display links for all image CVEs', () => {
-        verifySecondaryEntities(
-            entitiesKey,
-            'image-cves',
-            2,
-            /^\d+ CVEs?$/,
-            getCountAndNounFromImageCVEsLinkResults
-        );
-    });
-
-    it('should display links for fixable image CVEs and also Risk Acceptance tabs', () => {
-        verifyFixableCVEsLinkAndRiskAcceptanceTabs(
-            entitiesKey,
-            'image-cves',
-            2,
-            /^\d+ Fixable$/,
-            getCountAndNounFromImageCVEsLinkResults
-        );
-    });
-
-    it('should display links for deployments', () => {
-        verifySecondaryEntities(entitiesKey, 'deployments', 8, /^\d+ deployments?$/);
-    });
-
-    it('should display links for image-components', () => {
-        verifySecondaryEntities(entitiesKey, 'image-components', 8, /^\d+ image components?$/);
-    });
-
-    it('should show entity icon, not back button, if there is only one item on the side panel stack', () => {
-        visitVulnerabilityManagementEntities(entitiesKey);
-
-        cy.get(`${selectors.deploymentCountLink}:eq(0)`).click({ force: true });
-        cy.wait(1000);
-        cy.get(selectors.backButton).should('exist');
-        cy.get(selectors.entityIcon).should('not.exist');
-
-        cy.get(selectors.backButton).click();
-        cy.get(selectors.backButton).should('not.exist');
-        cy.get(selectors.entityIcon).should('exist');
     });
 });


### PR DESCRIPTION
## Description

Fill gaps in regression tests especially during database migration.

Number sorting for priority and score is working again.

Although Vulnerability Management vulnerability tables do not yet sort correctly by **Severity**, I added tests with `skip` to lean into the future, because severity is more relevant that raw score to customers.

The test failure also reminded me to distinguish severities:
* `const policySeverityValues = ['Low', 'Medium', 'High', 'Critical'];`
* `const vulnerabilitySeverityValues = ['Low', 'Moderate', 'Important', 'Critical'];`

<img width="1440" alt="nodeCvesListPages-Severity" src="https://user-images.githubusercontent.com/11862657/191303937-1ed22618-c938-4b2c-ad1e-e2a4c92e7fcd.png">

After the following failure in the first test run, I skipped the **Top CVSS** tests.
![imageComponentsListPages-Top-CVSS](https://user-images.githubusercontent.com/11862657/191330540-b4cc3e9d-4f34-4e2c-82fd-0c290cfc45b1.png)

Follow pattern from #3105

| segment          | initial col   |  direction | additional col |
| :---             | :---          |       ---: | :--- |
| cluster-cves     | CVSS Score    | descending |                |
| clusters         | Risk Priority |  ascending |                |
| deployments      | Risk Priority |  ascending |                |
| image-components | Risk Priority |  ascending |       Top CVSS |
| image-cves       | CVSS Score    | descending |       Severity |
| images           | Risk Priority |  ascending |       Top CVSS |
| namespaces       | Risk Priority |  ascending |                |
| node-components  | Risk Priority |  ascending |       Top CVSS |
| node-cves        | CVSS Score    | descending |       Severity |
| nodes            | Risk Priority |  ascending |       Top CVSS |
| policies         |               |            |       Severity |

Brad, here are a few notes to help you understand the new tests:
* `entitiesKey` the column in the preceding table, is a segment from the page address like /main/vulnerability-management/cluster-cves
* `interactAndWaitForVulnerabilityManagementEntities(interactionCallback, entitiesKey)` calls a helper function which calls a cypress method that waits 5 seconds for the relevant GraphQL query.
* `cy.location('search').should('eq', queryString)` asserts the change in page address changes.
* `cy.get(thSelector).should('have.class', class)` asserts (waits up to 4 seconds) the change in the indicator.
* `cy.get(tdSelector)` gets the sorted elements, for which the preceding 3 items  have reduced the risk of timing problems (that is, test got elements before UI re-rendered).

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Ran added tests one at a time with local deployment.