### PR TITLE
ROX-11927:Remove unsupported 'License' sub resolver from NodeComponent graphQL

### DIFF
--- a/central/graphql/resolvers/node_components.go
+++ b/central/graphql/resolvers/node_components.go
@@ -25,7 +25,6 @@ func init() {
 		schema.AddExtraResolvers("NodeComponent", []string{
 			"fixedIn: String!",
 			"lastScanned: Time",
-			"license: License",
 			"location(query: String): String!",
 			"nodes(query: String, scopeQuery: String, pagination: Pagination): [Node!]!",
 			"nodeCount(query: String, scopeQuery: String): Int!",
@@ -50,7 +49,6 @@ type NodeComponentResolver interface {
 	FixedIn(ctx context.Context) string
 	Id(ctx context.Context) graphql.ID
 	LastScanned(ctx context.Context) (*graphql.Time, error)
-	License(ctx context.Context) (*licenseResolver, error)
 	Location(ctx context.Context, args RawQuery) (string, error)
 	Name(ctx context.Context) string
 	Nodes(ctx context.Context, args PaginatedQuery) ([]*nodeResolver, error)
@@ -218,12 +216,6 @@ func (resolver *nodeComponentResolver) LastScanned(_ context.Context) (*graphql.
 	}
 
 	return timestamp(nodes[0].GetScan().GetScanTime())
-}
-
-// License of the node component
-func (resolver *nodeComponentResolver) License(_ context.Context) (*licenseResolver, error) {
-	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeComponents, "License")
-	return nil, nil
 }
 
 // Location of the node component.

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Image.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Image.js
@@ -68,11 +68,6 @@ const Image = ({ id, entityListType, entityId1, query, entityContext, pagination
                         name
                         layerIndex
                         version
-                        license {
-                            name
-                            type
-                            url
-                        }
                         vulns {
                             cve
                             cvss

--- a/ui/apps/platform/src/queries/image.js
+++ b/ui/apps/platform/src/queries/image.js
@@ -33,11 +33,6 @@ export const IMAGE_FRAGMENT = gql`
                 name
                 layerIndex
                 version
-                license {
-                    name
-                    type
-                    url
-                }
                 vulns {
                     cve
                     cvss


### PR DESCRIPTION
Removed license field from node components graphql query. Tested graphql query on  postgres db cluster
<img width="1337" alt="Screen Shot 2022-10-04 at 5 23 40 PM" src="https://user-images.githubusercontent.com/8596931/193954907-2fabfa2f-408b-47f0-a730-2dbef7cea4e1.png">
