### PR TITLE
Dashrews/ROX-12094 cleanup postgres after rollback to rocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -515,7 +515,7 @@ go-postgres-unit-tests: build-prep test-prep
 	@# The -p 1 passed to go test is required to ensure that tests of different packages are not run in parallel, so as to avoid conflicts when interacting with the DB.
 	set -o pipefail ; \
 	CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 ROX_POSTGRES_DATASTORE=true GOTAGS=$(GOTAGS),test,sql_integration scripts/go-test.sh -p 1 -race -cover -coverprofile test-output/coverage.out -v \
-		$(shell git ls-files -- '*postgres/*_test.go' '*postgres_test.go' '*datastore_sac_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
+		$(shell git ls-files -- '*postgres/*_test.go' '*postgres_test.go' '*datastore_sac_test.go' '*clone_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
 		| tee $(GO_TEST_OUTPUT_PATH)
 
 .PHONY: shell-unit-tests

--- a/migrator/clone/mock_central.go
+++ b/migrator/clone/mock_central.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -355,6 +356,12 @@ func (m *mockCentral) verifyMigrationVersion(dbPath string, ver *versionPair) {
 }
 
 func (m *mockCentral) verifyMigrationVersionPostgres(clone string, ver *versionPair) {
+	pc, _, _, ok := runtime.Caller(1)
+	details := runtime.FuncForPC(pc)
+	if ok && details != nil {
+		fmt.Printf("called from %s\n", details.Name())
+	}
+	log.Infof("SHREWS %q", clone)
 	pool := pgadmin.GetClonePool(m.adminConfig, clone)
 	defer pool.Close()
 

--- a/migrator/clone/mock_central.go
+++ b/migrator/clone/mock_central.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"testing"
 
@@ -121,7 +120,6 @@ func (m *mockCentral) upgradeCentral(ver *versionPair, breakpoint string) {
 	if env.PostgresDatastoreEnabled.BooleanSetting() && m.runBoth {
 		if version.CompareVersions(curVer.version, "3.0.57.0") >= 0 {
 			if pgadmin.CheckIfDBExists(m.adminConfig, postgres.PreviousClone) {
-				log.Info("SHREWS 1")
 				m.verifyClonePostgres(postgres.PreviousClone, curVer)
 			}
 		} else {
@@ -129,7 +127,6 @@ func (m *mockCentral) upgradeCentral(ver *versionPair, breakpoint string) {
 		}
 	} else if env.PostgresDatastoreEnabled.BooleanSetting() {
 		if version.CompareVersions(curVer.version, "3.0.57.0") >= 0 {
-			log.Info("SHREWS 2")
 			m.verifyClonePostgres(postgres.PreviousClone, curVer)
 		} else {
 			assert.False(m.t, pgadmin.CheckIfDBExists(m.adminConfig, postgres.PreviousClone))
@@ -270,7 +267,6 @@ func (m *mockCentral) restoreCentral(ver *versionPair, breakPoint string) {
 	}
 	m.runMigrator("", "")
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		log.Info("SHREWS 3")
 		m.verifyClonePostgres(postgres.BackupClone, curVer)
 		m.runCentral()
 	} else {
@@ -331,11 +327,6 @@ func (m *mockCentral) verifyClone(clone string, ver *versionPair) {
 }
 
 func (m *mockCentral) verifyClonePostgres(clone string, ver *versionPair) {
-	pc, _, _, ok := runtime.Caller(1)
-	details := runtime.FuncForPC(pc)
-	if ok && details != nil {
-		fmt.Printf("called from %s\n", details.Name())
-	}
 	if version.CompareVersions(ver.version, "3.0.57.0") >= 0 {
 		m.verifyMigrationVersionPostgres(clone, ver)
 	} else {
@@ -370,12 +361,6 @@ func (m *mockCentral) verifyMigrationVersion(dbPath string, ver *versionPair) {
 }
 
 func (m *mockCentral) verifyMigrationVersionPostgres(clone string, ver *versionPair) {
-	pc, _, _, ok := runtime.Caller(1)
-	details := runtime.FuncForPC(pc)
-	if ok && details != nil {
-		fmt.Printf("called from %s\n", details.Name())
-	}
-	log.Infof("SHREWS %q", clone)
 	pool := pgadmin.GetClonePool(m.adminConfig, clone)
 	defer pool.Close()
 

--- a/migrator/clone/mock_central.go
+++ b/migrator/clone/mock_central.go
@@ -220,6 +220,12 @@ func (m *mockCentral) runMigrator(breakPoint string, forceRollback string) {
 	m.updateBoth = false
 	if clone != "" && pgClone != "" {
 		m.updateBoth = true
+
+		// If we are migrating from Rocks, it could be a subsequent upgrade.  If so we will
+		// have deleted the current Postgres DB.  We need to re-create it here for the rest
+		// of the test.  This will naturally be recreated in migrator, but we are focused on the clones
+		// here and such that code is not executed as part of this test
+		pgtest.CreateDatabase(m.t, migrations.GetCurrentClone())
 	}
 
 	require.NoError(m.t, dbm.Persist(clone, pgClone, m.updateBoth))

--- a/migrator/clone/mock_central.go
+++ b/migrator/clone/mock_central.go
@@ -121,6 +121,7 @@ func (m *mockCentral) upgradeCentral(ver *versionPair, breakpoint string) {
 	if env.PostgresDatastoreEnabled.BooleanSetting() && m.runBoth {
 		if version.CompareVersions(curVer.version, "3.0.57.0") >= 0 {
 			if pgadmin.CheckIfDBExists(m.adminConfig, postgres.PreviousClone) {
+				log.Info("SHREWS 1")
 				m.verifyClonePostgres(postgres.PreviousClone, curVer)
 			}
 		} else {
@@ -128,6 +129,7 @@ func (m *mockCentral) upgradeCentral(ver *versionPair, breakpoint string) {
 		}
 	} else if env.PostgresDatastoreEnabled.BooleanSetting() {
 		if version.CompareVersions(curVer.version, "3.0.57.0") >= 0 {
+			log.Info("SHREWS 2")
 			m.verifyClonePostgres(postgres.PreviousClone, curVer)
 		} else {
 			assert.False(m.t, pgadmin.CheckIfDBExists(m.adminConfig, postgres.PreviousClone))
@@ -262,6 +264,7 @@ func (m *mockCentral) restoreCentral(ver *versionPair, breakPoint string) {
 	}
 	m.runMigrator("", "")
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		log.Info("SHREWS 3")
 		m.verifyClonePostgres(postgres.BackupClone, curVer)
 		m.runCentral()
 	} else {
@@ -322,6 +325,11 @@ func (m *mockCentral) verifyClone(clone string, ver *versionPair) {
 }
 
 func (m *mockCentral) verifyClonePostgres(clone string, ver *versionPair) {
+	pc, _, _, ok := runtime.Caller(1)
+	details := runtime.FuncForPC(pc)
+	if ok && details != nil {
+		fmt.Printf("called from %s\n", details.Name())
+	}
 	if version.CompareVersions(ver.version, "3.0.57.0") >= 0 {
 		m.verifyMigrationVersionPostgres(clone, ver)
 	} else {

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -165,6 +165,7 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 			// We want to start fresh as we are migrating from Rocks->Postgres.  So any data that exists in
 			// Postgres from a previous upgrade followed by a rollback needs to be ignored.  So just drop current
 			// and let it create anew.
+			log.Infof("To start with a clean Postgres, dropping database %q", CurrentClone)
 			err := pgadmin.DropDB(d.sourceMap, d.adminConfig, CurrentClone)
 			if err != nil {
 				log.Errorf("Unable to drop current clone: %v", err)

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -168,17 +168,7 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 			err := pgadmin.DropDB(d.sourceMap, d.adminConfig, CurrentClone)
 			if err != nil {
 				log.Errorf("Unable to drop current clone: %v", err)
-
-				// The drop of the current clone is unlikely to fail, in the event it does; we can try to
-				// process with temp.
-				err = pgadmin.DropDB(d.sourceMap, d.adminConfig, TempClone)
-				if err != nil {
-					log.Errorf("Unable to clean databases for migration: %v", err)
-					return "", true, err
-				}
-
-				d.cloneMap[TempClone] = metadata.NewPostgres(d.cloneMap[CurrentClone].GetMigVersion(), TempClone)
-				return TempClone, true, nil
+				return "", true, err
 			}
 
 			return CurrentClone, true, nil

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -162,24 +162,22 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 		// Rocks more recently updated than Postgres so need to migrate from there.  Otherwise, Postgres is more recent
 		// so just fall through to the rest of the processing.
 		if currClone.GetMigVersion().LastPersisted.Before(rocksVersion.LastPersisted) {
-			// Rollback is not enabled, so process the Rocks -> Postgres migration on CurrentClone.
-			if !d.rollbackEnabled() {
-				return CurrentClone, true, nil
-			}
+			// We want to start fresh as we are migrating from Rocks->Postgres.  So any data that exists in
+			// Postgres from a previous upgrade followed by a rollback needs to be ignored.
+			err := pgadmin.DropDB(d.sourceMap, d.adminConfig, CurrentClone)
 
 			// Create a temp clone for processing of current
 			// Seed it from an empty database because we need to run migrations from Rocks to Postgres.
-			if !d.databaseExists(TempClone) {
-				err := pgadmin.CreateDB(d.sourceMap, d.adminConfig, pgadmin.EmptyDB, TempClone)
-
-				// If for some reason, we cannot create a temp clone we will need to continue to upgrade
-				// with the current and thus no fallback.
-				if err != nil {
-					log.Errorf("Unable to create temp clone: %v", err)
-				}
+			err = pgadmin.CreateDB(d.sourceMap, d.adminConfig, pgadmin.EmptyDB, TempClone)
+			// If for some reason, we cannot create a temp clone we will need to continue to upgrade
+			// with the current.
+			if err != nil {
+				log.Errorf("Unable to create temp clone: %v", err)
+				return CurrentClone, false, nil
 			}
+
 			d.cloneMap[TempClone] = metadata.NewPostgres(d.cloneMap[CurrentClone].GetMigVersion(), TempClone)
-			return TempClone, true, nil
+			return CurrentClone, true, nil
 		}
 		log.Info("Postgres is the more recent version so we will process that.")
 	}

--- a/migrator/clone/postgres/db_clone_manager_impl_test.go
+++ b/migrator/clone/postgres/db_clone_manager_impl_test.go
@@ -277,7 +277,7 @@ func (s *PostgresCloneManagerSuite) TestGetCloneMigrateRocks() {
 
 	// Need to migrate from Rocks because Rocks is more current.
 	clone, migrateRocks, err := dbm.GetCloneToMigrate(rocksVersion)
-	s.Equal(clone, tempDB)
+	s.Equal(clone, CurrentClone)
 	s.True(migrateRocks)
 	s.Nil(err)
 
@@ -302,7 +302,7 @@ func (s *PostgresCloneManagerSuite) TestGetCloneMigrateRocks() {
 	// Need to re-scan to get the clone deletion
 	s.Nil(dbm.Scan())
 	clone, migrateRocks, err = dbm.GetCloneToMigrate(rocksVersion)
-	s.Equal(clone, tempDB)
+	s.Equal(clone, CurrentClone)
 	s.True(migrateRocks)
 	s.Nil(err)
 

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -238,7 +239,11 @@ func GetAdminPool(postgresConfig *pgxpool.Config) *pgxpool.Pool {
 // THIS POOL SHOULD BE CLOSED ONCE ITS PURPOSE HAS BEEN FULFILLED.
 func GetClonePool(postgresConfig *pgxpool.Config, clone string) *pgxpool.Pool {
 	log.Debugf("GetClonePool -- %q", clone)
-
+	pc, _, _, ok := runtime.Caller(1)
+	details := runtime.FuncForPC(pc)
+	if ok && details != nil {
+		fmt.Printf("called from %s\n", details.Name())
+	}
 	// Clone config to connect to template DB
 	tempConfig := postgresConfig.Copy()
 

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -345,13 +345,14 @@ func getAvailablePostgresCapacity(postgresConfig *pgxpool.Config) (int64, error)
 			}
 			return 0, err
 		}
-
+		log.Info(info)
 		rawCapacityInfo = append(rawCapacityInfo, info)
 	}
 
 	// We should only get the header row and the row for the size of $PGDATA.  If we
 	// get more than that, then $PGDATA is not defined
 	if len(rawCapacityInfo) > 2 {
+		log.Info(len(rawCapacityInfo))
 		if err := tx.Rollback(ctx); err != nil {
 			return 0, err
 		}

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -239,11 +238,7 @@ func GetAdminPool(postgresConfig *pgxpool.Config) *pgxpool.Pool {
 // THIS POOL SHOULD BE CLOSED ONCE ITS PURPOSE HAS BEEN FULFILLED.
 func GetClonePool(postgresConfig *pgxpool.Config, clone string) *pgxpool.Pool {
 	log.Debugf("GetClonePool -- %q", clone)
-	pc, _, _, ok := runtime.Caller(1)
-	details := runtime.FuncForPC(pc)
-	if ok && details != nil {
-		fmt.Printf("called from %s\n", details.Name())
-	}
+
 	// Clone config to connect to template DB
 	tempConfig := postgresConfig.Copy()
 
@@ -345,14 +340,12 @@ func getAvailablePostgresCapacity(postgresConfig *pgxpool.Config) (int64, error)
 			}
 			return 0, err
 		}
-		log.Info(info)
 		rawCapacityInfo = append(rawCapacityInfo, info)
 	}
 
 	// We should only get the header row and the row for the size of $PGDATA.  If we
 	// get more than that, then $PGDATA is not defined
 	if len(rawCapacityInfo) > 2 {
-		log.Info(len(rawCapacityInfo))
 		if err := tx.Rollback(ctx); err != nil {
 			return 0, err
 		}

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -340,6 +340,7 @@ func getAvailablePostgresCapacity(postgresConfig *pgxpool.Config) (int64, error)
 			}
 			return 0, err
 		}
+
 		rawCapacityInfo = append(rawCapacityInfo, info)
 	}
 


### PR DESCRIPTION
## Description

In the event we upgrade from Rocks to Postgres and then downgrade back to Rocks, we could leave ourselves in a situation where we have lingering stale Postgres data on the subsequent upgrade back to Postgres.  So to alleviate that, if we have a situation where we determine we need to migrate from Rocks to Postgres, either initially or on an upgrade, we will clear out the Postgres data and start Postgres fresh.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Updated the unit tests as well as the clone test.  I also noticed that the clone test was not executed in Postgres tests which was an oversight from before.  So I updated the Makefile to correct that oversight.
