### PR TITLE
[ROX-12955] : Add CVE field query instead of VULNERABILITY scoping in vuln request manager when Postgres is enabled

### DIFF
--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -409,14 +409,12 @@ func (m *managerImpl) getFixableDeferrals() ([]*storage.VulnerabilityRequest, er
 			// TODO: Determine if it's worth checking cvePkg.ContainsComponentBasedCVE(cve.GetTypes()) before doing this. It would involve going to the data store to read CVE data
 			// This is only necessary if somehow there ended up being a deferral on a cluster CVE. Or if it goes from an image cve to node cve
 			// TODO: Test what happens if it's a cluster cve
-			var cveScopedCtx context.Context
+			var ctx context.Context
 			if env.PostgresDatastoreEnabled.BooleanSetting() {
-				cveScopedCtx = scoped.Context(allAccessCtx, scoped.Scope{
-					Level: v1.SearchCategory_IMAGE_VULNERABILITIES,
-				})
+				ctx = allAccessCtx
 				qb.AddExactMatches(search.CVE, cve)
 			} else {
-				cveScopedCtx = scoped.Context(allAccessCtx, scoped.Scope{
+				ctx = scoped.Context(allAccessCtx, scoped.Scope{
 					ID:    cve,
 					Level: v1.SearchCategory_VULNERABILITIES,
 				})
@@ -426,7 +424,7 @@ func (m *managerImpl) getFixableDeferrals() ([]*storage.VulnerabilityRequest, er
 			if err != nil {
 				return nil, err
 			}
-			count, err := m.componentCVEEdges.Count(cveScopedCtx, fixableQuery)
+			count, err := m.componentCVEEdges.Count(ctx, fixableQuery)
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not fetch cve component edge for cve %q for request %q", cve, res.GetId())
 			}

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/batcher"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/sac"
@@ -406,10 +407,18 @@ func (m *managerImpl) getFixableDeferrals() ([]*storage.VulnerabilityRequest, er
 			// TODO: Determine if it's worth checking cvePkg.ContainsComponentBasedCVE(cve.GetTypes()) before doing this. It would involve going to the data store to read CVE data
 			// This is only necessary if somehow there ended up being a deferral on a cluster CVE. Or if it goes from an image cve to node cve
 			// TODO: Test what happens if it's a cluster cve
-			cveScopedCtx := scoped.Context(allAccessCtx, scoped.Scope{
-				ID:    cve,
-				Level: v1.SearchCategory_VULNERABILITIES,
-			})
+			var cveScopedCtx context.Context
+			if env.PostgresDatastoreEnabled.BooleanSetting() {
+				cveScopedCtx = scoped.Context(allAccessCtx, scoped.Scope{
+					ID:    cve,
+					Level: v1.SearchCategory_VULNERABILITIES,
+				})
+			} else {
+				cveScopedCtx = scoped.Context(allAccessCtx, scoped.Scope{
+					ID:    cve,
+					Level: v1.SearchCategory_VULNERABILITIES,
+				})
+			}
 
 			fixableQuery, err := utils.GetAffectedImagesQuery(res, search.NewQueryBuilder().AddBools(search.Fixable, true).ProtoQuery())
 			if err != nil {

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -403,19 +403,19 @@ func (m *managerImpl) getFixableDeferrals() ([]*storage.VulnerabilityRequest, er
 	}
 	var fixableReqs []*storage.VulnerabilityRequest
 	for _, res := range results {
-		for _, cve := range res.GetCves().GetIds() {
+		for _, cveId := range res.GetCves().GetIds() {
 			// TODO: Determine if it's worth checking cvePkg.ContainsComponentBasedCVE(cve.GetTypes()) before doing this. It would involve going to the data store to read CVE data
 			// This is only necessary if somehow there ended up being a deferral on a cluster CVE. Or if it goes from an image cve to node cve
 			// TODO: Test what happens if it's a cluster cve
 			var cveScopedCtx context.Context
 			if env.PostgresDatastoreEnabled.BooleanSetting() {
 				cveScopedCtx = scoped.Context(allAccessCtx, scoped.Scope{
-					ID:    cve,
-					Level: v1.SearchCategory_VULNERABILITIES,
+					ID:    cveId,
+					Level: v1.SearchCategory_IMAGE_VULNERABILITIES,
 				})
 			} else {
 				cveScopedCtx = scoped.Context(allAccessCtx, scoped.Scope{
-					ID:    cve,
+					ID:    cveId,
 					Level: v1.SearchCategory_VULNERABILITIES,
 				})
 			}
@@ -424,10 +424,10 @@ func (m *managerImpl) getFixableDeferrals() ([]*storage.VulnerabilityRequest, er
 			if err != nil {
 				return nil, err
 			}
-
+			log.Info("ROX-12955 : Vuln req manager about to query if cve is fixable")
 			count, err := m.componentCVEEdges.Count(cveScopedCtx, fixableQuery)
 			if err != nil {
-				return nil, errors.Wrapf(err, "could not fetch cve component edge for cve %q for request %q", cve, res.GetId())
+				return nil, errors.Wrapf(err, "could not fetch cve component edge for cve %q for request %q", cveId, res.GetId())
 			}
 
 			if count != 0 { // This CVE is fixable for this image (or for all images in the query)

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -403,19 +403,19 @@ func (m *managerImpl) getFixableDeferrals() ([]*storage.VulnerabilityRequest, er
 	}
 	var fixableReqs []*storage.VulnerabilityRequest
 	for _, res := range results {
-		for _, cveId := range res.GetCves().GetIds() {
+		for _, cve := range res.GetCves().GetIds() {
 			// TODO: Determine if it's worth checking cvePkg.ContainsComponentBasedCVE(cve.GetTypes()) before doing this. It would involve going to the data store to read CVE data
 			// This is only necessary if somehow there ended up being a deferral on a cluster CVE. Or if it goes from an image cve to node cve
 			// TODO: Test what happens if it's a cluster cve
 			var cveScopedCtx context.Context
 			if env.PostgresDatastoreEnabled.BooleanSetting() {
 				cveScopedCtx = scoped.Context(allAccessCtx, scoped.Scope{
-					ID:    cveId,
+					ID:    cve,
 					Level: v1.SearchCategory_IMAGE_VULNERABILITIES,
 				})
 			} else {
 				cveScopedCtx = scoped.Context(allAccessCtx, scoped.Scope{
-					ID:    cveId,
+					ID:    cve,
 					Level: v1.SearchCategory_VULNERABILITIES,
 				})
 			}
@@ -424,10 +424,9 @@ func (m *managerImpl) getFixableDeferrals() ([]*storage.VulnerabilityRequest, er
 			if err != nil {
 				return nil, err
 			}
-			log.Info("ROX-12955 : Vuln req manager about to query if cve is fixable")
 			count, err := m.componentCVEEdges.Count(cveScopedCtx, fixableQuery)
 			if err != nil {
-				return nil, errors.Wrapf(err, "could not fetch cve component edge for cve %q for request %q", cveId, res.GetId())
+				return nil, errors.Wrapf(err, "could not fetch cve component edge for cve %q for request %q", cve, res.GetId())
 			}
 
 			if count != 0 { // This CVE is fixable for this image (or for all images in the query)

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -411,7 +411,9 @@ func (m *managerImpl) getFixableDeferrals() ([]*storage.VulnerabilityRequest, er
 			// TODO: Test what happens if it's a cluster cve
 			var cveScopedCtx context.Context
 			if env.PostgresDatastoreEnabled.BooleanSetting() {
-				cveScopedCtx = allAccessCtx
+				cveScopedCtx = scoped.Context(allAccessCtx, scoped.Scope{
+					Level: v1.SearchCategory_IMAGE_VULNERABILITIES,
+				})
 				qb.AddExactMatches(search.CVE, cve)
 			} else {
 				cveScopedCtx = scoped.Context(allAccessCtx, scoped.Scope{

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -404,15 +404,15 @@ func (m *managerImpl) getFixableDeferrals() ([]*storage.VulnerabilityRequest, er
 	var fixableReqs []*storage.VulnerabilityRequest
 	for _, res := range results {
 		for _, cve := range res.GetCves().GetIds() {
+			qb := search.NewQueryBuilder().AddBools(search.Fixable, true)
+
 			// TODO: Determine if it's worth checking cvePkg.ContainsComponentBasedCVE(cve.GetTypes()) before doing this. It would involve going to the data store to read CVE data
 			// This is only necessary if somehow there ended up being a deferral on a cluster CVE. Or if it goes from an image cve to node cve
 			// TODO: Test what happens if it's a cluster cve
 			var cveScopedCtx context.Context
 			if env.PostgresDatastoreEnabled.BooleanSetting() {
-				cveScopedCtx = scoped.Context(allAccessCtx, scoped.Scope{
-					ID:    cve,
-					Level: v1.SearchCategory_IMAGE_VULNERABILITIES,
-				})
+				cveScopedCtx = allAccessCtx
+				qb.AddExactMatches(search.CVE, cve)
 			} else {
 				cveScopedCtx = scoped.Context(allAccessCtx, scoped.Scope{
 					ID:    cve,
@@ -420,7 +420,7 @@ func (m *managerImpl) getFixableDeferrals() ([]*storage.VulnerabilityRequest, er
 				})
 			}
 
-			fixableQuery, err := utils.GetAffectedImagesQuery(res, search.NewQueryBuilder().AddBools(search.Fixable, true).ProtoQuery())
+			fixableQuery, err := utils.GetAffectedImagesQuery(res, qb.ProtoQuery())
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Description

Scoping searches by searchCategory_VULNERABILITIES is not supported on Postgres. Also, the CVEs in vulnerability requests cannot be used as CVE IDs because Postgres datastores do not directly use CVE string as IDs. So, on postgres, vuln request manager should add a CVE conjunction query instead of scoping.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Manually tested by creating a deferral request until fixable, and see that deferral is handled properly post approval and does not cause any crashes on central restart. Perform the test for both postgres and rocksDB.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
