### PR TITLE
Make nightly tag clickable in Slack

### DIFF
--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -73,6 +73,7 @@ push_images() {
     fi
 }
 
+# TODO: this notification does not seem to belong to pushing images, move it to shared lib.sh and find a better place to call it
 slack_build_notice() {
     info "Slack a build notice"
 
@@ -108,10 +109,13 @@ slack_build_notice() {
         die "unexpected"
     fi
 
+    local github_url="https://github.com/stackrox/stackrox/releases/tag/$tag"
+
     jq -n \
     --arg build_url "$build_url" \
     --arg tag "$tag" \
-    '{"text": ":prow: Prow build for tag `\($tag)` started! Check the status of the build under the following URL: \($build_url)"}' \
+    --arg github_url "$github_url" \
+    '{"text": ":prow: Prow build for tag [\($tag)](\($github_url)) started! Check the status of the build under the following URL: \($build_url)"}' \
 | curl -XPOST -d @- -H 'Content-Type: application/json' "$webhook_url"
 }
 

--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -115,7 +115,7 @@ slack_build_notice() {
     --arg build_url "$build_url" \
     --arg tag "$tag" \
     --arg github_url "$github_url" \
-    '{"text": ":prow: Prow build for tag [\($tag)](\($github_url)) started! Check the status of the build under the following URL: \($build_url)"}' \
+    '{"text": ":prow: Prow build for tag <\($github_url)|\($tag)> started! Check the status of the build under the following URL: \($build_url)"}' \
 | curl -XPOST -d @- -H 'Content-Type: application/json' "$webhook_url"
 }
 


### PR DESCRIPTION
# Description

Make tag clickable in Slack so that one can find commit and its CI status from GitHub UI.

See context in
https://srox.slack.com/archives/C02JG23A93L/p1664910613602289

## Checklist
- [x] Investigated and inspected CI test results

Nothing else matters:

- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* Not much. I hope it will just work.
* Took JQ command and ran it in the terminal like this:
```sh
$ export build_url='https://cnn.com'
$ export tag='3.7something_nightly'
$ export github_url="https://github.com/stackrox/stackrox/releases/tag/$tag"
$ jq -n \
    --arg build_url "$build_url" \
    --arg tag "$tag" \
    --arg github_url "$github_url" \
    '{"text": ":prow: Prow build for tag [\($tag)](\($github_url)) started! Check the status of the build under the following URL: \($build_url)"}'
{
  "text": ":prow: Prow build for tag [3.7something_nightly](https://github.com/stackrox/stackrox/releases/tag/3.7something_nightly) started! Check the status of the build under the following URL: https://cnn.com"
}
```