### PR TITLE
ROX-12826 improve re-sync service tests

### DIFF
--- a/sensor/tests/resource/helper.go
+++ b/sensor/tests/resource/helper.go
@@ -245,7 +245,7 @@ func (c *TestContext) LastDeploymentState(name string, assertion AssertFunc, mes
 // that state until `timeout` the test fails.
 func (c *TestContext) LastDeploymentStateWithTimeout(name string, assertion AssertFunc, message string, timeout time.Duration) {
 	timer := time.NewTimer(timeout)
-	ticker := time.NewTicker(10 * time.Millisecond)
+	ticker := time.NewTicker(500 * time.Millisecond)
 	var lastErr error
 	for {
 		select {

--- a/sensor/tests/resource/service/service_test.go
+++ b/sensor/tests/resource/service/service_test.go
@@ -81,14 +81,14 @@ func checkPortConfig(deployment *storage.Deployment, ports []*storage.PortConfig
 						}
 					}
 					if !foundPortInfo {
-						return errors.Errorf("PortInfo '%v' not found", expectedPort)
+						return errors.Errorf("PortInfo '%+v' not found", expectedPortInfo)
 					}
 				}
 				foundPortConfig = true
 			}
 		}
 		if !foundPortConfig {
-			return errors.Errorf("PortConfig '%v' not found", expectedPort)
+			return errors.Errorf("PortConfig '%+v' not found", expectedPort)
 		}
 	}
 	return nil
@@ -105,7 +105,7 @@ func assertLastDeploymentMissingPortExposure(ports []*storage.PortConfig) resour
 		if err := checkPortConfig(deployment, ports); err != nil {
 			return nil
 		}
-		return errors.Errorf("PortConfig '%v' should not be present", ports)
+		return errors.Errorf("PortConfig '%+v' should not be present", ports)
 	}
 }
 
@@ -332,11 +332,6 @@ func (s *DeploymentExposureSuite) Test_MultipleDeploymentUpdates() {
 
 		testC.LastDeploymentState(nginxDeploymentName,
 			assertLastDeploymentMissingPortExposure([]*storage.PortConfig{
-				//{
-				//	Protocol:      "TCP",
-				//	ContainerPort: 80,
-				//	Exposure:      0,
-				// },
 				{
 					Protocol:      "TCP",
 					ContainerPort: 80,

--- a/sensor/tests/resource/service/yaml/nginx.yaml
+++ b/sensor/tests/resource/service/yaml/nginx.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: nginx
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: nginx


### PR DESCRIPTION
## Description

Re-sync service tests no longer wait for the re-sync to happen.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Manually and CI:

```
go test -race -count=1 github.com/stackrox/rox/sensor/tests/resource/service
```