### PR TITLE
ROX-12777: Add feature flag and section of Patternfly Network Graph

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -50,5 +50,5 @@ var (
 	ObjectCollections = registerFeature("Enable object collection entities", "ROX_OBJECT_COLLECTIONS", false)
 
 	// NetworkGraphPatternFly enables the PatternFly version of NetworkGraph. (used in the front-end app only)
-	NetworkGraphPatternFly = registerFeature("Enable PatternFly version of NetworkGraph", "ROX_NETWORK_GRAPH_PATTERNFLY", true)
+	NetworkGraphPatternFly = registerFeature("Enable PatternFly version of NetworkGraph", "ROX_NETWORK_GRAPH_PATTERNFLY", false)
 )

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -48,4 +48,7 @@ var (
 
 	// ObjectCollections enables 'collection' entity APIs and Frontend collection pages
 	ObjectCollections = registerFeature("Enable object collection entities", "ROX_OBJECT_COLLECTIONS", false)
+
+	// NetworkGraphPatternFly enables the PatternFly version of NetworkGraph. (used in the front-end app only)
+	NetworkGraphPatternFly = registerFeature("Enable PatternFly version of NetworkGraph", "ROX_NETWORK_GRAPH_PATTERNFLY", true)
 )

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -6,6 +6,7 @@ import {
     mainPath,
     dashboardPath,
     networkPath,
+    networkPathPF,
     violationsPath,
     compliancePath,
     clustersPathWithParam,
@@ -50,6 +51,9 @@ const AsyncSearchPage = asyncComponent(() => import('Containers/Search/SearchPag
 const AsyncApiDocsPage = asyncComponent(() => import('Containers/Docs/ApiPage'));
 const AsyncDashboardPage = asyncComponent(() => import('Containers/Dashboard/DashboardPage'));
 const AsyncNetworkPage = asyncComponent(() => import('Containers/Network/Page'));
+const AsyncNetworkGraphPage = asyncComponent(
+    () => import('Containers/NetworkGraph/NetworkGraphPage')
+);
 const AsyncClustersPage = asyncComponent(() => import('Containers/Clusters/ClustersPage'));
 const AsyncPFClustersPage = asyncComponent(() => import('Containers/Clusters/PF/ClustersPage'));
 const AsyncIntegrationsPage = asyncComponent(
@@ -96,6 +100,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
     const isSystemHealthPatternFlyEnabled = isFeatureFlagEnabled('ROX_SYSTEM_HEALTH_PF');
     const isSearchPageEnabled = isFeatureFlagEnabled('ROX_SEARCH_PAGE_UI');
     const isCollectionsEnabled = isFeatureFlagEnabled('ROX_OBJECT_COLLECTIONS');
+    const isNetworkGraphPatternflyEnabled = isFeatureFlagEnabled('ROX_NETWORK_GRAPH_PATTERNFLY');
 
     const hasVulnerabilityReportsPermission = hasReadAccess('VulnerabilityReports');
     // TODO Implement permissions once https://issues.redhat.com/browse/ROX-12619 is merged
@@ -113,6 +118,9 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     <Route path={mainPath} exact render={() => <Redirect to={dashboardPath} />} />
                     <Route path={dashboardPath} component={AsyncDashboardPage} />
                     <Route path={networkPath} component={AsyncNetworkPage} />
+                    {isNetworkGraphPatternflyEnabled && (
+                        <Route path={networkPathPF} component={AsyncNetworkGraphPage} />
+                    )}
                     <Route path={violationsPath} component={AsyncViolationsPage} />
                     <Route path={compliancePath} component={AsyncCompliancePage} />
                     <Route path={integrationsPath} component={AsyncIntegrationsPage} />

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -9,6 +9,7 @@ import {
     basePathToLabelMap,
     dashboardPath,
     networkBasePath,
+    networkPathPF,
     violationsBasePath,
     complianceBasePath,
     vulnManagementPath,
@@ -83,6 +84,13 @@ function NavigationSidebar({
                     path={networkBasePath}
                     title={basePathToLabelMap[networkBasePath]}
                 />
+                {isFeatureFlagEnabled('ROX_NETWORK_GRAPH_PATTERNFLY') && (
+                    <LeftNavItem
+                        isActive={location.pathname.includes(networkPathPF)}
+                        path={networkPathPF}
+                        title={basePathToLabelMap[networkPathPF]}
+                    />
+                )}
                 <LeftNavItem
                     isActive={location.pathname.includes(violationsBasePath)}
                     path={violationsBasePath}

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -71,6 +71,11 @@ function NavigationSidebar({
         );
     }
 
+    // TODO remove this temporary extra config menu item when the PF network graph goes live in the main menu
+    if (isFeatureFlagEnabled('ROX_NETWORK_GRAPH_PATTERNFLY')) {
+        platformConfigurationPaths.push(networkPathPF);
+    }
+
     const Navigation = (
         <Nav id="nav-primary-simple">
             <NavList id="nav-list-simple">
@@ -80,17 +85,13 @@ function NavigationSidebar({
                     title={basePathToLabelMap[dashboardPath]}
                 />
                 <LeftNavItem
-                    isActive={location.pathname.includes(networkBasePath)}
+                    isActive={
+                        location.pathname.includes(networkBasePath) &&
+                        !location.pathname.includes(networkPathPF)
+                    }
                     path={networkBasePath}
                     title={basePathToLabelMap[networkBasePath]}
                 />
-                {isFeatureFlagEnabled('ROX_NETWORK_GRAPH_PATTERNFLY') && (
-                    <LeftNavItem
-                        isActive={location.pathname.includes(networkPathPF)}
-                        path={networkPathPF}
-                        title={basePathToLabelMap[networkPathPF]}
-                    />
-                )}
                 <LeftNavItem
                     isActive={location.pathname.includes(violationsBasePath)}
                     path={violationsBasePath}

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { PageSection, Title, Flex, FlexItem } from '@patternfly/react-core';
+
+import PageTitle from 'Components/PageTitle';
+
+function NetworkGraphPage() {
+    return (
+        <>
+            <PageTitle title="Network Graph" />
+            <PageSection variant="light">
+                <Flex alignItems={{ default: 'alignItemsCenter' }}>
+                    <FlexItem flex={{ default: 'flex_1' }}>
+                        <Title headingLevel="h1">Network Graph</Title>
+                    </FlexItem>
+                </Flex>
+            </PageSection>
+        </>
+    );
+}
+
+export default NetworkGraphPage;

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -12,6 +12,7 @@ export const authResponsePrefix = '/auth/response/';
 export const dashboardPath = `${mainPath}/dashboard`;
 export const networkBasePath = `${mainPath}/network`;
 export const networkPath = `${networkBasePath}/:deploymentId?/:externalType?`;
+export const networkPathPF = `${mainPath}/network-graph`;
 export const violationsBasePath = `${mainPath}/violations`;
 export const violationsPath = `${violationsBasePath}/:alertId?`;
 export const clustersBasePath = `${mainPath}/clusters`;
@@ -146,6 +147,7 @@ const vulnManagementPathToLabelMap = {
 export const basePathToLabelMap = {
     [dashboardPath]: 'Dashboard',
     [networkBasePath]: 'Network Graph',
+    [networkPathPF]: 'Network Graph-Patterfly',
     [violationsBasePath]: 'Violations',
     [complianceBasePath]: 'Compliance',
     ...vulnManagementPathToLabelMap,

--- a/ui/apps/platform/src/types/featureFlag.ts
+++ b/ui/apps/platform/src/types/featureFlag.ts
@@ -10,4 +10,5 @@ export type FeatureFlagEnvVar =
     | 'ROX_SEARCH_PAGE_UI'
     | 'ROX_SYSTEM_HEALTH_PF'
     | 'ROX_FRONTEND_VM_UPDATES'
+    | 'ROX_NETWORK_GRAPH_PATTERNFLY'
     ;


### PR DESCRIPTION
## Description

- Adds feature flag for PatternFly version
- Creates page at `main/network-graph` for the PatternFly version
- Adds a Network Graph - PatternFly menu item to the Platform Configuration sub-menu, to make it easier for non-technicals (aka "normies") to see progress and compare to existing Network page


## Checklist
- [x] Investigated and inspected CI test results
- [-] Unit test and regression tests added (next PR)

## Testing Performed

Manual testing so far, with flag off and on

<img width="1644" alt="Screen Shot 2022-09-26 at 10 58 10 AM" src="https://user-images.githubusercontent.com/715729/192322073-2de35d1c-bdb4-4e95-b2ff-23d94103bacd.png">
