### PR TITLE
ROX-12585: Fix link to next milestone in cut-rc workflow

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -108,19 +108,19 @@ jobs:
         if: env.DRY_RUN == 'false' && steps.check.outputs.open-issues != ''
         run: |
           set -u
-          if ! http_code=$(gh api --silent -X POST \
+          if ! RESPONSE=$(gh api -X POST \
             "repos/${{github.repository}}/milestones" \
             -f "title"="${{needs.variables.outputs.next-milestone}}" \
             2>&1); then
-
-            if grep "HTTP 422" <<< "$http_code"; then
+            if grep "HTTP 422" <<< "$RESPONSE"; then
               echo "Milestone ${{needs.variables.outputs.next-milestone}} already exists." >> $GITHUB_STEP_SUMMARY
             else
-              echo "::error::Couldn't create milestone ${{needs.variables.outputs.next-milestone}}: $http_code"
+              echo "::error::Couldn't create milestone ${{needs.variables.outputs.next-milestone}}: $RESPONSE"
               exit 1
             fi
           else
-            echo "Milestone ${{needs.variables.outputs.next-milestone}} has been created." >> $GITHUB_STEP_SUMMARY
+            NEXT_MILESTONE_URL=$(echo ${RESPONSE} | jq -r '.html_url')
+            echo ":arrow_right: Close the newly created [milestone ${{ needs.variables.outputs.next-milestone }}](${NEXT_MILESTONE_URL}) when ready, or delete it when finishing the release." >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Move open PRs


### PR DESCRIPTION
## Description

Previously, the link to the next milestone pointed to the current milestone. By using the output of the milestone create command, we get the correct URL.

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Tested in private test repo at https://github.com/stackrox/test-gh-actions/pull/42.
