### PR TITLE
ROX-11323 Enable fake workloads in local-sensor

### DIFF
--- a/sensor/debugger/k8s/fake.go
+++ b/sensor/debugger/k8s/fake.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -71,7 +72,7 @@ type FakeEventsManager struct {
 	// Mode the creation mode (at the moment there is only one mode implemented)
 	Mode CreateMode
 	// Client the k8s ClientSet
-	Client *ClientSet
+	Client client.Interface
 	// Reader the TraceReader
 	Reader *TraceReader
 	// clientMap map with the k8s clients

--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -85,14 +85,33 @@ type WorkloadManager struct {
 	networkManager      manager.Manager
 }
 
+// WorkloadManagerConfig WorkloadManager's configuration
+type WorkloadManagerConfig struct {
+	workloadFile string
+	client       client.Interface
+}
+
+// ConfigDefaults default configuration
+func ConfigDefaults() *WorkloadManagerConfig {
+	return &WorkloadManagerConfig{
+		workloadFile: workloadPath,
+	}
+}
+
+// WithWorkloadFile configures the WorkloadManagerConfig's WorkloadFile field
+func (c *WorkloadManagerConfig) WithWorkloadFile(file string) *WorkloadManagerConfig {
+	c.workloadFile = file
+	return c
+}
+
 // Client returns the mock client
 func (w *WorkloadManager) Client() client.Interface {
 	return w.client
 }
 
 // NewWorkloadManager returns a fake kubernetes client interface that will be managed with the passed Workload
-func NewWorkloadManager() *WorkloadManager {
-	data, err := os.ReadFile(workloadPath)
+func NewWorkloadManager(config *WorkloadManagerConfig) *WorkloadManager {
+	data, err := os.ReadFile(config.workloadFile)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -88,7 +88,6 @@ type WorkloadManager struct {
 // WorkloadManagerConfig WorkloadManager's configuration
 type WorkloadManagerConfig struct {
 	workloadFile string
-	client       client.Interface
 }
 
 // ConfigDefaults default configuration

--- a/sensor/kubernetes/main.go
+++ b/sensor/kubernetes/main.go
@@ -40,7 +40,7 @@ func main() {
 	var sharedClientInterface client.Interface
 
 	// Workload manager is only non-nil when we are mocking out the k8s client
-	workloadManager := fake.NewWorkloadManager()
+	workloadManager := fake.NewWorkloadManager(fake.ConfigDefaults())
 	if workloadManager != nil {
 		sharedClientInterface = workloadManager.Client()
 	} else {

--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -20,6 +20,8 @@ import (
 	centralDebug "github.com/stackrox/rox/sensor/debugger/central"
 	"github.com/stackrox/rox/sensor/debugger/k8s"
 	"github.com/stackrox/rox/sensor/debugger/message"
+	"github.com/stackrox/rox/sensor/kubernetes/client"
+	"github.com/stackrox/rox/sensor/kubernetes/fake"
 	"github.com/stackrox/rox/sensor/kubernetes/sensor"
 	"github.com/stackrox/rox/sensor/testutils"
 	"google.golang.org/grpc"
@@ -74,6 +76,7 @@ type localSensorConfig struct {
 	CreateMode         k8s.CreateMode
 	Delay              time.Duration
 	PoliciesFile       string
+	FakeWorkloadFile   string
 }
 
 const (
@@ -135,6 +138,7 @@ func mustGetCommandLineArgs() localSensorConfig {
 		Delay:              5 * time.Second,
 		CreateMode:         k8s.Delay,
 		PoliciesFile:       "",
+		FakeWorkloadFile:   "",
 	}
 	flag.BoolVar(&sensorConfig.Verbose, "verbose", sensorConfig.Verbose, "prints all messages to stdout as well as to the output file")
 	flag.DurationVar(&sensorConfig.Duration, "duration", sensorConfig.Duration, "duration that the scenario should run (leave it empty to run it without timeout)")
@@ -147,12 +151,16 @@ func mustGetCommandLineArgs() localSensorConfig {
 	flag.DurationVar(&sensorConfig.ResyncPeriod, "resync", sensorConfig.ResyncPeriod, "resync period")
 	flag.DurationVar(&sensorConfig.Delay, "delay", sensorConfig.Delay, "create events with a given delay")
 	flag.StringVar(&sensorConfig.PoliciesFile, "with-policies", sensorConfig.PoliciesFile, " a file containing a list of policies")
+	flag.StringVar(&sensorConfig.FakeWorkloadFile, "with-fakeworkload", sensorConfig.FakeWorkloadFile, " a file containing a FakeWorkload definition")
 	flag.Parse()
 
 	sensorConfig.CentralOutput = path.Clean(sensorConfig.CentralOutput)
 
 	if sensorConfig.ReplayK8sEnabled && sensorConfig.RecordK8sEnabled {
 		log.Fatalf("cannot record and replay a trace at the same time. Use either -record or -replay flag")
+	}
+	if sensorConfig.ReplayK8sEnabled && sensorConfig.FakeWorkloadFile != "" {
+		log.Fatalf("cannot replay a trace and use fake workloads at the same time. Use either -replay or -record -with-fakeworkload")
 	}
 	if sensorConfig.RecordK8sEnabled && sensorConfig.RecordK8sFile == "" {
 		log.Printf("trace destination empty. Using default 'k8s-trace.jsonl'\n")
@@ -191,10 +199,18 @@ func registerHostKillSignals(startTime time.Time, fakeCentral *centralDebug.Fake
 // If a KUBECONFIG file is provided, then local-sensor will use that file to connect to a remote cluster.
 func main() {
 	localConfig := mustGetCommandLineArgs()
+	var fakeClient client.Interface
 	fakeClient, err := k8s.MakeOutOfClusterClient()
 	// when replying a trace, there is no need to connect to K8s cluster
 	if localConfig.ReplayK8sEnabled {
 		fakeClient = k8s.MakeFakeClient()
+	}
+	var workloadManager *fake.WorkloadManager = nil
+	// if we are using a fake workload we don't want to connect to a real K8s cluster
+	if localConfig.FakeWorkloadFile != "" {
+		workloadManager = fake.NewWorkloadManager(fake.ConfigDefaults().
+			WithWorkloadFile(localConfig.FakeWorkloadFile))
+		fakeClient = workloadManager.Client()
 	}
 	utils.CrashOnError(err)
 
@@ -235,7 +251,8 @@ func main() {
 		WithK8sClient(fakeClient).
 		WithCentralConnectionFactory(fakeConnectionFactory).
 		WithLocalSensor(true).
-		WithResyncPeriod(localConfig.ResyncPeriod)
+		WithResyncPeriod(localConfig.ResyncPeriod).
+		WithWorkloadManager(workloadManager)
 
 	if localConfig.RecordK8sEnabled {
 		traceRec := &k8s.TraceWriter{

--- a/tools/roxvet/analyzers/validateimports/analyzer.go
+++ b/tools/roxvet/analyzers/validateimports/analyzer.go
@@ -240,12 +240,12 @@ func verifyImportsFromAllowedPackagesOnly(pass *analysis.Pass, imports []*ast.Im
 	}
 
 	if validImportRoot == "sensor/debugger" {
-		allowedPackages = append(allowedPackages, "sensor/kubernetes/listener/resources")
+		allowedPackages = append(allowedPackages, "sensor/kubernetes/listener/resources", "sensor/kubernetes/client")
 	}
 
 	if validImportRoot == "tools" {
 		allowedPackages = append(allowedPackages, "central/globaldb", "central/metrics", "central/postgres", "central/role/resources",
-			"sensor/kubernetes/sensor", "sensor/debugger", "sensor/testutils")
+			"sensor/kubernetes/client", "sensor/kubernetes/fake", "sensor/kubernetes/sensor", "sensor/debugger", "sensor/testutils")
 	}
 
 	if validImportRoot == "sensor/kubernetes" {


### PR DESCRIPTION
## Description

These changes enable the fake workloads in `local-sensor`

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

```
go run tools/local-sensor/main.go -record -resync=0s -with-fakeworkload=scale/workloads/default.yaml
```

generates a trace file (`k8s-trace.jsonl`) with fake events.
