### PR TITLE
Do not depend on tools in system-/user-wide paths (or install tools into those)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ protoc-*
 coverage.out
 coverage.html
 combined_coverage.dat
+/.gotools/
 
 # Build output
 /bin/

--- a/make/gotools.mk
+++ b/make/gotools.mk
@@ -1,0 +1,128 @@
+# gotools.mk
+# Simplified installation & usage of Go-based tools
+#
+# Input variables:
+#   GOTOOLS_PROJECT_ROOT: the project root directory; defaults to $(CURDIR)
+#   GOTOOLS_ROOT: the directory in which this file stores auxiliary data (should be .gitignore'd); defaults to
+#                 $(GOTOOLS_PROJECT_ROOT)/.gotools
+#   GOTOOLS_BIN: the directory in which binaries are stored; defaults to $(GOTOOLS_ROOT)/bin.
+#
+# This file defines a single (user-facing) macro, `go-tool`, which can be invoked via
+#   $(call go-tool VARNAME, go-pkg [, module-root])
+# where go-pkg can be:
+# - an absolute Go import path with an explicit version, e.g.,
+#     github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0. In this case, the tool is installed via `go install`,
+#     and module information from the local workspace is ignored, in accordance with the normal behavior of go install
+#     with an explicit version given.
+# - an absolute Go import path WITHOUT a version, e.g., github.com/golangci/golangci-lint/cmd/golangci-lint. In this
+#     case, the tool is installed via `go install` from the module rooted at $(GOTOOLS_PROJECT_ROOT), or, if
+#     module-root is given, from the module rooted at that (relative) path. I.e., go-pkg must be provided by a module
+#     listed as a requirement in <module-root>/go.mod.
+# - a relative Go import path (WITHOUT a version), e.g., ./tools/roxvet. In this case, the tool is installed via
+#     `go install` from the module rooted at $(GOTOOLS_PROJECT_ROOT).
+#
+# Invoking go-tool will set up Makefile rules to build the tools, using reasonable strategies for caching to avoid
+# building a tool multiple times. In particular:
+# - when using an absolute Go import path with a version, the rule is set up such that the `go install` command is only
+#   run once.
+# - when using an absolute Go import path without a version, the rule is set up such that the `go install` command is
+#   re-run only when the respective go.mod file changes.
+# - when using a relative Go import path, the rule is set up such that the `go install` command is re-run on every
+#   `make` invocation.
+# Note that `go install` uses a pretty effective caching strategy under the hood, so even with relative import path,
+# you should not expect noticeable latency.
+#
+# In addition to setting up the rules for building, invoking go-tool will also set the value of the variable `VARNAME`
+# to the (canonical) location of the respective tool's binary, which is $(GOTOOLS_BIN)/<binary basename>. `$(VARNAME)`
+# should be used as the only way of both invoking the tool in the Makefile as well as expressing a dependency on the
+# installation of the tool.
+# For use in non-Makefile scripts, a target `which-<tool>` is added, whhere <tool> is the basename of the tool binary.
+# This target prints the canonical location of the binary and, if necessary, builds it. Note that invocations of
+# `make which-tool` should be made with the flags `--quiet --no-print-directory` set, as otherwise the output gets
+# clobbered.
+#
+# This file also defines two static, global targets:
+#   gotools-clean: this removes all gotools-related data
+#   gotools-all: this builds all gotools.
+
+GOTOOLS_PROJECT_ROOT ?= $(CURDIR)
+GOTOOLS_ROOT ?= $(GOTOOLS_PROJECT_ROOT)/.gotools
+GOTOOLS_BIN ?= $(GOTOOLS_ROOT)/bin
+
+_GOTOOLS_ALL_GOTOOLS :=
+
+define go-tool-impl
+# The variable via which the executable can be referenced
+_gotools_var_name := $(strip $(1))
+# The importable Go package path that contains the "main" package for the tool
+_gotools_pkg := $(firstword $(subst @, ,$(strip $(2))))
+# The version of the tool (if a version was explicitly specified)
+_gotools_version := $(word 2,$(subst @, ,$(strip $(2))))
+# The folder containing the go.mod file, if not the root folder
+ifeq ($(strip $(3)),)
+_gotools_mod_root := $(GOTOOLS_PROJECT_ROOT)
+else
+_gotools_mod_root := $(strip $(3))
+endif
+
+# We need to strip a `/v2` (etc.) suffix to derive the tool binary's basename.
+_gotools_bin_name := $$(notdir $$(shell echo "$$(_gotools_pkg)" | sed -E 's@/v[[:digit:]]+$$$$@@g'))
+_gotools_canonical_bin_path := $(GOTOOLS_BIN)/$$(_gotools_bin_name)
+$$(_gotools_var_name) := $$(_gotools_canonical_bin_path)
+
+.PHONY: which-$$(_gotools_bin_name)
+which-$$(_gotools_bin_name):
+	@$(MAKE) $$($(strip $(1))) >&2
+	@echo $$($(strip $(1)))
+
+ifneq ($(filter ./%,$(2)),)
+# Tool is built from local files. We have to introduce a phony target and let the Go compiler
+# do all the caching.
+.PHONY: $$(_gotools_canonical_bin_path)
+$$(_gotools_canonical_bin_path):
+	@echo "+ $$(notdir $$@)"
+	$$(SILENT)GOBIN="$$(dir $$@)" go install "$(strip $(2))"
+else
+# Tool is specified with version, so we don't take any info from the go.mod file.
+# We install the tool into a location that is version-dependent, and build it via this target. Since the name of
+# the tool under that path is version-dependent, we never have to rebuild it, as it's either the correct version, or
+# does not exist.
+ifneq ($$(_gotools_version),)
+_gotools_versioned_bin_path := $(GOTOOLS_ROOT)/versioned/$$(_gotools_pkg)/$$(_gotools_version)/$$(_gotools_bin_name)
+$$(_gotools_versioned_bin_path):
+	@echo "+ $$(notdir $$@)"
+	$$(SILENT)GOBIN="$$(dir $$@)" go install "$(strip $(2))"
+
+# To make the tool accessible in the canonical location, we create a symlink. This only depends on the versioned path,
+# i.e., only needs to be recreated when the version is bumped.
+$$(_gotools_canonical_bin_path): $$(_gotools_versioned_bin_path)
+	@mkdir -p "$(GOTOOLS_BIN)"
+	$$(SILENT)ln -sf "$$<" "$$@"
+
+else
+
+# Tool is specified with an absolute path without a version. Take info from go.mod file in the respective directory.
+$$(_gotools_canonical_bin_path): $$(_gotools_mod_root)/go.mod $$(_gotools_mod_root)/go.sum
+	@echo "+ $$(notdir $$@)"
+	$$(SILENT)cd "$$(dir $$<)" && GOBIN="$$(dir $$@)" go install "$(strip $(2))"
+
+endif
+endif
+
+_GOTOOLS_ALL_GOTOOLS += $$(_gotools_canonical_bin_path)
+
+endef
+
+go-tool = $(eval $(call go-tool-impl,$(1),$(2),$(3)))
+
+
+.PHONY: gotools-clean
+gotools-clean:
+	@echo "+ $@"
+	@git clean -dfX "$(GOTOOLS_ROOT)"  # don't use rm -rf to avoid catastrophes
+
+.PHONY: gotools-all
+gotools-all:
+	@# these cannot be dependencies, as we need `$(_GOTOOLS_ALL_GOTOOLS)` to be
+	@# evaluated when the target is actually run.
+	$(MAKE) $(_GOTOOLS_ALL_GOTOOLS)

--- a/pkg/docker/types/types_easyjson.go
+++ b/pkg/docker/types/types_easyjson.go
@@ -7,12 +7,9 @@ import (
 	types "github.com/docker/docker/api/types"
 	container "github.com/docker/docker/api/types/container"
 	image "github.com/docker/docker/api/types/image"
-	mount "github.com/docker/docker/api/types/mount"
 	network "github.com/docker/docker/api/types/network"
 	registry "github.com/docker/docker/api/types/registry"
 	swarm "github.com/docker/docker/api/types/swarm"
-	nat "github.com/docker/go-connections/nat"
-	go_units "github.com/docker/go-units"
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
@@ -65,7 +62,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes(in *jlexer.Lexer, 
 				}
 				for !in.IsDelim(']') {
 					var v1 ContainerJSON
-					easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes1(in, &v1)
+					(v1).UnmarshalEasyJSON(in)
 					out.Containers = append(out.Containers, v1)
 					in.WantComma()
 				}
@@ -88,7 +85,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes(in *jlexer.Lexer, 
 				}
 				for !in.IsDelim(']') {
 					var v2 ImageWrap
-					easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes2(in, &v2)
+					easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes1(in, &v2)
 					out.Images = append(out.Images, v2)
 					in.WantComma()
 				}
@@ -126,7 +123,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Write
 				if v3 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out, v4)
+				(v4).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}
@@ -142,7 +139,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Write
 				if v5 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes2(out, v6)
+				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out, v6)
 			}
 			out.RawByte(']')
 		}
@@ -1096,7 +1093,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork5(out *jwriter.Wr
 	}
 	out.RawByte('}')
 }
-func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes2(in *jlexer.Lexer, out *ImageWrap) {
+func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes1(in *jlexer.Lexer, out *ImageWrap) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1116,7 +1113,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes2(in *jlexer.Lexer,
 		}
 		switch key {
 		case "image":
-			easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes3(in, &out.Image)
+			(out.Image).UnmarshalEasyJSON(in)
 		case "history":
 			if in.IsNull() {
 				in.Skip()
@@ -1150,14 +1147,14 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes2(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes2(out *jwriter.Writer, in ImageWrap) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writer, in ImageWrap) {
 	out.RawByte('{')
 	first := true
 	_ = first
 	{
 		const prefix string = ",\"image\":"
 		out.RawString(prefix[1:])
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes3(out, in.Image)
+		(in.Image).MarshalEasyJSON(out)
 	}
 	{
 		const prefix string = ",\"history\":"
@@ -1286,1454 +1283,6 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesImage(out *jwriter.Write
 	}
 	out.RawByte('}')
 }
-func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes3(in *jlexer.Lexer, out *ImageInspect) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "Id":
-			out.ID = string(in.String())
-		case "RepoTags":
-			if in.IsNull() {
-				in.Skip()
-				out.RepoTags = nil
-			} else {
-				in.Delim('[')
-				if out.RepoTags == nil {
-					if !in.IsDelim(']') {
-						out.RepoTags = make([]string, 0, 4)
-					} else {
-						out.RepoTags = []string{}
-					}
-				} else {
-					out.RepoTags = (out.RepoTags)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v39 string
-					v39 = string(in.String())
-					out.RepoTags = append(out.RepoTags, v39)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		case "RepoDigests":
-			if in.IsNull() {
-				in.Skip()
-				out.RepoDigests = nil
-			} else {
-				in.Delim('[')
-				if out.RepoDigests == nil {
-					if !in.IsDelim(']') {
-						out.RepoDigests = make([]string, 0, 4)
-					} else {
-						out.RepoDigests = []string{}
-					}
-				} else {
-					out.RepoDigests = (out.RepoDigests)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v40 string
-					v40 = string(in.String())
-					out.RepoDigests = append(out.RepoDigests, v40)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		case "Config":
-			if in.IsNull() {
-				in.Skip()
-				out.Config = nil
-			} else {
-				if out.Config == nil {
-					out.Config = new(Config)
-				}
-				easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes4(in, out.Config)
-			}
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes3(out *jwriter.Writer, in ImageInspect) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"Id\":"
-		out.RawString(prefix[1:])
-		out.String(string(in.ID))
-	}
-	if len(in.RepoTags) != 0 {
-		const prefix string = ",\"RepoTags\":"
-		out.RawString(prefix)
-		{
-			out.RawByte('[')
-			for v41, v42 := range in.RepoTags {
-				if v41 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v42))
-			}
-			out.RawByte(']')
-		}
-	}
-	if len(in.RepoDigests) != 0 {
-		const prefix string = ",\"RepoDigests\":"
-		out.RawString(prefix)
-		{
-			out.RawByte('[')
-			for v43, v44 := range in.RepoDigests {
-				if v43 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v44))
-			}
-			out.RawByte(']')
-		}
-	}
-	if in.Config != nil {
-		const prefix string = ",\"Config\":"
-		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out, *in.Config)
-	}
-	out.RawByte('}')
-}
-func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes4(in *jlexer.Lexer, out *Config) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "Healthcheck":
-			if in.IsNull() {
-				in.Skip()
-				out.Healthcheck = nil
-			} else {
-				if out.Healthcheck == nil {
-					out.Healthcheck = new(container.HealthConfig)
-				}
-				easyjson6601e8cdDecodeGithubComDockerDockerApiTypesContainer(in, out.Healthcheck)
-			}
-		case "User":
-			out.User = string(in.String())
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out *jwriter.Writer, in Config) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.Healthcheck != nil {
-		const prefix string = ",\"Healthcheck\":"
-		first = false
-		out.RawString(prefix[1:])
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer(out, *in.Healthcheck)
-	}
-	if in.User != "" {
-		const prefix string = ",\"User\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.User))
-	}
-	out.RawByte('}')
-}
-func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesContainer(in *jlexer.Lexer, out *container.HealthConfig) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "Test":
-			if in.IsNull() {
-				in.Skip()
-				out.Test = nil
-			} else {
-				in.Delim('[')
-				if out.Test == nil {
-					if !in.IsDelim(']') {
-						out.Test = make([]string, 0, 4)
-					} else {
-						out.Test = []string{}
-					}
-				} else {
-					out.Test = (out.Test)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v45 string
-					v45 = string(in.String())
-					out.Test = append(out.Test, v45)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		case "Interval":
-			out.Interval = time.Duration(in.Int64())
-		case "Timeout":
-			out.Timeout = time.Duration(in.Int64())
-		case "StartPeriod":
-			out.StartPeriod = time.Duration(in.Int64())
-		case "Retries":
-			out.Retries = int(in.Int())
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer(out *jwriter.Writer, in container.HealthConfig) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if len(in.Test) != 0 {
-		const prefix string = ",\"Test\":"
-		first = false
-		out.RawString(prefix[1:])
-		{
-			out.RawByte('[')
-			for v46, v47 := range in.Test {
-				if v46 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v47))
-			}
-			out.RawByte(']')
-		}
-	}
-	if in.Interval != 0 {
-		const prefix string = ",\"Interval\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int64(int64(in.Interval))
-	}
-	if in.Timeout != 0 {
-		const prefix string = ",\"Timeout\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int64(int64(in.Timeout))
-	}
-	if in.StartPeriod != 0 {
-		const prefix string = ",\"StartPeriod\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int64(int64(in.StartPeriod))
-	}
-	if in.Retries != 0 {
-		const prefix string = ",\"Retries\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int(int(in.Retries))
-	}
-	out.RawByte('}')
-}
-func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes1(in *jlexer.Lexer, out *ContainerJSON) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	out.ContainerJSONBase = new(ContainerJSONBase)
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "Mounts":
-			if in.IsNull() {
-				in.Skip()
-				out.Mounts = nil
-			} else {
-				in.Delim('[')
-				if out.Mounts == nil {
-					if !in.IsDelim(']') {
-						out.Mounts = make([]MountPoint, 0, 0)
-					} else {
-						out.Mounts = []MountPoint{}
-					}
-				} else {
-					out.Mounts = (out.Mounts)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v48 MountPoint
-					easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes5(in, &v48)
-					out.Mounts = append(out.Mounts, v48)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		case "Config":
-			if in.IsNull() {
-				in.Skip()
-				out.Config = nil
-			} else {
-				if out.Config == nil {
-					out.Config = new(Config)
-				}
-				easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes4(in, out.Config)
-			}
-		case "NetworkSettings":
-			if in.IsNull() {
-				in.Skip()
-				out.NetworkSettings = nil
-			} else {
-				if out.NetworkSettings == nil {
-					out.NetworkSettings = new(NetworkSettings)
-				}
-				easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes6(in, out.NetworkSettings)
-			}
-		case "Id":
-			out.ID = string(in.String())
-		case "Image":
-			out.Image = string(in.String())
-		case "State":
-			if in.IsNull() {
-				in.Skip()
-				out.State = nil
-			} else {
-				if out.State == nil {
-					out.State = new(ContainerState)
-				}
-				easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes7(in, out.State)
-			}
-		case "Name":
-			out.Name = string(in.String())
-		case "AppArmorProfile":
-			out.AppArmorProfile = string(in.String())
-		case "HostConfig":
-			if in.IsNull() {
-				in.Skip()
-				out.HostConfig = nil
-			} else {
-				if out.HostConfig == nil {
-					out.HostConfig = new(HostConfig)
-				}
-				easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes8(in, out.HostConfig)
-			}
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writer, in ContainerJSON) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if len(in.Mounts) != 0 {
-		const prefix string = ",\"Mounts\":"
-		first = false
-		out.RawString(prefix[1:])
-		{
-			out.RawByte('[')
-			for v49, v50 := range in.Mounts {
-				if v49 > 0 {
-					out.RawByte(',')
-				}
-				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes5(out, v50)
-			}
-			out.RawByte(']')
-		}
-	}
-	if in.Config != nil {
-		const prefix string = ",\"Config\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out, *in.Config)
-	}
-	if in.NetworkSettings != nil {
-		const prefix string = ",\"NetworkSettings\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes6(out, *in.NetworkSettings)
-	}
-	{
-		const prefix string = ",\"Id\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.ID))
-	}
-	if in.Image != "" {
-		const prefix string = ",\"Image\":"
-		out.RawString(prefix)
-		out.String(string(in.Image))
-	}
-	if in.State != nil {
-		const prefix string = ",\"State\":"
-		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes7(out, *in.State)
-	}
-	if in.Name != "" {
-		const prefix string = ",\"Name\":"
-		out.RawString(prefix)
-		out.String(string(in.Name))
-	}
-	if in.AppArmorProfile != "" {
-		const prefix string = ",\"AppArmorProfile\":"
-		out.RawString(prefix)
-		out.String(string(in.AppArmorProfile))
-	}
-	if in.HostConfig != nil {
-		const prefix string = ",\"HostConfig\":"
-		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out, *in.HostConfig)
-	}
-	out.RawByte('}')
-}
-func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes8(in *jlexer.Lexer, out *HostConfig) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "CapAdd":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.CapAdd).UnmarshalJSON(data))
-			}
-		case "CapDrop":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.CapDrop).UnmarshalJSON(data))
-			}
-		case "SecurityOpt":
-			if in.IsNull() {
-				in.Skip()
-				out.SecurityOpt = nil
-			} else {
-				in.Delim('[')
-				if out.SecurityOpt == nil {
-					if !in.IsDelim(']') {
-						out.SecurityOpt = make([]string, 0, 4)
-					} else {
-						out.SecurityOpt = []string{}
-					}
-				} else {
-					out.SecurityOpt = (out.SecurityOpt)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v51 string
-					v51 = string(in.String())
-					out.SecurityOpt = append(out.SecurityOpt, v51)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		case "NetworkMode":
-			out.NetworkMode = container.NetworkMode(in.String())
-		case "RestartPolicy":
-			easyjson6601e8cdDecodeGithubComDockerDockerApiTypesContainer1(in, &out.RestartPolicy)
-		case "IpcMode":
-			out.IpcMode = container.IpcMode(in.String())
-		case "PidMode":
-			out.PidMode = container.PidMode(in.String())
-		case "Privileged":
-			out.Privileged = bool(in.Bool())
-		case "ReadonlyRootfs":
-			out.ReadonlyRootfs = bool(in.Bool())
-		case "UTSMode":
-			out.UTSMode = container.UTSMode(in.String())
-		case "UsernsMode":
-			out.UsernsMode = container.UsernsMode(in.String())
-		case "CgroupParent":
-			out.CgroupParent = string(in.String())
-		case "CpuShares":
-			out.CPUShares = int64(in.Int64())
-		case "Memory":
-			out.Memory = int64(in.Int64())
-		case "Devices":
-			if in.IsNull() {
-				in.Skip()
-				out.Devices = nil
-			} else {
-				in.Delim('[')
-				if out.Devices == nil {
-					if !in.IsDelim(']') {
-						out.Devices = make([]container.DeviceMapping, 0, 1)
-					} else {
-						out.Devices = []container.DeviceMapping{}
-					}
-				} else {
-					out.Devices = (out.Devices)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v52 container.DeviceMapping
-					easyjson6601e8cdDecodeGithubComDockerDockerApiTypesContainer2(in, &v52)
-					out.Devices = append(out.Devices, v52)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		case "PidsLimit":
-			out.PidsLimit = int64(in.Int64())
-		case "Ulimits":
-			if in.IsNull() {
-				in.Skip()
-				out.Ulimits = nil
-			} else {
-				in.Delim('[')
-				if out.Ulimits == nil {
-					if !in.IsDelim(']') {
-						out.Ulimits = make([]*go_units.Ulimit, 0, 8)
-					} else {
-						out.Ulimits = []*go_units.Ulimit{}
-					}
-				} else {
-					out.Ulimits = (out.Ulimits)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v53 *go_units.Ulimit
-					if in.IsNull() {
-						in.Skip()
-						v53 = nil
-					} else {
-						if v53 == nil {
-							v53 = new(go_units.Ulimit)
-						}
-						easyjson6601e8cdDecodeGithubComDockerGoUnits(in, v53)
-					}
-					out.Ulimits = append(out.Ulimits, v53)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out *jwriter.Writer, in HostConfig) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if len(in.CapAdd) != 0 {
-		const prefix string = ",\"CapAdd\":"
-		first = false
-		out.RawString(prefix[1:])
-		{
-			out.RawByte('[')
-			for v54, v55 := range in.CapAdd {
-				if v54 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v55))
-			}
-			out.RawByte(']')
-		}
-	}
-	if len(in.CapDrop) != 0 {
-		const prefix string = ",\"CapDrop\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		{
-			out.RawByte('[')
-			for v56, v57 := range in.CapDrop {
-				if v56 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v57))
-			}
-			out.RawByte(']')
-		}
-	}
-	if len(in.SecurityOpt) != 0 {
-		const prefix string = ",\"SecurityOpt\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		{
-			out.RawByte('[')
-			for v58, v59 := range in.SecurityOpt {
-				if v58 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v59))
-			}
-			out.RawByte(']')
-		}
-	}
-	if in.NetworkMode != "" {
-		const prefix string = ",\"NetworkMode\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.NetworkMode))
-	}
-	if true {
-		const prefix string = ",\"RestartPolicy\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer1(out, in.RestartPolicy)
-	}
-	if in.IpcMode != "" {
-		const prefix string = ",\"IpcMode\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.IpcMode))
-	}
-	if in.PidMode != "" {
-		const prefix string = ",\"PidMode\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.PidMode))
-	}
-	if in.Privileged {
-		const prefix string = ",\"Privileged\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Bool(bool(in.Privileged))
-	}
-	if in.ReadonlyRootfs {
-		const prefix string = ",\"ReadonlyRootfs\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Bool(bool(in.ReadonlyRootfs))
-	}
-	if in.UTSMode != "" {
-		const prefix string = ",\"UTSMode\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.UTSMode))
-	}
-	if in.UsernsMode != "" {
-		const prefix string = ",\"UsernsMode\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.UsernsMode))
-	}
-	if in.CgroupParent != "" {
-		const prefix string = ",\"CgroupParent\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.CgroupParent))
-	}
-	{
-		const prefix string = ",\"CpuShares\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int64(int64(in.CPUShares))
-	}
-	if in.Memory != 0 {
-		const prefix string = ",\"Memory\":"
-		out.RawString(prefix)
-		out.Int64(int64(in.Memory))
-	}
-	if len(in.Devices) != 0 {
-		const prefix string = ",\"Devices\":"
-		out.RawString(prefix)
-		{
-			out.RawByte('[')
-			for v60, v61 := range in.Devices {
-				if v60 > 0 {
-					out.RawByte(',')
-				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer2(out, v61)
-			}
-			out.RawByte(']')
-		}
-	}
-	if in.PidsLimit != 0 {
-		const prefix string = ",\"PidsLimit\":"
-		out.RawString(prefix)
-		out.Int64(int64(in.PidsLimit))
-	}
-	if len(in.Ulimits) != 0 {
-		const prefix string = ",\"Ulimits\":"
-		out.RawString(prefix)
-		{
-			out.RawByte('[')
-			for v62, v63 := range in.Ulimits {
-				if v62 > 0 {
-					out.RawByte(',')
-				}
-				if v63 == nil {
-					out.RawString("null")
-				} else {
-					easyjson6601e8cdEncodeGithubComDockerGoUnits(out, *v63)
-				}
-			}
-			out.RawByte(']')
-		}
-	}
-	out.RawByte('}')
-}
-func easyjson6601e8cdDecodeGithubComDockerGoUnits(in *jlexer.Lexer, out *go_units.Ulimit) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "Name":
-			out.Name = string(in.String())
-		case "Hard":
-			out.Hard = int64(in.Int64())
-		case "Soft":
-			out.Soft = int64(in.Int64())
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComDockerGoUnits(out *jwriter.Writer, in go_units.Ulimit) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"Name\":"
-		out.RawString(prefix[1:])
-		out.String(string(in.Name))
-	}
-	{
-		const prefix string = ",\"Hard\":"
-		out.RawString(prefix)
-		out.Int64(int64(in.Hard))
-	}
-	{
-		const prefix string = ",\"Soft\":"
-		out.RawString(prefix)
-		out.Int64(int64(in.Soft))
-	}
-	out.RawByte('}')
-}
-func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesContainer2(in *jlexer.Lexer, out *container.DeviceMapping) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "PathOnHost":
-			out.PathOnHost = string(in.String())
-		case "PathInContainer":
-			out.PathInContainer = string(in.String())
-		case "CgroupPermissions":
-			out.CgroupPermissions = string(in.String())
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer2(out *jwriter.Writer, in container.DeviceMapping) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"PathOnHost\":"
-		out.RawString(prefix[1:])
-		out.String(string(in.PathOnHost))
-	}
-	{
-		const prefix string = ",\"PathInContainer\":"
-		out.RawString(prefix)
-		out.String(string(in.PathInContainer))
-	}
-	{
-		const prefix string = ",\"CgroupPermissions\":"
-		out.RawString(prefix)
-		out.String(string(in.CgroupPermissions))
-	}
-	out.RawByte('}')
-}
-func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesContainer1(in *jlexer.Lexer, out *container.RestartPolicy) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "Name":
-			out.Name = string(in.String())
-		case "MaximumRetryCount":
-			out.MaximumRetryCount = int(in.Int())
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer1(out *jwriter.Writer, in container.RestartPolicy) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"Name\":"
-		out.RawString(prefix[1:])
-		out.String(string(in.Name))
-	}
-	{
-		const prefix string = ",\"MaximumRetryCount\":"
-		out.RawString(prefix)
-		out.Int(int(in.MaximumRetryCount))
-	}
-	out.RawByte('}')
-}
-func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes7(in *jlexer.Lexer, out *ContainerState) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "Running":
-			out.Running = bool(in.Bool())
-		case "Health":
-			if in.IsNull() {
-				in.Skip()
-				out.Health = nil
-			} else {
-				if out.Health == nil {
-					out.Health = new(Health)
-				}
-				easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes9(in, out.Health)
-			}
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes7(out *jwriter.Writer, in ContainerState) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.Running {
-		const prefix string = ",\"Running\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.Bool(bool(in.Running))
-	}
-	if in.Health != nil {
-		const prefix string = ",\"Health\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes9(out, *in.Health)
-	}
-	out.RawByte('}')
-}
-func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes9(in *jlexer.Lexer, out *Health) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "Status":
-			out.Status = string(in.String())
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes9(out *jwriter.Writer, in Health) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.Status != "" {
-		const prefix string = ",\"Status\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.String(string(in.Status))
-	}
-	out.RawByte('}')
-}
-func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes6(in *jlexer.Lexer, out *NetworkSettings) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "Networks":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				in.Delim('{')
-				if !in.IsDelim('}') {
-					out.Networks = make(map[string]struct{})
-				} else {
-					out.Networks = nil
-				}
-				for !in.IsDelim('}') {
-					key := string(in.String())
-					in.WantColon()
-					var v64 struct{}
-					easyjson6601e8cdDecode(in, &v64)
-					(out.Networks)[key] = v64
-					in.WantComma()
-				}
-				in.Delim('}')
-			}
-		case "Ports":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				in.Delim('{')
-				if !in.IsDelim('}') {
-					out.Ports = make(nat.PortMap)
-				} else {
-					out.Ports = nil
-				}
-				for !in.IsDelim('}') {
-					key := nat.Port(in.String())
-					in.WantColon()
-					var v65 []nat.PortBinding
-					if in.IsNull() {
-						in.Skip()
-						v65 = nil
-					} else {
-						in.Delim('[')
-						if v65 == nil {
-							if !in.IsDelim(']') {
-								v65 = make([]nat.PortBinding, 0, 2)
-							} else {
-								v65 = []nat.PortBinding{}
-							}
-						} else {
-							v65 = (v65)[:0]
-						}
-						for !in.IsDelim(']') {
-							var v66 nat.PortBinding
-							easyjson6601e8cdDecodeGithubComDockerGoConnectionsNat(in, &v66)
-							v65 = append(v65, v66)
-							in.WantComma()
-						}
-						in.Delim(']')
-					}
-					(out.Ports)[key] = v65
-					in.WantComma()
-				}
-				in.Delim('}')
-			}
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writer, in NetworkSettings) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if len(in.Networks) != 0 {
-		const prefix string = ",\"Networks\":"
-		first = false
-		out.RawString(prefix[1:])
-		{
-			out.RawByte('{')
-			v67First := true
-			for v67Name, v67Value := range in.Networks {
-				if v67First {
-					v67First = false
-				} else {
-					out.RawByte(',')
-				}
-				out.String(string(v67Name))
-				out.RawByte(':')
-				easyjson6601e8cdEncode(out, v67Value)
-			}
-			out.RawByte('}')
-		}
-	}
-	if len(in.Ports) != 0 {
-		const prefix string = ",\"Ports\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		{
-			out.RawByte('{')
-			v68First := true
-			for v68Name, v68Value := range in.Ports {
-				if v68First {
-					v68First = false
-				} else {
-					out.RawByte(',')
-				}
-				out.String(string(v68Name))
-				out.RawByte(':')
-				if v68Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-					out.RawString("null")
-				} else {
-					out.RawByte('[')
-					for v69, v70 := range v68Value {
-						if v69 > 0 {
-							out.RawByte(',')
-						}
-						easyjson6601e8cdEncodeGithubComDockerGoConnectionsNat(out, v70)
-					}
-					out.RawByte(']')
-				}
-			}
-			out.RawByte('}')
-		}
-	}
-	out.RawByte('}')
-}
-func easyjson6601e8cdDecodeGithubComDockerGoConnectionsNat(in *jlexer.Lexer, out *nat.PortBinding) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "HostIp":
-			out.HostIP = string(in.String())
-		case "HostPort":
-			out.HostPort = string(in.String())
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComDockerGoConnectionsNat(out *jwriter.Writer, in nat.PortBinding) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"HostIp\":"
-		out.RawString(prefix[1:])
-		out.String(string(in.HostIP))
-	}
-	{
-		const prefix string = ",\"HostPort\":"
-		out.RawString(prefix)
-		out.String(string(in.HostPort))
-	}
-	out.RawByte('}')
-}
-func easyjson6601e8cdDecode(in *jlexer.Lexer, out *struct{}) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncode(out *jwriter.Writer, in struct{}) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	out.RawByte('}')
-}
-func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes5(in *jlexer.Lexer, out *MountPoint) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "Type":
-			out.Type = mount.Type(in.String())
-		case "Name":
-			out.Name = string(in.String())
-		case "Source":
-			out.Source = string(in.String())
-		case "Destination":
-			out.Destination = string(in.String())
-		case "Driver":
-			out.Driver = string(in.String())
-		case "Mode":
-			out.Mode = string(in.String())
-		case "Propagation":
-			out.Propagation = mount.Propagation(in.String())
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes5(out *jwriter.Writer, in MountPoint) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.Type != "" {
-		const prefix string = ",\"Type\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.String(string(in.Type))
-	}
-	if in.Name != "" {
-		const prefix string = ",\"Name\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Name))
-	}
-	if in.Source != "" {
-		const prefix string = ",\"Source\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Source))
-	}
-	if in.Destination != "" {
-		const prefix string = ",\"Destination\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Destination))
-	}
-	if in.Driver != "" {
-		const prefix string = ",\"Driver\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Driver))
-	}
-	if in.Mode != "" {
-		const prefix string = ",\"Mode\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Mode))
-	}
-	if in.Propagation != "" {
-		const prefix string = ",\"Propagation\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Propagation))
-	}
-	out.RawByte('}')
-}
 func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes(in *jlexer.Lexer, out *types.Info) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
@@ -2783,16 +1332,16 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes(in *jlexer.Lexer, out *
 					out.DriverStatus = (out.DriverStatus)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v71 [2]string
+					var v39 [2]string
 					if in.IsNull() {
 						in.Skip()
 					} else {
 						in.Delim('[')
-						v72 := 0
+						v40 := 0
 						for !in.IsDelim(']') {
-							if v72 < 2 {
-								(v71)[v72] = string(in.String())
-								v72++
+							if v40 < 2 {
+								(v39)[v40] = string(in.String())
+								v40++
 							} else {
 								in.SkipRecursive()
 							}
@@ -2800,7 +1349,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes(in *jlexer.Lexer, out *
 						}
 						in.Delim(']')
 					}
-					out.DriverStatus = append(out.DriverStatus, v71)
+					out.DriverStatus = append(out.DriverStatus, v39)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2821,16 +1370,16 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes(in *jlexer.Lexer, out *
 					out.SystemStatus = (out.SystemStatus)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v73 [2]string
+					var v41 [2]string
 					if in.IsNull() {
 						in.Skip()
 					} else {
 						in.Delim('[')
-						v74 := 0
+						v42 := 0
 						for !in.IsDelim(']') {
-							if v74 < 2 {
-								(v73)[v74] = string(in.String())
-								v74++
+							if v42 < 2 {
+								(v41)[v42] = string(in.String())
+								v42++
 							} else {
 								in.SkipRecursive()
 							}
@@ -2838,7 +1387,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes(in *jlexer.Lexer, out *
 						}
 						in.Delim(']')
 					}
-					out.SystemStatus = append(out.SystemStatus, v73)
+					out.SystemStatus = append(out.SystemStatus, v41)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2929,9 +1478,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes(in *jlexer.Lexer, out *
 					out.GenericResources = (out.GenericResources)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v75 swarm.GenericResource
-					easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm(in, &v75)
-					out.GenericResources = append(out.GenericResources, v75)
+					var v43 swarm.GenericResource
+					easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm(in, &v43)
+					out.GenericResources = append(out.GenericResources, v43)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2962,9 +1511,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes(in *jlexer.Lexer, out *
 					out.Labels = (out.Labels)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v76 string
-					v76 = string(in.String())
-					out.Labels = append(out.Labels, v76)
+					var v44 string
+					v44 = string(in.String())
+					out.Labels = append(out.Labels, v44)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2986,9 +1535,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes(in *jlexer.Lexer, out *
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v77 types.Runtime
-					easyjson6601e8cdDecodeGithubComDockerDockerApiTypes4(in, &v77)
-					(out.Runtimes)[key] = v77
+					var v45 types.Runtime
+					easyjson6601e8cdDecodeGithubComDockerDockerApiTypes4(in, &v45)
+					(out.Runtimes)[key] = v45
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -3025,9 +1574,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes(in *jlexer.Lexer, out *
 					out.SecurityOptions = (out.SecurityOptions)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v78 string
-					v78 = string(in.String())
-					out.SecurityOptions = append(out.SecurityOptions, v78)
+					var v46 string
+					v46 = string(in.String())
+					out.SecurityOptions = append(out.SecurityOptions, v46)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3050,9 +1599,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes(in *jlexer.Lexer, out *
 					out.DefaultAddressPools = (out.DefaultAddressPools)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v79 types.NetworkAddressPool
-					easyjson6601e8cdDecodeGithubComDockerDockerApiTypes6(in, &v79)
-					out.DefaultAddressPools = append(out.DefaultAddressPools, v79)
+					var v47 types.NetworkAddressPool
+					easyjson6601e8cdDecodeGithubComDockerDockerApiTypes6(in, &v47)
+					out.DefaultAddressPools = append(out.DefaultAddressPools, v47)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3073,9 +1622,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes(in *jlexer.Lexer, out *
 					out.Warnings = (out.Warnings)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v80 string
-					v80 = string(in.String())
-					out.Warnings = append(out.Warnings, v80)
+					var v48 string
+					v48 = string(in.String())
+					out.Warnings = append(out.Warnings, v48)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3136,16 +1685,16 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v81, v82 := range in.DriverStatus {
-				if v81 > 0 {
+			for v49, v50 := range in.DriverStatus {
+				if v49 > 0 {
 					out.RawByte(',')
 				}
 				out.RawByte('[')
-				for v83 := range v82 {
-					if v83 > 0 {
+				for v51 := range v50 {
+					if v51 > 0 {
 						out.RawByte(',')
 					}
-					out.String(string((v82)[v83]))
+					out.String(string((v50)[v51]))
 				}
 				out.RawByte(']')
 			}
@@ -3157,16 +1706,16 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v84, v85 := range in.SystemStatus {
-				if v84 > 0 {
+			for v52, v53 := range in.SystemStatus {
+				if v52 > 0 {
 					out.RawByte(',')
 				}
 				out.RawByte('[')
-				for v86 := range v85 {
-					if v86 > 0 {
+				for v54 := range v53 {
+					if v54 > 0 {
 						out.RawByte(',')
 					}
-					out.String(string((v85)[v86]))
+					out.String(string((v53)[v54]))
 				}
 				out.RawByte(']')
 			}
@@ -3339,11 +1888,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v87, v88 := range in.GenericResources {
-				if v87 > 0 {
+			for v55, v56 := range in.GenericResources {
+				if v55 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm(out, v88)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm(out, v56)
 			}
 			out.RawByte(']')
 		}
@@ -3380,11 +1929,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v89, v90 := range in.Labels {
-				if v89 > 0 {
+			for v57, v58 := range in.Labels {
+				if v57 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v90))
+				out.String(string(v58))
 			}
 			out.RawByte(']')
 		}
@@ -3416,16 +1965,16 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')
-			v91First := true
-			for v91Name, v91Value := range in.Runtimes {
-				if v91First {
-					v91First = false
+			v59First := true
+			for v59Name, v59Value := range in.Runtimes {
+				if v59First {
+					v59First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v91Name))
+				out.String(string(v59Name))
 				out.RawByte(':')
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes4(out, v91Value)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes4(out, v59Value)
 			}
 			out.RawByte('}')
 		}
@@ -3477,11 +2026,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v92, v93 := range in.SecurityOptions {
-				if v92 > 0 {
+			for v60, v61 := range in.SecurityOptions {
+				if v60 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v93))
+				out.String(string(v61))
 			}
 			out.RawByte(']')
 		}
@@ -3496,11 +2045,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v94, v95 := range in.DefaultAddressPools {
-				if v94 > 0 {
+			for v62, v63 := range in.DefaultAddressPools {
+				if v62 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes6(out, v95)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes6(out, v63)
 			}
 			out.RawByte(']')
 		}
@@ -3512,11 +2061,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v96, v97 := range in.Warnings {
-				if v96 > 0 {
+			for v64, v65 := range in.Warnings {
+				if v64 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v97))
+				out.String(string(v65))
 			}
 			out.RawByte(']')
 		}
@@ -3666,9 +2215,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm1(in *jlexer.Lexer,
 					out.RemoteManagers = (out.RemoteManagers)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v98 swarm.Peer
-					easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm2(in, &v98)
-					out.RemoteManagers = append(out.RemoteManagers, v98)
+					var v66 swarm.Peer
+					easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm2(in, &v66)
+					out.RemoteManagers = append(out.RemoteManagers, v66)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3703,9 +2252,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm1(in *jlexer.Lexer,
 					out.Warnings = (out.Warnings)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v99 string
-					v99 = string(in.String())
-					out.Warnings = append(out.Warnings, v99)
+					var v67 string
+					v67 = string(in.String())
+					out.Warnings = append(out.Warnings, v67)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3756,11 +2305,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm1(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v100, v101 := range in.RemoteManagers {
-				if v100 > 0 {
+			for v68, v69 := range in.RemoteManagers {
+				if v68 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm2(out, v101)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm2(out, v69)
 			}
 			out.RawByte(']')
 		}
@@ -3785,11 +2334,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm1(out *jwriter.Writ
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v102, v103 := range in.Warnings {
-				if v102 > 0 {
+			for v70, v71 := range in.Warnings {
+				if v70 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v103))
+				out.String(string(v71))
 			}
 			out.RawByte(']')
 		}
@@ -3839,9 +2388,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm3(in *jlexer.Lexer,
 					out.DefaultAddrPool = (out.DefaultAddrPool)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v104 string
-					v104 = string(in.String())
-					out.DefaultAddrPool = append(out.DefaultAddrPool, v104)
+					var v72 string
+					v72 = string(in.String())
+					out.DefaultAddrPool = append(out.DefaultAddrPool, v72)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3901,11 +2450,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm3(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v105, v106 := range in.DefaultAddrPool {
-				if v105 > 0 {
+			for v73, v74 := range in.DefaultAddrPool {
+				if v73 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v106))
+				out.String(string(v74))
 			}
 			out.RawByte(']')
 		}
@@ -4099,9 +2648,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm4(in *jlexer.Lexer,
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v113 string
-					v113 = string(in.String())
-					(out.Labels)[key] = v113
+					var v81 string
+					v81 = string(in.String())
+					(out.Labels)[key] = v81
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -4198,16 +2747,16 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writ
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')
-			v114First := true
-			for v114Name, v114Value := range in.Labels {
-				if v114First {
-					v114First = false
+			v82First := true
+			for v82Name, v82Value := range in.Labels {
+				if v82First {
+					v82First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v114Name))
+				out.String(string(v82Name))
 				out.RawByte(':')
-				out.String(string(v114Value))
+				out.String(string(v82Value))
 			}
 			out.RawByte('}')
 		}
@@ -4341,9 +2890,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm13(in *jlexer.Lexer
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v115 string
-					v115 = string(in.String())
-					(out.Options)[key] = v115
+					var v83 string
+					v83 = string(in.String())
+					(out.Options)[key] = v83
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -4378,16 +2927,16 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm13(out *jwriter.Wri
 		}
 		{
 			out.RawByte('{')
-			v116First := true
-			for v116Name, v116Value := range in.Options {
-				if v116First {
-					v116First = false
+			v84First := true
+			for v84Name, v84Value := range in.Options {
+				if v84First {
+					v84First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v116Name))
+				out.String(string(v84Name))
 				out.RawByte(':')
-				out.String(string(v116Value))
+				out.String(string(v84Value))
 			}
 			out.RawByte('}')
 		}
@@ -4431,17 +2980,17 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm10(in *jlexer.Lexer
 					out.ExternalCAs = (out.ExternalCAs)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v117 *swarm.ExternalCA
+					var v85 *swarm.ExternalCA
 					if in.IsNull() {
 						in.Skip()
-						v117 = nil
+						v85 = nil
 					} else {
-						if v117 == nil {
-							v117 = new(swarm.ExternalCA)
+						if v85 == nil {
+							v85 = new(swarm.ExternalCA)
 						}
-						easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm14(in, v117)
+						easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm14(in, v85)
 					}
-					out.ExternalCAs = append(out.ExternalCAs, v117)
+					out.ExternalCAs = append(out.ExternalCAs, v85)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4482,14 +3031,14 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm10(out *jwriter.Wri
 		}
 		{
 			out.RawByte('[')
-			for v118, v119 := range in.ExternalCAs {
-				if v118 > 0 {
+			for v86, v87 := range in.ExternalCAs {
+				if v86 > 0 {
 					out.RawByte(',')
 				}
-				if v119 == nil {
+				if v87 == nil {
 					out.RawString("null")
 				} else {
-					easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm14(out, *v119)
+					easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm14(out, *v87)
 				}
 			}
 			out.RawByte(']')
@@ -4563,9 +3112,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm14(in *jlexer.Lexer
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v120 string
-					v120 = string(in.String())
-					(out.Options)[key] = v120
+					var v88 string
+					v88 = string(in.String())
+					(out.Options)[key] = v88
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -4601,16 +3150,16 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm14(out *jwriter.Wri
 		out.RawString(prefix)
 		{
 			out.RawByte('{')
-			v121First := true
-			for v121Name, v121Value := range in.Options {
-				if v121First {
-					v121First = false
+			v89First := true
+			for v89Name, v89Value := range in.Options {
+				if v89First {
+					v89First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v121Name))
+				out.String(string(v89Name))
 				out.RawByte(':')
-				out.String(string(v121Value))
+				out.String(string(v89Value))
 			}
 			out.RawByte('}')
 		}
@@ -4896,9 +3445,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes4(in *jlexer.Lexer, out 
 					out.Args = (out.Args)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v122 string
-					v122 = string(in.String())
-					out.Args = append(out.Args, v122)
+					var v90 string
+					v90 = string(in.String())
+					out.Args = append(out.Args, v90)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4927,11 +3476,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes4(out *jwriter.Writer, i
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v123, v124 := range in.Args {
-				if v123 > 0 {
+			for v91, v92 := range in.Args {
+				if v91 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v124))
+				out.String(string(v92))
 			}
 			out.RawByte(']')
 		}
@@ -5154,19 +3703,19 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesRegistry(in *jlexer.Lexe
 					out.AllowNondistributableArtifactsCIDRs = (out.AllowNondistributableArtifactsCIDRs)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v125 *registry.NetIPNet
+					var v93 *registry.NetIPNet
 					if in.IsNull() {
 						in.Skip()
-						v125 = nil
+						v93 = nil
 					} else {
-						if v125 == nil {
-							v125 = new(registry.NetIPNet)
+						if v93 == nil {
+							v93 = new(registry.NetIPNet)
 						}
 						if data := in.Raw(); in.Ok() {
-							in.AddError((*v125).UnmarshalJSON(data))
+							in.AddError((*v93).UnmarshalJSON(data))
 						}
 					}
-					out.AllowNondistributableArtifactsCIDRs = append(out.AllowNondistributableArtifactsCIDRs, v125)
+					out.AllowNondistributableArtifactsCIDRs = append(out.AllowNondistributableArtifactsCIDRs, v93)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5187,9 +3736,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesRegistry(in *jlexer.Lexe
 					out.AllowNondistributableArtifactsHostnames = (out.AllowNondistributableArtifactsHostnames)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v126 string
-					v126 = string(in.String())
-					out.AllowNondistributableArtifactsHostnames = append(out.AllowNondistributableArtifactsHostnames, v126)
+					var v94 string
+					v94 = string(in.String())
+					out.AllowNondistributableArtifactsHostnames = append(out.AllowNondistributableArtifactsHostnames, v94)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5210,19 +3759,19 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesRegistry(in *jlexer.Lexe
 					out.InsecureRegistryCIDRs = (out.InsecureRegistryCIDRs)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v127 *registry.NetIPNet
+					var v95 *registry.NetIPNet
 					if in.IsNull() {
 						in.Skip()
-						v127 = nil
+						v95 = nil
 					} else {
-						if v127 == nil {
-							v127 = new(registry.NetIPNet)
+						if v95 == nil {
+							v95 = new(registry.NetIPNet)
 						}
 						if data := in.Raw(); in.Ok() {
-							in.AddError((*v127).UnmarshalJSON(data))
+							in.AddError((*v95).UnmarshalJSON(data))
 						}
 					}
-					out.InsecureRegistryCIDRs = append(out.InsecureRegistryCIDRs, v127)
+					out.InsecureRegistryCIDRs = append(out.InsecureRegistryCIDRs, v95)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5236,17 +3785,17 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesRegistry(in *jlexer.Lexe
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v128 *registry.IndexInfo
+					var v96 *registry.IndexInfo
 					if in.IsNull() {
 						in.Skip()
-						v128 = nil
+						v96 = nil
 					} else {
-						if v128 == nil {
-							v128 = new(registry.IndexInfo)
+						if v96 == nil {
+							v96 = new(registry.IndexInfo)
 						}
-						easyjson6601e8cdDecodeGithubComDockerDockerApiTypesRegistry1(in, v128)
+						easyjson6601e8cdDecodeGithubComDockerDockerApiTypesRegistry1(in, v96)
 					}
-					(out.IndexConfigs)[key] = v128
+					(out.IndexConfigs)[key] = v96
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -5267,9 +3816,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesRegistry(in *jlexer.Lexe
 					out.Mirrors = (out.Mirrors)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v129 string
-					v129 = string(in.String())
-					out.Mirrors = append(out.Mirrors, v129)
+					var v97 string
+					v97 = string(in.String())
+					out.Mirrors = append(out.Mirrors, v97)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5295,14 +3844,14 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v130, v131 := range in.AllowNondistributableArtifactsCIDRs {
-				if v130 > 0 {
+			for v98, v99 := range in.AllowNondistributableArtifactsCIDRs {
+				if v98 > 0 {
 					out.RawByte(',')
 				}
-				if v131 == nil {
+				if v99 == nil {
 					out.RawString("null")
 				} else {
-					out.Raw((*v131).MarshalJSON())
+					out.Raw((*v99).MarshalJSON())
 				}
 			}
 			out.RawByte(']')
@@ -5315,11 +3864,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v132, v133 := range in.AllowNondistributableArtifactsHostnames {
-				if v132 > 0 {
+			for v100, v101 := range in.AllowNondistributableArtifactsHostnames {
+				if v100 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v133))
+				out.String(string(v101))
 			}
 			out.RawByte(']')
 		}
@@ -5331,14 +3880,14 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v134, v135 := range in.InsecureRegistryCIDRs {
-				if v134 > 0 {
+			for v102, v103 := range in.InsecureRegistryCIDRs {
+				if v102 > 0 {
 					out.RawByte(',')
 				}
-				if v135 == nil {
+				if v103 == nil {
 					out.RawString("null")
 				} else {
-					out.Raw((*v135).MarshalJSON())
+					out.Raw((*v103).MarshalJSON())
 				}
 			}
 			out.RawByte(']')
@@ -5351,19 +3900,19 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry(out *jwriter.Wr
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')
-			v136First := true
-			for v136Name, v136Value := range in.IndexConfigs {
-				if v136First {
-					v136First = false
+			v104First := true
+			for v104Name, v104Value := range in.IndexConfigs {
+				if v104First {
+					v104First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v136Name))
+				out.String(string(v104Name))
 				out.RawByte(':')
-				if v136Value == nil {
+				if v104Value == nil {
 					out.RawString("null")
 				} else {
-					easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry1(out, *v136Value)
+					easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry1(out, *v104Value)
 				}
 			}
 			out.RawByte('}')
@@ -5376,11 +3925,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v137, v138 := range in.Mirrors {
-				if v137 > 0 {
+			for v105, v106 := range in.Mirrors {
+				if v105 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v138))
+				out.String(string(v106))
 			}
 			out.RawByte(']')
 		}
@@ -5424,9 +3973,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesRegistry1(in *jlexer.Lex
 					out.Mirrors = (out.Mirrors)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v139 string
-					v139 = string(in.String())
-					out.Mirrors = append(out.Mirrors, v139)
+					var v107 string
+					v107 = string(in.String())
+					out.Mirrors = append(out.Mirrors, v107)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5461,11 +4010,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry1(out *jwriter.W
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v140, v141 := range in.Mirrors {
-				if v140 > 0 {
+			for v108, v109 := range in.Mirrors {
+				if v108 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v141))
+				out.String(string(v109))
 			}
 			out.RawByte(']')
 		}
@@ -5517,9 +4066,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes3(in *jlexer.Lexer, out 
 					out.Volume = (out.Volume)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v142 string
-					v142 = string(in.String())
-					out.Volume = append(out.Volume, v142)
+					var v110 string
+					v110 = string(in.String())
+					out.Volume = append(out.Volume, v110)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5540,9 +4089,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes3(in *jlexer.Lexer, out 
 					out.Network = (out.Network)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v143 string
-					v143 = string(in.String())
-					out.Network = append(out.Network, v143)
+					var v111 string
+					v111 = string(in.String())
+					out.Network = append(out.Network, v111)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5563,9 +4112,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes3(in *jlexer.Lexer, out 
 					out.Authorization = (out.Authorization)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v144 string
-					v144 = string(in.String())
-					out.Authorization = append(out.Authorization, v144)
+					var v112 string
+					v112 = string(in.String())
+					out.Authorization = append(out.Authorization, v112)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5586,9 +4135,9 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes3(in *jlexer.Lexer, out 
 					out.Log = (out.Log)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v145 string
-					v145 = string(in.String())
-					out.Log = append(out.Log, v145)
+					var v113 string
+					v113 = string(in.String())
+					out.Log = append(out.Log, v113)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5614,11 +4163,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes3(out *jwriter.Writer, i
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v146, v147 := range in.Volume {
-				if v146 > 0 {
+			for v114, v115 := range in.Volume {
+				if v114 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v147))
+				out.String(string(v115))
 			}
 			out.RawByte(']')
 		}
@@ -5630,11 +4179,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes3(out *jwriter.Writer, i
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v148, v149 := range in.Network {
-				if v148 > 0 {
+			for v116, v117 := range in.Network {
+				if v116 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v149))
+				out.String(string(v117))
 			}
 			out.RawByte(']')
 		}
@@ -5646,11 +4195,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes3(out *jwriter.Writer, i
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v150, v151 := range in.Authorization {
-				if v150 > 0 {
+			for v118, v119 := range in.Authorization {
+				if v118 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v151))
+				out.String(string(v119))
 			}
 			out.RawByte(']')
 		}
@@ -5662,11 +4211,11 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes3(out *jwriter.Writer, i
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v152, v153 := range in.Log {
-				if v152 > 0 {
+			for v120, v121 := range in.Log {
+				if v120 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v153))
+				out.String(string(v121))
 			}
 			out.RawByte(']')
 		}

--- a/scripts/generate-junit-reports.sh
+++ b/scripts/generate-junit-reports.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-mkdir -p junit-reports
-
-go-junit-report <"test-output/test.log" >"junit-reports/report.xml"

--- a/tools/generate-helpers/mockgen-wrapper
+++ b/tools/generate-helpers/mockgen-wrapper
@@ -30,6 +30,10 @@ function die() {
 	exit 1
 }
 
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+[[ -n "${MOCKGEN_BIN:-}" ]] || MOCKGEN_BIN="$(make --quiet --no-print-directory -C "${PROJECT_ROOT}" which-mockgen)"
+[[ -x "$MOCKGEN_BIN" ]] || die "mockgen binary not found or not executable at ${MOCKGEN_BIN}"
+
 interfaces="${1:-}"
 package="${2:-}"
 
@@ -40,7 +44,7 @@ if [[ -n "$interfaces" ]] && [[ -n "$package" ]]; then
   out_directory="$(dirname "${out_file}")"
   mkdir -p "${out_directory}"
 
-  exec mockgen -package mocks -destination "${out_file}" "${package}" "${interfaces}"
+  exec "$MOCKGEN_BIN" -package mocks -destination "${out_file}" "${package}" "${interfaces}"
 elif [[ -n "$interfaces" ]]; then
   # Generate mocks for only the specified interfaces in the calling GOFILE.
   [[ -n "$GOFILE" ]] || die "Required environment variable GOFILE not set, must run using go:generate"
@@ -50,7 +54,7 @@ elif [[ -n "$interfaces" ]]; then
   out_directory="$(dirname "${out_file}")"
   mkdir -p "${out_directory}"
 
-  exec mockgen -package mocks -destination "${out_file}" "${package}" "${interfaces}"
+  exec "$MOCKGEN_BIN" -package mocks -destination "${out_file}" "${package}" "${interfaces}"
 else
   # Generate mocks for all interfaces found in the calling GOFILE.
   [[ -n "$GOFILE" ]] || die "Required environment variable GOFILE not set, must run using go:generate"
@@ -58,5 +62,5 @@ else
   out_directory="$(dirname "${out_file}")"
   mkdir -p "${out_directory}"
 
-  exec mockgen -package mocks -destination "${out_file}" -source "${GOFILE}"
+  exec "$MOCKGEN_BIN" -package mocks -destination "${out_file}" -source "${GOFILE}"
 fi


### PR DESCRIPTION
## Description

This is a long-standing pet peeve of mine: most of the Go-based tools that we use (`golangci-lint`, `mockgen` etc.) are installed in system-wide or user-wide paths, e.g., the default `$GOBIN` (which is `$HOME/go/bin`). With other projects having a similar annoying behavior, this in the best case leads to frequent rebuilds of tools with changing versions, and in the worst case causes code to be generated with incorrect or even inconsistent versions of tools, causing unstable behavior (that is hopefully caught in CI via the generated files up-to-date check).

It doesn't need to be this way. This PR changes things in such a way that (a) Go tools are installed in a project-specific location (`.gotools/bin`) and (b) sets up `Makefile` rules to ensure that tools are always rebuilt when necessary (version bump, code change), but - in most cases - not rebuilt more often than necessary. Note that the last point is not a strict requirement, because `go install` already caches most of its work, so running `go install` repeatedly is really fast (~0.2s on my machine). However, that's still worse than 0s, which is why whenever we can easily prevent rebuilds by correct formulation of `Makefile` targets, we will.

The functionality is exposed via a reusable macro invoked via `$(call go-tool, ...)`. Please refer to the [documentation of that](https://github.com/stackrox/stackrox/pull/3292/files#diff-6680f14ebf202ac4f73d3741109aa75cdd3aad8fe66b1cbc9e389377694b896dR1) for further details.

This PR affects just the tools referenced in the top-level Makefile. For tools used in `protogen.mk`, the situation is already different; I plan to unify things in a follow-up PR and use `$(call go-tool, ...)` in `protogen.mk` as well.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- Local testing with `make reinstall-dev-tools` and the individual targets
- CI
- [ ] needs status check: Downstream testing with this commit at https://gitlab.cee.redhat.com/stackrox/rhacs-midstream/-/merge_requests/285