### PR TITLE
ROX-13065: Adding skeleton of DeploymentDetails component

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import {
+    EdgeModel,
     Model,
+    NodeModel,
     SELECTION_EVENT,
     TopologySideBar,
     TopologyView,
@@ -15,80 +17,86 @@ import './Topology.css';
 import stylesComponentFactory from './components/stylesComponentFactory';
 import defaultLayoutFactory from './layouts/defaultLayoutFactory';
 import defaultComponentFactory from './components/defaultComponentFactory';
+import DeploymentSideBar from './deployment/DeploymentSideBar';
+
+const model: Model = {
+    graph: {
+        id: 'g1',
+        type: 'graph',
+        layout: 'ColaNoForce',
+    },
+    nodes: [
+        {
+            id: 'n1',
+            label: 'Central',
+            type: 'node',
+            width: 75,
+            height: 75,
+            data: {
+                id: 'n1',
+                label: 'Central',
+                type: 'node',
+                width: 75,
+                height: 75,
+            },
+        },
+        {
+            id: 'n2',
+            label: 'Sensor',
+            type: 'node',
+            width: 75,
+            height: 75,
+            data: {
+                id: 'n2',
+                label: 'Sensor',
+                type: 'node',
+                width: 75,
+                height: 75,
+            },
+        },
+        {
+            id: 'group1',
+            type: 'group',
+            children: ['n1', 'n2'],
+            group: true,
+            label: 'stackrox',
+            style: { padding: 15 },
+            data: {
+                collapsible: true,
+                showContextMenu: false,
+            },
+        },
+    ],
+    edges: [
+        {
+            id: 'e1',
+            type: 'edge',
+            source: 'n1',
+            target: 'n2',
+        },
+        {
+            id: 'e2',
+            type: 'edge',
+            source: 'n2',
+            target: 'n1',
+        },
+    ],
+};
 
 const TopologyComponent = () => {
-    const [selectedId, setSelectedId] = useState<string | null>(null);
+    const [selectedObj, setSelectedObj] = useState<NodeModel | EdgeModel | null>(null);
 
     const controller = useVisualizationController();
 
     React.useEffect(() => {
-        const model: Model = {
-            graph: {
-                id: 'g1',
-                type: 'graph',
-                layout: 'ColaNoForce',
-            },
-            nodes: [
-                {
-                    id: 'n1',
-                    label: 'Central',
-                    type: 'node',
-                    width: 75,
-                    height: 75,
-                    data: {
-                        id: 'n1',
-                        label: 'Central',
-                        type: 'node',
-                        width: 75,
-                        height: 75,
-                    },
-                },
-                {
-                    id: 'n2',
-                    label: 'Sensor',
-                    type: 'node',
-                    width: 75,
-                    height: 75,
-                    data: {
-                        id: 'n2',
-                        label: 'Sensor',
-                        type: 'node',
-                        width: 75,
-                        height: 75,
-                    },
-                },
-                {
-                    id: 'group1',
-                    type: 'group',
-                    children: ['n1', 'n2'],
-                    group: true,
-                    label: 'stackrox',
-                    style: { padding: 15 },
-                    data: {
-                        collapsible: false,
-                        showContextMenu: false,
-                    },
-                },
-            ],
-            edges: [
-                {
-                    id: 'e1',
-                    type: 'edge',
-                    source: 'n1',
-                    target: 'n2',
-                },
-                {
-                    id: 'e2',
-                    type: 'edge',
-                    source: 'n2',
-                    target: 'n1',
-                },
-            ],
-        };
-
         function onSelect(ids: string[]) {
             const newSelectedId = ids?.[0] || null;
-            setSelectedId(newSelectedId);
+            // check if selected id is for a node
+            const newSelectedNode = model.nodes?.find((node) => node.id === newSelectedId);
+            if (newSelectedNode) {
+                setSelectedObj(newSelectedNode);
+            }
+            // if not then do nothing
         }
 
         controller.fromModel(model, false);
@@ -99,17 +107,25 @@ const TopologyComponent = () => {
         };
     }, [controller]);
 
+    const selectedIds = selectedObj ? [selectedObj.id] : [];
+
     return (
         <TopologyView
             sideBar={
-                <TopologySideBar show={!!selectedId} resizable onClose={() => setSelectedId(null)}>
-                    <div style={{ height: '100%' }}>{selectedId}</div>
+                <TopologySideBar
+                    show={!!selectedObj}
+                    resizable
+                    onClose={() => setSelectedObj(null)}
+                >
+                    {selectedObj?.type === 'group' && <div>Group</div>}
+                    {selectedObj?.type === 'node' && <DeploymentSideBar />}
+                    {selectedObj?.type === 'edge' && <div>Edge</div>}
                 </TopologySideBar>
             }
-            sideBarOpen={!!selectedId}
+            sideBarOpen={!!selectedObj}
             sideBarResizable
         >
-            <VisualizationSurface />
+            <VisualizationSurface state={{ selectedIds }} />
         </TopologyView>
     );
 };

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -112,14 +112,9 @@ const TopologyComponent = () => {
     return (
         <TopologyView
             sideBar={
-                <TopologySideBar
-                    show={!!selectedObj}
-                    resizable
-                    onClose={() => setSelectedObj(null)}
-                >
+                <TopologySideBar resizable onClose={() => setSelectedObj(null)}>
                     {selectedObj?.type === 'group' && <div>Group</div>}
                     {selectedObj?.type === 'node' && <DeploymentSideBar />}
-                    {selectedObj?.type === 'edge' && <div>Edge</div>}
                 </TopologySideBar>
             }
             sideBarOpen={!!selectedObj}

--- a/ui/apps/platform/src/Containers/NetworkGraph/Topology.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/Topology.css
@@ -70,3 +70,7 @@
     --pf-c-page__main-section--PaddingLeft: 0;
     --pf-c-page__main-section--PaddingBottom: 0;
 }
+
+.pf-c-tab-content[hidden] {
+    display: none !important;
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -1,0 +1,157 @@
+import React, { useState } from 'react';
+import {
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Divider,
+    ExpandableSection,
+    Text,
+    TextContent,
+    TextVariants,
+} from '@patternfly/react-core';
+
+function DetailSection({ title, children }) {
+    const [isExpanded, setIsExpanded] = useState(true);
+
+    const onToggle = (_isExpanded: boolean) => {
+        setIsExpanded(_isExpanded);
+    };
+
+    return (
+        <ExpandableSection
+            isExpanded={isExpanded}
+            onToggle={onToggle}
+            toggleContent={
+                <TextContent>
+                    <Text component={TextVariants.h1} className="pf-u-font-size-xl">
+                        {title}
+                    </Text>
+                </TextContent>
+            }
+        >
+            <div className="pf-u-px-sm pf-u-pb-md">{children}</div>
+        </ExpandableSection>
+    );
+}
+
+function DeploymentDetails() {
+    return (
+        <div className="pf-u-h-100 pf-u-p-md">
+            <ul>
+                <li>
+                    <DetailSection title="Security overview">
+                        <DescriptionList columnModifier={{ default: '2Col' }}>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Risk score</DescriptionListTerm>
+                                <DescriptionListDescription>Priority 1</DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Asset value</DescriptionListTerm>
+                                <DescriptionListDescription>High</DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Violations</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    1 deploy, 1 runtime
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Processes</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    3 anomalous, 12 running
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                        </DescriptionList>
+                    </DetailSection>
+                </li>
+                <Divider component="li" className="pf-u-mb-sm" />
+                <li>
+                    <DetailSection title="Network security">
+                        <DescriptionList columnModifier={{ default: '1Col' }}>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Network policy rules</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    0 egress, 1 ingress
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Flows observed</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    3 external, 2 anomalous, 4 active, 312 allowed
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                        </DescriptionList>
+                    </DetailSection>
+                </li>
+                <Divider component="li" className="pf-u-mb-sm" />
+                <li>
+                    <DetailSection title="Deployment configuration">
+                        <DescriptionList columnModifier={{ default: '2Col' }}>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Name</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    visa-processor
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Cluster</DescriptionListTerm>
+                                <DescriptionListDescription>Production</DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Created</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    12/09/21 | 6:03:23 PM
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Namespace</DescriptionListTerm>
+                                <DescriptionListDescription>Naples</DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Replicas</DescriptionListTerm>
+                                <DescriptionListDescription>2 pods</DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Service account</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    visa-processor
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Labels</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <span>app:visa-processor</span>{' '}
+                                    <span>helm.sh/release-namespace:naples</span>
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Annotations</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <span>deprecated.daemonset.template.generation:15</span>{' '}
+                                    <span>email:support@stackrox.com</span>
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>AddCapabilities</DescriptionListTerm>
+                                <DescriptionListDescription>SYS_ADMIN</DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Privileged</DescriptionListTerm>
+                                <DescriptionListDescription>true</DescriptionListDescription>
+                            </DescriptionListGroup>
+                        </DescriptionList>
+                    </DetailSection>
+                </li>
+                <Divider component="li" className="pf-u-mb-sm" />
+                <li>
+                    <DetailSection title="Port configurations">
+                        @TODO: Add port configurations section
+                    </DetailSection>
+                </li>
+            </ul>
+        </div>
+    );
+}
+
+export default DeploymentDetails;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import {
+    Badge,
+    Flex,
+    FlexItem,
+    Tab,
+    TabContent,
+    Tabs,
+    TabTitleText,
+    Text,
+    TextContent,
+    TextVariants,
+} from '@patternfly/react-core';
+
+import useTabs from 'hooks/patternfly/useTabs';
+import DeploymentDetails from './DeploymentDetails';
+
+function DeploymentSideBar() {
+    const { activeKeyTab, onSelectTab } = useTabs({
+        defaultTab: 'Details',
+    });
+
+    return (
+        <Flex direction={{ default: 'column' }} flex={{ default: 'flex_1' }} className="pf-u-h-100">
+            <Flex direction={{ default: 'row' }} className="pf-u-p-md">
+                <FlexItem>
+                    <Badge style={{ backgroundColor: 'rgb(0,102,205)' }}>D</Badge>
+                </FlexItem>
+                <FlexItem>
+                    <TextContent>
+                        <Text component={TextVariants.h1} className="pf-u-font-size-xl">
+                            visa-processor
+                        </Text>
+                    </TextContent>
+                    <TextContent>
+                        <Text
+                            component={TextVariants.h2}
+                            className="pf-u-font-size-sm pf-u-color-200"
+                        >
+                            in &quot;production / naples&quot;
+                        </Text>
+                    </TextContent>
+                </FlexItem>
+            </Flex>
+            <FlexItem flex={{ default: 'flex_1' }}>
+                <Tabs activeKey={activeKeyTab} onSelect={onSelectTab}>
+                    <Tab
+                        eventKey="Details"
+                        tabContentId="Details"
+                        title={<TabTitleText>Details</TabTitleText>}
+                    />
+                    <Tab
+                        eventKey="Flows"
+                        tabContentId="Flows"
+                        title={<TabTitleText>Flows</TabTitleText>}
+                    />
+                    <Tab
+                        eventKey="Baseline"
+                        tabContentId="Baseline"
+                        title={<TabTitleText>Baseline</TabTitleText>}
+                    />
+                    <Tab
+                        eventKey="Policies"
+                        tabContentId="Policies"
+                        title={<TabTitleText>Policies</TabTitleText>}
+                    />
+                    <Tab
+                        eventKey="Timeline"
+                        tabContentId="Timeline"
+                        title={<TabTitleText>Timeline</TabTitleText>}
+                    />
+                </Tabs>
+                <TabContent eventKey="Details" id="Details" hidden={activeKeyTab !== 'Details'}>
+                    <DeploymentDetails />
+                </TabContent>
+                <TabContent eventKey="Flows" id="Flows" hidden={activeKeyTab !== 'Flows'}>
+                    <div className="pf-u-h-100 pf-u-p-md">TODO: Add Flows</div>
+                </TabContent>
+                <TabContent eventKey="Baseline" id="Baseline" hidden={activeKeyTab !== 'Baseline'}>
+                    <div className="pf-u-h-100 pf-u-p-md">TODO: Add Baseline</div>
+                </TabContent>
+                <TabContent eventKey="Policies" id="Policies" hidden={activeKeyTab !== 'Policies'}>
+                    <div className="pf-u-h-100 pf-u-p-md">TODO: Add Policies</div>
+                </TabContent>
+                <TabContent eventKey="Timeline" id="Timeline" hidden={activeKeyTab !== 'Timeline'}>
+                    <div className="pf-u-h-100 pf-u-p-md">TODO: Add Timeline</div>
+                </TabContent>
+            </FlexItem>
+        </Flex>
+    );
+}
+
+export default DeploymentSideBar;


### PR DESCRIPTION
## Description

This PR adds a DeploymentSideBar and DeploymentDetails component that you can see by clicking on a node. This is just a skeleton and the remaining work was divided into subtasks you can view here: https://issues.redhat.com/browse/ROX-12903#view-subtasks. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

<img width="1552" alt="Screen Shot 2022-10-11 at 3 04 15 PM" src="https://user-images.githubusercontent.com/4805485/195207293-df8d8676-2925-491c-8036-7a5e4327b89a.png">
<img width="1552" alt="Screen Shot 2022-10-11 at 3 04 18 PM" src="https://user-images.githubusercontent.com/4805485/195207294-f9c4a44c-8223-4ea7-be5a-43a94e0803da.png">

