### PR TITLE
Add Jansi dependency to enable terminal color auto-sensing

### DIFF
--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.11'
     testImplementation group: 'org.yaml', name: 'snakeyaml', version: '1.29'
     implementation group: 'com.jayway.restassured', name: 'rest-assured', version: '2.9.0'
-    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.11'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.4'
     testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion
     testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: jacksonVersion
     testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
@@ -129,7 +129,7 @@ dependencies {
 
     // This should disable coloring when output is redirected.
     // See https://logback.qos.ch/manual/layouts.html#coloring
-    runtimeOnly group: 'org.fusesource.jansi', name: 'jansi', version: '2.4.0'
+    implementation group: 'org.fusesource.jansi', name: 'jansi', version: '1.18'
 }
 
 tasks.withType(Test) {

--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -126,6 +126,10 @@ dependencies {
     implementation group: 'org.picocontainer', name: 'picocontainer', version: '2.15'
 
     implementation 'commons-codec:commons-codec:1.15'
+
+    // This should disable coloring when output is redirected.
+    // See https://logback.qos.ch/manual/layouts.html#coloring
+    runtimeOnly group: 'org.fusesource.jansi', name: 'jansi', version: '2.4.0'
 }
 
 tasks.withType(Test) {

--- a/qa-tests-backend/src/test/resources/logback-test.xml
+++ b/qa-tests-backend/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <configuration>
-    <withJansi>true</withJansi>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
         <encoder>
             <pattern>%gray(%d{HH:mm:ss}) | %highlight(%-5level) | %-25logger{0} | %m%n%rEx{full,
                 com.sun,

--- a/qa-tests-backend/src/test/resources/logback-test.xml
+++ b/qa-tests-backend/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
     <withJansi>true</withJansi>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss} | %-5level | %-25logger{0} | %m%n%rEx{full,
+            <pattern>%gray(%d{HH:mm:ss}) | %highlight(%-5level) | %-25logger{0} | %m%n%rEx{full,
                 com.sun,
                 com.jayway.restassured.internal,
                 groovy.lang,


### PR DESCRIPTION
## Description

See https://github.com/stackrox/stackrox/pull/3386#discussion_r992606091

The coloring works when ran in the terminal
![image](https://user-images.githubusercontent.com/537715/195161384-4fa4fd53-506e-4571-bb4e-fa0e5f35b3f4.png)

Waiting to see CI results.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
