### PR TITLE
Dashrews/ROX-12926 Fix query building parse issue that manifested in a broken graphql postgres tests

### DIFF
--- a/central/graphql/resolvers/pods.go
+++ b/central/graphql/resolvers/pods.go
@@ -29,7 +29,6 @@ func init() {
 
 // Pod returns a GraphQL resolver for a given id.
 func (resolver *Resolver) Pod(ctx context.Context, args struct{ *graphql.ID }) (*podResolver, error) {
-	log.Info("SHREWS -- Pod")
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "Pod")
 	if err := readDeployments(ctx); err != nil {
 		return nil, err
@@ -39,7 +38,6 @@ func (resolver *Resolver) Pod(ctx context.Context, args struct{ *graphql.ID }) (
 
 // Pods returns GraphQL resolvers for all pods.
 func (resolver *Resolver) Pods(ctx context.Context, args PaginatedQuery) ([]*podResolver, error) {
-	log.Info("SHREWS -- Pods")
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "Pods")
 	if err := readDeployments(ctx); err != nil {
 		return nil, err
@@ -53,13 +51,11 @@ func (resolver *Resolver) Pods(ctx context.Context, args PaginatedQuery) ([]*pod
 
 // PodCount returns count of all pods across deployments
 func (resolver *Resolver) PodCount(ctx context.Context, args RawQuery) (int32, error) {
-	log.Info("SHREWS -- PodCount")
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "PodCount")
 	if err := readDeployments(ctx); err != nil {
 		return 0, err
 	}
 	q, err := args.AsV1QueryOrEmpty()
-	log.Infof("Query => %v", q)
 	if err != nil {
 		return 0, err
 	}
@@ -73,7 +69,6 @@ func (resolver *Resolver) PodCount(ctx context.Context, args RawQuery) (int32, e
 // ContainerCount returns the number of active containers.
 // Active is defined by being present in the pod spec.
 func (resolver *podResolver) ContainerCount() int32 {
-	log.Info("SHREWS -- ContainerCount")
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Pods, "ContainerCount")
 
 	containerNames := set.NewStringSet()
@@ -96,7 +91,6 @@ func (resolver *podResolver) ContainerCount() int32 {
 
 // policyViolationEvents returns all policy violations associated with this pod.
 func (resolver *podResolver) policyViolationEvents(ctx context.Context) ([]*PolicyViolationEventResolver, error) {
-	log.Info("SHREWS -- policyViolationEvents")
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Pods, "PolicyViolationEvents")
 
 	q := search.ConjunctionQuery(
@@ -104,7 +98,6 @@ func (resolver *podResolver) policyViolationEvents(ctx context.Context) ([]*Poli
 		search.NewQueryBuilder().AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery(),
 		search.NewQueryBuilder().AddExactMatches(search.LifecycleStage, storage.LifecycleStage_RUNTIME.String()).ProtoQuery(),
 	)
-	log.Infof("Query => %v", q)
 
 	predicateFn := func(alert *storage.Alert) bool {
 		for _, proc := range alert.GetProcessViolation().GetProcesses() {
@@ -121,7 +114,6 @@ func (resolver *podResolver) policyViolationEvents(ctx context.Context) ([]*Poli
 
 // processActivityEvents returns all the process activities associated with this pod.
 func (resolver *podResolver) processActivityEvents(ctx context.Context) ([]*ProcessActivityEventResolver, error) {
-	log.Info("SHREWS -- processActivityEvents")
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Pods, "ProcessActivityEvents")
 
 	// It is possible that not all process indicators have PodUID populated. For now, it is safer to not use it.
@@ -130,7 +122,6 @@ func (resolver *podResolver) processActivityEvents(ctx context.Context) ([]*Proc
 		search.NewQueryBuilder().AddExactMatches(search.DeploymentID, resolver.data.GetDeploymentId()).ProtoQuery(),
 		search.NewQueryBuilder().AddExactMatches(search.PodID, resolver.data.GetName()).ProtoQuery(),
 	)
-	log.Infof("Query => %v", query)
 
 	return resolver.root.getProcessActivityEvents(ctx, query)
 }
@@ -209,7 +200,6 @@ func (resolver *podResolver) containerTerminationEvents() []*ContainerTerminatio
 
 // Events returns all events associated with this pod sorted by timestamp.
 func (resolver *podResolver) Events(ctx context.Context) ([]*DeploymentEventResolver, error) {
-	log.Info("SHREWS -- Events")
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Pods, "Events")
 
 	var events []*DeploymentEventResolver

--- a/pkg/search/parser.go
+++ b/pkg/search/parser.go
@@ -86,7 +86,7 @@ func parsePair(pair string, allowEmpty bool) (key string, values string, valid b
 			spl[1] = spl[1] + WildcardString
 		}
 	}
-	return spl[0], spl[1], true
+	return spl[0], strings.TrimSpace(spl[1]), true
 }
 
 func queryFromFieldValues(field string, values []string, highlight bool) *v1.Query {
@@ -163,8 +163,9 @@ func docIDQuery(ids []string) *v1.Query {
 	})
 }
 
-//go:generate stringer -type=QueryModifier
 // QueryModifier describes the query modifiers for a specific individual query
+//
+//go:generate stringer -type=QueryModifier
 type QueryModifier int
 
 // These are the currently supported modifiers

--- a/pkg/search/parser.go
+++ b/pkg/search/parser.go
@@ -164,7 +164,6 @@ func docIDQuery(ids []string) *v1.Query {
 }
 
 // QueryModifier describes the query modifiers for a specific individual query
-//
 //go:generate stringer -type=QueryModifier
 type QueryModifier int
 

--- a/pkg/search/parser.go
+++ b/pkg/search/parser.go
@@ -86,7 +86,7 @@ func parsePair(pair string, allowEmpty bool) (key string, values string, valid b
 			spl[1] = spl[1] + WildcardString
 		}
 	}
-	return spl[0], strings.TrimSpace(spl[1]), true
+	return strings.TrimSpace(spl[0]), strings.TrimSpace(spl[1]), true
 }
 
 func queryFromFieldValues(field string, values []string, highlight bool) *v1.Query {
@@ -164,6 +164,7 @@ func docIDQuery(ids []string) *v1.Query {
 }
 
 // QueryModifier describes the query modifiers for a specific individual query
+//
 //go:generate stringer -type=QueryModifier
 type QueryModifier int
 

--- a/pkg/search/parser_test.go
+++ b/pkg/search/parser_test.go
@@ -51,3 +51,70 @@ func TestSplitQuery(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePairs(t *testing.T) {
+	cases := []struct {
+		query      string
+		allowEmpty bool
+		pairs      []string
+		valid      bool
+	}{
+		{
+			query:      "Deployment Label:label",
+			allowEmpty: false,
+			pairs:      []string{"Deployment Label", "label"},
+			valid:      true,
+		},
+		{
+			query:      "Deployment Label:label,label",
+			allowEmpty: false,
+			pairs:      []string{"Deployment Label", "label,label"},
+			valid:      true,
+		},
+		{
+			query:      "  Deployment Label :  label+label  ",
+			allowEmpty: false,
+			pairs:      []string{"Deployment Label", "label+label"},
+			valid:      true,
+		},
+		{
+			query:      "Deployment Label:label+label",
+			allowEmpty: false,
+			pairs:      []string{"Deployment Label", "label+label"},
+			valid:      true,
+		},
+		{
+			query:      "Deployment Label",
+			allowEmpty: false,
+			pairs:      []string{"", ""},
+			valid:      false,
+		},
+		{
+			query:      "Deployment Label:",
+			allowEmpty: false,
+			pairs:      []string{"", ""},
+			valid:      false,
+		},
+		{
+			query:      "Deployment Label:",
+			allowEmpty: true,
+			pairs:      []string{"Deployment Label", WildcardString},
+			valid:      true,
+		},
+		{
+			query:      "Deployment Label:attempted-alerts-dep-6+Policy:Kubernetes Actions: Exec into Pod",
+			allowEmpty: false,
+			pairs:      []string{"Deployment Label", "attempted-alerts-dep-6+Policy:Kubernetes Actions: Exec into Pod"},
+			valid:      true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.query, func(t *testing.T) {
+			key, value, valid := parsePair(c.query, c.allowEmpty)
+			assert.Equal(t, valid, c.valid)
+			assert.Equal(t, key, c.pairs[0])
+			assert.Equal(t, value, c.pairs[1])
+		})
+	}
+}

--- a/pkg/search/parser_test.go
+++ b/pkg/search/parser_test.go
@@ -90,6 +90,12 @@ func TestParsePairs(t *testing.T) {
 			valid:      false,
 		},
 		{
+			query:      "Deployment Label",
+			allowEmpty: true,
+			pairs:      []string{"", ""},
+			valid:      false,
+		},
+		{
 			query:      "Deployment Label:",
 			allowEmpty: false,
 			pairs:      []string{"", ""},

--- a/qa-tests-backend/src/test/groovy/DeploymentEventGraphQLTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentEventGraphQLTest.groovy
@@ -4,11 +4,13 @@ import static Services.waitForViolation
 import java.util.stream.Collectors
 
 import groups.BAT
+import groups.GraphQL
 import objects.Deployment
 import services.GraphQLService
 
 import org.junit.experimental.categories.Category
 
+@Category([BAT, GraphQL])
 class DeploymentEventGraphQLTest extends BaseSpecification {
     private static final String DEPLOYMENT_NAME = "eventnginx"
     private static final String PARENT_NAME = "/bin/sh"
@@ -89,7 +91,6 @@ class DeploymentEventGraphQLTest extends BaseSpecification {
 
     private final gqlService = new GraphQLService()
 
-    @Category(BAT)
     def "Verify Deployment Events in GraphQL"() {
         when:
         "Validate Policy Violation is Triggered"

--- a/qa-tests-backend/src/test/groovy/DeploymentEventGraphQLTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentEventGraphQLTest.groovy
@@ -89,7 +89,7 @@ class DeploymentEventGraphQLTest extends BaseSpecification {
 
     private final gqlService = new GraphQLService()
 
-    @Category(GraphQL)
+    @Category(BAT)
     def "Verify Deployment Events in GraphQL"() {
         when:
         "Validate Policy Violation is Triggered"

--- a/qa-tests-backend/src/test/groovy/DeploymentEventGraphQLTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentEventGraphQLTest.groovy
@@ -3,7 +3,7 @@ import static Services.waitForViolation
 
 import java.util.stream.Collectors
 
-import groups.GraphQL
+import groups.BAT
 import objects.Deployment
 import services.GraphQLService
 


### PR DESCRIPTION
## Description

Turns out this was not a flake.  the pods query was of the form:
"Deployment ID:  d4b04bae-9d9d-46a2-8c43-b615e07d9969"

Notice the space after the colon.  When the parser was processing the parameters and getting the value it did not strip the space from the value portion.  So when the search was done, it was trying to match the deploymentid column to:
" d4b04bae-9d9d-46a2-8c43-b615e07d9969" 
That would not find any rows because it didn't match the string exactly.  So the simple fix was to trim the space of the value portion when it is parsed out.  Feedback from those of you more familiar with the graphql processing would be greatly appreciated in the event there is a more optimal place to strip out this space.

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Existing tests are sufficient.  The whole purpose of this ticket was because one was failing due to this issue.
