### PR TITLE
Mirror versions for Postgres utilities in main image

### DIFF
--- a/image/postgres/Dockerfile.envsubst
+++ b/image/postgres/Dockerfile.envsubst
@@ -1,6 +1,6 @@
 ARG BASE_REGISTRY=registry.access.redhat.com
 ARG BASE_IMAGE=ubi8/ubi
-ARG BASE_TAG=8.5
+ARG BASE_TAG=8.6
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
 #WORKDIR /bundle

--- a/image/postgres/create-bundle.sh
+++ b/image/postgres/create-bundle.sh
@@ -39,7 +39,7 @@ fi
 postgres_repo_url="https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-${arch}/pgdg-redhat-repo-latest.noarch.rpm"
 postgres_major="13"
 pg_rhel_major="8"
-pg_rhel_minor="5"
+pg_rhel_minor="6"
 pg_rhel_version="${pg_rhel_major}.${pg_rhel_minor}"
 
 if [[ "${NATIVE_PG_INSTALL}" == "true" ]]; then
@@ -64,10 +64,7 @@ fi
 # Dockerfile.
 
 # Get postgres RPMs directly
-postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_version}-${arch}"
-if [[ ${arch} != "x86_64" ]]; then
-  postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_major}-${arch}"
-fi
+postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_major}-${arch}"
 
 curl -sS --fail -o "${bundle_root}/postgres.rpm" \
     "${postgres_url}/postgresql${postgres_major}-${postgres_minor}.rpm"

--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -125,7 +125,6 @@ curl -s -f -o "${bundle_root}/snappy.rpm" "${rpm_base_url}/snappy-1.1.8-3.${rpm_
 # Get postgres RPMs directly
 postgres_major="13"
 pg_rhel_major="8"
-pg_rhel_minor="6"
 postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_major}-${arch}"
 postgres_minor="13.8-1PGDG.rhel8.${arch}"
 

--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -123,10 +123,11 @@ curl -s -f -o "${bundle_root}/snappy.rpm" "${rpm_base_url}/snappy-1.1.8-3.${rpm_
 
 # Install Postgres Client so central can initiate backups/restores
 # Get postgres RPMs directly
-postgres_major="14"
-pg_rhel_version="8.5"
-postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_version}-${arch}"
-postgres_minor="14.2-1PGDG.rhel8.${arch}"
+postgres_major="13"
+pg_rhel_major="8"
+pg_rhel_minor="6"
+postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_major}-${arch}"
+postgres_minor="13.8-1PGDG.rhel8.${arch}"
 
 curl -sS --fail -o "${bundle_root}/postgres.rpm" \
     "${postgres_url}/postgresql${postgres_major}-${postgres_minor}.rpm"


### PR DESCRIPTION
## Description

Unifies base images on 8.6 and postgres 13

We should have a follow up and rework these as there is too much magic in them. Namely, that we have seamless minor upgrades by running a container and looking up the most current version

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
