### PR TITLE
ROX-11946: Fix SACTest for no masked deployments

### DIFF
--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -619,11 +619,8 @@ class SACTest extends BaseSpecification {
 
         and:
         "The flows should be equal to the flows obtained with all access after removing masked endpoints"
-        def sacFlowsFiltered = new HashSet<String>(sacFlows)
-        sacFlowsFiltered.removeAll { it.contains("masked deployment") }
-
-        def sacFlowsNoQueryFiltered = new HashSet<String>(sacFlowsNoQuery)
-        sacFlowsNoQueryFiltered.removeAll { it.contains("masked deployment") }
+        Set<String> sacFlowsFiltered = sacFlows.findAll { !it.contains("masked deployment") }
+        Set<String> sacFlowsNoQueryFiltered = sacFlowsNoQuery.findAll { !it.contains("masked deployment") }
 
         assert allAccessFlowsWithoutNeighbors == sacFlowsFiltered
         assert allAccessFlowsWithoutNeighbors == sacFlowsNoQueryFiltered


### PR DESCRIPTION
## Description

`removeAll` returns `false` when no element was removed. This fails when there is no masked deployments becauses this happens in `then` section where every statement is `assert`ed by default. 
This PR changes the behavior from coping deployments and removing masked deployments to filter original deployments.

Refs: https://blog.solidsoft.pl/2020/03/18/places-where-you-really-need-to-use-assert-keyword-in-spock-assertions/

## Testing Performed

CI