### PR TITLE
Dashrews/ROX-10199 delete stale network flows

### DIFF
--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -14,6 +14,22 @@ const (
 	pruneClusterHealthStatusesStmt = `DELETE FROM cluster_health_statuses child WHERE NOT EXISTS
 		(SELECT 1 FROM clusters parent WHERE
 		child.Id = parent.Id)`
+
+	pruneStaleNetworkFlowsStmt = `DELETE FROM network_flows a USING (
+      SELECT MAX(flow_id) as max_flow, props_srcentity_type, props_srcentity_id, props_dstentity_type, props_dstentity_id, props_dstport, props_l4protocol, clusterid
+        FROM network_flows
+        GROUP BY props_srcentity_type, props_srcentity_id, props_dstentity_type, props_dstentity_id, props_dstport, props_l4protocol, clusterid
+		HAVING COUNT(*) > 1
+      ) b
+      WHERE a.props_srcentity_type = b.props_srcentity_type
+ 	AND a.props_srcentity_id = b.props_srcentity_id
+ 	AND a.props_dstentity_type = b.props_dstentity_type
+ 	AND a.props_dstentity_id = b.props_dstentity_id
+	AND a.props_dstport = b.props_dstport
+	AND a.props_l4protocol = b.props_l4protocol
+	AND a.clusterid = b.clusterid
+      AND a.flow_id <> b.max_flow;
+	`
 )
 
 var (
@@ -33,5 +49,12 @@ func PruneActiveComponents(ctx context.Context, pool *pgxpool.Pool) {
 func PruneClusterHealthStatuses(ctx context.Context, pool *pgxpool.Pool) {
 	if _, err := pool.Exec(ctx, pruneClusterHealthStatusesStmt); err != nil {
 		log.Errorf("failed to prune cluster health statuses: %v", err)
+	}
+}
+
+// PruneStaleNetworkFlows - prunes duplicate network flows
+func PruneStaleNetworkFlows(ctx context.Context, pool *pgxpool.Pool) {
+	if _, err := pool.Exec(ctx, pruneStaleNetworkFlowsStmt); err != nil {
+		log.Errorf("failed to prune stale network flows: %v", err)
 	}
 }

--- a/central/postgres/pruning_test.go
+++ b/central/postgres/pruning_test.go
@@ -51,7 +51,7 @@ func (s *PostgresPruningSuite) SetupSuite() {
 }
 
 func (s *PostgresPruningSuite) TearDownSuite() {
-	//s.testDB.Teardown(s.T())
+	s.testDB.Teardown(s.T())
 	s.envIsolator.RestoreAll()
 }
 

--- a/central/postgres/pruning_test.go
+++ b/central/postgres/pruning_test.go
@@ -4,16 +4,23 @@ import (
 	"context"
 	"testing"
 
+	"github.com/gogo/protobuf/types"
 	activeComponent "github.com/stackrox/rox/central/activecomponent/datastore"
 	clusterStore "github.com/stackrox/rox/central/cluster/datastore"
 	clusterHealthPostgresStore "github.com/stackrox/rox/central/cluster/store/clusterhealth/postgres"
 	deploymentStore "github.com/stackrox/rox/central/deployment/datastore"
+	clusterFlow "github.com/stackrox/rox/central/networkgraph/flow/datastore"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/testutils/envisolator"
+	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stretchr/testify/suite"
+)
+
+const (
+	clusterID = "22"
 )
 
 type PostgresPruningSuite struct {
@@ -135,4 +142,118 @@ func (s *PostgresPruningSuite) TestPruneClusterHealthStatuses() {
 	exists, err = clusterHealthStore.Exists(s.ctx, "randomCluster")
 	s.Nil(err)
 	s.False(exists)
+}
+
+func (s *PostgresPruningSuite) TestPruneStaleNetworkFlows() {
+	cds, err := clusterFlow.GetTestPostgresClusterDataStore(s.T(), s.testDB.Pool)
+	s.Nil(err)
+
+	flowStore, err := cds.GetFlowStore(s.ctx, clusterID)
+	s.Nil(err)
+
+	flows := []*storage.NetworkFlow{
+		{
+			Props: &storage.NetworkFlowProperties{
+				DstPort: 22,
+				DstEntity: &storage.NetworkEntityInfo{
+					Type: 1,
+					Id:   "TestDst1",
+				},
+				SrcEntity: &storage.NetworkEntityInfo{
+					Type: 1,
+					Id:   "TestSrc1",
+				},
+			},
+			ClusterId:         clusterID,
+			LastSeenTimestamp: types.TimestampNow(),
+		},
+		{
+			Props: &storage.NetworkFlowProperties{
+				DstPort: 22,
+				DstEntity: &storage.NetworkEntityInfo{
+					Type: 1,
+					Id:   "TestDst1",
+				},
+				SrcEntity: &storage.NetworkEntityInfo{
+					Type: 1,
+					Id:   "TestSrc1",
+				},
+			},
+			ClusterId:         clusterID,
+			LastSeenTimestamp: types.TimestampNow(),
+		},
+		{
+			Props: &storage.NetworkFlowProperties{
+				DstPort: 22,
+				DstEntity: &storage.NetworkEntityInfo{
+					Type: 1,
+					Id:   "TestDst1",
+				},
+				SrcEntity: &storage.NetworkEntityInfo{
+					Type: 1,
+					Id:   "TestSrc1",
+				},
+			},
+			ClusterId:         clusterID,
+			LastSeenTimestamp: types.TimestampNow(),
+		},
+		{
+			Props: &storage.NetworkFlowProperties{
+				DstPort: 22,
+				DstEntity: &storage.NetworkEntityInfo{
+					Type: 1,
+					Id:   "TestDst1",
+				},
+				SrcEntity: &storage.NetworkEntityInfo{
+					Type: 1,
+					Id:   "TestSrc1",
+				},
+			},
+			ClusterId:         clusterID,
+			LastSeenTimestamp: types.TimestampNow(),
+		},
+		{
+			Props: &storage.NetworkFlowProperties{
+				DstPort: 22,
+				DstEntity: &storage.NetworkEntityInfo{
+					Type: 1,
+					Id:   "TestDst2",
+				},
+				SrcEntity: &storage.NetworkEntityInfo{
+					Type: 1,
+					Id:   "TestSrc2",
+				},
+			},
+			ClusterId:         clusterID,
+			LastSeenTimestamp: types.TimestampNow(),
+		},
+		{
+			Props: &storage.NetworkFlowProperties{
+				DstPort: 22,
+				DstEntity: &storage.NetworkEntityInfo{
+					Type: 1,
+					Id:   "TestDst2",
+				},
+				SrcEntity: &storage.NetworkEntityInfo{
+					Type: 1,
+					Id:   "TestSrc2",
+				},
+			},
+			ClusterId:         clusterID,
+			LastSeenTimestamp: types.TimestampNow(),
+		},
+	}
+
+	err = flowStore.UpsertFlows(s.ctx, flows, timestamp.Now())
+	s.Nil(err)
+
+	storedFlows, _, err := flowStore.GetAllFlows(s.ctx, nil)
+	s.Nil(err)
+	s.Equal(len(storedFlows), 6)
+
+	PruneStaleNetworkFlows(s.ctx, s.testDB.Pool)
+
+	storedFlows, _, err = flowStore.GetAllFlows(s.ctx, nil)
+	s.Nil(err)
+	s.Equal(len(storedFlows), 2)
 }

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -143,6 +143,7 @@ func (g *garbageCollectorImpl) pruneBasedOnConfig() {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		postgres.PruneActiveComponents(pruningCtx, globaldb.GetPostgres())
 		postgres.PruneClusterHealthStatuses(pruningCtx, globaldb.GetPostgres())
+		postgres.PruneStaleNetworkFlows(pruningCtx, globaldb.GetPostgres())
 	}
 
 	log.Info("[Pruning] Finished garbage collection cycle")


### PR DESCRIPTION
## Description

Prune of stale network flows as part of garbage collection to help keep the size of the table down.  I chose to go with straight SQL in the posgtres/pruning.go because this way allows use to easily remove the stale flows for all clusters at once.  If we were to put this in the store, it would either only remove the stale flows per each cluster because there is a store per cluster or have an operation against all clusters that would seem out of place.  I felt it would be confusing it f we had a bunch of cluster specific operations in a store and 1 global one.  Thus I implemented this outside of the store.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Added unit tests.
