### PR TITLE
Implement toolbar with search and pagination for collections table.

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -101,7 +101,12 @@ function CollectionsTable({
                             page={page}
                             perPage={perPage}
                             onSetPage={(_, newPage) => setPage(newPage)}
-                            onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                            onPerPageSelect={(_, newPerPage) => {
+                                if (collectionsCount < (page - 1) * newPerPage) {
+                                    setPage(1);
+                                }
+                                setPerPage(newPerPage);
+                            }}
                         />
                     </ToolbarItem>
                 </ToolbarContent>

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -1,16 +1,16 @@
 import React, { useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
+    Bullseye,
+    Button,
+    ButtonVariant,
+    Pagination,
+    SearchInput,
+    Text,
     Toolbar,
     ToolbarContent,
     ToolbarItem,
-    Pagination,
-    Button,
-    ButtonVariant,
     Truncate,
-    SearchInput,
-    Bullseye,
-    Text,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
@@ -35,8 +35,7 @@ export type CollectionsTableProps = {
     hasWriteAccess: boolean;
 };
 
-// TODO We are using this value elsewhere in the app - extract to a central location?
-const TYPING_DELAY = 800;
+const SEARCH_INPUT_REQUEST_DELAY = 800;
 
 function CollectionsTable({
     collections,
@@ -71,7 +70,11 @@ function CollectionsTable({
     }
 
     const onSearchInputChange = useMemo(
-        () => debounce((value: string) => setSearchFilter({ Collection: value }), TYPING_DELAY),
+        () =>
+            debounce(
+                (value: string) => setSearchFilter({ Collection: value }),
+                SEARCH_INPUT_REQUEST_DELAY
+            ),
         [setSearchFilter]
     );
 
@@ -86,7 +89,7 @@ function CollectionsTable({
                     <ToolbarItem variant="search-filter" className="pf-u-flex-grow-1">
                         <SearchInput
                             aria-label="Search by name"
-                            placeholder="Search by name..."
+                            placeholder="Search by name"
                             value={searchValue}
                             onChange={onSearchInputChange}
                         />

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -78,6 +78,9 @@ function CollectionsTable({
         [setSearchFilter]
     );
 
+    // Currently, it is not expected that the value of `searchFilter.Collection` will
+    // be an array even though it would valid. This is a safeguard for future code
+    // changes that might change this assumption.
     const searchValue = Array.isArray(searchFilter.Collection)
         ? searchFilter.Collection.join('+')
         : searchFilter.Collection;

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -1,24 +1,54 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Button, ButtonVariant, Truncate, Bullseye, Text } from '@patternfly/react-core';
+import {
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+    Pagination,
+    Button,
+    ButtonVariant,
+    Truncate,
+    SearchInput,
+    Bullseye,
+    Text,
+} from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import debounce from 'lodash/debounce';
 
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import useTableSelection from 'hooks/useTableSelection';
-import { CollectionResponse } from 'services/CollectionsService';
+import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import { GetSortParams } from 'hooks/useURLSort';
+import { CollectionResponse } from 'services/CollectionsService';
+import { SearchFilter } from 'types/search';
 import { collectionsPath } from 'routePaths';
 
 export type CollectionsTableProps = {
     collections: CollectionResponse[];
+    collectionsCount: number;
+    pagination: UseURLPaginationResult;
+    searchFilter: SearchFilter;
+    setSearchFilter: (searchFilter: SearchFilter) => void;
     getSortParams: GetSortParams;
     hasWriteAccess: boolean;
 };
 
-function CollectionsTable({ collections, getSortParams, hasWriteAccess }: CollectionsTableProps) {
+// TODO We are using this value elsewhere in the app - extract to a central location?
+const TYPING_DELAY = 800;
+
+function CollectionsTable({
+    collections,
+    collectionsCount,
+    pagination,
+    searchFilter,
+    setSearchFilter,
+    getSortParams,
+    hasWriteAccess,
+}: CollectionsTableProps) {
     const history = useHistory();
+    const { page, perPage, setPage, setPerPage } = pagination;
     const { selected, allRowsSelected, onSelect, onSelectAll } = useTableSelection(collections);
     const hasCollections = collections.length > 0;
 
@@ -40,8 +70,39 @@ function CollectionsTable({ collections, getSortParams, hasWriteAccess }: Collec
         });
     }
 
+    const onSearchInputChange = useMemo(
+        () => debounce((value: string) => setSearchFilter({ Collection: value }), TYPING_DELAY),
+        [setSearchFilter]
+    );
+
+    const searchValue = Array.isArray(searchFilter.Collection)
+        ? searchFilter.Collection.join('+')
+        : searchFilter.Collection;
+
     return (
         <>
+            <Toolbar>
+                <ToolbarContent>
+                    <ToolbarItem variant="search-filter" className="pf-u-flex-grow-1">
+                        <SearchInput
+                            aria-label="Search by name"
+                            placeholder="Search by name..."
+                            value={searchValue}
+                            onChange={onSearchInputChange}
+                        />
+                    </ToolbarItem>
+                    <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>
+                        <Pagination
+                            isCompact
+                            itemCount={collectionsCount}
+                            page={page}
+                            perPage={perPage}
+                            onSetPage={(_, newPage) => setPage(newPage)}
+                            onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                        />
+                    </ToolbarItem>
+                </ToolbarContent>
+            </Toolbar>
             <TableComposable variant={TableVariant.compact}>
                 <Thead>
                     <Tr>
@@ -76,7 +137,7 @@ function CollectionsTable({ collections, getSortParams, hasWriteAccess }: Collec
                                         icon={SearchIcon}
                                     >
                                         <Text>Clear all filters and try again.</Text>
-                                        <Button variant="link" onClick={() => {}}>
+                                        <Button variant="link" onClick={() => setSearchFilter({})}>
                                             Clear all filters
                                         </Button>
                                     </EmptyStateTemplate>

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
@@ -21,7 +21,6 @@ import { getCollectionCount, listCollections } from 'services/CollectionsService
 import useURLSearch from 'hooks/useURLSearch';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
-import useEffectAfterFirstRender from 'hooks/useEffectAfterFirstRender';
 import CollectionsTable from './CollectionsTable';
 
 type CollectionsTablePageProps = {
@@ -51,13 +50,6 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
     const isLoading = !isDataAvailable && (listLoading || countLoading);
     const loadError = listError || countError;
 
-    useEffectAfterFirstRender(() => {
-        // Prevent viewing a page beyond the maximum page count
-        if (typeof countData !== 'undefined' && page > Math.ceil(countData / perPage)) {
-            setPage(1);
-        }
-    }, [countData, perPage, setPage]);
-
     let pageContent = (
         <PageSection variant="light" isFilled>
             <Bullseye>
@@ -84,7 +76,10 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
                     collectionsCount={countData}
                     pagination={pagination}
                     searchFilter={searchFilter}
-                    setSearchFilter={setSearchFilter}
+                    setSearchFilter={(value) => {
+                        setPage(1);
+                        setSearchFilter(value);
+                    }}
                     getSortParams={getSortParams}
                     hasWriteAccess={hasWriteAccessForCollections}
                 />

--- a/ui/apps/platform/src/hooks/useURLPagination.ts
+++ b/ui/apps/platform/src/hooks/useURLPagination.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import useURLParameter from './useURLParameter';
 
-type UseURLPaginationResult = {
+export type UseURLPaginationResult = {
     page: number;
     perPage: number;
     setPage: (page: number) => void;


### PR DESCRIPTION
## Description

Adds a toolbar with search by name and pagination functionality to the collections table.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Visit the collections page to see the table with toolbar, defaulting to no search value and the first page of results.
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/192782009-f7dd66fc-2474-41a1-a97a-0c26d07f91fc.png">

Begin editing text into the search field:
- The results in the table should update to reflect a case-insensitive match on the name field. 
- Result requests should be debounced and only populate x00 ms after the user finishes typing. 
- The search value should be present in the URL.
- The pagination numbers should reflect the new number of items displayed, if less than the page size.
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/192788694-7a100ec1-b0e1-4cd8-9310-24feb9076fb3.png">

Clicking the back button should remove the search filter:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/192788860-32687d3b-6614-4b47-bf1b-7d42989cab56.png">

Pagination limits the amount of data shown in the table at one time. Page size and page number should be tracked in the URL. (Duplicate mock data was used here to increase the result set).
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/192791939-9fe31cab-ff68-4240-8e5f-18b95c6e6e5e.png">
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/192791981-35abeb17-5cc5-42d0-907f-1b9c436eec4a.png">
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/192792018-e55d453d-d39a-42b1-9dfe-01549b2f6351.png">

Test that sorting works in conjunction with filtering and pagination:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/192821108-75d0f2f5-2e9f-4673-b4f7-af373459ce0e.png">



