### PR TITLE
Dashrews/ROX-13063 fix network flow deadlock when we have overlapping delete calls

### DIFF
--- a/central/networkgraph/flow/datastore/flow.go
+++ b/central/networkgraph/flow/datastore/flow.go
@@ -9,6 +9,7 @@ import (
 )
 
 // FlowDataStore stores all of the flows for a single cluster.
+//
 //go:generate mockgen-wrapper
 type FlowDataStore interface {
 	GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error)
@@ -21,4 +22,5 @@ type FlowDataStore interface {
 	UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) error
 	RemoveFlowsForDeployment(ctx context.Context, id string) error
 	RemoveMatchingFlows(ctx context.Context, keyMatchFn func(props *storage.NetworkFlowProperties) bool, valueMatchFn func(flow *storage.NetworkFlow) bool) error
+	RemoveStaleFlows(ctx context.Context) error
 }

--- a/central/networkgraph/flow/datastore/flow_impl.go
+++ b/central/networkgraph/flow/datastore/flow_impl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/central/networkgraph/flow/datastore/internal/store"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac"
@@ -130,4 +131,17 @@ func (fds *flowDataStoreImpl) RemoveMatchingFlows(ctx context.Context, keyMatchF
 		return sac.ErrResourceAccessDenied
 	}
 	return fds.storage.RemoveMatchingFlows(ctx, keyMatchFn, valueMatchFn)
+}
+
+// RemoveStaleFlows - remove stale duplicate network flows
+func (fds *flowDataStoreImpl) RemoveStaleFlows(ctx context.Context) error {
+	if ok, err := networkGraphSAC.WriteAllowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return fds.storage.RemoveStaleFlows(ctx)
+	}
+	return nil
 }

--- a/central/networkgraph/flow/datastore/internal/store/flow.go
+++ b/central/networkgraph/flow/datastore/internal/store/flow.go
@@ -9,6 +9,7 @@ import (
 )
 
 // FlowStore stores all of the flows for a single cluster.
+//
 //go:generate mockgen-wrapper
 type FlowStore interface {
 	GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error)
@@ -21,4 +22,7 @@ type FlowStore interface {
 
 	RemoveFlowsForDeployment(ctx context.Context, id string) error
 	RemoveMatchingFlows(ctx context.Context, keyMatchFn func(props *storage.NetworkFlowProperties) bool, valueMatchFn func(flow *storage.NetworkFlow) bool) error
+
+	// RemoveStaleFlows - remove stale duplicate network flows
+	RemoveStaleFlows(ctx context.Context) error
 }

--- a/central/networkgraph/flow/datastore/internal/store/mocks/flow.go
+++ b/central/networkgraph/flow/datastore/internal/store/mocks/flow.go
@@ -126,6 +126,20 @@ func (mr *MockFlowStoreMockRecorder) RemoveMatchingFlows(ctx, keyMatchFn, valueM
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveMatchingFlows", reflect.TypeOf((*MockFlowStore)(nil).RemoveMatchingFlows), ctx, keyMatchFn, valueMatchFn)
 }
 
+// RemoveStaleFlows mocks base method.
+func (m *MockFlowStore) RemoveStaleFlows(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveStaleFlows", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveStaleFlows indicates an expected call of RemoveStaleFlows.
+func (mr *MockFlowStoreMockRecorder) RemoveStaleFlows(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveStaleFlows", reflect.TypeOf((*MockFlowStore)(nil).RemoveStaleFlows), ctx)
+}
+
 // UpsertFlows mocks base method.
 func (m *MockFlowStore) UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) error {
 	m.ctrl.T.Helper()

--- a/central/networkgraph/flow/datastore/internal/store/postgres/cluster_impl.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/cluster_impl.go
@@ -5,28 +5,42 @@ import (
 
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/central/networkgraph/flow/datastore/internal/store"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 // NewClusterStore returns a new ClusterStore instance using the provided rocksdb instance.
 func NewClusterStore(db *pgxpool.Pool) store.ClusterStore {
 	return &clusterStoreImpl{
-		db: db,
+		db:        db,
+		flowStore: make(map[string]store.FlowStore),
 	}
 }
 
 type clusterStoreImpl struct {
-	db *pgxpool.Pool
+	db        *pgxpool.Pool
+	lock      sync.Mutex
+	flowStore map[string]store.FlowStore
 }
 
 // GetFlowStore returns the FlowStore for the cluster ID, or nil if none exists.
 func (s *clusterStoreImpl) GetFlowStore(clusterID string) store.FlowStore {
-	return &flowStoreImpl{
-		db:        s.db,
-		clusterID: clusterID,
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	flowStore, found := s.flowStore[clusterID]
+	if !found || flowStore == nil {
+		flowStore = New(s.db, clusterID)
+		s.flowStore[clusterID] = flowStore
 	}
+	return flowStore
 }
 
 // CreateFlowStore returns the FlowStore for the cluster ID, or creates one if none exists.
 func (s *clusterStoreImpl) CreateFlowStore(_ context.Context, clusterID string) (store.FlowStore, error) {
-	return New(s.db, clusterID), nil
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	flowStore := New(s.db, clusterID)
+	s.flowStore[clusterID] = flowStore
+	return flowStore, nil
 }

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store.go
@@ -67,20 +67,20 @@ const (
 		`WHERE nf.Props_DstEntity_Type = 1 AND nf.Props_DstEntity_Id = $1 AND nf.ClusterId = $2`
 
 	pruneStaleNetworkFlowsStmt = `DELETE FROM network_flows a USING (
-      SELECT MAX(flow_id) as max_flow, props_srcentity_type, props_srcentity_id, props_dstentity_type, props_dstentity_id, props_dstport, props_l4protocol, clusterid
+      SELECT MAX(flow_id) as Max_Flow, Props_SrcEntity_Type, Props_SrcEntity_Id, Props_DstEntity_Type, Props_DstEntity_Id, Props_DstPort, Props_L4Protocol, ClusterId
         FROM network_flows
-		WHERE clusterid = $1
-        GROUP BY props_srcentity_type, props_srcentity_id, props_dstentity_type, props_dstentity_id, props_dstport, props_l4protocol, clusterid
+		WHERE ClusterId = $1
+        GROUP BY Props_SrcEntity_Type, Props_SrcEntity_Id, Props_DstEntity_Type, Props_DstEntity_Id, Props_DstPort, Props_L4Protocol, ClusterId
 		HAVING COUNT(*) > 1
       ) b
-      WHERE a.props_srcentity_type = b.props_srcentity_type
- 	AND a.props_srcentity_id = b.props_srcentity_id
- 	AND a.props_dstentity_type = b.props_dstentity_type
- 	AND a.props_dstentity_id = b.props_dstentity_id
-	AND a.props_dstport = b.props_dstport
-	AND a.props_l4protocol = b.props_l4protocol
-	AND a.clusterid = b.clusterid
-      AND a.flow_id <> b.max_flow;
+      WHERE a.Props_SrcEntity_Type = b.Props_SrcEntity_Type
+ 	AND a.Props_SrcEntity_Id = b.Props_SrcEntity_Id
+ 	AND a.Props_DstEntity_Type = b.Props_DstEntity_Type
+ 	AND a.Props_DstEntity_Id = b.Props_DstEntity_Id
+	AND a.Props_DstPort = b.Props_DstPort
+	AND a.Props_L4Protocol = b.Props_L4Protocol
+	AND a.ClusterId = b.ClusterId
+      AND a.Flow_Id <> b.Max_Flow;
 	`
 )
 

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store_test.go
@@ -13,18 +13,29 @@ import (
 	"github.com/stackrox/rox/pkg/testutils/envisolator"
 	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+)
+
+const (
+	clusterID = "22"
+
+	flowsCountStmt = "select count(*) from network_flows"
 )
 
 type NetworkflowStoreSuite struct {
 	suite.Suite
 	envIsolator *envisolator.EnvIsolator
+	store       FlowStore
+	ctx         context.Context
+	pool        *pgxpool.Pool
+	gormDB      *gorm.DB
 }
 
 func TestNetworkflowStore(t *testing.T) {
 	suite.Run(t, new(NetworkflowStoreSuite))
 }
 
-func (s *NetworkflowStoreSuite) SetupTest() {
+func (s *NetworkflowStoreSuite) SetupSuite() {
 	s.envIsolator = envisolator.NewEnvIsolator(s.T())
 
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
@@ -33,10 +44,38 @@ func (s *NetworkflowStoreSuite) SetupTest() {
 	} else {
 		s.envIsolator.Setenv(env.PostgresDatastoreEnabled.EnvVar(), "true")
 	}
+
+	s.ctx = context.Background()
+
+	source := pgtest.GetConnectionString(s.T())
+	config, err := pgxpool.ParseConfig(source)
+	s.Require().NoError(err)
+	s.pool, err = pgxpool.ConnectConfig(s.ctx, config)
+	s.NoError(err)
+	s.gormDB = pgtest.OpenGormDB(s.T(), source)
+}
+
+func (s *NetworkflowStoreSuite) SetupTest() {
+	Destroy(s.ctx, s.pool)
+	s.store = CreateTableAndNewStore(s.ctx, s.pool, s.gormDB, clusterID)
 }
 
 func (s *NetworkflowStoreSuite) TearDownTest() {
+	if s.pool != nil {
+		// Clean up
+		Destroy(s.ctx, s.pool)
+	}
+}
+
+func (s *NetworkflowStoreSuite) TearDownSuite() {
 	s.envIsolator.RestoreAll()
+
+	if s.pool != nil {
+		s.pool.Close()
+	}
+	if s.gormDB != nil {
+		pgtest.CloseGormDB(s.T(), s.gormDB)
+	}
 }
 
 func getTimestamp(seconds int64) *types.Timestamp {
@@ -46,22 +85,8 @@ func getTimestamp(seconds int64) *types.Timestamp {
 }
 
 func (s *NetworkflowStoreSuite) TestStore() {
-	ctx := context.Background()
-	clusterID := "22"
 	secondCluster := "43"
-
-	source := pgtest.GetConnectionString(s.T())
-	config, err := pgxpool.ParseConfig(source)
-	s.Require().NoError(err)
-	pool, err := pgxpool.ConnectConfig(ctx, config)
-	s.NoError(err)
-	defer pool.Close()
-
-	Destroy(ctx, pool)
-	gormDB := pgtest.OpenGormDB(s.T(), source)
-	defer pgtest.CloseGormDB(s.T(), gormDB)
-	store := CreateTableAndNewStore(ctx, pool, gormDB, clusterID)
-	store2 := CreateTableAndNewStore(ctx, pool, gormDB, secondCluster)
+	store2 := New(s.pool, secondCluster)
 
 	networkFlow := &storage.NetworkFlow{
 		Props: &storage.NetworkFlowProperties{
@@ -75,35 +100,35 @@ func (s *NetworkflowStoreSuite) TestStore() {
 	}
 	zeroTs := timestamp.MicroTS(0)
 
-	foundNetworkFlows, _, err := store.GetAllFlows(ctx, nil)
+	foundNetworkFlows, _, err := s.store.GetAllFlows(s.ctx, nil)
 	s.NoError(err)
 	s.Len(foundNetworkFlows, 0)
 
 	// Adding the same thing twice to ensure that we only retrieve 1 based on serial Flow_Id implementation
-	s.NoError(store.UpsertFlows(ctx, []*storage.NetworkFlow{networkFlow}, zeroTs))
+	s.NoError(s.store.UpsertFlows(s.ctx, []*storage.NetworkFlow{networkFlow}, zeroTs))
 	networkFlow.LastSeenTimestamp = getTimestamp(2)
-	s.NoError(store.UpsertFlows(ctx, []*storage.NetworkFlow{networkFlow}, zeroTs))
-	foundNetworkFlows, _, err = store.GetAllFlows(ctx, nil)
+	s.NoError(s.store.UpsertFlows(s.ctx, []*storage.NetworkFlow{networkFlow}, zeroTs))
+	foundNetworkFlows, _, err = s.store.GetAllFlows(s.ctx, nil)
 	s.NoError(err)
 	s.Len(foundNetworkFlows, 1)
 	s.Equal(networkFlow, foundNetworkFlows[0])
 
 	// Check the get all flows by since time
-	foundNetworkFlows, _, err = store.GetAllFlows(ctx, getTimestamp(3))
+	foundNetworkFlows, _, err = s.store.GetAllFlows(s.ctx, getTimestamp(3))
 	s.NoError(err)
 	s.Len(foundNetworkFlows, 0)
 
-	s.NoError(store.RemoveFlow(ctx, networkFlow.GetProps()))
-	foundNetworkFlows, _, err = store.GetAllFlows(ctx, nil)
+	s.NoError(s.store.RemoveFlow(s.ctx, networkFlow.GetProps()))
+	foundNetworkFlows, _, err = s.store.GetAllFlows(s.ctx, nil)
 	s.NoError(err)
 	s.Len(foundNetworkFlows, 0)
 
-	s.NoError(store.UpsertFlows(ctx, []*storage.NetworkFlow{networkFlow}, zeroTs))
+	s.NoError(s.store.UpsertFlows(s.ctx, []*storage.NetworkFlow{networkFlow}, zeroTs))
 
-	err = store.RemoveFlowsForDeployment(ctx, networkFlow.GetProps().GetSrcEntity().GetId())
+	err = s.store.RemoveFlowsForDeployment(s.ctx, networkFlow.GetProps().GetSrcEntity().GetId())
 	s.NoError(err)
 
-	foundNetworkFlows, _, err = store.GetAllFlows(ctx, nil)
+	foundNetworkFlows, _, err = s.store.GetAllFlows(s.ctx, nil)
 	s.NoError(err)
 	s.Len(foundNetworkFlows, 0)
 
@@ -115,22 +140,22 @@ func (s *NetworkflowStoreSuite) TestStore() {
 		networkFlows = append(networkFlows, networkFlow)
 	}
 
-	s.NoError(store.UpsertFlows(ctx, networkFlows, zeroTs))
+	s.NoError(s.store.UpsertFlows(s.ctx, networkFlows, zeroTs))
 
-	foundNetworkFlows, _, err = store.GetAllFlows(ctx, nil)
+	foundNetworkFlows, _, err = s.store.GetAllFlows(s.ctx, nil)
 	s.NoError(err)
 	s.Len(foundNetworkFlows, flowCount)
 
 	// Make sure store for second cluster does not find any flows
-	foundNetworkFlows, _, err = store2.GetAllFlows(ctx, nil)
+	foundNetworkFlows, _, err = store2.GetAllFlows(s.ctx, nil)
 	s.NoError(err)
 	s.Len(foundNetworkFlows, 0)
 
 	// Add a flow to the second cluster
 	networkFlow.ClusterId = secondCluster
-	s.NoError(store2.UpsertFlows(ctx, []*storage.NetworkFlow{networkFlow}, zeroTs))
+	s.NoError(store2.UpsertFlows(s.ctx, []*storage.NetworkFlow{networkFlow}, zeroTs))
 
-	foundNetworkFlows, _, err = store2.GetAllFlows(ctx, nil)
+	foundNetworkFlows, _, err = store2.GetAllFlows(s.ctx, nil)
 	s.NoError(err)
 	s.Len(foundNetworkFlows, 1)
 
@@ -140,23 +165,132 @@ func (s *NetworkflowStoreSuite) TestStore() {
 	flowPredicate := func(flow *storage.NetworkFlow) bool {
 		return true
 	}
-	foundNetworkFlows, _, err = store2.GetMatchingFlows(ctx, pred, nil)
+	foundNetworkFlows, _, err = store2.GetMatchingFlows(s.ctx, pred, nil)
 	s.NoError(err)
 	s.Len(foundNetworkFlows, 1)
 
-	err = store2.RemoveMatchingFlows(ctx, pred, flowPredicate)
+	err = store2.RemoveMatchingFlows(s.ctx, pred, flowPredicate)
 	s.NoError(err)
 
 	// Store 2 flows should be removed.
-	foundNetworkFlows, _, err = store2.GetAllFlows(ctx, nil)
+	foundNetworkFlows, _, err = store2.GetAllFlows(s.ctx, nil)
 	s.NoError(err)
 	s.Len(foundNetworkFlows, 0)
 
 	// Store 1 flows should remain
-	foundNetworkFlows, _, err = store.GetAllFlows(ctx, nil)
+	foundNetworkFlows, _, err = s.store.GetAllFlows(s.ctx, nil)
 	s.NoError(err)
 	s.Len(foundNetworkFlows, flowCount)
+}
 
-	// Clean up
-	Destroy(ctx, pool)
+func (s *NetworkflowStoreSuite) TestPruneStaleNetworkFlows() {
+	flows := []*storage.NetworkFlow{
+		{
+			Props: &storage.NetworkFlowProperties{
+				DstPort: 22,
+				DstEntity: &storage.NetworkEntityInfo{
+					Type: 2,
+					Id:   "TestDst1",
+				},
+				SrcEntity: &storage.NetworkEntityInfo{
+					Type: 2,
+					Id:   "TestSrc1",
+				},
+			},
+			ClusterId:         clusterID,
+			LastSeenTimestamp: nil,
+		},
+		{
+			Props: &storage.NetworkFlowProperties{
+				DstPort: 22,
+				DstEntity: &storage.NetworkEntityInfo{
+					Type: 2,
+					Id:   "TestDst2",
+				},
+				SrcEntity: &storage.NetworkEntityInfo{
+					Type: 2,
+					Id:   "TestSrc2",
+				},
+			},
+			ClusterId:         clusterID,
+			LastSeenTimestamp: types.TimestampNow(),
+		},
+		{
+			Props: &storage.NetworkFlowProperties{
+				DstPort: 22,
+				DstEntity: &storage.NetworkEntityInfo{
+					Type: 2,
+					Id:   "TestDst1",
+				},
+				SrcEntity: &storage.NetworkEntityInfo{
+					Type: 2,
+					Id:   "TestSrc1",
+				},
+			},
+			ClusterId:         clusterID,
+			LastSeenTimestamp: types.TimestampNow(),
+		},
+		{
+			Props: &storage.NetworkFlowProperties{
+				DstPort: 22,
+				DstEntity: &storage.NetworkEntityInfo{
+					Type: 2,
+					Id:   "TestDst1",
+				},
+				SrcEntity: &storage.NetworkEntityInfo{
+					Type: 2,
+					Id:   "TestSrc1",
+				},
+			},
+			ClusterId:         clusterID,
+			LastSeenTimestamp: types.TimestampNow(),
+		},
+		{
+			Props: &storage.NetworkFlowProperties{
+				DstPort: 22,
+				DstEntity: &storage.NetworkEntityInfo{
+					Type: 2,
+					Id:   "TestDst1",
+				},
+				SrcEntity: &storage.NetworkEntityInfo{
+					Type: 2,
+					Id:   "TestSrc1",
+				},
+			},
+			ClusterId:         clusterID,
+			LastSeenTimestamp: types.TimestampNow(),
+		},
+		{
+			Props: &storage.NetworkFlowProperties{
+				DstPort: 22,
+				DstEntity: &storage.NetworkEntityInfo{
+					Type: 2,
+					Id:   "TestDst2",
+				},
+				SrcEntity: &storage.NetworkEntityInfo{
+					Type: 2,
+					Id:   "TestSrc2",
+				},
+			},
+			ClusterId:         clusterID,
+			LastSeenTimestamp: nil,
+		},
+	}
+
+	err := s.store.UpsertFlows(s.ctx, flows, timestamp.Now())
+	s.Nil(err)
+
+	row := s.pool.QueryRow(s.ctx, flowsCountStmt)
+	var count int
+	err = row.Scan(&count)
+	s.Nil(err)
+	s.Equal(count, len(flows))
+
+	err = s.store.RemoveStaleFlows(s.ctx)
+	s.Nil(err)
+
+	row = s.pool.QueryRow(s.ctx, flowsCountStmt)
+	err = row.Scan(&count)
+	s.Nil(err)
+	s.Equal(count, 2)
 }

--- a/central/networkgraph/flow/datastore/internal/store/rocksdb/flow_impl.go
+++ b/central/networkgraph/flow/datastore/internal/store/rocksdb/flow_impl.go
@@ -242,8 +242,14 @@ func (s *flowStoreImpl) readFlows(pred func(*storage.NetworkFlowProperties) bool
 	return
 }
 
+// RemoveStaleFlows - remove stale duplicate network flows
+// Only used for Postgres, needed to satisfy the interface for the datastore.
+func (s *flowStoreImpl) RemoveStaleFlows(ctx context.Context) error {
+	return nil
+}
+
 // Static helper functions.
-/////////////////////////
+// ///////////////////////
 func (s *flowStoreImpl) readFlow(id []byte) (flow *storage.NetworkFlow, err error) {
 	slice, err := s.db.Get(readOptions, id)
 	if err != nil {

--- a/central/networkgraph/flow/datastore/mocks/flow.go
+++ b/central/networkgraph/flow/datastore/mocks/flow.go
@@ -112,6 +112,20 @@ func (mr *MockFlowDataStoreMockRecorder) RemoveMatchingFlows(ctx, keyMatchFn, va
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveMatchingFlows", reflect.TypeOf((*MockFlowDataStore)(nil).RemoveMatchingFlows), ctx, keyMatchFn, valueMatchFn)
 }
 
+// RemoveStaleFlows mocks base method.
+func (m *MockFlowDataStore) RemoveStaleFlows(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveStaleFlows", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveStaleFlows indicates an expected call of RemoveStaleFlows.
+func (mr *MockFlowDataStoreMockRecorder) RemoveStaleFlows(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveStaleFlows", reflect.TypeOf((*MockFlowDataStore)(nil).RemoveStaleFlows), ctx)
+}
+
 // UpsertFlows mocks base method.
 func (m *MockFlowDataStore) UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) error {
 	m.ctrl.T.Helper()

--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -14,22 +14,6 @@ const (
 	pruneClusterHealthStatusesStmt = `DELETE FROM cluster_health_statuses child WHERE NOT EXISTS
 		(SELECT 1 FROM clusters parent WHERE
 		child.Id = parent.Id)`
-
-	pruneStaleNetworkFlowsStmt = `DELETE FROM network_flows a USING (
-      SELECT MAX(flow_id) as max_flow, props_srcentity_type, props_srcentity_id, props_dstentity_type, props_dstentity_id, props_dstport, props_l4protocol, clusterid
-        FROM network_flows
-        GROUP BY props_srcentity_type, props_srcentity_id, props_dstentity_type, props_dstentity_id, props_dstport, props_l4protocol, clusterid
-		HAVING COUNT(*) > 1
-      ) b
-      WHERE a.props_srcentity_type = b.props_srcentity_type
- 	AND a.props_srcentity_id = b.props_srcentity_id
- 	AND a.props_dstentity_type = b.props_dstentity_type
- 	AND a.props_dstentity_id = b.props_dstentity_id
-	AND a.props_dstport = b.props_dstport
-	AND a.props_l4protocol = b.props_l4protocol
-	AND a.clusterid = b.clusterid
-      AND a.flow_id <> b.max_flow;
-	`
 )
 
 var (
@@ -49,12 +33,5 @@ func PruneActiveComponents(ctx context.Context, pool *pgxpool.Pool) {
 func PruneClusterHealthStatuses(ctx context.Context, pool *pgxpool.Pool) {
 	if _, err := pool.Exec(ctx, pruneClusterHealthStatusesStmt); err != nil {
 		log.Errorf("failed to prune cluster health statuses: %v", err)
-	}
-}
-
-// PruneStaleNetworkFlows - prunes duplicate network flows
-func PruneStaleNetworkFlows(ctx context.Context, pool *pgxpool.Pool) {
-	if _, err := pool.Exec(ctx, pruneStaleNetworkFlowsStmt); err != nil {
-		log.Errorf("failed to prune stale network flows: %v", err)
 	}
 }

--- a/central/postgres/pruning_test.go
+++ b/central/postgres/pruning_test.go
@@ -4,25 +4,16 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gogo/protobuf/types"
 	activeComponent "github.com/stackrox/rox/central/activecomponent/datastore"
 	clusterStore "github.com/stackrox/rox/central/cluster/datastore"
 	clusterHealthPostgresStore "github.com/stackrox/rox/central/cluster/store/clusterhealth/postgres"
 	deploymentStore "github.com/stackrox/rox/central/deployment/datastore"
-	clusterFlow "github.com/stackrox/rox/central/networkgraph/flow/datastore"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/testutils/envisolator"
-	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stretchr/testify/suite"
-)
-
-const (
-	clusterID = "22"
-
-	flowsCountStmt = "select count(*) from network_flows"
 )
 
 type PostgresPruningSuite struct {
@@ -144,121 +135,4 @@ func (s *PostgresPruningSuite) TestPruneClusterHealthStatuses() {
 	exists, err = clusterHealthStore.Exists(s.ctx, "randomCluster")
 	s.Nil(err)
 	s.False(exists)
-}
-
-func (s *PostgresPruningSuite) TestPruneStaleNetworkFlows() {
-	cds, err := clusterFlow.GetTestPostgresClusterDataStore(s.T(), s.testDB.Pool)
-	s.Nil(err)
-
-	flowStore, err := cds.GetFlowStore(s.ctx, clusterID)
-	s.Nil(err)
-
-	flows := []*storage.NetworkFlow{
-		{
-			Props: &storage.NetworkFlowProperties{
-				DstPort: 22,
-				DstEntity: &storage.NetworkEntityInfo{
-					Type: 2,
-					Id:   "TestDst1",
-				},
-				SrcEntity: &storage.NetworkEntityInfo{
-					Type: 2,
-					Id:   "TestSrc1",
-				},
-			},
-			ClusterId:         clusterID,
-			LastSeenTimestamp: nil,
-		},
-		{
-			Props: &storage.NetworkFlowProperties{
-				DstPort: 22,
-				DstEntity: &storage.NetworkEntityInfo{
-					Type: 2,
-					Id:   "TestDst2",
-				},
-				SrcEntity: &storage.NetworkEntityInfo{
-					Type: 2,
-					Id:   "TestSrc2",
-				},
-			},
-			ClusterId:         clusterID,
-			LastSeenTimestamp: types.TimestampNow(),
-		},
-		{
-			Props: &storage.NetworkFlowProperties{
-				DstPort: 22,
-				DstEntity: &storage.NetworkEntityInfo{
-					Type: 2,
-					Id:   "TestDst1",
-				},
-				SrcEntity: &storage.NetworkEntityInfo{
-					Type: 2,
-					Id:   "TestSrc1",
-				},
-			},
-			ClusterId:         clusterID,
-			LastSeenTimestamp: types.TimestampNow(),
-		},
-		{
-			Props: &storage.NetworkFlowProperties{
-				DstPort: 22,
-				DstEntity: &storage.NetworkEntityInfo{
-					Type: 2,
-					Id:   "TestDst1",
-				},
-				SrcEntity: &storage.NetworkEntityInfo{
-					Type: 2,
-					Id:   "TestSrc1",
-				},
-			},
-			ClusterId:         clusterID,
-			LastSeenTimestamp: types.TimestampNow(),
-		},
-		{
-			Props: &storage.NetworkFlowProperties{
-				DstPort: 22,
-				DstEntity: &storage.NetworkEntityInfo{
-					Type: 2,
-					Id:   "TestDst1",
-				},
-				SrcEntity: &storage.NetworkEntityInfo{
-					Type: 2,
-					Id:   "TestSrc1",
-				},
-			},
-			ClusterId:         clusterID,
-			LastSeenTimestamp: types.TimestampNow(),
-		},
-		{
-			Props: &storage.NetworkFlowProperties{
-				DstPort: 22,
-				DstEntity: &storage.NetworkEntityInfo{
-					Type: 2,
-					Id:   "TestDst2",
-				},
-				SrcEntity: &storage.NetworkEntityInfo{
-					Type: 2,
-					Id:   "TestSrc2",
-				},
-			},
-			ClusterId:         clusterID,
-			LastSeenTimestamp: nil,
-		},
-	}
-
-	err = flowStore.UpsertFlows(s.ctx, flows, timestamp.Now())
-	s.Nil(err)
-
-	row := s.testDB.Pool.QueryRow(s.ctx, flowsCountStmt)
-	var count int
-	err = row.Scan(&count)
-	s.Nil(err)
-	s.Equal(count, len(flows))
-
-	PruneStaleNetworkFlows(s.ctx, s.testDB.Pool)
-
-	row = s.testDB.Pool.QueryRow(s.ctx, flowsCountStmt)
-	err = row.Scan(&count)
-	s.Nil(err)
-	s.Equal(count, 2)
 }


### PR DESCRIPTION
## Description

Between removing flows when a deployment is remove and removing stale flows from the garbage collector, it is possible to get in a deadlock situation when those bulk remove operations coincide.  I considered simply wrapping it in a retry and also considered using the Postgres feature `SKIP LOCKED`.  I determined that the cleanest and best way is to avoid the deadlock situation altogether.  So I pushed the pruning of stale network flows down to the store and wrap the remove calls in a lock so only one of those is processing at time.  The store is implemented in such a way that there should be an instance per cluster.  in actuality it was creating a new version of the store all the time.  so locking on the removes did not work.  Updated the store to have one per cluster so that I could use a mutex to lock the calls to remove.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Mostly an exercise in moving code.  Tests exists.  But setup some long running and scale tests to verify deadlock has been avoided.
