### PR TITLE
Enable setting extra arch labels for operator

### DIFF
--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -22,6 +22,8 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     support: Red Hat
+  labels:
+    operatorframework.io/arch.amd64: supported
   name: rhacs-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -47,7 +47,7 @@ def must_replace_suffix(str, suffix, replacement):
     return splits[0] + replacement
 
 
-def patch_csv(csv_doc, version, operator_image, first_version, no_related_images, rbac_proxy_replacements):
+def patch_csv(csv_doc, version, operator_image, first_version, no_related_images, extra_supported_arches, rbac_proxy_replacements):
     csv_doc['metadata']['annotations']['createdAt'] = datetime.now(timezone.utc).isoformat()
 
     placeholder_image = csv_doc['metadata']['annotations']['containerImage']
@@ -68,6 +68,10 @@ def patch_csv(csv_doc, version, operator_image, first_version, no_related_images
     first_x, first_y, first_z = (int(c) for c in first_version.split('-', maxsplit=1)[0].split('.'))
     # An olm.skipRange doesn't hurt if it references non-existing versions.
     csv_doc["metadata"]["annotations"]["olm.skipRange"] = f'>= {x}.{y-1}.0 < {version}'
+
+    # multi-arch
+    for arch in extra_supported_arches:
+        csv_doc["metadata"]["labels"][f"operatorframework.io/arch.{arch}"] = "supported"
 
     if (x, y, z) > (first_x, first_y, first_z):
         if z == 0:
@@ -91,6 +95,9 @@ def parse_args():
     parser.add_argument("--replace-rbac-proxy", required=False, metavar='original-tag:replacement-image',
                         nargs='+', help='Replacement directives for the RBAC proxy image',
                         default=[])
+    parser.add_argument("--add-supported-arch", action='append', required=False,
+                        help='Add label to CSV for an additional operator (may be passed multiple times)',
+                        default=[])
     return parser.parse_args()
 
 
@@ -102,6 +109,7 @@ def main():
               version=args.use_version,
               first_version=args.first_version,
               no_related_images=args.no_related_images,
+              extra_supported_arches=args.add_supported_arch,
               rbac_proxy_replacements={
                     tag: img
                     for tag, img in (spec.split(':', maxsplit=1) for spec in args.replace_rbac_proxy)

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -12,6 +12,8 @@ metadata:
     operatorframework.io/suggested-namespace: rhacs-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
     support: Red Hat
+  labels:
+    operatorframework.io/arch.amd64: supported
   name: rhacs-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
## Description

These labels are required in order to display an operator in the OperatorHub on architectures other than x86_64 (amd64).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))
