### PR TITLE
Generify some reflection-based utility functions for slices and maps

### DIFF
--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -1430,7 +1430,7 @@ func (suite *DefaultPoliciesTestSuite) TestDefaultPolicies() {
 				for deploymentID, processes := range c.expectedProcessViolations {
 					expectedProcesses := set.NewStringSet(sliceutils.Map(processes, func(p *storage.ProcessIndicator) string {
 						return p.GetId()
-					}).([]string)...)
+					})...)
 					deployment := suite.deployments[deploymentID]
 
 					for _, process := range suite.deploymentsToIndicators[deploymentID] {
@@ -1868,9 +1868,9 @@ func policyWithSingleKeyValue(fieldName, value string, negate bool) *storage.Pol
 }
 
 func policyWithSingleFieldAndValues(fieldName string, values []string, negate bool, op storage.BooleanOperator) *storage.Policy {
-	return policyWithGroups(storage.EventSource_NOT_APPLICABLE, &storage.PolicyGroup{FieldName: fieldName, Values: sliceutils.Map(values, func(val *string) *storage.PolicyValue {
-		return &storage.PolicyValue{Value: *val}
-	}).([]*storage.PolicyValue), Negate: negate, BooleanOperator: op})
+	return policyWithGroups(storage.EventSource_NOT_APPLICABLE, &storage.PolicyGroup{FieldName: fieldName, Values: sliceutils.Map(values, func(val string) *storage.PolicyValue {
+		return &storage.PolicyValue{Value: val}
+	}), Negate: negate, BooleanOperator: op})
 }
 
 func processBaselineMessage(dep *storage.Deployment, baseline bool, privileged bool, processNames ...string) []*storage.Alert_Violation {

--- a/pkg/booleanpolicy/evaluator/pathutil/augmented_obj_meta_test.go
+++ b/pkg/booleanpolicy/evaluator/pathutil/augmented_obj_meta_test.go
@@ -174,7 +174,7 @@ func TestOnDeployment(t *testing.T) {
 	require.NoError(t, err)
 	path, found := pathMap.Get("Container Name")
 	assert.True(t, found)
-	assert.Equal(t, []string{"Containers", "Name"}, sliceutils.Map(path, func(s *MetaStep) string {
+	assert.Equal(t, []string{"Containers", "Name"}, sliceutils.Map(path, func(s MetaStep) string {
 		return s.FieldName
-	}).([]string))
+	}))
 }

--- a/pkg/booleanpolicy/policyversion/version.go
+++ b/pkg/booleanpolicy/policyversion/version.go
@@ -38,7 +38,7 @@ var (
 
 	// versionRanks maps known versions to their sequence numbers. Note that
 	// the sequence number may vary among different builds.
-	versionRanks = utils.Invert(versions[:]).(map[string]int)
+	versionRanks = utils.InvertSlice(versions[:])
 )
 
 // CurrentVersion is the current version of boolean policies that is handled

--- a/pkg/containers/ports.go
+++ b/pkg/containers/ports.go
@@ -15,7 +15,7 @@ var (
 		storage.PortConfig_ROUTE,
 		storage.PortConfig_EXTERNAL,
 	}
-	exposureRank = utils.Invert(exposureOrder).(map[storage.PortConfig_ExposureLevel]int)
+	exposureRank = utils.InvertSlice(exposureOrder)
 )
 
 // CompareExposureLevel compares two exposure levels.

--- a/pkg/postgres/pgutils/utils.go
+++ b/pkg/postgres/pgutils/utils.go
@@ -42,12 +42,10 @@ func ErrNilIfNoRows(err error) error {
 }
 
 // ConvertEnumSliceToIntArray converts an enum slice into a Postgres intarray
-func ConvertEnumSliceToIntArray(i interface{}) []int32 {
-	enumSlice := reflect.ValueOf(i)
-	enumSliceLen := enumSlice.Len()
-	resultSlice := make([]int32, 0, enumSliceLen)
-	for i := 0; i < enumSlice.Len(); i++ {
-		resultSlice = append(resultSlice, int32(enumSlice.Index(i).Int()))
+func ConvertEnumSliceToIntArray[T ~int32](enumSlice []T) []int32 {
+	resultSlice := make([]int32, 0, len(enumSlice))
+	for _, v := range enumSlice {
+		resultSlice = append(resultSlice, int32(v))
 	}
 	return resultSlice
 }

--- a/pkg/sliceutils/find.go
+++ b/pkg/sliceutils/find.go
@@ -1,19 +1,9 @@
 package sliceutils
 
-import (
-	"fmt"
-	"reflect"
-)
-
 // Find returns the index of elem in slice, or -1 if slice does not contain elem.
-func Find(slice interface{}, elem interface{}) int {
-	val := reflect.ValueOf(slice)
-	if val.Kind() != reflect.Slice {
-		panic(fmt.Errorf("value is not of slice kind but %v", val.Kind()))
-	}
-	l := val.Len()
-	for i := 0; i < l; i++ {
-		if val.Index(i).Interface() == elem {
+func Find[T comparable](slice []T, elem T) int {
+	for i, v := range slice {
+		if v == elem {
 			return i
 		}
 	}
@@ -33,35 +23,9 @@ func Find(slice interface{}, elem interface{}) int {
 // It panics at runtime if the arguments are of invalid types. There is no compile-time
 // safety of any kind.
 // Use ONLY in program initialization blocks, and in tests.
-func FindMatching(slice interface{}, predicate interface{}) int {
-	sliceVal := reflect.ValueOf(slice)
-	if sliceVal.Kind() != reflect.Slice {
-		panic(fmt.Errorf("FindMatching: value is not of slice kind but %v", sliceVal.Kind()))
-	}
-
-	predVal := reflect.ValueOf(predicate)
-	if predVal.Kind() != reflect.Func {
-		panic(fmt.Errorf("FindMatching: value is not of predicate kind but %v", predVal.Kind()))
-	}
-
-	predType := predVal.Type()
-	if predType.NumIn() != 1 {
-		panic(fmt.Errorf("FindMatching: expected func to be unary but it was %d-ary", predType.NumIn()))
-	}
-	if predType.NumOut() != 1 {
-		panic(fmt.Errorf("FindMatching: expected func to have exactly one return value, but it had %d", predType.NumOut()))
-	}
-
-	funcNeedsPtr := reflect.PtrTo(sliceVal.Type().Elem()).AssignableTo(predType.In(0))
-
-	l := sliceVal.Len()
-	for i := 0; i < l; i++ {
-		valToUse := sliceVal.Index(i)
-		if funcNeedsPtr {
-			valToUse = valToUse.Addr()
-		}
-		out := predVal.Call([]reflect.Value{valToUse})
-		if out[0].Bool() {
+func FindMatching[T any](slice []T, predicate func(T) bool) int {
+	for i, v := range slice {
+		if predicate(v) {
 			return i
 		}
 	}

--- a/pkg/sliceutils/find.go
+++ b/pkg/sliceutils/find.go
@@ -10,19 +10,13 @@ func Find[T comparable](slice []T, elem T) int {
 	return -1
 }
 
-// FindMatching returns the first index of slice where the passed predicate -- which must be a
-// func(elemType) bool OR a func(*elemType) bool -- returns true, or -1 if it doesn't return true for any element.
+// FindMatching returns the first index of slice where the passed predicate returns true, or -1 if it doesn't return
+// true for any element.
 // Example usage:
 // FindMatching([]string{"a", "b", "cd"}, func(s string) bool {
 //   return len(s) > 1
 // })
 // will return 2.
-// Note that the predicate could also be a func(s *string) bool if you want to avoid copying.
-// This function will automatically pass pointers to each slice element if you pass such a predicate.
-// It uses reflect, and will be slow.
-// It panics at runtime if the arguments are of invalid types. There is no compile-time
-// safety of any kind.
-// Use ONLY in program initialization blocks, and in tests.
 func FindMatching[T any](slice []T, predicate func(T) bool) int {
 	for i, v := range slice {
 		if predicate(v) {

--- a/pkg/sliceutils/find_test.go
+++ b/pkg/sliceutils/find_test.go
@@ -12,8 +12,8 @@ func TestFind(t *testing.T) {
 	t.Parallel()
 
 	slice := []myType{1, 3, 7}
-	assert.Equal(t, -1, Find(slice, 3))
-	assert.Equal(t, 1, Find(slice, myType(3)))
+	assert.Equal(t, 1, Find(slice, 3))
+	assert.Equal(t, -1, Find(slice, 6))
 }
 
 type myWeirdStruct struct {

--- a/pkg/sliceutils/find_test.go
+++ b/pkg/sliceutils/find_test.go
@@ -38,17 +38,4 @@ func TestFindMatching(t *testing.T) {
 	a.Equal(1, FindMatching(slice, func(weirdStruct myWeirdStruct) bool {
 		return weirdStruct.b > 1
 	}))
-	a.Equal(1, FindMatching(slice, func(weirdStruct *myWeirdStruct) bool {
-		return weirdStruct.b > 1
-	}))
-	a.Panics(func() {
-		FindMatching([]string{"1", "2"}, func(int) bool {
-			return false
-		})
-	})
-	a.Panics(func() {
-		FindMatching("1", func(string) bool {
-			return false
-		})
-	})
 }

--- a/pkg/sliceutils/map.go
+++ b/pkg/sliceutils/map.go
@@ -1,63 +1,29 @@
 package sliceutils
 
-import (
-	"fmt"
-	"reflect"
-)
-
-// Map maps the elements of slice, using the given mapFunc, which MUST be a
-// func(elemType) returnElemType OR a func(*elemType) returnElemType.
-// It returns a []returnElemType.
+// Map maps the elements of slice, using the given mapFunc
 // Example usage:
 // Map([]string{"a", "b", "cd"}, func(s string) int {
 //   return len(s)
 // })
 // will return []int{1, 1, 2}.
-// Note that the predicate could also be a func(s *string) int if you want to avoid copying.
-// This function will automatically pass pointers to each slice element if you pass such a function.
-// It uses reflect, and will be slow.
-// It panics at runtime if the arguments are of invalid types. There is no compile-time
-// safety of any kind.
-// Use ONLY in program initialization blocks, and in tests.
-func Map(slice, mapFunc interface{}) interface{} {
-	sliceVal := reflect.ValueOf(slice)
-	if sliceVal.Kind() != reflect.Slice {
-		panic(fmt.Errorf("FindMatching: value is not of slice kind but %v", sliceVal.Kind()))
+func Map[T, U any](slice []T, mapFunc func(T) U) []U {
+	result := make([]U, 0, len(slice))
+	for _, elem := range slice {
+		result = append(result, mapFunc(elem))
 	}
-
-	predVal := reflect.ValueOf(mapFunc)
-	if predVal.Kind() != reflect.Func {
-		panic(fmt.Errorf("FindMatching: value is not of predicate kind but %v", predVal.Kind()))
-	}
-
-	predType := predVal.Type()
-	if predType.NumIn() != 1 {
-		panic(fmt.Errorf("FindMatching: expected func to be unary but it was %d-ary", predType.NumIn()))
-	}
-	if predType.NumOut() != 1 {
-		panic(fmt.Errorf("FindMatching: expected func to have exactly one return value, but it had %d", predType.NumOut()))
-	}
-
-	funcNeedsPtr := reflect.PtrTo(sliceVal.Type().Elem()).AssignableTo(predType.In(0))
-
-	l := sliceVal.Len()
-	outSlice := reflect.MakeSlice(reflect.SliceOf(predType.Out(0)), l, l)
-	for i := 0; i < l; i++ {
-		valToUse := sliceVal.Index(i)
-		if funcNeedsPtr {
-			valToUse = valToUse.Addr()
-		}
-		outSlice.Index(i).Set(predVal.Call([]reflect.Value{valToUse})[0])
-	}
-	return outSlice.Interface()
+	return result
 }
 
 // MapsIntersect returns true if there is at least one key-value pair that is present in both maps
 // If both, or either maps are empty, it returns false
 // TODO : Convert to generics after upgrade to go 1.18
-func MapsIntersect(m1 map[string]string, m2 map[string]string) bool {
+func MapsIntersect[K, V comparable](m1 map[K]V, m2 map[K]V) bool {
 	if len(m2) == 0 {
 		return false
+	}
+	if len(m1) > len(m2) {
+		// Range over smaller map
+		m1, m2 = m2, m1
 	}
 	for k, v := range m1 {
 		if val, exists := m2[k]; exists {

--- a/pkg/sliceutils/map_test.go
+++ b/pkg/sliceutils/map_test.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,94 +11,40 @@ type randomTestStruct struct {
 	blah string
 }
 
-func TestMap(t *testing.T) {
-	testCases := []struct {
-		desc        string
-		slice       interface{}
-		mapFunc     interface{}
-		shouldPanic bool
-		expectedOut interface{}
-	}{
-		{
-			"simple func on string",
-			[]string{"1", "2"},
-			func(s string) string {
-				return s + s
-			},
-			false,
-			[]string{"11", "22"},
-		},
-		{
-			"same func, but with ptr",
-			[]string{"1", "2"},
-			func(s *string) string {
-				return *s + *s
-			},
-			false,
-			[]string{"11", "22"},
-		},
-		{
-			"func of int to string array",
-			[]int{1, 2},
-			func(val int) []string {
-				out := make([]string, 0, val)
-				for i := 0; i < val; i++ {
-					out = append(out, strconv.Itoa(i))
-				}
-				return out
-			},
-			false,
-			[][]string{{"0"}, {"0", "1"}},
-		},
-		{
-			"extract element from struct",
-			[]randomTestStruct{{"1"}, {"2"}},
-			func(s randomTestStruct) string {
-				return s.blah
-			},
-			false,
-			[]string{"1", "2"},
-		},
-		{
-			"extract element from struct with pointer",
-			[]randomTestStruct{{"1"}, {"2"}},
-			func(s *randomTestStruct) string {
-				return s.blah
-			},
-			false,
-			[]string{"1", "2"},
-		},
-		{
-			"extract element from struct with pointer to pointer, should panic",
-			[]randomTestStruct{{"1"}, {"2"}},
-			func(s **randomTestStruct) string {
-				return (*s).blah
-			},
-			true,
-			[]string{"1", "2"},
-		},
-		{
-			"extract element from struct with pointer to pointer",
-			[]*randomTestStruct{{"1"}, {"2"}},
-			func(s **randomTestStruct) string {
-				return (*s).blah
-			},
-			false,
-			[]string{"1", "2"},
-		},
-	}
+func testMap[T, U any](t *testing.T, desc string, slice []T, mapFunc func(T) U, expectedOut []U) {
+	t.Run(desc, func(t *testing.T) {
+		out := Map(slice, mapFunc)
+		require.Equal(t, expectedOut, out)
+	})
+}
 
-	for _, testCase := range testCases {
-		c := testCase
-		t.Run(c.desc, func(t *testing.T) {
-			if c.shouldPanic {
-				assert.Panics(t, func() {
-					Map(c.slice, c.mapFunc)
-				})
-				return
+func TestMap(t *testing.T) {
+	testMap(t,
+		"simple func on string",
+		[]string{"1", "2"},
+		func(s string) string {
+			return s + s
+		},
+		[]string{"11", "22"},
+	)
+	testMap(t,
+		"func of int to string array",
+		[]int{1, 2},
+		func(val int) []string {
+			out := make([]string, 0, val)
+			for i := 0; i < val; i++ {
+				out = append(out, strconv.Itoa(i))
 			}
-			out := Map(c.slice, c.mapFunc)
-			require.Equal(t, c.expectedOut, out)
-		})
-	}
+			return out
+		},
+		[][]string{{"0"}, {"0", "1"}},
+	)
+	testMap(t,
+		"extract element from struct",
+		[]randomTestStruct{{"1"}, {"2"}},
+		func(s randomTestStruct) string {
+			return s.blah
+		},
+		[]string{"1", "2"},
+	)
 }

--- a/pkg/sliceutils/reverse.go
+++ b/pkg/sliceutils/reverse.go
@@ -1,7 +1,6 @@
 package sliceutils
 
 import (
-	"fmt"
 	"reflect"
 )
 
@@ -15,25 +14,18 @@ func reverseInPlace(sliceVal reflect.Value, l int) {
 }
 
 // ReverseInPlace reverses the elements of the given slice in-place.
-func ReverseInPlace(slice interface{}) {
-	val := reflect.ValueOf(slice)
-	if val.Kind() != reflect.Slice {
-		panic(fmt.Errorf("value is not of slice kind but %v", val.Kind()))
+func ReverseInPlace[T any](slice []T) {
+	l := len(slice)
+	for i := 0; i < l/2; i++ {
+		slice[i], slice[l-1-i] = slice[l-1-i], slice[i]
 	}
-	l := val.Len()
-	reverseInPlace(val, l)
 }
 
 // Reversed returns a slice that contains the elements of the input slice in reverse order.
-func Reversed(slice interface{}) interface{} {
-	val := reflect.ValueOf(slice)
-	if val.Kind() != reflect.Slice {
-		panic(fmt.Errorf("value is not of slice kind but %v", val.Kind()))
+func Reversed[T any](slice []T) []T {
+	out := make([]T, 0, len(slice))
+	for i := len(slice) - 1; i >= 0; i-- {
+		out = append(out, slice[i])
 	}
-
-	l := val.Len()
-	out := reflect.MakeSlice(val.Type(), l, l)
-	reflect.Copy(out, val)
-	reverseInPlace(out, l)
-	return out.Interface()
+	return out
 }

--- a/pkg/sliceutils/reverse_test.go
+++ b/pkg/sliceutils/reverse_test.go
@@ -14,7 +14,7 @@ func TestReverseInPlace(t *testing.T) {
 
 func TestReversed(t *testing.T) {
 	in := []string{"foo", "bar", "baz"}
-	out := Reversed(in).([]string)
+	out := Reversed(in)
 	assert.Equal(t, []string{"baz", "bar", "foo"}, out)
 	assert.Equal(t, []string{"foo", "bar", "baz"}, in)
 }

--- a/pkg/sliceutils/unique.go
+++ b/pkg/sliceutils/unique.go
@@ -1,33 +1,16 @@
 package sliceutils
 
-import (
-	"fmt"
-	"reflect"
-)
-
 // Unique returns a new slice that contains only the first occurrence of each element in slice.
-// Callers should be able to cast the returned value to the same slice type that they passed in.
-// Example: Unique([]string{"a", "a", b"}).([]string) will work.
-// Use only in tests or initialization code, where the performance penalty
-// and lack of compile-time safety are worth it.
-// For all other cases, use code generation (see generic.go).
-func Unique(slice interface{}) interface{} {
-	val := reflect.ValueOf(slice)
-	if val.Kind() != reflect.Slice {
-		panic(fmt.Errorf("value is not of slice kind but %v", val.Kind()))
-	}
+// Example: Unique([]string{"a", "a", b"}) will return []string{"a", "b"}
+func Unique[T comparable](slice []T) []T {
+	out := make([]T, 0, len(slice))
 
-	l := val.Len()
-	out := reflect.MakeSlice(val.Type(), 0, l)
-
-	seenElems := make(map[interface{}]struct{})
-	for i := 0; i < l; i++ {
-		elem := val.Index(i).Interface()
-		if _, ok := seenElems[elem]; !ok {
-			out = reflect.Append(out, reflect.ValueOf(elem))
-			seenElems[elem] = struct{}{}
+	seenElems := make(map[T]struct{})
+	for _, elem := range slice {
+		if _, ok := seenElems[elem]; ok {
+			continue
 		}
+		out = append(out, elem)
 	}
-
-	return out.Interface()
+	return out
 }

--- a/pkg/sliceutils/unique.go
+++ b/pkg/sliceutils/unique.go
@@ -7,7 +7,9 @@ func Unique[T comparable](slice []T) []T {
 
 	seenElems := make(map[T]struct{})
 	for _, elem := range slice {
-		if _, ok := seenElems[elem]; ok {
+		preNumElems := len(seenElems)
+		seenElems[elem] = struct{}{}
+		if len(seenElems) == preNumElems { // not added
 			continue
 		}
 		out = append(out, elem)

--- a/pkg/utils/invert.go
+++ b/pkg/utils/invert.go
@@ -1,57 +1,17 @@
 package utils
 
-import (
-	"fmt"
-	"reflect"
-)
-
-var (
-	intTy = reflect.TypeOf(0)
-)
-
-// Invert inverts an object, which must be a map, array, or slice, and returns a map mapping elements to keys (or
-// indices). If multiple keys/indices map to the same element, the resulting mapping is non-deterministic.
-// An error is returned if the given object is not of kind map, array, or slice.
-// Note: since this function is based on reflection, it should not be used in performance-critical code. Its intended
-// use is in global variable definitions and `init()` blocks. For this reason, there is no explicit error handling - all
-// errors are reported as panics.
-func Invert(obj interface{}) interface{} {
-	objVal := reflect.ValueOf(obj)
-	switch objVal.Kind() {
-	case reflect.Slice, reflect.Array:
-		return invertSliceOrArray(objVal)
-	case reflect.Map:
-		return invertMap(objVal)
-	default:
-		panic(fmt.Errorf("object is neither of kind slice, array, or map, but %v", objVal.Kind()))
+func InvertSlice[T comparable](slice []T) map[T]int {
+	result := make(map[T]int, len(slice))
+	for i, v := range slice {
+		result[v] = i
 	}
+	return result
 }
 
-func invertSliceOrArray(sliceVal reflect.Value) interface{} {
-	elemTy := sliceVal.Type().Elem()
-	length := sliceVal.Len()
-	mapTy := reflect.MapOf(elemTy, intTy)
-	result := reflect.MakeMapWithSize(mapTy, length)
-	for i := 0; i < length; i++ {
-		elem := sliceVal.Index(i)
-		result.SetMapIndex(elem, reflect.ValueOf(i))
+func InvertMap[K, V comparable](m map[K]V) map[V]K {
+	result := make(map[V]K, len(m))
+	for k, v := range m {
+		result[v] = k
 	}
-	return result.Interface()
-}
-
-func invertMap(mapVal reflect.Value) interface{} {
-	length := mapVal.Len()
-	keyTy, elemTy := mapVal.Type().Key(), mapVal.Type().Elem()
-	mapTy := reflect.MapOf(elemTy, keyTy)
-	result := reflect.MakeMapWithSize(mapTy, length)
-	for _, keyVal := range mapVal.MapKeys() {
-		elemVal := mapVal.MapIndex(keyVal)
-		result.SetMapIndex(elemVal, keyVal)
-	}
-	return result.Interface()
-}
-
-// InvertList inverts the given variadic argument list, returning a map mapping elements to indices.
-func InvertList(objs ...interface{}) interface{} {
-	return Invert(objs)
+	return result
 }

--- a/pkg/utils/invert.go
+++ b/pkg/utils/invert.go
@@ -1,5 +1,6 @@
 package utils
 
+// InvertSlice inverts an slice, returning a map mapping each element in the slice to the _last_ index it occurs at.
 func InvertSlice[T comparable](slice []T) map[T]int {
 	result := make(map[T]int, len(slice))
 	for i, v := range slice {
@@ -8,6 +9,9 @@ func InvertSlice[T comparable](slice []T) map[T]int {
 	return result
 }
 
+// InvertMap inverts a map, returning a map mapping each value contained in the original map to a key that mapped to
+// said value in the original map. In case of multiple keys mapping to a single value in the original map, one key is
+// chosen non-deterministically.
 func InvertMap[K, V comparable](m map[K]V) map[V]K {
 	result := make(map[V]K, len(m))
 	for k, v := range m {

--- a/pkg/utils/invert.go
+++ b/pkg/utils/invert.go
@@ -1,6 +1,6 @@
 package utils
 
-// InvertSlice inverts an slice, returning a map mapping each element in the slice to the _last_ index it occurs at.
+// InvertSlice inverts a slice, returning a map mapping each element in the slice to the _last_ index it occurs at.
 func InvertSlice[T comparable](slice []T) map[T]int {
 	result := make(map[T]int, len(slice))
 	for i, v := range slice {

--- a/roxctl/central/db/restore/v2_restorer.go
+++ b/roxctl/central/db/restore/v2_restorer.go
@@ -49,7 +49,7 @@ const (
 
 var (
 	defaultSpinner = []string{"⠇", "⠏", "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"}
-	waitingSpinner = sliceutils.ConcatStringSlices(defaultSpinner, sliceutils.Reversed(defaultSpinner).([]string))
+	waitingSpinner = sliceutils.ConcatStringSlices(defaultSpinner, sliceutils.Reversed(defaultSpinner))
 )
 
 type v2Restorer struct {

--- a/roxctl/scanner/clustertype/wrapper.go
+++ b/roxctl/scanner/clustertype/wrapper.go
@@ -19,7 +19,7 @@ var (
 		"openshift4": storage.ClusterType_OPENSHIFT4_CLUSTER,
 	}
 
-	clusterEnumToString = utils.Invert(clusterStringToType).(map[storage.ClusterType]string)
+	clusterEnumToString = utils.InvertMap(clusterStringToType)
 
 	validClusterStrings = func() []string {
 		out := make([]string, 0, len(clusterStringToType))

--- a/sensor/upgrader/plan/order.go
+++ b/sensor/upgrader/plan/order.go
@@ -7,11 +7,10 @@ import (
 	"github.com/stackrox/rox/pkg/k8sutil/k8sobjects"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/upgrader/common"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var (
-	gvkPriorities = utils.Invert(common.OrderedBundleResourceTypes).(map[schema.GroupVersionKind]int)
+	gvkPriorities = utils.InvertSlice(common.OrderedBundleResourceTypes)
 )
 
 func sortObjects(objects []k8sutil.Object, reverse bool) {

--- a/tests/container_instances_test.go
+++ b/tests/container_instances_test.go
@@ -46,12 +46,12 @@ func TestContainerInstances(testT *testing.T) {
 			// Expecting 1 process: nginx
 			require.Len(retryEventsT, groupedContainers[0].Events, 1)
 			firstContainerEvents :=
-				sliceutils.Map(groupedContainers[0].Events, func(event Event) string { return event.Name }).([]string)
+				sliceutils.Map(groupedContainers[0].Events, func(event Event) string { return event.Name })
 			require.ElementsMatch(retryEventsT, firstContainerEvents, []string{"/usr/sbin/nginx"})
 			// Expecting 3 processes: sh, date, sleep
 			require.Len(retryEventsT, groupedContainers[1].Events, 3)
 			secondContainerEvents :=
-				sliceutils.Map(groupedContainers[1].Events, func(event Event) string { return event.Name }).([]string)
+				sliceutils.Map(groupedContainers[1].Events, func(event Event) string { return event.Name })
 			require.ElementsMatch(retryEventsT, secondContainerEvents, []string{"/bin/sh", "/bin/date", "/bin/sleep"})
 
 			// Verify the container group's timestamp is no later than the timestamp of the first event

--- a/tests/csv_utils.go
+++ b/tests/csv_utils.go
@@ -64,7 +64,7 @@ func verifyRiskEventTimelineCSV(t testutils.T, deploymentID string, eventNamesEx
 
 	// Check event names match
 	// Index 0 of a row is the timestamp and 2 is the event name
-	eventNamesInCSV := sliceutils.Map(rows, func(row []string) string { return row[2] }).([]string)
+	eventNamesInCSV := sliceutils.Map(rows, func(row []string) string { return row[2] })
 	assert.ElementsMatch(t, eventNamesExpected, eventNamesInCSV)
 
 	// All the records should be ordered by their event timestamp in a reverse order (latest first)

--- a/tests/graphql_sorting_test.go
+++ b/tests/graphql_sorting_test.go
@@ -34,10 +34,10 @@ func getDeploymentsWithSortOption(t *testing.T, field string, reversed bool) []*
 }
 
 func testDeploymentSorting(t *testing.T, field string, extractor func(d *storage.Deployment) string) {
-	sorted := sliceutils.Map(getDeploymentsWithSortOption(t, field, false), extractor).([]string)
+	sorted := sliceutils.Map(getDeploymentsWithSortOption(t, field, false), extractor)
 	assert.True(t, sort.StringsAreSorted(sorted), "field %s not sorted in response (got %v)", field, sorted)
 
-	sortedReverse := sliceutils.Map(getDeploymentsWithSortOption(t, field, true), extractor).([]string)
+	sortedReverse := sliceutils.Map(getDeploymentsWithSortOption(t, field, true), extractor)
 	assert.True(t, sort.SliceIsSorted(sortedReverse, func(i, j int) bool {
 		return sortedReverse[i] > sortedReverse[j]
 	}), "field %s not sorted in reverse in response (got %v)", field, sortedReverse)

--- a/tests/pods_test.go
+++ b/tests/pods_test.go
@@ -72,7 +72,7 @@ func TestPod(testT *testing.T) {
 		}
 
 		// Expecting processes: nginx, sh, date, sleep
-		eventNames := sliceutils.Map(events, func(event Event) string { return event.Name }).([]string)
+		eventNames := sliceutils.Map(events, func(event Event) string { return event.Name })
 		require.ElementsMatch(retryT, eventNames, []string{"/bin/date", "/bin/sh", "/usr/sbin/nginx", "/bin/sleep"})
 
 		// Verify the pod's timestamp is no later than the timestamp of the earliest event.


### PR DESCRIPTION
## Description

This rewrites some functions in `pkg/utils` and `pkg/sliceutils` that are currently based on reflection using generics.

While some flexibility is given up (e.g., the ability to transparently handle arrays in `utils.Invert`, or the ability to handle both functions that receive values and pointers in `sliceutils.Map`), this is not a concern because of the added benefit of compile-time static type checking, that prevents any mixups here.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- CI