### PR TITLE
ROX-12823: Fix links in Most Common Image Vulnerabilities

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabilities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabilities.js
@@ -49,13 +49,15 @@ const MOST_COMMON_IMAGE_VULNERABILITIES = gql`
     }
 `;
 
-const processData = (data, workflowState) => {
+const processData = (data, workflowState, showVMUpdates) => {
     // @TODO: filter on the client side until multiple sorts, including derived fields, is supported by BE
     const results = sortBy(data.results, ['cvss']);
 
+    const cveType = showVMUpdates ? entityTypes.IMAGE_CVE : entityTypes.CVE;
+
     return results.map((vuln) => {
         const { id, cve, cvss, scoreVersion, isFixable, deploymentCount } = vuln;
-        const url = workflowState.pushRelatedEntity(entityTypes.CVE, id).toUrl();
+        const url = workflowState.pushRelatedEntity(cveType, id).toUrl();
         const tooltip = getTooltip(vuln);
 
         return {
@@ -110,7 +112,7 @@ const MostCommonVulnerabilities = ({ entityContext, search, limit }) => {
 
             content = <NoResultsMessage message={parsedMessage} className="p-3" icon="warn" />;
         } else {
-            const processedData = processData(data, workflowState);
+            const processedData = processData(data, workflowState, showVMUpdates);
             if (!processedData || processedData.length === 0) {
                 content = (
                     <NoResultsMessage


### PR DESCRIPTION
## Description

Problem addressed:
- On Vulnerability Management Dashboard, in a Postgres environment, click a link in Most Common Image Vulnerabilities.
- See that the link URL is still trying to go to the old CVE type, `/cve/...`, instead of to the new IMAGE_CVE type, `image-cve`

This change makes those links conditional on whether you are in a Postgres environment or not.


## Checklist
- [ ] Investigated and inspected CI test results
- [-] Unit test and regression tests added (@pedrottimark is fixing the skipped tests that caused us to miss this problem, in another PR)


## Testing Performed

Before
<img width="1445" alt="Screen Shot 2022-09-26 at 4 03 04 PM" src="https://user-images.githubusercontent.com/715729/192528035-44ef440b-5b52-400b-aad2-87587326d599.png">


After
<img width="1644" alt="Screen Shot 2022-09-26 at 4 57 15 PM" src="https://user-images.githubusercontent.com/715729/192528050-8052064f-7e53-4afa-966f-639d30a8683c.png">
