### PR TITLE
Bump sensor integration tests creation timeout

### DIFF
--- a/sensor/tests/resource/helper.go
+++ b/sensor/tests/resource/helper.go
@@ -42,6 +42,10 @@ import (
 const (
 	// DefaultNamespace the default namespace used to create the resources
 	DefaultNamespace string = "sensor-integration"
+
+	// defaultCreationTimeout maximum time the test will wait until sensor emits
+	// resource creation event to central after fake resource was applied.
+	defaultCreationTimeout time.Duration = 10 * time.Second
 )
 
 // YamlTestFile is a test file in YAML
@@ -403,7 +407,7 @@ func (c *TestContext) ApplyFile(ctx context.Context, ns string, file YamlTestFil
 	}
 
 	if file.Kind == "Deployment" || file.Kind == "Pod" {
-		if err := c.waitForResource(5*time.Second, deploymentName(obj.GetName())); err != nil {
+		if err := c.waitForResource(defaultCreationTimeout, deploymentName(obj.GetName())); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Description

Quick way to _hopefully_ reduce flakiness in sensor-integration tests.

Flaky tests / tickets that might be a sympthom of this:
- [ROX-12849](https://issues.redhat.com/browse/ROX-12849) (Pod Hierarchy)
- [ROX-12745](https://issues.redhat.com/browse/ROX-12745) (Role Dependency)
- [Master job failure](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-nongroovy-e2e-tests/1578352127707713536) (Network Policy)

All these tests failed at least once in the last two weeks with the same error message:
```
helper.go:178: fail to apply resource: timeout reached waiting for event
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Just running tests
