### PR TITLE
Set Postgres connect timeout to 15s instead of 2m

### DIFF
--- a/pkg/postgres/pgconfig/config.go
+++ b/pkg/postgres/pgconfig/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
@@ -20,6 +21,8 @@ const (
 
 	// capacity - Minimum recommended Postgres capacity
 	capacity = 100 * size.GB
+
+	connectTimeout = 15 * time.Second
 )
 
 // GetPostgresConfig - gets the configuration used to connect to Postgres
@@ -36,6 +39,7 @@ func GetPostgresConfig() (map[string]string, *pgxpool.Config, error) {
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "Could not parse postgres config")
 	}
+	config.ConnConfig.ConnectTimeout = connectTimeout
 
 	sourceMap, err := ParseSource(source)
 	if err != nil {


### PR DESCRIPTION
## Description

The default connect timeout is 2m. This is excruciatingly long as it happens almost every time the product is deployed. Cut this down so the retry will happen faster

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI