### PR TITLE
Move paginationWrapper to generic function

### DIFF
--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -491,10 +491,7 @@ func (resolver *clusterResolver) Subjects(ctx context.Context, args PaginatedQue
 		return nil, err
 	}
 
-	resolvers, err := paginationWrapper{
-		pv: pagination,
-	}.paginate(subjectResolvers, nil)
-	return resolvers.([]*subjectResolver), err
+	return paginate(pagination, subjectResolvers, nil)
 }
 
 // SubjectCount returns count of Users and Groups in this cluster
@@ -792,11 +789,7 @@ func (resolver *clusterResolver) Policies(ctx context.Context, args PaginatedQue
 			ID:    resolver.data.GetId(),
 		})
 	}
-
-	resolvers, err := paginationWrapper{
-		pv: pagination,
-	}.paginate(policyResolvers, nil)
-	return resolvers.([]*policyResolver), err
+	return paginate(pagination, policyResolvers, nil)
 }
 
 func (resolver *clusterResolver) getApplicablePolicies(ctx context.Context, q *v1.Query) ([]*storage.Policy, error) {
@@ -928,7 +921,7 @@ func (resolver *clusterResolver) Controls(ctx context.Context, args RawQuery) ([
 	if err != nil || rs == nil {
 		return nil, err
 	}
-	resolvers, err := resolver.root.wrapComplianceControls(getComplianceControlsFromAggregationResults(rs, any, resolver.root.ComplianceStandardStore))
+	resolvers, err := resolver.root.wrapComplianceControls(getComplianceControlsFromAggregationResults(rs, all, resolver.root.ComplianceStandardStore))
 	if err != nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/compliance.go
+++ b/central/graphql/resolvers/compliance.go
@@ -672,7 +672,7 @@ func (resolver *complianceControlResolver) ComplianceControlNodes(ctx context.Co
 		if err != nil {
 			return nil, err
 		}
-		resolvers, err := resolver.root.wrapNodes(getResultNodesFromAggregationResults(rs, any, ds))
+		resolvers, err := resolver.root.wrapNodes(getResultNodesFromAggregationResults(rs, all, ds))
 		if err != nil {
 			return nil, err
 		}
@@ -790,7 +790,7 @@ type resultType int
 const (
 	failing resultType = iota
 	passing
-	any
+	all
 )
 
 func getScopeIDFromAggregationResult(result *storage.ComplianceAggregation_Result, scope storage.ComplianceAggregation_Scope) (string, error) {

--- a/central/graphql/resolvers/components_v1.go
+++ b/central/graphql/resolvers/components_v1.go
@@ -34,10 +34,7 @@ func (resolver *imageScanResolver) Components(ctx context.Context, args Paginate
 		},
 	}, query)
 
-	resolvers, err := paginationWrapper{
-		pv: pagination,
-	}.paginate(vulns, err)
-	return resolvers.([]*EmbeddedImageScanComponentResolver), err
+	return paginate(pagination, vulns, err)
 }
 
 func (resolver *imageScanResolver) ComponentCount(ctx context.Context, args RawQuery) (int32, error) {
@@ -167,16 +164,12 @@ func (eicr *EmbeddedImageScanComponentResolver) Vulns(ctx context.Context, args 
 		})
 	}
 
-	resolvers, err := paginationWrapper{
-		pv: query.GetPagination(),
-	}.paginate(vulns, nil)
+	resolvers, err := paginate(query.GetPagination(), vulns, nil)
 	if err != nil {
 		return nil, err
 	}
-	paginatedVulns := resolvers.([]*EmbeddedVulnerabilityResolver)
-
-	ret := make([]VulnerabilityResolver, 0, len(paginatedVulns))
-	for _, resolver := range paginatedVulns {
+	ret := make([]VulnerabilityResolver, 0, len(resolvers))
+	for _, resolver := range resolvers {
 		ret = append(ret, resolver)
 	}
 	return ret, err

--- a/central/graphql/resolvers/deployments.go
+++ b/central/graphql/resolvers/deployments.go
@@ -251,10 +251,7 @@ func (resolver *deploymentResolver) Policies(ctx context.Context, args Paginated
 		})
 	}
 
-	resolvers, err := paginationWrapper{
-		pv: pagination,
-	}.paginate(policyResolvers, nil)
-	return resolvers.([]*policyResolver), err
+	return paginate(pagination, policyResolvers, nil)
 }
 
 func (resolver *deploymentResolver) PolicyCount(ctx context.Context, args RawQuery) (int32, error) {
@@ -333,10 +330,7 @@ func (resolver *deploymentResolver) FailingPolicies(ctx context.Context, args Pa
 		})
 	}
 
-	resolvers, err := paginationWrapper{
-		pv: pagination,
-	}.paginate(policyResolvers, nil)
-	return resolvers.([]*policyResolver), err
+	return paginate(pagination, policyResolvers, nil)
 }
 
 // FailingPolicyCount returns count of policies failing on this deployment
@@ -428,10 +422,7 @@ func (resolver *deploymentResolver) Secrets(ctx context.Context, args PaginatedQ
 		return nil, err
 	}
 
-	resolvers, err := paginationWrapper{
-		pv: pagination,
-	}.paginate(secrets, nil)
-	return resolvers.([]*secretResolver), err
+	return paginate(pagination, secrets, nil)
 }
 
 // SecretCount returns the total number of secrets for this deployment

--- a/central/graphql/resolvers/image_components.go
+++ b/central/graphql/resolvers/image_components.go
@@ -542,8 +542,5 @@ func getImageCVEResolvers(ctx context.Context, root *Resolver, os string, vulns 
 	for _, resolver := range resolvers {
 		resolverI = append(resolverI, resolver)
 	}
-	ret, err := paginationWrapper{
-		pv: query.GetPagination(),
-	}.paginate(resolverI, nil)
-	return ret.([]ImageVulnerabilityResolver), err
+	return paginate(query.GetPagination(), resolverI, nil)
 }

--- a/central/graphql/resolvers/image_scan.go
+++ b/central/graphql/resolvers/image_scan.go
@@ -84,8 +84,5 @@ func getImageComponentResolvers(ctx context.Context, root *Resolver, imageScan *
 	for _, resolver := range resolvers {
 		resolverI = append(resolverI, resolver)
 	}
-	ret, err := paginationWrapper{
-		pv: query.GetPagination(),
-	}.paginate(resolverI, nil)
-	return ret.([]ImageComponentResolver), err
+	return paginate(query.GetPagination(), resolverI, nil)
 }

--- a/central/graphql/resolvers/k8sroles.go
+++ b/central/graphql/resolvers/k8sroles.go
@@ -76,11 +76,7 @@ func (resolver *Resolver) K8sRoles(ctx context.Context, arg PaginatedQuery) ([]*
 		k8SRoleResolvers = append(k8SRoleResolvers, &k8SRoleResolver{root: resolver, data: k8srole})
 	}
 
-	resolvers, err := paginationWrapper{
-		pv: query.Pagination,
-	}.paginate(k8SRoleResolvers, nil)
-
-	return resolvers.([]*k8SRoleResolver), err
+	return paginate(query.Pagination, k8SRoleResolvers, nil)
 }
 
 // K8sRoleCount returns count of all k8s roles across infrastructure
@@ -185,10 +181,7 @@ func (resolver *k8SRoleResolver) Subjects(ctx context.Context, args PaginatedQue
 	if err != nil {
 		return nil, err
 	}
-	resolvers, err := paginationWrapper{
-		pv: pagination,
-	}.paginate(subjectResolvers, nil)
-	return resolvers.([]*subjectResolver), err
+	return paginate(pagination, subjectResolvers, nil)
 }
 
 func (resolver *k8SRoleResolver) getSubjects(ctx context.Context, filterQ *v1.Query) ([]*storage.Subject, error) {
@@ -223,10 +216,7 @@ func (resolver *k8SRoleResolver) ServiceAccounts(ctx context.Context, args Pagin
 	if err != nil {
 		return nil, err
 	}
-	resolvers, err := paginationWrapper{
-		pv: pagination,
-	}.paginate(serviceAccountResolvers, nil)
-	return resolvers.([]*serviceAccountResolver), err
+	return paginate(pagination, serviceAccountResolvers, nil)
 }
 
 // ServiceAccountCount returns the count of service accounts granted permissions to by a given k8s role

--- a/central/graphql/resolvers/namespaces.go
+++ b/central/graphql/resolvers/namespaces.go
@@ -236,10 +236,7 @@ func (resolver *namespaceResolver) Subjects(ctx context.Context, args PaginatedQ
 		resolvers = append(resolvers, &subjectResolver{ctx, resolver.root, subject})
 	}
 
-	paginatedResolvers, err := paginationWrapper{
-		pv: pagination,
-	}.paginate(resolvers, nil)
-	return paginatedResolvers.([]*subjectResolver), err
+	return paginate(pagination, resolvers, nil)
 }
 
 // ServiceAccountCount returns the count of ServiceAccounts which have any permission on this cluster namespace
@@ -392,10 +389,7 @@ func (resolver *namespaceResolver) Policies(ctx context.Context, args PaginatedQ
 		})
 	}
 
-	resolvers, err := paginationWrapper{
-		pv: pagination,
-	}.paginate(policyResolvers, nil)
-	return resolvers.([]*policyResolver), err
+	return paginate(pagination, policyResolvers, nil)
 }
 
 // FailingPolicyCounter returns a policy counter for all the failed policies.

--- a/central/graphql/resolvers/node_components_v1.go
+++ b/central/graphql/resolvers/node_components_v1.go
@@ -52,10 +52,7 @@ func (resolver *nodeScanResolver) Components(ctx context.Context, args Paginated
 		},
 	}, query)
 
-	resolvers, err := paginationWrapper{
-		pv: pagination,
-	}.paginate(vulns, err)
-	return resolvers.([]*EmbeddedNodeScanComponentResolver), err
+	return paginate(pagination, vulns, err)
 }
 
 func (resolver *nodeScanResolver) ComponentCount(ctx context.Context, args RawQuery) (int32, error) {
@@ -154,16 +151,13 @@ func (encr *EmbeddedNodeScanComponentResolver) Vulns(ctx context.Context, args P
 		})
 	}
 
-	resolvers, err := paginationWrapper{
-		pv: query.GetPagination(),
-	}.paginate(vulns, nil)
+	resolvers, err := paginate(query.GetPagination(), vulns, nil)
 	if err != nil {
 		return nil, err
 	}
-	paginatedVulns := resolvers.([]*EmbeddedVulnerabilityResolver)
 
-	ret := make([]VulnerabilityResolver, 0, len(paginatedVulns))
-	for _, resolver := range paginatedVulns {
+	ret := make([]VulnerabilityResolver, 0, len(resolvers))
+	for _, resolver := range resolvers {
 		ret = append(ret, resolver)
 	}
 	return ret, err

--- a/central/graphql/resolvers/nodes.go
+++ b/central/graphql/resolvers/nodes.go
@@ -245,7 +245,7 @@ func (resolver *nodeResolver) Controls(ctx context.Context, args RawQuery) ([]*c
 	if err != nil {
 		return nil, err
 	}
-	resolvers, err := resolver.root.wrapComplianceControls(getComplianceControlsFromAggregationResults(results, any, resolver.root.ComplianceStandardStore))
+	resolvers, err := resolver.root.wrapComplianceControls(getComplianceControlsFromAggregationResults(results, all, resolver.root.ComplianceStandardStore))
 	if err != nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/plotted_vulnerabilities_common.go
+++ b/central/graphql/resolvers/plotted_vulnerabilities_common.go
@@ -59,14 +59,12 @@ func unwrappedPlottedVulnerabilities(ctx context.Context, resolver *Resolver, cv
 		return nil, nil
 	}
 
-	cvesInterface, err := paginationWrapper{
-		pv: q.GetPagination(),
-	}.paginate(cveIds, nil)
+	cves, err := paginate(q.GetPagination(), cveIds, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	vulns, err := resolver.CVEDataStore.GetBatch(ctx, cvesInterface.([]string))
+	vulns, err := resolver.CVEDataStore.GetBatch(ctx, cves)
 	if err != nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/service_accounts.go
+++ b/central/graphql/resolvers/service_accounts.go
@@ -58,10 +58,8 @@ func (resolver *Resolver) ServiceAccounts(ctx context.Context, args PaginatedQue
 		return nil, err
 	}
 
-	resolvers, err := paginationWrapper{
-		pv: query.Pagination,
-	}.paginate(resolver.wrapServiceAccounts(resolver.ServiceAccountsDataStore.SearchRawServiceAccounts(ctx, query)))
-	return resolvers.([]*serviceAccountResolver), err
+	serviceAccountResolvers, err := resolver.wrapServiceAccounts(resolver.ServiceAccountsDataStore.SearchRawServiceAccounts(ctx, query))
+	return paginate(query.GetPagination(), serviceAccountResolvers, err)
 }
 
 // ServiceAccountCount returns count of all service accounts across infrastructure
@@ -129,11 +127,7 @@ func (resolver *serviceAccountResolver) K8sRoles(ctx context.Context, args Pagin
 		return nil, err
 	}
 
-	resolvers, err := paginationWrapper{
-		pv: pagination,
-	}.paginate(roleResolvers, nil)
-
-	return resolvers.([]*k8SRoleResolver), err
+	return paginate(pagination, roleResolvers, nil)
 }
 
 func (resolver *serviceAccountResolver) getRolesAndBindings(ctx context.Context, passedQuery *v1.Query) ([]*storage.K8SRoleBinding, []*storage.K8SRole, error) {

--- a/central/graphql/resolvers/subjects.go
+++ b/central/graphql/resolvers/subjects.go
@@ -70,11 +70,7 @@ func (resolver *Resolver) Subjects(ctx context.Context, args PaginatedQuery) ([]
 		subjectResolvers = append(subjectResolvers, &subjectResolver{root: resolver, data: subject})
 	}
 
-	resolvers, err := paginationWrapper{
-		pv: query.Pagination,
-	}.paginate(subjectResolvers, nil)
-
-	return resolvers.([]*subjectResolver), err
+	return paginate(query.Pagination, subjectResolvers, nil)
 }
 
 // SubjectCount returns count of all subjects across infrastructure
@@ -170,13 +166,11 @@ func (resolver *subjectResolver) K8sRoles(ctx context.Context, args PaginatedQue
 		return nil, err
 	}
 
-	resolvers, err := paginationWrapper{
-		pv: filterQ.Pagination,
-	}.paginate(resolver.root.wrapK8SRoles(roles, nil))
+	roleResolvers, err := resolver.root.wrapK8SRoles(roles, nil)
 	if err != nil {
 		return nil, err
 	}
-	return resolvers.([]*k8SRoleResolver), err
+	return paginate(filterQ.Pagination, roleResolvers, nil)
 }
 
 func (resolver *subjectResolver) getRolesForSubject(ctx context.Context, filterQ *v1.Query) ([]*storage.K8SRole, error) {

--- a/central/graphql/resolvers/utils_test.go
+++ b/central/graphql/resolvers/utils_test.go
@@ -7,29 +7,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPaginationWrapper(t *testing.T) {
+func TestPagination(t *testing.T) {
 	stuff := []int{1, 2}
-	result, _ := paginationWrapper{pv: &v1.QueryPagination{Offset: 0, Limit: 2}}.paginate(stuff, nil)
-	rs := result.([]int)
-	assert.Equal(t, []int{1, 2}, rs)
+	result, _ := paginate(&v1.QueryPagination{Offset: 0, Limit: 2}, stuff, nil)
+	assert.Equal(t, []int{1, 2}, result)
 
 	stuff = []int{1, 2, 3}
-	result, _ = paginationWrapper{pv: &v1.QueryPagination{Offset: 1, Limit: 2}}.paginate(stuff, nil)
-	rs = result.([]int)
-	assert.Equal(t, []int{2, 3}, rs)
+	result, _ = paginate(&v1.QueryPagination{Offset: 1, Limit: 2}, stuff, nil)
+	assert.Equal(t, []int{2, 3}, result)
 
 	stuff = []int{1, 2, 3}
-	result, _ = paginationWrapper{pv: &v1.QueryPagination{Offset: 2, Limit: 2}}.paginate(stuff, nil)
-	rs = result.([]int)
-	assert.Equal(t, []int{3}, rs)
+	result, _ = paginate(&v1.QueryPagination{Offset: 2, Limit: 2}, stuff, nil)
+	assert.Equal(t, []int{3}, result)
 
 	stuff = []int{1, 2}
-	result, _ = paginationWrapper{pv: &v1.QueryPagination{Offset: 2, Limit: 2}}.paginate(stuff, nil)
-	rs = result.([]int)
-	assert.Equal(t, ([]int)(nil), rs)
+	result, _ = paginate(&v1.QueryPagination{Offset: 2, Limit: 2}, stuff, nil)
+	assert.Equal(t, ([]int)(nil), result)
 
 	stuff = []int{}
-	result, _ = paginationWrapper{pv: &v1.QueryPagination{Offset: 2, Limit: 2}}.paginate(stuff, nil)
-	rs = result.([]int)
-	assert.Equal(t, []int{}, rs)
+	result, _ = paginate(&v1.QueryPagination{Offset: 2, Limit: 2}, stuff, nil)
+	assert.Equal(t, []int{}, result)
 }

--- a/central/graphql/resolvers/vul_mgmt_widgets.go
+++ b/central/graphql/resolvers/vul_mgmt_widgets.go
@@ -124,10 +124,7 @@ func deploymentsWithMostSevereViolations(ctx context.Context, resolver *Resolver
 
 	sortBySeverity(ret)
 
-	resolvers, err := paginationWrapper{
-		pv: pagination,
-	}.paginate(ret, nil)
-	return resolvers.([]*DeploymentsWithMostSevereViolationsResolver), err
+	return paginate(pagination, ret, nil)
 }
 
 func sortBySeverity(deps []*DeploymentsWithMostSevereViolationsResolver) {

--- a/central/graphql/resolvers/vulnerabilities_v2.go
+++ b/central/graphql/resolvers/vulnerabilities_v2.go
@@ -382,13 +382,10 @@ func (resolver *Resolver) unwrappedVulnerabilitiesV2Query(ctx context.Context, q
 	// If query was modified, it means the result was not paginated since the filtering removes pagination.
 	// If post sorting was needed, which means pagination was not performed because it was removed above.
 	if queryModified || postSortingNeeded {
-		paginatedVulns, err := paginationWrapper{
-			pv: originalQuery.GetPagination(),
-		}.paginate(vulns, nil)
+		vulns, err = paginate(originalQuery.GetPagination(), vulns, nil)
 		if err != nil {
 			return nil, err
 		}
-		vulns = paginatedVulns.([]*storage.CVE)
 	}
 
 	vulnResolvers, err := resolver.wrapCVEs(vulns, err)


### PR DESCRIPTION
## Description

Remove the paginate wrapper now that we can use generics

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI plus unit test modificatinos
