### PR TITLE
Allow revert PRs to re-introduce TODO comments

### DIFF
--- a/scripts/ci/jobs/check-pr-fixes.sh
+++ b/scripts/ci/jobs/check-pr-fixes.sh
@@ -23,6 +23,11 @@ check-pr-fixes() {
         exit 0
     fi
 
+    if get_pr_details | jq -r '.title' | grep -iqF 'revert'; then
+       echo "This PR is a revert of another PR - it may introduce new TODOs!"
+       exit 0
+    fi
+
     echo "Tickets this PR claims to fix:"
     printf " - %s\n" "${tickets[@]}"
 


### PR DESCRIPTION
## Description

Allow PRs that revert another PR that references a ROX ticket in its description to re-introduce TODO comments.

Previously, this would lead to failing CI (see [this PR](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/3247/pull-ci-stackrox-stackrox-master-grouped-static-checks/1575564481113624576#1:build-log.txt%3A172) as example).
