### PR TITLE
Add operator architectures explicitly in Makefile

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -442,6 +442,7 @@ bundle-post-process: operator-sdk ## Post-process CSV file to include correct op
 		--first-version 3.62.0 `# 3.62.0 is the first operator version ever released` \
 		--operator-image $(IMG) \
 		--no-related-images \
+		--add-supported-arch amd64 \
 		< bundle/manifests/rhacs-operator.clusterserviceversion.yaml \
 	| sed 's,replaces: rhacs-operator.v3.66.0,replaces: rhacs-operator.v3.66.1,' > build/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
 # TODO(ROX-8618): make the above sed on `replaces:` line generic (quick hack to address ROX-8630)

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -398,7 +398,7 @@ upgrade-dirty-tag-via-olm: kuttl
 # Commands to enter local Python virtual environment and get needed dependencies there.
 ACTIVATE_PYTHON = python3 -m venv bundle_helpers/.venv ;\
 	. bundle_helpers/.venv/bin/activate ;\
-	pip3 install --upgrade pip==22.2.2 setuptools==65.3.0 ;\
+	pip3 install --upgrade pip==21.3.1 setuptools==59.6.0 ;\
 	pip3 install -r bundle_helpers/requirements.txt
 
 .PHONY: bundle

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -398,7 +398,7 @@ upgrade-dirty-tag-via-olm: kuttl
 # Commands to enter local Python virtual environment and get needed dependencies there.
 ACTIVATE_PYTHON = python3 -m venv bundle_helpers/.venv ;\
 	. bundle_helpers/.venv/bin/activate ;\
-	pip3 install --upgrade pip==21.3.1 setuptools==59.6.0 ;\
+	pip3 install --upgrade pip==22.2.2 setuptools==65.3.0 ;\
 	pip3 install -r bundle_helpers/requirements.txt
 
 .PHONY: bundle

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -444,8 +444,7 @@ bundle-post-process: operator-sdk ## Post-process CSV file to include correct op
 		--no-related-images \
 		--add-supported-arch amd64 \
 		< bundle/manifests/rhacs-operator.clusterserviceversion.yaml \
-	| sed 's,replaces: rhacs-operator.v3.66.0,replaces: rhacs-operator.v3.66.1,' > build/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
-# TODO(ROX-8618): make the above sed on `replaces:` line generic (quick hack to address ROX-8630)
+		> build/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
 # Check that the resulting bundle still passes validations.
 	$(OPERATOR_SDK) bundle validate ./build/bundle --select-optional suite=operatorframework
 

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -22,8 +22,6 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     support: Red Hat
-  labels:
-    operatorframework.io/arch.amd64: supported
   name: rhacs-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -98,7 +98,7 @@ def parse_args():
                         nargs='+', help='Replacement directives for the RBAC proxy image',
                         default=[])
     parser.add_argument("--add-supported-arch", action='append', required=False,
-                        help='Enable additional operator architecture via CSV labels (may be passed multiple times)',
+                        help='Enable specified operator architecture via CSV labels (may be passed multiple times)',
                         default=[])
     return parser.parse_args()
 

--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -70,6 +70,8 @@ def patch_csv(csv_doc, version, operator_image, first_version, no_related_images
     csv_doc["metadata"]["annotations"]["olm.skipRange"] = f'>= {x}.{y-1}.0 < {version}'
 
     # multi-arch
+    if "labels" not in csv_doc["metadata"]:
+        csv_doc["metadata"]["labels"] = {}
     for arch in extra_supported_arches:
         csv_doc["metadata"]["labels"][f"operatorframework.io/arch.{arch}"] = "supported"
 
@@ -96,7 +98,7 @@ def parse_args():
                         nargs='+', help='Replacement directives for the RBAC proxy image',
                         default=[])
     parser.add_argument("--add-supported-arch", action='append', required=False,
-                        help='Add label to CSV for an additional operator (may be passed multiple times)',
+                        help='Enable additional operator architecture via CSV labels (may be passed multiple times)',
                         default=[])
     return parser.parse_args()
 

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -12,8 +12,6 @@ metadata:
     operatorframework.io/suggested-namespace: rhacs-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
     support: Red Hat
-  labels:
-    operatorframework.io/arch.amd64: supported
   name: rhacs-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
## Description

This follows up on #3163. That PR introduces some code which is for downstream to enable multiple architectures there. The issue is the code is never called upstream and so we're risking it gets rusty or may even get removed as unnecessary.
Having a code that always works is better than having conditional code that works rarely.

Also couple other tiny maintenance changes (see commit descriptions).

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- Hoping for CI to cover it.
- Ran `make bundle bundle-build` locally and checked tat `build/bundle/manifests/rhacs-operator.clusterserviceversion.yaml` has `amd64` architecture label.