### PR TITLE
Add CI check for fixed shellcheck scripts that previously failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,12 @@ shell-style:
 	@echo "+ $@"
 	$(SILENT)$(BASE_DIR)/scripts/style/shellcheck.sh
 
+.PHONY: update-shellcheck-skip
+update-shellcheck-skip:
+	@echo "+ $@"
+	$(SILENT)rm -f scripts/style/shellcheck_skip.txt
+	$(SILENT)$(BASE_DIR)/scripts/style/shellcheck.sh update_failing_list
+
 .PHONY: ci-config-validate
 ci-config-validate:
 	@echo "+ $@"

--- a/scripts/ci/jobs/check-generated.sh
+++ b/scripts/ci/jobs/check-generated.sh
@@ -45,3 +45,12 @@ function check-operator-generated-files-up-to-date() {
     git diff --exit-code HEAD
 }
 check-operator-generated-files-up-to-date
+
+# shellcheck disable=SC2016
+echo 'Check if a script that was on the failed shellcheck list is now fixed. (If this fails, run `make update-shellcheck-skip` and commit the result.)'
+function check-shellcheck-failing-list() {
+    make update-shellcheck-skip
+    echo 'Checking for diffs after updating shellcheck failing list...'
+    git diff --exit-code HEAD
+}
+check-shellcheck-failing-list

--- a/scripts/style/shellcheck_skip.txt
+++ b/scripts/style/shellcheck_skip.txt
@@ -1,5 +1,4 @@
 .github/workflows/scripts/cherry-pick.sh
-.github/workflows/scripts/common.sh
 .github/workflows/scripts/patch-changelog.sh
 deploy/common/deploy.sh
 deploy/common/docker-auth.sh


### PR DESCRIPTION
## Description

This PR adds a make target for updating `scripts/style/shellcheck_skip.txt` and adds a CI check to determine if a previously failed script is now passing shellcheck.  

## Testing Performed

CI

Successful failure case: [prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/3325/pull-ci-stackrox-stackrox-master-grouped-static-checks/1578437190130601984](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/3325/pull-ci-stackrox-stackrox-master-grouped-static-checks/1578437190130601984)
