### PR TITLE
Fix permissions in central service account to allow diagnostic bundle to retrieve pod data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   The default SCC for sensor is now `restricted[-v2]` or `stackrox-sensor` depending on the settings.
   Both the `runAsUser` and `fsGroup` for the admission-control and sensor deployments are no longer hardcoded to 4000 on Openshift clusters
   to allow using the `restricted` and `restricted-v2` SCCs.
+- The service account "central", which is used by the central deployment, will now include `get and list` access to the pod resource in the namespace
+  where central is deployed to. This fixes an issue when generating diagnostic bundles to now correctly include all logs within the namespace of central.
 
 ## [3.72.0]
 

--- a/image/templates/helm/stackrox-central/templates/01-central-03-diagnostics-rbac.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-03-diagnostics-rbac.yaml
@@ -18,6 +18,7 @@ rules:
   - "replicasets"
   - "configmaps"
   - "services"
+  - "pods"
   verbs:
   - get
   - list


### PR DESCRIPTION
## Description

Currently, whe ncreating a diagnostic bundle, the central cluster will contain a `errors.txt` file with the following error message:
```
could not list pods in namespace "stackrox": pods is forbidden: User "system:serviceaccount:stackrox:central" cannot list resource "pods" in API group "" in the namespace "stackrox"
```

Before trying to retrieve any pod data (e.g. logs), we will first [check if we can list pods in the specific namespace](https://github.com/stackrox/stackrox/blob/eb7696c4b33e285969130d8ede4faf88e901ded2/pkg/k8sintrospect/collector.go#L341-L345).

However, the service account of central, which will be used, does not have the permission to list `pods` within [the stackrox-central-diagnostics 
role](https://github.com/stackrox/stackrox/blob/3d1daa92cfa7a9117753cae8aa58a5beb0bda272/image/templates/helm/stackrox-central/templates/01-central-03-diagnostics-rbac.yaml#L15-L20).

This leads to the error during checking if we can list pods, as well as the `errors.txt` file being created.

This PR fixes the listed resources within the role.

Although we previously didn't announce any changes related to the service accounts RBAC, I've added a changelog to let customers know that the role now includes one additional resource.


## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
- [X] Evaluated and added CHANGELOG entry if required
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- Create a diganostic bundle
- Ensure that within `_central-cluster` folder, no `errors.txt` is found and the log data is available for each pod.

