### PR TITLE
Implement core state and data flow for collections form

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { ReactElement, useCallback } from 'react';
 import { PageSection } from '@patternfly/react-core';
 import { useMediaQuery } from 'react-responsive';
 
@@ -6,14 +6,26 @@ import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
 import { getCollection } from 'services/CollectionsService';
 import { CollectionPageAction } from './collections.utils';
 import CollectionForm from './CollectionForm';
+import { Collection } from './types';
 
 export type CollectionsFormPageProps = {
     hasWriteAccessForCollections: boolean;
     pageAction: CollectionPageAction;
 };
 
+const emptyCollection: Collection = {
+    name: '',
+    description: '',
+    inUse: false,
+    embeddedCollectionIds: [],
+    selectorRules: {
+        Deployment: {},
+        Namespace: {},
+        Cluster: {},
+    },
+};
 const noopRequest = {
-    request: Promise.resolve(undefined),
+    request: Promise.resolve(emptyCollection),
     cancel: () => {},
 };
 
@@ -22,27 +34,42 @@ function CollectionsFormPage({
     pageAction,
 }: CollectionsFormPageProps) {
     const isLargeScreen = useMediaQuery({ query: '(min-width: 992px)' }); // --pf-global--breakpoint--lg
-    const action = pageAction.type;
-    const collectionId = action !== 'create' ? pageAction.collectionId : undefined;
+    const collectionId = pageAction.type !== 'create' ? pageAction.collectionId : undefined;
     const collectionFetcher = useCallback(
         () => (collectionId ? getCollection(collectionId) : noopRequest),
         [collectionId]
     );
-    const { data } = useRestQuery(collectionFetcher);
+    const { data, loading, error } = useRestQuery<Collection, AggregateError>(collectionFetcher);
+
+    let content: ReactElement | undefined;
+
+    if (error) {
+        content = <>{/* TODO - Handle UI for parse errors */}</>;
+    }
+
+    if (loading) {
+        content = <>{/* TODO - Handle UI for loading state */}</>;
+    }
+
+    if (data) {
+        content = (
+            <CollectionForm
+                hasWriteAccessForCollections={hasWriteAccessForCollections}
+                action={pageAction}
+                initialData={data}
+                useInlineDrawer={isLargeScreen}
+                showBreadcrumbs
+                appendTableLinkAction={() => {
+                    /* TODO */
+                }}
+            />
+        );
+    }
 
     return (
         <>
             <PageSection className="pf-u-h-100" padding={{ default: 'noPadding' }}>
-                <CollectionForm
-                    hasWriteAccessForCollections={hasWriteAccessForCollections}
-                    action={pageAction}
-                    initialData={data}
-                    useInlineDrawer={isLargeScreen}
-                    showBreadcrumbs
-                    appendTableLinkAction={() => {
-                        /* TODO */
-                    }}
-                />
+                {content}
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -18,6 +18,18 @@ const noopRequest = {
     cancel: () => {},
 };
 
+const defaultCollectionData = {
+    name: '',
+    description: '',
+    inUse: false,
+    embeddedCollectionIds: [],
+    selectorRules: {
+        Deployment: null,
+        Namespace: null,
+        Cluster: null,
+    },
+};
+
 function CollectionsFormPage({
     hasWriteAccessForCollections,
     pageAction,
@@ -29,22 +41,32 @@ function CollectionsFormPage({
         [collectionId]
     );
     const { data, loading, error } = useRestQuery(collectionFetcher);
-    const collection = data ? parseCollection(data.collection) : undefined;
+    const initialData = data ? parseCollection(data.collection) : defaultCollectionData;
 
     let content: ReactElement | undefined;
 
     if (error) {
-        content = <>{/* TODO - Handle UI for network errors */}</>;
-    } else if (collection instanceof AggregateError) {
-        content = <>{/* TODO - Handle UI for parse errors */}</>;
-    } else if (loading && !collection) {
+        content = (
+            <>
+                {error.message}
+                {/* TODO - Handle UI for network errors */}
+            </>
+        );
+    } else if (initialData instanceof AggregateError) {
+        content = (
+            <>
+                {initialData.errors}
+                {/* TODO - Handle UI for parse errors */}
+            </>
+        );
+    } else if (loading && !initialData) {
         content = <>{/* TODO - Handle UI for loading state */}</>;
-    } else if (collection) {
+    } else if (initialData) {
         content = (
             <CollectionForm
                 hasWriteAccessForCollections={hasWriteAccessForCollections}
                 action={pageAction}
-                initialData={collection}
+                initialData={initialData}
                 useInlineDrawer={isLargeScreen}
                 showBreadcrumbs
                 appendTableLinkAction={() => {

--- a/ui/apps/platform/src/Containers/Collections/parser.ts
+++ b/ui/apps/platform/src/Containers/Collections/parser.ts
@@ -1,0 +1,81 @@
+import { CollectionResponse } from 'services/CollectionsService';
+import { Collection, SelectorField, SelectorEntityType } from './types';
+
+const fieldToEntityMap: Record<SelectorField, SelectorEntityType> = {
+    Deployment: 'Deployment',
+    'Deployment Label': 'Deployment',
+    'Deployment Annotation': 'Deployment',
+    Namespace: 'Namespace',
+    'Namespace Label': 'Namespace',
+    'Namespace Annotation': 'Namespace',
+    Cluster: 'Cluster',
+    'Cluster Label': 'Cluster',
+    'Cluster Annotation': 'Cluster',
+};
+
+/**
+ * This function takes a raw `CollectionResponse` from the server and parses it into a representation
+ * of a `Collection` that can be supported by the current UI controls. If any incompatibilities are detected
+ * it will return a list of validation errors to the caller.
+ */
+export function parseCollection(data: CollectionResponse): Collection | AggregateError {
+    const collection: Collection = {
+        name: data.name,
+        description: data.description,
+        inUse: data.inUse,
+        embeddedCollectionIds: data.embeddedCollections.map(({ id }) => id),
+        selectorRules: {
+            Deployment: null,
+            Namespace: null,
+            Cluster: null,
+        },
+    };
+
+    const errors: string[] = [];
+
+    if (data.resourceSelectors.length > 1) {
+        errors.push(
+            `Multiple 'ResourceSelectors' were found for this collection. Only a single resource selector is supported in the UI. Further validation errors will only apply to the first resource selector in the response.`
+        );
+    }
+
+    data.resourceSelectors[0]?.rules.forEach((rule) => {
+        const entity = fieldToEntityMap[rule.fieldName];
+        const field = rule.fieldName;
+        const existingEntityField = collection.selectorRules[entity]?.field;
+        const hasMultipleFieldsForEntity = existingEntityField && existingEntityField !== field;
+        const isRuleForAnnotationField = rule.fieldName.endsWith('Annotation');
+        const isUnsupportedRuleOperator = rule.operator !== 'OR';
+
+        if (hasMultipleFieldsForEntity) {
+            errors.push(
+                `Each entity type can only contain rules for a single field. A new rule was found for [${entity} -> ${field}], when rules have already been applied for [${entity} -> ${existingEntityField}].`
+            );
+        }
+        if (isRuleForAnnotationField) {
+            errors.push(
+                `Collection rules for 'Annotation' field names are not supported at this time. Found field name [${rule.fieldName}].`
+            );
+        }
+        if (isUnsupportedRuleOperator) {
+            errors.push(
+                `Only the disjunction operation ('OR') is currently supported in the front end collection editor. Received an operator of [${rule.operator}].`
+            );
+        }
+
+        if (hasMultipleFieldsForEntity || isRuleForAnnotationField || isUnsupportedRuleOperator) {
+            return;
+        }
+
+        if (!collection.selectorRules[entity]) {
+            collection.selectorRules[entity] = {
+                field,
+                rules: [],
+            };
+        }
+
+        collection.selectorRules[entity]?.rules.push(rule);
+    });
+
+    return errors.length > 0 ? new AggregateError(errors) : collection;
+}

--- a/ui/apps/platform/src/Containers/Collections/types.ts
+++ b/ui/apps/platform/src/Containers/Collections/types.ts
@@ -27,15 +27,11 @@ export type ResourceSelector = {
  * This type extracts the `fieldName` property from the individual rules and groups them
  * using a single `field` property due to the UI only supporting a single field per entity
  * type in collection rules.
- *
- * This also excludes `Annotation` selector fields that are not supported by the UI.
  */
-export type ScopedResourceSelector =
-    | {
-          field: Exclude<SelectorField, `${SelectorEntityType} Annotation`>;
-          rules: Omit<DisjunctionSelectorRule, 'fieldName'>[];
-      }
-    | Record<string, never>;
+export type ScopedResourceSelector = {
+    field: SelectorField;
+    rules: Omit<DisjunctionSelectorRule, 'fieldName'>[];
+} | null;
 
 /**
  * `Collection` is the front end representation of a valid collection, which is more

--- a/ui/apps/platform/src/Containers/Collections/types.ts
+++ b/ui/apps/platform/src/Containers/Collections/types.ts
@@ -1,0 +1,51 @@
+export const selectorEntityTypes = ['Cluster', 'Namespace', 'Deployment'] as const;
+export type SelectorEntityType = typeof selectorEntityTypes[number];
+
+export type SelectorField =
+    | `${SelectorEntityType}`
+    | `${SelectorEntityType} Label`
+    | `${SelectorEntityType} Annotation`;
+
+type BaseSelectorRule = {
+    fieldName: SelectorField;
+    values: { value: string }[];
+};
+
+export type DisjunctionSelectorRule = BaseSelectorRule & { operator: 'OR' };
+export type ConjunctionSelectorRule = BaseSelectorRule & { operator: 'AND' };
+/**
+ * A valid `SelectorRule` can use either 'AND' or 'OR' operations to resolve values, but
+ * since the current UI implementation only supports 'OR', we need to maintain separate types here.
+ */
+export type SelectorRule = DisjunctionSelectorRule | ConjunctionSelectorRule;
+
+export type ResourceSelector = {
+    rules: SelectorRule[];
+};
+
+/**
+ * This type extracts the `fieldName` property from the individual rules and groups them
+ * using a single `field` property due to the UI only supporting a single field per entity
+ * type in collection rules.
+ *
+ * This also excludes `Annotation` selector fields that are not supported by the UI.
+ */
+export type ScopedResourceSelector =
+    | {
+          field: Exclude<SelectorField, `${SelectorEntityType} Annotation`>;
+          rules: Omit<DisjunctionSelectorRule, 'fieldName'>[];
+      }
+    | Record<string, never>;
+
+/**
+ * `Collection` is the front end representation of a valid collection, which is more
+ * restricted than Collection objects that can be created via the API.
+ */
+export type Collection = {
+    id?: string;
+    name: string;
+    description: string;
+    inUse: boolean;
+    selectorRules: Record<SelectorEntityType, ScopedResourceSelector>;
+    embeddedCollectionIds: string[];
+};

--- a/ui/apps/platform/src/Containers/Collections/types.ts
+++ b/ui/apps/platform/src/Containers/Collections/types.ts
@@ -24,12 +24,21 @@ export type ResourceSelector = {
 };
 
 /**
+ * The front end currently only supports rules defined for names and labels, annotations are excluded.
+ */
+export type SupportedSelectorField = Exclude<SelectorField, `${SelectorEntityType} Annotation`>;
+
+export function isSupportedSelectorField(field: SelectorField): field is SupportedSelectorField {
+    return !field.endsWith('Annotation');
+}
+
+/**
  * This type extracts the `fieldName` property from the individual rules and groups them
  * using a single `field` property due to the UI only supporting a single field per entity
  * type in collection rules.
  */
 export type ScopedResourceSelector = {
-    field: SelectorField;
+    field: SupportedSelectorField;
     rules: Omit<DisjunctionSelectorRule, 'fieldName'>[];
 } | null;
 

--- a/ui/apps/platform/src/Containers/Dashboard/hooks/useRestQuery.ts
+++ b/ui/apps/platform/src/Containers/Dashboard/hooks/useRestQuery.ts
@@ -1,19 +1,19 @@
 import { useCallback, useEffect, useState } from 'react';
 import { CancellableRequest } from 'services/cancellationUtils';
 
-export type UseRestQueryReturn<ReturnType, ErrorType extends Error> = {
+export type UseRestQueryReturn<ReturnType> = {
     data: ReturnType | undefined;
     loading: boolean;
-    error?: ErrorType;
+    error?: Error;
     refetch: () => void;
 };
 
-export default function useRestQuery<ReturnType, ErrorType extends Error>(
+export default function useRestQuery<ReturnType>(
     cancellableRequestFn: () => CancellableRequest<ReturnType>
-): UseRestQueryReturn<ReturnType, ErrorType> {
+): UseRestQueryReturn<ReturnType> {
     const [data, setData] = useState<ReturnType>();
     const [loading, setLoading] = useState<boolean>(true);
-    const [error, setError] = useState<ErrorType | undefined>();
+    const [error, setError] = useState<Error | undefined>();
 
     const execFetch = useCallback(() => {
         const { request, cancel } = cancellableRequestFn();

--- a/ui/apps/platform/src/Containers/Dashboard/hooks/useRestQuery.ts
+++ b/ui/apps/platform/src/Containers/Dashboard/hooks/useRestQuery.ts
@@ -1,19 +1,19 @@
 import { useCallback, useEffect, useState } from 'react';
 import { CancellableRequest } from 'services/cancellationUtils';
 
-export type UseRestQueryReturn<ReturnType> = {
+export type UseRestQueryReturn<ReturnType, ErrorType extends Error> = {
     data: ReturnType | undefined;
     loading: boolean;
-    error?: Error;
+    error?: ErrorType;
     refetch: () => void;
 };
 
-export default function useRestQuery<ReturnType>(
+export default function useRestQuery<ReturnType, ErrorType extends Error>(
     cancellableRequestFn: () => CancellableRequest<ReturnType>
-): UseRestQueryReturn<ReturnType> {
+): UseRestQueryReturn<ReturnType, ErrorType> {
     const [data, setData] = useState<ReturnType>();
     const [loading, setLoading] = useState<boolean>(true);
-    const [error, setError] = useState<Error | undefined>();
+    const [error, setError] = useState<ErrorType | undefined>();
 
     const execFetch = useCallback(() => {
         const { request, cancel } = cancellableRequestFn();

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -70,88 +70,6 @@ export type ResolvedCollectionResponse = {
     deployments: ListDeployment[];
 };
 
-const fieldToEntityMap: Record<SelectorField, SelectorEntityType> = {
-    Deployment: 'Deployment',
-    'Deployment Label': 'Deployment',
-    'Deployment Annotation': 'Deployment',
-    Namespace: 'Namespace',
-    'Namespace Label': 'Namespace',
-    'Namespace Annotation': 'Namespace',
-    Cluster: 'Cluster',
-    'Cluster Label': 'Cluster',
-    'Cluster Annotation': 'Cluster',
-};
-
-function isAggregateError(value: Collection | AggregateError): value is AggregateError {
-    return value instanceof AggregateError;
-}
-
-/**
- * This function takes a raw `CollectionResponse` from the server and parses it into a representation
- * of a `Collection` that can be supported by the current UI controls. If any incompatibilities are detected
- * it will return a list of validation errors to the caller.
- */
-function parseCollection(data: CollectionResponse): Collection | AggregateError {
-    const collection: Collection = {
-        name: data.name,
-        description: data.description,
-        inUse: data.inUse,
-        embeddedCollectionIds: data.embeddedCollections.map(({ id }) => id),
-        selectorRules: {
-            Deployment: {},
-            Namespace: {},
-            Cluster: {},
-        },
-    };
-
-    const errors: string[] = [];
-
-    if (data.resourceSelectors.length > 1) {
-        errors.push(
-            `Multiple 'ResourceSelectors' were found for this collection. Only a single resource selector is supported in the UI. Further validation errors will only apply to the first resource selector in the response.`
-        );
-    }
-
-    data.resourceSelectors[0]?.rules.forEach((rule) => {
-        const entity = fieldToEntityMap[rule.fieldName];
-        const field = rule.fieldName;
-        collection.selectorRules[entity] = collection.selectorRules[entity] ?? {
-            field,
-            rules: [],
-        };
-
-        const hasMultipleFieldsForEntity = collection.selectorRules[entity].field !== field;
-        const isRuleForAnnotationField = rule.fieldName.endsWith('Annotation');
-        const isUnsupportedRuleOperator = rule.operator !== 'OR';
-
-        if (hasMultipleFieldsForEntity) {
-            errors.push(
-                `Each entity type can only contain rules for a single field. A new rule was found for [${entity} -> ${field}], when rules have already been applied for [${entity} -> ${collection.selectorRules[entity].field}].`
-            );
-        }
-        if (isRuleForAnnotationField) {
-            errors.push(
-                `Collection rules for 'Annotation' field names are not supported at this time. Found field name [${rule.fieldName}].`
-            );
-        }
-        if (isUnsupportedRuleOperator) {
-            errors.push(
-                `Only the disjunction operation ('OR') is currently supported in the front end collection editor. Received an operator of [${rule.operator}].`
-            );
-        }
-
-        if (
-            !hasMultipleFieldsForEntity &&
-            !isRuleForAnnotationField &&
-            !isUnsupportedRuleOperator
-        ) {
-            collection.selectorRules[entity].rules.push(rule);
-        }
-    });
-
-    return errors.length > 0 ? new AggregateError(errors) : collection;
-}
-
 /**
  * Fetch a single collection by id
  *
@@ -164,18 +82,12 @@ function parseCollection(data: CollectionResponse): Collection | AggregateError 
 export function getCollection(
     id: string,
     options: { withMatches: boolean } = { withMatches: false }
-): CancellableRequest<Collection> {
+): CancellableRequest<ResolvedCollectionResponse> {
     const params = qs.stringify(options);
     return makeCancellableAxiosRequest((signal) =>
         axios
             .get<ResolvedCollectionResponse>(`${collectionsBaseUrl}/${id}?${params}`, { signal })
-            .then((response) => {
-                const parsedCollection = parseCollection(response.data.collection);
-                if (isAggregateError(parsedCollection)) {
-                    return Promise.reject(parsedCollection);
-                }
-                return parsedCollection;
-            })
+            .then((response) => response.data)
     );
 }
 

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -4,8 +4,8 @@ import { ListDeployment } from 'types/deployment.proto';
 import { SearchFilter, ApiSortOption } from 'types/search';
 import { ResourceSelector, SelectorField } from 'Containers/Collections/types';
 import { getListQueryParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
-import axios from './instance';
 import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
+import axios from './instance';
 import { Empty, Pagination } from './types';
 
 export const collectionsBaseUrl = '/v1/collections';

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -2,12 +2,7 @@ import qs from 'qs';
 
 import { ListDeployment } from 'types/deployment.proto';
 import { SearchFilter, ApiSortOption } from 'types/search';
-import {
-    Collection,
-    ResourceSelector,
-    SelectorEntityType,
-    SelectorField,
-} from 'Containers/Collections/types';
+import { ResourceSelector, SelectorField } from 'Containers/Collections/types';
 import { getListQueryParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import axios from './instance';
 import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';


### PR DESCRIPTION
## Description

This implements the data structures and related types that are needed for the main collections form.

There is a mismatch between what is a valid collection representation on the server, and the actions that the UI can support. In cases where valid data is returned from the server that cannot be handled in the UI (such as collections created directly from the CLI), we will display an error screen letting the user know that the collection cannot be viewed/edited. 

The specific mismatches are:
- The back end allows multiple top level `resourceSelector` objects in the collection response. These are logically 'AND'ed together, but the UI only supports a single `resourceSelector` object.
- The back end supports both "AND" and "OR" operators for rules attached to a `resourceSelector`. The current UI controls will only support "OR" for both name and label field rules.
- The back end can support rules for multiple fields that are related to a single entity. For example, you could apply a rule that selected Namespaces based on both "Namespace (name)" and "Namespace Label" via the API, but the UI only supports name _xor_ label when selecting Namespaces.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

The only testable change is to test the nothing renders on the main form page when the request is in an "error" or "loading" state, and instead a white page is rendered. The rest of the changes are type-level and do not functionally change the UI at this point.
