### PR TITLE
RS-574: Reuse cluster create

### DIFF
--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -85,11 +85,6 @@ jobs:
           # Ensure that the binary works
           infractl --version
 
-      - name: Env OK
-        run: |
-          echo "STACKROX_GHA_VERSION: $STACKROX_GHA_VERSION" || true
-          echo "env.STACKROX_GHA_VERSION: ${{ env.STACKROX_GHA_VERSION }}" || true
-
       - name: Create Cluster
         env:
           INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
@@ -102,7 +97,6 @@ jobs:
           if [[ "${{ inputs.STACKROX_GHA_VERSION }}" != "" ]]; then
             script_url="/repos/stackrox/stackrox/contents/.github/workflows/scripts/common.sh?ref=${{ inputs.STACKROX_GHA_VERSION }}"
           fi
-          echo "script_url: $script_url"
           gh api -H "$ACCEPT_RAW" "$script_url" | bash -s -- \
             create-cluster \
             "${{inputs.flavor}}" \

--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -87,8 +87,7 @@ jobs:
         run: |
           set -uo pipefail
           if [[ "${{inputs.direct_exec}}" == "true" ]]; then
-            ls -l
-            pwd
+            echo "${{ toJson(github) }}"
             source ./.github/workflows/scripts/common.sh
               ./.github/workflows/scripts/create-cluster \
               "${{inputs.flavor}}" \

--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -29,6 +29,11 @@ on:
         type: boolean
         required: false
         default: false
+      STACKROX_GHA_VERSION:
+        description: Sets a version ref for callers in other repos
+        type: string
+        required: false
+        default: ""
 
   workflow_dispatch:
     inputs:
@@ -85,11 +90,12 @@ jobs:
           INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
           GH_TOKEN: ${{ github.token }}
           GH_NO_UPDATE_NOTIFIER: 1
+          STACKROX_GHA_VERSION: ${{ inputs.STACKROX_GHA_VERSION }}
         run: |
           set -uo pipefail
           script_url="${{env.script_url}}"
-          if [[ "${{github.repository}}" == "stackrox/infra" ]]; then
-            script_url="/repos/stackrox/stackrox/contents/.github/workflows/scripts/common.sh?ref=gavin/RS-574/reuse-cluster-create"
+          if [[ "${{ inputs.STACKROX_GHA_VERSION }}" != "" ]]; then
+            script_url="/repos/stackrox/stackrox/contents/.github/workflows/scripts/common.sh?ref=${{ inputs.STACKROX_GHA_VERSION }}"
           fi
           echo "script_url: $script_url"
           gh api -H "$ACCEPT_RAW" "$script_url" | bash -s -- \

--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -29,6 +29,10 @@ on:
         type: boolean
         required: false
         default: false
+      direct_exec:
+        type: boolean
+        required: false
+        default: false
 
   workflow_dispatch:
     inputs:
@@ -82,10 +86,20 @@ jobs:
           GH_NO_UPDATE_NOTIFIER: 1
         run: |
           set -uo pipefail
-          gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
-            create-cluster \
-            "${{inputs.flavor}}" \
-            "${{inputs.name}}" \
-            "${{inputs.lifespan}}" \
-            "${{inputs.wait}}" \
-            "${{inputs.args}}"
+          if [[ "${{inputs.direct_exec}}" == "true" ]]; then
+            source ./scripts/common.sh
+              ./scripts/create-cluster \
+              "${{inputs.flavor}}" \
+              "${{inputs.name}}" \
+              "${{inputs.lifespan}}" \
+              "${{inputs.wait}}" \
+              "${{inputs.args}}"
+          else
+            gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
+              create-cluster \
+              "${{inputs.flavor}}" \
+              "${{inputs.name}}" \
+              "${{inputs.lifespan}}" \
+              "${{inputs.wait}}" \
+              "${{inputs.args}}"
+          fi

--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -29,10 +29,6 @@ on:
         type: boolean
         required: false
         default: false
-      direct_exec:
-        type: boolean
-        required: false
-        default: false
 
   workflow_dispatch:
     inputs:
@@ -78,6 +74,11 @@ jobs:
           chmod +x ~/.local/bin/infractl
           # Ensure that the binary works
           infractl --version
+
+      - name: Env OK
+        run: |
+          echo "STACKROX_GHA_VERSION: $STACKROX_GHA_VERSION" || true
+          echo "env.STACKROX_GHA_VERSION: ${{ env.STACKROX_GHA_VERSION }}" || true
 
       - name: Create Cluster
         env:

--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -121,5 +121,5 @@ jobs:
           info="$(infractl 2>/dev/null get "$name" --json)"
           echo "Cluster info:"
           echo "$info"
-          status="$(echo $name | jq -r '.Status')"
+          status="$(echo $info | jq -r '.Status')"
           echo "::set-output name=status::$status"

--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -90,6 +90,7 @@ jobs:
           if [[ "${{github.repository}}" == "stackrox/infra" ]]; then
             script_url="/repos/stackrox/stackrox/contents/.github/workflows/scripts/common.sh?ref=gavin/RS-574/reuse-cluster-create"
           fi
+          echo "URL: $script_url"
           gh api -H "$ACCEPT_RAW" "$script_url" | bash -s -- \
             create-cluster \
             "${{inputs.flavor}}" \

--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -86,21 +86,14 @@ jobs:
           GH_NO_UPDATE_NOTIFIER: 1
         run: |
           set -uo pipefail
-          if [[ "${{inputs.direct_exec}}" == "true" ]]; then
-            echo "${{ toJson(github) }}"
-            source ./.github/workflows/scripts/common.sh
-              ./.github/workflows/scripts/create-cluster \
-              "${{inputs.flavor}}" \
-              "${{inputs.name}}" \
-              "${{inputs.lifespan}}" \
-              "${{inputs.wait}}" \
-              "${{inputs.args}}"
-          else
-            gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
-              create-cluster \
-              "${{inputs.flavor}}" \
-              "${{inputs.name}}" \
-              "${{inputs.lifespan}}" \
-              "${{inputs.wait}}" \
-              "${{inputs.args}}"
+          script_url="${{env.script_url}}"
+          if [[ "${{github.repository}}" == "stackrox/infra" ]]; then
+            script_url="/repos/stackrox/stackrox/contents/.github/workflows/scripts/common.sh?ref=gavin/RS-574/reuse-cluster-create"
           fi
+          gh api -H "$ACCEPT_RAW" "$script_url" | bash -s -- \
+            create-cluster \
+            "${{inputs.flavor}}" \
+            "${{inputs.name}}" \
+            "${{inputs.lifespan}}" \
+            "${{inputs.wait}}" \
+            "${{inputs.args}}"

--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -87,6 +87,8 @@ jobs:
         run: |
           set -uo pipefail
           if [[ "${{inputs.direct_exec}}" == "true" ]]; then
+            ls -l
+            pwd
             source ./.github/workflows/scripts/common.sh
               ./.github/workflows/scripts/create-cluster \
               "${{inputs.flavor}}" \

--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -87,8 +87,8 @@ jobs:
         run: |
           set -uo pipefail
           if [[ "${{inputs.direct_exec}}" == "true" ]]; then
-            source ./scripts/common.sh
-              ./scripts/create-cluster \
+            source ./.github/workflows/scripts/common.sh
+              ./.github/workflows/scripts/create-cluster \
               "${{inputs.flavor}}" \
               "${{inputs.name}}" \
               "${{inputs.lifespan}}" \

--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -60,6 +60,11 @@ on:
         type: boolean
         required: false
         default: false
+      STACKROX_GHA_VERSION:
+        description: Sets a version ref for callers in other repos
+        type: string
+        required: false
+        default: ""
 
 env:
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"

--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -90,7 +90,7 @@ jobs:
           if [[ "${{github.repository}}" == "stackrox/infra" ]]; then
             script_url="/repos/stackrox/stackrox/contents/.github/workflows/scripts/common.sh?ref=gavin/RS-574/reuse-cluster-create"
           fi
-          echo "URL: $script_url"
+          echo "script_url: $script_url"
           gh api -H "$ACCEPT_RAW" "$script_url" | bash -s -- \
             create-cluster \
             "${{inputs.flavor}}" \

--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -69,10 +69,6 @@ on:
         type: string
         required: false
         default: ""
-    outputs:
-      status:
-        description: The status of the cluster after this workflow completes
-        value: ${{ jobs.infra.outputs.status }}
 
 env:
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"

--- a/.github/workflows/create-cluster.yml
+++ b/.github/workflows/create-cluster.yml
@@ -34,6 +34,10 @@ on:
         type: string
         required: false
         default: ""
+    outputs:
+      status:
+        description: The status of the cluster after this workflow completes
+        value: ${{ jobs.infra.outputs.status }}
 
   workflow_dispatch:
     inputs:
@@ -65,6 +69,10 @@ on:
         type: string
         required: false
         default: ""
+    outputs:
+      status:
+        description: The status of the cluster after this workflow completes
+        value: ${{ jobs.infra.outputs.status }}
 
 env:
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
@@ -73,6 +81,8 @@ env:
 jobs:
   infra:
     runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.info.outputs.status }}
     steps:
       - name: Download infractl
         run: |
@@ -104,3 +114,16 @@ jobs:
             "${{inputs.lifespan}}" \
             "${{inputs.wait}}" \
             "${{inputs.args}}"
+
+      - name: Get Cluster Info
+        env:
+          INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
+        id: info
+        run: |
+          name="${{inputs.name}}"
+          name="${name//./-}"
+          info="$(infractl 2>/dev/null get "$name" --json)"
+          echo "Cluster info:"
+          echo "$info"
+          status="$(echo $name | jq -r '.Status')"
+          echo "::set-output name=status::$status"

--- a/.github/workflows/scripts/common.sh
+++ b/.github/workflows/scripts/common.sh
@@ -78,7 +78,7 @@ if ! (return 0 2>/dev/null); then # called
 
     URL="/repos/$GITHUB_REPOSITORY/contents/.github/workflows/scripts/$SCRIPT.sh?ref=$GITHUB_REF_NAME"
     if [[ "$GITHUB_REPOSITORY" == "stackrox/infra" ]]; then
-        URL="/repos/stackrox/stackrox/contents/.github/workflows/scripts/common.sh?ref=gavin/RS-574/reuse-cluster-create"
+        URL="/repos/stackrox/stackrox/contents/.github/workflows/scripts/$SCRIPT.sh?ref=gavin/RS-574/reuse-cluster-create"
     fi
     echo "URL: $URL"
     shift

--- a/.github/workflows/scripts/common.sh
+++ b/.github/workflows/scripts/common.sh
@@ -77,6 +77,10 @@ if ! (return 0 2>/dev/null); then # called
         GITHUB_REF_NAME
 
     URL="/repos/$GITHUB_REPOSITORY/contents/.github/workflows/scripts/$SCRIPT.sh?ref=$GITHUB_REF_NAME"
+    if [[ "$GITHUB_REPOSITORY" == "stackrox/infra" ]]; then
+        URL="/repos/stackrox/stackrox/contents/.github/workflows/scripts/common.sh?ref=gavin/RS-574/reuse-cluster-create"
+    fi
+    echo "URL: $URL"
     shift
     gh_log debug "Executing '$SCRIPT.sh' from '$GITHUB_REPOSITORY' $GITHUB_REF_NAME branch with: ${*@Q}"
     gh api -H "Accept: application/vnd.github.v3.raw" "$URL" | bash -s -- "$@"

--- a/.github/workflows/scripts/common.sh
+++ b/.github/workflows/scripts/common.sh
@@ -77,8 +77,8 @@ if ! (return 0 2>/dev/null); then # called
         GITHUB_REF_NAME
 
     URL="/repos/$GITHUB_REPOSITORY/contents/.github/workflows/scripts/$SCRIPT.sh?ref=$GITHUB_REF_NAME"
-    if [[ "$GITHUB_REPOSITORY" == "stackrox/infra" ]]; then
-        URL="/repos/stackrox/stackrox/contents/.github/workflows/scripts/$SCRIPT.sh?ref=gavin/RS-574/reuse-cluster-create"
+    if [[ "${STACKROX_GHA_VERSION:-}" != "" ]]; then
+        URL="/repos/stackrox/stackrox/contents/.github/workflows/scripts/$SCRIPT.sh?ref=$STACKROX_GHA_VERSION"
     fi
     echo "URL: $URL"
     shift

--- a/.github/workflows/scripts/common.sh
+++ b/.github/workflows/scripts/common.sh
@@ -80,7 +80,6 @@ if ! (return 0 2>/dev/null); then # called
     if [[ "${STACKROX_GHA_VERSION:-}" != "" ]]; then
         URL="/repos/stackrox/stackrox/contents/.github/workflows/scripts/$SCRIPT.sh?ref=$STACKROX_GHA_VERSION"
     fi
-    echo "URL: $URL"
     shift
     gh_log debug "Executing '$SCRIPT.sh' from '$GITHUB_REPOSITORY' $GITHUB_REF_NAME branch with: ${*@Q}"
     gh api -H "Accept: application/vnd.github.v3.raw" "$URL" | bash -s -- "$@"


### PR DESCRIPTION
## Description

Allows the cluster-create.yml workflow to be reused by other repos. e.g. https://github.com/stackrox/infra/pull/710

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient