### PR TITLE
ROX-11323 Add labels pool in fake workloads

### DIFF
--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -168,8 +168,9 @@ func (w *WorkloadManager) initializePreexistingResources() {
 		objects = append(objects, node)
 	}
 
+	labelsPool.matchLabels = w.workload.MatchLabels
+
 	objects = append(objects, getRBAC(w.workload.RBACWorkload)...)
-	objects = append(objects, getService(w.workload.ServiceWorkload)...)
 	var resources []*deploymentResourcesToBeManaged
 	for _, deploymentWorkload := range w.workload.DeploymentWorkload {
 		for i := 0; i < deploymentWorkload.NumDeployments; i++ {
@@ -183,6 +184,7 @@ func (w *WorkloadManager) initializePreexistingResources() {
 		}
 	}
 
+	objects = append(objects, getService(w.workload.ServiceWorkload)...)
 	var npResources []*networkPolicyToBeManaged
 	for _, npWorkload := range w.workload.NetworkPolicyWorkload {
 		for i := 0; i < npWorkload.NumNetworkPolicies; i++ {

--- a/sensor/kubernetes/fake/labels.go
+++ b/sensor/kubernetes/fake/labels.go
@@ -1,0 +1,45 @@
+package fake
+
+import (
+	"math/rand"
+
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	labelsPool = newLabelsPool()
+)
+
+type labelsPoolPerNamespace struct {
+	pool        map[string][]map[string]string
+	matchLabels bool
+	lock        sync.RWMutex
+}
+
+func newLabelsPool() *labelsPoolPerNamespace {
+	p := &labelsPoolPerNamespace{
+		pool: make(map[string][]map[string]string),
+	}
+	return p
+}
+
+func (p *labelsPoolPerNamespace) add(namespace string, labels map[string]string) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if p.matchLabels {
+		p.pool[namespace] = append(p.pool[namespace], labels)
+	}
+}
+
+func (p *labelsPoolPerNamespace) randomElem(namespace string) map[string]string {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	if !p.matchLabels {
+		return createRandMap(16, 3)
+	}
+	labelsSlice, ok := p.pool[namespace]
+	if !ok {
+		return createRandMap(16, 3)
+	}
+	return labelsSlice[rand.Intn(len(labelsSlice))]
+}

--- a/sensor/kubernetes/fake/namespace.go
+++ b/sensor/kubernetes/fake/namespace.go
@@ -8,7 +8,8 @@ import (
 )
 
 var (
-	namespacePool = newPool()
+	namespacePool                 = newPool()
+	namespacesWithDeploymentsPool = newPool()
 )
 
 func getNamespace(name string) *corev1.Namespace {

--- a/sensor/kubernetes/fake/networkpolicy.go
+++ b/sensor/kubernetes/fake/networkpolicy.go
@@ -2,7 +2,6 @@ package fake
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -16,20 +15,9 @@ type networkPolicyToBeManaged struct {
 	networkPolicy *networkingV1.NetworkPolicy
 }
 
-func createMap(entries int) map[string]string {
-	m := make(map[string]string, entries)
-	for i := 0; i < entries; i++ {
-		m[fmt.Sprintf("key-%d", i)] = fmt.Sprintf("value-%d", i)
-	}
-	return m
-}
-
 func (w *WorkloadManager) getNetworkPolicy(workload NetworkPolicyWorkload) *networkPolicyToBeManaged {
-	labels := createMap(workload.NumLabels)
-	namespace, valid := namespacePool.randomElem()
-	if !valid {
-		namespace = "default"
-	}
+	namespace := namespacesWithDeploymentsPool.mustGetRandomElem()
+	labels := labelsPool.randomElem(namespace)
 	np := &networkingV1.NetworkPolicy{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NetworkPolicy",

--- a/sensor/kubernetes/fake/service.go
+++ b/sensor/kubernetes/fake/service.go
@@ -26,14 +26,9 @@ func getIPFamily() string {
 	return ipFamilies[rand.Intn(len(ipFamilies))]
 }
 
-func getClusterIP(numLabels int) *v1.Service {
-	ns := namespacePool.mustGetRandomElem()
-	var labels map[string]string
-	if numLabels == 0 {
-		labels = createRandMap(16, 3)
-	} else {
-		labels = createMap(numLabels)
-	}
+func getClusterIP() *v1.Service {
+	ns := namespacesWithDeploymentsPool.mustGetRandomElem()
+	labels := labelsPool.randomElem(ns)
 	clusterIP := generateIP()
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -61,14 +56,9 @@ func getClusterIP(numLabels int) *v1.Service {
 	}
 }
 
-func getNodePort(numLabels int) *v1.Service {
-	ns := namespacePool.mustGetRandomElem()
-	var labels map[string]string
-	if numLabels == 0 {
-		labels = createRandMap(16, 3)
-	} else {
-		labels = createMap(numLabels)
-	}
+func getNodePort() *v1.Service {
+	ns := namespacesWithDeploymentsPool.mustGetRandomElem()
+	labels := labelsPool.randomElem(ns)
 	clusterIP := generateIP()
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -97,14 +87,9 @@ func getNodePort(numLabels int) *v1.Service {
 	}
 }
 
-func getLoadBalancer(numLabels int) *v1.Service {
-	ns := namespacePool.mustGetRandomElem()
-	var labels map[string]string
-	if numLabels == 0 {
-		labels = createRandMap(16, 3)
-	} else {
-		labels = createMap(numLabels)
-	}
+func getLoadBalancer() *v1.Service {
+	ns := namespacesWithDeploymentsPool.mustGetRandomElem()
+	labels := labelsPool.randomElem(ns)
 	clusterIP := generateIP()
 	internalTrafficPolicy := v1.ServiceInternalTrafficPolicyCluster
 	allocateLoadBalancerNodePorts := true
@@ -153,15 +138,15 @@ func getLoadBalancer(numLabels int) *v1.Service {
 func getService(workload ServiceWorkload) []runtime.Object {
 	objects := make([]runtime.Object, 0, workload.NumClusterIPs+workload.NumNodePorts+workload.NumLoadBalancers)
 	for i := 0; i < workload.NumClusterIPs; i++ {
-		clusterIP := getClusterIP(workload.NumLabels)
+		clusterIP := getClusterIP()
 		objects = append(objects, clusterIP)
 	}
 	for i := 0; i < workload.NumNodePorts; i++ {
-		nodePort := getNodePort(workload.NumLabels)
+		nodePort := getNodePort()
 		objects = append(objects, nodePort)
 	}
 	for i := 0; i < workload.NumLoadBalancers; i++ {
-		loadBalancer := getLoadBalancer(workload.NumLabels)
+		loadBalancer := getLoadBalancer()
 		objects = append(objects, loadBalancer)
 	}
 	return objects

--- a/sensor/kubernetes/fake/workload.go
+++ b/sensor/kubernetes/fake/workload.go
@@ -1,13 +1,16 @@
 package fake
 
-import "time"
+import (
+	"time"
+)
 
 // DeploymentWorkload defines a workload of deployment objects
 type DeploymentWorkload struct {
 	DeploymentType string `yaml:"deploymentType"`
 	NumDeployments int    `yaml:"numDeployments"`
 
-	NumLabels int `yaml:"numLabels"`
+	NumLabels    int  `yaml:"numLabels"`
+	RandomLabels bool `yaml:"randomLabels"`
 
 	PodWorkload PodWorkload `yaml:"podWorkload"`
 
@@ -19,8 +22,6 @@ type DeploymentWorkload struct {
 // NetworkPolicyWorkload defines a workload of networkPolicy objects
 type NetworkPolicyWorkload struct {
 	NumNetworkPolicies int `yaml:"numNetworkPolicies"`
-
-	NumLabels int `yaml:"numLabels"`
 
 	UpdateInterval    time.Duration `yaml:"updateInterval"`
 	LifecycleDuration time.Duration `yaml:"lifecycleDuration"`
@@ -69,7 +70,6 @@ type RBACWorkload struct {
 
 // ServiceWorkload defines the workload of services
 type ServiceWorkload struct {
-	NumLabels        int `yaml:"numLabels"`
 	NumClusterIPs    int `yaml:"numClusterIPs"`
 	NumNodePorts     int `yaml:"numNodePorts"`
 	NumLoadBalancers int `yaml:"numLoadBalancers"`
@@ -84,4 +84,5 @@ type Workload struct {
 	RBACWorkload          RBACWorkload            `yaml:"rbacWorkload"`
 	ServiceWorkload       ServiceWorkload         `yaml:"serviceWorkload"`
 	NumNamespaces         int                     `yaml:"numNamespaces"`
+	MatchLabels           bool                    `yaml:"matchLabels"`
 }


### PR DESCRIPTION
## Description

Follow up PR to #3341. Creates a pool of labels to ensure label matching between resources.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Use a workload with `matchLabels: true` configured.

```
go run tools/local-sensor/main.go -record -with-fakeworkload=workload.yaml
```

Labels used by services and network policies should match labels used by deployments
