### PR TITLE
ROX-12962 PLoP sensor implementation

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -45,4 +45,7 @@ var (
 
 	// RHCOSNodeScanning enables phase 1 functions of "Full host level vulnerability scanning for RHCOS nodes" (ROX-10818)
 	RHCOSNodeScanning = registerFeature("Enable RHCOS node scanning of OS and installed packages", "ROX_RHCOS_NODE_SCANNING", false)
+
+	// ProcessesListeningOnPort enables the NetworkFlow code to also update the processes that are listening on ports
+	ProcessesListeningOnPort = registerFeature("Enable Processes Listening on Port", "ROX_PROCESSES_LISTENING_ON_PORT", false)
 )

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -170,12 +170,12 @@ func IncrementTotalNetworkEndpointsReceivedCounter(numberOfEndpoints int) {
 	totalNetworkEndpointsReceivedCounter.Add(float64(numberOfEndpoints))
 }
 
-// IncrementTotalNetworkEndpointsSentCounter increments the total number of endpoints sent
+// IncrementTotalProcessesSentCounter increments the total number of endpoints sent
 func IncrementTotalProcessesSentCounter(numberOfProcesses int) {
 	totalNetworkEndpointsSentCounter.Add(float64(numberOfProcesses))
 }
 
-// IncrementTotalNetworkEndpointsReceivedCounter increments the total number of endpoints received
+// IncrementTotalProcessesReceivedCounter increments the total number of endpoints received
 func IncrementTotalProcessesReceivedCounter(numberOfProcesses int) {
 	totalNetworkEndpointsReceivedCounter.Add(float64(numberOfProcesses))
 }

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -85,6 +85,20 @@ var (
 		Help:      "A counter of the total number of network endpoints received by Sensor from Collector",
 	})
 
+	totalProcessesSentCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "total_processes_sent_counter",
+		Help:      "A counter of the total number of processes sent to Central by Sensor",
+	})
+
+	totalProcessesReceivedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "total_processes_received_counter",
+		Help:      "A counter of the total number of processes received by Sensor from Collector",
+	})
+
 	sensorEvents = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
@@ -154,6 +168,16 @@ func IncrementTotalNetworkEndpointsSentCounter(numberOfEndpoints int) {
 // IncrementTotalNetworkEndpointsReceivedCounter increments the total number of endpoints received
 func IncrementTotalNetworkEndpointsReceivedCounter(numberOfEndpoints int) {
 	totalNetworkEndpointsReceivedCounter.Add(float64(numberOfEndpoints))
+}
+
+// IncrementTotalNetworkEndpointsSentCounter increments the total number of endpoints sent
+func IncrementTotalProcessesSentCounter(numberOfProcesses int) {
+	totalNetworkEndpointsSentCounter.Add(float64(numberOfProcesses))
+}
+
+// IncrementTotalNetworkEndpointsReceivedCounter increments the total number of endpoints received
+func IncrementTotalProcessesReceivedCounter(numberOfProcesses int) {
+	totalNetworkEndpointsReceivedCounter.Add(float64(numberOfProcesses))
 }
 
 // IncrementProcessEnrichmentDrops increments the number of times we could not enrich.

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -127,9 +127,9 @@ func (i *processListeningIndicator) toProto(ts timestamp.MicroTS) *storage.Proce
 		Process: &storage.ProcessIndicatorUniqueKey{
 			PodId:               i.key.podID,
 			ContainerName:       i.key.containerName,
-			ProcessName:         i.key.process.process_name,
-			ProcessExecFilePath: i.key.process.process_exec,
-			ProcessArgs:         i.key.process.process_args,
+			ProcessName:         i.key.process.processName,
+			ProcessExecFilePath: i.key.process.processExec,
+			ProcessArgs:         i.key.process.processArgs,
 		},
 	}
 
@@ -155,13 +155,13 @@ func (c *connection) String() string {
 }
 
 type processInfo struct {
-	process_name string
-	process_args string
-	process_exec string
+	processName string
+	processArgs string
+	processExec string
 }
 
 func (p *processInfo) String() string {
-	return fmt.Sprintf("%s: %s %s", p.process_exec, p.process_name, p.process_args)
+	return fmt.Sprintf("%s: %s %s", p.processExec, p.processName, p.processArgs)
 }
 
 type containerEndpoint struct {
@@ -487,8 +487,6 @@ func (m *networkFlowManager) enrichProcessListening(ep *containerEndpoint, statu
 		protocol: ep.endpoint.L4Proto.ToProtobuf(),
 	}
 
-	log.Debugf("Enriched: %s", indicator)
-
 	// Multiple endpoints from a collector can result in a single enriched endpoint,
 	// hence update the timestamp only if we have a more recent endpoint than the one we have already enriched.
 	if oldTS, found := processesListening[indicator]; !found || oldTS < status.lastSeen {
@@ -801,9 +799,9 @@ func getProcessKey(originator *storage.NetworkProcessUniqueKey) *processInfo {
 	log.Debugf("Got process key: %s %s %s", originator.ProcessExecFilePath, originator.ProcessName, originator.ProcessArgs)
 
 	return &processInfo{
-		process_name: originator.ProcessName,
-		process_args: originator.ProcessArgs,
-		process_exec: originator.ProcessExecFilePath,
+		processName: originator.ProcessName,
+		processArgs: originator.ProcessArgs,
+		processExec: originator.ProcessExecFilePath,
 	}
 }
 

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/pkg/netutil"
 	"github.com/stackrox/rox/pkg/networkgraph"
@@ -244,7 +245,9 @@ func (m *networkFlowManager) enrichConnections() {
 		case <-ticker.C:
 			m.enrichAndSend()
 		case <-processTicker.C:
-			m.enrichAndSendProcesses()
+			if features.ProcessesListeningOnPort.Enabled() {
+				m.enrichAndSendProcesses()
+			}
 		}
 	}
 }

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -236,7 +236,6 @@ func (m *networkFlowManager) ResponsesC() <-chan *central.MsgFromSensor {
 
 func (m *networkFlowManager) enrichConnections() {
 	ticker := time.NewTicker(time.Second * 30)
-	processTicker := time.NewTicker(time.Second * 30)
 
 	for {
 		select {
@@ -244,7 +243,7 @@ func (m *networkFlowManager) enrichConnections() {
 			return
 		case <-ticker.C:
 			m.enrichAndSend()
-		case <-processTicker.C:
+
 			if features.ProcessesListeningOnPort.Enabled() {
 				m.enrichAndSendProcesses()
 			}

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -307,7 +307,6 @@ func (m *networkFlowManager) enrichAndSendProcesses() {
 	}
 
 	metrics.IncrementTotalProcessesSentCounter(len(processesToSend.ProcessesListeningOnPorts))
-	log.Debugf("Processes update : %v", processesToSend)
 	select {
 	case <-m.done.Done():
 		return
@@ -794,8 +793,6 @@ func getProcessKey(originator *storage.NetworkProcessUniqueKey) *processInfo {
 	if originator == nil {
 		return nil
 	}
-
-	log.Debugf("Got process key: %s %s %s", originator.ProcessExecFilePath, originator.ProcessName, originator.ProcessArgs)
 
 	return &processInfo{
 		processName: originator.ProcessName,

--- a/sensor/common/networkflow/metrics/metrics.go
+++ b/sensor/common/networkflow/metrics/metrics.go
@@ -76,4 +76,10 @@ var (
 		Name:      "network_flow_host_endpoints_removed",
 		Help:      "Total number of endpoints stored in the host connections maps",
 	})
+	HostProcessesRemoved = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "processes_listening_on_port_removed",
+		Help:      "Total number of processes listening on ports",
+	})
 )


### PR DESCRIPTION
## Description

This PR adds the necessary changes to sensor in order for it to properly handle information regarding a process listening on a given port.

The basic idea is that collector will be sending some additional information on the processes that is listening on a given port in a deployment, sensor will then enrich that information with the pod id and container name and send it over to central. A new endpoint for central will be implemented in another PR, so the new data sent by collector will be stored next to the received endpoints at first and split into their own stream when sent to central.

A feature flag has been put in place to try and minimize the impact of these changes while we implement the missing features in collector and central.

## TODO
- [x] Get rid of some of the additional logging that has been added once we are done testing manually.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manually checked that sending mock data into sensor pretending to be collector resulted in the processes being forwarded to central, but more testing will be needed.
