### PR TITLE
Suppress duplicates in the `vuln_check.sh` output

### DIFF
--- a/release/scripts/vuln_check.sh
+++ b/release/scripts/vuln_check.sh
@@ -53,7 +53,7 @@ function compare_fixable_vulns {
     FAIL_SCRIPT=true
   else
     echo "Trying to get any fixable vulns for ${image_name}"
-    CURRENT_FIXABLE=$(quay_curl "${image_name}/manifest/${CURRENT_IMAGE}/security?vulnerabilities=true" | jq -r '.data.Layer.Features | .[] | select(.Vulnerabilities != null) | .Vulnerabilities | .[] | select(.FixedBy | . != null and . != "") | .Name' | uniq)
+    CURRENT_FIXABLE=$(quay_curl "${image_name}/manifest/${CURRENT_IMAGE}/security?vulnerabilities=true" | jq -r '.data.Layer.Features | .[] | select(.Vulnerabilities != null) | .Vulnerabilities | .[] | select(.FixedBy | . != null and . != "") | .Name' | sort -u)
 
     # fail the check if fixable vulns are found that are not allowed
     if [[ -n "$CURRENT_FIXABLE" ]]; then

--- a/release/scripts/vuln_check.sh
+++ b/release/scripts/vuln_check.sh
@@ -53,7 +53,7 @@ function compare_fixable_vulns {
     FAIL_SCRIPT=true
   else
     echo "Trying to get any fixable vulns for ${image_name}"
-    CURRENT_FIXABLE=$(quay_curl "${image_name}/manifest/${CURRENT_IMAGE}/security?vulnerabilities=true" | jq -r '.data.Layer.Features | .[] | select(.Vulnerabilities != null) | .Vulnerabilities | .[] | select(.FixedBy | . != null and . != "") | .Name')
+    CURRENT_FIXABLE=$(quay_curl "${image_name}/manifest/${CURRENT_IMAGE}/security?vulnerabilities=true" | jq -r '.data.Layer.Features | .[] | select(.Vulnerabilities != null) | .Vulnerabilities | .[] | select(.FixedBy | . != null and . != "") | .Name' | uniq)
 
     # fail the check if fixable vulns are found that are not allowed
     if [[ -n "$CURRENT_FIXABLE" ]]; then


### PR DESCRIPTION
## Description

`release/scripts/vuln_check.sh` would print vulnerabilities names for each repository and each FixedBy version which results in duplicate entries. Remove those duplicates with `uniq`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Locally:
```sh
$ release/scripts/vuln_check.sh
RHSA-2022:6206: systemd security update (Important)               
RHSA-2022:5313: curl security update (Moderate)                               
RHSA-2022:6159: curl security update (Moderate)                               
RHSA-2022:5313: curl security update (Moderate)                               
RHSA-2022:6159: curl security update (Moderate)                               
RHSA-2022:5809: pcre2 security update (Moderate)                                                                                                            
RHSA-2022:5317: libxml2 security update (Moderate)                                                                                                          
RHSA-2022:5314: expat security update (Moderate)                                                                                                            
RHSA-2022:6463: gnupg2 security update (Moderate)                                                                                                           
RHSA-2022:5311: libgcrypt security update (Moderate)                                                                                                        
RHSA-2022:6457: python3 security update (Moderate)                                                                                                          
RHSA-2022:5818: openssl security update (Moderate)                                                                                                          
RHSA-2022:6457: python3 security update (Moderate)
```