### PR TITLE
Distinguish helper functions with and without feature flag in vulnmanagement integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -475,3 +475,21 @@ export function verifyFixableCVEsLinkAndRiskAcceptanceTabs(
             });
         });
 }
+
+// table
+
+/*
+ * Assert table column headings in order with empty string if no text (for example, checkbox).
+ */
+export function hasTableColumnHeadings(tableColumnHeadings) {
+    tableColumnHeadings.forEach((tableColumnHeading, index0) => {
+        const index1 = index0 + 1; // nth-child selector has one-based index
+        if (tableColumnHeading.length === 0) {
+            cy.get(`.rt-th:nth-child(${index1})`);
+        } else {
+            cy.get(`.rt-th:nth-child(${index1}) > div:contains("${tableColumnHeading}")`);
+        }
+    });
+
+    cy.get('.rt-th').should('have.length', tableColumnHeadings.length);
+}

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -487,7 +487,7 @@ export function hasTableColumnHeadings(tableColumnHeadings) {
         if (tableColumnHeading.length === 0) {
             cy.get(`.rt-th:nth-child(${index1})`);
         } else {
-            cy.get(`.rt-th:nth-child(${index1}) > div:contains("${tableColumnHeading}")`);
+            cy.get(`.rt-th:nth-child(${index1}):contains("${tableColumnHeading}")`);
         }
     });
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusterCvesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusterCvesListPages.test.js
@@ -6,8 +6,8 @@ import {
     callbackForPairOfAscendingNumberValuesFromElements,
     callbackForPairOfDescendingNumberValuesFromElements,
 } from '../../helpers/sort';
-import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
+    hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
@@ -38,19 +38,19 @@ describe('Vulnerability Management Cluster (Platform) CVEs', () => {
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
-        hasExpectedHeaderColumns(
-            [
-                'CVE',
-                'Type',
-                'Fixable',
-                'CVSS Score',
-                'Env. Impact',
-                'Impact Score',
-                'Entities',
-                'Published',
-            ],
-            1 // skip 1 additional column to account for checkbox column
-        );
+        hasTableColumnHeadings([
+            '', // checkbox
+            '', // hidden
+            'CVE',
+            'Type',
+            'Fixable',
+            'CVSS Score',
+            'Env. Impact',
+            'Impact Score',
+            'Entities',
+            'Published',
+            '', // hidden
+        ]);
     });
 
     it('should sort the CVSS Score column', () => {

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clustersListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clustersListPages.test.js
@@ -5,10 +5,10 @@ import {
     callbackForPairOfAscendingNumberValuesFromElements,
     callbackForPairOfDescendingNumberValuesFromElements,
 } from '../../helpers/sort';
-import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
     getCountAndNounFromImageCVEsLinkResults,
     getCountAndNounFromNodeCVEsLinkResults,
+    hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
     verifyFilteredSecondaryEntitiesLink,
     verifySecondaryEntities,
@@ -37,7 +37,8 @@ describe('Vulnerability Management Clusters', () => {
     it('should display all the columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
-        hasExpectedHeaderColumns([
+        hasTableColumnHeadings([
+            '', // hidden
             'Cluster',
             'Image CVEs',
             'Node CVEs',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsListPages.test.js
@@ -14,6 +14,7 @@ import {
 } from '../../helpers/vmWorkflowUtils';
 import {
     getCountAndNounFromImageCVEsLinkResults,
+    hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
     verifyFilteredSecondaryEntitiesLink,
     verifySecondaryEntities,
@@ -74,7 +75,8 @@ describe('Vulnerability Management Deployments', () => {
         it('should display table columns', () => {
             visitVulnerabilityManagementEntities(entitiesKey);
 
-            hasExpectedHeaderColumns([
+            hasTableColumnHeadings([
+                '', // hidden
                 'Deployment',
                 'Image CVEs',
                 'Latest Violation',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageComponentsListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageComponentsListPages.test.js
@@ -5,9 +5,9 @@ import {
     callbackForPairOfAscendingNumberValuesFromElements,
     callbackForPairOfDescendingNumberValuesFromElements,
 } from '../../helpers/sort';
-import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
     getCountAndNounFromImageCVEsLinkResults,
+    hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
     verifyFilteredSecondaryEntitiesLink,
     verifySecondaryEntities,
@@ -28,7 +28,8 @@ describe('Vulnerability Management Image Components', () => {
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
-        hasExpectedHeaderColumns([
+        hasTableColumnHeadings([
+            '', // hidden
             'Component',
             'Operating System',
             'CVEs',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageCvesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageCvesListPages.test.js
@@ -8,8 +8,8 @@ import {
     callbackForPairOfDescendingNumberValuesFromElements,
     callbackForPairOfDescendingVulnerabilitySeverityValuesFromElements,
 } from '../../helpers/sort';
-import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
+    hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
@@ -29,21 +29,21 @@ describe('Vulnerability Management Image CVEs', () => {
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
-        hasExpectedHeaderColumns(
-            [
-                'CVE',
-                'Operating System',
-                'Fixable',
-                'Severity',
-                'CVSS Score',
-                'Env. Impact',
-                'Impact Score',
-                'Entities',
-                'Discovered Time',
-                'Published',
-            ],
-            1 // skip 1 additional column to account for checkbox column
-        );
+        hasTableColumnHeadings([
+            '', // checkbox
+            '', // hidden
+            'CVE',
+            'Operating System',
+            'Fixable',
+            'Severity',
+            'CVSS Score',
+            'Env. Impact',
+            'Impact Score',
+            'Entities',
+            'Discovered Time',
+            'Published',
+            '', // hidden
+        ]);
     });
 
     it('should sort the CVSS Score column', () => {

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imagesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imagesListPages.test.js
@@ -6,9 +6,9 @@ import {
     callbackForPairOfAscendingNumberValuesFromElements,
     callbackForPairOfDescendingNumberValuesFromElements,
 } from '../../helpers/sort';
-import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
     getCountAndNounFromImageCVEsLinkResults,
+    hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
     verifyFixableCVEsLinkAndRiskAcceptanceTabs,
     verifySecondaryEntities,
@@ -29,7 +29,8 @@ describe('Vulnerability Management Images', () => {
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
-        hasExpectedHeaderColumns([
+        hasTableColumnHeadings([
+            '', // hidden
             'Image',
             'CVEs',
             'Top CVSS',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespacesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespacesListPages.test.js
@@ -14,6 +14,7 @@ import {
 } from '../../helpers/vmWorkflowUtils';
 import {
     getCountAndNounFromImageCVEsLinkResults,
+    hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
     verifyFilteredSecondaryEntitiesLink,
     verifySecondaryEntities,
@@ -78,7 +79,8 @@ describe('Vulnerability Management Namespaces', () => {
         it('should display table columns', () => {
             visitVulnerabilityManagementEntities(entitiesKey);
 
-            hasExpectedHeaderColumns([
+            hasTableColumnHeadings([
+                '', // hidden
                 'Namespace',
                 'Image CVEs',
                 'Cluster',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponentsListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponentsListPages.test.js
@@ -5,9 +5,9 @@ import {
     callbackForPairOfAscendingNumberValuesFromElements,
     callbackForPairOfDescendingNumberValuesFromElements,
 } from '../../helpers/sort';
-import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
     getCountAndNounFromNodeCVEsLinkResults,
+    hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
     verifyFilteredSecondaryEntitiesLink,
     verifySecondaryEntities,
@@ -28,7 +28,8 @@ describe('Vulnerability Management Node Components', () => {
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
-        hasExpectedHeaderColumns([
+        hasTableColumnHeadings([
+            '', // hidden
             'Component',
             'Operating System',
             'Node CVEs',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeCvesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeCvesListPages.test.js
@@ -8,8 +8,8 @@ import {
     callbackForPairOfDescendingNumberValuesFromElements,
     callbackForPairOfDescendingVulnerabilitySeverityValuesFromElements,
 } from '../../helpers/sort';
-import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
+    hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
@@ -29,21 +29,21 @@ describe('Vulnerability Management Node CVEs', () => {
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
-        hasExpectedHeaderColumns(
-            [
-                'CVE',
-                'Operating System',
-                'Fixable',
-                'Severity',
-                'CVSS Score',
-                'Env. Impact',
-                'Impact Score',
-                'Entities',
-                'Discovered Time',
-                'Published',
-            ],
-            1 // skip 1 additional column to account for checkbox column
-        );
+        hasTableColumnHeadings([
+            '', // checkbox
+            '', // hidden
+            'CVE',
+            'Operating System',
+            'Fixable',
+            'Severity',
+            'CVSS Score',
+            'Env. Impact',
+            'Impact Score',
+            'Entities',
+            'Discovered Time',
+            'Published',
+            '', // hidden
+        ]);
     });
 
     it('should sort the CVSS Score column', () => {

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodesListPages.test.js
@@ -5,8 +5,8 @@ import {
     callbackForPairOfAscendingNumberValuesFromElements,
     callbackForPairOfDescendingNumberValuesFromElements,
 } from '../../helpers/sort';
-import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
+    hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
@@ -25,7 +25,8 @@ describe('Vulnerability Management Nodes', () => {
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
-        hasExpectedHeaderColumns([
+        hasTableColumnHeadings([
+            '', // hidden
             'Node',
             'Node CVEs',
             'Top CVSS',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/policiesListpages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/policiesListpages.test.js
@@ -6,8 +6,8 @@ import {
     callbackForPairOfAscendingPolicySeverityValuesFromElements,
     callbackForPairOfDescendingPolicySeverityValuesFromElements,
 } from '../../helpers/sort';
-import { hasExpectedHeaderColumns } from '../../helpers/vmWorkflowUtils';
 import {
+    hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
     verifyFilteredSecondaryEntitiesLink,
     visitVulnerabilityManagementEntities,
@@ -27,20 +27,21 @@ describe('Vulnerability Management Policies', () => {
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
-        hasExpectedHeaderColumns(
-            [
-                'Policy',
-                'Description',
-                'Policy Status',
-                'Last Updated',
-                'Latest Violation',
-                'Severity',
-                'Deployments',
-                'Lifecycle',
-                'Enforcement',
-            ],
-            2 // skip 2 additional columns to account for checkbox column, and untitled Statuses column
-        );
+        hasTableColumnHeadings([
+            '', // checkbox
+            '', // hidden
+            '', // invisible
+            'Policy',
+            'Description',
+            'Policy Status',
+            'Last Updated',
+            'Latest Violation',
+            'Severity',
+            'Deployments',
+            'Lifecycle',
+            'Enforcement',
+            '', // hidden
+        ]);
     });
 
     it('should sort the Severity column', () => {


### PR DESCRIPTION
## Description

**Goal**: Be able to delete vmWorkflowUtils.js file in cleanup after ROX_POSTGRES_DATASTORE feature flag.

**Change**: Adapt `hasExpectedHeaderColumns` function to write `hasTableHeadingColumns` function in entities.js file and call it in tests for feature flag enabled or unaffected by feature flag. Arguments of forward-looking function account for all columns, including checkbox, hidden, and invisible.

**Result**: Only 4 occurrences of backward-looking function.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed