### PR TITLE
[concurrency] Fix error with AsContext() result spuriously returning non-nil Err()

### DIFF
--- a/pkg/concurrency/context.go
+++ b/pkg/concurrency/context.go
@@ -28,9 +28,25 @@ func CancelContextOnSignal(ctx context.Context, cancel context.CancelFunc, signa
 
 type contextWrapper struct {
 	ErrorWaitable
+	isDone func() bool
+}
+
+func (w *contextWrapper) IsDone() bool {
+	if w.isDone != nil {
+		return w.isDone()
+	}
+	select {
+	case <-w.Done():
+		return true
+	default:
+		return false
+	}
 }
 
 func (w *contextWrapper) Err() error {
+	if !w.IsDone() {
+		return nil
+	}
 	err := w.ErrorWaitable.Err()
 	if err != context.DeadlineExceeded {
 		return context.Canceled
@@ -51,8 +67,13 @@ func AsContext(w Waitable) context.Context {
 	if ctx, _ := w.(context.Context); ctx != nil {
 		return ctx
 	}
+	var isDone func() bool
+	if supportsIsDone, _ := w.(interface{ IsDone() bool }); supportsIsDone != nil {
+		isDone = supportsIsDone.IsDone
+	}
 
 	return &contextWrapper{
 		ErrorWaitable: AsErrorWaitable(w),
+		isDone:        isDone,
 	}
 }

--- a/pkg/concurrency/context_test.go
+++ b/pkg/concurrency/context_test.go
@@ -1,0 +1,34 @@
+package concurrency
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsContext_ErrReturnsNilWhileNotDone(t *testing.T) {
+	sig := NewSignal()
+	errSig := NewErrorSignal()
+	ch := make(WaitableChan)
+	ctx := context.Background()
+	for _, w := range []Waitable{
+		&sig,
+		&errSig,
+		ch,
+		ctx,
+	} {
+		t.Run(fmt.Sprintf("AsContext(%T)", w), func(t *testing.T) {
+			wCtx := AsContext(w)
+			err := wCtx.Err()
+			select {
+			case <-w.Done():
+				require.Fail(t, "waitable was done")
+			default:
+			}
+			assert.Nil(t, err, "waitable should return a nil Err() while not done")
+		})
+	}
+}

--- a/pkg/concurrency/error_wait.go
+++ b/pkg/concurrency/error_wait.go
@@ -113,6 +113,10 @@ func (w *errorWaitableWrapper) Err() error {
 	return nil
 }
 
+func (w *errorWaitableWrapper) IsDone() bool {
+	return w.isDone()
+}
+
 func (w *errorWaitableWrapper) Done() <-chan struct{} {
 	return w.w.Done()
 }


### PR DESCRIPTION
## Description

The `ErrorWaitable` interface is a generalization of `context.Context`, which loosens the restrictions as to what `Err()` may return. Because it is legitimate for an `ErrorSignal` to return `Err() == nil` even when done (signaling the success of an asynchronous operation that could also have errored), the `contextWrapper` that wraps an `ErrorWaitable` to conform to the `Context` interface needs to address this fact by also mapping a `nil` `Err()` of a done signal to `context.Canceled`. However, the current implementation did this eagerly, not bothering to check whether the underlying `ErrorWaitable` was actually done.

The existing code worked fine with code that only checked `ctx.Err()` after the context indicated it was done, e.g., as in the following:
```
for {
  select {
  case <-ctx.Done():
    return ctx.Err()
  case <-someOtherChan:
    makeProgress()
  }
}
```
However, when adding a fast-exit condition:
```
for ctx.Err() == nil {
  ...
}
return ctx.Err()
```
the loop would never be entered and the function would immediately return with an error, in spite of the waitable wrapped via `AsContext()` not actually being done.

I caught this in the [attempt to upgrade k8s deps](https://github.com/stackrox/stackrox/pull/3255), observing that the `admission-control` config map would no longer get created, which was accompanied by a `context canceled` error in the sensor logs. Apparently, the authors of k8s `client-go` library added some early-exit checks to prevent making an attempt to the API server when the context was (or seemed) already cancelled at the time of invocation.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- Unit test