### PR TITLE
Wrap Postgres upserts with graceful retries

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -312,7 +312,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ActiveComponent) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -325,7 +325,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ActiveCompon
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -312,7 +312,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ActiveComponent) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -325,7 +325,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ActiveCompon
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -312,7 +312,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ActiveComponent) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ActiveComponent) error {
@@ -323,17 +325,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ActiveCompon
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -364,7 +364,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Alert) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Alert) error {
@@ -384,17 +386,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Alert) error
 		}
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -364,7 +364,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Alert) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -386,7 +386,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Alert) error
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -364,7 +364,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Alert) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -386,7 +386,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Alert) error
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TokenMetadata) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TokenMetadat
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TokenMetadata) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TokenMetadat
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -215,7 +215,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TokenMetadata) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TokenMetadata) error {
@@ -226,17 +228,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TokenMetadat
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -221,7 +221,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.AuthProvider) error
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -234,7 +234,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.AuthProvider
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -221,7 +221,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.AuthProvider) error
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -234,7 +234,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.AuthProvider
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -221,7 +221,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.AuthProvider) error
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.AuthProvider) error {
@@ -232,17 +234,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.AuthProvider
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -136,7 +136,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Cluster) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -136,7 +136,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Cluster) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Cluster) error {

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -136,7 +136,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Cluster) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -247,7 +247,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ClusterHealthStatus
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -260,7 +260,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterHealt
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -247,7 +247,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ClusterHealthStatus
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -260,7 +260,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterHealt
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -247,7 +247,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ClusterHealthStatus
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterHealthStatus) error {
@@ -258,17 +260,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterHealt
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -214,7 +214,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.InitBundleMeta) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.InitBundleMe
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -214,7 +214,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.InitBundleMeta) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.InitBundleMe
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -214,7 +214,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.InitBundleMeta) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.InitBundleMeta) error {
@@ -226,17 +228,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.InitBundleMe
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -217,7 +217,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceDomain) e
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -230,7 +230,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceDo
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -217,7 +217,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceDomain) e
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceDomain) error {
@@ -228,17 +230,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceDo
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -217,7 +217,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceDomain) e
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -230,7 +230,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceDo
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -234,7 +234,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceRunMetada
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -256,7 +256,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRu
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -234,7 +234,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceRunMetada
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -256,7 +256,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRu
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -234,7 +234,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceRunMetada
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRunMetadata) error {
@@ -254,17 +256,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRu
 		}
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -234,7 +234,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceRunResult
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -256,7 +256,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRu
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -234,7 +234,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceRunResult
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRunResults) error {
@@ -254,17 +256,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRu
 		}
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -234,7 +234,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceRunResult
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -256,7 +256,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRu
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -216,7 +216,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceStrings) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -229,7 +229,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceSt
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -216,7 +216,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceStrings) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceStrings) error {
@@ -227,17 +229,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceSt
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -216,7 +216,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceStrings) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -229,7 +229,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceSt
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -215,7 +215,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorC
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorCheckResult) error {
@@ -226,17 +228,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorC
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorC
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -215,7 +215,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorP
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorProfile) error {
@@ -226,17 +228,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorP
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorP
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -215,7 +215,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorR
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorRule) error {
@@ -226,17 +228,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorR
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorR
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorS
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorS
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -215,7 +215,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorS
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorScan) error {
@@ -226,17 +228,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -215,7 +215,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorS
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorScanSettingBinding) error {
@@ -226,17 +228,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorS
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorS
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -262,7 +262,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ClusterCVE) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -275,7 +275,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterCVE) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -262,7 +262,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ClusterCVE) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -275,7 +275,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterCVE) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -262,7 +262,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ClusterCVE) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterCVE) error {
@@ -273,17 +275,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterCVE) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -262,7 +262,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageCVE) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageCVE) error {
@@ -273,17 +275,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageCVE) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -262,7 +262,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageCVE) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -275,7 +275,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageCVE) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -262,7 +262,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageCVE) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -275,7 +275,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageCVE) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -262,7 +262,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NodeCVE) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -275,7 +275,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NodeCVE) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -262,7 +262,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NodeCVE) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -275,7 +275,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NodeCVE) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -262,7 +262,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NodeCVE) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NodeCVE) error {
@@ -273,17 +275,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NodeCVE) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -908,7 +908,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Deployment) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -930,7 +930,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Deployment) 
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -908,7 +908,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Deployment) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Deployment) error {
@@ -928,17 +930,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Deployment) 
 		}
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -908,7 +908,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Deployment) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -930,7 +930,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Deployment) 
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -216,7 +216,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ExternalBackup) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ExternalBackup) error {
@@ -227,17 +229,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ExternalBack
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -216,7 +216,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ExternalBackup) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -229,7 +229,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ExternalBack
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -216,7 +216,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ExternalBackup) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -229,7 +229,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ExternalBack
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -216,7 +216,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Group) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -229,7 +229,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Group) error
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -216,7 +216,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Group) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -229,7 +229,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Group) error
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -216,7 +216,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Group) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Group) error {
@@ -227,17 +229,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Group) error
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -252,7 +252,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageComponent) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -265,7 +265,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageCompone
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -252,7 +252,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageComponent) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -265,7 +265,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageCompone
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -252,7 +252,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageComponent) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageComponent) error {
@@ -263,17 +265,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageCompone
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -227,7 +227,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageIntegration) e
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -240,7 +240,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageIntegra
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -227,7 +227,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageIntegration) e
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageIntegration) error {
@@ -238,17 +240,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageIntegra
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -227,7 +227,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageIntegration) e
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -240,7 +240,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageIntegra
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -214,7 +214,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.IntegrationHealth) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.IntegrationH
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -214,7 +214,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.IntegrationHealth) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.IntegrationH
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -214,7 +214,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.IntegrationHealth) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.IntegrationHealth) error {
@@ -226,17 +228,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.IntegrationH
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -216,7 +216,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.LogImbue) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -229,7 +229,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.LogImbue) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -216,7 +216,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.LogImbue) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -229,7 +229,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.LogImbue) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -216,7 +216,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.LogImbue) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.LogImbue) error {
@@ -227,17 +229,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.LogImbue) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -244,7 +244,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NamespaceMetadata) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -266,7 +266,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NamespaceMet
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -244,7 +244,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NamespaceMetadata) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -266,7 +266,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NamespaceMet
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -244,7 +244,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NamespaceMetadata) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NamespaceMetadata) error {
@@ -264,17 +266,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NamespaceMet
 		}
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -229,7 +229,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkBaseline) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -251,7 +251,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkBasel
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -229,7 +229,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkBaseline) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkBaseline) error {
@@ -249,17 +251,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkBasel
 		}
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -229,7 +229,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkBaseline) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -251,7 +251,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkBasel
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkGraphConfig)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkGraph
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkGraphConfig)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkGraph
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -215,7 +215,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkGraphConfig)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkGraphConfig) error {
@@ -226,17 +228,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkGraph
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -220,7 +220,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkEntity) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -234,7 +234,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkEntit
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -220,7 +220,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkEntity) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkEntity) error {
@@ -232,17 +234,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkEntit
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -220,7 +220,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkEntity) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -234,7 +234,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkEntit
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -229,7 +229,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicy) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -251,7 +251,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolic
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -229,7 +229,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicy) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolicy) error {
@@ -249,17 +251,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolic
 		}
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -229,7 +229,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicy) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -251,7 +251,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolic
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -216,7 +216,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicyApplic
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolicyApplicationUndoDeploymentRecord) error {
@@ -227,17 +229,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolic
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -216,7 +216,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicyApplic
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -229,7 +229,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolic
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -216,7 +216,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicyApplic
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -229,7 +229,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolic
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -216,7 +216,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicyApplic
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolicyApplicationUndoRecord) error {
@@ -227,17 +229,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolic
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -216,7 +216,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicyApplic
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -229,7 +229,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolic
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -216,7 +216,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicyApplic
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -229,7 +229,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolic
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -247,7 +247,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NodeComponent) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -260,7 +260,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NodeComponen
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -247,7 +247,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NodeComponent) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -260,7 +260,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NodeComponen
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -247,7 +247,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NodeComponent) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NodeComponent) error {
@@ -258,17 +260,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NodeComponen
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -221,7 +221,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Notifier) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -234,7 +234,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Notifier) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -221,7 +221,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Notifier) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -234,7 +234,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Notifier) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -319,7 +319,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Pod) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -341,7 +341,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Pod) error {
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -319,7 +319,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Pod) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Pod) error {
@@ -339,17 +341,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Pod) error {
 		}
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -319,7 +319,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Pod) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -341,7 +341,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Pod) error {
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -272,7 +272,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Policy) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) error {
@@ -283,17 +285,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -272,7 +272,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Policy) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -285,7 +285,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -272,7 +272,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Policy) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -285,7 +285,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -221,7 +221,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PolicyCategory) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PolicyCategory) error {
@@ -232,17 +234,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PolicyCatego
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -221,7 +221,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PolicyCategory) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -234,7 +234,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PolicyCatego
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -221,7 +221,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PolicyCategory) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -234,7 +234,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PolicyCatego
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -234,7 +234,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaseline) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -256,7 +256,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBasel
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -234,7 +234,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaseline) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBaseline) error {
@@ -254,17 +256,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBasel
 		}
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -234,7 +234,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaseline) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -256,7 +256,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBasel
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -229,7 +229,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaselineResu
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -251,7 +251,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBasel
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -229,7 +229,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaselineResu
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBaselineResults) error {
@@ -249,17 +251,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBasel
 		}
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -229,7 +229,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaselineResu
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -251,7 +251,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBasel
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -274,7 +274,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessIndicator) e
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -296,7 +296,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessIndic
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -274,7 +274,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessIndicator) e
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -296,7 +296,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessIndic
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -254,7 +254,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.K8SRole) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -276,7 +276,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRole) err
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -254,7 +254,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.K8SRole) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -276,7 +276,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRole) err
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -254,7 +254,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.K8SRole) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRole) error {
@@ -274,17 +276,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRole) err
 		}
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -344,7 +344,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.K8SRoleBinding) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -366,7 +366,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRoleBindi
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -344,7 +344,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.K8SRoleBinding) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRoleBinding) error {
@@ -364,17 +366,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRoleBindi
 		}
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -344,7 +344,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.K8SRoleBinding) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -366,7 +366,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRoleBindi
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -226,7 +226,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ReportConfiguration
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -239,7 +239,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ReportConfig
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -226,7 +226,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ReportConfiguration
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ReportConfiguration) error {
@@ -237,17 +239,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ReportConfig
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -226,7 +226,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ReportConfiguration
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -239,7 +239,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ReportConfig
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -311,7 +311,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ResourceCollection)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -324,7 +324,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ResourceColl
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -311,7 +311,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ResourceCollection)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ResourceCollection) error {
@@ -322,17 +324,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ResourceColl
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -311,7 +311,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ResourceCollection)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -324,7 +324,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ResourceColl
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -239,7 +239,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Risk) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Risk) error {
@@ -259,17 +261,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Risk) error 
 		}
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -239,7 +239,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Risk) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -261,7 +261,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Risk) error 
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -239,7 +239,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Risk) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -261,7 +261,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Risk) error 
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -220,7 +220,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PermissionSet) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -233,7 +233,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSe
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -220,7 +220,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PermissionSet) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error {
@@ -231,17 +233,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSe
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -220,7 +220,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PermissionSet) erro
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -233,7 +233,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSe
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Role) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Role) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Role) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Role) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -215,7 +215,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Role) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Role) error {
@@ -226,17 +228,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Role) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -220,7 +220,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SimpleAccessScope) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -233,7 +233,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SimpleAccess
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -220,7 +220,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SimpleAccessScope) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -233,7 +233,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SimpleAccess
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -220,7 +220,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SimpleAccessScope) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SimpleAccessScope) error {
@@ -231,17 +233,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SimpleAccess
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -414,7 +414,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Secret) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -436,7 +436,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Secret) erro
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -414,7 +414,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Secret) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -436,7 +436,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Secret) erro
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -414,7 +414,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Secret) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Secret) error {
@@ -434,17 +436,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Secret) erro
 		}
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -249,7 +249,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ServiceAccount) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceAccount) error {
@@ -269,17 +271,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceAccou
 		}
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -249,7 +249,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ServiceAccount) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -271,7 +271,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceAccou
 		}
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -249,7 +249,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ServiceAccount) err
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -271,7 +271,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceAccou
 		}
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -216,7 +216,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ServiceIdentity) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -229,7 +229,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceIdent
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -216,7 +216,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ServiceIdentity) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceIdentity) error {
@@ -227,17 +229,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceIdent
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -216,7 +216,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ServiceIdentity) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -229,7 +229,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceIdent
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -220,7 +220,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SignatureIntegratio
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SignatureIntegration) error {
@@ -231,17 +233,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SignatureInt
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -220,7 +220,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SignatureIntegratio
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -233,7 +233,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SignatureInt
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -220,7 +220,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SignatureIntegratio
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -233,7 +233,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SignatureInt
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -413,7 +413,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.VulnerabilityReques
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.VulnerabilityRequest) error {
@@ -425,17 +427,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Vulnerabilit
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -413,7 +413,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.VulnerabilityReques
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -427,7 +427,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Vulnerabilit
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -413,7 +413,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.VulnerabilityReques
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -427,7 +427,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Vulnerabilit
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.WatchedImage) error
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.WatchedImage
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -215,7 +215,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.WatchedImage) error
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.WatchedImage) error {
@@ -226,17 +228,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.WatchedImage
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.WatchedImage) error
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -228,7 +228,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.WatchedImage
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
@@ -122,7 +122,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Cluster) error 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Cluster) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }

--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
@@ -122,7 +122,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Cluster) error 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Cluster) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }

--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
@@ -122,7 +122,9 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Cluster) error 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Cluster) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Cluster) error {

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
@@ -230,22 +230,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NamespaceMetada
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NamespaceMetadata) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NamespaceMetadata) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
@@ -230,14 +230,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NamespaceMetada
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NamespaceMetadata) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NamespaceMetadata) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
@@ -230,14 +230,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NamespaceMetada
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NamespaceMetadata) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NamespaceMetadata) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
@@ -894,14 +894,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Deployment) err
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Deployment) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Deployment) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
@@ -894,22 +894,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Deployment) err
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Deployment) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Deployment) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
@@ -894,14 +894,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Deployment) err
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Deployment) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Deployment) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
@@ -350,14 +350,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Alert) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Alert) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Alert) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
@@ -350,14 +350,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Alert) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Alert) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Alert) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
@@ -350,22 +350,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Alert) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Alert) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Alert) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TokenMetadata) 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TokenMetadata) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TokenMetadata) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TokenMetadata) 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TokenMetadata) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TokenMetadata) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
@@ -204,22 +204,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TokenMetadata) 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TokenMetadata) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TokenMetadata) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
@@ -210,22 +210,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.AuthProvider) e
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.AuthProvider) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.AuthProvider) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
@@ -210,14 +210,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.AuthProvider) e
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.AuthProvider) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.AuthProvider) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
@@ -210,14 +210,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.AuthProvider) e
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.AuthProvider) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.AuthProvider) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
@@ -235,14 +235,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ClusterHealthSt
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ClusterHealthStatus) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterHealthStatus) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
@@ -235,14 +235,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ClusterHealthSt
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ClusterHealthStatus) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterHealthStatus) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
@@ -235,22 +235,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ClusterHealthSt
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ClusterHealthStatus) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterHealthStatus) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.InitBundleMeta)
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.InitBundleMeta) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.InitBundleMeta) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
@@ -204,22 +204,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.InitBundleMeta)
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.InitBundleMeta) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.InitBundleMeta) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.InitBundleMeta)
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.InitBundleMeta) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.InitBundleMeta) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
@@ -205,14 +205,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceDomai
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceDomain) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceDomain) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
@@ -205,22 +205,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceDomai
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceDomain) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceDomain) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
@@ -205,14 +205,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceDomai
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceDomain) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceDomain) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
@@ -204,22 +204,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorCheckResult) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorCheckResult) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorCheckResult) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorCheckResult) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorCheckResult) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorCheckResult) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorProfile) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorProfile) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
@@ -204,22 +204,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorProfile) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorProfile) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorProfile) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorProfile) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorRule) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorRule) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorRule) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorRule) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
@@ -204,22 +204,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorRule) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorRule) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
@@ -204,22 +204,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorScanSettingBinding) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorScanSettingBinding) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorScanSettingBinding) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorScanSettingBinding) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorScanSettingBinding) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorScanSettingBinding) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorScan) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorScan) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorScan) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorScan) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
@@ -204,22 +204,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorScan) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOperatorScan) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
@@ -220,14 +220,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceRunMe
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceRunMetadata) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRunMetadata) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
@@ -220,22 +220,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceRunMe
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceRunMetadata) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRunMetadata) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
@@ -220,14 +220,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceRunMe
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceRunMetadata) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRunMetadata) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
@@ -220,14 +220,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceRunRe
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceRunResults) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRunResults) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
@@ -220,22 +220,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceRunRe
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceRunResults) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRunResults) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
@@ -220,14 +220,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceRunRe
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceRunResults) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRunResults) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceStrin
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceStrings) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceStrings) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
@@ -204,22 +204,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceStrin
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceStrings) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceStrings) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceStrin
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceStrings) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceStrings) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
@@ -205,14 +205,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ExternalBackup)
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ExternalBackup) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ExternalBackup) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
@@ -205,14 +205,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ExternalBackup)
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ExternalBackup) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ExternalBackup) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
@@ -205,22 +205,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ExternalBackup)
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ExternalBackup) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ExternalBackup) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
@@ -216,14 +216,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ImageIntegratio
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageIntegration) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageIntegration) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
@@ -216,14 +216,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ImageIntegratio
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageIntegration) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageIntegration) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
@@ -216,22 +216,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ImageIntegratio
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageIntegration) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageIntegration) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
@@ -204,22 +204,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.IntegrationHeal
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.IntegrationHealth) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.IntegrationHealth) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.IntegrationHeal
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.IntegrationHealth) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.IntegrationHealth) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.IntegrationHeal
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.IntegrationHealth) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.IntegrationHealth) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
@@ -240,14 +240,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.K8SRole) error 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.K8SRole) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRole) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
@@ -240,22 +240,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.K8SRole) error 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.K8SRole) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRole) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
@@ -240,14 +240,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.K8SRole) error 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.K8SRole) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRole) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
@@ -215,14 +215,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkBaseline
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkBaseline) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkBaseline) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
@@ -215,22 +215,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkBaseline
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkBaseline) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkBaseline) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
@@ -215,14 +215,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkBaseline
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkBaseline) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkBaseline) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
@@ -210,22 +210,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkEntity) 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkEntity) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkEntity) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
@@ -210,14 +210,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkEntity) 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkEntity) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkEntity) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
@@ -210,14 +210,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkEntity) 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkEntity) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkEntity) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkGraphCon
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkGraphConfig) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkGraphConfig) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkGraphCon
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkGraphConfig) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkGraphConfig) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
@@ -204,22 +204,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkGraphCon
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkGraphConfig) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkGraphConfig) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
@@ -215,22 +215,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkPolicy) 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicy) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolicy) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
@@ -215,14 +215,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkPolicy) 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicy) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolicy) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
@@ -215,14 +215,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkPolicy) 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicy) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolicy) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
@@ -204,22 +204,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkPolicyAp
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicyApplicationUndoDeploymentRecord) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolicyApplicationUndoDeploymentRecord) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkPolicyAp
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicyApplicationUndoDeploymentRecord) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolicyApplicationUndoDeploymentRecord) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkPolicyAp
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicyApplicationUndoDeploymentRecord) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolicyApplicationUndoDeploymentRecord) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkPolicyAp
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicyApplicationUndoRecord) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolicyApplicationUndoRecord) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkPolicyAp
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicyApplicationUndoRecord) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolicyApplicationUndoRecord) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
@@ -204,22 +204,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkPolicyAp
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicyApplicationUndoRecord) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolicyApplicationUndoRecord) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
@@ -210,14 +210,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Notifier) error
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Notifier) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Notifier) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
@@ -210,22 +210,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Notifier) error
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Notifier) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Notifier) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
@@ -210,14 +210,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Notifier) error
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Notifier) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Notifier) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
@@ -209,14 +209,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PermissionSet) 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PermissionSet) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
@@ -209,22 +209,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PermissionSet) 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PermissionSet) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
@@ -209,14 +209,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PermissionSet) 
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PermissionSet) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
@@ -305,22 +305,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Pod) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Pod) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Pod) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
@@ -305,14 +305,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Pod) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Pod) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Pod) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
@@ -305,14 +305,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Pod) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Pod) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Pod) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
@@ -261,14 +261,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Policy) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Policy) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
@@ -261,22 +261,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Policy) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Policy) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
@@ -261,14 +261,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Policy) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Policy) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
@@ -215,22 +215,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ProcessBaseline
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaselineResults) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBaselineResults) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
@@ -215,14 +215,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ProcessBaseline
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaselineResults) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBaselineResults) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
@@ -215,14 +215,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ProcessBaseline
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaselineResults) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBaselineResults) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
@@ -220,14 +220,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ProcessBaseline
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaseline) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBaseline) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
@@ -220,22 +220,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ProcessBaseline
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaseline) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBaseline) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
@@ -220,14 +220,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ProcessBaseline
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaseline) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBaseline) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
@@ -260,22 +260,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ProcessIndicato
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessIndicator) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessIndicator) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
@@ -260,14 +260,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ProcessIndicato
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessIndicator) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessIndicator) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
@@ -260,14 +260,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ProcessIndicato
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessIndicator) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessIndicator) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
@@ -215,14 +215,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ReportConfigura
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ReportConfiguration) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ReportConfiguration) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
@@ -215,22 +215,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ReportConfigura
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ReportConfiguration) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ReportConfiguration) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
@@ -215,14 +215,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ReportConfigura
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ReportConfiguration) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ReportConfiguration) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
@@ -225,14 +225,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Risk) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Risk) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Risk) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
@@ -225,14 +225,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Risk) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Risk) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Risk) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
@@ -225,22 +225,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Risk) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Risk) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Risk) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
@@ -330,14 +330,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.K8SRoleBinding)
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.K8SRoleBinding) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRoleBinding) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
@@ -330,22 +330,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.K8SRoleBinding)
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.K8SRoleBinding) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRoleBinding) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
@@ -330,14 +330,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.K8SRoleBinding)
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.K8SRoleBinding) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRoleBinding) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
@@ -204,22 +204,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Role) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Role) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Role) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Role) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Role) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Role) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Role) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Role) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Role) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
@@ -400,22 +400,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Secret) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Secret) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Secret) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
@@ -400,14 +400,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Secret) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Secret) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Secret) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
@@ -400,14 +400,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Secret) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Secret) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Secret) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
@@ -235,22 +235,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ServiceAccount)
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ServiceAccount) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceAccount) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
@@ -235,14 +235,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ServiceAccount)
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ServiceAccount) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceAccount) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
@@ -235,14 +235,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ServiceAccount)
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ServiceAccount) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceAccount) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
@@ -205,14 +205,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ServiceIdentity
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ServiceIdentity) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceIdentity) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
@@ -205,14 +205,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ServiceIdentity
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ServiceIdentity) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceIdentity) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
@@ -205,22 +205,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ServiceIdentity
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ServiceIdentity) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceIdentity) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
@@ -209,22 +209,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.SignatureIntegr
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SignatureIntegration) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SignatureIntegration) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
@@ -209,14 +209,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.SignatureIntegr
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SignatureIntegration) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SignatureIntegration) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
@@ -209,14 +209,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.SignatureIntegr
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SignatureIntegration) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SignatureIntegration) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
@@ -209,14 +209,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.SimpleAccessSco
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SimpleAccessScope) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SimpleAccessScope) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
@@ -209,22 +209,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.SimpleAccessSco
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SimpleAccessScope) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SimpleAccessScope) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
@@ -209,14 +209,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.SimpleAccessSco
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SimpleAccessScope) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SimpleAccessScope) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
@@ -403,14 +403,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.VulnerabilityRe
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.VulnerabilityRequest) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.VulnerabilityRequest) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
@@ -403,14 +403,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.VulnerabilityRe
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.VulnerabilityRequest) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.VulnerabilityRequest) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
@@ -403,22 +403,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.VulnerabilityRe
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.VulnerabilityRequest) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.VulnerabilityRequest) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
@@ -204,22 +204,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.WatchedImage) e
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.WatchedImage) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.WatchedImage) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.WatchedImage) e
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.WatchedImage) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.WatchedImage) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
@@ -204,14 +204,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.WatchedImage) e
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.WatchedImage) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.WatchedImage) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
@@ -210,14 +210,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PolicyCategory)
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PolicyCategory) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PolicyCategory) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
@@ -210,14 +210,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PolicyCategory)
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PolicyCategory) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PolicyCategory) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
@@ -210,22 +210,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PolicyCategory)
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PolicyCategory) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PolicyCategory) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
@@ -205,14 +205,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Group) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Group) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Group) error {
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
@@ -205,14 +205,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Group) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Group) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Group) error {
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
@@ -205,22 +205,26 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Group) error {
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Group) error {
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Group) error {
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -383,7 +383,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestMultiKeyStruct)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestMultiKeyStruct) error {
@@ -394,17 +396,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestMultiKey
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -383,7 +383,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestMultiKeyStruct)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -396,7 +396,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestMultiKey
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -383,7 +383,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestMultiKeyStruct)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -396,7 +396,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestMultiKey
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -350,7 +350,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *{{.Type}}) error {
     {{- end }}
     {{- end }}{{/* if not $inMigration */}}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -395,7 +395,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*{{.Type}}) error {
     return s.upsert(ctx, objs...)
     {{- else }}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -350,7 +350,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *{{.Type}}) error {
     {{- end }}
     {{- end }}{{/* if not $inMigration */}}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -395,7 +395,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*{{.Type}}) error {
     return s.upsert(ctx, objs...)
     {{- else }}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -350,7 +350,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *{{.Type}}) error {
     {{- end }}
     {{- end }}{{/* if not $inMigration */}}
 
-    return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*{{.Type}}) error {
@@ -393,17 +395,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*{{.Type}}) error {
     return s.upsert(ctx, objs...)
     {{- else }}
 
-    // Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-    // same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-    // violations
-    s.mutex.Lock()
-    defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-    if len(objs) < batchAfter {
-        return s.upsert(ctx, objs...)
-    } else {
-        return s.copyFrom(ctx, objs...)
-    }
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
     {{- end }}
 }
 {{- end }}

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -268,7 +268,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestSingleKeyStruct
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -281,7 +281,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestSingleKe
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -268,7 +268,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestSingleKeyStruct
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -281,7 +281,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestSingleKe
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -268,7 +268,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestSingleKeyStruct
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestSingleKeyStruct) error {
@@ -279,17 +281,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestSingleKe
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -222,7 +222,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestChild1) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -235,7 +235,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild1) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -222,7 +222,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestChild1) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild1) error {
@@ -233,17 +235,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild1) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -222,7 +222,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestChild1) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -235,7 +235,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild1) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -227,7 +227,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestChild1P4) error
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -240,7 +240,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild1P4
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -227,7 +227,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestChild1P4) error
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -240,7 +240,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild1P4
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -227,7 +227,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestChild1P4) error
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild1P4) error {
@@ -238,17 +240,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild1P4
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -232,7 +232,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestChild2) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -245,7 +245,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild2) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -232,7 +232,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestChild2) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -245,7 +245,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild2) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -232,7 +232,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestChild2) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild2) error {
@@ -243,17 +245,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild2) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -232,7 +232,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestG2GrandChild1) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -245,7 +245,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestG2GrandC
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -232,7 +232,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestG2GrandChild1) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -245,7 +245,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestG2GrandC
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -232,7 +232,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestG2GrandChild1) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestG2GrandChild1) error {
@@ -243,17 +245,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestG2GrandC
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -222,7 +222,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestG3GrandChild1) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestG3GrandChild1) error {
@@ -233,17 +235,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestG3GrandC
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -222,7 +222,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestG3GrandChild1) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -235,7 +235,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestG3GrandC
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -222,7 +222,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestG3GrandChild1) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -235,7 +235,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestG3GrandC
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -222,7 +222,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGGrandChild1) e
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGGrandChild1) error {
@@ -233,17 +235,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGGrandCh
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -222,7 +222,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGGrandChild1) e
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -235,7 +235,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGGrandCh
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -222,7 +222,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGGrandChild1) e
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -235,7 +235,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGGrandCh
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -232,7 +232,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGrandChild1) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -245,7 +245,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandChi
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -232,7 +232,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGrandChild1) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -245,7 +245,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandChi
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -232,7 +232,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGrandChild1) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandChild1) error {
@@ -243,17 +245,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandChi
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -397,7 +397,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGrandparent) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -410,7 +410,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandpar
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -397,7 +397,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGrandparent) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -410,7 +410,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandpar
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -397,7 +397,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGrandparent) er
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandparent) error {
@@ -408,17 +410,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandpar
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -307,7 +307,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent1) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -320,7 +320,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent1)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -307,7 +307,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent1) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent1) error {
@@ -318,17 +320,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent1)
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -307,7 +307,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent1) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -320,7 +320,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent1)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -227,7 +227,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent2) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -240,7 +240,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent2)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -227,7 +227,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent2) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -240,7 +240,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent2)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -227,7 +227,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent2) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent2) error {
@@ -238,17 +240,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent2)
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -227,7 +227,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent3) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -240,7 +240,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent3)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -227,7 +227,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent3) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -240,7 +240,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent3)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -227,7 +227,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent3) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent3) error {
@@ -238,17 +240,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent3)
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -227,7 +227,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent4) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -240,7 +240,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent4)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -227,7 +227,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent4) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -240,7 +240,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent4)
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -227,7 +227,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent4) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent4) error {
@@ -238,17 +240,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent4)
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -227,7 +227,9 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestShortCircuit) e
 		return sac.ErrResourceAccessDenied
 	}
 
-	return s.upsert(ctx, obj)
+	return pgutils.RetryExecQuery(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestShortCircuit) error {
@@ -238,17 +240,19 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestShortCir
 		return sac.ErrResourceAccessDenied
 	}
 
-	// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
-	// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
-	// violations
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	return pgutils.RetryExecQuery(ctx, func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 
-	if len(objs) < batchAfter {
-		return s.upsert(ctx, objs...)
-	} else {
-		return s.copyFrom(ctx, objs...)
-	}
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
 }
 
 // Count returns the number of objects in the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -227,7 +227,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestShortCircuit) e
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -240,7 +240,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestShortCir
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(ctx, func() error {
+	return pgutils.RetryExecQuery(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -227,7 +227,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestShortCircuit) e
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -240,7 +240,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestShortCir
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.RetryExecQuery(func() error {
+	return pgutils.Retry(func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations


### PR DESCRIPTION
## Description

Generation to retry upserts gracefully. Only review: tools/generate-helpers/pg-table-bindings/store.go.tpl

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI