### PR TITLE
ROX-12272: Don't allow auto-upgrades in managed centrals

### DIFF
--- a/central/sensorupgradeconfig/datastore/datastore_impl.go
+++ b/central/sensorupgradeconfig/datastore/datastore_impl.go
@@ -2,11 +2,13 @@ package datastore
 
 import (
 	"context"
+	"github.com/pkg/errors"
 
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/central/sensorupgradeconfig/datastore/internal/store"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sac"
 )
 
@@ -18,6 +20,7 @@ type dataStore struct {
 
 var (
 	sacHelper = sac.ForResource(resources.SensorUpgradeConfig)
+	ErrAutoUpgradeNotAllowed = errors.New("auto-upgrade not allowed on managed central")
 )
 
 func (d *dataStore) initialize() error {
@@ -49,6 +52,10 @@ func (d *dataStore) UpsertSensorUpgradeConfig(ctx context.Context, sensorUpgrade
 		return err
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
+	}
+
+	if env.ManagedCentral.BooleanSetting() && sensorUpgradeConfig.EnableAutoUpgrade {
+		return ErrAutoUpgradeNotAllowed
 	}
 
 	if err := d.store.Upsert(ctx, sensorUpgradeConfig); err != nil {

--- a/central/sensorupgradeconfig/datastore/datastore_impl.go
+++ b/central/sensorupgradeconfig/datastore/datastore_impl.go
@@ -2,8 +2,8 @@ package datastore
 
 import (
 	"context"
-	"github.com/pkg/errors"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/central/sensorupgradeconfig/datastore/internal/store"
 	"github.com/stackrox/rox/generated/storage"
@@ -20,7 +20,6 @@ type dataStore struct {
 
 var (
 	sacHelper = sac.ForResource(resources.SensorUpgradeConfig)
-	ErrAutoUpgradeNotAllowed = errors.New("auto-upgrade not allowed on managed central")
 )
 
 func (d *dataStore) initialize() error {
@@ -55,7 +54,7 @@ func (d *dataStore) UpsertSensorUpgradeConfig(ctx context.Context, sensorUpgrade
 	}
 
 	if env.ManagedCentral.BooleanSetting() && sensorUpgradeConfig.EnableAutoUpgrade {
-		return ErrAutoUpgradeNotAllowed
+		return errors.New("auto-upgrade not allowed on managed central")
 	}
 
 	if err := d.store.Upsert(ctx, sensorUpgradeConfig); err != nil {

--- a/central/sensorupgradeconfig/datastore/datastore_impl.go
+++ b/central/sensorupgradeconfig/datastore/datastore_impl.go
@@ -53,7 +53,7 @@ func (d *dataStore) UpsertSensorUpgradeConfig(ctx context.Context, sensorUpgrade
 		return sac.ErrResourceAccessDenied
 	}
 
-	if env.ManagedCentral.BooleanSetting() && sensorUpgradeConfig.EnableAutoUpgrade {
+	if env.ManagedCentral.BooleanSetting() && sensorUpgradeConfig.GetEnableAutoUpgrade() {
 		return errors.New("auto-upgrade not allowed on managed central")
 	}
 

--- a/central/sensorupgradeconfig/datastore/datastore_test.go
+++ b/central/sensorupgradeconfig/datastore/datastore_test.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -9,6 +10,7 @@ import (
 	storeMocks "github.com/stackrox/rox/central/sensorupgradeconfig/datastore/internal/store/mocks"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/testutils/envisolator"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -29,6 +31,8 @@ type sensorUpgradeConfigDataStoreTestSuite struct {
 	storage   *storeMocks.MockStore
 
 	mockCtrl *gomock.Controller
+
+	envIsolator *envisolator.EnvIsolator
 }
 
 func (s *sensorUpgradeConfigDataStoreTestSuite) SetupTest() {
@@ -52,10 +56,13 @@ func (s *sensorUpgradeConfigDataStoreTestSuite) SetupTest() {
 	var err error
 	s.dataStore, err = New(s.storage)
 	s.Require().NoError(err)
+
+	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 }
 
 func (s *sensorUpgradeConfigDataStoreTestSuite) TearDownTest() {
 	s.mockCtrl.Finish()
+	s.envIsolator.RestoreAll()
 }
 
 func (s *sensorUpgradeConfigDataStoreTestSuite) TestEnforcesGet() {
@@ -102,8 +109,18 @@ func (s *sensorUpgradeConfigDataStoreTestSuite) TestAllowsUpdate() {
 }
 
 func (s *sensorUpgradeConfigDataStoreTestSuite) TestDefault() {
-	s.storage.EXPECT().Get(gomock.Any()).Return(nil, false, nil)
-	s.storage.EXPECT().Upsert(gomock.Any(), upgradeConfig(true)).Return(nil)
+	testCases := map[string]struct{
+		env bool
+		expectedAutoUpgradeFlag bool
+	}{
+		"ROX_MANAGED_CENTRAL=true":  { true, false },
+		"ROX_MANAGED_CENTRAL=false": { false, true },
+	}
 
-	s.Require().NoError(addDefaultConfigIfEmpty(s.dataStore))
+	for _, testCase := range testCases {
+		s.envIsolator.Setenv("ROX_MANAGED_CENTRAL", strconv.FormatBool(testCase.env))
+		s.storage.EXPECT().Get(gomock.Any()).Return(nil, false, nil)
+		s.storage.EXPECT().Upsert(gomock.Any(), gomock.Eq(upgradeConfig(testCase.expectedAutoUpgradeFlag))).Return(nil)
+		s.Require().NoError(addDefaultConfigIfEmpty(s.dataStore))
+	}
 }

--- a/central/sensorupgradeconfig/datastore/datastore_test.go
+++ b/central/sensorupgradeconfig/datastore/datastore_test.go
@@ -109,12 +109,12 @@ func (s *sensorUpgradeConfigDataStoreTestSuite) TestAllowsUpdate() {
 }
 
 func (s *sensorUpgradeConfigDataStoreTestSuite) TestDefault() {
-	testCases := map[string]struct{
-		env bool
+	testCases := map[string]struct {
+		env                     bool
 		expectedAutoUpgradeFlag bool
 	}{
-		"ROX_MANAGED_CENTRAL=true":  { true, false },
-		"ROX_MANAGED_CENTRAL=false": { false, true },
+		"ROX_MANAGED_CENTRAL=true":  {true, false},
+		"ROX_MANAGED_CENTRAL=false": {false, true},
 	}
 
 	for _, testCase := range testCases {

--- a/central/sensorupgradeconfig/datastore/datastore_test.go
+++ b/central/sensorupgradeconfig/datastore/datastore_test.go
@@ -103,7 +103,7 @@ func (s *sensorUpgradeConfigDataStoreTestSuite) TestAllowsUpdate() {
 
 func (s *sensorUpgradeConfigDataStoreTestSuite) TestDefault() {
 	s.storage.EXPECT().Get(gomock.Any()).Return(nil, false, nil)
-	s.storage.EXPECT().Upsert(gomock.Any(), defaultConfig).Return(nil)
+	s.storage.EXPECT().Upsert(gomock.Any(), upgradeConfig(true)).Return(nil)
 
 	s.Require().NoError(addDefaultConfigIfEmpty(s.dataStore))
 }

--- a/central/sensorupgradeconfig/datastore/singleton.go
+++ b/central/sensorupgradeconfig/datastore/singleton.go
@@ -20,11 +20,11 @@ var (
 	singleton DataStore
 )
 
-var (
-	defaultConfig = &storage.SensorUpgradeConfig{
-		EnableAutoUpgrade: true,
+func upgradeConfig(autoUpgrade bool) *storage.SensorUpgradeConfig {
+	return &storage.SensorUpgradeConfig{
+		EnableAutoUpgrade: autoUpgrade,
 	}
-)
+}
 
 func addDefaultConfigIfEmpty(d DataStore) error {
 	ctx := sac.WithAllAccess(context.Background())
@@ -35,7 +35,9 @@ func addDefaultConfigIfEmpty(d DataStore) error {
 	if currentConfig != nil {
 		return nil
 	}
-	return d.UpsertSensorUpgradeConfig(ctx, defaultConfig)
+
+	// Auto upgrade is disabled by default if managed central flag is set
+	return d.UpsertSensorUpgradeConfig(ctx, upgradeConfig(!env.ManagedCentral.BooleanSetting()))
 }
 
 func initialize() {

--- a/central/sensorupgradeconfig/datastore/singleton.go
+++ b/central/sensorupgradeconfig/datastore/singleton.go
@@ -32,7 +32,7 @@ func addDefaultConfigIfEmpty(d DataStore) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to check initial sensor upgrade config")
 	}
-	if currentConfig != nil {
+	if currentConfig != nil && (!env.ManagedCentral.BooleanSetting() || !currentConfig.GetEnableAutoUpgrade()) {
 		return nil
 	}
 


### PR DESCRIPTION
## Description

This PR disables auto-upgrades for any sensor connected to a managed central.

1. Toggle is disabled by default
2. API rejects request that tries to set it to true if `ROX_MANAGED_CENTRAL` is set

There's a possible UX discussion here. The problem is that in a MS scenario, central version will most likely always be *higher* than sensor. Therefore, there will be a period, after upgrading managed centrals and before releasing the image for sensors to be upgraded, where we identify that a manual upgrade is required, but there's no image available for sensor's to be upgraded to. Probably for limited availability won't be an issue. 

Additionally, we could disable the toggle in the Front-End on a managed central. Because even though it's enabled the auto-upgrade will not be triggered and the warning will be present (covered in #3331)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

When on managed centrals, the toggle won't be allowed to be set since the request returns 500:

```json
{
   "error":"auto-upgrade not allowed on managed central",
   "code":13,
   "message":"auto-upgrade not allowed on managed central",
   "details":[]
}
```

https://user-images.githubusercontent.com/6811076/194374104-905392b3-a9c3-4ad3-bfac-2167c83f7318.mov

