### PR TITLE
ROX-12827: Use a more generous timeout in local scanner TLS issuer test

### DIFF
--- a/sensor/kubernetes/localscanner/tls_issuer_test.go
+++ b/sensor/kubernetes/localscanner/tls_issuer_test.go
@@ -270,7 +270,7 @@ func (s *localScannerTLSIssueIntegrationTests) TestSuccessfulRefresh() {
 	}
 	for tcName, tc := range testCases {
 		s.Run(tcName, func() {
-			testTimeout := 100 * time.Millisecond
+			testTimeout := 1 * time.Second
 			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 			defer cancel()
 			ca, err := mtls.CAForSigning()


### PR DESCRIPTION
## Description

100 ms are too sharp for shared build workers running parallel tests. Increase to 1 second, a timeout that other tests in the same suite that are not failing are using as well.

(Saw this failing on my branch)

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- CI (unit test was passing locally anyway)
