### PR TITLE
Refactor service api `Record<string, never>` to use exported `Empty` type

### DIFF
--- a/ui/apps/platform/src/services/AccessScopesService.ts
+++ b/ui/apps/platform/src/services/AccessScopesService.ts
@@ -1,4 +1,5 @@
 import axios from './instance';
+import { Empty } from './types';
 
 const accessScopessUrl = '/v1/simpleaccessscopes';
 
@@ -80,7 +81,7 @@ export function createAccessScope(entity: AccessScope): Promise<AccessScope> {
 /*
  * Update entity and return empty object.
  */
-export function updateAccessScope(entity: AccessScope): Promise<Record<string, never>> {
+export function updateAccessScope(entity: AccessScope): Promise<Empty> {
     const { id } = entity;
     return axios.put(`${accessScopessUrl}/${id}`, entity);
 }
@@ -88,7 +89,7 @@ export function updateAccessScope(entity: AccessScope): Promise<Record<string, n
 /*
  * Delete entity which has id and return empty object.
  */
-export function deleteAccessScope(id: string): Promise<Record<string, never>> {
+export function deleteAccessScope(id: string): Promise<Empty> {
     return axios.delete(`${accessScopessUrl}/${id}`);
 }
 

--- a/ui/apps/platform/src/services/AlertsService.ts
+++ b/ui/apps/platform/src/services/AlertsService.ts
@@ -6,6 +6,7 @@ import { ApiSortOption, SearchFilter } from 'types/search';
 import { getListQueryParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import axios from './instance';
 import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
+import { Empty } from './types';
 
 const baseUrl = '/v1/alerts';
 const baseCountUrl = '/v1/alertscount';
@@ -119,21 +120,15 @@ export function fetchAlert(id: string): Promise<Alert> {
 /*
  * Resolve an alert given an alert ID.
  */
-export function resolveAlert(
-    alertId: string,
-    addToBaseline = false
-): Promise<Record<string, never>> {
+export function resolveAlert(alertId: string, addToBaseline = false): Promise<Empty> {
     return axios
-        .patch<Record<string, never>>(`${baseUrl}/${alertId}/resolve`, { addToBaseline })
+        .patch<Empty>(`${baseUrl}/${alertId}/resolve`, { addToBaseline })
         .then((response) => response.data);
 }
 
 /*
  * Resolve a list of alerts by alert ID.
  */
-export function resolveAlerts(
-    alertIds: string[] = [],
-    addToBaseline = false
-): Promise<Record<string, never>[]> {
+export function resolveAlerts(alertIds: string[] = [], addToBaseline = false): Promise<Empty[]> {
     return Promise.all(alertIds.map((id) => resolveAlert(id, addToBaseline)));
 }

--- a/ui/apps/platform/src/services/AuthService/AuthService.ts
+++ b/ui/apps/platform/src/services/AuthService/AuthService.ts
@@ -6,6 +6,7 @@ import queryString from 'qs';
 
 import { Role } from 'services/RolesService';
 
+import { Empty } from 'services/types';
 import AccessTokenManager from './AccessTokenManager';
 import addTokenRefreshInterceptors, {
     doNotStallRequestConfig,
@@ -168,7 +169,7 @@ export function saveAuthProvider(authProvider: AuthProvider): string | Promise<A
  *
  * @returns {Promise} promise which is fullfilled when the request is complete TODO verify return empty object
  */
-export function deleteAuthProvider(authProviderId: string): Promise<Record<string, never>> {
+export function deleteAuthProvider(authProviderId: string): Promise<Empty> {
     if (!authProviderId) {
         throw new Error('Auth provider ID must be defined');
     }

--- a/ui/apps/platform/src/services/BackupIntegrationsService.ts
+++ b/ui/apps/platform/src/services/BackupIntegrationsService.ts
@@ -1,6 +1,7 @@
 import axios from './instance';
 
 import { IntegrationBase, IntegrationOptions } from './IntegrationsService';
+import { Empty } from './types';
 
 const backupIntegrationsUrl = '/v1/externalbackups';
 
@@ -55,7 +56,7 @@ export function fetchBackupIntegrations(): Promise<BackupIntegrationBase[]> {
 export function saveBackupIntegration(
     integration: BackupIntegrationBase,
     { updatePassword }: IntegrationOptions = {}
-): Promise<Record<string, never>> {
+): Promise<Empty> {
     const { id } = integration;
 
     if (!id) {
@@ -84,7 +85,7 @@ export function saveBackupIntegration(
 export function testBackupIntegration(
     integration: BackupIntegrationBase,
     { updatePassword }: IntegrationOptions = {}
-): Promise<Record<string, never>> {
+): Promise<Empty> {
     if (typeof updatePassword === 'boolean') {
         return axios.post(`${backupIntegrationsUrl}/test/updated`, {
             [updateIntegrationKey]: integration,
@@ -98,20 +99,20 @@ export function testBackupIntegration(
 /*
  * Delete integration (singular).
  */
-export function deleteBackupIntegration(id: string): Promise<Record<string, never>> {
+export function deleteBackupIntegration(id: string): Promise<Empty> {
     return axios.delete(`${backupIntegrationsUrl}/${id}`);
 }
 
 /*
  * Delete integrations (plural).
  */
-export function deleteBackupIntegrations(ids: string[]): Promise<Record<string, never>[]> {
+export function deleteBackupIntegrations(ids: string[]): Promise<Empty[]> {
     return Promise.all(ids.map((id) => deleteBackupIntegration(id)));
 }
 
 /*
  * Trigger external backup.
  */
-export function triggerBackup(id: string): Promise<Record<string, never>> {
+export function triggerBackup(id: string): Promise<Empty> {
     return axios.post(`${backupIntegrationsUrl}/${id}`);
 }

--- a/ui/apps/platform/src/services/ClustersService.ts
+++ b/ui/apps/platform/src/services/ClustersService.ts
@@ -10,6 +10,7 @@ import {
 } from 'types/clusterService.proto';
 import axios from './instance';
 import { cluster as clusterSchema } from './schemas';
+import { Empty } from './types';
 
 const clustersUrl = '/v1/clusters';
 const clusterDefaultsUrl = '/v1/cluster-defaults';
@@ -120,21 +121,21 @@ export function saveAutoUpgradeConfig(config: AutoUpgradeConfig): Promise<AutoUp
 /**
  * Manually start a sensor upgrade given the cluster ID.
  */
-export function upgradeCluster(id: string): Promise<Record<string, never>> {
+export function upgradeCluster(id: string): Promise<Empty> {
     return axios.post(`${manualUpgradeUrl}/${id}`);
 }
 
 /**
  * Start a cluster cert rotation.
  */
-export function rotateClusterCerts(id: string): Promise<Record<string, never>> {
+export function rotateClusterCerts(id: string): Promise<Empty> {
     return axios.post(`${upgradesUrl}/rotateclustercerts/${id}`);
 }
 
 /**
  * Manually start a sensor upgrade for an array of clusters.
  */
-export function upgradeClusters(ids = []): Promise<Record<string, never>[]> {
+export function upgradeClusters(ids = []): Promise<Empty[]> {
     return Promise.all(ids.map((id) => upgradeCluster(id)));
 }
 
@@ -152,14 +153,14 @@ export function fetchCluster(id: string) {
 /**
  * Deletes cluster given the cluster ID. Returns an empty object.
  */
-export function deleteCluster(id: string): Promise<Record<string, never>> {
+export function deleteCluster(id: string): Promise<Empty> {
     return axios.delete(`${clustersUrl}/${id}`);
 }
 
 /**
  * Deletes clusters given a list of cluster IDs.
  */
-export function deleteClusters(ids: string[] = []): Promise<Record<string, never>[]> {
+export function deleteClusters(ids: string[] = []): Promise<Empty[]> {
     return Promise.all(ids.map((id) => deleteCluster(id)));
 }
 

--- a/ui/apps/platform/src/services/ImageIntegrationsService.ts
+++ b/ui/apps/platform/src/services/ImageIntegrationsService.ts
@@ -1,6 +1,7 @@
 import axios from './instance';
 
 import { IntegrationBase, IntegrationOptions } from './IntegrationsService';
+import { Empty } from './types';
 
 const imageIntegrationsUrl = '/v1/imageintegrations';
 
@@ -49,7 +50,7 @@ export function fetchImageIntegrations(): Promise<ImageIntegrationBase[]> {
 export function saveImageIntegration(
     integration: ImageIntegrationBase,
     { updatePassword }: IntegrationOptions = {}
-): Promise<Record<string, never>> {
+): Promise<Empty> {
     const { id } = integration;
 
     if (!id) {
@@ -78,7 +79,7 @@ export function saveImageIntegration(
 export function testImageIntegration(
     integration: ImageIntegrationBase,
     { updatePassword }: IntegrationOptions = {}
-): Promise<Record<string, never>> {
+): Promise<Empty> {
     if (typeof updatePassword === 'boolean') {
         return axios.post(`${imageIntegrationsUrl}/test/updated`, {
             [updateIntegrationKey]: integration,
@@ -92,13 +93,13 @@ export function testImageIntegration(
 /*
  * Delete integration (singular).
  */
-export function deleteImageIntegration(id: string): Promise<Record<string, never>> {
+export function deleteImageIntegration(id: string): Promise<Empty> {
     return axios.delete(`${imageIntegrationsUrl}/${id}`);
 }
 
 /*
  * Delete integrations (plural).
  */
-export function deleteImageIntegrations(ids: string[]): Promise<Record<string, never>[]> {
+export function deleteImageIntegrations(ids: string[]): Promise<Empty[]> {
     return Promise.all(ids.map((id) => deleteImageIntegration(id)));
 }

--- a/ui/apps/platform/src/services/IntegrationsService.ts
+++ b/ui/apps/platform/src/services/IntegrationsService.ts
@@ -1,4 +1,5 @@
 import axios from './instance';
+import { Empty } from './types';
 
 type IntegrationSource =
     | 'authProviders'
@@ -63,7 +64,7 @@ export function saveIntegration(
     source: IntegrationSource,
     data: IntegrationBase,
     options: IntegrationOptions = {} // TODO can destructure { updatePassword } for new forms
-): Promise<Record<string, never>> {
+): Promise<Empty> {
     const { id } = data;
 
     if (!id) {
@@ -89,7 +90,7 @@ export function saveIntegration(
 export function saveIntegrationV2(
     source: IntegrationSource,
     data: IntegrationOptions // can also include config, externalBackup, notifier
-): Promise<Record<string, never>> {
+): Promise<Empty> {
     const hasUpdatePassword = typeof data.updatePassword === 'boolean';
     if (hasUpdatePassword) {
         // If the data has a config object, use the contents of that config object.
@@ -121,7 +122,7 @@ export function testIntegration(
     source: IntegrationSource,
     data: IntegrationBase,
     options: IntegrationOptions = {} // TODO can destructure { updatePassword } for new forms
-): Promise<Record<string, never>> {
+): Promise<Empty> {
     const updatePassword = options?.updatePassword; // ROX-7884 because setFormSubmissionOptions can return null
 
     // if the integration is not one that could possibly have stored credentials, use the previous API
@@ -141,7 +142,7 @@ export function testIntegration(
 export function testIntegrationV2(
     source: IntegrationSource,
     data: IntegrationOptions // can also include config, externalBackup, notifier
-): Promise<Record<string, never>> {
+): Promise<Empty> {
     if (typeof data.updatePassword === 'boolean') {
         return axios.post(`${getPath(source)}/test/updated`, data);
     }
@@ -151,10 +152,7 @@ export function testIntegrationV2(
 /*
  * Delete an integration by source.
  */
-export function deleteIntegration(
-    source: IntegrationSource,
-    id: string
-): Promise<Record<string, never>> {
+export function deleteIntegration(source: IntegrationSource, id: string): Promise<Empty> {
     return axios.delete(`${getPath(source)}/${id}`);
 }
 
@@ -164,6 +162,6 @@ export function deleteIntegration(
 export function deleteIntegrations(
     source: IntegrationSource,
     ids: string[] = []
-): Promise<Record<string, never>[]> {
+): Promise<Empty[]> {
     return Promise.all(ids.map((id) => deleteIntegration(source, id)));
 }

--- a/ui/apps/platform/src/services/NotifierIntegrationsService.ts
+++ b/ui/apps/platform/src/services/NotifierIntegrationsService.ts
@@ -1,6 +1,7 @@
 import axios from './instance';
 
 import { IntegrationBase, IntegrationOptions } from './IntegrationsService';
+import { Empty } from './types';
 
 const notifierIntegrationsUrl = '/v1/notifiers';
 
@@ -45,7 +46,7 @@ export function fetchNotifierIntegrations(): Promise<NotifierIntegrationBase[]> 
 export function saveNotifierIntegration(
     integration: NotifierIntegrationBase,
     { updatePassword }: IntegrationOptions = {}
-): Promise<Record<string, never>> {
+): Promise<Empty> {
     const { id } = integration;
 
     if (!id) {
@@ -74,7 +75,7 @@ export function saveNotifierIntegration(
 export function testNotifierIntegration(
     integration: NotifierIntegrationBase,
     { updatePassword }: IntegrationOptions = {}
-): Promise<Record<string, never>> {
+): Promise<Empty> {
     if (typeof updatePassword === 'boolean') {
         return axios.post(`${notifierIntegrationsUrl}/test/updated`, {
             [updateIntegrationKey]: integration,
@@ -88,13 +89,13 @@ export function testNotifierIntegration(
 /*
  * Delete integration (singular).
  */
-export function deleteNotifierIntegration(id: string): Promise<Record<string, never>> {
+export function deleteNotifierIntegration(id: string): Promise<Empty> {
     return axios.delete(`${notifierIntegrationsUrl}/${id}`);
 }
 
 /*
  * Delete integrations (plural).
  */
-export function deleteNotifierIntegrations(ids: string[]): Promise<Record<string, never>[]> {
+export function deleteNotifierIntegrations(ids: string[]): Promise<Empty[]> {
     return Promise.all(ids.map((id) => deleteNotifierIntegration(id)));
 }

--- a/ui/apps/platform/src/services/PoliciesService.ts
+++ b/ui/apps/platform/src/services/PoliciesService.ts
@@ -6,11 +6,10 @@ import { addBrandedTimestampToString } from 'utils/dateUtils';
 import { transformPolicyCriteriaValuesToStrings } from 'utils/policyUtils';
 
 import axios from './instance';
+import { Empty } from './types';
 
 const baseUrl = '/v1/policies';
 const policyCategoriesUrl = '/v1/policyCategories';
-
-type Empty = Record<string, never>;
 
 /*
  * Get a policy. Policy is a superset of ListPolicy.

--- a/ui/apps/platform/src/services/PolicyCategoriesService.ts
+++ b/ui/apps/platform/src/services/PolicyCategoriesService.ts
@@ -1,5 +1,6 @@
 import { PolicyCategory } from 'types/policy.proto';
 import axios from './instance';
+import { Empty } from './types';
 
 const policyCategoriesUrl = '/v1/policycategories';
 
@@ -37,5 +38,3 @@ export function renamePolicyCategory(id: string, newCategoryName: string): Promi
 export function deletePolicyCategory(id: string): Promise<Empty> {
     return axios.delete<Empty>(`${policyCategoriesUrl}/${id}`).then((response) => response.data);
 }
-
-type Empty = Record<string, never>;

--- a/ui/apps/platform/src/services/ReportsService.ts
+++ b/ui/apps/platform/src/services/ReportsService.ts
@@ -4,6 +4,7 @@ import { ReportConfiguration } from 'types/report.proto';
 import searchOptionsToQuery, { RestSearchOption } from 'services/searchOptionsToQuery';
 import { ApiSortOption } from 'types/search';
 import axios from './instance';
+import { Empty } from './types';
 
 const reportUrl = '/v1/report';
 const reportServiceUrl = `${reportUrl}/run`;
@@ -79,10 +80,10 @@ export function saveReport(report: ReportConfiguration): Promise<ReportConfigura
     });
 }
 
-export function deleteReport(reportId: string): Promise<Record<string, never>> {
+export function deleteReport(reportId: string): Promise<Empty> {
     return axios.delete(`${reportConfigurationsUrl}/${reportId}`);
 }
 
-export function runReport(reportId: string): Promise<Record<string, never>> {
+export function runReport(reportId: string): Promise<Empty> {
     return axios.post(`${reportServiceUrl}/${reportId}`);
 }

--- a/ui/apps/platform/src/services/RolesService.ts
+++ b/ui/apps/platform/src/services/RolesService.ts
@@ -1,4 +1,5 @@
 import axios from './instance';
+import { Empty } from './types';
 
 const resourcesUrl = '/v1/resources';
 
@@ -45,7 +46,7 @@ export function fetchRolesAsArray(): Promise<Role[]> {
 /*
  * Create entity and return empty object (unlike most create requests).
  */
-export function createRole(entity: Role): Promise<Record<string, never>> {
+export function createRole(entity: Role): Promise<Empty> {
     const { name } = entity;
     return axios.post(`${rolesUrl}/${name}`, entity);
 }
@@ -53,7 +54,7 @@ export function createRole(entity: Role): Promise<Record<string, never>> {
 /**
  * Update entity and return empty object.
  */
-export function updateRole(entity: Role): Promise<Record<string, never>> {
+export function updateRole(entity: Role): Promise<Empty> {
     const { name } = entity;
     return axios.put(`${rolesUrl}/${name}`, entity);
 }
@@ -61,7 +62,7 @@ export function updateRole(entity: Role): Promise<Record<string, never>> {
 /*
  * Delete entity which has name and return empty object.
  */
-export function deleteRole(name: string): Promise<Record<string, never>> {
+export function deleteRole(name: string): Promise<Empty> {
     return axios.delete(`${rolesUrl}/${name}`);
 }
 
@@ -104,7 +105,7 @@ export function createPermissionSet(entity: PermissionSet): Promise<PermissionSe
 /*
  * Update entity and return empty object.
  */
-export function updatePermissionSet(entity: PermissionSet): Promise<Record<string, never>> {
+export function updatePermissionSet(entity: PermissionSet): Promise<Empty> {
     const { id } = entity;
     return axios.put(`${permissionSetsUrl}/${id}`, entity);
 }
@@ -112,6 +113,6 @@ export function updatePermissionSet(entity: PermissionSet): Promise<Record<strin
 /*
  * Delete entity which has id and return empty object.
  */
-export function deletePermissionSet(id: string): Promise<Record<string, never>> {
+export function deletePermissionSet(id: string): Promise<Empty> {
     return axios.delete(`${permissionSetsUrl}/${id}`);
 }

--- a/ui/apps/platform/src/services/imageService.ts
+++ b/ui/apps/platform/src/services/imageService.ts
@@ -1,6 +1,7 @@
 import { ListImage, WatchedImage } from 'types/image.proto';
 
 import axios from './instance';
+import { Empty } from './types';
 
 const imagesUrl = '/v1/images';
 const watchedImagesUrl = '/v1/watchedimages';
@@ -34,8 +35,6 @@ export function unwatchImage(name: string): Promise<Empty> {
         .delete<Empty>(`${watchedImagesUrl}?name=${name}`)
         .then((response) => response.data);
 }
-
-type Empty = Record<string, never>;
 
 /*
  * Start watching an image fully-qualified image, even if inactive, identified by name.


### PR DESCRIPTION
## Description

Refactors duplicated `Record<string, never>` to use `Empty` type from common service API types file.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

N/A - nonfunctional type-level refactor
