### PR TITLE
ROX-12981: Add wait for networkbaseline status request in networkFlows integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/NetworkPage.js
+++ b/ui/apps/platform/cypress/constants/NetworkPage.js
@@ -1,8 +1,6 @@
 import scopeSelectors from '../helpers/scopeSelectors';
 import search from '../selectors/search';
 
-export const url = '/main/network';
-
 const networkPanels = {
     creatorPanel: '[data-testid="network-creator-panel"]',
     simulatorPanel: '[data-testid="network-simulator-panel"]',

--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -104,6 +104,7 @@ export const dashboard = {
 export const metadata = 'v1/metadata';
 
 export const network = {
+    networkBaseline: '/v1/networkbaseline/*', // deployment id
     networkBaselineLock: '/v1/networkbaseline/*/lock',
     networkBaselineUnlock: '/v1/networkbaseline/*/unlock',
     networkBaselinePeers: '/v1/networkbaseline/*/peers',

--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -321,7 +321,7 @@ export function clickBaselineSettingsTab() {
         {
             routeMatcherMap: {
                 [networkBaselineAlias]: {
-                    method: 'POST',
+                    method: 'GET',
                     url: api.network.networkBaseline,
                 },
             },

--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -1,9 +1,10 @@
 import * as api from '../constants/apiEndpoints';
-import { selectors as networkGraphSelectors, url as networkUrl } from '../constants/NetworkPage';
+import { selectors as networkGraphSelectors } from '../constants/NetworkPage';
 import { visitFromLeftNav } from './nav';
 import { interactAndWaitForResponses } from './request';
 import { visit } from './visit';
 import selectSelectors from '../selectors/select';
+import tabSelectors from '../selectors/tab';
 
 const getNodeErrorMessage = (node) => `Could not find node "${node.name}" of type "${node.type}"`;
 
@@ -31,8 +32,21 @@ export function clickOnNodeByName(cytoscape, node) {
     filteredNodes.emit('click');
 }
 
+export const networkBaselineStatusAlias = 'networkbaseline/id/status';
+
+const requestConfigForDeploymentNode = {
+    routeMatcherMap: {
+        [networkBaselineStatusAlias]: {
+            method: 'POST',
+            url: api.network.networkBaselineStatus,
+        },
+    },
+};
+
 export function clickOnDeploymentNodeByName(cytoscape, name) {
-    clickOnNodeByName(cytoscape, { type: 'DEPLOYMENT', name });
+    interactAndWaitForResponses(() => {
+        clickOnNodeByName(cytoscape, { type: 'DEPLOYMENT', name });
+    }, requestConfigForDeploymentNode);
 }
 
 export function mouseOverNodeById(cytoscape, node) {
@@ -204,34 +218,51 @@ export function selectNamespaceFilterWithNetworkGraphResponse(namespace, respons
 
 // visit helpers
 
+export const notifiersAlias = 'notifiers';
+export const clustersAlias = 'clusters';
+export const networkPoliciesGraphEpochAlias = 'networkpolicies/graph/epoch';
+export const searchMetadataOptionsAlias = 'search/metadata/options';
+export const getClusterNamespaceNamesAlias = 'getClusterNamespaceNames';
+
 const requestConfigToVisitGraph = {
     routeMatcherMap: {
-        clusters: {
+        [notifiersAlias]: {
+            method: 'GET',
+            url: api.integrations.notifiers,
+        },
+        [clustersAlias]: {
             method: 'GET',
             url: api.clusters.list,
         },
-        // Network Graph makes the following query on the first visit, but not subsequent visit via browser Back button.
-        // Include it because each cypress test has a new connection, therefore behaves as a first visit.
-        getClusterNamespaceNames: {
-            method: 'POST',
-            url: api.graphql('getClusterNamespaceNames'),
+        [networkPoliciesGraphEpochAlias]: {
+            method: 'GET',
+            url: `${api.network.epoch}?clusterId=null`,
         },
-        'search/metadata/options': {
+        [searchMetadataOptionsAlias]: {
             method: 'GET',
             url: api.search.optionsCategories('DEPLOYMENTS'),
+        },
+        // Network Graph makes the following query on the first visit, but not subsequent visit via browser Back button.
+        // Include it because each cypress test has a new connection, therefore behaves as a first visit.
+        [getClusterNamespaceNamesAlias]: {
+            method: 'POST',
+            url: api.graphql('getClusterNamespaceNames'),
         },
     },
 };
 
+export const basePath = '/main/network';
+
 export function visitNetworkGraphFromLeftNav() {
     visitFromLeftNav('Network', requestConfigToVisitGraph);
 
+    cy.location('pathname').should('eq', basePath);
     cy.get(networkGraphSelectors.networkGraphHeading);
     cy.get(networkGraphSelectors.emptyStateSubheading);
 }
 
 export function visitNetworkGraph(staticResponseMap) {
-    visit(networkUrl, requestConfigToVisitGraph, staticResponseMap);
+    visit(basePath, requestConfigToVisitGraph, staticResponseMap);
 
     cy.get(networkGraphSelectors.networkGraphHeading);
     cy.get(networkGraphSelectors.emptyStateSubheading);
@@ -248,5 +279,52 @@ export function visitNetworkGraphWithMockedData() {
         'stackrox',
         'network/networkGraph.json',
         'network/networkPolicies.json'
+    );
+}
+
+// deployment Network Flows
+
+export const networkBaselinePeersAlias = 'networkbaseline/id/peers';
+
+export function interactAndWaitForChangeToNetworkFlows(interactionCallback) {
+    interactAndWaitForResponses(interactionCallback, {
+        routeMatcherMap: {
+            [networkBaselinePeersAlias]: {
+                method: 'PATCH',
+                url: api.network.networkBaselinePeers,
+            },
+            [networkGraphClusterAlias]: {
+                method: 'GET',
+                url: api.network.networkGraph,
+            },
+            [networkPoliciesClusterAlias]: {
+                method: 'GET',
+                url: api.network.networkPoliciesGraph,
+            },
+            [networkBaselineStatusAlias]: {
+                method: 'POST',
+                url: api.network.networkBaselineStatus,
+            },
+        },
+    });
+}
+
+// deployment Baseline Settings
+
+export const networkBaselineAlias = 'networkbaseline/id';
+
+export function clickBaselineSettingsTab() {
+    interactAndWaitForResponses(
+        () => {
+            cy.get(`${tabSelectors.tabs}:contains('Baseline Settings')`).click();
+        },
+        {
+            routeMatcherMap: {
+                [networkBaselineAlias]: {
+                    method: 'POST',
+                    url: api.network.networkBaseline,
+                },
+            },
+        }
     );
 }


### PR DESCRIPTION
## Description

### Test failure

1. 1575524459123576832 from master build for #3202 on 2022-09-29

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-ui-e2e-tests/1575524459123576832

> Timed out retrying after 4000ms: `cy.trigger()` failed because this element is detached from the DOM.

> `<tr class="relative border-b bg-base-100 border-base-300 " data-testid="data-row">...</tr>`

![prow](https://user-images.githubusercontent.com/11862657/194602098-add648db-e4a0-4720-aeff-75c215fadaf7.png)

cypress/integration/networkGraph/networkFlows.test.js

### Analysis

The test gets ahead of the user interface.

1. An **element is detached from the DOM** failure makes sense, because `clickOnDeploymentNodeByName` helper function did not wait on the relevant request.

2. Even after wait for relevant requests, the last `cy.get(sensorTableRow).trigger('mouseover')` got the row element too soon, before it moved to the opposite table. A more specific selector for row in the expected table gives cypress what it needs to wait until tables re-render. 

### Changed files

1. Edit cypress/constants/apiEndpoints.js
    * Add `networkBaseline` endpoint for **Baseline Settings** tab.

2. Edit cypress/constants/NetworkPage.js
    * Delete `url` so network helpers can encapsulate page addresses.

3. Edit cypress/helpers/networkGraph.js
    * Wait on request in `clickOnDeploymentNodeByName` function.
    * Wait on additional relevant requests in visit functions.
    * Add `interactAndWaitForChangeToNetworkFlows` function for **Network Flows** tab.
    * Add `clickBaselineSettingsTab` function for **Baseline Settings** tab.

4. Edit cypress/integration/networkGraph/networkFlows.test.js
    * Call `interactAndWaitForChangeToNetworkFlows` helper function in `clickFlowsConfirmationButton` function.
    * Call `interactAndWaitForChangeToNetworkFlows` helper function in `'should be able to toggle status of a single flow'` test.
    * Also include **Anomalous Flows** or **Baseline Flows** in sensor table row selector so test waits to call `trigger('mouseover')` method **after** the row re-renders in the opposite table.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Ran tests locally with infra central. However, the test fails because **sensor** does not move from **Baseline Flows** to **Anomalous Flows**.