### PR TITLE
ROX-11323 Hide FakeEventsManager logs behind the verbose flag

### DIFF
--- a/sensor/debugger/k8s/fake.go
+++ b/sensor/debugger/k8s/fake.go
@@ -79,6 +79,8 @@ type FakeEventsManager struct {
 	clientMap map[string]func(string) interface{}
 	// resourceMap map with the k8s resources
 	resourceMap map[string]interface{}
+	// Verbose prints messages to stdout
+	Verbose bool
 }
 
 const (
@@ -299,7 +301,9 @@ func (f *FakeEventsManager) eventsCreation() (<-chan string, <-chan error) {
 				errorCh <- err
 				return
 			}
-			log.Printf("%s Event: %s", msg.Action, msg.ObjectType)
+			if f.Verbose {
+				log.Printf("%s Event: %s", msg.Action, msg.ObjectType)
+			}
 			if err := f.createEvent(msg, ch); err != nil {
 				errorCh <- errors.Wrapf(err, "cannot create event for %s", msg.ObjectType)
 				return

--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -273,10 +273,11 @@ func main() {
 		}
 
 		fm := k8s.FakeEventsManager{
-			Delay:  localConfig.Delay,
-			Mode:   localConfig.CreateMode,
-			Client: fakeClient,
-			Reader: trReader,
+			Delay:   localConfig.Delay,
+			Mode:    localConfig.CreateMode,
+			Client:  fakeClient,
+			Reader:  trReader,
+			Verbose: localConfig.Verbose,
 		}
 		min, errCh := fm.CreateEvents(ctx)
 		select {


### PR DESCRIPTION
## Description

Hide the `FakeEventsManager`'s logs behind the verbose flag.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

```
go run tools/local-sensor/main.go -replay -replay-in=sensor/tests/replay/data/safety-net-alerts-k8s-trace.jsonl -delay=0s
```

Should not print any info logs from `FakeEventsManager`

```
go run tools/local-sensor/main.go -verbose -replay -replay-in=sensor/tests/replay/data/safety-net-alerts-k8s-trace.jsonl -delay=0s
```

Should print info logs from `FakeEventsManager`
