### PR TITLE
ROX-13028: Skip Configuration Management Controls tests which have intermittent failures

### DIFF
--- a/ui/apps/platform/cypress/integration/configmanagement/ciscontrols.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/ciscontrols.test.js
@@ -43,7 +43,8 @@ describe('Configuration Management Controls', () => {
         hasCountWidgetsFor(['Nodes']);
     });
 
-    it('should click on the nodes count widget in the entity page and show the nodes tab', () => {
+    // ROX-13028: skip pending investigation why sometimes 0 nodes for control, therefore widget is disabled.
+    it.skip('should click on the nodes count widget in the entity page and show the nodes tab', () => {
         renderListAndSidePanel(entitiesKey);
         navigateToSingleEntityPage(entitiesKey);
         clickOnCountWidget('nodes', 'entityList');
@@ -81,7 +82,8 @@ describe('Configuration Management Controls', () => {
         cy.get(configManagementSelectors.failingNodes).should('have.length', 0);
     });
 
-    it('should show failing nodes in the control findings section of a failing control', () => {
+    // ROX-13028: skip pending investigation why sometimes table has 0 failing nodes.
+    it.skip('should show failing nodes in the control findings section of a failing control', () => {
         visitConfigurationManagementEntities(entitiesKey);
 
         cy.get(configManagementSelectors.tableCells)


### PR DESCRIPTION
## Description

### Test failures

1. Configuration Management Controls should click on the nodes count widget in the entity page and show the nodes tab
 
    > Timed out retrying after 4050ms: `cy.click()` failed because this element is `disabled`:

    > `<button type="button" disabled="" class="h-full w-full no-underline text-primary-700 hover:bg-primary-100" data-testid="related-entity-list-count-value">...</button>`

    ![ciscontrols-nodes-0](https://user-images.githubusercontent.com/11862657/195185360-5ce03deb-37a8-4aa6-b2db-bfa242e52fce.png)

2. Configuration Management Controls should show failing nodes in the control findings section of a failing control

    > Timed out retrying after 4000ms: Expected to find element: `[data-testid="widget"] .rt-tr-group > .rt-tr`, but never found it.

    ![ciscontrols-findings-undefined](https://user-images.githubusercontent.com/11862657/195185392-acb5a2b3-d2c4-46e2-8f63-dd1755fa5891.png)

Skip the tests pending investigation why 0 nodes for control in the following intermittent failures:

1. 1578519049527103488 from master build for 3326 on 2022-10-07
2. 1579384216087433216 from master build for 3364 on 2022-10-10
3. 1579535251267391488 from branch build for 3376 on 2022-10-10

## Checklist
- [x] Investigated and inspected CI test results
- [x] Skipped integration tests

## Testing Performed