### PR TITLE
Fix upgrade test by using newer metrics server

### DIFF
--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -235,7 +235,7 @@ test_upgrader() {
 install_metrics_server_and_deactivate() {
     info "Install the metrics server and deactivate it to reproduce ROX-4429"
 
-    kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.8.2/components.yaml
+    kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.8.2/components.yaml
 
     echo "Waiting for metrics.k8s.io to be in kubectl API resources..."
     local success=0

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -235,7 +235,7 @@ test_upgrader() {
 install_metrics_server_and_deactivate() {
     info "Install the metrics server and deactivate it to reproduce ROX-4429"
 
-    kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.6/components.yaml
+    kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.8.2/components.yaml
 
     echo "Waiting for metrics.k8s.io to be in kubectl API resources..."
     local success=0

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -84,6 +84,7 @@ preamble() {
     case "$(uname -m)" in
         x86_64) TEST_HOST_PLATFORM="${host_os}_amd64" ;;
         aarch64) TEST_HOST_PLATFORM="${host_os}_arm64" ;;
+        arm64) TEST_HOST_PLATFORM="${host_os}_arm64" ;;
         ppc64le) TEST_HOST_PLATFORM="${host_os}_ppc64le" ;;
         s390x) TEST_HOST_PLATFORM="${host_os}_s390x" ;;
         *) die "Unknown architecture" ;;


### PR DESCRIPTION
## Description

k8s 1.22 deprecated v1beta1 of apiregistration and it is now v1. So just use the newer version of the components.yaml from the metrics server which has the fix

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Upgrade tests should pass :)