### PR TITLE
Fixes useToasts hook to allow multiple toasts to display

### DIFF
--- a/ui/apps/platform/src/hooks/patternfly/useToasts.test.ts
+++ b/ui/apps/platform/src/hooks/patternfly/useToasts.test.ts
@@ -1,0 +1,46 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useToasts from './useToasts';
+
+test('useToasts should allow addition and removal of toasts', () => {
+    const { result } = renderHook(useToasts);
+    expect(result.current.toasts).toHaveLength(0);
+
+    // Test adding a single toast
+    act(() => {
+        const { addToast } = result.current;
+        addToast('First toast');
+    });
+    expect(result.current.toasts).toHaveLength(1);
+
+    // Test adding multiple toasts in succession
+    act(() => {
+        const { addToast } = result.current;
+        addToast('Second toast');
+        addToast('Third toast');
+    });
+    // Test reverse chronological ordering
+    expect(result.current.toasts).toHaveLength(3);
+    expect(result.current.toasts[2].title).toBe('First toast');
+    expect(result.current.toasts[1].title).toBe('Second toast');
+    expect(result.current.toasts[0].title).toBe('Third toast');
+    // Test that each item has a unique key
+    const toastKeys = result.current.toasts.map((t) => t.key);
+    expect(toastKeys.length).toEqual(new Set(toastKeys).size);
+
+    // Test removal of toast in the middle (e.g. via clicking the close button)
+    act(() => {
+        const { removeToast } = result.current;
+        removeToast(result.current.toasts[1].key);
+    });
+    expect(result.current.toasts).toHaveLength(2);
+    expect(result.current.toasts[1].title).toBe('First toast');
+    expect(result.current.toasts[0].title).toBe('Third toast');
+
+    // Test removing of multiple remaining toasts
+    act(() => {
+        const { removeToast } = result.current;
+        result.current.toasts.map((t) => t.key).forEach(removeToast);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+});

--- a/ui/apps/platform/src/hooks/patternfly/useToasts.tsx
+++ b/ui/apps/platform/src/hooks/patternfly/useToasts.tsx
@@ -5,7 +5,7 @@ export type AlertVariantType = 'default' | 'info' | 'success' | 'danger' | 'warn
 export type Toast = {
     title: string;
     variant: AlertVariantType;
-    key: number;
+    key: string;
     children?: ReactNode;
 };
 
@@ -19,7 +19,7 @@ function useToasts(): UseToasts {
     const [toasts, setToasts] = useState<Toast[]>([]);
 
     function getUniqueId() {
-        return new Date().getTime() + Math.random();
+        return `${new Date().toISOString()} ${Math.random()}`;
     }
 
     function addToast(title, variant = 'default' as AlertVariantType, children) {

--- a/ui/apps/platform/src/hooks/patternfly/useToasts.tsx
+++ b/ui/apps/platform/src/hooks/patternfly/useToasts.tsx
@@ -19,16 +19,16 @@ function useToasts(): UseToasts {
     const [toasts, setToasts] = useState<Toast[]>([]);
 
     function getUniqueId() {
-        return new Date().getTime();
+        return new Date().getTime() + Math.random();
     }
 
     function addToast(title, variant = 'default' as AlertVariantType, children) {
         const key = getUniqueId();
-        setToasts([...toasts, { title, variant, key, children }]);
+        setToasts((prevToasts) => [{ title, variant, key, children }, ...prevToasts]);
     }
 
     function removeToast(key) {
-        setToasts([...toasts.filter((el) => el.key !== key)]);
+        setToasts((prevToasts) => [...prevToasts.filter((el) => el.key !== key)]);
     }
 
     return {


### PR DESCRIPTION
## Description

Updates the `useToasts` hook to support displaying multiple toasts when `addToast` is called before previous toasts expire. I believe this was the intended effect, but a stale closure on the `toasts` local var was overwriting the entire array with a single item instead.

This also:
- Swaps the ordering of the array when a new item is added so that newer toasts are displayed first, to be in line with the [PatternFly design guidelines](https://www.patternfly.org/v4/components/alert-group/design-guidelines).
- Adds more randomness to key generation to ensure two toasts added back-to-back don't get the same key

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

Tested in local development work for Collections, where individual deletions can succeed or fail. The below screenshot is a situation where two deletions failed, but the rest succeeded.
![image](https://user-images.githubusercontent.com/1292638/193030164-6638cb25-a5a0-4767-aff8-d0f9ee9f3bff.png)

Tested on main polices page by quickly doing an "Export policy as JSON" followed by "delete policy".
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193031186-cabd8de0-421d-40ec-9035-fa1a6eced16c.png">

