### PR TITLE
Add Postgres query retry mechanism to handle transient errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/heroku/docker-registry-client v0.0.0
+	github.com/jackc/pgconn v1.13.0
 	github.com/jackc/pgtype v1.12.0
 	github.com/jackc/pgx/v4 v4.17.2
 	github.com/jinzhu/now v1.1.5 // indirect
@@ -248,7 +249,6 @@ require (
 	github.com/itchyny/gojq v0.12.5 // indirect
 	github.com/itchyny/timefmt-go v0.1.3 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.13.0 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.1 // indirect

--- a/pkg/errorhelpers/utils.go
+++ b/pkg/errorhelpers/utils.go
@@ -1,0 +1,16 @@
+package errorhelpers
+
+import "github.com/pkg/errors"
+
+// IsAny returns a bool if it matches any of the target errors
+// This helps consolidate code from
+// errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.ErrClosedPipe)
+// to errors.IsAny(err, io.EOF. io.ErrUnexpectedEOF, io.ErrClosedPipe)
+func IsAny(err error, targets ...error) bool {
+	for _, target := range targets {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/postgres/pgutils/error.go
+++ b/pkg/postgres/pgutils/error.go
@@ -1,0 +1,58 @@
+package pgutils
+
+import (
+	"io"
+	"net"
+
+	"github.com/jackc/pgconn"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/set"
+)
+
+var transientPGCodes = set.NewFrozenStringSet(
+	// Class 08 — Connection Exception
+	"08000", // connection_exception
+	"08003", // connection_does_not_exist
+	"08006", // connection_failure
+	"08001", // sqlclient_unable_to_establish_sqlconnection
+	"08004", // sqlserver_rejected_establishment_of_sqlconnection
+	"08007", // transaction_resolution_unknown
+	"08P01", // protocol_violation
+
+	// Class 40 — Transaction Rollback
+	"40000", // transaction_rollback
+	"40002", // transaction_integrity_constraint_violation
+	"40001", // serialization_failure
+	"40003", // statement_completion_unknown
+	"40P01", // deadlock_detected
+
+	// Class 55 — Object Not In Prerequisite State
+	"55000", // object_not_in_prerequisite_state
+	"55006", // object_in_use
+	"55P03", // lock_not_available
+
+	// Class 57 — Operator Intervention
+	"57000", // operator_intervention
+	"57014", // query_canceled
+	"57P01", // admin_shutdown
+	"57P02", // crash_shutdown
+	"57P03", // cannot_connect_now
+	"57P04", // database_dropped
+	"57P05", // idle_session_timeout
+
+	// Class 58 — System Error (errors external to PostgreSQL itself)
+	"58000", // system_error
+	"58030", // io_error
+)
+
+// isTransientError specifies if the passed error is transient and should be retried
+func isTransientError(err error) bool {
+	if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
+		return transientPGCodes.Contains(pgErr.Code)
+	}
+	if netErr := (*net.OpError)(nil); errors.As(err, &netErr) {
+		return netErr.Temporary() || netErr.Timeout()
+	}
+	return errorhelpers.IsAny(err, io.EOF, io.ErrUnexpectedEOF, io.ErrClosedPipe)
+}

--- a/pkg/postgres/pgutils/retry.go
+++ b/pkg/postgres/pgutils/retry.go
@@ -26,8 +26,8 @@ func RetryExecQuery(fn func() error) error {
 // that fails with Transient errors
 func RetryQuery[T any](fn func() (T, error)) (T, error) {
 	// Run query immediately
-	if T, err := fn(); err == nil || !isTransientError(err) {
-		return T, err
+	if val, err := fn(); err == nil || !isTransientError(err) {
+		return val, err
 	}
 
 	expirationTimer := time.NewTimer(timeout)

--- a/pkg/postgres/pgutils/retry.go
+++ b/pkg/postgres/pgutils/retry.go
@@ -1,0 +1,54 @@
+package pgutils
+
+import (
+	"time"
+
+	"github.com/stackrox/rox/pkg/timeutil"
+)
+
+const (
+	interval = 5 * time.Second
+	timeout  = 5 * time.Minute
+)
+
+// RetryExecQuery is used to specify how long to retry to successfully run an exec query
+// that fails with Transient errors
+func RetryExecQuery(fn func() error) error {
+	// Shape fn to match the RetryQuery below
+	fnWithReturn := func() (struct{}, error) {
+		return struct{}{}, fn()
+	}
+	_, err := RetryQuery(fnWithReturn)
+	return err
+}
+
+// RetryQuery is used to specify how long to retry to successfully run a query
+// that fails with Transient errors
+func RetryQuery[T any](fn func() (T, error)) (T, error) {
+	// Run query immediately
+	if T, err := fn(); err == nil || !isTransientError(err) {
+		return T, err
+	}
+
+	expirationTimer := time.NewTimer(timeout)
+	defer timeutil.StopTimer(expirationTimer)
+
+	intervalTicker := time.NewTicker(interval)
+	defer intervalTicker.Stop()
+
+	var err error
+	for {
+		select {
+		case <-expirationTimer.C:
+			log.Fatalf("unsuccessful in reconnecting to the database: %v. Exiting...", err)
+		case <-intervalTicker.C:
+			// Uses err outside the for loop to allow for the expiration to show the last err received
+			// and provide context for the expiration
+			var ret T
+			ret, err = fn()
+			if err == nil || !isTransientError(err) {
+				return ret, err
+			}
+		}
+	}
+}

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/pointers"
 	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/random"
 	searchPkg "github.com/stackrox/rox/pkg/search"
@@ -556,46 +557,14 @@ func tracedQueryRow(ctx context.Context, pool *pgxpool.Pool, sql string, args ..
 // RunSearchRequest executes a request against the database for given category
 func RunSearchRequest(ctx context.Context, category v1.SearchCategory, q *v1.Query, db *pgxpool.Pool) ([]searchPkg.Result, error) {
 	schema := mapping.GetTableFromCategory(category)
-	return RunSearchRequestForSchema(ctx, schema, q, db)
+
+	return pgutils.RetryQuery(func() ([]searchPkg.Result, error) {
+		return RunSearchRequestForSchema(ctx, schema, q, db)
+	})
 }
 
-// RunSearchRequestForSchema executes a request against the database for given schema
-func RunSearchRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1.Query, db *pgxpool.Pool) (searchResults []searchPkg.Result, err error) {
-	var query *query
-	// Add this to be safe and convert panics to errors,
-	// since we do a lot of casting and other operations that could potentially panic in this code.
-	// Panics are expected ONLY in the event of a programming error, all foreseeable errors are handled
-	// the usual way.
-	defer func() {
-		if r := recover(); r != nil {
-			if query != nil {
-				log.Errorf("Query issue: %s %+v: %v", query.AsSQL(), query.Data, r)
-			} else {
-				log.Errorf("Unexpected error running search request: %v", r)
-			}
-			debug.PrintStack()
-			err = fmt.Errorf("unexpected error running search request: %v", r)
-		}
-	}()
-
-	query, err = standardizeQueryAndPopulatePath(q, schema, SEARCH)
-	if err != nil {
-		return nil, err
-	}
-	// A nil-query implies no results.
-	if query == nil {
-		return nil, nil
-	}
-
+func retriableRunSearchRequestForSchema(ctx context.Context, query *query, schema *walker.Schema, db *pgxpool.Pool) ([]searchPkg.Result, error) {
 	queryStr := query.AsSQL()
-	rows, err := tracedQuery(ctx, db, queryStr, query.Data...)
-	if err != nil {
-		debug.PrintStack()
-		log.Errorf("Query issue: %s %+v: %v", queryStr, query.Data, err)
-		return nil, err
-	}
-	defer rows.Close()
-	log.Debugf("SEARCH: ran query %s; data %+v", queryStr, query.Data)
 
 	// Assumes that ids are strings.
 	numPrimaryKeys := len(schema.PrimaryKeys())
@@ -623,7 +592,20 @@ func RunSearchRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1
 	for i, field := range extraSelectedFields {
 		bufferToScanRowInto[i+len(query.SelectedFields)+numFieldsForPrimaryKey] = mustAllocForDataType(field.FieldType)
 	}
+
 	recordIDIdxMap := make(map[string]int)
+	var searchResults []searchPkg.Result
+
+	rows, err := tracedQuery(ctx, db, queryStr, query.Data...)
+	if err != nil {
+		// TODO(ROX-12858)
+		debug.PrintStack()
+		log.Errorf("Query issue: %s %+v: %v", queryStr, query.Data, err)
+		return nil, err
+	}
+	defer rows.Close()
+	log.Debugf("SEARCH: ran query %s; data %+v", queryStr, query.Data)
+
 	for rows.Next() {
 		if err := rows.Scan(bufferToScanRowInto...); err != nil {
 			return nil, err
@@ -668,10 +650,46 @@ func RunSearchRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1
 	return searchResults, nil
 }
 
+// RunSearchRequestForSchema executes a request against the database for given schema
+func RunSearchRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1.Query, db *pgxpool.Pool) ([]searchPkg.Result, error) {
+	var query *query
+	var err error
+	// Add this to be safe and convert panics to errors,
+	// since we do a lot of casting and other operations that could potentially panic in this code.
+	// Panics are expected ONLY in the event of a programming error, all foreseeable errors are handled
+	// the usual way.
+	defer func() {
+		if r := recover(); r != nil {
+			if query != nil {
+				log.Errorf("Query issue: %s %+v: %v", query.AsSQL(), query.Data, r)
+			} else {
+				log.Errorf("Unexpected error running search request: %v", r)
+			}
+			debug.PrintStack()
+			err = fmt.Errorf("unexpected error running search request: %v", r)
+		}
+	}()
+
+	query, err = standardizeQueryAndPopulatePath(q, schema, SEARCH)
+	if err != nil {
+		return nil, err
+	}
+	// A nil-query implies no results.
+	if query == nil {
+		return nil, nil
+	}
+	return pgutils.RetryQuery(func() ([]searchPkg.Result, error) {
+		return retriableRunSearchRequestForSchema(ctx, query, schema, db)
+	})
+}
+
 // RunCountRequest executes a request for just the count against the database
 func RunCountRequest(ctx context.Context, category v1.SearchCategory, q *v1.Query, db *pgxpool.Pool) (int, error) {
 	schema := mapping.GetTableFromCategory(category)
-	return RunCountRequestForSchema(ctx, schema, q, db)
+
+	return pgutils.RetryQuery(func() (int, error) {
+		return RunCountRequestForSchema(ctx, schema, q, db)
+	})
 }
 
 // RunCountRequestForSchema executes a request for just the count against the database
@@ -680,16 +698,19 @@ func RunCountRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1.
 	if err != nil || query == nil {
 		return 0, err
 	}
-
 	queryStr := query.AsSQL()
-	var count int
-	row := tracedQueryRow(ctx, db, queryStr, query.Data...)
-	if err := row.Scan(&count); err != nil {
-		debug.PrintStack()
-		log.Errorf("Query issue: %s %+v: %v", queryStr, query.Data, err)
-		return 0, err
-	}
-	return count, nil
+
+	return pgutils.RetryQuery(func() (int, error) {
+		var count int
+		row := tracedQueryRow(ctx, db, queryStr, query.Data...)
+		if err := row.Scan(&count); err != nil {
+			// TODO(ROX-12858)
+			debug.PrintStack()
+			log.Errorf("Query issue: %s %+v: %v", queryStr, query.Data, err)
+			return 0, err
+		}
+		return count, nil
+	})
 }
 
 // RunGetQueryForSchema executes a request for just the search against the database
@@ -701,25 +722,19 @@ func RunGetQueryForSchema(ctx context.Context, schema *walker.Schema, q *v1.Quer
 	if query == nil {
 		return nil, emptyQueryErr
 	}
-
 	queryStr := query.AsSQL()
-	row := tracedQueryRow(ctx, db, queryStr, query.Data...)
 
-	var data []byte
-	err = row.Scan(&data)
-	return data, err
+	return pgutils.RetryQuery(func() ([]byte, error) {
+		var data []byte
+		row := tracedQueryRow(ctx, db, queryStr, query.Data...)
+		if err := row.Scan(&data); err != nil {
+			return nil, err
+		}
+		return data, nil
+	})
 }
 
-// RunGetManyQueryForSchema executes a request for just the search against the database
-func RunGetManyQueryForSchema(ctx context.Context, schema *walker.Schema, q *v1.Query, db *pgxpool.Pool) ([][]byte, error) {
-	query, err := standardizeQueryAndPopulatePath(q, schema, GET)
-	if err != nil {
-		return nil, err
-	}
-	if query == nil {
-		return nil, emptyQueryErr
-	}
-
+func retriableRunGetManyQueryForSchema(ctx context.Context, query *query, db *pgxpool.Pool) ([][]byte, error) {
 	queryStr := query.AsSQL()
 	rows, err := tracedQuery(ctx, db, queryStr, query.Data...)
 	if err != nil {
@@ -736,6 +751,21 @@ func RunGetManyQueryForSchema(ctx context.Context, schema *walker.Schema, q *v1.
 		results = append(results, data)
 	}
 	return results, nil
+}
+
+// RunGetManyQueryForSchema executes a request for just the search against the database
+func RunGetManyQueryForSchema(ctx context.Context, schema *walker.Schema, q *v1.Query, db *pgxpool.Pool) ([][]byte, error) {
+	query, err := standardizeQueryAndPopulatePath(q, schema, GET)
+	if err != nil {
+		return nil, err
+	}
+	if query == nil {
+		return nil, emptyQueryErr
+	}
+
+	return pgutils.RetryQuery(func() ([][]byte, error) {
+		return retriableRunGetManyQueryForSchema(ctx, query, db)
+	})
 }
 
 // RunCursorQueryForSchema creates a cursor against the database
@@ -756,7 +786,7 @@ func RunCursorQueryForSchema(ctx context.Context, schema *walker.Schema, q *v1.Q
 	}
 	closer = func() {
 		if err := tx.Commit(ctx); err != nil {
-			log.Errorf("error comitting cursor transaction: %v", err)
+			log.Errorf("error committing cursor transaction: %v", err)
 		}
 	}
 
@@ -797,9 +827,11 @@ func RunDeleteRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1
 		return err
 	}
 
-	_, err = db.Exec(ctx, query.AsSQL(), query.Data...)
-	if err != nil {
-		return errors.Wrapf(err, "could not delete from %q", schema.Table)
-	}
-	return nil
+	return pgutils.RetryExecQuery(func() error {
+		_, err = db.Exec(ctx, query.AsSQL(), query.Data...)
+		if err != nil {
+			return errors.Wrapf(err, "could not delete from %q", schema.Table)
+		}
+		return err
+	})
 }


### PR DESCRIPTION
## Description

There is really no free way to do this. I have added the logic and wired it into searches, gets and deletions. Upserts are in the stores and will be added in a different PR because that will modify autogen and muddy the PR. Effectively, if Postgres is unavailable with a transient error then we should try to be successful in the background while still respecting contexts

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

All postgres tests should pass and will add some more chaos-like tests in a follow up