### PR TITLE
Fixes useURLParameter hook to allow multiple sequential mutations.

### DIFF
--- a/ui/apps/platform/src/hooks/useURLParameter.ts
+++ b/ui/apps/platform/src/hooks/useURLParameter.ts
@@ -36,6 +36,12 @@ function useURLParameter(keyPrefix: string, defaultValue: QueryValue): UseURLPar
     // as the URL parameters do not change
     const setValue = useCallback(
         (newValue: QueryValue, historyAction: Action = 'push') => {
+            // Note that we use the version of `location` on `history` here, since it is mutable (compared
+            // to the immutable `location` when used directly.) In this case, we aren't looking
+            // for a reference change to trigger a rerender, we are looking for the current up-to-date
+            // location search parameters.
+            //
+            // https://v5.reactrouter.com/web/api/history/history-is-mutable
             const previousQuery = getQueryObject(history.location.search) || {};
             const newQuery = {
                 ...previousQuery,

--- a/ui/apps/platform/src/hooks/useURLParameter.ts
+++ b/ui/apps/platform/src/hooks/useURLParameter.ts
@@ -36,23 +36,23 @@ function useURLParameter(keyPrefix: string, defaultValue: QueryValue): UseURLPar
     // as the URL parameters do not change
     const setValue = useCallback(
         (newValue: QueryValue, historyAction: Action = 'push') => {
-            const previousQuery = getQueryObject(location.search) || {};
-            const newQueryString = getQueryString({
+            const previousQuery = getQueryObject(history.location.search) || {};
+            const newQuery = {
                 ...previousQuery,
                 [keyPrefix]: newValue,
-            });
+            };
 
             // If the value passed in is `undefined`, don't display it in the URL at all
             if (typeof newValue === 'undefined') {
-                delete newQueryString[keyPrefix];
+                delete newQuery[keyPrefix];
             }
 
             // Do not change history states if setter is called with current value
             if (!isEqual(previousQuery[keyPrefix], newValue)) {
-                history[historyAction]({ search: newQueryString });
+                history[historyAction]({ search: getQueryString(newQuery) });
             }
         },
-        [keyPrefix, history, location.search]
+        [keyPrefix, history]
     );
 
     const nextValue = getQueryObject(location.search)[keyPrefix] || defaultValue;


### PR DESCRIPTION
## Description

The useURLParameter hook previously did not allow sequential updates to different URL parameters if they were in a single tick of the event loop, due to asynchronous code in `react-router-dom`.

```typescript
// e.g.
const [, setPage] = useURLParameter('page', 1);
const [, setPerPage] = useURLParameter('perPage', 10);

setPage(2);
setPerPage(20);

// Results in a URL search query of `?page=1&perPage=20` instead of the 
// expected `?page=2&perPage=20`, since the first call is overwritten by the second.
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

Added unit test to cover this case.
Manual testing of the Violations page, which uses this hook for search/sort/pagination.
