### PR TITLE
ROX-12808: Increase diagnostic bundle timeouts

### DIFF
--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -60,8 +60,8 @@ const (
 
 	centralClusterPrefix = "_central-cluster"
 
-	metricsPullTimeout     = 10 * time.Second
-	diagnosticsPullTimeout = 10 * time.Second
+	metricsPullTimeout     = 20 * time.Second
+	diagnosticsPullTimeout = 20 * time.Second
 	layout                 = "2006-01-02T15:04:05.000Z"
 	logWindow              = 20 * time.Minute
 )
@@ -529,11 +529,11 @@ func (s *serviceImpl) writeZippedDebugDump(ctx context.Context, w http.ResponseW
 
 	if opts.logs == fullK8sIntrospectionData {
 		if err := s.getK8sDiagnostics(ctx, zipWriter, opts); err != nil {
-			log.Error(err)
+			log.Errorf("could not get K8s diagnostics: %+q", err)
 			opts.logs = localLogs // fallback to local logs
 		}
 		if err := s.pullSensorMetrics(ctx, zipWriter, opts); err != nil {
-			log.Error(err)
+			log.Errorf("could not get sensor metrics: %+q", err)
 		}
 	}
 

--- a/roxctl/central/debug/download_diagnostics.go
+++ b/roxctl/central/debug/download_diagnostics.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	diagnosticBundleDownloadTimeout = 20 * time.Second
+	diagnosticBundleDownloadTimeout = 60 * time.Second
 )
 
 // downloadDiagnosticsCommand allows downloading the diagnostics bundle.


### PR DESCRIPTION
## Description

We experience multiple timeouts on diagnostic bundle creation on rosa cluster.
This PR doubles the time for sensor metrics gathering. 

## Testing Performed
CI