### PR TITLE
ROX-12925: Increase timeout for Network Baseline test

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -10,6 +10,8 @@ import spock.lang.Retry
 import util.NetworkGraphUtil
 import util.Timer
 
+import spock.lang.Timeout
+
 @Retry(count = 0)
 class NetworkBaselineTest extends BaseSpecification {
     static final private String SERVER_DEP_NAME = "net-bl-server"
@@ -160,6 +162,7 @@ class NetworkBaselineTest extends BaseSpecification {
     }
 
     @Category(NetworkBaseline)
+    @Timeout(1600)
     def "Verify network baseline functionality"() {
         when:
         "Create initial set of deployments, wait for baseline to populate"


### PR DESCRIPTION
## Description

This flake happened twice in nightly builds in the last 2 weeks (Oct. 7th and Oct. 3rd)

Here's my understanding of this failure:

- Test takes too long to run. Above all else, the two failures happed due to a timeout:
  ```
  org.junit.runners.model.TestTimedOutException: test timed out after 800 seconds
  ```
- This test increased in size recently with PR #1844 merging two tests into one.
- There is a default timeout limit for groovy tests of `800s`. That's why both the failures show this exception. The test below fails with an exception with same error message:
  ```groovy
  @Category(NetworkBaseline)
  def "test timeout"() {
    when:
      sleep(802000)
    then:
      log.info("Should have slept")
  }
  ```
- The test is riddled with assertions with a high number of retries. Making the logs very ambiguous on why the test failed. Both logs have different exceptions right before the test fails, this is very likely because the timeout happened at different stages of the test in both runs. Green runs of this tests also have many exceptions logged in `stdout` for assertions that *eventually* pass. 

Alternatives of how to fix this:

1. Bump the timeout (easy)
2. Reduce the scope of this tests (hard)

My suggestion is to bump this timeout now to at least squash the flake (or reduce the likelihood of happening). I can create a follow up task to either split this test into two QA tests (like it was before) or write unit/integration tests for the same behavior and keep the QA test as minimal as possible.
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- Running this on CI
