### PR TITLE
Implement deletion functionalty for collections table

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -1,23 +1,30 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
     Bullseye,
     Button,
     ButtonVariant,
+    Dropdown,
+    DropdownItem,
+    DropdownToggle,
     Pagination,
     SearchInput,
     Text,
     Toolbar,
     ToolbarContent,
     ToolbarItem,
+    ToolbarItemVariant,
     Truncate,
 } from '@patternfly/react-core';
-import { SearchIcon } from '@patternfly/react-icons';
+import { CaretDownIcon, SearchIcon } from '@patternfly/react-icons';
 import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import debounce from 'lodash/debounce';
+import pluralize from 'pluralize';
 
+import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import LinkShim from 'Components/PatternFly/LinkShim';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import useTableSelection from 'hooks/useTableSelection';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import { GetSortParams } from 'hooks/useURLSort';
@@ -32,6 +39,7 @@ export type CollectionsTableProps = {
     searchFilter: SearchFilter;
     setSearchFilter: (searchFilter: SearchFilter) => void;
     getSortParams: GetSortParams;
+    onCollectionDelete: (ids: string[]) => Promise<void>;
     hasWriteAccess: boolean;
 };
 
@@ -44,11 +52,16 @@ function CollectionsTable({
     searchFilter,
     setSearchFilter,
     getSortParams,
+    onCollectionDelete,
     hasWriteAccess,
 }: CollectionsTableProps) {
     const history = useHistory();
     const { page, perPage, setPage, setPerPage } = pagination;
-    const { selected, allRowsSelected, onSelect, onSelectAll } = useTableSelection(collections);
+    const { isOpen, onToggle, closeSelect } = useSelectToggle();
+    const { selected, allRowsSelected, hasSelections, onSelect, onSelectAll, getSelectedIds } =
+        useTableSelection(collections);
+    const [isDeleting, setIsDeleting] = useState(false);
+    const [deletingIds, setDeletingIds] = useState<string[]>([]);
     const hasCollections = collections.length > 0;
 
     function getEnabledSortParams(field: string) {
@@ -78,6 +91,29 @@ function CollectionsTable({
         [setSearchFilter]
     );
 
+    function onConfirmDeleteCollection() {
+        setIsDeleting(true);
+        onCollectionDelete(deletingIds).finally(() => {
+            setDeletingIds([]);
+            setIsDeleting(false);
+        });
+    }
+
+    function onCancelDeleteCollection() {
+        setDeletingIds([]);
+    }
+
+    const unusedSelectedCollectionIds = collections
+        .filter((c) => getSelectedIds().includes(c.id) && !c.inUse)
+        .map((c) => c.id);
+
+    // A map to keep track of row index within the table to the collection id
+    // for checkbox selection after the table has been sorted.
+    const rowIdToIndex = {};
+    collections.forEach(({ id }, idx) => {
+        rowIdToIndex[id] = idx;
+    });
+
     // Currently, it is not expected that the value of `searchFilter.Collection` will
     // be an array even though it would valid. This is a safeguard for future code
     // changes that might change this assumption.
@@ -97,6 +133,41 @@ function CollectionsTable({
                             onChange={onSearchInputChange}
                         />
                     </ToolbarItem>
+                    {hasWriteAccess && (
+                        <>
+                            <ToolbarItem variant={ToolbarItemVariant.separator} />
+                            <ToolbarItem className="pf-u-flex-grow-1">
+                                <Dropdown
+                                    onSelect={closeSelect}
+                                    toggle={
+                                        <DropdownToggle
+                                            isDisabled={!hasSelections}
+                                            isPrimary
+                                            onToggle={onToggle}
+                                            toggleIndicator={CaretDownIcon}
+                                        >
+                                            Bulk actions
+                                        </DropdownToggle>
+                                    }
+                                    isOpen={isOpen}
+                                    dropdownItems={[
+                                        <DropdownItem
+                                            key="Delete collection"
+                                            component="button"
+                                            isDisabled={unusedSelectedCollectionIds.length === 0}
+                                            onClick={() => {
+                                                setDeletingIds(unusedSelectedCollectionIds);
+                                            }}
+                                        >
+                                            {unusedSelectedCollectionIds.length > 0
+                                                ? `Delete collections (${unusedSelectedCollectionIds.length})`
+                                                : 'Cannot delete (in use)'}
+                                        </DropdownItem>,
+                                    ]}
+                                />
+                            </ToolbarItem>
+                        </>
+                    )}
                     <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>
                         <Pagination
                             isCompact
@@ -156,7 +227,8 @@ function CollectionsTable({
                             </Td>
                         </Tr>
                     )}
-                    {collections.map(({ id, name, description, inUse }, rowIndex) => {
+                    {collections.map(({ id, name, description, inUse }) => {
+                        const rowIndex = rowIdToIndex[id];
                         const actionItems = [
                             {
                                 title: 'Edit collection',
@@ -171,7 +243,7 @@ function CollectionsTable({
                             },
                             {
                                 title: inUse ? 'Cannot delete (in use)' : 'Delete collection',
-                                onClick: () => {},
+                                onClick: () => setDeletingIds([id]),
                                 isDisabled: inUse,
                             },
                         ];
@@ -180,7 +252,9 @@ function CollectionsTable({
                             <Tr key={id}>
                                 {hasWriteAccess && (
                                     <Td
+                                        title={inUse ? 'Collection is in use' : ''}
                                         select={{
+                                            disable: inUse,
                                             rowIndex,
                                             onSelect,
                                             isSelected: selected[rowIndex],
@@ -207,6 +281,17 @@ function CollectionsTable({
                     })}
                 </Tbody>
             </TableComposable>
+            <ConfirmationModal
+                ariaLabel="Confirm delete"
+                confirmText="Delete"
+                isLoading={isDeleting}
+                isOpen={deletingIds.length !== 0}
+                onConfirm={onConfirmDeleteCollection}
+                onCancel={onCancelDeleteCollection}
+            >
+                Are you sure you want to delete {deletingIds.length}&nbsp;
+                {pluralize('collection', deletingIds.length)}?
+            </ConfirmationModal>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
@@ -13,7 +13,6 @@ import {
     Spinner,
     AlertActionCloseButton,
     AlertGroup,
-    AlertVariant,
 } from '@patternfly/react-core';
 import pluralize from 'pluralize';
 

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
@@ -11,16 +11,22 @@ import {
     Alert,
     Bullseye,
     Spinner,
+    AlertActionCloseButton,
+    AlertGroup,
+    AlertVariant,
 } from '@patternfly/react-core';
+import pluralize from 'pluralize';
 
 import PageTitle from 'Components/PageTitle';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import { collectionsPath } from 'routePaths';
 import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
-import { getCollectionCount, listCollections } from 'services/CollectionsService';
+import { deleteCollection, getCollectionCount, listCollections } from 'services/CollectionsService';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
+import { Empty } from 'services/types';
+import useToasts, { Toast } from 'hooks/patternfly/useToasts';
 import CollectionsTable from './CollectionsTable';
 
 type CollectionsTablePageProps = {
@@ -37,18 +43,66 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
     const pagination = useURLPagination(20);
     const { page, perPage, setPage } = pagination;
     const { sortOption, getSortParams } = useURLSort(sortOptions);
+    const { toasts, addToast, removeToast } = useToasts();
 
     const listQuery = useCallback(
         () => listCollections(searchFilter, sortOption, page - 1, perPage),
         [searchFilter, sortOption, page, perPage]
     );
-    const { data: listData, loading: listLoading, error: listError } = useRestQuery(listQuery);
+    const {
+        data: listData,
+        loading: listLoading,
+        error: listError,
+        refetch: listRefetch,
+    } = useRestQuery(listQuery);
 
     const countQuery = useCallback(() => getCollectionCount(searchFilter), [searchFilter]);
-    const { data: countData, loading: countLoading, error: countError } = useRestQuery(countQuery);
+    const {
+        data: countData,
+        loading: countLoading,
+        error: countError,
+        refetch: countRefetch,
+    } = useRestQuery(countQuery);
     const isDataAvailable = typeof listData !== 'undefined' && typeof countData !== 'undefined';
     const isLoading = !isDataAvailable && (listLoading || countLoading);
     const loadError = listError || countError;
+
+    /**
+     * Deletes an array of collections by ids. Will alert individually for any deletion
+     * requests that fail.
+     */
+    function onCollectionDelete(ids: string[]) {
+        const promises: Promise<Empty>[] = [];
+        ids.forEach((id) => {
+            const deletionPromise = deleteCollection(id).request.catch((err) => {
+                addToast(`Could not delete collection ${id}`, 'danger', err.message);
+                return Promise.reject(err);
+            });
+            promises.push(deletionPromise);
+        });
+
+        return Promise.allSettled(promises).then((promiseResults) => {
+            const totalDeleted = promiseResults.filter((res) => res.status === 'fulfilled').length;
+            const collectionText = pluralize('collection', ids.length);
+
+            if (totalDeleted > 0 && totalDeleted === ids.length) {
+                // All collections deleted successfully
+                addToast(
+                    `Successfully deleted ${totalDeleted} selected ${collectionText}`,
+                    'success'
+                );
+                // Some, but not all, deletion requests failed
+            } else if (totalDeleted > 0) {
+                addToast(
+                    `Deleted ${totalDeleted} of ${ids.length} selected ${collectionText}`,
+                    'warning'
+                );
+            }
+
+            listRefetch();
+            countRefetch();
+        });
+    }
 
     let pageContent = (
         <PageSection variant="light" isFilled>
@@ -81,6 +135,7 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
                         setSearchFilter(value);
                     }}
                     getSortParams={getSortParams}
+                    onCollectionDelete={onCollectionDelete}
                     hasWriteAccess={hasWriteAccessForCollections}
                 />
             </PageSection>
@@ -113,6 +168,26 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
             </PageSection>
             <Divider component="div" />
             {pageContent}
+            <AlertGroup isToast isLiveRegion>
+                {toasts.map(({ key, variant, title, children }: Toast) => (
+                    <Alert
+                        key={key}
+                        variant={variant}
+                        title={title}
+                        timeout
+                        onTimeout={() => removeToast(key)}
+                        actionClose={
+                            <AlertActionCloseButton
+                                title={title}
+                                variantLabel={variant}
+                                onClose={() => removeToast(key)}
+                            />
+                        }
+                    >
+                        {children}
+                    </Alert>
+                ))}
+            </AlertGroup>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Dashboard/hooks/useRestQuery.ts
+++ b/ui/apps/platform/src/Containers/Dashboard/hooks/useRestQuery.ts
@@ -1,10 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { CancellableRequest } from 'services/cancellationUtils';
 
 export type UseRestQueryReturn<ReturnType> = {
     data: ReturnType | undefined;
     loading: boolean;
     error?: Error;
+    refetch: () => void;
 };
 
 export default function useRestQuery<ReturnType>(
@@ -14,7 +15,7 @@ export default function useRestQuery<ReturnType>(
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<Error | undefined>();
 
-    useEffect(() => {
+    const execFetch = useCallback(() => {
         const { request, cancel } = cancellableRequestFn();
 
         setError(undefined);
@@ -33,5 +34,7 @@ export default function useRestQuery<ReturnType>(
         return cancel;
     }, [cancellableRequestFn]);
 
-    return { data, loading, error };
+    useEffect(execFetch, [execFetch]);
+
+    return { data, loading, error, refetch: execFetch };
 }

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -127,6 +127,18 @@ button.pf-c-tree-view__node {
     list-style: decimal;
 }
 
+/*
+ * Override disabled checkbox styles when the input element is in a PF table
+ */
+.pf-c-table__check input[type="checkbox"]:disabled {
+    cursor: not-allowed;
+    border-color: revert;
+}
+.pf-c-table__check input[type="checkbox"]:checked:disabled {
+    background-color: var(--pf-global--disabled-color--200);
+    border-color: transparent;
+}
+
 /* For classic components to equal or exceed z-index of PatternFly elements. */
 
 .z-xs-100 {


### PR DESCRIPTION
## Description

Adds the ability to delete collections from the collection table.

In addition to the core functionality, there are a couple of UX items that could use feedback that I didn't find an exact example of in the app:

### 1. Disabled table checkboxes for collections that are "in use"

Currently the only available action in "Bulk actions" is to delete a collection, which is not a valid option for collections that are in use. This is handled by disabling the checkboxes for these rows to give the user an indication that they cannot be interacted with. The checkboxes have title text explaining this when hovered.
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193122138-3ef180ad-d097-4e6b-8b80-453769cc6824.png">
Additionally, if the user clicks the "select all" checkbox at the top of the table, the items are selected but still disabled. The collections are unable to be deleted from the bulk actions dropdown and the count reflects this.
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193122348-a7262fa8-bb2e-407c-85de-ba37955d85a5.png">
This is somewhat based on how the Policies table works, except that there isn't a need to disable checkboxes in that table due to there being valid options other than "Delete".

### 2. Alert toasts when delete requests return an error

When one or more collections are deleted, the happy path show a single "success" toast message and refreshes the data. Since each delete request is sent separately, it is possible that some requests will fail while other requests succeed.

Each request that fails to delete will individually display a single "error" toast message with the reason the request failed. If one or more requests fail during a bulk delete action, but _at least one succeeds_, an additional "warning" toast will be displayed that shows the user how many of the collections were deleted.
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193123576-2d8b4a10-8ee8-494d-b552-519d04273443.png">


## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Collections that are `inUse` cannot be deleted.

Load the collections table and see that any collection listed as `inUse` has its selection checkbox disabled. The "Bulk actions" dropdown will also be disabled when no collections are selected.
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193118924-ab26c1ab-2d43-48c1-86a4-3dafc006ebdf.png">

Opening the menu of an `inUse` collection has the delete option disabled:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193118980-b6b2883a-2c8c-4000-b1fb-4b5b8311ac8c.png">
Collections that are not `inUse` have the delete option enabled:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193119071-5dea8cba-2fa7-4700-b25d-75bf2c794caf.png">

If the user selects all rows via the "select all" checkbox at the top of the table, the `inUse` row checkboxes are still disabled. Opening the "Bulk actions" dropdown will prompt for deletion of only selected collections that are not `inUse`.
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193119218-da09fa5c-c2cc-4b9b-acd2-d3500024ffe5.png">

If the user clicks the "select all" checkbox, and then individually unchecks each collection that is not `inUse`, the "Bulk actions" dropdown will show a message that the collections cannot be deleted:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193119763-39bf1fcc-1c63-4dce-bee1-b6bb85af9c47.png">

Selecting the "Delete collection" item from the menu of a single collection will prompt the user to confirm deletion:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193120140-9cc4600e-2d96-4fa1-aab1-0f08cf341d76.png">

Selecting the cancel option will close the modal and keep the data intact. Selecting the confirmation option will delete the collection and present a toast to the user:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193120321-ccb76430-52e0-4216-a9ce-c79b01b6a847.png">

Selecting multiple collections via checkbox and using the "Bulk action" delete option will present the user with the confirmation modal. The modal will specify how many selected collections that are not `inUse` will be deleted:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193120625-9b8edb9a-bae2-4e11-9163-970a7983fda9.png">

If one or more of the collections fails to delete, each failure will result in a toast message telling the user about the error. In the case of a partial success, an additional modal will tell the user how many of the selected collections were successfully deleted. If no deletions were successful, this additional modal will not be shown.
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193120882-85c81091-f009-4ea8-ac25-95080ffced9d.png">
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193120929-4cd146b3-f359-4ac5-8955-b9548d3dbc5e.png">


