### PR TITLE
ROX-13011: Prevent failures because no controls in configmanagement integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
+++ b/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
@@ -273,8 +273,6 @@ export function renderListAndSidePanel(entitiesKey, entityName = null) {
             .eq(1)
             .click();
     }, entitiesKey);
-
-    cy.get(configManagementSelectors.widgets);
 }
 
 export function navigateToSingleEntityPage(entitiesKey) {

--- a/ui/apps/platform/cypress/integration/configmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/clusters.test.js
@@ -189,7 +189,8 @@ describe('Configuration Management Clusters', () => {
         });
     });
 
-    it('should open the side panel to show the same number of Controls when the Controls link is clicked', () => {
+    // ROX-13011: Prevent failures, pending investigation into reason why No Controls instead of link sometimes.
+    it.skip('should open the side panel to show the same number of Controls when the Controls link is clicked', () => {
         visitConfigurationManagementDashboard();
 
         // This test assumes that scan results are available


### PR DESCRIPTION
## Description

### Test failures

Several test failures since 10-03 merge of #3268

1. 1577432122728124416 from master build on 10-04
2. 1577952133469179904 from master build on 10-07
3. 1578271804542160896 from master build on 10-08
4. 1578281493262766080 from master build on 10-08
5. 1578352127816765440 from master build on 10-08
6. 1578399067069747200 from master build on 10-08

### Analysis

1. /main/configmanagement/clusters has **No Controls** text instead of link.
2. /main/configmanagement/controls does not have widget in side panel for control.

Prevent failures, pending investigation into reason why No Controls for clusters or nodes.

### Changed files

1. Edit cypress/helpers/configWorkflowUtils.js
    * Delete `cy.get(configManagementSelectors.widgets)` because helper function encapsulates an entity-specific DOM assertion.
2. Edit cypress/integration/configmanagement/clusters.test.js
    * Add comment and `skip` to `'should open the side panel to show the same number of Controls when the Controls link is clicked'` test.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed