### PR TITLE
ROX-12397: add transient retry to Makefile kuttl

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -201,9 +201,10 @@ GET_GITHUB_RELEASE_FN = get_github_release() { \
 	[ -x $${1} ] || { \
 		set -euxo pipefail ;\
 		mkdir -p bin ;\
-		for i in {1..5}; do \
+		attempts=5 ;\
+		for i in $$(seq $$attempts); do \
 			curl --fail --location --output $${1} $${2} && break ;\
-			[ $$i -eq 5 ] && exit 1; \
+			[ $$i -eq $$attempts ] && exit 1; \
 		done ;\
 		[[ "$$(uname -s)" != "Darwin" ]] || xattr -c $${1} ;\
 		chmod +x $${1} ;\

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -201,7 +201,7 @@ GET_GITHUB_RELEASE_FN = get_github_release() { \
 	[ -x $${1} ] || { \
 		set -euxo pipefail ;\
 		mkdir -p bin ;\
-		curl --fail --retry 5 --location --output $${1} $${2} ;\
+		curl --fail --retry 5 --retry-all-errors --location --output $${1} $${2} ;\
 		[[ "$$(uname -s)" != "Darwin" ]] || xattr -c $${1} ;\
 		chmod +x $${1} ;\
 	} \

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -204,8 +204,9 @@ GET_GITHUB_RELEASE_FN = get_github_release() { \
 		for i in {1..5}; do \
 			set +e ;\
 			curl --fail --location --output $${1} $${2} ;\
-			[ $$? -eq 0 ] && break ;\
+			code=$$? ;\
 			set -e ;\
+			[ $$code -eq 0 ] && break ;\
 			[ $$i -eq 5 ] && exit 1; \
 		done ;\
 		[[ "$$(uname -s)" != "Darwin" ]] || xattr -c $${1} ;\

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -201,7 +201,7 @@ GET_GITHUB_RELEASE_FN = get_github_release() { \
 	[ -x $${1} ] || { \
 		set -euxo pipefail ;\
 		mkdir -p bin ;\
-		curl --fail --location --output $${1} $${2} ;\
+		curl --fail --retry 5 --location --output $${1} $${2} ;\
 		[[ "$$(uname -s)" != "Darwin" ]] || xattr -c $${1} ;\
 		chmod +x $${1} ;\
 	} \

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -201,7 +201,13 @@ GET_GITHUB_RELEASE_FN = get_github_release() { \
 	[ -x $${1} ] || { \
 		set -euxo pipefail ;\
 		mkdir -p bin ;\
-		curl --fail --retry 5 --retry-all-errors --location --output $${1} $${2} ;\
+		for i in {1..5}; do \
+			set +e ;\
+			curl --fail --location --output $${1} $${2} ;\
+			[ $$? -eq 0 ] && break ;\
+			set -e ;\
+			[ $$i -eq 5 ] && exit 1; \
+		done ;\
 		[[ "$$(uname -s)" != "Darwin" ]] || xattr -c $${1} ;\
 		chmod +x $${1} ;\
 	} \

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -202,11 +202,7 @@ GET_GITHUB_RELEASE_FN = get_github_release() { \
 		set -euxo pipefail ;\
 		mkdir -p bin ;\
 		for i in {1..5}; do \
-			set +e ;\
-			curl --fail --location --output $${1} $${2} ;\
-			code=$$? ;\
-			set -e ;\
-			[ $$code -eq 0 ] && break ;\
+			curl --fail --location --output $${1} $${2} && break ;\
 			[ $$i -eq 5 ] && exit 1; \
 		done ;\
 		[[ "$$(uname -s)" != "Darwin" ]] || xattr -c $${1} ;\


### PR DESCRIPTION
## Description

Added transient retry to operator build process. Namely the target `kuttl` hadn't any retry behaviour.

## Checklist
- [x] Added `--retry 5` flag to `curl` command

## Testing Performed

Performed the following command and the execution was successful. The output shows that `curl` is executed with the `--retry 5` flag.

```bash
$ make -C operator kuttl
+ mkdir -p bin
+ curl --fail --retry 5 --location --output /Users/atlekbai/Proj/stackrox/operator//bin/kubectl-kuttl-0.13.0 https://github.com/kudobuilder/kuttl/releases/download/v0.13.0/kubectl-kuttl_0.13.0_darwin_arm64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
100 35.3M  100 35.3M    0     0   604k      0  0:00:59  0:00:59 --:--:--  529k
++ uname -s
+ [[ Darwin != \D\a\r\w\i\n ]]
+ xattr -c /Users/atlekbai/Proj/stackrox/operator//bin/kubectl-kuttl-0.13.0
+ chmod +x /Users/atlekbai/Proj/stackrox/operator//bin/kubectl-kuttl-0.13.0
```

### Updated 05.10.2022 00:07+06:00
The retry mechanism is rewritten to for loop instead of using `--retry` flag.

Closes #3172
