### PR TITLE
Dashrews/ROX-12999 Central should not crash for central-db restarts (WIP)

### DIFF
--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -403,6 +403,13 @@ func (ds *datastoreImpl) UpdateClusterHealth(ctx context.Context, id string, clu
 		return err
 	}
 
+	// Postgres does not need to update indexes and things of that nature and thus does not need to obtain a lock
+	// to perform a simple database upsert.
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		clusterHealthStatus.Id = id
+		return ds.clusterHealthStorage.Upsert(ctx, clusterHealthStatus)
+	}
+
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 


### PR DESCRIPTION
## Description

When restarting central-db, central would crash.  It would come back up and connect fine, but the crash was unnecessary.  The Postgres retry logic was handling everything just fine, but there were locks at the datastore level that were expiring and thus causing central to crash.  In a release build central would have just held the lock and not crashed but since we have timeout locks in dev builds to help us make sure our code quality is good, we were able to see these crashes and address them.  The issue is that we were acquiring locks in some of the datastores to ensure we updated the store and the indexer together.  In Postgres we no longer need to separately update an indexer and as such the locks I've encountered have been unnecessary, so the code was updated not to use those locks in Postgres mode as they are no longer necessary.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
