### PR TITLE
Dashrews/ROX-13072 migrator cleanup of rocks causes bad symlink and crashing migrator

### DIFF
--- a/migrator/clone/clone_test.go
+++ b/migrator/clone/clone_test.go
@@ -155,6 +155,14 @@ func doTestCloneMigrationToPostgres(t *testing.T, runBoth bool) {
 				mock.upgradeCentral(c.furtherToVersion, "")
 				if c.moreFurtherToVersion != nil {
 					mock.upgradeCentral(c.moreFurtherToVersion, "")
+
+					// Now try to go back to Rocks and make sure that fails
+					// Turn Postgres back off
+					require.NoError(t, os.Setenv(env.PostgresDatastoreEnabled.EnvVar(), strconv.FormatBool(false)))
+					mock.runMigrator("", "", true)
+
+					// Turn Postgres back on
+					require.NoError(t, os.Setenv(env.PostgresDatastoreEnabled.EnvVar(), strconv.FormatBool(true)))
 				}
 			}
 		})
@@ -165,7 +173,7 @@ func createAndRunCentral(t *testing.T, ver *versionPair, runBoth bool) *mockCent
 	mock := createCentral(t, runBoth)
 	mock.setVersion = setVersion
 	mock.setVersion(t, ver)
-	mock.runMigrator("", "")
+	mock.runMigrator("", "", false)
 	mock.runCentral()
 	return mock
 }
@@ -179,7 +187,7 @@ func createAndRunCentralStartRocks(t *testing.T, ver *versionPair, runBoth bool)
 	// First get a Rocks up and current.  This way when we do the next upgrade we should get a previous rocks.
 	require.NoError(t, os.Setenv(env.PostgresDatastoreEnabled.EnvVar(), strconv.FormatBool(false)))
 
-	mock.runMigrator("", "")
+	mock.runMigrator("", "", false)
 	mock.runCentral()
 
 	// Turn Postgres back on
@@ -248,7 +256,7 @@ func doTestCloneMigrationFailureAndReentry(t *testing.T) {
 			}
 			if c.furtherToVersion != nil {
 				// Run migrator multiple times
-				mock.runMigrator("", "")
+				mock.runMigrator("", "", false)
 				mock.upgradeCentral(c.furtherToVersion, "")
 			}
 		})

--- a/migrator/clone/metadata/db_clone_impl.go
+++ b/migrator/clone/metadata/db_clone_impl.go
@@ -29,6 +29,9 @@ kubectl -n stackrox set env deploy/central ROX_DONT_COMPARE_DEV_BUILDS=true
 
 	// ErrUnableToRestore -- cannot restore upgraded backup to a downgraded central
 	ErrUnableToRestore = "The backup bundle being restored is from an upgraded version of central and thus cannot applied.  The restored version %s, current version %s"
+
+	// ErrUnsupportedDatabase -- cannot use this database as it is stale after previous upgrades to Postgres
+	ErrUnsupportedDatabase = "Central has previously underwent multiple upgrades to Postgres.  This version of RocksDB is stale and not supported."
 )
 
 // DBClone -- holds information related to DB clones

--- a/migrator/clone/mock_central.go
+++ b/migrator/clone/mock_central.go
@@ -189,6 +189,7 @@ func (m *mockCentral) runMigrator(breakPoint string, forceRollback string, unsup
 	}
 	if unsupportedRocks {
 		require.Error(m.t, err, metadata.ErrUnsupportedDatabase)
+		return
 	}
 	require.NoError(m.t, err)
 	if breakPoint == breakAfterScan {

--- a/migrator/clone/rocksdb/db_clone_manager_impl.go
+++ b/migrator/clone/rocksdb/db_clone_manager_impl.go
@@ -104,7 +104,7 @@ func (d *dbCloneManagerImpl) Scan() error {
 		}
 	}
 
-	// Remove unknown clones that is not in use
+	// Remove unknown clones that are not in use
 	for _, r := range d.cloneMap {
 		clonesToRemove.Remove(r.GetDirName())
 	}

--- a/migrator/clone/rocksdb/db_clone_manager_impl.go
+++ b/migrator/clone/rocksdb/db_clone_manager_impl.go
@@ -341,15 +341,9 @@ func (d *dbCloneManagerImpl) DecommissionRocksDB() {
 		} else if exists {
 			// TODO(ROX-9882): While there is still stuff on the PVC there is an expectation that current
 			// exists in a certain state.  So until we can remove the rest of the components on the PVC, it
-			// is safer to clear the contents.  This will keep the link and directory in place to ensure
-			// things behave in a safe manner on restarts.
+			// is safer to put the contents in an obviously deprecated location.
 			if k == CurrentClone {
-				dir, err := os.ReadDir(dirPath)
-				if err != nil {
-					log.Error(err)
-					continue
-				}
-				// Move the data to the decommissioned rocks directory and point current there.
+				// Get the location Current points to
 				linkTo, err := fileutils.ResolveIfSymlink(dirPath)
 				if err != nil {
 					log.Error(err)
@@ -372,6 +366,7 @@ func (d *dbCloneManagerImpl) DecommissionRocksDB() {
 				}
 				// Remove clone symbolic link only, if exists.
 				_ = os.Remove(d.getPath(CurrentClone))
+				// Set the new symbolic link
 				if err := fileutils.AtomicSymlink(decommissionedCurrent, d.getPath(CurrentClone)); err != nil {
 					log.Error(err)
 					continue

--- a/migrator/clone/rocksdb/db_clone_manager_impl.go
+++ b/migrator/clone/rocksdb/db_clone_manager_impl.go
@@ -345,7 +345,10 @@ func (d *dbCloneManagerImpl) DecommissionRocksDB() {
 				}
 				for _, d := range dir {
 					log.Infof("Removing %q", d.Name())
-					os.RemoveAll(path.Join([]string{dirPath, d.Name()}...))
+					if err = os.RemoveAll(path.Join([]string{dirPath, d.Name()}...)); err != nil {
+						log.Error(err)
+						continue
+					}
 				}
 			} else {
 				log.Infof("Removing database %s", dirPath)

--- a/migrator/clone/rocksdb/db_clone_manager_impl.go
+++ b/migrator/clone/rocksdb/db_clone_manager_impl.go
@@ -354,16 +354,9 @@ func (d *dbCloneManagerImpl) DecommissionRocksDB() {
 					log.Info("we have already moved to the RocksDB current to be decomissioned")
 					continue
 				}
-				decommissionExists, err := fileutils.Exists(d.getPath(decommissionedCurrent))
-				if err != nil {
+				if err := os.MkdirAll(d.getPath(decommissionedCurrent), 0755); err != nil {
 					log.Error(err)
 					continue
-				}
-				if !decommissionExists {
-					if err := os.Mkdir(d.getPath(decommissionedCurrent), 0755); err != nil {
-						log.Error(err)
-						continue
-					}
 				}
 				// Set the new symbolic link
 				if err := fileutils.AtomicSymlink(decommissionedCurrent, d.getPath(CurrentClone)); err != nil {

--- a/migrator/runner/runner.go
+++ b/migrator/runner/runner.go
@@ -22,6 +22,10 @@ func Run(databases *types.Databases) error {
 		return errors.Wrap(err, "getting current seq num")
 	}
 	currSeqNum := pkgMigrations.CurrentDBVersionSeqNum()
+	if dbSeqNum == 0 {
+		log.WriteToStderr("Sequence number of 0 means starting fresh, no migrations to execute")
+		return nil
+	}
 	if dbSeqNum > currSeqNum {
 		return fmt.Errorf("DB sequence number %d is greater than the latest one we have (%d). This means "+
 			"the migration binary is likely out of date", dbSeqNum, currSeqNum)


### PR DESCRIPTION
## Description

When we determined that we no longer need RocksDB, the migrator will decomission it and removed current and .db-*.  The problem is that since the PVC hasn't been fully cleaned up yet, central adds some stuff back to the PVC and doesn't create things in the expected way.  This causes an issue where migrator will not be able to recover because the symlink of current is pointing to something invalid.  This is evident if you try to rollback but forget to add the forceRollbackVersion to the config map.  You should be able to recover from that by editing the config map.  But when we remove the directory and links we get ourselves in a position we cannot recover from..  So the simplest and safest path for now is to simply  remove the migration_version.yaml and rename the database current points to, to be an obviously unsupported database.  This ensures we have nothing in there to interfere with Postgres and allows us to recover from situations like this.  When we finally get all the stuff off the PVC then we can safely remove the directory.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Deploy a central
Upgrade central to a new version
Rollback central
Notice we are in a crash back because forceRollbackVersion is not set
Set forceRollbackVersion in the config map
Notice central stops crashing.
