### PR TITLE
ROX-7273 Google SCC Integration Does Not Map Severity Properly

### DIFF
--- a/central/notifiers/cscc/client/client.go
+++ b/central/notifiers/cscc/client/client.go
@@ -43,7 +43,7 @@ type Config struct {
 
 func (c *Config) postURL(findingID string) string {
 	return fmt.Sprintf(
-		"https://securitycenter.googleapis.com/v1beta1/%s/findings?findingId=%s",
+		"https://securitycenter.googleapis.com/v1p1beta1/%s/findings?findingId=%s",
 		c.SourceID,
 		findingID,
 	)
@@ -84,6 +84,7 @@ func (c *Config) request(finding *findings.Finding, id string) (*http.Request, e
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal")
 	}
+
 	c.Logger.Debugf("Request: %s", string(b))
 
 	req, err := http.NewRequest("POST", c.postURL(id), bytes.NewReader(b))

--- a/central/notifiers/cscc/cscc_test.go
+++ b/central/notifiers/cscc/cscc_test.go
@@ -1,0 +1,87 @@
+package cscc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/golang/mock/gomock"
+	clusterMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
+	"github.com/stackrox/rox/central/notifiers/cscc/findings"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	projectKey = "FJ"
+)
+
+func TestWithFakeCSCC(t *testing.T) {
+
+	sourceID := "organizations/0000000000/sources/0000000000"
+
+	s := &storage.Notifier{
+		Name:         "FakeSCC",
+		UiEndpoint:   "https://central.stackrox",
+		Type:         "scc",
+		LabelDefault: projectKey,
+		Config: &storage.Notifier_Cscc{
+			Cscc: &storage.CSCC{
+				ServiceAccount: "test_service_account",
+				SourceId:       sourceID,
+			},
+		},
+	}
+
+	cluster := &storage.Cluster{
+		Id:   "test_id",
+		Name: "test_cluster",
+		Status: &storage.ClusterStatus{
+			ProviderMetadata: &storage.ProviderMetadata{
+				Zone: "test_zone",
+				Provider: &storage.ProviderMetadata_Google{
+					Google: &storage.GoogleProviderMetadata{
+						Project:     "test_project",
+						ClusterName: "test_cluster",
+					},
+				},
+			},
+		},
+	}
+
+	mockCtrl := gomock.NewController(t)
+	clusterStore := clusterMocks.NewMockDataStore(mockCtrl)
+	clusterStore.EXPECT().GetCluster(gomock.Any(), "test_id").Return(cluster, true, nil)
+	scc, _ := newCSCC(s, clusterStore)
+
+	alertID := "myAlertID"
+	severity := findings.High
+
+	testAlert := &storage.Alert{
+		Id: alertID,
+		Policy: &storage.Policy{
+			Id:             "myPolicyID",
+			Name:           "myPolicy",
+			Description:    "Fake policy",
+			PolicySections: []*storage.PolicySection{},
+			Severity:       storage.Severity_HIGH_SEVERITY,
+		},
+		Entity: &storage.Alert_Deployment_{Deployment: &storage.Alert_Deployment{
+			Name:      "myDeployment",
+			Id:        "myDeploymentID",
+			ClusterId: "test_id",
+		}},
+		Time: types.TimestampNow(),
+	}
+	findingID := ""
+	var finding *findings.Finding
+	var err error
+	findingID, finding, err = scc.initFinding(context.Background(), testAlert)
+	assert.NoError(t, err)
+	assert.Equal(t, "myAlertID", findingID)
+	assert.NotEmpty(t, finding)
+	assert.Equal(t, severity, finding.Severity)
+	assert.Equal(t, sourceID, finding.Parent)
+	assert.Contains(t, finding.URL, alertID)
+
+}

--- a/central/notifiers/cscc/findings/findings.go
+++ b/central/notifiers/cscc/findings/findings.go
@@ -20,6 +20,18 @@ const (
 	StateInactive State = "INACTIVE"
 )
 
+// Severity indicates severity of alert
+type Severity string
+
+// Severity values are defined in google cloud scc api
+const (
+	High     Severity = "HIGH"
+	Low      Severity = "LOW"
+	Medium   Severity = "MEDIUM"
+	Critical Severity = "CRITICAL"
+	Default  Severity = "SEVERITY_UNSPECIFIED"
+)
+
 // A Finding represents a single Finding created by StackRox (as a Source).
 type Finding struct {
 	ID           string                 `json:"name,omitempty"`
@@ -30,6 +42,7 @@ type Finding struct {
 	URL          string                 `json:"externalUri,omitempty"`
 	Properties   map[string]interface{} `json:"sourceProperties,omitempty"`
 	Timestamp    string                 `json:"eventTime"`
+	Severity     Severity               `json:"severity,omitempty"`
 	// The time at which the event took place. For example, if the finding represents an open firewall it would capture the time the open firewall was detected.
 	// A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".
 	// See https://cloud.google.com/security-command-center/docs/reference/rest/v1beta1/organizations.sources.findings#Finding
@@ -56,7 +69,6 @@ type Enforcement struct {
 
 // Properties includes various values, by key, for a new Finding.
 type Properties struct {
-	Severity string `json:"severity,omitempty"`
 
 	// These fields are custom and defined by StackRox.
 	Namespace      string `json:"namespace,omitempty"`


### PR DESCRIPTION
PR fixes scc integration notifier to show severity correctly. The fix was tested by introducing exec policy violation which triggered scc notifier to notify SCC. See screenshot attached 


