### PR TITLE
Conditionally skip with hasFeatureFlag in vulnmanagement integration tests

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusterCvesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusterCvesListPages.test.js
@@ -101,8 +101,7 @@ describe('Vulnerability Management Cluster (Platform) CVEs', () => {
 
     // Some tests might fail in local deployment.
 
-    // TODO Investigate why CI displays No clusters instead of 2 clusters.
-    it.skip('should display links for clusters', () => {
+    it('should display links for clusters', () => {
         verifySecondaryEntities(
             entitiesKey,
             'clusters',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
@@ -76,17 +76,27 @@ describe('Vulnerability Management Dashboard', () => {
             });
     });
 
-    // TODO Delete skip when we delete ROX_POSTGRES_DATASTORE feature flag.
+    it('should show same number of Image CVEs in menu item and entities list', function () {
+        if (!hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
+            this.skip();
+        }
 
-    it.skip('should show same number of Image CVEs in menu item and entities list', () => {
         verifyVulnerabilityManagementDashboardCVEs('image-cves', /^\d+ Image CVEs?$/);
     });
 
-    it.skip('should show same number of Node CVEs in menu item and entities list', () => {
+    it('should show same number of Node CVEs in menu item and entities list', function () {
+        if (!hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
+            this.skip();
+        }
+
         verifyVulnerabilityManagementDashboardCVEs('node-cves', /^\d+ Node CVEs?$/);
     });
 
-    it.skip('should show same number of Cluster (Platform) CVEs in menu item and entities list', () => {
+    it('should show same number of Cluster (Platform) CVEs in menu item and entities list', function () {
+        if (!hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
+            this.skip();
+        }
+
         verifyVulnerabilityManagementDashboardCVEs('cluster-cves', /^\d+ Platform CVEs?$/);
     });
 
@@ -142,9 +152,11 @@ describe('Vulnerability Management Dashboard', () => {
         );
     });
 
-    // TODO Delete skip when we delete ROX_POSTGRES_DATASTORE feature flag.
+    it('should navigate to the node components list', function () {
+        if (!hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
+            this.skip();
+        }
 
-    it.skip('should navigate to the node components list', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'node-components';
@@ -156,7 +168,11 @@ describe('Vulnerability Management Dashboard', () => {
         );
     });
 
-    it.skip('should navigate to the image components list', () => {
+    it('should navigate to the image components list', function () {
+        if (!hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
+            this.skip();
+        }
+
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'image-components';


### PR DESCRIPTION
## Description

Follow up after #3131

Run tests when `'ROX_POSTGRES_DATASTORE'` feature flag is enabled.

1. Edit cypress/integration/vulnmanagement/clusterCvesListPages.test.js
    * Delete `skip` because problem has been fixed.

2. Edit cypress/integration/vulnmanagement/dashboard.test.js
    * Delete 2 comments and replace unconditional `skip` with conditional skip in 5 tests.

### Residue

Investigate whether not yet supported or incorrect field in payload.

1. Severity
    * cypress/integration/vulnmanagement/imageCvesListPages.test.js
    * cypress/integration/vulnmanagement/nodeCvesListPages.test.js

2. Top CVSS
    * cypress/integration/vulnmanagement/imageComponentsListPages.test.js
    * cypress/integration/vulnmanagement/imagesListPages.test.js
    * cypress/integration/vulnmanagement/nodeComponentsListPages.test.js
    * cypress/integration/vulnmanagement/nodesListPages.test.js

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed