### PR TITLE
Pull k8s events as yaml file also in case of test failure

### DIFF
--- a/scripts/ci/collect-service-logs.sh
+++ b/scripts/ci/collect-service-logs.sh
@@ -80,7 +80,9 @@ main() {
         done
     done
 
+    kubectl -n "${namespace}" get events -o wide >"${log_dir}/events.txt"
     kubectl -n "${namespace}" get events -o yaml >"${log_dir}/events.yaml"
+
     find "${log_dir}" -type f -size 0 -delete
 }
 

--- a/scripts/ci/collect-service-logs.sh
+++ b/scripts/ci/collect-service-logs.sh
@@ -80,7 +80,7 @@ main() {
         done
     done
 
-    kubectl -n "${namespace}" get events -o wide >"${log_dir}/events.txt"
+    kubectl -n "${namespace}" get events -o yaml >"${log_dir}/events.yaml"
     find "${log_dir}" -type f -size 0 -delete
 }
 


### PR DESCRIPTION
## Description

The problem with `kubectl get events -o wide` is that the `LAST SEEN` and the `FIRST SEEN` columns have _relative_ timestamps like `4m11s`. This is very inconvenient in investigating CI failures because one needs to know the instant when `kubectl get events` was ran and do the math.

I suggest that we dump events in yaml format which preserves the original info and absolute timestamps like `2022-10-05T10:31:32Z`.

This relates to https://issues.redhat.com/browse/ROX-12963

## Checklist
- [x] Investigated and inspected CI test results

None of these needed:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* None. Should just work.
