### PR TITLE
Add page parameter parsing and component shell for collection form page

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormPage.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { CollectionPageAction } from './collections.utils';
+
+export type CollectionsFormPageProps = {
+    pageAction: CollectionPageAction;
+};
+
+function CollectionsFormPage({ pageAction }: CollectionsFormPageProps) {
+    return pageAction.type === 'create' ? (
+        <>{pageAction.type}</>
+    ) : (
+        <>
+            {pageAction.type} {pageAction.collectionId}
+        </>
+    );
+}
+
+export default CollectionsFormPage;

--- a/ui/apps/platform/src/Containers/Collections/CollectionsPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsPage.tsx
@@ -1,11 +1,32 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+
+import useURLParameter from 'hooks/useURLParameter';
 
 import CollectionsTablePage from './CollectionsTablePage';
+import CollectionsFormPage from './CollectionFormPage';
+import { parsePageActionProp } from './collections.utils';
 
 function CollectionsPage() {
     // TODO Implement permissions once https://issues.redhat.com/browse/ROX-12619 is merged
     // const { hasWriteAccess } = usePermissions();
     const hasWriteAccessForCollections = true; // hasWriteAccess('TODO');
+
+    const [pageAction, setPageAction] = useURLParameter('action', undefined);
+    const { collectionId } = useParams();
+    const validPageActionProp = parsePageActionProp(pageAction, collectionId);
+
+    useEffect(() => {
+        // If the URL structure somehow gets into a state with an invalid action, clear
+        // the parameter to avoid confusing the user.
+        if (typeof pageAction !== 'undefined' && !validPageActionProp) {
+            setPageAction(undefined);
+        }
+    }, [pageAction, validPageActionProp, setPageAction]);
+
+    if (validPageActionProp) {
+        return <CollectionsFormPage pageAction={validPageActionProp} />;
+    }
 
     return <CollectionsTablePage hasWriteAccessForCollections={hasWriteAccessForCollections} />;
 }

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -23,7 +23,7 @@ import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import { GetSortParams } from 'hooks/useURLSort';
 import { CollectionResponse } from 'services/CollectionsService';
 import { SearchFilter } from 'types/search';
-import { collectionsPath } from 'routePaths';
+import { collectionsBasePath } from 'routePaths';
 
 export type CollectionsTableProps = {
     collections: CollectionResponse[];
@@ -57,14 +57,14 @@ function CollectionsTable({
 
     function onEditCollection(id: string) {
         history.push({
-            pathname: `${collectionsPath}/${id}`,
+            pathname: `${collectionsBasePath}/${id}`,
             search: 'action=edit',
         });
     }
 
     function onCloneCollection(id: string) {
         history.push({
-            pathname: `${collectionsPath}/${id}`,
+            pathname: `${collectionsBasePath}/${id}`,
             search: 'action=clone',
         });
     }
@@ -192,7 +192,7 @@ function CollectionsTable({
                                         variant={ButtonVariant.link}
                                         isInline
                                         component={LinkShim}
-                                        href={`${collectionsPath}/${id}`}
+                                        href={`${collectionsBasePath}/${id}`}
                                     >
                                         {name}
                                     </Button>

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
@@ -15,7 +15,7 @@ import {
 
 import PageTitle from 'Components/PageTitle';
 import LinkShim from 'Components/PatternFly/LinkShim';
-import { collectionsPath } from 'routePaths';
+import { collectionsBasePath } from 'routePaths';
 import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
 import { getCollectionCount, listCollections } from 'services/CollectionsService';
 import useURLSearch from 'hooks/useURLSearch';
@@ -103,7 +103,7 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
                             <Button
                                 variant={ButtonVariant.primary}
                                 component={LinkShim}
-                                href={`${collectionsPath}?action=create`}
+                                href={`${collectionsBasePath}?action=create`}
                             >
                                 Create collection
                             </Button>

--- a/ui/apps/platform/src/Containers/Collections/collections.utils.ts
+++ b/ui/apps/platform/src/Containers/Collections/collections.utils.ts
@@ -1,0 +1,41 @@
+export type CollectionPageAction =
+    | {
+          type: 'create';
+      }
+    | {
+          type: 'edit' | 'clone' | 'view';
+          collectionId: string;
+      };
+
+/**
+ * Parses raw URL parameters into a valid page action for the collections form.
+ *
+ * This ensures that page cannot get into invalid states, such as loading a collection ID
+ * with 'action=create', or having 'action={edit,clone,view}' without a collection ID.
+ *
+ * @param action The URL action search parameter
+ * @param collectionId The collection ID passed in the URL path
+ *
+ * @returns A valid collection page action object, or null if the provided parameters are invalid
+ */
+export function parsePageActionProp(
+    action: unknown,
+    collectionId: string | undefined
+): CollectionPageAction | null {
+    if (typeof collectionId === 'undefined' && action === 'create') {
+        return { type: 'create' };
+    }
+
+    if (typeof collectionId !== 'undefined' && typeof action === 'undefined') {
+        return { collectionId, type: 'view' };
+    }
+
+    if (
+        typeof collectionId !== 'undefined' &&
+        (action === 'clone' || action === 'edit' || action === 'view')
+    ) {
+        return { collectionId, type: action };
+    }
+
+    return null;
+}

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -23,7 +23,7 @@ import {
     accessControlBasePathV2,
     systemConfigPath,
     systemHealthPath,
-    collectionsPath,
+    collectionsBasePath,
 } from 'routePaths';
 
 import LeftNavItem from './LeftNavItem';
@@ -67,7 +67,7 @@ function NavigationSidebar({
         platformConfigurationPaths.splice(
             platformConfigurationPaths.indexOf(policyManagementBasePath) + 1,
             0,
-            collectionsPath
+            collectionsBasePath
         );
     }
 

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -45,7 +45,8 @@ export const compliancePath = `${mainPath}/:context(compliance)`;
 export const dataRetentionPath = `${mainPath}/retention`;
 export const systemHealthPath = `${mainPath}/system-health`;
 export const systemHealthPathPF = `${mainPath}/system-health-pf`;
-export const collectionsPath = `${mainPath}/collections`;
+export const collectionsBasePath = `${mainPath}/collections`;
+export const collectionsPath = `${mainPath}/collections/:collectionId?`;
 export const productDocsPath = '/docs/product';
 
 // Configuration Management
@@ -159,7 +160,7 @@ export const basePathToLabelMap = {
     [policyManagementBasePath]: 'Policy Management',
     [policiesBasePath]: 'Policy Management',
     [policyCategoriesPath]: 'Policy Categories',
-    [collectionsPath]: 'Collections',
+    [collectionsBasePath]: 'Collections',
     [integrationsPath]: 'Integrations',
     [accessControlPath]: 'Access Control',
     [accessControlBasePathV2]: 'Access Control',


### PR DESCRIPTION
## Description

This adds the empty shell of the main collection form page as well as parsing out the page action (view/create/edit/clone) from the URL.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

For visual testing purposes, the page action and ID are rendered in the form page component.

Visit the collection page and load the table of collections in the system.
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193353983-e8b4b148-268b-4f79-8860-d661f452b85f.png">

Click the name of one of the collections in the table, this should update the page URL and take you to an empty "view mode" page for the collection.
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193354072-9220916b-36ab-4915-9678-2659fd6b2b1d.png">

From the table, open the menu of one of the collection and click the "Edit" button:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193354151-3fc24cc8-2798-4a9a-b99f-210f9add32cf.png">

From the table, open the menu of one of the collection and click the "Clone" button:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193354177-e18598d3-045e-4660-a918-c5fd933aee7d.png">

From the table page, click the "Create collection" button in the header:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/193354288-4d02e3b9-2106-447a-8d29-292904c9b994.png">

Error handling checks - for each of the below URLs, enter the value manually in the address bar:

`/main/collections/2?action=create` (will update the URL to `/main/collections/2` and display "view 2")
`/main/collections/2?action=bogus` (will update the URL to `/main/collections/2` and display "view 2")
`/main/collections?action=edit` (will update the URL to `/main/collections` and display the collections table)
`/main/collections?action=clone` (will update the URL to `/main/collections` and display the collections table)
`/main/collections?action=view` (will update the URL to `/main/collections` and display the collections table)
`/main/collections?action=bogus` (will update the URL to `/main/collections` and display the collections table)



