### PR TITLE
CI: fix 3.70.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2905,7 +2905,7 @@ jobs:
           command: make -C operator/ build docker-build
       - run:
           name: Check that Operator image is runnable
-          command: docker run --rm stackrox/stackrox-operator:$(make --quiet -C operator tag) --help
+          command: docker run --rm quay.io/stackrox-io/stackrox-operator:$(make --quiet -C operator tag) --help
 
       - run:
           name: Push images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2852,9 +2852,6 @@ jobs:
           command: |
             TAG="$(make --quiet tag)"
 
-            docker login -u "$DOCKER_IO_PUSH_USERNAME" --password-stdin \<<<"$DOCKER_IO_PUSH_PASSWORD" docker.io
-            ./scripts/ci/push-as-manifest-list.sh "docker.io/stackrox/main:${TAG}" | cat
-
             docker login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin \<<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
             docker tag "stackrox/main:${TAG}" "quay.io/rhacs-eng/main:${TAG}"
             ./scripts/ci/push-as-manifest-list.sh "quay.io/rhacs-eng/main:${TAG}" | cat
@@ -2890,7 +2887,6 @@ jobs:
       - run:
           name: Login to Docker Hub and Quay.io
           command: |
-            docker login -u "$DOCKER_IO_PUSH_USERNAME" --password-stdin \<<<"$DOCKER_IO_PUSH_PASSWORD" docker.io
             docker login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin \<<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
 
       - attach_workspace:
@@ -3045,26 +3041,9 @@ jobs:
       - run:
           name: Build images
           command: |
-            # docker login -u "$DOCKER_IO_PUSH_USERNAME" --password-stdin \<<<"$DOCKER_IO_PUSH_PASSWORD" docker.io
             make scale-image mock-grpc-server-image
 
       - *saveGoBuildCache
-
-      - run:
-          name: Push new Docker image
-          command: |
-            # docker login -u "$DOCKER_IO_PUSH_USERNAME" --password-stdin \<<<"$DOCKER_IO_PUSH_PASSWORD" docker.io
-            docker login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin \<<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
-
-            TAG=$(make --quiet tag)
-
-            QUAY_REPO="rhacs-eng"
-            for img in scale grpc-server; do
-              # ./scripts/ci/push-as-manifest-list.sh "docker.io/stackrox/${img}:${TAG}" | cat
-              ./scripts/ci/push-as-manifest-list.sh "quay.io/${QUAY_REPO}/${img}:${TAG}" | cat
-            done
-
-      - cleanup-clusters-on-fail
 
   provision-gke-api-scale-tests:
     executor: custom
@@ -4324,60 +4303,6 @@ jobs:
       - setup_remote_docker
       - attach_workspace:
           at: /go/src/github.com/stackrox/rox
-
-      - run:
-          name: Retag docs image with release-version tag in Docker Hub
-          command: |
-            docker login -u "$DOCKER_IO_PUSH_USERNAME" --password-stdin \<<<"$DOCKER_IO_PUSH_PASSWORD" docker.io
-
-            DOCS_TAG=$(make --quiet docs-tag)
-            MAIN_TAG=$(make --quiet tag)
-
-            # The docs image uses the same tag as main for releases,
-            # but is built as part of the main build with a different tag.
-            # This step places it in Docker Hub with the release tag
-            # for convenience before running the stackrox.io push.
-            ./scripts/ci/pull-retag-push.sh  "docker.io/stackrox/docs:$DOCS_TAG" "docker.io/stackrox/docs:$MAIN_TAG"
-
-      - run:
-          name: Push image into stackrox.io
-          command: |
-            docker login -u "$DOCKER_IO_PUSH_USERNAME" --password-stdin \<<<"$DOCKER_IO_PUSH_PASSWORD" docker.io
-            docker login -u "$STACKROX_IO_PUSH_USERNAME" --password-stdin \<<<"$STACKROX_IO_PUSH_PASSWORD" stackrox.io
-            docker login -u "$STACKROX_IO_PUSH_USERNAME" --password-stdin \<<<"$STACKROX_IO_PUSH_PASSWORD" collector.stackrox.io
-
-            MAIN_TAG=$(make --quiet tag)
-            COLLECTOR_TAG=$(make --quiet collector-tag)
-            ./scripts/ci/pull-retag-push.sh "docker.io/stackrox/main:$MAIN_TAG" "stackrox.io/main:$MAIN_TAG"
-
-            # The docs image uses the same tag as main for releases.
-            ./scripts/ci/pull-retag-push.sh "docker.io/stackrox/docs:$MAIN_TAG"   "stackrox.io/docs:$MAIN_TAG"
-            ./scripts/ci/pull-retag-push.sh "docker.io/stackrox/roxctl:$MAIN_TAG" "stackrox.io/roxctl:$MAIN_TAG"
-            ./scripts/ci/pull-retag-push.sh "docker.io/stackrox/central-db:$MAIN_TAG" "stackrox.io/central-db:$MAIN_TAG"
-
-            ./scripts/ci/pull-retag-push.sh "docker.io/stackrox/collector:${COLLECTOR_TAG}"        "collector.stackrox.io/collector:${COLLECTOR_TAG}"
-            ./scripts/ci/pull-retag-push.sh "docker.io/stackrox/collector:${COLLECTOR_TAG}-latest" "collector.stackrox.io/collector:${COLLECTOR_TAG}-latest"
-            ./scripts/ci/pull-retag-push.sh "docker.io/stackrox/collector:${COLLECTOR_TAG}-slim"   "collector.stackrox.io/collector:${COLLECTOR_TAG}-slim"
-
-      - run:
-          name: Push collector & scanner images tagged with main-version to stackrox.io
-          command: |
-            docker login -u "$QUAY_RHACS_ENG_RO_USERNAME" --password-stdin \<<<"$QUAY_RHACS_ENG_RO_PASSWORD" quay.io
-            docker login -u "$STACKROX_IO_PUSH_USERNAME" --password-stdin \<<<"$STACKROX_IO_PUSH_PASSWORD" stackrox.io
-            docker login -u "$STACKROX_IO_PUSH_USERNAME" --password-stdin \<<<"$STACKROX_IO_PUSH_PASSWORD" collector.stackrox.io
-
-            MAIN_TAG="$(make --quiet tag)"
-            SCANNER_VERSION="$(make --quiet scanner-tag)"
-            COLLECTOR_VERSION="$(make --quiet collector-tag)"
-
-            ./scripts/ci/pull-retag-push.sh "quay.io/rhacs-eng/scanner:${SCANNER_VERSION}"         "stackrox.io/scanner:${MAIN_TAG}"
-            ./scripts/ci/pull-retag-push.sh "quay.io/rhacs-eng/scanner-db:${SCANNER_VERSION}"      "stackrox.io/scanner-db:${MAIN_TAG}"
-            ./scripts/ci/pull-retag-push.sh "quay.io/rhacs-eng/scanner-slim:${SCANNER_VERSION}"    "stackrox.io/scanner-slim:${MAIN_TAG}"
-            ./scripts/ci/pull-retag-push.sh "quay.io/rhacs-eng/scanner-db-slim:${SCANNER_VERSION}" "stackrox.io/scanner-db-slim:${MAIN_TAG}"
-
-            ./scripts/ci/pull-retag-push.sh "quay.io/rhacs-eng/collector:${COLLECTOR_VERSION}"      "collector.stackrox.io/collector:${MAIN_TAG}"
-            ./scripts/ci/pull-retag-push.sh "quay.io/rhacs-eng/collector:${COLLECTOR_VERSION}-slim" "collector.stackrox.io/collector-slim:${MAIN_TAG}"
-
 
       - run:
           name: Push roxctl to stackrox-hub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3045,6 +3045,20 @@ jobs:
 
       - *saveGoBuildCache
 
+      - run:
+          name: Push new Docker image
+          command: |
+            docker login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin \<<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
+
+            TAG=$(make --quiet tag)
+
+            QUAY_REPO="rhacs-eng"
+            for img in scale grpc-server; do
+              ./scripts/ci/push-as-manifest-list.sh "quay.io/${QUAY_REPO}/${img}:${TAG}" | cat
+            done
+
+      - cleanup-clusters-on-fail
+
   provision-gke-api-scale-tests:
     executor: custom
     resource_class: small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3045,7 +3045,7 @@ jobs:
       - run:
           name: Build images
           command: |
-            docker login -u "$DOCKER_IO_PUSH_USERNAME" --password-stdin \<<<"$DOCKER_IO_PUSH_PASSWORD" docker.io
+            # docker login -u "$DOCKER_IO_PUSH_USERNAME" --password-stdin \<<<"$DOCKER_IO_PUSH_PASSWORD" docker.io
             make scale-image mock-grpc-server-image
 
       - *saveGoBuildCache
@@ -3053,14 +3053,14 @@ jobs:
       - run:
           name: Push new Docker image
           command: |
-            docker login -u "$DOCKER_IO_PUSH_USERNAME" --password-stdin \<<<"$DOCKER_IO_PUSH_PASSWORD" docker.io
+            # docker login -u "$DOCKER_IO_PUSH_USERNAME" --password-stdin \<<<"$DOCKER_IO_PUSH_PASSWORD" docker.io
             docker login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin \<<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
 
             TAG=$(make --quiet tag)
 
             QUAY_REPO="rhacs-eng"
             for img in scale grpc-server; do
-              ./scripts/ci/push-as-manifest-list.sh "docker.io/stackrox/${img}:${TAG}" | cat
+              # ./scripts/ci/push-as-manifest-list.sh "docker.io/stackrox/${img}:${TAG}" | cat
               ./scripts/ci/push-as-manifest-list.sh "quay.io/${QUAY_REPO}/${img}:${TAG}" | cat
             done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2887,7 +2887,7 @@ jobs:
       - run:
           name: Login to Docker Hub and Quay.io
           command: |
-            docker login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin \<<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
+            docker login -u "$QUAY_STACKROX_IO_RW_USERNAME" --password-stdin \<<<"$QUAY_STACKROX_IO_RW_PASSWORD" quay.io
 
       - attach_workspace:
           at: /go/src/github.com/stackrox/rox
@@ -2924,8 +2924,10 @@ jobs:
             make -C operator/ docker-push-index | cat
 
       - run:
-          name: Build and push images for quay.io
+          name: Build and push images for quay.io/rhacs-eng
           command: |
+            docker logout quay.io
+            docker login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin \<<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
             IMAGE_REPO=quay.io/rhacs-eng make -C operator/ everything
 
   ###

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4755,8 +4755,6 @@ workflows:
           <<: *runOnAllTagsWithQuayIOPullCtx
       - go-unit-tests-release:
           <<: *runOnAllTagsWithQuayIOPullCtx
-      - go-postgres-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
       - shell-unit-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
       - ui-unit-tests:
@@ -4830,15 +4828,6 @@ workflows:
             - build-rhacs
             - build-scale-monitoring-and-mock-server
             - provision-gke-api-e2e-tests
-      - provision-gke-postgres-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-      - gke-postgres-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-          requires:
-            - build-stackrox
-            - build-rhacs
-            - build-scale-monitoring-and-mock-server
-            - provision-gke-postgres-api-e2e-tests
       - provision-gke-kernel-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
       - gke-kernel-api-e2e-tests:
@@ -4865,33 +4854,6 @@ workflows:
             - build-rhacs
             - build-scale-monitoring-and-mock-server
             - provision-gke-api-scale-tests
-      - provision-gke-postgres-api-scale-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-      - gke-postgres-api-scale-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-          requires:
-          - build-stackrox
-          - build-rhacs
-          - build-scale-monitoring-and-mock-server
-          - provision-gke-postgres-api-scale-tests
-      - provision-openshift-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-      - openshift-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-          requires:
-            - build-stackrox
-            - build-rhacs
-            - build-scale-monitoring-and-mock-server
-            - provision-openshift-api-e2e-tests
-      - provision-openshift-crio-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-      - openshift-crio-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-          requires:
-            - build-stackrox
-            - build-rhacs
-            - build-scale-monitoring-and-mock-server
-            - provision-openshift-crio-api-e2e-tests
       - provision-eks-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
       - eks-api-e2e-tests:
@@ -4901,16 +4863,6 @@ workflows:
             - build-rhacs
             - build-scale-monitoring-and-mock-server
             - provision-eks-api-e2e-tests
-      # ROX-8306 - Disabled due to Azure account issue
-      # - provision-aks-api-e2e-tests:
-      #     <<: *runOnAllTagsWithQuayIOPullCtx
-      # - aks-api-e2e-tests:
-      #     <<: *runOnAllTagsWithQuayIOPullCtx
-      #     requires:
-      #       - build-stackrox
-      #       - build-rhacs
-      #       - build-scale-monitoring-and-mock-server
-      #       - provision-aks-api-e2e-tests
       - provision-openshift-4-api-e2e-tests:
           <<: *runOnAllTagsWithQuayIOPullCtx
       - openshift-4-api-e2e-tests:
@@ -4961,23 +4913,6 @@ workflows:
             - ui-unit-tests
             - push-release
 
-      - provision-openshift-rosa-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-          context:
-            - osd-cluster-manager
-            - quay-rhacs-eng-readonly
-
-      - openshift-rosa-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-          requires:
-            - build-scale-monitoring-and-mock-server
-            - provision-openshift-rosa-api-e2e-tests
-            - build-stackrox
-            - build-rhacs
-          context:
-            - osd-cluster-manager
-            - quay-rhacs-eng-readonly
-
       - check-docs-job:
           <<: *runOnlyOnReleaseCandidateBuilds
           context:
@@ -4986,63 +4921,6 @@ workflows:
           <<: *runOnlyOnReleaseCandidateBuilds
           context:
           - custom-executor-pull
-
-      - provision-openshift-aro-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-          context:
-            - com-redhat-cloud
-            - quay-rhacs-eng-readonly
-            - azure-ci
-            - aro-cluster-manager
-            - osd-cluster-manager
-
-      - openshift-aro-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-          requires:
-            - build-scale-monitoring-and-mock-server
-            - provision-openshift-aro-api-e2e-tests
-            - build-stackrox
-            - build-rhacs
-          context:
-            - com-redhat-cloud
-            - quay-rhacs-eng-readonly
-            - azure-ci
-            - aro-cluster-manager
-            - osd-cluster-manager
-
-      - provision-osd-aws-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-          context:
-            - quay-rhacs-eng-readonly
-            - osd-cluster-manager
-
-      - osd-aws-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-          requires:
-            - build-scale-monitoring-and-mock-server
-            - provision-osd-aws-api-e2e-tests
-            - build-stackrox
-            - build-rhacs
-          context:
-            - quay-rhacs-eng-readonly
-            - osd-cluster-manager
-
-      - provision-osd-gcp-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-          context:
-            - quay-rhacs-eng-readonly
-            - osd-cluster-manager
-
-      - osd-gcp-api-e2e-tests:
-          <<: *runOnAllTagsWithQuayIOPullCtx
-          requires:
-            - build-scale-monitoring-and-mock-server
-            - provision-osd-gcp-api-e2e-tests
-            - build-stackrox
-            - build-rhacs
-          context:
-            - quay-rhacs-eng-readonly
-            - osd-cluster-manager
 
       - push-release:
           <<: *runOnlyOnReleaseBuilds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,10 +457,6 @@ parameters:
     type: string
     # https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
     default: "ubuntu-2004:202111-02"
-  docker_version:
-    type: string
-    # https://circleci.com/docs/2.0/building-docker-images/#docker-version
-    default: "20.10.14"
   release_rc_tag_bash_regex:
     type: string
     # Caution when editing: make sure groups would correspond to BASH_REMATCH use.
@@ -921,8 +917,7 @@ commands:
       - check-scanner-and-collector-release-step:
           fail-on-rc: false
 
-      - setup_remote_docker:
-          version: << pipeline.parameters.docker_version >>
+      - setup_remote_docker
       - setup-dep-env:
           docker-login: true
 
@@ -1469,7 +1464,7 @@ commands:
 
       - steps: << parameters.determine-whether-to-run >>
 
-      - setup_remote_docker
+      # - setup_remote_docker
 
       - attach_workspace:
           at: /go/src/github.com/stackrox/rox
@@ -2831,8 +2826,7 @@ jobs:
             echo "${TAG}-rcd" > CI_TAG
             make --quiet tag
 
-      - setup_remote_docker:
-          version: << pipeline.parameters.docker_version >>
+      - setup_remote_docker
 
       - restore-go-mod-cache
       - setup-go-build-env
@@ -2892,9 +2886,7 @@ jobs:
     steps:
       - checkout
 
-      - setup_remote_docker:
-          # Default docker server version isn't new enough therefore we're asking for more recent one to enjoy Buildkit.
-          version: << pipeline.parameters.docker_version >>
+      - setup_remote_docker
       - run:
           name: Login to Docker Hub and Quay.io
           command: |

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -32,8 +32,8 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # IMAGE_REPO is the repository (server and namespace) into which the operator images will get pushed.
-IMAGE_REPO ?= docker.io/stackrox
-# IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
+IMAGE_REPO ?= quay.io/stackrox-io
+# IMAGE_TAG_BASE defines the IMAGE_REPO namespace and part of the image name for remote images.
 # This variable is used to construct full image tags for bundle and catalog images.
 IMAGE_TAG_BASE ?= $(IMAGE_REPO)/stackrox-operator
 
@@ -239,11 +239,11 @@ test-upgrade: kuttl bundle-post-process ## Run OLM-based operator upgrade tests.
 	NEW_PRODUCT_VERSION=$$(make --quiet --no-print-directory -C .. tag) \
 	KUTTL=$(KUTTL) $(KUTTL) test --config kuttl-test.yaml tests/upgrade
 
-stackrox-image-pull-secret: ## Create default image pull secret for StackRox images on DockerHub. Used by Helm chart.
+stackrox-image-pull-secret: ## Create default image pull secret for StackRox images on Quay,io. Used by Helm chart.
 # Create stackrox namespace if not exists.
 	echo '{ "apiVersion": "v1", "kind": "Namespace", "metadata": { "name": "stackrox" } }' | kubectl apply -f -
 # Create stackrox image pull secret in stackrox namespace.
-	$(PROJECT_DIR)/../deploy/common/pull-secret.sh stackrox docker.io | kubectl -n stackrox apply -f -
+	$(PROJECT_DIR)/../deploy/common/pull-secret.sh stackrox quay.io | kubectl -n stackrox apply -f -
 
 .PHONY: check-ci-setup
 check-ci-setup: ## Make sure this target is not started in CI environment.
@@ -348,10 +348,10 @@ ACTIVATE_PYTHON = python3 -m venv bundle_helpers/.venv ;\
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 # Version is hardcoded to 0.0.1 here because otherwise git-versioned files are changed which we want to avoid.
 # The correct version is updated later.
-# Likewise, we hardcode the image reference to docker.io/stackrox/stackrox-operator. If this is overridden via
+# Likewise, we hardcode the image reference to quay.io/stackrox-io/stackrox-operator. If this is overridden via
 # the IMG_REPO environment variable, the final reference will be injected in the bundle-post-process step.
 	$(OPERATOR_SDK) generate kustomize manifests -q
-	cd config/manager && $(KUSTOMIZE) edit set image controller=docker.io/stackrox/stackrox-operator:0.0.1
+	cd config/manager && $(KUSTOMIZE) edit set image controller=quay.io/stackrox-io/stackrox-operator:0.0.1
 	cd config/scorecard-versioned && $(KUSTOMIZE) edit set image scorecard-test=quay.io/operator-framework/scorecard-test:v$(OPERATOR_SDK_VERSION)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version 0.0.1 $(BUNDLE_METADATA_OPTS)
 # Delete lines that copy the original bundle files in bundle.Dockerfile (we can't just use `rm` in scratch image).

--- a/operator/README.md
+++ b/operator/README.md
@@ -190,7 +190,7 @@ $ kubectl -n bundle-test patch serviceaccount default -p '{"imagePullSecrets": [
 
 # 4. Run bundle.
 $ bin/operator-sdk-1.9.0 run bundle \
-  docker.io/stackrox/stackrox-operator-bundle:v$(make --quiet tag) \
+  quay.io/stackrox-io/stackrox-operator-bundle:v$(make --quiet tag) \
   --pull-secret-name my-opm-image-pull-secrets \
   --service-account default \
   --namespace bundle-test

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
       : \"my-cluster\"\n    }\n  }\n]"
     capabilities: Seamless Upgrades
     categories: Security
-    containerImage: docker.io/stackrox/stackrox-operator:0.0.1
+    containerImage: quay.io/stackrox-io/stackrox-operator:0.0.1
     createdAt: '1999-12-31T23:59:59Z'
     description: Red Hat Advanced Cluster Security (RHACS) operator provisions the
       services necessary to secure each of your OpenShift and Kubernetes clusters.

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -784,7 +784,7 @@ spec:
                 - name: RELATED_IMAGE_COLLECTOR_FULL
                 - name: RELATED_IMAGE_ROXCTL
                 - name: RELATED_IMAGE_DOCS
-                image: docker.io/stackrox/stackrox-operator:0.0.1
+                image: quay.io/stackrox-io/stackrox-operator:0.0.1
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: docker.io/stackrox/stackrox-operator
+  newName: quay.io/stackrox-io/stackrox-operator
   newTag: 0.0.1

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Seamless Upgrades
     categories: Security
-    containerImage: docker.io/stackrox/stackrox-operator:0.0.1
+    containerImage: quay.io/stackrox-io/stackrox-operator:0.0.1
     createdAt: "1999-12-31T23:59:59Z"
     description: Red Hat Advanced Cluster Security (RHACS) operator provisions the
       services necessary to secure each of your OpenShift and Kubernetes clusters.

--- a/operator/hack/build-index-image.sh
+++ b/operator/hack/build-index-image.sh
@@ -13,9 +13,9 @@ Usage:
   build-index-image.sh MANDATORY [OPTION]
 
 MANDATORY:
-  --base-index-tag     The base index image tag. Example: docker.io/stackrox/stackrox-operator-index:v1.0.0
-  --index-tag          The new index image tag. Example: docker.io/stackrox/stackrox-operator-index:v1.1.0
-  --bundle-tag         The bundle image tag that should be appended to base index. Example: docker.io/stackrox/stackrox-operator-bundle:v1.1.0
+  --base-index-tag     The base index image tag. Example: quay.io/stackrox-io/stackrox-operator-index:v1.0.0
+  --index-tag          The new index image tag. Example: quay.io/stackrox-io/stackrox-operator-index:v1.1.0
+  --bundle-tag         The bundle image tag that should be appended to base index. Example: quay.io/stackrox-io/stackrox-operator-bundle:v1.1.0
   --replaced-version   Version that the bundle replaces. Example: v1.0.0
 
 OPTION:

--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -1,6 +1,6 @@
 # A library of bash functions useful for installing operator using OLM.
 
-declare -r IMAGE_TAG_BASE="${IMAGE_TAG_BASE:-docker.io/stackrox/stackrox-operator}"
+declare -r IMAGE_TAG_BASE="${IMAGE_TAG_BASE:-quay.io/stackrox-io/stackrox-operator}"
 declare -r KUTTL="${KUTTL:-kubectl-kuttl}"
 declare -r pull_secret="operator-pull-secret"
 # `declare` ignores `errexit`: http://mywiki.wooledge.org/BashFAQ/105

--- a/operator/hack/ensure-rox-image-exist.sh
+++ b/operator/hack/ensure-rox-image-exist.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 git fetch origin
 
 docker_repo="stackrox/main"
-base_image="docker.io/stackrox/main"
+base_image="quay.io/stackrox-io/main"
 root_dir="$(git rev-parse --show-toplevel)"
 main_image_tag=${MAIN_IMAGE_TAG:-"$(make -C "$root_dir" tag)"}
 main_image="$base_image:$main_image_tag"

--- a/operator/pkg/reconciler/env.go
+++ b/operator/pkg/reconciler/env.go
@@ -3,6 +3,6 @@ package reconciler
 import "github.com/stackrox/rox/pkg/env"
 
 var (
-	collectorRegistryOverride = env.RegisterSetting("ROX_OPERATOR_MAIN_REGISTRY", env.WithDefault("docker.io/stackrox"))
-	mainRegistryOverride      = env.RegisterSetting("ROX_OPERATOR_COLLECTOR_REGISTRY", env.WithDefault("docker.io/stackrox"))
+	collectorRegistryOverride = env.RegisterSetting("ROX_OPERATOR_MAIN_REGISTRY", env.WithDefault("quay.io/stackrox-io"))
+	mainRegistryOverride      = env.RegisterSetting("ROX_OPERATOR_COLLECTOR_REGISTRY", env.WithDefault("quay.io/stackrox-io"))
 )

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -231,8 +231,6 @@ push_matching_collector_scanner_images() {
         local source_registry="quay.io/stackrox-io"
         local target_registries=( "quay.io/stackrox-io" )
     elif [[ "$brand" == "RHACS_BRANDING" ]]; then
-        require_environment "DOCKER_IO_PUSH_USERNAME"
-        require_environment "DOCKER_IO_PUSH_PASSWORD"
         require_environment "QUAY_RHACS_ENG_RW_USERNAME"
         require_environment "QUAY_RHACS_ENG_RW_PASSWORD"
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -183,15 +183,12 @@ push_main_image_set() {
 
         local destination_registries=("quay.io/stackrox-io")
     elif [[ "$brand" == "RHACS_BRANDING" ]]; then
-        require_environment "DOCKER_IO_PUSH_USERNAME"
-        require_environment "DOCKER_IO_PUSH_PASSWORD"
         require_environment "QUAY_RHACS_ENG_RW_USERNAME"
         require_environment "QUAY_RHACS_ENG_RW_PASSWORD"
 
-        docker login -u "$DOCKER_IO_PUSH_USERNAME" --password-stdin <<<"$DOCKER_IO_PUSH_PASSWORD" docker.io
         docker login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin <<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
 
-        local destination_registries=("docker.io/stackrox" "quay.io/rhacs-eng")
+        local destination_registries=("quay.io/rhacs-eng")
     else
         die "$brand is not a supported brand"
     fi
@@ -217,7 +214,7 @@ push_main_image_set() {
 }
 
 push_matching_collector_scanner_images() {
-    info "Pushing collector & scanner images tagged with main-version to docker.io/stackrox and quay.io/rhacs-eng"
+    info "Pushing collector & scanner images tagged with main-version to quay.io/rhacs-eng"
 
     if [[ "$#" -ne 1 ]]; then
         die "missing arg. usage: push_matching_collector_scanner_images <brand>"
@@ -239,11 +236,10 @@ push_matching_collector_scanner_images() {
         require_environment "QUAY_RHACS_ENG_RW_USERNAME"
         require_environment "QUAY_RHACS_ENG_RW_PASSWORD"
 
-        docker login -u "$DOCKER_IO_PUSH_USERNAME" --password-stdin <<<"$DOCKER_IO_PUSH_PASSWORD" docker.io
         docker login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin <<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
 
         local source_registry="quay.io/rhacs-eng"
-        local target_registries=( "docker.io/stackrox" "quay.io/rhacs-eng" )
+        local target_registries=( "quay.io/rhacs-eng" )
     else
         die "$brand is not a supported brand"
     fi

--- a/scripts/ensure_image.sh
+++ b/scripts/ensure_image.sh
@@ -30,15 +30,14 @@ echo "Building the image since it doesn't exist"
 docker build -t "${image}" -f "${dockerfile}" "${dir}"
 if [[ -n "${CI}" ]]; then
   docker login -u  "${QUAY_RHACS_ENG_RW_USERNAME}" -p "${QUAY_RHACS_ENG_RW_PASSWORD}" quay.io
-  docker push "${image}" | cat
 
   if [[ $image == docker* || $image == stackrox* ]]; then
     repo=${image#docker.io/}
     repo=${repo#stackrox/}
 
     quay_image="quay.io/rhacs-eng/${repo}"
-    docker tag ${image} ${quay_image}
-    docker push ${quay_image} | cat
+    docker tag "${image}" "${quay_image}"
+    docker push "${quay_image}" | cat
   fi
 
 else

--- a/scripts/ensure_image.sh
+++ b/scripts/ensure_image.sh
@@ -29,7 +29,6 @@ set -e
 echo "Building the image since it doesn't exist"
 docker build -t "${image}" -f "${dockerfile}" "${dir}"
 if [[ -n "${CI}" ]]; then
-  docker login -u "$DOCKER_IO_PUSH_USERNAME" -p "$DOCKER_IO_PUSH_PASSWORD" docker.io
   docker login -u  "${QUAY_RHACS_ENG_RW_USERNAME}" -p "${QUAY_RHACS_ENG_RW_PASSWORD}" quay.io
   docker push "${image}" | cat
 
@@ -40,10 +39,6 @@ if [[ -n "${CI}" ]]; then
     quay_image="quay.io/rhacs-eng/${repo}"
     docker tag ${image} ${quay_image}
     docker push ${quay_image} | cat
-  elif [[ $image == quay* ]]; then
-    docker_image="docker.io/stackrox/${image#quay.io/rhacs-eng/}"
-    docker tag ${image} ${docker_image}
-    docker push ${docker_image} | cat
   fi
 
 else


### PR DESCRIPTION
## Description

Changes:
- Removed setup_remote_docker from run-qa-tests. It is not needed and was causing Circle CI to barf.
- Removed uses of docker.io and stackrox.io.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient. There are failures in the e2e tests and the upgrade tests that are to be expected and will be justified elsewhere.
