### PR TITLE
Add protobuf format to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,6 @@
 [{Makefile,**.mk}]
 indent_style = tab
+
+[**.proto]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
## Description

Adds `.editorconfig` formatting for protobuf files.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))


## Testing Performed

- Used in #3179 
