### PR TITLE
ROX-11754: SAC integration tests for image datastore

### DIFF
--- a/central/image/datastore/datastore.go
+++ b/central/image/datastore/datastore.go
@@ -2,17 +2,14 @@ package datastore
 
 import (
 	"context"
-	"testing"
 
 	"github.com/blevesearch/bleve"
-	"github.com/jackc/pgx/v4/pgxpool"
 	componentCVEEdgeIndexer "github.com/stackrox/rox/central/componentcveedge/index"
 	cveIndexer "github.com/stackrox/rox/central/cve/index"
 	deploymentIndexer "github.com/stackrox/rox/central/deployment/index"
 	"github.com/stackrox/rox/central/image/datastore/search"
 	"github.com/stackrox/rox/central/image/datastore/store"
 	dackBoxStore "github.com/stackrox/rox/central/image/datastore/store/dackbox"
-	postgresStore "github.com/stackrox/rox/central/image/datastore/store/postgres"
 	imageIndexer "github.com/stackrox/rox/central/image/index"
 	componentIndexer "github.com/stackrox/rox/central/imagecomponent/index"
 	imageComponentEdgeIndexer "github.com/stackrox/rox/central/imagecomponentedge/index"
@@ -23,7 +20,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/dackbox"
 	"github.com/stackrox/rox/pkg/dackbox/concurrency"
-	rocksdbBase "github.com/stackrox/rox/pkg/rocksdb"
 	searchPkg "github.com/stackrox/rox/pkg/search"
 )
 
@@ -85,28 +81,4 @@ func NewWithPostgres(storage store.Store, index imageIndexer.Indexer, risks risk
 	ds := newDatastoreImpl(storage, index, search.NewV2(storage, index), risks, imageRanker, imageComponentRanker)
 	ds.initializeRankers()
 	return ds
-}
-
-// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(t *testing.T, pool *pgxpool.Pool) (DataStore, error) {
-	dbstore := postgresStore.New(pool, false, concurrency.NewKeyFence())
-	indexer := postgresStore.NewIndexer(pool)
-	riskStore, err := riskDS.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
-	imageRanker := ranking.ImageRanker()
-	imageComponentRanker := ranking.ComponentRanker()
-	return NewWithPostgres(dbstore, indexer, riskStore, imageRanker, imageComponentRanker), nil
-}
-
-// GetTestRocksBleveDataStore provides a datastore connected to rocksdb and bleve for testing purposes.
-func GetTestRocksBleveDataStore(t *testing.T, rocksengine *rocksdbBase.RocksDB, bleveIndex bleve.Index, dacky *dackbox.DackBox, keyFence concurrency.KeyFence) (DataStore, error) {
-	riskStore, err := riskDS.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
-	if err != nil {
-		return nil, err
-	}
-	imageRanker := ranking.ImageRanker()
-	imageComponentRanker := ranking.ComponentRanker()
-	return New(dacky, keyFence, bleveIndex, bleveIndex, false, riskStore, imageRanker, imageComponentRanker), nil
 }

--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -16,7 +16,6 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
-	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/images/enricher"
 	imageTypes "github.com/stackrox/rox/pkg/images/types"
@@ -136,9 +135,6 @@ func (ds *datastoreImpl) CountImages(ctx context.Context) (int, error) {
 }
 
 func (ds *datastoreImpl) canReadImage(ctx context.Context, sha string) (bool, error) {
-	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return true, nil
-	}
 	if ok, err := imagesSAC.ReadAllowed(ctx); err != nil {
 		return false, err
 	} else if ok {

--- a/central/image/datastore/datastore_test_constructors.go
+++ b/central/image/datastore/datastore_test_constructors.go
@@ -1,0 +1,38 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/blevesearch/bleve"
+	"github.com/jackc/pgx/v4/pgxpool"
+	postgresStore "github.com/stackrox/rox/central/image/datastore/store/postgres"
+	"github.com/stackrox/rox/central/ranking"
+	riskDS "github.com/stackrox/rox/central/risk/datastore"
+	"github.com/stackrox/rox/pkg/dackbox"
+	"github.com/stackrox/rox/pkg/dackbox/concurrency"
+	rocksdbBase "github.com/stackrox/rox/pkg/rocksdb"
+)
+
+// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetTestPostgresDataStore(t *testing.T, pool *pgxpool.Pool) (DataStore, error) {
+	dbstore := postgresStore.New(pool, false, concurrency.NewKeyFence())
+	indexer := postgresStore.NewIndexer(pool)
+	riskStore, err := riskDS.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	imageRanker := ranking.ImageRanker()
+	imageComponentRanker := ranking.ComponentRanker()
+	return NewWithPostgres(dbstore, indexer, riskStore, imageRanker, imageComponentRanker), nil
+}
+
+// GetTestRocksBleveDataStore provides a datastore connected to rocksdb and bleve for testing purposes.
+func GetTestRocksBleveDataStore(t *testing.T, rocksengine *rocksdbBase.RocksDB, bleveIndex bleve.Index, dacky *dackbox.DackBox, keyFence concurrency.KeyFence) (DataStore, error) {
+	riskStore, err := riskDS.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
+	if err != nil {
+		return nil, err
+	}
+	imageRanker := ranking.ImageRanker()
+	imageComponentRanker := ranking.ComponentRanker()
+	return New(dacky, keyFence, bleveIndex, bleveIndex, false, riskStore, imageRanker, imageComponentRanker), nil
+}

--- a/central/image/datastore/store/postgres/store.go
+++ b/central/image/datastore/store/postgres/store.go
@@ -1116,7 +1116,7 @@ func (s *storeImpl) retryableGetManyImageMetadata(ctx context.Context, ids []str
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err := sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err := sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/central/image/datastoretest/datastore_sac_test.go
+++ b/central/image/datastoretest/datastore_sac_test.go
@@ -1,0 +1,546 @@
+package datastoretest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blevesearch/bleve"
+	activeComponentDackbox "github.com/stackrox/rox/central/activecomponent/dackbox"
+	activeComponentIndex "github.com/stackrox/rox/central/activecomponent/datastore/index"
+	clusterCVEEdgeDackbox "github.com/stackrox/rox/central/clustercveedge/dackbox"
+	clusterCVEEdgeIndex "github.com/stackrox/rox/central/clustercveedge/index"
+	componentCVEEdgeDackbox "github.com/stackrox/rox/central/componentcveedge/dackbox"
+	componentCVEEdgeIndex "github.com/stackrox/rox/central/componentcveedge/index"
+	cveDackbox "github.com/stackrox/rox/central/cve/dackbox"
+	cveIndex "github.com/stackrox/rox/central/cve/index"
+	deploymentDackbox "github.com/stackrox/rox/central/deployment/dackbox"
+	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
+	deploymentIndex "github.com/stackrox/rox/central/deployment/index"
+	"github.com/stackrox/rox/central/globalindex"
+	imageDackbox "github.com/stackrox/rox/central/image/dackbox"
+	"github.com/stackrox/rox/central/image/datastore"
+	imageIndex "github.com/stackrox/rox/central/image/index"
+	"github.com/stackrox/rox/central/image/mappings"
+	imageComponentDackbox "github.com/stackrox/rox/central/imagecomponent/dackbox"
+	imageComponentIndex "github.com/stackrox/rox/central/imagecomponent/index"
+	imageComponentEdgeDackbox "github.com/stackrox/rox/central/imagecomponentedge/dackbox"
+	imageComponentEdgeIndex "github.com/stackrox/rox/central/imagecomponentedge/index"
+	imageCVEEdgeDackbox "github.com/stackrox/rox/central/imagecveedge/dackbox"
+	imageCVEEdgeDataStore "github.com/stackrox/rox/central/imagecveedge/datastore"
+	imageCVEEdgeIndex "github.com/stackrox/rox/central/imagecveedge/index"
+	namespaceDataStore "github.com/stackrox/rox/central/namespace/datastore"
+	nodeDackbox "github.com/stackrox/rox/central/node/dackbox"
+	nodeIndex "github.com/stackrox/rox/central/node/index"
+	nodeComponentEdgeDackbox "github.com/stackrox/rox/central/nodecomponentedge/dackbox"
+	nodeComponentEdgeIndex "github.com/stackrox/rox/central/nodecomponentedge/index"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/dackbox"
+	dackboxConcurrency "github.com/stackrox/rox/pkg/dackbox/concurrency"
+	"github.com/stackrox/rox/pkg/dackbox/edges"
+	"github.com/stackrox/rox/pkg/dackbox/indexer"
+	"github.com/stackrox/rox/pkg/dackbox/utils/queue"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/rocksdb"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/sac/testutils"
+	searchPkg "github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestImageDataStoreSAC(t *testing.T) {
+	suite.Run(t, new(imageDatastoreSACSuite))
+}
+
+type imageDatastoreSACSuite struct {
+	suite.Suite
+
+	// Elements for bleve+rocksdb mode
+	engine   *rocksdb.RocksDB
+	index    bleve.Index
+	dacky    *dackbox.DackBox
+	keyFence dackboxConcurrency.KeyFence
+	indexQ   queue.WaitableQueue
+
+	// Elements for postgres mode
+	pgtestbase *pgtest.TestPostgres
+
+	datastore datastore.DataStore
+
+	imageVulnDatastore  imageCVEEdgeDataStore.DataStore
+	deploymentDatastore deploymentDataStore.DataStore
+	namespaceDatastore  namespaceDataStore.DataStore
+
+	optionsMap searchPkg.OptionsMap
+
+	testContexts map[string]context.Context
+	testImageIDs []string
+}
+
+func (s *imageDatastoreSACSuite) SetupSuite() {
+	var err error
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		s.pgtestbase = pgtest.ForT(s.T())
+		s.Require().NotNil(s.pgtestbase)
+		s.datastore, err = datastore.GetTestPostgresDataStore(s.T(), s.pgtestbase.Pool)
+		s.Require().NoError(err)
+		s.imageVulnDatastore = imageCVEEdgeDataStore.GetTestPostgresDataStore(s.T(), s.pgtestbase.Pool)
+		s.deploymentDatastore, err = deploymentDataStore.GetTestPostgresDataStore(s.T(), s.pgtestbase.Pool)
+		s.Require().NoError(err)
+		s.namespaceDatastore, err = namespaceDataStore.GetTestPostgresDataStore(s.T(), s.pgtestbase.Pool)
+		s.Require().NoError(err)
+		s.optionsMap = schema.ImagesSchema.OptionsMap
+	} else {
+		s.engine, err = rocksdb.NewTemp("imageSACTest")
+		s.Require().NoError(err)
+		s.index, err = globalindex.MemOnlyIndex()
+		s.Require().NoError(err)
+		s.keyFence = dackboxConcurrency.NewKeyFence()
+		s.indexQ = queue.NewWaitableQueue()
+		s.dacky, err = dackbox.NewRocksDBDackBox(s.engine, s.indexQ, []byte("graph"), []byte("dirty"), []byte("valid"))
+		s.Require().NoError(err)
+		reg := indexer.NewWrapperRegistry()
+		indexer.NewLazy(s.indexQ, reg, s.index, s.dacky.AckIndexed).Start()
+		reg.RegisterWrapper(activeComponentDackbox.Bucket, activeComponentIndex.Wrapper{})
+		reg.RegisterWrapper(clusterCVEEdgeDackbox.Bucket, clusterCVEEdgeIndex.Wrapper{})
+		reg.RegisterWrapper(componentCVEEdgeDackbox.Bucket, componentCVEEdgeIndex.Wrapper{})
+		reg.RegisterWrapper(cveDackbox.Bucket, cveIndex.Wrapper{})
+		reg.RegisterWrapper(deploymentDackbox.Bucket, deploymentIndex.Wrapper{})
+		reg.RegisterWrapper(imageDackbox.Bucket, imageIndex.Wrapper{})
+		reg.RegisterWrapper(imageComponentDackbox.Bucket, imageComponentIndex.Wrapper{})
+		reg.RegisterWrapper(imageComponentEdgeDackbox.Bucket, imageComponentEdgeIndex.Wrapper{})
+		reg.RegisterWrapper(imageCVEEdgeDackbox.Bucket, imageCVEEdgeIndex.Wrapper{})
+		reg.RegisterWrapper(nodeDackbox.Bucket, nodeIndex.Wrapper{})
+		reg.RegisterWrapper(nodeComponentEdgeDackbox.Bucket, nodeComponentEdgeIndex.Wrapper{})
+
+		s.datastore, err = datastore.GetTestRocksBleveDataStore(s.T(), s.engine, s.index, s.dacky, s.keyFence)
+		s.Require().NoError(err)
+		s.imageVulnDatastore = imageCVEEdgeDataStore.GetTestRocksBleveDataStore(s.T(), s.index, s.dacky, s.keyFence)
+		s.deploymentDatastore, err = deploymentDataStore.GetTestRocksBleveDataStore(s.T(), s.engine, s.index, s.dacky, s.keyFence)
+		s.Require().NoError(err)
+		s.namespaceDatastore, err = namespaceDataStore.GetTestRocksBleveDataStore(s.T(), s.engine, s.index, s.dacky, s.keyFence)
+		s.Require().NoError(err)
+		s.optionsMap = mappings.OptionsMap
+	}
+
+	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(),
+		resources.Image)
+}
+
+func (s *imageDatastoreSACSuite) TearDownSuite() {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		s.pgtestbase.Pool.Close()
+	} else {
+		s.Require().NoError(rocksdb.CloseAndRemove(s.engine))
+		s.Require().NoError(s.index.Close())
+	}
+}
+
+func (s *imageDatastoreSACSuite) SetupTest() {
+	s.testImageIDs = make([]string, 0)
+}
+
+func (s *imageDatastoreSACSuite) TearDownTest() {
+	for _, id := range s.testImageIDs {
+		s.deleteImage(id)
+	}
+}
+
+func (s *imageDatastoreSACSuite) waitForIndexing() {
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		// Some cases need to wait for dackbox indexing to complete.
+		doneSignal := concurrency.NewSignal()
+		s.indexQ.PushSignal(&doneSignal)
+		<-doneSignal.Done()
+	}
+}
+
+func (s *imageDatastoreSACSuite) deleteImage(id string) {
+	s.Require().NoError(s.datastore.DeleteImages(s.testContexts[testutils.UnrestrictedReadWriteCtx], id))
+}
+
+func (s *imageDatastoreSACSuite) deleteDeployment(clusterid, id string) {
+	s.Require().NoError(s.deploymentDatastore.RemoveDeployment(sac.WithAllAccess(context.Background()), clusterid, id))
+}
+
+func (s *imageDatastoreSACSuite) deleteNamespace(id string) {
+	s.Require().NoError(s.namespaceDatastore.RemoveNamespace(sac.WithAllAccess(context.Background()), id))
+}
+
+func getImageCVEID(cve string) string {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return cve + "#crime-stories"
+	}
+	return cve
+}
+
+// getImageCVEEdgeID returns base 64 encoded Image:CVE ids
+func getImageCVEEdgeID(image, cve string) string {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return postgres.IDFromPks([]string{image, getImageCVEID(cve)})
+	}
+	return edges.EdgeID{ParentID: image, ChildID: getImageCVEID(cve)}.ToString()
+}
+
+func (s *imageDatastoreSACSuite) TestUpsertImage() {
+	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), testutils.VerbUpsert)
+
+	for name, testCase := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[testCase.ScopeKey]
+			image := fixtures.GetImageSherlockHolmes1()
+			err := s.datastore.UpsertImage(ctx, image)
+			defer s.deleteImage(image.GetId())
+			if testCase.ExpectError {
+				s.Error(err)
+				s.ErrorIs(err, testCase.ExpectedError)
+			} else {
+				s.NoError(err)
+				checkCtx := s.testContexts[testutils.UnrestrictedReadCtx]
+				readImage, found, checkErr := s.datastore.GetImage(checkCtx, image.GetId())
+				s.NoError(checkErr)
+				s.True(found)
+				s.Equal(*image.GetName(), *readImage.GetName())
+			}
+		})
+	}
+}
+
+func (s *imageDatastoreSACSuite) TestUpdateVulnerabilityState() {
+	cases := testutils.GenericGlobalSACUpsertTestCases(s.T(), "update vulnerability state")
+
+	for name, testCase := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[testCase.ScopeKey]
+			writeCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+			checkCtx := s.testContexts[testutils.UnrestrictedReadCtx]
+			image := fixtures.GetImageSherlockHolmes1()
+			cve1 := fixtures.GetEmbeddedImageCVE1234x0001()
+			cve2 := fixtures.GetEmbeddedImageCVE4567x0002()
+			cve3 := fixtures.GetEmbeddedImageCVE1234x0003()
+			cve4 := fixtures.GetEmbeddedImageCVE3456x0004()
+			cve5 := fixtures.GetEmbeddedImageCVE3456x0005()
+			cve6 := fixtures.GetEmbeddedImageCVE2345x0006()
+			foundCVEs := []*storage.EmbeddedVulnerability{cve1, cve2, cve3, cve4, cve5}
+			missingCVEs := []*storage.EmbeddedVulnerability{cve6}
+			insertErr := s.datastore.UpsertImage(writeCtx, image)
+			defer s.deleteImage(image.GetId())
+			s.Require().NoError(insertErr)
+			for _, cve := range foundCVEs {
+				edgeId := getImageCVEEdgeID(image.GetId(), cve.GetCve())
+				edge, found, err := s.imageVulnDatastore.Get(checkCtx, edgeId)
+				s.NoError(err)
+				s.True(found)
+				s.Equal(storage.VulnerabilityState_OBSERVED, edge.GetState())
+			}
+			for _, cve := range missingCVEs {
+				edgeId := getImageCVEEdgeID(image.GetId(), cve.GetCve())
+				edge, found, err := s.imageVulnDatastore.Get(checkCtx, edgeId)
+				s.NoError(err)
+				s.False(found)
+				s.Nil(edge)
+			}
+			targetCve := cve3.GetCve()
+			newState := storage.VulnerabilityState_DEFERRED
+			updateErr := s.datastore.UpdateVulnerabilityState(ctx, targetCve, []string{image.GetId()}, newState)
+			if testCase.ExpectError {
+				s.Error(updateErr)
+				s.ErrorIs(updateErr, testCase.ExpectedError)
+			} else {
+				s.NoError(updateErr)
+				for _, cve := range foundCVEs {
+					expectedState := storage.VulnerabilityState_OBSERVED
+					if !env.PostgresDatastoreEnabled.BooleanSetting() && cve.GetCve() == cve3.GetCve() {
+						// Currently, UpdateVulnerabilityState only updates the state column, but not the stored serialized object
+						expectedState = storage.VulnerabilityState_DEFERRED
+					}
+					edgeId := getImageCVEEdgeID(image.GetId(), cve.GetCve())
+					edge, found, err := s.imageVulnDatastore.Get(checkCtx, edgeId)
+					s.NoError(err)
+					s.True(found)
+					s.Equal(expectedState, edge.GetState())
+				}
+				for _, cve := range missingCVEs {
+					edgeId := getImageCVEEdgeID(image.GetId(), cve.GetCve())
+					edge, found, err := s.imageVulnDatastore.Get(checkCtx, edgeId)
+					s.NoError(err)
+					s.False(found)
+					s.Nil(edge)
+				}
+			}
+		})
+	}
+}
+
+func (s *imageDatastoreSACSuite) TestDeleteImages() {
+	cases := testutils.GenericGlobalSACDeleteTestCases(s.T())
+
+	for name, testCase := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[testCase.ScopeKey]
+			writeCtx := s.testContexts[testutils.UnrestrictedReadWriteCtx]
+			checkCtx := s.testContexts[testutils.UnrestrictedReadCtx]
+			image := fixtures.GetImageSherlockHolmes1()
+			defer s.deleteImage(image.GetId())
+			upsertErr := s.datastore.UpsertImage(writeCtx, image)
+			s.Require().NoError(upsertErr)
+			_, found, check1Err := s.datastore.GetImage(checkCtx, image.GetId())
+			s.Require().NoError(check1Err)
+			s.Require().True(found)
+			deleteErr := s.datastore.DeleteImages(ctx, image.GetId())
+			if testCase.ExpectError {
+				s.Error(deleteErr)
+				s.ErrorIs(deleteErr, testCase.ExpectedError)
+				_, postRemovalFound, check2Err := s.datastore.GetImage(checkCtx, image.GetId())
+				s.NoError(check2Err)
+				s.True(postRemovalFound)
+			} else {
+				s.NoError(deleteErr)
+				_, postRemovalFound, check2Err := s.datastore.GetImage(checkCtx, image.GetId())
+				s.NoError(check2Err)
+				s.False(postRemovalFound)
+			}
+		})
+	}
+}
+
+func (s *imageDatastoreSACSuite) setupReadTest() ([]*storage.Image, func(), error) {
+	var setupErr error
+	namespacesToDelete := make([]string, 0, 1)
+	deploymentsToDelete := make([]*storage.Deployment, 0, 1)
+	imagesToDelete := make([]string, 0, 1)
+	images := make([]*storage.Image, 0, 1)
+	cleanup := func() {
+		for _, img := range imagesToDelete {
+			s.deleteImage(img)
+		}
+		for _, deployment := range deploymentsToDelete {
+			s.deleteDeployment(deployment.GetClusterId(), deployment.GetId())
+		}
+		for _, ns := range namespacesToDelete {
+			s.deleteNamespace(ns)
+		}
+	}
+	setupCtx := sac.WithAllAccess(context.Background())
+	namespace := fixtures.GetNamespace(testconsts.Cluster2, testconsts.Cluster2, testconsts.NamespaceB)
+	namespacesToDelete = append(namespacesToDelete, namespace.GetId())
+	setupErr = s.namespaceDatastore.AddNamespace(setupCtx, namespace)
+	if setupErr != nil {
+		return nil, cleanup, setupErr
+	}
+	deployment := fixtures.GetDeploymentSherlockHolmes1(uuid.NewV4().String(), namespace)
+	deploymentsToDelete = append(deploymentsToDelete, deployment)
+	setupErr = s.deploymentDatastore.UpsertDeployment(setupCtx, deployment)
+	if setupErr != nil {
+		return nil, cleanup, setupErr
+	}
+	deployment2 := fixtures.GetDeploymentDoctorJekyll2(uuid.NewV4().String(), namespace)
+	deploymentsToDelete = append(deploymentsToDelete, deployment2)
+	setupErr = s.deploymentDatastore.UpsertDeployment(setupCtx, deployment2)
+	if setupErr != nil {
+		return nil, cleanup, setupErr
+	}
+	image := fixtures.GetImageSherlockHolmes1()
+	imagesToDelete = append(imagesToDelete, image.GetId())
+	images = append(images, image)
+	setupErr = s.datastore.UpsertImage(setupCtx, image)
+	if setupErr != nil {
+		return nil, cleanup, setupErr
+	}
+	image2 := fixtures.GetImageDoctorJekyll2()
+	imagesToDelete = append(imagesToDelete, image2.GetId())
+	images = append(images, image2)
+	setupErr = s.datastore.UpsertImage(setupCtx, image2)
+	if setupErr != nil {
+		return nil, cleanup, setupErr
+	}
+	s.waitForIndexing()
+	return images, cleanup, nil
+}
+
+func (s *imageDatastoreSACSuite) TestExists() {
+	images, cleanup, setupErr := s.setupReadTest()
+	defer cleanup()
+	s.Require().NoError(setupErr)
+	s.Require().NotZero(len(images))
+	image := images[0]
+
+	cases := testutils.GenericNamespaceSACGetTestCases(s.T())
+
+	for name, testCase := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[testCase.ScopeKey]
+			exists, err := s.datastore.Exists(ctx, image.GetId())
+			s.NoError(err)
+			if testCase.ExpectedFound {
+				s.True(exists)
+			} else {
+				s.False(exists)
+			}
+		})
+	}
+}
+
+func (s *imageDatastoreSACSuite) TestListImage() {
+	images, cleanup, setupErr := s.setupReadTest()
+	defer cleanup()
+	s.Require().NoError(setupErr)
+	s.Require().NotZero(len(images))
+	image := images[0]
+
+	cases := testutils.GenericNamespaceSACGetTestCases(s.T())
+
+	for name, testCase := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[testCase.ScopeKey]
+			readImage, found, err := s.datastore.ListImage(ctx, image.GetId())
+			s.Require().NoError(err)
+			if testCase.ExpectedFound {
+				s.True(found)
+				s.Equal(image.GetId(), readImage.GetId())
+				s.Equal(image.GetComponents(), readImage.GetComponents())
+				s.Equal(image.GetCves(), readImage.GetCves())
+			} else {
+				s.False(found)
+				s.Nil(readImage)
+			}
+		})
+	}
+}
+
+func (s *imageDatastoreSACSuite) TestGetImage() {
+	images, cleanup, setupErr := s.setupReadTest()
+	defer cleanup()
+	s.Require().NoError(setupErr)
+	s.Require().NotZero(len(images))
+	image := images[0]
+
+	cases := testutils.GenericNamespaceSACGetTestCases(s.T())
+
+	for name, testCase := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[testCase.ScopeKey]
+			readImage, found, err := s.datastore.GetImage(ctx, image.GetId())
+			s.Require().NoError(err)
+			if testCase.ExpectedFound {
+				s.True(found)
+				s.Equal(image.GetId(), readImage.GetId())
+				s.Equal(image.GetComponents(), readImage.GetComponents())
+				s.Equal(image.GetCves(), readImage.GetCves())
+			} else {
+				s.False(found)
+				s.Nil(readImage)
+			}
+		})
+	}
+}
+
+func (s *imageDatastoreSACSuite) TestGetImageMetadata() {
+	images, cleanup, setupErr := s.setupReadTest()
+	defer cleanup()
+	s.Require().NoError(setupErr)
+	s.Require().NotZero(len(images))
+	image := images[0]
+
+	cases := testutils.GenericNamespaceSACGetTestCases(s.T())
+
+	for name, testCase := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[testCase.ScopeKey]
+			readImageMeta, found, err := s.datastore.GetImageMetadata(ctx, image.GetId())
+			s.Require().NoError(err)
+			if testCase.ExpectedFound {
+				s.True(found)
+				s.Equal(image.GetId(), readImageMeta.GetId())
+				s.Equal(image.GetComponents(), readImageMeta.GetComponents())
+				s.Equal(image.GetCves(), readImageMeta.GetCves())
+			} else {
+				s.False(found)
+				s.Nil(readImageMeta)
+			}
+		})
+	}
+
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		s.Require().True(len(images) > 1)
+		image2 := images[1]
+		// Test GetManyImageMetadata in postgres mode (only supported mode).
+		for name, testCase := range cases {
+			s.Run("Many_"+name, func() {
+				ctx := s.testContexts[testCase.ScopeKey]
+				readMeta, err := s.datastore.GetManyImageMetadata(ctx, []string{image.GetId(), image2.GetId()})
+				s.Require().NoError(err)
+				if testCase.ExpectedFound {
+					s.Require().Equal(2, len(readMeta))
+					readImageMeta1 := readMeta[0]
+					readImageMeta2 := readMeta[1]
+					if readImageMeta1.GetId() == image.GetId() {
+						s.Equal(image.GetId(), readImageMeta1.GetId())
+						s.Equal(image.GetComponents(), readImageMeta1.GetComponents())
+						s.Equal(image.GetCves(), readImageMeta1.GetCves())
+						s.Equal(image2.GetId(), readImageMeta2.GetId())
+						s.Equal(image2.GetComponents(), readImageMeta2.GetComponents())
+						s.Equal(image2.GetCves(), readImageMeta2.GetCves())
+					} else {
+						s.Equal(image2.GetId(), readImageMeta1.GetId())
+						s.Equal(image2.GetComponents(), readImageMeta1.GetComponents())
+						s.Equal(image2.GetCves(), readImageMeta1.GetCves())
+						s.Equal(image.GetId(), readImageMeta2.GetId())
+						s.Equal(image.GetComponents(), readImageMeta2.GetComponents())
+						s.Equal(image.GetCves(), readImageMeta2.GetCves())
+					}
+				} else {
+					s.Equal(0, len(readMeta))
+				}
+			})
+		}
+	}
+}
+
+func (s *imageDatastoreSACSuite) TestGetImagesBatch() {
+	images, cleanup, setupErr := s.setupReadTest()
+	defer cleanup()
+	s.Require().NoError(setupErr)
+	s.Require().True(len(images) > 1)
+	image1 := images[0]
+	image2 := images[1]
+
+	cases := testutils.GenericNamespaceSACGetTestCases(s.T())
+
+	for name, testCase := range cases {
+		s.Run(name, func() {
+			ctx := s.testContexts[testCase.ScopeKey]
+			readMeta, err := s.datastore.GetImagesBatch(ctx, []string{image1.GetId(), image2.GetId()})
+			s.Require().NoError(err)
+			if testCase.ExpectedFound {
+				s.Require().Equal(2, len(readMeta))
+				readImageMeta1 := readMeta[0]
+				readImageMeta2 := readMeta[1]
+				if readImageMeta1.GetId() == image1.GetId() {
+					s.Equal(image1.GetId(), readImageMeta1.GetId())
+					s.Equal(image1.GetComponents(), readImageMeta1.GetComponents())
+					s.Equal(image1.GetCves(), readImageMeta1.GetCves())
+					s.Equal(image2.GetId(), readImageMeta2.GetId())
+					s.Equal(image2.GetComponents(), readImageMeta2.GetComponents())
+					s.Equal(image2.GetCves(), readImageMeta2.GetCves())
+				} else {
+					s.Equal(image2.GetId(), readImageMeta1.GetId())
+					s.Equal(image2.GetComponents(), readImageMeta1.GetComponents())
+					s.Equal(image2.GetCves(), readImageMeta1.GetCves())
+					s.Equal(image1.GetId(), readImageMeta2.GetId())
+					s.Equal(image1.GetComponents(), readImageMeta2.GetComponents())
+					s.Equal(image1.GetCves(), readImageMeta2.GetCves())
+				}
+			} else {
+				s.Equal(0, len(readMeta))
+			}
+		})
+	}
+}

--- a/central/image/datastoretest/datastore_sac_test.go
+++ b/central/image/datastoretest/datastore_sac_test.go
@@ -285,8 +285,8 @@ func (s *imageDatastoreSACSuite) TestUpdateVulnerabilityState() {
 					s.Equal(expectedState, edge.GetState())
 				}
 				for _, cve := range missingCVEs {
-					edgeId := getImageCVEEdgeID(image.GetId(), cve.GetCve())
-					edge, found, err := s.imageVulnDatastore.Get(checkCtx, edgeId)
+					edgeID := getImageCVEEdgeID(image.GetId(), cve.GetCve())
+					edge, found, err := s.imageVulnDatastore.Get(checkCtx, edgeID)
 					s.NoError(err)
 					s.False(found)
 					s.Nil(edge)

--- a/central/image/datastoretest/datastore_sac_test.go
+++ b/central/image/datastoretest/datastore_sac_test.go
@@ -251,15 +251,15 @@ func (s *imageDatastoreSACSuite) TestUpdateVulnerabilityState() {
 			defer s.deleteImage(image.GetId())
 			s.Require().NoError(insertErr)
 			for _, cve := range foundCVEs {
-				edgeId := getImageCVEEdgeID(image.GetId(), cve.GetCve())
-				edge, found, err := s.imageVulnDatastore.Get(checkCtx, edgeId)
+				edgeID := getImageCVEEdgeID(image.GetId(), cve.GetCve())
+				edge, found, err := s.imageVulnDatastore.Get(checkCtx, edgeID)
 				s.NoError(err)
 				s.True(found)
 				s.Equal(storage.VulnerabilityState_OBSERVED, edge.GetState())
 			}
 			for _, cve := range missingCVEs {
-				edgeId := getImageCVEEdgeID(image.GetId(), cve.GetCve())
-				edge, found, err := s.imageVulnDatastore.Get(checkCtx, edgeId)
+				edgeID := getImageCVEEdgeID(image.GetId(), cve.GetCve())
+				edge, found, err := s.imageVulnDatastore.Get(checkCtx, edgeID)
 				s.NoError(err)
 				s.False(found)
 				s.Nil(edge)
@@ -278,8 +278,8 @@ func (s *imageDatastoreSACSuite) TestUpdateVulnerabilityState() {
 						// Currently, UpdateVulnerabilityState only updates the state column, but not the stored serialized object
 						expectedState = storage.VulnerabilityState_DEFERRED
 					}
-					edgeId := getImageCVEEdgeID(image.GetId(), cve.GetCve())
-					edge, found, err := s.imageVulnDatastore.Get(checkCtx, edgeId)
+					edgeID := getImageCVEEdgeID(image.GetId(), cve.GetCve())
+					edge, found, err := s.imageVulnDatastore.Get(checkCtx, edgeID)
 					s.NoError(err)
 					s.True(found)
 					s.Equal(expectedState, edge.GetState())
@@ -790,7 +790,7 @@ func (s *imageDatastoreSACSuite) TestSearch() {
 				resultIDHeap[r.ID] = struct{}{}
 			}
 			resultIDs := make([]string, 0, len(resultIDHeap))
-			for k, _ := range resultIDHeap {
+			for k := range resultIDHeap {
 				resultIDs = append(resultIDs, k)
 			}
 			s.ElementsMatch(expectedIDs, resultIDs)
@@ -820,7 +820,7 @@ func (s *imageDatastoreSACSuite) TestSearchImages() {
 				resultIDHeap[r.GetId()] = struct{}{}
 			}
 			resultIDs := make([]string, 0, len(resultIDHeap))
-			for k, _ := range resultIDHeap {
+			for k := range resultIDHeap {
 				resultIDs = append(resultIDs, k)
 			}
 			s.ElementsMatch(expectedIDs, resultIDs)
@@ -855,7 +855,7 @@ func (s *imageDatastoreSACSuite) TestSearchRawImages() {
 				resultImages[r.GetId()] = r
 			}
 			resultIDs := make([]string, 0, len(resultImages))
-			for k, _ := range resultImages {
+			for k := range resultImages {
 				resultIDs = append(resultIDs, k)
 			}
 			s.ElementsMatch(expectedIDs, resultIDs)
@@ -893,7 +893,7 @@ func (s *imageDatastoreSACSuite) TestSearchListImages() {
 				resultListImages[r.GetId()] = r
 			}
 			resultIDs := make([]string, 0, len(resultListImages))
-			for k, _ := range resultListImages {
+			for k := range resultListImages {
 				resultIDs = append(resultIDs, k)
 			}
 			s.ElementsMatch(expectedIDs, resultIDs)

--- a/central/imagecveedge/datastore/datastore_test_constructors.go
+++ b/central/imagecveedge/datastore/datastore_test_constructors.go
@@ -1,0 +1,49 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/blevesearch/bleve"
+	"github.com/jackc/pgx/v4/pgxpool"
+	clusterIndex "github.com/stackrox/rox/central/cluster/index"
+	componentCVEEdgeIndex "github.com/stackrox/rox/central/componentcveedge/index"
+	"github.com/stackrox/rox/central/cve/index"
+	deploymentIndex "github.com/stackrox/rox/central/deployment/index"
+	imageIndex "github.com/stackrox/rox/central/image/index"
+	componentIndex "github.com/stackrox/rox/central/imagecomponent/index"
+	imageComponentEdgeIndex "github.com/stackrox/rox/central/imagecomponentedge/index"
+	"github.com/stackrox/rox/central/imagecveedge/datastore/postgres"
+	imageCVEEdgeIndex "github.com/stackrox/rox/central/imagecveedge/index"
+	"github.com/stackrox/rox/central/imagecveedge/search"
+	dackboxStore "github.com/stackrox/rox/central/imagecveedge/store/dackbox"
+	"github.com/stackrox/rox/pkg/dackbox"
+	"github.com/stackrox/rox/pkg/dackbox/concurrency"
+)
+
+// GetTestRocksBleveDataStore provides a datastore connected to rocksdb and bleve for testing purposes.
+func GetTestRocksBleveDataStore(_ *testing.T, bleveIndex bleve.Index, dacky *dackbox.DackBox, keyFence concurrency.KeyFence) DataStore {
+	return New(
+		dacky,
+		dackboxStore.New(dacky, keyFence),
+		search.New(dackboxStore.New(dacky, keyFence),
+			index.New(bleveIndex),
+			imageCVEEdgeIndex.New(bleveIndex),
+			componentCVEEdgeIndex.New(bleveIndex),
+			componentIndex.New(bleveIndex),
+			imageComponentEdgeIndex.New(bleveIndex),
+			imageIndex.New(bleveIndex),
+			deploymentIndex.New(bleveIndex, bleveIndex),
+			clusterIndex.New(bleveIndex),
+		))
+}
+
+// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetTestPostgresDataStore(_ *testing.T, pool *pgxpool.Pool) DataStore {
+	return New(
+		nil,
+		postgres.New(pool),
+		search.NewV2(postgres.New(pool),
+			postgres.NewIndexer(pool),
+		),
+	)
+}


### PR DESCRIPTION
## Description

With the migration to postgres as a datastore, it is good to have a test harness that guarantees the consistency of behaviour of scoped access control (and associated data filtering) between the possible data storage engines.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.