### PR TITLE
Dashrews/ROX-12944 connect non existing clone error

### DIFF
--- a/central/centralhealth/service/service_impl.go
+++ b/central/centralhealth/service/service_impl.go
@@ -81,24 +81,24 @@ func (s *serviceImpl) GetUpgradeStatus(ctx context.Context, empty *v1.Empty) (*v
 				if err != nil {
 					return nil, errors.Wrapf(err, "Fail to get database size %s", migrations.PreviousDatabase)
 				}
+
+				// Get a short-lived connection for the purposes of checking the version of the previous clone.
+				pool := pgadmin.GetClonePool(adminConfig, migrations.GetPreviousClone())
+				defer pool.Close()
+
+				// Get rollback to version
+				migVer, err := migrations.ReadVersionPostgres(pool)
+				if err != nil {
+					log.Infof("Unable to get previous version, leaving ForceRollbackTo empty.  %v", err)
+				}
+				if err == nil && migVer.SeqNum > 0 && version.CompareVersionsOr(migVer.MainVersion, minForceRollbackTo, -1) >= 0 {
+					upgradeStatus.ForceRollbackTo = migVer.MainVersion
+				}
 			}
 
 			upgradeStatus.CanRollbackAfterUpgrade = freeBytes+toBeFreedBytes > requiredBytes
 			upgradeStatus.SpaceAvailableForRollbackAfterUpgrade = freeBytes + toBeFreedBytes
 			upgradeStatus.SpaceRequiredForRollbackAfterUpgrade = requiredBytes
-		}
-
-		// Get a short-lived connection for the purposes of checking the version of the replica.
-		pool := pgadmin.GetClonePool(adminConfig, migrations.GetPreviousClone())
-		defer pool.Close()
-
-		// Get rollback to version
-		migVer, err := migrations.ReadVersionPostgres(pool)
-		if err != nil {
-			log.Infof("Unable to get previous version, leaving ForceRollbackTo empty.  %v", err)
-		}
-		if err == nil && migVer.SeqNum > 0 && version.CompareVersionsOr(migVer.MainVersion, minForceRollbackTo, -1) >= 0 {
-			upgradeStatus.ForceRollbackTo = migVer.MainVersion
 		}
 
 		return &v1.GetUpgradeStatusResponse{


### PR DESCRIPTION
## Description

Found a bug while working ROX-11730 where if a call to v1/centralhealth/upgradestatus is made and no central_previous exists, central will restart failing to get a connection.  

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested locally by starting central in Postgres mode and hitting the endpoint, v1/centralhealth/upgradestatus.  After initial Postgres that will return an empty rollback version.  Upgraded central, ran again and it returned a rollback version of the previous central.  This will be more thoroughly tested as part of the upgrade tests in ROX-11730.
