### PR TITLE
ROX-12826: Improve sensor integration tests to remove `time.Sleep`

### DIFF
--- a/sensor/tests/resource/helper.go
+++ b/sensor/tests/resource/helper.go
@@ -40,7 +40,7 @@ import (
 )
 
 const (
-	// DefaultNamespace - the default namespace used to create the resources
+	// DefaultNamespace the default namespace used to create the resources
 	DefaultNamespace string = "sensor-integration"
 )
 
@@ -74,10 +74,13 @@ func objByKind(kind string) k8s.Object {
 	}
 }
 
-// TestCallback the test callback
+// TestCallback represents the test case function written in the go test file.
 type TestCallback func(t *testing.T, testContext *TestContext, objects map[string]k8s.Object)
 
-// TestContext the test context
+// TestContext holds all the information about the cluster and sensor under test. A TestContext represents
+// a test case run where the input is a set of resources applied to the cluster and the output is a set of
+// messages emitted by Sensor. Each Go test should use a single TestContext instance to manage cluster interaction
+// and assertions.
 type TestContext struct {
 	t               *testing.T
 	r               *resources.Resources
@@ -100,12 +103,12 @@ func defaultCentralConfig() CentralConfig {
 	}
 }
 
-// NewContext creates a new test context
+// NewContext creates a new test context with default configuration.
 func NewContext(t *testing.T) (*TestContext, error) {
 	return NewContextWithConfig(t, defaultCentralConfig())
 }
 
-// NewContextWithConfig creates a new test context with custom central configuration
+// NewContextWithConfig creates a new test context with custom central configuration.
 func NewContextWithConfig(t *testing.T, config CentralConfig) (*TestContext, error) {
 	envConfig := envconf.New().WithKubeconfigFile(conf.ResolveKubeConfigFile())
 	r, err := resources.New(envConfig.Client().RESTConfig())
@@ -124,12 +127,12 @@ func NewContextWithConfig(t *testing.T, config CentralConfig) (*TestContext, err
 	}, nil
 }
 
-// Stop - stop the test
+// Stop test context and sensor.
 func (c *TestContext) Stop() {
 	c.stopFn()
 }
 
-// Resources - test resources
+// Resources object is used to interact with the cluster and apply new resources.
 func (c *TestContext) Resources() *resources.Resources {
 	return c.r
 }
@@ -154,12 +157,12 @@ func createTestNs(ctx context.Context, r *resources.Resources, name string) (*v1
 	}, nil
 }
 
-// GetFakeCentral - gets a fake central
+// GetFakeCentral gets a fake central instance. This is used to fetch messages sent by sensor under test.
 func (c *TestContext) GetFakeCentral() *centralDebug.FakeService {
 	return c.fakeCentral
 }
 
-// RunWithResources - runs with resources
+// RunWithResources runs the test case applying files in `files` slice in order.
 func (c *TestContext) RunWithResources(files []YamlTestFile, testCase TestCallback) {
 	_, removeNamespace, err := createTestNs(context.Background(), c.r, DefaultNamespace)
 	defer utils.IgnoreError(removeNamespace)
@@ -185,7 +188,7 @@ func (c *TestContext) RunWithResources(files []YamlTestFile, testCase TestCallba
 	testCase(c.t, c, fileToObj)
 }
 
-// RunBare - runs bare
+// RunBare runs a test case without applying any resources to the cluster.
 func (c *TestContext) RunBare(name string, testCase TestCallback) {
 	c.t.Run(name, func(t *testing.T) {
 		_, removeNamespace, err := createTestNs(context.Background(), c.r, DefaultNamespace)
@@ -197,7 +200,8 @@ func (c *TestContext) RunBare(name string, testCase TestCallback) {
 	})
 }
 
-// RunWithResourcesPermutation - runs with resource permutation
+// RunWithResourcesPermutation runs the test cases using `files` similarly to `RunWithResources` but it will run the
+// test case for each possible permutation of `files` slice.
 func (c *TestContext) RunWithResourcesPermutation(files []YamlTestFile, name string, testCase TestCallback) {
 	runPermutation(files, 0, func(f []YamlTestFile) {
 		newF := make([]YamlTestFile, len(f))
@@ -229,12 +233,16 @@ func runPermutation(files []YamlTestFile, i int, cb func([]YamlTestFile)) {
 	}
 }
 
+// AssertFunc is the deployment state assertion function signature.
 type AssertFunc func(deployment *storage.Deployment) bool
 
+// LastDeploymentState checks the deployment state similarly to `LastDeploymentStateWithTimeout` with a default 3 seconds timeout.
 func (c *TestContext) LastDeploymentState(name string, assertion AssertFunc, message string) {
 	c.LastDeploymentStateWithTimeout(name, assertion, message, 3*time.Second)
 }
 
+// LastDeploymentStateWithTimeout checks that a deployment reaches a state asserted by `assertion`. If the deployment does not reach
+// that state until `timeout` the test fails.
 func (c *TestContext) LastDeploymentStateWithTimeout(name string, assertion AssertFunc, message string, timeout time.Duration) {
 	timer := time.NewTimer(timeout)
 	for {
@@ -253,13 +261,17 @@ func (c *TestContext) LastDeploymentStateWithTimeout(name string, assertion Asse
 	}
 }
 
+// AlertAssertFunc is the alert assertion function signature.
 type AlertAssertFunc func(alertResults *central.AlertResults) bool
 
+// LastViolationState checks the violation state similarly to `LastViolationStateWithTimeout` with a default 3 seconds timeout.
 func (c *TestContext) LastViolationState(name string, assertion AlertAssertFunc, message string) {
-	c.LastViolationStateForDeployment(name, assertion, message, 3 * time.Second)
+	c.LastViolationStateWithTimeout(name, assertion, message, 3*time.Second)
 }
 
-func (c *TestContext) LastViolationStateForDeployment(name string, assertion AlertAssertFunc, message string, timeout time.Duration) {
+// LastViolationStateWithTimeout checks that a violation state for a deployment must match `assertion`. If violation state does not match
+// until `timeout` the test fails.
+func (c *TestContext) LastViolationStateWithTimeout(name string, assertion AlertAssertFunc, message string, timeout time.Duration) {
 	timer := time.NewTimer(timeout)
 	for {
 		select {
@@ -281,6 +293,7 @@ func (c *TestContext) LastViolationStateForDeployment(name string, assertion Ale
 
 }
 
+// GetAllAlertsForDeploymentName filters sensor messages and gets all alerts for a deployment with `name`
 func GetAllAlertsForDeploymentName(messages []*central.MsgFromSensor, name string) []*central.MsgFromSensor {
 	var selected []*central.MsgFromSensor
 	for _, m := range messages {
@@ -420,7 +433,7 @@ func (c *TestContext) waitForResource(timeout time.Duration, fn condition) error
 	}
 }
 
-// GetLastMessageWithDeploymentName - gets the last message by deployment name
+// GetLastMessageWithDeploymentName find most recent sensor messages by namespace and deployment name
 func GetLastMessageWithDeploymentName(messages []*central.MsgFromSensor, ns, name string) *central.MsgFromSensor {
 	var lastMessage *central.MsgFromSensor
 	for i := len(messages) - 1; i >= 0; i-- {
@@ -433,7 +446,7 @@ func GetLastMessageWithDeploymentName(messages []*central.MsgFromSensor, ns, nam
 	return lastMessage
 }
 
-// GetLastAlertsWithDeploymentID - gets the last AlertResults by deployment ID
+// GetLastAlertsWithDeploymentID find most recent alert message by deployment ID
 func GetLastAlertsWithDeploymentID(messages []*central.MsgFromSensor, id string) *central.MsgFromSensor {
 	var lastMessage *central.MsgFromSensor
 	for i := len(messages) - 1; i >= 0; i-- {
@@ -445,7 +458,7 @@ func GetLastAlertsWithDeploymentID(messages []*central.MsgFromSensor, id string)
 	return lastMessage
 }
 
-// GetUniquePodNamesFromPrefix - gets unique pod names by prefix
+// GetUniquePodNamesFromPrefix find all unique pod names from sensor events
 func GetUniquePodNamesFromPrefix(messages []*central.MsgFromSensor, ns, prefix string) []string {
 	uniqueNames := set.NewStringSet()
 	for _, msg := range messages {
@@ -459,7 +472,7 @@ func GetUniquePodNamesFromPrefix(messages []*central.MsgFromSensor, ns, prefix s
 	return uniqueNames.AsSlice()
 }
 
-// GetUniqueDeploymentNames - gets unique deployment names
+// GetUniqueDeploymentNames find all unique deployment names from sensor events
 func GetUniqueDeploymentNames(messages []*central.MsgFromSensor, ns string) []string {
 	uniqueNames := set.NewStringSet()
 	for _, msg := range messages {

--- a/sensor/tests/resource/networkpolicy/networkpolicy_test.go
+++ b/sensor/tests/resource/networkpolicy/networkpolicy_test.go
@@ -74,4 +74,3 @@ func (s *NetworkPolicySuite) Test_DeploymentShouldHaveViolation() {
 		}, "Should have a violation")
 	})
 }
-

--- a/sensor/tests/resource/networkpolicy/networkpolicy_test.go
+++ b/sensor/tests/resource/networkpolicy/networkpolicy_test.go
@@ -43,6 +43,10 @@ var (
 )
 
 func checkIfAlertsHaveViolation(result *central.AlertResults, name string) bool {
+	if result == nil {
+		return false
+	}
+
 	alerts := result.GetAlerts()
 	if len(alerts) == 0 {
 		return false
@@ -59,6 +63,10 @@ func (s *NetworkPolicySuite) Test_DeploymentShouldNotHaveViolation() {
 	s.testContext.RunWithResources([]resource.YamlTestFile{
 		NginxDeployment, NetpolAllow443,
 	}, func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
+		// There's a caveat to this test: the state HAS a violation at the beginning, but
+		// it disappears once re-sync kicks-in and processes the relationship betwee the network policy
+		// and this deployment. Therefore, this test passes as is, but the opposite assertion would also
+		// pass. e.g. "check if there IS an alert", because there will be a state where the alert is there.
 		testC.LastViolationState("nginx-deployment", func(result *central.AlertResults) bool {
 			return !checkIfAlertsHaveViolation(result, ingressNetpolViolationName)
 		}, "Should not have a violation")

--- a/sensor/tests/resource/role/role_test.go
+++ b/sensor/tests/resource/role/role_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/tests/resource"
@@ -44,8 +45,11 @@ func (s *RoleDependencySuite) SetupSuite() {
 }
 
 func assertPermissionLevel(permissionLevel storage.PermissionLevel) resource.AssertFunc {
-	return func(deployment *storage.Deployment) bool {
-		return deployment.ServiceAccountPermissionLevel == permissionLevel
+	return func(deployment *storage.Deployment) error {
+		if deployment.ServiceAccountPermissionLevel != permissionLevel {
+			return errors.Errorf("expected permission level %s but found %s", permissionLevel, deployment.ServiceAccountPermissionLevel)
+		}
+		return nil
 	}
 
 }

--- a/sensor/tests/resource/role/role_test.go
+++ b/sensor/tests/resource/role/role_test.go
@@ -58,10 +58,9 @@ func (s *RoleDependencySuite) Test_PermutationTest() {
 			NginxRole,
 			NginxRoleBinding,
 		}, "Role Dependency", func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
-			testC.LastDeploymentStateWithTimeout("nginx-deployment",
+			testC.LastDeploymentState("nginx-deployment",
 				assertPermissionLevel(storage.PermissionLevel_ELEVATED_IN_NAMESPACE),
-				"Permission level has to be elevated in namespace",
-				3*time.Second)
+				"Permission level has to be elevated in namespace")
 			testC.GetFakeCentral().ClearReceivedBuffer()
 		},
 	)

--- a/sensor/tests/resource/role/role_test.go
+++ b/sensor/tests/resource/role/role_test.go
@@ -2,15 +2,12 @@ package role
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/tests/resource"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
@@ -21,29 +18,6 @@ var (
 	NginxRole        = resource.YamlTestFile{Kind: "Role", File: "nginx-role.yaml"}
 	NginxRoleBinding = resource.YamlTestFile{Kind: "Binding", File: "nginx-binding.yaml"}
 )
-
-func GetLastMessageWithDeploymentName(messages []*central.MsgFromSensor, n string) *central.MsgFromSensor {
-	var lastMessage *central.MsgFromSensor
-	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].GetEvent().GetDeployment().GetName() == n {
-			lastMessage = messages[i]
-			break
-		}
-	}
-	return lastMessage
-}
-
-func assertLastDeploymentHasPermissionLevel(t *testing.T, messages []*central.MsgFromSensor, permissionLevel storage.PermissionLevel) {
-	lastNginxDeploymentUpdate := GetLastMessageWithDeploymentName(messages, "nginx-deployment")
-	require.NotNil(t, lastNginxDeploymentUpdate, "should have found a message for nginx-deployment")
-	deployment := lastNginxDeploymentUpdate.GetEvent().GetDeployment()
-	assert.Equal(
-		t,
-		deployment.ServiceAccountPermissionLevel,
-		permissionLevel,
-		fmt.Sprintf("permission level has to be %s", permissionLevel),
-	)
-}
 
 type RoleDependencySuite struct {
 	testContext *resource.TestContext
@@ -70,6 +44,13 @@ func (s *RoleDependencySuite) SetupSuite() {
 	}
 }
 
+func assertPermissionLevel(permissionLevel storage.PermissionLevel) resource.AssertFunc {
+	return func(deployment *storage.Deployment) bool {
+		return deployment.ServiceAccountPermissionLevel == permissionLevel
+	}
+
+}
+
 func (s *RoleDependencySuite) Test_PermutationTest() {
 	s.testContext.RunWithResourcesPermutation(
 		[]resource.YamlTestFile{
@@ -77,13 +58,10 @@ func (s *RoleDependencySuite) Test_PermutationTest() {
 			NginxRole,
 			NginxRoleBinding,
 		}, "Role Dependency", func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
-			// Test context already takes care of creating and destroying resources
-			time.Sleep(2 * time.Second)
-			assertLastDeploymentHasPermissionLevel(
-				t,
-				testC.GetFakeCentral().GetAllMessages(),
-				storage.PermissionLevel_ELEVATED_IN_NAMESPACE,
-			)
+			testC.LastDeploymentStateWithTimeout("nginx-deployment",
+				assertPermissionLevel(storage.PermissionLevel_ELEVATED_IN_NAMESPACE),
+				"Permission level has to be elevated in namespace",
+				3*time.Second)
 			testC.GetFakeCentral().ClearReceivedBuffer()
 		},
 	)
@@ -95,13 +73,9 @@ func (s *RoleDependencySuite) Test_PermissionLevelIsNone() {
 			NginxDeployment,
 			NginxRole,
 		}, func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
-			// Test context already takes care of creating and destroying resources
-			time.Sleep(2 * time.Second)
-			assertLastDeploymentHasPermissionLevel(
-				t,
-				testC.GetFakeCentral().GetAllMessages(),
-				storage.PermissionLevel_NONE,
-			)
+			testC.LastDeploymentState("nginx-deployment",
+				assertPermissionLevel(storage.PermissionLevel_NONE),
+				"Permission level has to be none if role binding is missing")
 			testC.GetFakeCentral().ClearReceivedBuffer()
 		})
 }
@@ -121,27 +95,17 @@ func (s *RoleDependencySuite) Test_MultipleDeploymentUpdates() {
 		defer utils.IgnoreError(deleteRole)
 		require.NoError(t, err)
 
-		// Wait because of re-sync
-		time.Sleep(3 * time.Second)
-
-		assertLastDeploymentHasPermissionLevel(
-			t,
-			testC.GetFakeCentral().GetAllMessages(),
-			storage.PermissionLevel_ELEVATED_IN_NAMESPACE,
-		)
+		testC.LastDeploymentState("nginx-deployment",
+			assertPermissionLevel(storage.PermissionLevel_ELEVATED_IN_NAMESPACE),
+			"Permission level has to be elevated in namespace")
 		testC.GetFakeCentral().ClearReceivedBuffer()
 
 		utils.IgnoreError(deleteRole)
 		utils.IgnoreError(deleteRoleBinding)
 
-		// Wait because of re-sync
-		time.Sleep(3 * time.Second)
-
-		assertLastDeploymentHasPermissionLevel(
-			t,
-			testC.GetFakeCentral().GetAllMessages(),
-			storage.PermissionLevel_NONE,
-		)
+		testC.LastDeploymentState("nginx-deployment",
+			assertPermissionLevel(storage.PermissionLevel_NONE),
+			"Permission level has to be none after deleting role and binding")
 		testC.GetFakeCentral().ClearReceivedBuffer()
 	})
 }

--- a/sensor/tests/resource/role/role_test.go
+++ b/sensor/tests/resource/role/role_test.go
@@ -3,7 +3,6 @@ package role
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/utils"


### PR DESCRIPTION
## Description

We wanted for a while to remove the `time.Sleep` call in sensor integration tests to reduce the possible flakiness to it. 

This PR introduces a new set of functions `LastDeploymentState` and `LastViolationStateForDeployment` that will try an assertion multiple times until it times-out. 

The problem was originally pointed out by @porridge during the show-and-tell presentation. 

Previously, a test was written as:
```go
time.Sleep(2 * time.Second)
lastNginxDeploymentUpdate := GetLastMessageWithDeploymentName(messages, "nginx-deployment")
deployment := lastNginxDeploymentUpdate.GetEvent().GetDeployment()
assert.Equal(
		t,
		deployment.ServiceAccountPermissionLevel,
		storage.PermissionLevel_ELEVATED_IN_NAMESPACE,
		fmt.Sprintf("permission level has to be %s", storage.PermissionLevel_ELEVATED_IN_NAMESPACE),
)
```
Now can be written as:
```go
testC.LastDeploymentState("nginx-deployment",
        func(deployment *storage.Deployment) bool {
		return deployment.ServiceAccountPermissionLevel == storage.PermissionLevel_ELEVATED_IN_NAMESPACE
	},
	"Permission level has to be elevated in namespace")
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- Current sensor integration tests ran with new code. 