### PR TITLE
CI: Increase a range of CVE count to avoid flakes

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -283,7 +283,7 @@ class ImageScanningTest extends BaseSpecification {
             assert vuln.link && vuln.link != ""
         }
         assert imageDetail.components >= components
-        assert ((imageDetail.cves - 5)..(imageDetail.cves + 5)).contains(totalCves)
+        assert ((imageDetail.cves - 10)..(imageDetail.cves + 10)).contains(totalCves)
         assert imageDetail.fixableCves >= fixable
 
         where:


### PR DESCRIPTION
## Description

Looks the expected CVE range introduced in https://github.com/stackrox/stackrox/pull/2527 is not enough: I've seen "Verify Image Registry+Scanner Integrations" test fail today on most flavours with 181 CVEs.

Increasing the range seems harmless since a reasonable ballpark very likely means a successful test. 0 or 100500 CVE would indicate that something is wrong.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI run.