### PR TITLE
Simplify configmanagement integration tests

### DIFF
--- a/ui/apps/platform/cypress/integration/configmanagement/ciscontrols.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/ciscontrols.test.js
@@ -16,9 +16,9 @@ import {
 } from '../../constants/ConfigManagementPage';
 import withAuth from '../../helpers/basicAuth';
 
-// const entitiesKey = 'controls'; // omit to minimize changed lines
+const entitiesKey = 'controls';
 
-describe('Config Management Entities (CIS controls)', () => {
+describe('Configuration Management Controls', () => {
     withAuth();
 
     it('should render the controls list and open the side panel when a row is clicked', () => {
@@ -29,49 +29,49 @@ describe('Config Management Entities (CIS controls)', () => {
             cy.get('[data-testid="scan-button"]').click();
         });
 
-        renderListAndSidePanel('controls');
+        renderListAndSidePanel(entitiesKey);
     });
 
     it('should take you to a control single when the "navigate away" button is clicked', () => {
-        renderListAndSidePanel('controls');
-        navigateToSingleEntityPage('controls');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
     });
 
     it('should have the correct count widgets for a single entity view', () => {
-        renderListAndSidePanel('controls');
-        navigateToSingleEntityPage('controls');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasCountWidgetsFor(['Nodes']);
     });
 
     it('should click on the nodes count widget in the entity page and show the nodes tab', () => {
-        renderListAndSidePanel('controls');
-        navigateToSingleEntityPage('controls');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         clickOnCountWidget('nodes', 'entityList');
     });
 
     it('should have the correct tabs for a single entity view', () => {
-        renderListAndSidePanel('controls');
-        navigateToSingleEntityPage('controls');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasTabsFor(['nodes']);
     });
 
-    it('should have the same number of Nodes in the count widget as in the Nodes table', () => {
+    describe('should have same number in nodes table as in count widget', () => {
         const entitiesKey2 = 'nodes';
 
-        context('Page', () => {
-            renderListAndSidePanel('controls');
-            navigateToSingleEntityPage('controls');
-            pageEntityCountMatchesTableRows('controls', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('controls');
-            sidePanelEntityCountMatchesTableRows('controls', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
     it('should show no failing nodes in the control findings section of a passing control', () => {
-        visitConfigurationManagementEntities('controls');
+        visitConfigurationManagementEntities(entitiesKey);
 
         cy.get(configManagementSelectors.tableNextPage).click();
         cy.get(configManagementSelectors.tableCells)
@@ -82,7 +82,7 @@ describe('Config Management Entities (CIS controls)', () => {
     });
 
     it('should show failing nodes in the control findings section of a failing control', () => {
-        visitConfigurationManagementEntities('controls');
+        visitConfigurationManagementEntities(entitiesKey);
 
         cy.get(configManagementSelectors.tableCells)
             .contains(controlStatus.fail)

--- a/ui/apps/platform/cypress/integration/configmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/clusters.test.js
@@ -13,23 +13,23 @@ import {
 import { selectors } from '../../constants/ConfigManagementPage';
 import withAuth from '../../helpers/basicAuth';
 
-// const entitiesKey = 'clusters'; // omit to minimize changed lines
+const entitiesKey = 'clusters';
 
-describe('Config Management Entities (Clusters)', () => {
+describe('Configuration Management Clusters', () => {
     withAuth();
 
     it('should render the clusters list and open the side panel when a row is clicked', () => {
-        renderListAndSidePanel('clusters');
+        renderListAndSidePanel(entitiesKey);
     });
 
     it('should take you to a cluster single when the "navigate away" button is clicked', () => {
-        renderListAndSidePanel('clusters');
-        navigateToSingleEntityPage('clusters');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
     });
 
     it('should have the correct count widgets for a single entity view', () => {
-        renderListAndSidePanel('clusters');
-        navigateToSingleEntityPage('clusters');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasCountWidgetsFor([
             'Nodes',
             'Namespaces',
@@ -44,8 +44,8 @@ describe('Config Management Entities (Clusters)', () => {
     });
 
     it('should have the correct tabs for a single entity view', () => {
-        renderListAndSidePanel('clusters');
-        navigateToSingleEntityPage('clusters');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasTabsFor([
             'nodes',
             'namespaces',
@@ -60,7 +60,7 @@ describe('Config Management Entities (Clusters)', () => {
     });
 
     it('should have items in the Findings section', () => {
-        visitConfigurationManagementEntities('clusters');
+        visitConfigurationManagementEntities(entitiesKey);
 
         cy.get(`${selectors.tableCells}:contains(fail)`).eq(0).click();
 
@@ -69,123 +69,123 @@ describe('Config Management Entities (Clusters)', () => {
         ).should('exist');
     });
 
-    it('should have the same number of Nodes in the count widget as in the Nodes table', () => {
+    describe('should have same number in nodes table as in count widget', () => {
         const entitiesKey2 = 'nodes';
 
-        context('Page', () => {
-            renderListAndSidePanel('clusters');
-            navigateToSingleEntityPage('clusters');
-            pageEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('clusters');
-            sidePanelEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
-    it('should have the same number of Namespaces in the count widget as in the Namespaces table', () => {
+    describe('should have same number in namespaces table as in count widget', () => {
         const entitiesKey2 = 'namespaces';
 
-        context('Page', () => {
-            renderListAndSidePanel('clusters');
-            navigateToSingleEntityPage('clusters');
-            pageEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('clusters');
-            sidePanelEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
-    it('should have the same number of Deployments in the count widget as in the Deployments table', () => {
+    describe('should have same number in deployments table as in count widget', () => {
         const entitiesKey2 = 'deployments';
 
-        context('Page', () => {
-            renderListAndSidePanel('clusters');
-            navigateToSingleEntityPage('clusters');
-            pageEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('clusters');
-            sidePanelEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
-    it('should have the same number of Images in the count widget as in the Images table', () => {
+    describe('should have same number in images table as in count widget', () => {
         const entitiesKey2 = 'images';
 
-        context('Page', () => {
-            renderListAndSidePanel('clusters');
-            navigateToSingleEntityPage('clusters');
-            pageEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('clusters');
-            sidePanelEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
-    it('should have the same number of Users & Groups in the count widget as in the Users & Groups table', () => {
+    describe('should have same number in users and groups table as in count widget', () => {
         const entitiesKey2 = 'subjects';
 
-        context('Page', () => {
-            renderListAndSidePanel('clusters');
-            navigateToSingleEntityPage('clusters');
-            pageEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('clusters');
-            sidePanelEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
-    it('should have the same number of Service Accounts in the count widget as in the Service Accounts table', () => {
+    describe('should have same number in service accounts table as in count widget', () => {
         const entitiesKey2 = 'serviceaccounts';
 
-        context('Page', () => {
-            renderListAndSidePanel('clusters');
-            navigateToSingleEntityPage('clusters');
-            pageEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('clusters');
-            sidePanelEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
-    it('should have the same number of Roles in the count widget as in the Roles table', () => {
+    describe('should have same number in roles table as in count widget', () => {
         const entitiesKey2 = 'roles';
 
-        context('Page', () => {
-            renderListAndSidePanel('clusters');
-            navigateToSingleEntityPage('clusters');
-            pageEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('clusters');
-            sidePanelEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
-    it('should have the same number of Controls in the count widget as in the Controls table', () => {
+    describe('should have same number in controls table as in count widget', () => {
         const entitiesKey2 = 'controls';
 
-        context('Page', () => {
-            renderListAndSidePanel('clusters');
-            navigateToSingleEntityPage('clusters');
-            pageEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('clusters');
-            sidePanelEntityCountMatchesTableRows('clusters', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
@@ -197,22 +197,22 @@ describe('Config Management Entities (Clusters)', () => {
             cy.get('[data-testid="scan-button"]').click();
         });
 
-        entityListCountMatchesTableLinkCount('clusters', 'controls', /\d+ Controls?$/);
+        entityListCountMatchesTableLinkCount(entitiesKey, 'controls', /\d+ Controls?$/);
     });
 
     it('should open the side panel to show the same number of Users & Groups when the Users & Groups link is clicked', () => {
-        entityListCountMatchesTableLinkCount('clusters', 'subjects', /^\d+ Users & Groups$/);
+        entityListCountMatchesTableLinkCount(entitiesKey, 'subjects', /^\d+ Users & Groups$/);
     });
 
     it('should open the side panel to show the same number of Service Accounts when the Service Accounts link is clicked', () => {
         entityListCountMatchesTableLinkCount(
-            'clusters',
+            entitiesKey,
             'serviceaccounts',
             /^\d+ Service Accounts?$/
         );
     });
 
     it('should open the side panel to show the same number of Roles when the Roles link is clicked', () => {
-        entityListCountMatchesTableLinkCount('clusters', 'roles', /^\d+ Roles?$/);
+        entityListCountMatchesTableLinkCount(entitiesKey, 'roles', /^\d+ Roles?$/);
     });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/dashboard.test.js
@@ -7,8 +7,6 @@ import {
     visitConfigurationManagementDashboard,
 } from '../../helpers/configWorkflowUtils';
 
-// Name in this file is keyPlural instead of entitiesKey to minimize changed lines.
-
 // This function is more generic than its name implies.
 const policyViolationsBySeverityLinkShouldMatchList = (linkSelector, linkRegExp, keyPlural) => {
     cy.get(linkSelector)
@@ -24,11 +22,11 @@ const policyViolationsBySeverityLinkShouldMatchList = (linkSelector, linkRegExp,
         });
 };
 
-describe('Config Management Dashboard Page', () => {
+describe('Configuration Management Dashboard', () => {
     withAuth();
 
     it('should show same number of policies between the tile and the policies list', () => {
-        const keyPlural = 'policies';
+        const entitiesKey = 'policies';
 
         visitConfigurationManagementDashboard();
 
@@ -39,7 +37,7 @@ describe('Config Management Dashboard Page', () => {
 
                 interactAndWaitForConfigurationManagementEntities(() => {
                     cy.get(`${selectors.tileLinks}:eq(0)`).click();
-                }, keyPlural);
+                }, entitiesKey);
 
                 cy.get(`[data-testid="panel"] [data-testid="panel-header"]`)
                     .invoke('text')
@@ -50,7 +48,7 @@ describe('Config Management Dashboard Page', () => {
     });
 
     it('should show same number of controls between the tile and the controls list', () => {
-        const keyPlural = 'controls';
+        const entitiesKey = 'controls';
 
         visitConfigurationManagementDashboard();
 
@@ -61,7 +59,7 @@ describe('Config Management Dashboard Page', () => {
 
                 interactAndWaitForConfigurationManagementEntities(() => {
                     cy.get(`${selectors.tileLinks}:eq(1)`).click();
-                }, keyPlural);
+                }, entitiesKey);
 
                 cy.get(`[data-testid="panel"] [data-testid="panel-header"]`)
                     .invoke('text')
@@ -72,126 +70,126 @@ describe('Config Management Dashboard Page', () => {
     });
 
     it('should properly navigate to the policies list', () => {
-        const keyPlural = 'policies';
+        const entitiesKey = 'policies';
 
         visitConfigurationManagementDashboard();
 
         interactAndWaitForConfigurationManagementEntities(() => {
             cy.get(`${selectors.tileLinks}:eq(0)`).click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('should properly navigate to the cis controls list', () => {
-        const keyPlural = 'controls';
+        const entitiesKey = 'controls';
 
         visitConfigurationManagementDashboard();
 
         interactAndWaitForConfigurationManagementEntities(() => {
             cy.get(`${selectors.tileLinks}:eq(1)`).click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('should properly navigate to the clusters list', () => {
-        const keyPlural = 'clusters';
+        const entitiesKey = 'clusters';
 
         visitConfigurationManagementDashboard();
 
         cy.get(selectors.applicationAndInfrastructureDropdown).click();
         interactAndWaitForConfigurationManagementEntities(() => {
             cy.get(selectors.getMenuListItem('clusters')).click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('should properly navigate to the namespaces list', () => {
-        const keyPlural = 'namespaces';
+        const entitiesKey = 'namespaces';
 
         visitConfigurationManagementDashboard();
 
         cy.get(selectors.applicationAndInfrastructureDropdown).click();
         interactAndWaitForConfigurationManagementEntities(() => {
             cy.get(selectors.getMenuListItem('namespaces')).click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('should properly navigate to the nodes list', () => {
-        const keyPlural = 'nodes';
+        const entitiesKey = 'nodes';
 
         visitConfigurationManagementDashboard();
 
         cy.get(selectors.applicationAndInfrastructureDropdown).click();
         interactAndWaitForConfigurationManagementEntities(() => {
             cy.get(selectors.getMenuListItem('nodes')).click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('should properly navigate to the deployments list', () => {
-        const keyPlural = 'deployments';
+        const entitiesKey = 'deployments';
 
         visitConfigurationManagementDashboard();
 
         cy.get(selectors.applicationAndInfrastructureDropdown).click();
         interactAndWaitForConfigurationManagementEntities(() => {
             cy.get(selectors.getMenuListItem('deployments')).click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('should properly navigate to the images list', () => {
-        const keyPlural = 'images';
+        const entitiesKey = 'images';
 
         visitConfigurationManagementDashboard();
 
         cy.get(selectors.applicationAndInfrastructureDropdown).click();
         interactAndWaitForConfigurationManagementEntities(() => {
             cy.get(selectors.getMenuListItem('images')).click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('should properly navigate to the secrets list', () => {
-        const keyPlural = 'secrets';
+        const entitiesKey = 'secrets';
 
         visitConfigurationManagementDashboard();
 
         cy.get(selectors.applicationAndInfrastructureDropdown).click();
         interactAndWaitForConfigurationManagementEntities(() => {
             cy.get(selectors.getMenuListItem('secrets')).click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('should properly navigate to the users and groups list', () => {
-        const keyPlural = 'subjects';
+        const entitiesKey = 'subjects';
 
         visitConfigurationManagementDashboard();
 
         cy.get(selectors.rbacVisibilityDropdown).click();
         interactAndWaitForConfigurationManagementEntities(() => {
             cy.get(selectors.getMenuListItem('users and groups')).click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('should properly navigate to the service accounts list', () => {
-        const keyPlural = 'serviceaccounts';
+        const entitiesKey = 'serviceaccounts';
 
         visitConfigurationManagementDashboard();
 
         cy.get(selectors.rbacVisibilityDropdown).click();
         interactAndWaitForConfigurationManagementEntities(() => {
             cy.get(selectors.getMenuListItem('service accounts')).click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('should properly navigate to the roles list', () => {
-        const keyPlural = 'roles';
+        const entitiesKey = 'roles';
 
         visitConfigurationManagementDashboard();
 
         cy.get(selectors.rbacVisibilityDropdown).click();
         interactAndWaitForConfigurationManagementEntities(() => {
             cy.get(selectors.getMenuListItem('roles')).click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('clicking the "Policy Violations By Severity" widget\'s "View All" button should take you to the policies list', () => {
-        const keyPlural = 'policies';
+        const entitiesKey = 'policies';
 
         visitConfigurationManagementDashboard();
 
@@ -199,11 +197,11 @@ describe('Config Management Dashboard Page', () => {
             cy.get(selectors.getWidget('Policy Violations by Severity'))
                 .find(selectors.viewAllButton)
                 .click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('clicking the "CIS Standard Across Clusters" widget\'s "View All" button should take you to the controls list', () => {
-        const keyPlural = 'controls';
+        const entitiesKey = 'controls';
 
         visitConfigurationManagementDashboard();
 
@@ -211,11 +209,11 @@ describe('Config Management Dashboard Page', () => {
             cy.get(selectors.cisStandardsAcrossClusters.widget)
                 .find(selectors.viewStandardButton)
                 .click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('clicking the "Users with most Cluster Admin Roles" widget\'s "View All" button should take you to the users & groups list', () => {
-        const keyPlural = 'subjects';
+        const entitiesKey = 'subjects';
 
         visitConfigurationManagementDashboard();
 
@@ -223,11 +221,11 @@ describe('Config Management Dashboard Page', () => {
             cy.get(selectors.getWidget('Users with most Cluster Admin Roles'))
                 .find(selectors.viewAllButton)
                 .click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('clicking a specific user in the "Users with most Cluster Admin Roles" widget should take you to a single subject page', () => {
-        const keyPlural = 'subjects';
+        const entitiesKey = 'subjects';
 
         visitConfigurationManagementDashboard();
 
@@ -236,11 +234,11 @@ describe('Config Management Dashboard Page', () => {
                 .find(selectors.horizontalBars)
                 .eq(0)
                 .click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('clicking the "Secrets Most Used Across Deployments" widget\'s "View All" button should take you to the secrets list', () => {
-        const keyPlural = 'secrets';
+        const entitiesKey = 'secrets';
 
         visitConfigurationManagementDashboard();
 
@@ -248,19 +246,19 @@ describe('Config Management Dashboard Page', () => {
             cy.get(selectors.getWidget('Secrets Most Used Across Deployments'))
                 .find(selectors.viewAllButton)
                 .click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     // This test might fail in local deployment.
     it('should show the same number of high severity policies in the "Policy Violations By Severity" widget as it does in the Policies list', () => {
-        const keyPlural = 'policies';
+        const entitiesKey = 'policies';
 
         visitConfigurationManagementDashboard();
 
         policyViolationsBySeverityLinkShouldMatchList(
             selectors.policyViolationsBySeverity.link.ratedAsHigh,
             /^(\d+) rated as high/,
-            keyPlural
+            entitiesKey
         );
 
         cy.location('search').should('contain', '[Severity]=HIGH_SEVERITY');
@@ -269,14 +267,14 @@ describe('Config Management Dashboard Page', () => {
 
     // This test might fail in local deployment.
     it('should show the same number of low severity policies in the "Policy Violations By Severity" widget as it does in the Policies list', () => {
-        const keyPlural = 'policies';
+        const entitiesKey = 'policies';
 
         visitConfigurationManagementDashboard();
 
         policyViolationsBySeverityLinkShouldMatchList(
             selectors.policyViolationsBySeverity.link.ratedAsLow,
             /^(\d+) rated as low/,
-            keyPlural
+            entitiesKey
         );
 
         cy.location('search').should('contain', '[Severity]=LOW_SEVERITY');
@@ -284,21 +282,21 @@ describe('Config Management Dashboard Page', () => {
     });
 
     it('should show the same number of policies without violations in the "Policy Violations By Severity" widget as it does in the Policies list', () => {
-        const keyPlural = 'policies';
+        const entitiesKey = 'policies';
 
         visitConfigurationManagementDashboard();
 
         policyViolationsBySeverityLinkShouldMatchList(
             selectors.policyViolationsBySeverity.link.policiesWithoutViolations,
             /^(\d+) (policy|policies)/,
-            keyPlural
+            entitiesKey
         );
 
         cy.location('search').should('contain', '[Policy%20Status]=Pass');
     });
 
     it('clicking the "CIS Standard Across Clusters" widget\'s "passing controls" link should take you to the controls list and filter by passing controls', () => {
-        const keyPlural = 'controls';
+        const entitiesKey = 'controls';
 
         visitConfigurationManagementDashboard();
 
@@ -311,13 +309,13 @@ describe('Config Management Dashboard Page', () => {
             cy.get(selectors.cisStandardsAcrossClusters.widget)
                 .find(selectors.cisStandardsAcrossClusters.passingControlsLink)
                 .click();
-        }, keyPlural);
+        }, entitiesKey);
 
         cy.location('search').should('contain', '[Compliance%20State]=Pass');
     });
 
     it('clicking the "CIS Standard Across Clusters" widget\'s "failing controls" link should take you to the controls list and filter by failing controls', () => {
-        const keyPlural = 'controls';
+        const entitiesKey = 'controls';
 
         visitConfigurationManagementDashboard();
 
@@ -325,13 +323,13 @@ describe('Config Management Dashboard Page', () => {
             cy.get(selectors.cisStandardsAcrossClusters.widget)
                 .find(selectors.cisStandardsAcrossClusters.failingControlsLinks)
                 .click();
-        }, keyPlural);
+        }, entitiesKey);
 
         cy.location('search').should('contain', '[Compliance%20State]=Fail');
     });
 
     it('clicking the "Secrets Most Used Across Deployments" widget\'s individual list items should take you to the secret\'s single page', () => {
-        const keyPlural = 'secrets';
+        const entitiesKey = 'secrets';
 
         visitConfigurationManagementDashboard();
 
@@ -340,7 +338,7 @@ describe('Config Management Dashboard Page', () => {
                 .find('ul li')
                 .eq(0)
                 .click();
-        }, keyPlural);
+        }, entitiesKey);
     });
 
     it('switching clusters in the "CIS Standard Across Clusters" widget\'s should change the data', () => {

--- a/ui/apps/platform/cypress/integration/configmanagement/deployments.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/deployments.test.js
@@ -12,82 +12,82 @@ import {
 } from '../../helpers/configWorkflowUtils';
 import withAuth from '../../helpers/basicAuth';
 
-// const entitiesKey = 'deployments'; // omit to minimize changed lines
+const entitiesKey = 'deployments';
 
-describe('Config Management Entities (Deployments)', () => {
+describe('Configuration Management Deployments', () => {
     withAuth();
 
     it('should render the deployments list and open the side panel when a row is clicked', () => {
-        renderListAndSidePanel('deployments');
+        renderListAndSidePanel(entitiesKey);
     });
 
     it('should open the side panel to show the same number of secrets when the secrets link is clicked', () => {
-        entityListCountMatchesTableLinkCount('deployments', 'secrets', /\d+ secrets?$/);
+        entityListCountMatchesTableLinkCount(entitiesKey, 'secrets', /\d+ secrets?$/);
     });
 
     it('should click on the cluster entity widget in the side panel and match the header ', () => {
-        renderListAndSidePanel('deployments');
-        clickOnSingularEntityWidgetInSidePanel('deployments', 'clusters');
+        renderListAndSidePanel(entitiesKey);
+        clickOnSingularEntityWidgetInSidePanel(entitiesKey, 'clusters');
     });
 
     it('should take you to a deployments single when the "navigate away" button is clicked', () => {
-        renderListAndSidePanel('deployments');
-        navigateToSingleEntityPage('deployments');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
     });
 
     it('should show the related cluster, namespace, and service account widgets', () => {
-        renderListAndSidePanel('deployments');
-        navigateToSingleEntityPage('deployments');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasRelatedEntityFor('Cluster');
         hasRelatedEntityFor('Namespace');
         hasRelatedEntityFor('Service Account');
     });
 
     it('should have the correct count widgets for a single entity view', () => {
-        renderListAndSidePanel('deployments');
-        navigateToSingleEntityPage('deployments');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasCountWidgetsFor(['Images', 'Secrets']);
     });
 
     it('should have the correct tabs for a single entity view', () => {
-        renderListAndSidePanel('deployments');
-        navigateToSingleEntityPage('deployments');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasTabsFor(['images', 'secrets']);
     });
 
     it('should click on the images count widget in the entity page and show the images tab', () => {
-        renderListAndSidePanel('deployments', 'collector');
-        navigateToSingleEntityPage('deployments');
+        renderListAndSidePanel(entitiesKey, 'collector');
+        navigateToSingleEntityPage(entitiesKey);
         clickOnCountWidget('images', 'entityList');
     });
 
-    it('should have the same number of Images in the count widget as in the Images table', () => {
+    describe('should have same number in images table as in count widget', () => {
         const entitiesKey2 = 'images';
 
-        context('Page', () => {
-            renderListAndSidePanel('deployments');
-            navigateToSingleEntityPage('deployments');
-            pageEntityCountMatchesTableRows('deployments', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('deployments');
-            sidePanelEntityCountMatchesTableRows('deployments', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
-    it('should have the same number of Secrets in the count widget as in the Secrets table', () => {
+    describe('should have same number in secrets table as in count widget', () => {
         const entitiesKey2 = 'secrets';
 
-        context('Page', () => {
-            renderListAndSidePanel('deployments');
-            navigateToSingleEntityPage('deployments');
-            pageEntityCountMatchesTableRows('deployments', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('deployments');
-            sidePanelEntityCountMatchesTableRows('deployments', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/images.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/images.test.js
@@ -11,62 +11,62 @@ import {
 import { selectors as configManagementSelectors } from '../../constants/ConfigManagementPage';
 import withAuth from '../../helpers/basicAuth';
 
-// const entitiesKey = 'images'; // omit to minimize changed lines
+const entitiesKey = 'images';
 
-describe('Config Management Entities (Images)', () => {
+describe('Configuration Management Images', () => {
     withAuth();
 
     it('should render the images list and open the side panel when a row is clicked', () => {
-        renderListAndSidePanel('images');
+        renderListAndSidePanel(entitiesKey);
     });
 
     it('should open the side panel to show the same number of deployments when the deployments link is clicked', () => {
-        entityListCountMatchesTableLinkCount('images', 'deployments', /^\d+ deployments?$/);
+        entityListCountMatchesTableLinkCount(entitiesKey, 'deployments', /^\d+ deployments?$/);
     });
 
     it('should take you to a images single when the "navigate away" button is clicked', () => {
-        renderListAndSidePanel('images');
-        navigateToSingleEntityPage('images');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
     });
 
     it('should have the correct count widgets for a single entity view', () => {
-        renderListAndSidePanel('images');
-        navigateToSingleEntityPage('images');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasCountWidgetsFor(['Deployments']);
     });
 
     it('should click on the deployments count widget in the entity page and show the deployments tab', () => {
-        renderListAndSidePanel('images');
-        navigateToSingleEntityPage('images');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasCountWidgetsFor(['Deployments']);
         clickOnCountWidget('deployments', 'entityList');
     });
 
     it('should have the correct tabs for a single entity view', () => {
-        renderListAndSidePanel('images');
-        navigateToSingleEntityPage('images');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasTabsFor(['deployments']);
     });
 
-    it('should have the same number of Deployments in the count widget as in the Deployments table', () => {
+    describe('should have same number in deployments table as in count widget', () => {
         const entitiesKey2 = 'deployments';
 
-        context('Page', () => {
-            renderListAndSidePanel('images');
-            navigateToSingleEntityPage('images');
-            pageEntityCountMatchesTableRows('images', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('images');
-            sidePanelEntityCountMatchesTableRows('images', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
     // regression test for ROX-4543-crash-when-drilling-down-to-image-deployments
     it('should allow user to drill down from cluster to image to image-deployments', () => {
         renderListAndSidePanel('clusters');
-        clickOnCountWidget('images', 'side-panel');
+        clickOnCountWidget(entitiesKey, 'side-panel');
         cy.get(`[data-testid="side-panel"] ${configManagementSelectors.tableRows}:last`).click({
             force: true,
         });

--- a/ui/apps/platform/cypress/integration/configmanagement/namespaces.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/namespaces.test.js
@@ -13,107 +13,107 @@ import {
 } from '../../helpers/configWorkflowUtils';
 import withAuth from '../../helpers/basicAuth';
 
-// const entitiesKey = 'namespaces'; // omit to minimize changed lines
+const entitiesKey = 'namespaces';
 
-describe('Config Management Entities (Namespaces)', () => {
+describe('Configuration Management Namespaces', () => {
     withAuth();
 
     it('should render the namespaces list and open the side panel when a row is clicked', () => {
-        renderListAndSidePanel('namespaces');
+        renderListAndSidePanel(entitiesKey);
     });
 
     it('should render the namespaces list and open the side panel with the clicked cluster value', () => {
-        clickOnSingleEntityInTable('namespaces', 'clusters');
+        clickOnSingleEntityInTable(entitiesKey, 'clusters');
     });
 
     it('should click on the cluster entity widget in the side panel and match the header ', () => {
-        renderListAndSidePanel('namespaces');
-        clickOnSingularEntityWidgetInSidePanel('namespaces', 'clusters');
+        renderListAndSidePanel(entitiesKey);
+        clickOnSingularEntityWidgetInSidePanel(entitiesKey, 'clusters');
     });
 
     it('should take you to a namespace single when the "navigate away" button is clicked', () => {
-        renderListAndSidePanel('namespaces');
-        navigateToSingleEntityPage('namespaces');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
     });
 
     it('should show the related cluster widget', () => {
-        renderListAndSidePanel('namespaces');
-        navigateToSingleEntityPage('namespaces');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasRelatedEntityFor('Cluster');
     });
 
     it('should have the correct count widgets for a single entity view', () => {
-        renderListAndSidePanel('namespaces');
-        navigateToSingleEntityPage('namespaces');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasCountWidgetsFor(['Deployments', 'Secrets', 'Images']);
     });
 
     it('should click on the secrets count widget in the entity page and show the secrets tab', () => {
-        renderListAndSidePanel('namespaces', 'stackrox');
-        navigateToSingleEntityPage('namespaces');
+        renderListAndSidePanel(entitiesKey, 'stackrox');
+        navigateToSingleEntityPage(entitiesKey);
         clickOnCountWidget('secrets', 'entityList');
     });
 
     it('should have the correct tabs for a single entity view', () => {
-        renderListAndSidePanel('namespaces');
-        navigateToSingleEntityPage('namespaces');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasTabsFor(['deployments', 'secrets', 'images']);
     });
 
-    it('should have the same number of Deployments in the count widget as in the Deployments table', () => {
+    describe('should have same number in deployments table as in count widget', () => {
         const entitiesKey2 = 'deployments';
 
-        context('Page', () => {
-            renderListAndSidePanel('namespaces');
-            navigateToSingleEntityPage('namespaces');
-            pageEntityCountMatchesTableRows('namespaces', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('namespaces');
-            sidePanelEntityCountMatchesTableRows('namespaces', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
-    it('should have the same number of Secrets in the count widget as in the Secrets table', () => {
+    describe('should have same number in secrets table as in count widget', () => {
         const entitiesKey2 = 'secrets';
 
-        context('Page', () => {
-            renderListAndSidePanel('namespaces');
-            navigateToSingleEntityPage('namespaces');
-            pageEntityCountMatchesTableRows('namespaces', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('namespaces');
-            sidePanelEntityCountMatchesTableRows('namespaces', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
-    it('should have the same number of Images in the count widget as in the Images table', () => {
+    describe('should have same number in images table as in count widget', () => {
         const entitiesKey2 = 'images';
 
-        context('Page', () => {
-            renderListAndSidePanel('namespaces');
-            navigateToSingleEntityPage('namespaces');
-            pageEntityCountMatchesTableRows('namespaces', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('namespaces');
-            sidePanelEntityCountMatchesTableRows('namespaces', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
     it('should open the side panel to show the same number of Service Accounts when the Service Accounts link is clicked', () => {
         entityListCountMatchesTableLinkCount(
-            'namespaces',
+            entitiesKey,
             'serviceaccounts',
             /^\d+ Service Accounts?$/
         );
     });
 
     it('should open the side panel to show the same number of Roles when the Roles link is clicked', () => {
-        entityListCountMatchesTableLinkCount('namespaces', 'roles', /^\d+ Roles?$/);
+        entityListCountMatchesTableLinkCount(entitiesKey, 'roles', /^\d+ Roles?$/);
     });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/nodes.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/nodes.test.js
@@ -13,67 +13,67 @@ import {
 import withAuth from '../../helpers/basicAuth';
 import { triggerScan } from '../../helpers/compliance';
 
-// const entitiesKey = 'nodes'; // omit to minimize changed lines
+const entitiesKey = 'nodes';
 
-describe('Config Management Entities (Nodes)', () => {
+describe('Configuration Management Nodes', () => {
     withAuth();
 
     it('should render the nodes list and open the side panel when a row is clicked', () => {
-        renderListAndSidePanel('nodes');
+        renderListAndSidePanel(entitiesKey);
     });
 
     it('should render the nodes list and open the side panel with the clicked cluster value', () => {
-        clickOnSingleEntityInTable('nodes', 'clusters');
+        clickOnSingleEntityInTable(entitiesKey, 'clusters');
     });
 
     it('should click on the cluster entity widget in the side panel and match the header ', () => {
-        renderListAndSidePanel('nodes');
-        clickOnSingularEntityWidgetInSidePanel('nodes', 'clusters');
+        renderListAndSidePanel(entitiesKey);
+        clickOnSingularEntityWidgetInSidePanel(entitiesKey, 'clusters');
     });
 
     it('should take you to a nodes single when the "navigate away" button is clicked', () => {
-        renderListAndSidePanel('nodes');
-        navigateToSingleEntityPage('nodes');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
     });
 
     it('should show the related cluster widget', () => {
-        renderListAndSidePanel('nodes');
-        navigateToSingleEntityPage('nodes');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasRelatedEntityFor('Cluster');
     });
 
     it('should have the correct count widgets for a single entity view', () => {
-        renderListAndSidePanel('nodes');
-        navigateToSingleEntityPage('nodes');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasCountWidgetsFor(['Controls']);
     });
 
     it('should have the correct tabs for a single entity view', () => {
-        renderListAndSidePanel('nodes');
-        navigateToSingleEntityPage('nodes');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasTabsFor(['controls']);
     });
 
     it('should click on the controls count widget in the entity page and show the controls tab', () => {
         triggerScan(); // because test assumes that scan results are available
 
-        renderListAndSidePanel('nodes');
-        navigateToSingleEntityPage('nodes');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         clickOnCountWidget('controls', 'entityList');
     });
 
-    it('should have the same number of Controls in the count widget as in the Controls table', () => {
+    describe('should have same number in controls table as in count widget', () => {
         const entitiesKey2 = 'controls';
 
-        context('Page', () => {
-            renderListAndSidePanel('nodes');
-            navigateToSingleEntityPage('nodes');
-            pageEntityCountMatchesTableRows('nodes', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('nodes');
-            sidePanelEntityCountMatchesTableRows('nodes', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/policies.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/policies.test.js
@@ -9,50 +9,50 @@ import {
 } from '../../helpers/configWorkflowUtils';
 import withAuth from '../../helpers/basicAuth';
 
-// const entitiesKey = 'policies'; // omit to minimize changed lines
+const entitiesKey = 'policies';
 
-describe('Config Management Entities (Policies)', () => {
+describe('Configuration Management Policies', () => {
     withAuth();
 
     it('should render the policies list and open the side panel when a row is clicked', () => {
-        renderListAndSidePanel('policies');
+        renderListAndSidePanel(entitiesKey);
     });
 
     it('should take you to a policy single when the "navigate away" button is clicked', () => {
-        renderListAndSidePanel('policies');
-        navigateToSingleEntityPage('policies');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
     });
 
     it('should have the correct count widgets for a single entity view', () => {
-        renderListAndSidePanel('policies');
-        navigateToSingleEntityPage('policies');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasCountWidgetsFor(['Deployments']);
     });
 
     it('should click on the deployments count widget in the entity page and show the deployments tab', () => {
-        renderListAndSidePanel('policies');
-        navigateToSingleEntityPage('policies');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         clickOnCountWidget('deployments', 'entityList');
     });
 
     it('should have the correct tabs for a single entity view', () => {
-        renderListAndSidePanel('policies');
-        navigateToSingleEntityPage('policies');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasTabsFor(['deployments']);
     });
 
-    it('should have the same number of Deployments in the count widget as in the Deployments table', () => {
+    describe('should have same number in deployments table as in count widget', () => {
         const entitiesKey2 = 'deployments';
 
-        context('Page', () => {
-            renderListAndSidePanel('policies');
-            navigateToSingleEntityPage('policies');
-            pageEntityCountMatchesTableRows('policies', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('policies');
-            sidePanelEntityCountMatchesTableRows('policies', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/roles.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/roles.test.js
@@ -9,65 +9,65 @@ import {
 } from '../../helpers/configWorkflowUtils';
 import withAuth from '../../helpers/basicAuth';
 
-// const entitiesKey = 'roles'; // omit to minimize changed lines
+const entitiesKey = 'roles';
 
-describe('Config Management Entities (Roles)', () => {
+describe('Configuration Management Roles', () => {
     withAuth();
 
     it('should render the roles list and open the side panel when a row is clicked', () => {
-        renderListAndSidePanel('roles');
+        renderListAndSidePanel(entitiesKey);
     });
 
     it('should take you to a roles single when the "navigate away" button is clicked', () => {
-        renderListAndSidePanel('roles');
-        navigateToSingleEntityPage('roles');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
     });
 
     it('should show the related cluster widget', () => {
-        renderListAndSidePanel('roles');
-        navigateToSingleEntityPage('roles');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasRelatedEntityFor('Cluster');
     });
 
     it('should have the correct count widgets for a single entity view', () => {
-        renderListAndSidePanel('roles');
-        navigateToSingleEntityPage('roles');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasCountWidgetsFor(['Users & Groups', 'Service Accounts']);
     });
 
     it('should have the correct tabs for a single entity view', () => {
-        renderListAndSidePanel('roles');
-        navigateToSingleEntityPage('roles');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasTabsFor(['users and groups', 'service accounts']);
     });
 
-    it('should have the same number of Users & Groups in the count widget as in the Users & Groups table', () => {
+    describe('should have same number in users and groups table as in count widget', () => {
         const entitiesKey2 = 'subjects';
 
-        context('Page', () => {
-            renderListAndSidePanel('roles');
-            navigateToSingleEntityPage('roles');
-            pageEntityCountMatchesTableRows('roles', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('roles');
-            sidePanelEntityCountMatchesTableRows('roles', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
-    it('should have the same number of Service Accounts in the count widget as in the Service Accounts table', () => {
+    describe('should have same number in service accounts table as in count widget', () => {
         const entitiesKey2 = 'serviceaccounts';
 
-        context('Page', () => {
-            renderListAndSidePanel('roles');
-            navigateToSingleEntityPage('roles');
-            pageEntityCountMatchesTableRows('roles', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('roles');
-            sidePanelEntityCountMatchesTableRows('roles', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/secrets.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/secrets.test.js
@@ -13,17 +13,17 @@ import {
 import { selectors as configManagementSelectors } from '../../constants/ConfigManagementPage';
 import withAuth from '../../helpers/basicAuth';
 
-// const entitiesKey = 'secrets'; // omit to minimize changed lines
+const entitiesKey = 'secrets';
 
-describe('Config Management Entities (Secrets)', () => {
+describe('Configuration Management Secrets', () => {
     withAuth();
 
     it('should render the secrets list and open the side panel when a row is clicked', () => {
-        renderListAndSidePanel('secrets');
+        renderListAndSidePanel(entitiesKey);
     });
 
     it('should render the deployments link and open the side panel when a row is clicked', () => {
-        visitConfigurationManagementEntities('secrets');
+        visitConfigurationManagementEntities(entitiesKey);
 
         cy.get(configManagementSelectors.tableRows)
             .find(`${configManagementSelectors.tableCells} a[data-testid='deployment']`)
@@ -38,51 +38,51 @@ describe('Config Management Entities (Secrets)', () => {
     });
 
     it('should click on the cluster entity widget in the side panel and match the header ', () => {
-        renderListAndSidePanel('secrets');
-        clickOnSingularEntityWidgetInSidePanel('secrets', 'clusters');
+        renderListAndSidePanel(entitiesKey);
+        clickOnSingularEntityWidgetInSidePanel(entitiesKey, 'clusters');
     });
 
     it('should take you to a secrets single when the "navigate away" button is clicked', () => {
-        renderListAndSidePanel('secrets');
-        navigateToSingleEntityPage('secrets');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
     });
 
     it('should show the related cluster widget', () => {
-        renderListAndSidePanel('secrets');
-        navigateToSingleEntityPage('secrets');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasRelatedEntityFor('Cluster');
     });
 
     it('should have the correct count widgets for a single entity view', () => {
-        renderListAndSidePanel('secrets');
-        navigateToSingleEntityPage('secrets');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasCountWidgetsFor(['Deployments']);
     });
 
     it('should have the correct tabs for a single entity view', () => {
-        renderListAndSidePanel('secrets');
-        navigateToSingleEntityPage('secrets');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasTabsFor(['deployments']);
     });
 
     it('should click on the deployments count widget in the entity page and show the deployments tab', () => {
-        renderListAndSidePanel('secrets');
-        navigateToSingleEntityPage('secrets');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         clickOnCountWidget('deployments', 'entityList');
     });
 
-    it('should have the same number of Deployments in the count widget as in the Deployments table', () => {
+    describe('should have same number in deployments table as in count widget', () => {
         const entitiesKey2 = 'deployments';
 
-        context('Page', () => {
-            renderListAndSidePanel('secrets');
-            navigateToSingleEntityPage('secrets');
-            pageEntityCountMatchesTableRows('secrets', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('secrets');
-            sidePanelEntityCountMatchesTableRows('secrets', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/serviceaccount.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/serviceaccount.test.js
@@ -13,7 +13,7 @@ import withAuth from '../../helpers/basicAuth';
 
 const entitiesKey = 'serviceaccounts';
 
-describe('Config Management Entities (Service Accounts)', () => {
+describe('Configuration Management Service Accounts', () => {
     withAuth();
 
     it('should render the service accounts list and open the side panel when a row is clicked', () => {
@@ -52,31 +52,31 @@ describe('Config Management Entities (Service Accounts)', () => {
         hasTabsFor(['deployments', 'roles']);
     });
 
-    it('should have the same number of Deployments in the count widget as in the Deployments table', () => {
+    describe('should have same number in deployments table as in count widget', () => {
         const entitiesKey2 = 'deployments';
 
-        context('Page', () => {
+        it('of page', () => {
             renderListAndSidePanel(entitiesKey);
             navigateToSingleEntityPage(entitiesKey);
             pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
+        it('of side panel', () => {
             renderListAndSidePanel(entitiesKey);
             sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 
-    it('should have the same number of Roles in the count widget as in the Roles table', () => {
+    describe('should have same number in roles table as in count widget', () => {
         const entitiesKey2 = 'roles';
 
-        context('Page', () => {
+        it('of page', () => {
             renderListAndSidePanel(entitiesKey);
             navigateToSingleEntityPage(entitiesKey);
             pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
+        it('of side panel', () => {
             renderListAndSidePanel(entitiesKey);
             sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });

--- a/ui/apps/platform/cypress/integration/configmanagement/usersandgroups.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/usersandgroups.test.js
@@ -10,54 +10,54 @@ import {
 } from '../../helpers/configWorkflowUtils';
 import withAuth from '../../helpers/basicAuth';
 
-// const entitiesKey = 'subjects'; // omit to minimize changed lines
+const entitiesKey = 'subjects';
 
-describe('Config Management Entities (Subjects - Users & Groups', () => {
+describe('Configuration Management Subjects (Users and Groups)', () => {
     withAuth();
 
     it('should render the users & groups list and open the side panel when a row is clicked', () => {
-        renderListAndSidePanel('subjects');
+        renderListAndSidePanel(entitiesKey);
     });
 
     it('should open the side panel to show the same number of roles when the roles link is clicked', () => {
-        entityListCountMatchesTableLinkCount('subjects', 'roles', /^\d+ Roles?$/);
+        entityListCountMatchesTableLinkCount(entitiesKey, 'roles', /^\d+ Roles?$/);
     });
 
     it('should take you to a subject single when the "navigate away" button is clicked', () => {
-        renderListAndSidePanel('subjects');
-        navigateToSingleEntityPage('subjects');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
     });
 
     it('should have the correct count widgets for a single entity view', () => {
-        renderListAndSidePanel('subjects');
-        navigateToSingleEntityPage('subjects');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasCountWidgetsFor(['Roles']);
     });
 
     it('should have the correct tabs for a single entity view', () => {
-        renderListAndSidePanel('subjects');
-        navigateToSingleEntityPage('subjects');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         hasTabsFor(['roles']);
     });
 
     it('should click on the roles count widget in the entity page and show the roles tab', () => {
-        renderListAndSidePanel('subjects');
-        navigateToSingleEntityPage('subjects');
+        renderListAndSidePanel(entitiesKey);
+        navigateToSingleEntityPage(entitiesKey);
         clickOnCountWidget('roles', 'entityList');
     });
 
-    it('should have the same number of Roles in the count widget as in the Roles table', () => {
+    describe('should have same number in roles table as in count widget', () => {
         const entitiesKey2 = 'roles';
 
-        context('Page', () => {
-            renderListAndSidePanel('subjects');
-            navigateToSingleEntityPage('subjects');
-            pageEntityCountMatchesTableRows('subjects', entitiesKey2);
+        it('of page', () => {
+            renderListAndSidePanel(entitiesKey);
+            navigateToSingleEntityPage(entitiesKey);
+            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
 
-        context('Side Panel', () => {
-            renderListAndSidePanel('subjects');
-            sidePanelEntityCountMatchesTableRows('subjects', entitiesKey2);
+        it('of side panel', () => {
+            renderListAndSidePanel(entitiesKey);
+            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
         });
     });
 });


### PR DESCRIPTION
## Description

Follow up with improvements not included to minimize changed lines in #3268

1. Simplify test file description.
2. Replace repeated strings with `entitiesKey` variable.
3. Split tests which have pair of `config` blocks into pairs of tests.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed