### PR TITLE
Jv rox 12933 build and push mock grpc server in osci

### DIFF
--- a/.openshift-ci/build/Dockerfile.build-mock-grpc-server
+++ b/.openshift-ci/build/Dockerfile.build-mock-grpc-server
@@ -1,0 +1,21 @@
+FROM replaced-by-osci:root as builder
+# note the above FROM line is ignored and OpenShift CI uses build_root image instead
+
+COPY . /go/src/github.com/stackrox/stackrox
+WORKDIR /go/src/github.com/stackrox/stackrox
+
+
+RUN sed -i 's|.*git .*|done < <(grep -rn '//XDef:' --include=${SCRIPT_DIR}/../*.go)|' scripts/go-tool.sh
+RUN sed -i 's|STABLE_MAIN_VERSION .*|STABLE_MAIN_VERSION 3.72.x-231-g7e13305647|' status.sh
+RUN sed -i 's|STABLE_GIT_SHORT_SHA .*|STABLE_GIT_SHORT_SHA 7e13305647|' status.sh
+RUN cat scripts/go-tool.sh
+
+RUN make mock-grpc-server-build; cp bin/linux_amd64/mock-grpc-server /
+
+FROM scratch
+
+COPY --from=builder /mock-grpc-server /mock-grpc-server
+
+EXPOSE 9090
+USER 1000:1000
+ENTRYPOINT ["/mock-grpc-server"]

--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -65,6 +65,9 @@ push_images() {
             push_operator_image_set "$push_context" "$brand"
         fi
     fi
+    if [[ -n "${MOCK_GRPC_SERVER_IMAGE:-}" ]]; then
+        push_mock_grpc_server_image
+    fi
 
     if is_in_PR_context && [[ "$brand" == "STACKROX_BRANDING" ]] && [[ -n "${MAIN_IMAGE}" ]]; then
         add_build_comment_to_pr || {

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -344,6 +344,21 @@ push_race_condition_debug_image() {
     oc_image_mirror "$MAIN_RCD_IMAGE" "${registry}/main:$(make --quiet tag)-rcd"
 }
 
+push_mock_grpc_server_image() {
+    local registry="quay.io/rhacs-eng"
+    image="${registry}/grpc-server:$(make --quiet tag)"
+    info "Pushing the mock grpc server image: $MOCK_GRPC_SERVER_IMAGE to $image"
+
+    if ! is_OPENSHIFT_CI; then
+        die "Only supported in OpenShift CI"
+    fi
+
+    oc registry login
+
+    registry_rw_login "$registry"
+    oc_image_mirror "$MOCK_GRPC_SERVER_IMAGE" "$image"
+}
+
 registry_rw_login() {
     if [[ "$#" -ne 1 ]]; then
         die "missing arg. usage: registry_rw_login <registry>"


### PR DESCRIPTION
## Description

Currently the mock grpc server image used for Collector integration tests is only built manually in a developers local environment. It must also be pushed manually. To make this more convenient and automated OSCI will build and push the mock grpc server image.

See the corresponding openshift/release PR at https://github.com/openshift/release/pull/32814

## Checklist
- [x] Investigated and inspected CI test results
- [x] Tested the mock grpc server image

If any of these don't apply, please comment below.

## Testing Performed

After running CI get the tag of the mock grpc server image. 
Cd into the collector repo.
Change GRPCServerImage in the collector integration tests in the file integration-tests/collector_manager.go. Run the integration tests in collector. Go back to the collector main repo directory. Run make.
