### PR TITLE
Remove colors from qa tests

### DIFF
--- a/qa-tests-backend/src/test/resources/logback-test.xml
+++ b/qa-tests-backend/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
     <withJansi>true</withJansi>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%gray(%d{HH:mm:ss}) | %highlight(%-5level) | %-25logger{0} | %m%n%rEx{full,
+            <pattern>%d{HH:mm:ss} | %-5level | %-25logger{0} | %m%n%rEx{full,
                 com.sun,
                 com.jayway.restassured.internal,
                 groovy.lang,


### PR DESCRIPTION
## Description

Prow does not handle colorful logs as CircleCI did. Let's remove color modifier to make logs cleaner and easier to read for human.
#### Before:
```
^[[1;30m16:02:19^[[0;39m | ^[[34mINFO ^[[0;39m | DeploymentEventGraphQLTest | Starting testsuite
^[[1;30m16:02:19^[[0;39m | ^[[34mINFO ^[[0;39m | BaseSpecification         | Performing global setup
^[[1;30m16:02:19^[[0;39m | ^[[34mINFO ^[[0;39m | BaseSpecification         | Will perform strict integration testing (if any is required)
^[[1;30m16:02:21^[[0;39m | ^[[39mDEBUG^[[0;39m | Kubernetes                | quay: secret created.
^[[1;30m16:02:21^[[0;39m | ^[[39mDEBUG^[[0;39m | Kubernetes                | public-dockerhub: secret created.
^[[1;30m16:02:21^[[0;39m | ^[[39mDEBUG^[[0;39m | Kubernetes                | gcr-image-pull-secret: secret created.
^[[1;30m16:02:22^[[0;39m | ^[[39mDEBUG^[[0;39m | Helpers                   | Caught exception. Retrying in 1s

```
#### After:
```
15:57:00 | INFO  | ExternalNetworkSourcesTest | Starting testsuite
15:57:00 | INFO  | BaseSpecification         | Performing global setup
15:57:00 | INFO  | BaseSpecification         | Will perform strict integration testing (if any is required)
15:57:01 | DEBUG | Kubernetes                | quay: secret created.
15:57:01 | DEBUG | Kubernetes                | public-dockerhub: secret created.
15:57:01 | DEBUG | Kubernetes                | gcr-image-pull-secret: secret created.
15:57:01 | DEBUG | Helpers                   | Caught exception. Retrying in 1s
```

## Testing Performed

CI