### PR TITLE
build hygiene: Get cgo flags for rocksdb from explicit env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,9 +202,12 @@ ci-config-validate:
 	circleci config validate --org-slug gh/stackrox
 
 .PHONY: fast-central-build
-fast-central-build:
+fast-central-build: central-build-nodeps
+
+.PHONY: central-build-nodeps
+central-build-nodeps:
 	@echo "+ $@"
-	$(GOBUILD) central
+	CGO_CFLAGS="$(CGO_CFLAGS) $(ROCKSDB_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS) $(ROCKSDB_LDFLAGS)" $(GOBUILD) central
 
 .PHONY: fast-central
 fast-central: deps
@@ -230,9 +233,12 @@ fast-migrator:
 	docker run --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make fast-migrator-build
 
 .PHONY: fast-migrator-build
-fast-migrator-build:
+fast-migrator-build: migrator-build-nodeps
+
+.PHONY: migrator-build-nodeps
+migrator-build-nodeps:
 	@echo "+ $@"
-	$(GOBUILD) migrator
+	CGO_CFLAGS="$(CGO_CFLAGS) $(ROCKSDB_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS) $(ROCKSDB_LDFLAGS)" $(GOBUILD) migrator
 
 .PHONY: check-service-protos
 check-service-protos:
@@ -444,8 +450,8 @@ else
 endif
 
 .PHONY: main-build-nodeps
-main-build-nodeps:
-	$(GOBUILD) central migrator sensor/kubernetes sensor/admission-control compliance/collection
+main-build-nodeps: central-build-nodeps migrator-build-nodeps
+	$(GOBUILD) sensor/kubernetes sensor/admission-control compliance/collection
 	CGO_ENABLED=0 $(GOBUILD) sensor/upgrader
 ifndef CI
     CGO_ENABLED=0 $(GOBUILD) roxctl


### PR DESCRIPTION
## Description

Rather than assuming the build container has `CGO_CFLAGS` and `CGO_LDFLAGS` set, explicitly augment those env vars by appending the contents of `$ROCKSDB_CFLAGS` and `$ROCKSDB_LDFLAGS` to them for the binaries that need rocksdb.

This change is designed such that it can go in immediately, without waiting for a change of the builder image to set those vars.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- CI