### PR TITLE
ROX-11323 Allow the fake workloads to create services

### DIFF
--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -169,6 +169,7 @@ func (w *WorkloadManager) initializePreexistingResources() {
 	}
 
 	objects = append(objects, getRBAC(w.workload.RBACWorkload)...)
+	objects = append(objects, getService(w.workload.ServiceWorkload)...)
 	var resources []*deploymentResourcesToBeManaged
 	for _, deploymentWorkload := range w.workload.DeploymentWorkload {
 		for i := 0; i < deploymentWorkload.NumDeployments; i++ {

--- a/sensor/kubernetes/fake/service.go
+++ b/sensor/kubernetes/fake/service.go
@@ -9,14 +9,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func getRandProtocol() string {
-	protocols := []string{"TCP", "UDP", "SCTP"}
-	return protocols[rand.Intn(len(protocols))]
-}
+var (
+	protocols  = [...]string{"TCP", "UDP", "SCTP"}
+	ipFamilies = [...]string{"IPv4", "IPv6"}
+)
 
-func getRandIP() string {
-	ip := generateIP()
-	return ip
+func getRandProtocol() string {
+	return protocols[rand.Intn(len(protocols))]
 }
 
 func getRandPort() uint32 {
@@ -24,7 +23,6 @@ func getRandPort() uint32 {
 }
 
 func getIPFamily() string {
-	ipFamilies := []string{"IPv4", "IPv6"}
 	return ipFamilies[rand.Intn(len(ipFamilies))]
 }
 
@@ -36,7 +34,7 @@ func getClusterIP(numLabels int) *v1.Service {
 	} else {
 		labels = createMap(numLabels)
 	}
-	clusterIP := getRandIP()
+	clusterIP := generateIP()
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      randStringWithLength(16),
@@ -71,7 +69,7 @@ func getNodePort(numLabels int) *v1.Service {
 	} else {
 		labels = createMap(numLabels)
 	}
-	clusterIP := getRandIP()
+	clusterIP := generateIP()
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      randStringWithLength(16),
@@ -107,7 +105,7 @@ func getLoadBalancer(numLabels int) *v1.Service {
 	} else {
 		labels = createMap(numLabels)
 	}
-	clusterIP := getRandIP()
+	clusterIP := generateIP()
 	internalTrafficPolicy := v1.ServiceInternalTrafficPolicyCluster
 	allocateLoadBalancerNodePorts := true
 	ipFamilyPolicy := v1.IPFamilyPolicySingleStack
@@ -144,7 +142,7 @@ func getLoadBalancer(numLabels int) *v1.Service {
 			LoadBalancer: v1.LoadBalancerStatus{
 				Ingress: []v1.LoadBalancerIngress{
 					{
-						IP: getRandIP(),
+						IP: generateIP(),
 					},
 				},
 			},
@@ -159,12 +157,12 @@ func getService(workload ServiceWorkload) []runtime.Object {
 		objects = append(objects, clusterIP)
 	}
 	for i := 0; i < workload.NumNodePorts; i++ {
-		clusterIP := getNodePort(workload.NumLabels)
-		objects = append(objects, clusterIP)
+		nodePort := getNodePort(workload.NumLabels)
+		objects = append(objects, nodePort)
 	}
 	for i := 0; i < workload.NumLoadBalancers; i++ {
-		clusterIP := getLoadBalancer(workload.NumLabels)
-		objects = append(objects, clusterIP)
+		loadBalancer := getLoadBalancer(workload.NumLabels)
+		objects = append(objects, loadBalancer)
 	}
 	return objects
 }

--- a/sensor/kubernetes/fake/service.go
+++ b/sensor/kubernetes/fake/service.go
@@ -1,0 +1,170 @@
+package fake
+
+import (
+	"math/rand"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func getRandProtocol() string {
+	protocols := []string{"TCP", "UDP", "SCTP"}
+	return protocols[rand.Intn(len(protocols))]
+}
+
+func getRandIP() string {
+	ip := generateIP()
+	return ip
+}
+
+func getRandPort() uint32 {
+	return rand.Uint32() % 63556
+}
+
+func getIPFamily() string {
+	ipFamilies := []string{"IPv4", "IPv6"}
+	return ipFamilies[rand.Intn(len(ipFamilies))]
+}
+
+func getClusterIP(numLabels int) *v1.Service {
+	ns := namespacePool.mustGetRandomElem()
+	var labels map[string]string
+	if numLabels == 0 {
+		labels = createRandMap(16, 3)
+	} else {
+		labels = createMap(numLabels)
+	}
+	clusterIP := getRandIP()
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      randStringWithLength(16),
+			Namespace: ns,
+			UID:       newUUID(),
+		},
+		Spec: v1.ServiceSpec{
+			Type:     v1.ServiceTypeClusterIP,
+			Selector: labels,
+			Ports: []v1.ServicePort{
+				{
+					Protocol: v1.Protocol(getRandProtocol()),
+					Port:     int32(getRandPort()),
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: int32(getRandPort()),
+					},
+				},
+			},
+			ClusterIP:  clusterIP,
+			ClusterIPs: []string{clusterIP},
+			IPFamilies: []v1.IPFamily{v1.IPFamily(getIPFamily())},
+		},
+	}
+}
+
+func getNodePort(numLabels int) *v1.Service {
+	ns := namespacePool.mustGetRandomElem()
+	var labels map[string]string
+	if numLabels == 0 {
+		labels = createRandMap(16, 3)
+	} else {
+		labels = createMap(numLabels)
+	}
+	clusterIP := getRandIP()
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      randStringWithLength(16),
+			Namespace: ns,
+			UID:       newUUID(),
+		},
+		Spec: v1.ServiceSpec{
+			Type:     v1.ServiceTypeNodePort,
+			Selector: labels,
+			Ports: []v1.ServicePort{
+				{
+					Protocol: v1.Protocol(getRandProtocol()),
+					Port:     int32(getRandPort()),
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: int32(getRandPort()),
+					},
+					NodePort: int32(getRandPort()),
+				},
+			},
+			ClusterIP:  clusterIP,
+			ClusterIPs: []string{clusterIP},
+			IPFamilies: []v1.IPFamily{v1.IPFamily(getIPFamily())},
+		},
+	}
+}
+
+func getLoadBalancer(numLabels int) *v1.Service {
+	ns := namespacePool.mustGetRandomElem()
+	var labels map[string]string
+	if numLabels == 0 {
+		labels = createRandMap(16, 3)
+	} else {
+		labels = createMap(numLabels)
+	}
+	clusterIP := getRandIP()
+	internalTrafficPolicy := v1.ServiceInternalTrafficPolicyCluster
+	allocateLoadBalancerNodePorts := true
+	ipFamilyPolicy := v1.IPFamilyPolicySingleStack
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      randStringWithLength(16),
+			Namespace: ns,
+			UID:       newUUID(),
+		},
+		Spec: v1.ServiceSpec{
+			Type:     v1.ServiceTypeLoadBalancer,
+			Selector: labels,
+			Ports: []v1.ServicePort{
+				{
+					Protocol: v1.Protocol(getRandProtocol()),
+					Port:     int32(getRandPort()),
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: int32(getRandPort()),
+					},
+					NodePort: int32(getRandPort()),
+				},
+			},
+			ClusterIP:                     clusterIP,
+			ClusterIPs:                    []string{clusterIP},
+			IPFamilies:                    []v1.IPFamily{v1.IPFamily(getIPFamily())},
+			ExternalTrafficPolicy:         v1.ServiceExternalTrafficPolicyTypeCluster,
+			InternalTrafficPolicy:         &internalTrafficPolicy,
+			AllocateLoadBalancerNodePorts: &allocateLoadBalancerNodePorts,
+			PublishNotReadyAddresses:      false,
+			IPFamilyPolicy:                &ipFamilyPolicy,
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{
+						IP: getRandIP(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func getService(workload ServiceWorkload) []runtime.Object {
+	objects := make([]runtime.Object, 0, workload.NumClusterIPs+workload.NumNodePorts+workload.NumLoadBalancers)
+	for i := 0; i < workload.NumClusterIPs; i++ {
+		clusterIP := getClusterIP(workload.NumLabels)
+		objects = append(objects, clusterIP)
+	}
+	for i := 0; i < workload.NumNodePorts; i++ {
+		clusterIP := getNodePort(workload.NumLabels)
+		objects = append(objects, clusterIP)
+	}
+	for i := 0; i < workload.NumLoadBalancers; i++ {
+		clusterIP := getLoadBalancer(workload.NumLabels)
+		objects = append(objects, clusterIP)
+	}
+	return objects
+}

--- a/sensor/kubernetes/fake/workload.go
+++ b/sensor/kubernetes/fake/workload.go
@@ -67,6 +67,14 @@ type RBACWorkload struct {
 	NumServiceAccounts int `yaml:"numServiceAccounts"`
 }
 
+// ServiceWorkload defines the workload of services
+type ServiceWorkload struct {
+	NumLabels        int `yaml:"numLabels"`
+	NumClusterIPs    int `yaml:"numClusterIPs"`
+	NumNodePorts     int `yaml:"numNodePorts"`
+	NumLoadBalancers int `yaml:"numLoadBalancers"`
+}
+
 // Workload is the definition of a scale workload
 type Workload struct {
 	DeploymentWorkload    []DeploymentWorkload    `yaml:"deploymentWorkload"`
@@ -74,5 +82,6 @@ type Workload struct {
 	NodeWorkload          NodeWorkload            `yaml:"nodeWorkload"`
 	NetworkWorkload       NetworkWorkload         `yaml:"networkWorkload"`
 	RBACWorkload          RBACWorkload            `yaml:"rbacWorkload"`
+	ServiceWorkload       ServiceWorkload         `yaml:"serviceWorkload"`
 	NumNamespaces         int                     `yaml:"numNamespaces"`
 }


### PR DESCRIPTION
## Description

Enables the fake workloads to create services.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Generate a workload configMap like:

```yaml
deploymentWorkload:
- deploymentType: Deployment
  lifecycleDuration: 10m0s
  numDeployments: 2500
  numLifecycles: 0
  podWorkload:
    containerWorkload:
      numImages: 0
    lifecycleDuration: 2m0s
    numContainers: 3
    numPods: 5
    processWorkload:
      alertRate: 0.001
      processInterval: 30s
  updateInterval: 100s
networkWorkload:
  batchSize: 100
  flowInterval: 1s
nodeWorkload:
  numNodes: 1000
rbacWorkload:
  numBindings: 1000
  numRoles: 1000
  numServiceAccounts: 1000
serviceWorkload:
  numLabels: 10
  numClusterIPs: 2 
  numNodePorts: 2
  numLoadBalancers: 2
```

Start `local-sensor` using the previously mentioned configMap:

```
go run tools/local-sensor/main.go -record -with-fakeworkload=default.yaml
```

The fake workloads should create services.
