### PR TITLE
ROX-13066: Add links and icons for description list descriptions

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -1,15 +1,23 @@
 import React, { useState } from 'react';
 import {
+    Button,
     DescriptionList,
     DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
     Divider,
     ExpandableSection,
+    Flex,
+    FlexItem,
+    Label,
+    LabelGroup,
+    Stack,
+    StackItem,
     Text,
     TextContent,
     TextVariants,
 } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 function DetailSection({ title, children }) {
     const [isExpanded, setIsExpanded] = useState(true);
@@ -53,13 +61,45 @@ function DeploymentDetails() {
                             <DescriptionListGroup>
                                 <DescriptionListTerm>Violations</DescriptionListTerm>
                                 <DescriptionListDescription>
-                                    1 deploy, 1 runtime
+                                    <Flex
+                                        direction={{ default: 'row' }}
+                                        alignItems={{ default: 'alignItemsCenter' }}
+                                    >
+                                        <FlexItem>
+                                            <ExclamationCircleIcon className="pf-u-danger-color-100" />
+                                        </FlexItem>
+                                        <FlexItem>
+                                            <Button variant="link" isInline>
+                                                1 deploy
+                                            </Button>
+                                            ,{' '}
+                                            <Button variant="link" isInline>
+                                                1 runtime
+                                            </Button>
+                                        </FlexItem>
+                                    </Flex>
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                             <DescriptionListGroup>
                                 <DescriptionListTerm>Processes</DescriptionListTerm>
                                 <DescriptionListDescription>
-                                    3 anomalous, 12 running
+                                    <Flex
+                                        direction={{ default: 'row' }}
+                                        alignItems={{ default: 'alignItemsCenter' }}
+                                    >
+                                        <FlexItem>
+                                            <ExclamationCircleIcon className="pf-u-danger-color-100" />
+                                        </FlexItem>
+                                        <FlexItem>
+                                            <Button variant="link" isInline>
+                                                3 anomalous
+                                            </Button>
+                                            ,{' '}
+                                            <Button variant="link" isInline>
+                                                12 running
+                                            </Button>
+                                        </FlexItem>
+                                    </Flex>
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                         </DescriptionList>
@@ -72,13 +112,50 @@ function DeploymentDetails() {
                             <DescriptionListGroup>
                                 <DescriptionListTerm>Network policy rules</DescriptionListTerm>
                                 <DescriptionListDescription>
-                                    0 egress, 1 ingress
+                                    <Flex
+                                        direction={{ default: 'row' }}
+                                        alignItems={{ default: 'alignItemsCenter' }}
+                                    >
+                                        <FlexItem>
+                                            <ExclamationCircleIcon className="pf-u-warning-color-100" />
+                                        </FlexItem>
+                                        <FlexItem>
+                                            0 egress,{' '}
+                                            <Button variant="link" isInline>
+                                                1 ingress
+                                            </Button>
+                                        </FlexItem>
+                                    </Flex>
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                             <DescriptionListGroup>
                                 <DescriptionListTerm>Flows observed</DescriptionListTerm>
                                 <DescriptionListDescription>
-                                    3 external, 2 anomalous, 4 active, 312 allowed
+                                    <Flex
+                                        direction={{ default: 'row' }}
+                                        alignItems={{ default: 'alignItemsCenter' }}
+                                    >
+                                        <FlexItem>
+                                            <ExclamationCircleIcon className="pf-u-danger-color-100" />
+                                        </FlexItem>
+                                        <FlexItem>
+                                            <Button variant="link" isInline>
+                                                3 external
+                                            </Button>
+                                            ,{' '}
+                                            <Button variant="link" isInline>
+                                                2 anomalous
+                                            </Button>
+                                            ,{' '}
+                                            <Button variant="link" isInline>
+                                                4 active
+                                            </Button>
+                                            ,{' '}
+                                            <Button variant="link" isInline>
+                                                312 allowed
+                                            </Button>
+                                        </FlexItem>
+                                    </Flex>
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                         </DescriptionList>
@@ -87,60 +164,102 @@ function DeploymentDetails() {
                 <Divider component="li" className="pf-u-mb-sm" />
                 <li>
                     <DetailSection title="Deployment configuration">
-                        <DescriptionList columnModifier={{ default: '2Col' }}>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Name</DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    visa-processor
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Cluster</DescriptionListTerm>
-                                <DescriptionListDescription>Production</DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Created</DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    12/09/21 | 6:03:23 PM
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Namespace</DescriptionListTerm>
-                                <DescriptionListDescription>Naples</DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Replicas</DescriptionListTerm>
-                                <DescriptionListDescription>2 pods</DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Service account</DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    visa-processor
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Labels</DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <span>app:visa-processor</span>{' '}
-                                    <span>helm.sh/release-namespace:naples</span>
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Annotations</DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <span>deprecated.daemonset.template.generation:15</span>{' '}
-                                    <span>email:support@stackrox.com</span>
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>AddCapabilities</DescriptionListTerm>
-                                <DescriptionListDescription>SYS_ADMIN</DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Privileged</DescriptionListTerm>
-                                <DescriptionListDescription>true</DescriptionListDescription>
-                            </DescriptionListGroup>
-                        </DescriptionList>
+                        <Stack hasGutter>
+                            <StackItem>
+                                <DescriptionList columnModifier={{ default: '2Col' }}>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Name</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <Button variant="link" isInline>
+                                                visa-processor
+                                            </Button>
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Cluster</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <Button variant="link" isInline>
+                                                Production
+                                            </Button>
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Created</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            12/09/21 | 6:03:23 PM
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Namespace</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <Button variant="link" isInline>
+                                                Naples
+                                            </Button>
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Replicas</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <Button variant="link" isInline>
+                                                2 pods
+                                            </Button>
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Service account</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <Button variant="link" isInline>
+                                                visa-processor
+                                            </Button>
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                </DescriptionList>
+                            </StackItem>
+                            <StackItem>
+                                <DescriptionList columnModifier={{ default: '1Col' }}>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Labels</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <LabelGroup>
+                                                <Label color="blue">app:visa-processor</Label>
+                                                <Label color="blue">
+                                                    helm.sh/release-namespace:naples
+                                                </Label>
+                                            </LabelGroup>
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Annotations</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <LabelGroup>
+                                                <Label color="blue">
+                                                    deprecated.daemonset.template.generation:15
+                                                </Label>
+                                                <Label color="blue">
+                                                    email:support@stackrox.com
+                                                </Label>
+                                            </LabelGroup>
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                </DescriptionList>
+                            </StackItem>
+                            <StackItem>
+                                <DescriptionList columnModifier={{ default: '2Col' }}>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>AddCapabilities</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            SYS_ADMIN
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Privileged</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            true
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                </DescriptionList>
+                            </StackItem>
+                        </Stack>
                     </DetailSection>
                 </li>
                 <Divider component="li" className="pf-u-mb-sm" />


### PR DESCRIPTION
## Description

This PR adds inline links and icons for the description list descriptions. This is just iterative work and it will be fleshed out more in future PRs. The remaining work was divided into subtasks you can view here: https://issues.redhat.com/browse/ROX-12903#view-subtasks.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

<img width="1552" alt="Screen Shot 2022-10-11 at 6 07 57 PM" src="https://user-images.githubusercontent.com/4805485/195225869-1f14d154-02bb-4d7d-820c-54bff632d273.png">
<img width="1552" alt="Screen Shot 2022-10-11 at 6 07 59 PM" src="https://user-images.githubusercontent.com/4805485/195225876-123c2b3f-1e07-4068-b1e6-fd78b91b0427.png">
van