### PR TITLE
Build out service functions for collections API

### DIFF
--- a/ui/apps/platform/src/services/AlertsService.ts
+++ b/ui/apps/platform/src/services/AlertsService.ts
@@ -3,7 +3,7 @@ import queryString from 'qs';
 import { Alert, ListAlert } from 'Containers/Violations/types/violationTypes';
 
 import { ApiSortOption, SearchFilter } from 'types/search';
-import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { getListQueryParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import axios from './instance';
 import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
 
@@ -83,19 +83,7 @@ export function fetchAlerts(
     page: number,
     pageSize: number
 ): CancellableRequest<ListAlert[]> {
-    const offset = page > 0 ? page * pageSize : 0;
-    const query = getRequestQueryStringForSearchFilter(searchFilter);
-    const params = queryString.stringify(
-        {
-            query,
-            pagination: {
-                offset,
-                limit: pageSize,
-                sortOption,
-            },
-        },
-        { arrayFormat: 'repeat', allowDots: true }
-    );
+    const params = getListQueryParams(searchFilter, sortOption, page, pageSize);
     return makeCancellableAxiosRequest((signal) =>
         axios
             .get<{ alerts: ListAlert[] }>(`${baseUrl}?${params}`, { signal })

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -7,10 +7,10 @@ import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationU
 import axios from './instance';
 import { Empty, Pagination } from './types';
 
-const collectionsBaseUrl = '/v1/collections';
-const collectionsCountUrl = '/v1/collections/count';
-const collectionsDryRunUrl = '/v1/collections/dryrun';
-const collectionsAutocompleteUrl = '/v1/collections/autocomplete';
+export const collectionsBaseUrl = '/v1/collections';
+export const collectionsCountUrl = '/v1/collections/count';
+export const collectionsDryRunUrl = '/v1/collections/dryrun';
+export const collectionsAutocompleteUrl = '/v1/collections/autocomplete';
 
 type CollectionResource = 'Cluster' | 'Namespace' | 'Deployment';
 
@@ -29,14 +29,14 @@ type ResourceSelector = {
     rules: SelectorRule[];
 };
 
-type CollectionRequest = {
+export type CollectionRequest = {
     name: string;
     description: string;
     resourceSelectors: ResourceSelector[];
     embeddedCollectionIds: string[];
 };
 
-type CollectionResponse = {
+export type CollectionResponse = {
     id: string;
     name: string;
     description: string;

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -9,7 +9,6 @@ import { Empty, Pagination } from './types';
 
 const collectionsBaseUrl = '/v1/collections';
 const collectionsCountUrl = '/v1/collections/count';
-const collectionsSelectorsUrl = '/v1/collections/selectors';
 const collectionsDryRunUrl = '/v1/collections/dryrun';
 const collectionsAutocompleteUrl = '/v1/collections/autocomplete';
 
@@ -50,7 +49,6 @@ type CollectionResponse = {
  * Fetch a paginated list of Collection objects
  */
 export function listCollections(
-    // TODO Verify with [BE] that search filter wlll use the typical format of `Collection:<collection_name>`
     searchFilter: SearchFilter,
     sortOption: ApiSortOption,
     page: number,
@@ -127,8 +125,8 @@ export function createCollection(
 }
 
 /**
- * Updates an existing collection object. 
- * 
+ * Updates an existing collection object.
+ *
  * @param id
  *      The ID of the collection to update
  * @param collection
@@ -136,15 +134,14 @@ export function createCollection(
  * @returns
  *      The updated collection object
  *
-TODO The server spec says this is a `post` instead of `put` - verify with [BE]
-*/
+ */
 export function updateCollection(
     id: string,
     collection: CollectionRequest
 ): CancellableRequest<CollectionResponse> {
     return makeCancellableAxiosRequest((signal) =>
         axios
-            .put<CollectionResponse>(`${collectionsBaseUrl}/${id}`, collection, { signal })
+            .post<CollectionResponse>(`${collectionsBaseUrl}/${id}`, collection, { signal })
             .then((response) => response.data)
     );
 }
@@ -154,8 +151,6 @@ export function updateCollection(
  *
  * @param id
  *      The ID of the collection to delete
- TODO The server spec declares a request that takes an array of IDs, but then shows the request URL as containing
- the ID - verify with [BE]
  */
 export function deleteCollection(id: string): CancellableRequest<Empty> {
     return makeCancellableAxiosRequest((signal) =>
@@ -165,22 +160,9 @@ export function deleteCollection(id: string): CancellableRequest<Empty> {
     );
 }
 
-/**
- * Fetch the supported fields that can be used in collection selector rules
- TODO We may not need this function client side
- */
-export function getCollectionSelectors(): CancellableRequest<SelectorField[]> {
-    return makeCancellableAxiosRequest((signal) =>
-        axios
-            .get<GetCollectionSelectorsResponse>(collectionsSelectorsUrl, { signal })
-            .then((response) => response.data.selectors)
-    );
-}
-
 export type CollectionDryRunRequest = CollectionRequest & {
     options: {
         pagination: Pagination;
-        // TODO [Ask BE] What does this option mean?
         skipDeploymentMatching: boolean;
     };
 };
@@ -202,7 +184,9 @@ export type CollectionDryRunResponse = {
  * @param dryRunRequest.options.pagination
  *      Pagination options for the dry run deployment results
  * @param dryRunRequest.options.skipDeploymentMatching
-TODO ??? Add description for this ^ param
+ *      This flag will skip the resolution of matching deployments on the back end
+ *      in order to do more efficient error checking. Used in order to determine if
+ *      a config is valid, without returning a full data payload.
  *
  * @returns A list of deployments that are resolved by the collection.
  */

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -141,7 +141,7 @@ export function updateCollection(
 ): CancellableRequest<CollectionResponse> {
     return makeCancellableAxiosRequest((signal) =>
         axios
-            .post<CollectionResponse>(`${collectionsBaseUrl}/${id}`, collection, { signal })
+            .put<CollectionResponse>(`${collectionsBaseUrl}/${id}`, collection, { signal })
             .then((response) => response.data)
     );
 }

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -12,12 +12,12 @@ export const collectionsCountUrl = '/v1/collections/count';
 export const collectionsDryRunUrl = '/v1/collections/dryrun';
 export const collectionsAutocompleteUrl = '/v1/collections/autocomplete';
 
-type CollectionResource = 'Cluster' | 'Namespace' | 'Deployment';
+type SelectorEntityType = 'Cluster' | 'Namespace' | 'Deployment';
 
 type SelectorField =
-    | `${CollectionResource}`
-    | `${CollectionResource} Label`
-    | `${CollectionResource} Annotation`;
+    | `${SelectorEntityType}`
+    | `${SelectorEntityType} Label`
+    | `${SelectorEntityType} Annotation`;
 
 type SelectorRule = {
     fieldName: SelectorField;

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -1,0 +1,250 @@
+import qs from 'qs';
+
+import { ListDeployment } from 'types/deployment.proto';
+import { SearchFilter, ApiSortOption } from 'types/search';
+import { getListQueryParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
+import axios from './instance';
+import { Empty, Pagination } from './types';
+
+const collectionsBaseUrl = '/v1/collections';
+const collectionsCountUrl = '/v1/collections/count';
+const collectionsSelectorsUrl = '/v1/collections/selectors';
+const collectionsDryRunUrl = '/v1/collections/dryrun';
+const collectionsAutocompleteUrl = '/v1/collections/autocomplete';
+
+type CollectionResource = 'Cluster' | 'Namespace' | 'Deployment';
+
+type SelectorField =
+    | `${CollectionResource}`
+    | `${CollectionResource} Label`
+    | `${CollectionResource} Annotation`;
+
+type SelectorRule = {
+    fieldName: SelectorField;
+    operator: 'OR';
+    values: { value: string }[];
+};
+
+type ResourceSelector = {
+    rules: SelectorRule[];
+};
+
+type CollectionRequest = {
+    name: string;
+    description: string;
+    resourceSelectors: ResourceSelector[];
+    embeddedCollectionIds: string[];
+};
+
+type CollectionResponse = {
+    id: string;
+    name: string;
+    description: string;
+    inUse: boolean;
+    resourceSelectors: ResourceSelector[];
+    embeddedCollections: { id: string }[];
+};
+
+/**
+ * Fetch a paginated list of Collection objects
+ */
+export function listCollections(
+    // TODO Verify with [BE] that search filter wlll use the typical format of `Collection:<collection_name>`
+    searchFilter: SearchFilter,
+    sortOption: ApiSortOption,
+    page: number,
+    pageSize: number
+): CancellableRequest<CollectionResponse[]> {
+    const params = getListQueryParams(searchFilter, sortOption, page, pageSize);
+    return makeCancellableAxiosRequest((signal) =>
+        axios
+            .get<{
+                collections: CollectionResponse[];
+            }>(`${collectionsBaseUrl}?${params}`, { signal })
+            .then((response) => response.data.collections)
+    );
+}
+
+/**
+ * Fetch the number of collections
+ */
+export function getCollectionCount(searchFilter: SearchFilter): CancellableRequest<number> {
+    const query = getRequestQueryStringForSearchFilter(searchFilter);
+    return makeCancellableAxiosRequest((signal) =>
+        axios
+            .get<{ count: number }>(`${collectionsCountUrl}?query=${query}`, { signal })
+            .then((response) => response.data.count)
+    );
+}
+
+export type ResolvedCollectionResponse = {
+    collection: CollectionResponse;
+    deployments: ListDeployment[];
+};
+
+/**
+ * Fetch a single collection by id
+ *
+ * @param id
+ *      The collection ID
+ * @param options.withMatches
+ *      When true, returns the list of deployments that match the collection
+ *      rules, otherwise returns an empty array.
+ */
+export function getCollection(
+    id: string,
+    options: { withMatches: boolean } = { withMatches: false }
+): CancellableRequest<ResolvedCollectionResponse> {
+    const params = qs.stringify(options);
+    return makeCancellableAxiosRequest((signal) =>
+        axios
+            .get<ResolvedCollectionResponse>(`${collectionsBaseUrl}/${id}?${params}`, { signal })
+            .then((response) => response.data)
+    );
+}
+
+export type GetCollectionSelectorsResponse = {
+    selectors: SelectorField[];
+};
+
+/**
+ * Create a new collection
+ *
+ * @param collection
+ *      The collection object details to be created
+ * @returns
+ *      The created collection object, with ID
+ */
+export function createCollection(
+    collection: CollectionRequest
+): CancellableRequest<CollectionResponse> {
+    return makeCancellableAxiosRequest((signal) =>
+        axios
+            .post<CollectionResponse>(collectionsBaseUrl, collection, { signal })
+            .then((response) => response.data)
+    );
+}
+
+/**
+ * Updates an existing collection object. 
+ * 
+ * @param id
+ *      The ID of the collection to update
+ * @param collection
+ *      The new collection object details.
+ * @returns
+ *      The updated collection object
+ *
+TODO The server spec says this is a `post` instead of `put` - verify with [BE]
+*/
+export function updateCollection(
+    id: string,
+    collection: CollectionRequest
+): CancellableRequest<CollectionResponse> {
+    return makeCancellableAxiosRequest((signal) =>
+        axios
+            .put<CollectionResponse>(`${collectionsBaseUrl}/${id}`, collection, { signal })
+            .then((response) => response.data)
+    );
+}
+
+/**
+ * Deletes a collection
+ *
+ * @param id
+ *      The ID of the collection to delete
+ TODO The server spec declares a request that takes an array of IDs, but then shows the request URL as containing
+ the ID - verify with [BE]
+ */
+export function deleteCollection(id: string): CancellableRequest<Empty> {
+    return makeCancellableAxiosRequest((signal) =>
+        axios
+            .delete<Empty>(`${collectionsBaseUrl}/${id}`, { signal })
+            .then((response) => response.data)
+    );
+}
+
+/**
+ * Fetch the supported fields that can be used in collection selector rules
+ TODO We may not need this function client side
+ */
+export function getCollectionSelectors(): CancellableRequest<SelectorField[]> {
+    return makeCancellableAxiosRequest((signal) =>
+        axios
+            .get<GetCollectionSelectorsResponse>(collectionsSelectorsUrl, { signal })
+            .then((response) => response.data.selectors)
+    );
+}
+
+export type CollectionDryRunRequest = CollectionRequest & {
+    options: {
+        pagination: Pagination;
+        // TODO [Ask BE] What does this option mean?
+        skipDeploymentMatching: boolean;
+    };
+};
+
+export type CollectionDryRunResponse = {
+    deployments: ListDeployment[];
+};
+
+/**
+ * Fetches the currently matching deployments for a collection based on the applied resource
+ * selectors and embedded collections. Note that the deployments in a collection are resolved
+ * dynamically and may change over time as new deployments are added to a cluster.
+ *
+ * @param dryRunRequest.resourceSelectors
+ *      The resource selector rules used to match deployments
+ * @param dryRunRequest.embeddedCollectionIds
+ *      An array of collection ids whose matching deployments should
+ *      be added to the result set.
+ * @param dryRunRequest.options.pagination
+ *      Pagination options for the dry run deployment results
+ * @param dryRunRequest.options.skipDeploymentMatching
+TODO ??? Add description for this ^ param
+ *
+ * @returns A list of deployments that are resolved by the collection.
+ */
+export function dryRunCollection(
+    dryRunRequest: CollectionDryRunRequest
+    // TODO `ListDeployment` will make this impossible to paginate without loading the entire
+    // dataset client side. Ask [BE] if there is an efficient way to aggregate namespaces/clusters
+    // under a matching deployment name similar to the graphql query. An alternative might be to
+    // change the rendering of the list to not group deployments, but to sort alphabetically.
+): CancellableRequest<ListDeployment[]> {
+    return makeCancellableAxiosRequest((signal) =>
+        axios
+            .post<CollectionDryRunResponse>(collectionsDryRunUrl, dryRunRequest, {
+                signal,
+            })
+            .then((response) => response.data.deployments)
+    );
+}
+
+/**
+ * Function that returns a list of autocomplete suggestions for selector fields based on resources
+ * that match the provided resource selectors.
+ *
+ * @param resourceSelectors
+ *      The resource selectors used to scope the autocomplete search
+ * @param searchCategory
+ *      The field that autocomplete results should be returned for
+ * @param searchLabel
+ *      The user provided search text
+ */
+export function getCollectionAutoComplete(
+    resourceSelectors: ResourceSelector[],
+    searchCategory: SelectorField,
+    searchLabel: string
+): CancellableRequest<string[]> {
+    const params = qs.stringify(
+        { resourceSelectors, searchCategory, searchLabel },
+        { arrayFormat: 'repeat' }
+    );
+    return makeCancellableAxiosRequest((signal) =>
+        axios
+            .get<{ values: string[] }>(`${collectionsAutocompleteUrl}?${params}`, { signal })
+            .then((response) => response.data.values)
+    );
+}

--- a/ui/apps/platform/src/services/types.ts
+++ b/ui/apps/platform/src/services/types.ts
@@ -1,0 +1,9 @@
+import { ApiSortOption } from 'types/search';
+
+export type Pagination = {
+    offset: number;
+    limit: number;
+    sortOption: ApiSortOption;
+};
+
+export type Empty = Record<string, never>;

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -172,3 +172,33 @@ export function flattenFilterValue<UndefinedFallback>(
     }
     return [value];
 }
+
+/**
+ * Function to convert the standard list API pagination and query parameters into a
+ * URL query string.
+ *
+ * @param searchFilter The `SearchFilter` to apply to the list query
+ * @param sortOption The field to sort results by and whether to sort ascending or descending
+ * @param page The page offset to return
+ * @param pageSize The number of items per page
+ */
+export function getListQueryParams(
+    searchFilter: SearchFilter,
+    sortOption: ApiSortOption,
+    page: number,
+    pageSize: number
+): string {
+    const offset = page > 0 ? page * pageSize : 0;
+    const query = getRequestQueryStringForSearchFilter(searchFilter);
+    return qs.stringify(
+        {
+            query,
+            pagination: {
+                offset,
+                limit: pageSize,
+                sortOption,
+            },
+        },
+        { arrayFormat: 'repeat', allowDots: true }
+    );
+}


### PR DESCRIPTION
## Description

Implements the front end collection service based on the [backend API design document](https://docs.google.com/document/d/1Yb9lFAZRTYNF-JCt-GbuSidzeI8y3Qf4r3XVkpksDRQ/edit#heading=h.2btpaey9h5q4). The details of these APIs might shift slightly during development, but the overall architecture should remain the same.

## Follow ups
- [Unit test for query param util function](https://github.com/stackrox/stackrox/pull/3155)
- [Refactor existing `Empty` types to use the top level `services/types` export](https://github.com/stackrox/stackrox/pull/3154)
- Add MSW mocks for these endpoints (either in the codebase or externally)

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Manual testing of Violations page (sorting, searching, pagination) due to minor util function refactor.

