### PR TITLE
Implement basic markup structure of collection form

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function CollectionAttacher() {
+    return <></>;
+}
+
+export default CollectionAttacher;

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -1,0 +1,157 @@
+import React, { useEffect } from 'react';
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    Button,
+    Card,
+    CardBody,
+    Divider,
+    Drawer,
+    DrawerActions,
+    DrawerCloseButton,
+    DrawerContent,
+    DrawerContentBody,
+    DrawerHead,
+    DrawerPanelBody,
+    DrawerPanelContent,
+    Flex,
+    FlexItem,
+    Text,
+    Title,
+} from '@patternfly/react-core';
+
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { collectionsBasePath } from 'routePaths';
+import { ResolvedCollectionResponse } from 'services/CollectionsService';
+import { CollectionPageAction } from './collections.utils';
+import RuleSelector from './RuleSelector';
+import CollectionAttacher from './CollectionAttacher';
+import CollectionResults from './CollectionResults';
+
+export type CollectionFormProps = {
+    /* The user's workflow action for this collection */
+    action: CollectionPageAction['type'];
+    /* initial data used to populate the form, or `undefined` in the case of a new collection */
+    initialData: ResolvedCollectionResponse | undefined;
+    /* Whether or not to display the collection results in an inline drawer. If false, will
+    display collection results in an overlay drawer. */
+    useInlineDrawer: boolean;
+    /* Whether or not to show breadcrumb navigation at the top of the form */
+    showBreadcrumbs: boolean;
+    /* Callback used when clicking on a collection name in the CollectionAttacher section. If
+    left undefined, collection names will not be linked. */
+    appendTableLinkAction?: (collectionId: string) => void;
+};
+
+function CollectionForm({
+    action,
+    initialData,
+    useInlineDrawer,
+    showBreadcrumbs,
+}: CollectionFormProps) {
+    const {
+        isOpen,
+        closeSelect: closeDrawer,
+        openSelect: openDrawer,
+        toggleSelect: toggleDrawer,
+    } = useSelectToggle(useInlineDrawer);
+
+    useEffect(() => {
+        toggleDrawer(useInlineDrawer);
+    }, [toggleDrawer, useInlineDrawer]);
+
+    const pageTitle = initialData ? initialData.collection.name : 'Create collection';
+
+    return (
+        <>
+            <Drawer isExpanded={isOpen} isInline={useInlineDrawer}>
+                <DrawerContent
+                    panelContent={
+                        <DrawerPanelContent
+                            style={{
+                                borderLeft: 'var(--pf-global--BorderColor--100) 1px solid',
+                            }}
+                        >
+                            <DrawerHead>
+                                <Title headingLevel="h2">Collection results</Title>
+                                <Text>See a live preview of current matches.</Text>
+                                <DrawerActions>
+                                    <DrawerCloseButton onClick={closeDrawer} />
+                                </DrawerActions>
+                            </DrawerHead>
+                            <DrawerPanelBody style={{ overflow: 'auto', height: '100%' }}>
+                                <CollectionResults />
+                            </DrawerPanelBody>
+                        </DrawerPanelContent>
+                    }
+                >
+                    <DrawerContentBody className="pf-u-background-color-100 pf-u-display-flex pf-u-flex-direction-column">
+                        {showBreadcrumbs && (
+                            <>
+                                <Breadcrumb className="pf-u-my-xs pf-u-px-lg pf-u-py-md">
+                                    <BreadcrumbItemLink to={collectionsBasePath}>
+                                        Collections
+                                    </BreadcrumbItemLink>
+                                    <BreadcrumbItem>{pageTitle}</BreadcrumbItem>
+                                </Breadcrumb>
+                                <Divider component="div" />
+                            </>
+                        )}
+                        <Flex className="pf-u-p-lg" alignItems={{ default: 'alignItemsCenter' }}>
+                            <FlexItem flex={{ default: 'flex_1' }}>
+                                <Title headingLevel="h1">{pageTitle}</Title>
+                            </FlexItem>
+                            <FlexItem align={{ default: 'alignRight' }}>
+                                {isOpen ? (
+                                    <Button variant="secondary" onClick={closeDrawer}>
+                                        Hide collection results
+                                    </Button>
+                                ) : (
+                                    <Button variant="secondary" onClick={openDrawer}>
+                                        Preview collection results
+                                    </Button>
+                                )}
+                            </FlexItem>
+                        </Flex>
+                        <Divider component="div" />
+                        <Flex
+                            className="pf-u-background-color-200 pf-u-p-lg"
+                            spaceItems={{ default: 'spaceItemsMd' }}
+                            direction={{ default: 'column' }}
+                        >
+                            <Card>
+                                <CardBody>
+                                    <Title headingLevel="h2">Collection details</Title>
+                                </CardBody>
+                            </Card>
+                            <Card>
+                                <CardBody>
+                                    <Title headingLevel="h2">Add new collection rules</Title>
+                                    <RuleSelector />
+                                    <RuleSelector />
+                                    <RuleSelector />
+                                </CardBody>
+                            </Card>
+                            <Card>
+                                <CardBody>
+                                    <Title headingLevel="h2">Attach existing collections</Title>
+                                    <CollectionAttacher />
+                                </CardBody>
+                            </Card>
+                        </Flex>
+
+                        <div className="pf-u-p-lg pf-u-py-md">
+                            <Button className="pf-u-mr-md">
+                                {action === 'view' ? 'Edit' : 'Save'}
+                            </Button>
+                            <Button variant="secondary">Cancel</Button>
+                        </div>
+                    </DrawerContentBody>
+                </DrawerContent>
+            </Drawer>
+        </>
+    );
+}
+
+export default CollectionForm;

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -41,6 +41,7 @@ import CollectionAttacher from './CollectionAttacher';
 import CollectionResults from './CollectionResults';
 
 export type CollectionFormProps = {
+    hasWriteAccessForCollections: boolean;
     /* The user's workflow action for this collection */
     action: CollectionPageAction;
     /* initial data used to populate the form, or `undefined` in the case of a new collection */
@@ -56,6 +57,7 @@ export type CollectionFormProps = {
 };
 
 function CollectionForm({
+    hasWriteAccessForCollections,
     action,
     initialData,
     useInlineDrawer,
@@ -152,7 +154,7 @@ function CollectionForm({
                                 <Title headingLevel="h1">{pageTitle}</Title>
                             </FlexItem>
                             <FlexItem align={{ default: 'alignRight' }}>
-                                {action.type === 'view' && (
+                                {action.type === 'view' && hasWriteAccessForCollections && (
                                     <>
                                         <Dropdown
                                             onSelect={actionMenuToggle.closeSelect}

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -80,7 +80,7 @@ function CollectionForm({
                                     <DrawerCloseButton onClick={closeDrawer} />
                                 </DrawerActions>
                             </DrawerHead>
-                            <DrawerPanelBody style={{ overflow: 'auto', height: '100%' }}>
+                            <DrawerPanelBody className="pf-u-h-100" style={{ overflow: 'auto' }}>
                                 <CollectionResults />
                             </DrawerPanelBody>
                         </DrawerPanelContent>

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -64,15 +64,24 @@ function CollectionForm({
     showBreadcrumbs,
 }: CollectionFormProps) {
     const history = useHistory();
-    const drawerToggle = useSelectToggle(useInlineDrawer);
-    const actionMenuToggle = useSelectToggle();
+    const {
+        isOpen: drawerIsOpen,
+        toggleSelect: toggleDrawer,
+        closeSelect: closeDrawer,
+        openSelect: openDrawer,
+    } = useSelectToggle(useInlineDrawer);
+    const {
+        isOpen: menuIsOpen,
+        toggleSelect: toggleMenu,
+        closeSelect: closeMenu,
+    } = useSelectToggle();
     const [deleteId, setDeleteId] = useState<string | null>(null);
     const [isDeleting, setIsDeleting] = useState(false);
     const { toasts, addToast, removeToast } = useToasts();
 
     useEffect(() => {
-        drawerToggle.toggleSelect(useInlineDrawer);
-    }, [drawerToggle, useInlineDrawer]);
+        toggleDrawer(useInlineDrawer);
+    }, [toggleDrawer, useInlineDrawer]);
 
     const pageTitle = initialData ? initialData.collection.name : 'Create collection';
 
@@ -116,7 +125,7 @@ function CollectionForm({
 
     return (
         <>
-            <Drawer isExpanded={drawerToggle.isOpen} isInline={useInlineDrawer}>
+            <Drawer isExpanded={drawerIsOpen} isInline={useInlineDrawer}>
                 <DrawerContent
                     panelContent={
                         <DrawerPanelContent
@@ -128,7 +137,7 @@ function CollectionForm({
                                 <Title headingLevel="h2">Collection results</Title>
                                 <Text>See a live preview of current matches.</Text>
                                 <DrawerActions>
-                                    <DrawerCloseButton onClick={drawerToggle.closeSelect} />
+                                    <DrawerCloseButton onClick={closeDrawer} />
                                 </DrawerActions>
                             </DrawerHead>
                             <DrawerPanelBody className="pf-u-h-100" style={{ overflow: 'auto' }}>
@@ -157,18 +166,18 @@ function CollectionForm({
                                 {action.type === 'view' && hasWriteAccessForCollections && (
                                     <>
                                         <Dropdown
-                                            onSelect={actionMenuToggle.closeSelect}
+                                            onSelect={closeMenu}
                                             position="right"
                                             toggle={
                                                 <DropdownToggle
                                                     isPrimary
-                                                    onToggle={actionMenuToggle.onToggle}
+                                                    onToggle={toggleMenu}
                                                     toggleIndicator={CaretDownIcon}
                                                 >
                                                     Actions
                                                 </DropdownToggle>
                                             }
-                                            isOpen={actionMenuToggle.isOpen}
+                                            isOpen={menuIsOpen}
                                             dropdownItems={[
                                                 <DropdownItem
                                                     key="Edit collection"
@@ -207,12 +216,12 @@ function CollectionForm({
                                         />
                                     </>
                                 )}
-                                {drawerToggle.isOpen ? (
-                                    <Button variant="secondary" onClick={drawerToggle.closeSelect}>
+                                {drawerIsOpen ? (
+                                    <Button variant="secondary" onClick={closeDrawer}>
                                         Hide collection results
                                     </Button>
                                 ) : (
-                                    <Button variant="secondary" onClick={drawerToggle.openSelect}>
+                                    <Button variant="secondary" onClick={openDrawer}>
                                         Preview collection results
                                     </Button>
                                 )}

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormPage.tsx
@@ -30,7 +30,7 @@ function CollectionsFormPage({ pageAction }: CollectionsFormPageProps) {
         <>
             <PageSection className="pf-u-h-100" padding={{ default: 'noPadding' }}>
                 <CollectionForm
-                    action={action}
+                    action={pageAction}
                     initialData={data}
                     useInlineDrawer={isLargeScreen}
                     showBreadcrumbs

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormPage.tsx
@@ -1,16 +1,44 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import { PageSection } from '@patternfly/react-core';
+import { useMediaQuery } from 'react-responsive';
+
+import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
+import { getCollection } from 'services/CollectionsService';
 import { CollectionPageAction } from './collections.utils';
+import CollectionForm from './CollectionForm';
 
 export type CollectionsFormPageProps = {
     pageAction: CollectionPageAction;
 };
 
+const noopRequest = {
+    request: Promise.resolve(undefined),
+    cancel: () => {},
+};
+
 function CollectionsFormPage({ pageAction }: CollectionsFormPageProps) {
-    return pageAction.type === 'create' ? (
-        <>{pageAction.type}</>
-    ) : (
+    const isLargeScreen = useMediaQuery({ query: '(min-width: 992px)' }); // --pf-global--breakpoint--lg
+    const action = pageAction.type;
+    const collectionId = action !== 'create' ? pageAction.collectionId : undefined;
+    const collectionFetcher = useCallback(
+        () => (collectionId ? getCollection(collectionId) : noopRequest),
+        [collectionId]
+    );
+    const { data } = useRestQuery(collectionFetcher);
+
+    return (
         <>
-            {pageAction.type} {pageAction.collectionId}
+            <PageSection className="pf-u-h-100" padding={{ default: 'noPadding' }}>
+                <CollectionForm
+                    action={action}
+                    initialData={data}
+                    useInlineDrawer={isLargeScreen}
+                    showBreadcrumbs
+                    appendTableLinkAction={() => {
+                        /* TODO */
+                    }}
+                />
+            </PageSection>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function CollectionResults() {
+    return <></>;
+}
+
+export default CollectionResults;

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -8,6 +8,7 @@ import { CollectionPageAction } from './collections.utils';
 import CollectionForm from './CollectionForm';
 
 export type CollectionsFormPageProps = {
+    hasWriteAccessForCollections: boolean;
     pageAction: CollectionPageAction;
 };
 
@@ -16,7 +17,10 @@ const noopRequest = {
     cancel: () => {},
 };
 
-function CollectionsFormPage({ pageAction }: CollectionsFormPageProps) {
+function CollectionsFormPage({
+    hasWriteAccessForCollections,
+    pageAction,
+}: CollectionsFormPageProps) {
     const isLargeScreen = useMediaQuery({ query: '(min-width: 992px)' }); // --pf-global--breakpoint--lg
     const action = pageAction.type;
     const collectionId = action !== 'create' ? pageAction.collectionId : undefined;
@@ -30,6 +34,7 @@ function CollectionsFormPage({ pageAction }: CollectionsFormPageProps) {
         <>
             <PageSection className="pf-u-h-100" padding={{ default: 'noPadding' }}>
                 <CollectionForm
+                    hasWriteAccessForCollections={hasWriteAccessForCollections}
                     action={pageAction}
                     initialData={data}
                     useInlineDrawer={isLargeScreen}

--- a/ui/apps/platform/src/Containers/Collections/CollectionsPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsPage.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router-dom';
 import useURLParameter from 'hooks/useURLParameter';
 
 import CollectionsTablePage from './CollectionsTablePage';
-import CollectionsFormPage from './CollectionFormPage';
+import CollectionsFormPage from './CollectionsFormPage';
 import { parsePageActionProp } from './collections.utils';
 
 function CollectionsPage() {
@@ -25,7 +25,12 @@ function CollectionsPage() {
     }, [pageAction, validPageActionProp, setPageAction]);
 
     if (validPageActionProp) {
-        return <CollectionsFormPage pageAction={validPageActionProp} />;
+        return (
+            <CollectionsFormPage
+                hasWriteAccessForCollections={hasWriteAccessForCollections}
+                pageAction={validPageActionProp}
+            />
+        );
     }
 
     return <CollectionsTablePage hasWriteAccessForCollections={hasWriteAccessForCollections} />;

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+// TODO - Evaluate whether or not this makes sense to move into Component/PatternFly for general use
+function RuleSelector() {
+    return <></>;
+}
+
+export default RuleSelector;


### PR DESCRIPTION
## Description

Adds the main layout of the collection form page, with empty components stubbed in where they will be located once implemented.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

Visit the main collections page and click the "Create collection" button. If on a large screen, the preview drawer should be open by default. If on a small screen, the preview drawer should be closed.
<img width="1678" alt="image" src="https://user-images.githubusercontent.com/1292638/195095849-f2bf1b6f-0d15-4355-8176-86096a06effe.png">
<img width="742" alt="image" src="https://user-images.githubusercontent.com/1292638/195096045-9e9b137f-e8d8-49df-9e9d-bee74ce39ced.png">

Test that resizing the browser window beyond the "large" threshold sets the preview drawer state to open (when the window is large) and closed (when the window is small).

Test that clicking the "Hide preview results" button closes the drawer and updates the button text. Test that clicking the button again re-opens the drawer.
<img width="1660" alt="image" src="https://user-images.githubusercontent.com/1292638/195097880-9dcf55b3-efda-4007-990b-c18e1b7b4177.png">

Test the the drawer open state in the small screen view results in an "overlay" drawer, as opposed to the drawer the pushes the content to the left in the large screen view.
<img width="820" alt="image" src="https://user-images.githubusercontent.com/1292638/195098060-6f16f4ff-42d7-47a6-bfcf-fa2134d4c150.png">

Test that the top level "Collections" link in the breadcrumbs takes you back to the main collections table page.
<img width="806" alt="image" src="https://user-images.githubusercontent.com/1292638/194626124-9a396fde-9adc-4d22-bf4a-125bd93961b5.png">

Test the visiting a page in "Create", "Clone", or "Edit" mode removes the action menu and places a "Save" and "Cancel" button in the page footer.
<img width="820" alt="image" src="https://user-images.githubusercontent.com/1292638/195098449-a1a54353-1144-41eb-8667-7b31fb5ce40e.png">


