### PR TITLE
ROX-10890: add monitoring for long running cluster (upstream release)

### DIFF
--- a/deploy/charts/monitoring/.gitignore
+++ b/deploy/charts/monitoring/.gitignore
@@ -1,0 +1,2 @@
+# Helm dependencies
+charts/

--- a/deploy/charts/monitoring/Chart.yaml
+++ b/deploy/charts/monitoring/Chart.yaml
@@ -1,6 +1,14 @@
+apiVersion: v2
 name: monitoring
 description: StackRox Monitoring
 version: 1.0.0
 maintainers:
   - name: stackrox
     email: support@stackrox.com
+dependencies:
+  - name: kube-state-metrics
+    version: 4.20.0
+    repository: https://prometheus-community.github.io/helm-charts
+  - name: alertmanager
+    version: 0.20.1
+    repository: https://prometheus-community.github.io/helm-charts

--- a/deploy/charts/monitoring/README.md
+++ b/deploy/charts/monitoring/README.md
@@ -5,9 +5,11 @@ This Helm chart is for StackRox Monitoring. INTERNAL USE ONLY.
 Run the following command to render this chart:
 - for Helm v2
 ```
+helm dependency update ./monitoring
 helm install --name monitoring ./monitoring
 ```
 - for Helm v3
 ```
+helm dependency update ./monitoring
 helm install monitoring ./monitoring
 ```

--- a/deploy/charts/monitoring/dashboards/central.json
+++ b/deploy/charts/monitoring/dashboards/central.json
@@ -117,7 +117,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "increase(process_cpu_seconds_total{instance=~\"$Instance\"}[1m])",
+          "expr": "increase(process_cpu_seconds_total{instance=~\"$Instance\",job!=\"kubernetes-pods\"}[1m])",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
@@ -207,7 +207,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "go_memstats_heap_alloc_bytes{instance=~\"$Instance\"} / 1024^2",
+          "expr": "go_memstats_heap_alloc_bytes{instance=~\"$Instance\",job!=\"kubernetes-pods\"} / 1024^2",
           "interval": "",
           "legendFormat": "{{job}}: alloc",
           "refId": "A"
@@ -218,7 +218,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "go_memstats_heap_inuse_bytes{instance=~\"$Instance\"} / 1024^2",
+          "expr": "go_memstats_heap_inuse_bytes{instance=~\"$Instance\",job!=\"kubernetes-pods\"} / 1024^2",
           "interval": "",
           "legendFormat": "{{job}}: inuse",
           "refId": "B"
@@ -229,7 +229,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "go_memstats_heap_idle_bytes{instance=~\"$Instance\"} / 1024^2",
+          "expr": "go_memstats_heap_idle_bytes{instance=~\"$Instance\",job!=\"kubernetes-pods\"} / 1024^2",
           "interval": "",
           "legendFormat": "{{job}}: idle",
           "refId": "C"

--- a/deploy/charts/monitoring/dashboards/cluster-health.json
+++ b/deploy/charts/monitoring/dashboards/cluster-health.json
@@ -1,0 +1,355 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 3,
+    "links": [],
+    "panels": [
+      {
+        "collapsed": false,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 8,
+        "panels": [],
+        "title": "Deployment status",
+        "type": "row"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {},
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 11,
+          "w": 24,
+          "x": 0,
+          "y": 1
+        },
+        "hiddenSeries": false,
+        "id": 6,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "rightSide": true,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null as zero",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.5.15",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "kube_replicaset_spec_replicas - kube_replicaset_status_ready_replicas > 0",
+            "interval": "",
+            "legendFormat": "{{ exported_namespace }}::{{ replicaset }}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Missing replicas",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:409",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "$$hashKey": "object:410",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "collapsed": false,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 12
+        },
+        "id": 10,
+        "panels": [],
+        "title": "Pod status",
+        "type": "row"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {},
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 13
+        },
+        "hiddenSeries": false,
+        "id": 4,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "rightSide": true,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null as zero",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.5.15",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "increase(kube_pod_container_status_restarts_total[5m]) > 0",
+            "interval": "",
+            "legendFormat": "{{ exported_namespace }}:{{ exported_pod }}:{{ container }}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Pod Restarts",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {},
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 13
+        },
+        "hiddenSeries": false,
+        "id": 2,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "rightSide": true,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null as zero",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.5.15",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "(kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 10m >= 1) and ignoring (reason) min_over_time(kube_pod_container_status_last_terminated_reason{reason=\"OOMKilled\"}[10m]) == 1",
+            "interval": "",
+            "legendFormat": "{{ exported_namespace }}::{{ exported_pod }}::{{ container }}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "OOMKills",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+    ],
+    "schemaVersion": 27,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Cluster Health",
+    "uid": "GSb3z8n4k",
+    "version": 2
+}

--- a/deploy/charts/monitoring/requirements.lock
+++ b/deploy/charts/monitoring/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: kube-state-metrics
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 4.20.0
+- name: alertmanager
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 0.20.1
+digest: sha256:4efdfc4b2132dedad382ceafad1003437d4c64227881731d046e24cc9f143b26
+generated: "2022-09-22T16:51:51.884579+02:00"

--- a/deploy/charts/monitoring/templates/grafana.yaml
+++ b/deploy/charts/monitoring/templates/grafana.yaml
@@ -66,5 +66,7 @@ data:
           path: /etc/grafana/provisioning/dashboards
   central.json: |-
 {{ .Files.Get "dashboards/central.json" | indent 4 }}
+  cluster-health.json: |-
+{{ .Files.Get "dashboards/cluster-health.json" | indent 4 }}
   dataplane.json: |-
 {{ .Files.Get "dashboards/dataplane.json" | indent 4 }}

--- a/deploy/charts/monitoring/templates/prometheus.yaml
+++ b/deploy/charts/monitoring/templates/prometheus.yaml
@@ -10,26 +10,78 @@ data:
     global:
       scrape_interval: 30s
 
-    scrape_configs:
-      - job_name: stackrox
+    alerting:
+      alertmanagers:
+        - static_configs:
+            - targets:
+                - {{ .Release.Name }}-alertmanager:9093
 
+    rule_files:
+      - /etc/prometheus/rules_*.yml
+
+    scrape_configs:
+      - job_name: "kubernetes-pods"
         tls_config:
           insecure_skip_verify: false
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              own_namespace: true
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: pod
 
+      - job_name: stackrox
+        tls_config:
+          insecure_skip_verify: false
         kubernetes_sd_configs:
           - role: endpoints
             namespaces:
               own_namespace: true
-
         relabel_configs:
           - source_labels: [__meta_kubernetes_endpoint_port_name]
             action: keep
             regex: monitoring
-
           - source_labels: [__meta_kubernetes_endpoints_name]
             action: replace
             target_label: job
-
           - source_labels: [__meta_kubernetes_namespace]
             action: replace
             target_label: namespace
+
+  rules_alerts_kubernetes.yml: |-
+    groups:
+    - name: Kubernetes
+      rules:
+        - alert: KubernetesContainerOomKiller
+          expr: (kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 10m >= 1) and ignoring (reason) min_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}[10m]) == 1
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: Kubernetes container OOM killer (pod {{ "{{" }} $labels.exported_pod {{ "}}" }})
+            description: "Container {{ "{{" }} $labels.container {{ "}}" }} in pod {{ "{{" }} $labels.exported_namespace {{ "}}" }}/{{ "{{" }} $labels.exported_pod {{ "}}" }} has been OOMKilled {{ "{{" }} $value {{ "}}" }} times in the last 10 minutes."
+
+        - alert: KubernetesPodCrashLooping
+          expr: increase(kube_pod_container_status_restarts_total[5m]) > 0
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: Kubernetes pod crash looping (pod {{ "{{" }} $labels.exported_pod {{ "}}" }})
+            description: "Pod {{ "{{" }} $labels.exported_namespace {{ "}}" }}/{{ "{{" }} $labels.exported_pod {{ "}}" }} is crash looping."
+
+        - alert: KubernetesReplicaSetMismatch
+          expr: kube_replicaset_spec_replicas != kube_replicaset_status_ready_replicas
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Kubernetes ReplicaSet mismatch (replicaset {{ "{{" }} $labels.replicaset {{ "}}" }})
+            description: "Replicas mismatch in ReplicaSet {{ "{{" }} $labels.exported_namespace {{ "}}" }}/{{ "{{" }} $labels.replicaset {{ "}}" }}"

--- a/deploy/charts/monitoring/values.yaml
+++ b/deploy/charts/monitoring/values.yaml
@@ -1,4 +1,3 @@
-image: null
 grafanaImage: grafana/grafana:7.5.15
 prometheusImage: prom/prometheus:v2.34.0
 password: stackrox
@@ -21,3 +20,20 @@ persistence:
   storageClass: null
 
 nodeSelector: {}
+
+kube-state-metrics:
+  releaseNamespace: true
+
+alertmanager:
+  persistence:
+    enabled: false
+  config:
+    receivers:
+      - name: pagerduty-notifications
+        pagerduty_configs:
+          - service_key: ${PAGERDUTY_INTEGRATION_KEY}
+    route:
+      receiver: pagerduty-notifications
+      group_by: [alertname]
+  configmapReload:
+    enabled: true

--- a/scale/launch_workload.sh
+++ b/scale/launch_workload.sh
@@ -27,8 +27,8 @@ fi
 # Create signature integrations to verify image signatures.
 "${DIR}"/signatures/create-signature-integrations.sh
 
-kubectl -n "${namespace}" delete deploy/admission-control
-kubectl -n "${namespace}" delete daemonset collector
+kubectl -n "${namespace}" delete deploy/admission-control || true
+kubectl -n "${namespace}" delete daemonset collector || true
 
 kubectl -n "${namespace}" set env deploy/sensor MUTEX_WATCHDOG_TIMEOUT_SECS=0
 kubectl -n "${namespace}" set env deploy/central MUTEX_WATCHDOG_TIMEOUT_SECS=0  ROX_SCALE_TEST=true


### PR DESCRIPTION
## Description

* Adds subcharts to monitoring for Kubernetes metrics (kube-state-metrics) and Prometheus AlertManager integration.
* Also makes `k8sbased` a little bit more idempotent by using `helm upgrade --install` instead of `helm install` and `kubectl apply` instead of `kubectl create`. 

Follow up: setup + document rotation/escalation policies on PagerDuty. 

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Deployed with Github Actions: https://github.com/stackrox/test-gh-actions/actions/runs/3219013209.
If you want to play around, the cluster name in infra is: `gke-long-running-3-72-0-rc-1`.

Port forward for Grafana + Prometheus: `kubectl -n stackrox port-forward service/monitoring 48443:8443 49090:9090`
Port forward for AlertManager: `kubectl -n stackrox port-forward sts/stackrox-monitoring-alertmanager 49093:9093`
