### PR TITLE
ROX-12813: Give the metrics server more time to become available after scaling up

### DIFF
--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -282,8 +282,10 @@ activate_metrics_server() {
 
     echo "Waiting for metrics.k8s.io to be in kubectl API resources..."
     local success=0
+    # Metrics server needs some time to be able to respond, even after it marks itself as ready, so use
+    # a generous timeout. It will respond eventually.
     # shellcheck disable=SC2034
-    for i in $(seq 1 10); do
+    for i in $(seq 1 30); do
         if kubectl api-resources 2>&1 | sed -e 's/^/out: /' | grep metrics.k8s.io; then
             success=1
             break


### PR DESCRIPTION
## Description

The ticket describes a test flake. This should be fixable through a more generous timeout.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- CI
