### PR TITLE
Add sorting to collections table.

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -8,16 +8,23 @@ import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import useTableSelection from 'hooks/useTableSelection';
 import { CollectionResponse } from 'services/CollectionsService';
+import { GetSortParams } from 'hooks/useURLSort';
 import { collectionsPath } from 'routePaths';
 
 export type CollectionsTableProps = {
     collections: CollectionResponse[];
+    getSortParams: GetSortParams;
     hasWriteAccess: boolean;
 };
 
-function CollectionsTable({ collections, hasWriteAccess }: CollectionsTableProps) {
+function CollectionsTable({ collections, getSortParams, hasWriteAccess }: CollectionsTableProps) {
     const history = useHistory();
     const { selected, allRowsSelected, onSelect, onSelectAll } = useTableSelection(collections);
+    const hasCollections = collections.length > 0;
+
+    function getEnabledSortParams(field: string) {
+        return hasCollections ? getSortParams(field) : undefined;
+    }
 
     function onEditCollection(id: string) {
         history.push({
@@ -46,18 +53,20 @@ function CollectionsTable({ collections, hasWriteAccess }: CollectionsTableProps
                                 }}
                             />
                         )}
-                        <Th modifier="wrap" width={25}>
+                        <Th modifier="wrap" width={25} sort={getEnabledSortParams('name')}>
                             Collection
                         </Th>
-                        <Th modifier="wrap">Description</Th>
-                        <Th modifier="wrap" width={10}>
+                        <Th modifier="wrap" sort={getEnabledSortParams('description')}>
+                            Description
+                        </Th>
+                        <Th modifier="wrap" width={10} sort={getEnabledSortParams('inUse')}>
                             In use
                         </Th>
                         <Th aria-label="Row actions" />
                     </Tr>
                 </Thead>
                 <Tbody>
-                    {collections.length === 0 && (
+                    {hasCollections || (
                         <Tr>
                             <Td colSpan={hasWriteAccess ? 5 : 3}>
                                 <Bullseye>

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
@@ -18,17 +18,21 @@ import LinkShim from 'Components/PatternFly/LinkShim';
 import { collectionsPath } from 'routePaths';
 import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
 import { getCollectionCount, listCollections } from 'services/CollectionsService';
+import useURLSort from 'hooks/useURLSort';
 import CollectionsTable from './CollectionsTable';
 
 type CollectionsTablePageProps = {
     hasWriteAccessForCollections: boolean;
 };
 
+const sortOptions = {
+    sortFields: ['name', 'description', 'inUse'],
+    defaultSortOption: { field: 'name', direction: 'asc' } as const,
+};
+
 function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTablePageProps) {
-    const listQuery = useCallback(
-        () => listCollections({}, { field: 'name', reversed: false }, 0, 20),
-        []
-    );
+    const { sortOption, getSortParams } = useURLSort(sortOptions);
+    const listQuery = useCallback(() => listCollections({}, sortOption, 0, 20), [sortOption]);
     const { data: listData, loading: listLoading, error: listError } = useRestQuery(listQuery);
 
     const countQuery = useCallback(() => getCollectionCount({}), []);
@@ -61,6 +65,7 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
             <PageSection>
                 <CollectionsTable
                     collections={listData}
+                    getSortParams={getSortParams}
                     hasWriteAccess={hasWriteAccessForCollections}
                 />
             </PageSection>


### PR DESCRIPTION
## Description

Adds sorting to the collection table column headers.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Load the collections page. The table should default to sorted by name, ascending, with the "Collection" column header highlighted in blue.
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/192618790-22cbca38-125e-4f8f-bb18-58c651bb3536.png">

Clicking on the column header reverses the sort.
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/192618873-f2fc45fb-e1db-44d7-8b8a-7dd669fc2a70.png">

The description and inUse fields follow the same behavior:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/192620008-e06f1b23-98cb-427e-93b1-e6321552787e.png">
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/192620027-25a64417-8a67-470d-a352-f0401ab35d70.png">
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/192620058-2901f163-ff27-4d65-8e44-cfc075f91a75.png">
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/192620074-050686f1-b82b-404c-9149-0d1ff0a323cf.png">

If no results are returned from the server, the sorting functionality of the headers is disabled:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/192620189-a24719b9-72c2-4d3a-a5d3-a4a7de9e161c.png">


