### PR TITLE
ROX-12956: Increase requestTimeout and disable colors for integration tests

### DIFF
--- a/ui/apps/platform/cypress.config.js
+++ b/ui/apps/platform/cypress.config.js
@@ -10,6 +10,7 @@ module.exports = {
     blockHosts: ['*.*'], // Browser options
     chromeWebSecurity: false, // Browser options
     numTestsKeptInMemory: 0, // Global options
+    requestTimeout: 10000, // Timeouts options
     viewportHeight: 850, // Viewport options
     viewportWidth: 1440, // Viewport options
 

--- a/ui/apps/platform/cypress/helpers/compliance.js
+++ b/ui/apps/platform/cypress/helpers/compliance.js
@@ -64,7 +64,6 @@ const opnameAliasesMap = {
 };
 
 const waitOptions = {
-    requestTimeout: 10000, // because so many requests
     responseTimeout: 20000, // for 6 complianceStandards responses
 };
 

--- a/ui/apps/platform/cypress/helpers/compliance.js
+++ b/ui/apps/platform/cypress/helpers/compliance.js
@@ -63,11 +63,7 @@ const opnameAliasesMap = {
     complianceStandards,
 };
 
-const waitOptions = {
-    responseTimeout: 20000, // for 6 complianceStandards responses
-};
-
-const requestConfig = { routeMatcherMap, opnameAliasesMap, waitOptions };
+const requestConfig = { routeMatcherMap, opnameAliasesMap };
 
 export function visitComplianceDashboard() {
     visit(url.dashboard, requestConfig);

--- a/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
+++ b/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
@@ -185,14 +185,6 @@ const requestConfigForDashboard = {
     routeMatcherMap: routeMatcherMapForDashboard,
 };
 
-const requestConfigForScan = {
-    routeMatcherMap: routeMatcherMapForDashboard,
-    waitOptions: {
-        requestTimeout: 10000, // because so many requests
-        responseTimeout: 20000, // for responses
-    },
-};
-
 export function visitConfigurationManagementDashboard() {
     visit(basePath, requestConfigForDashboard);
 
@@ -265,7 +257,7 @@ export function interactAndWaitForConfigurationManagementSecondaryEntities(
 }
 
 export function interactAndWaitForConfigurationManagementScan(interactionCallback) {
-    interactAndWaitForResponses(interactionCallback, requestConfigForScan);
+    interactAndWaitForResponses(interactionCallback, requestConfigForDashboard);
 }
 
 // specifying an "entityName" will try to select that row in the table

--- a/ui/apps/platform/scripts/cypress.sh
+++ b/ui/apps/platform/scripts/cypress.sh
@@ -33,5 +33,5 @@ if [ $2 == "--spec" ]; then
     fi
     cypress run --spec "cypress/integration/$3"
 else
-    DEBUG="*" cypress "$@" 2> /dev/null
+    DEBUG="*" NO_COLOR=1 cypress "$@" 2> /dev/null
 fi


### PR DESCRIPTION
## Description

### Test failure

1. 1576986632538558464 from master build for #3272 on 2022-10-03

> Policy wizard, Step 3 Policy Criteria Existing values should populate select dropdown

> `cy.wait()` timed out waiting `5000ms` for the 1st request to the route: `credentialexpiry_CENTRAL`. No request ever occurred.

![prow](https://user-images.githubusercontent.com/11862657/193907897-5f31b2d0-5e4f-49a1-8a11-0297f0423911.png)

cypress/integration/policies/policyWizardStep3.test.js

### Analysis

This is the third investigation to examine the build-log.text file. The second was in #3268

Compare 5 occurrences of **Refreshing the GKE auth token**. TL;DR see 4 below

1. During video processing and docs.test.js which is an external link which does not have API requests.
    ```text
    INFO: Mon Oct  3 18:12:35 UTC 2022: Refreshing the GKE auth token
       -  Finished processing: /go/src/github.com/stackrox/stackrox/ui/test-results/artifa    (4 seconds)
                               cts/videos/certexpiration.test.js.mp4                                     
     ────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                         
       Running:  docs.test.js                                                                   (4 of 82)
     
       Documentation Access
    Fetching cluster endpoint and auth data.
         ✓ should load the documentation page
       1 passing (2s)
    kubeconfig entry generated for rox-ci-ui-e2e-test-1576986632538558464.
    ```

2. During video processing and maybe after the last test had finished.
    ```text
        ✓ should have the same number of Deployments in the count widget as in the Deployments table (10756ms)
    INFO: Mon Oct  3 18:27:44 UTC 2022: Refreshing the GKE auth token
        ✓ should allow user to drill down from cluster to image to image-deployments
    8 passing (30s)
    (Results)
    ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
    │ Tests:        8                                                                                │
    │ Passing:      8                                                                                │
    │ Failing:      0                                                                                │
    │ Pending:      0                                                                                │
    │ Skipped:      0                                                                                │
    │ Screenshots:  0                                                                                │
    │ Video:        true                                                                             │
    │ Duration:     29 seconds                                                                       │
    │ Spec Ran:     images.test.js                                                                   │
    └────────────────────────────────────────────────────────────────────────────────────────────────┘
    (Video)
    -  Started processing:  Compressing to 32 CRF                                                     
    Fetching cluster endpoint and auth data.
    kubeconfig entry generated for rox-ci-ui-e2e-test-1576986632538558464.
    ```

3. Maybe before the first test had started.
    ```text
    Signature Integrations Test
    INFO: Mon Oct  3 18:42:53 UTC 2022: Refreshing the GKE auth token
    Fetching cluster endpoint and auth data.
    kubeconfig entry generated for rox-ci-ui-e2e-test-1576986632538558464.
        ✓ should create a new signature integration (41533ms)
    ```

4. **Bingo!** picture above is for `should populate select dropdown`
    ```text
        Existing values
        ✓ should populate boolean radio buttons (8340ms)
    INFO: Mon Oct  3 18:58:06 UTC 2022: Refreshing the GKE auth token
        ✓ should populate string radio buttons (10395ms)
    Fetching cluster endpoint and auth data.
    kubeconfig entry generated for rox-ci-ui-e2e-test-1576986632538558464.
        ✓ should populate text input (10999ms)
        1) should populate select dropdown
        ✓ should populate multiselect dropdown (10035ms)
        ✓ should populate policy field input nested group (10960ms)
    27 passing (7m)
    1 failing
    ```

5. During video processing between test files.
    ```text
    -  Started processing:  Compressing to 32 CRF                                                     
    INFO: Mon Oct  3 19:13:20 UTC 2022: Refreshing the GKE auth token
    -  Finished processing: /go/src/github.com/stackrox/stackrox/ui/test-results/artifa    (5 seconds)
                            cts/videos/vulnmanagement/namespacesListPages.test.js.mp4                 
    ────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                        
    Running:  nodeComponentsListPages.test.js                                               (73 of 82)
    Fetching cluster endpoint and auth data.
    kubeconfig entry generated for rox-ci-ui-e2e-test-1576986632538558464.
    ```

### Solution

1. Edit scripts/cypress.sh

    To simplify search and eliminate editing, disable color in cypress output to build-log.txt file.

    > If you want colors to be disabled, you can pass the `NO_COLOR` environment variable to disable colors. You may want to do this if ASCII characters or colors are not properly formatted in your CI.

    https://docs.cypress.io/guides/continuous-integration/introduction#Colors

2. Edit cypress.config.js

    Double `requestTimeout` from 5000 to 10000 milliseconds.

    > `requestTimeout` default `5000` Time, in milliseconds, to wait until a response

    https://docs.cypress.io/guides/references/configuration#Timeouts

3. Delete `waitOptions` because default `responseTimeout` is `30000`
    * Edit cypress/helpers/compliance.js
    * Edit cypress/helpers/configWorkflowUtils.js

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed