### PR TITLE
Add basic collections data loading and table display

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import { Button, ButtonVariant, Truncate, Bullseye, Text } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+import LinkShim from 'Components/PatternFly/LinkShim';
+import useTableSelection from 'hooks/useTableSelection';
+import { CollectionResponse } from 'services/CollectionsService';
+import { collectionsPath } from 'routePaths';
+
+export type CollectionsTableProps = {
+    collections: CollectionResponse[];
+    hasWriteAccess: boolean;
+};
+
+function CollectionsTable({ collections, hasWriteAccess }: CollectionsTableProps) {
+    const history = useHistory();
+    const { selected, allRowsSelected, onSelect, onSelectAll } = useTableSelection(collections);
+
+    function onEditCollection(id: string) {
+        history.push({
+            pathname: `${collectionsPath}/${id}`,
+            search: 'action=edit',
+        });
+    }
+
+    function onCloneCollection(id: string) {
+        history.push({
+            pathname: `${collectionsPath}/${id}`,
+            search: 'action=clone',
+        });
+    }
+
+    return (
+        <>
+            <TableComposable variant={TableVariant.compact}>
+                <Thead>
+                    <Tr>
+                        {hasWriteAccess && (
+                            <Th
+                                select={{
+                                    onSelect: onSelectAll,
+                                    isSelected: allRowsSelected,
+                                }}
+                            />
+                        )}
+                        <Th modifier="wrap" width={25}>
+                            Collection
+                        </Th>
+                        <Th modifier="wrap">Description</Th>
+                        <Th modifier="wrap" width={10}>
+                            In use
+                        </Th>
+                        <Th aria-label="Row actions" />
+                    </Tr>
+                </Thead>
+                <Tbody>
+                    {collections.length === 0 && (
+                        <Tr>
+                            <Td colSpan={hasWriteAccess ? 5 : 3}>
+                                <Bullseye>
+                                    <EmptyStateTemplate
+                                        title="No collections found"
+                                        headingLevel="h2"
+                                        icon={SearchIcon}
+                                    >
+                                        <Text>Clear all filters and try again.</Text>
+                                        <Button variant="link" onClick={() => {}}>
+                                            Clear all filters
+                                        </Button>
+                                    </EmptyStateTemplate>
+                                </Bullseye>
+                            </Td>
+                        </Tr>
+                    )}
+                    {collections.map(({ id, name, description, inUse }, rowIndex) => {
+                        const actionItems = [
+                            {
+                                title: 'Edit collection',
+                                onClick: () => onEditCollection(id),
+                            },
+                            {
+                                title: 'Clone collection',
+                                onClick: () => onCloneCollection(id),
+                            },
+                            {
+                                isSeparator: true,
+                            },
+                            {
+                                title: inUse ? 'Cannot delete (in use)' : 'Delete collection',
+                                onClick: () => {},
+                                isDisabled: inUse,
+                            },
+                        ];
+
+                        return (
+                            <Tr key={id}>
+                                {hasWriteAccess && (
+                                    <Td
+                                        select={{
+                                            rowIndex,
+                                            onSelect,
+                                            isSelected: selected[rowIndex],
+                                        }}
+                                    />
+                                )}
+                                <Td dataLabel="Collection">
+                                    <Button
+                                        variant={ButtonVariant.link}
+                                        isInline
+                                        component={LinkShim}
+                                        href={`${collectionsPath}/${id}`}
+                                    >
+                                        {name}
+                                    </Button>
+                                </Td>
+                                <Td dataLabel="Description">
+                                    <Truncate content={description || '-'} tooltipPosition="top" />
+                                </Td>
+                                <Td dataLabel="In Use">{inUse ? 'Yes' : 'No'}</Td>
+                                {hasWriteAccess && <Td actions={{ items: actionItems }} />}
+                            </Tr>
+                        );
+                    })}
+                </Tbody>
+            </TableComposable>
+        </>
+    );
+}
+
+export default CollectionsTable;

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
     PageSection,
     Title,
@@ -7,17 +7,66 @@ import {
     Flex,
     FlexItem,
     ButtonVariant,
+    Divider,
+    Alert,
+    Bullseye,
+    Spinner,
 } from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import { collectionsPath } from 'routePaths';
+import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
+import { getCollectionCount, listCollections } from 'services/CollectionsService';
+import CollectionsTable from './CollectionsTable';
 
 type CollectionsTablePageProps = {
     hasWriteAccessForCollections: boolean;
 };
 
 function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTablePageProps) {
+    const listQuery = useCallback(
+        () => listCollections({}, { field: 'name', reversed: false }, 0, 20),
+        []
+    );
+    const { data: listData, loading: listLoading, error: listError } = useRestQuery(listQuery);
+
+    const countQuery = useCallback(() => getCollectionCount({}), []);
+    const { data: countData, loading: countLoading, error: countError } = useRestQuery(countQuery);
+
+    const isDataAvailable = typeof listData !== 'undefined' && typeof countData !== 'undefined';
+    const isLoading = !isDataAvailable && (listLoading || countLoading);
+    const loadError = listError || countError;
+
+    let pageContent = (
+        <PageSection variant="light" isFilled>
+            <Bullseye>
+                <Spinner isSVG />
+            </Bullseye>
+        </PageSection>
+    );
+
+    if (loadError) {
+        pageContent = (
+            <PageSection variant="light" isFilled>
+                <Bullseye>
+                    <Alert variant="danger" title={loadError.message} />
+                </Bullseye>
+            </PageSection>
+        );
+    }
+
+    if (isDataAvailable && !isLoading && !loadError) {
+        pageContent = (
+            <PageSection>
+                <CollectionsTable
+                    collections={listData}
+                    hasWriteAccess={hasWriteAccessForCollections}
+                />
+            </PageSection>
+        );
+    }
+
     return (
         <>
             <PageTitle title="Collections" />
@@ -42,6 +91,8 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
                     )}
                 </Flex>
             </PageSection>
+            <Divider component="div" />
+            {pageContent}
         </>
     );
 }


### PR DESCRIPTION
## Description

Adds a bare-bones table for collections display on the landing page.

_As an aside, given the recent UX changes to the "Append collections" functionality, I don't think there is value in making the link behavior, etc. configurable for this component from the start. The new mocks are sufficiently different enough that I think they should be separate components._

**Follow ups**

- Implement sorting by column
- Implement a table toolbar with pagination and filtering
- Implement correct selection handling and delete functionality
- File a PatternFly issue for the cut off checkbox layout in an empty table with the `variant='compact'` prop

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

(The following tests were performed with a mock server running locally to provide data.)

Visit the collection page, and see a spinner while data loads:
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/1292638/192018631-51addff5-c105-48f3-9502-be06fddca262.png">

If an error occurs, display a brief message to the user. (This message is the descriptive message returned by the server.)
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/1292638/192024271-71ec470a-2e94-4aa7-ac9d-2b2bd1313158.png">


After loading, the collections data should be displayed in the table:
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/1292638/192021593-2fcf2e5f-b5d4-407e-a264-b2a76891a1b0.png">
![image](https://user-images.githubusercontent.com/1292638/192021930-007af7be-1d9a-4756-9e68-e8b93bd0a6a6.png)

If no data is returned by the request, and EmptyState is displayed with a possible user action. (No effect right now).
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/1292638/192025322-d522bcd5-b3fb-480b-984e-49a91648385f.png">


The table menu should display three options, with the "delete" option disabled if the collection is in use:
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/1292638/192022893-4e6824e9-80d7-487e-b734-ee69f8d55a49.png">
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/1292638/192022944-66d22399-04a3-4b75-bc3b-ee7a2439eacd.png">

Selecting the "edit" option should route the user to the edit page for that collection.( No effect right now other than URL change.)
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/1292638/192023146-ff36e74f-7b7e-4fbf-8e76-6c675d65666e.png">

Selecting the "clone" option should route the user to the clone page for that collection.( No effect right now other than URL change.)
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/1292638/192023362-15716f66-c189-4b01-abac-be43dd08259e.png">

Clicking on the name of a collection should route the user to that collection's page, by ID. (No effect right now other than URL change.)
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/1292638/192022439-8498f052-4dd6-442c-8c51-1a239a1d4d03.png">


