### PR TITLE
ROX-9156: Secured Cluster Services Helm Chart: make sure to not reference non-existing secrets

### DIFF
--- a/image/templates/helm/shared/templates/_image-pull-secrets.tpl
+++ b/image/templates/helm/shared/templates/_image-pull-secrets.tpl
@@ -49,7 +49,15 @@
   {{ include "srox.fail" $msg }}
 {{ end }}
 
-{{ $imagePullSecretNames = concat (append $imagePullSecretNames $secretResourceName) $defaultSecretNames | uniq | sortAlpha }}
+{{ range $defaultSecretName := $defaultSecretNames }}
+  {{ $secret := dict }}
+  {{ include "srox.safeLookup" (list $ $secret "v1" "Secret" $namespace $defaultSecretName) }}
+  {{ if $secret.result }}
+    {{ $imagePullSecretNames = append $imagePullSecretNames $defaultSecretName }}
+  {{ end }}
+{{ end }}
+
+{{ $imagePullSecretNames = $imagePullSecretNames | uniq | sortAlpha }}
 {{ $_ := set $imagePullSecrets "_names" $imagePullSecretNames }}
 {{ $_ := set $imagePullSecrets "_creds" $imagePullCreds }}
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/_lookup.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_lookup.tpl
@@ -20,6 +20,14 @@
   {{ end }}
   {{ include "srox._doLookup" . }}
   {{ $_ := set $out "reliable" $._rox._state.lookupWorks }}
+{{ else if $._rox.meta.useFakeLookup }}
+  {{ $apiVersion := index . 2 }}
+  {{ $kind := index . 3 }}
+  {{ $resource := index . 4 }}
+  {{ $resourceRef := printf "%s/%s/%s" $apiVersion $kind $resource }}
+  {{ $fakeObj := get $._rox.meta.fakeLookupResources $resourceRef }}
+  {{ $_ := set $out "result" $fakeObj }}
+  {{ $_ := set $out "reliable" true }}
 {{ end }}
 {{ end }}
 

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
@@ -11,109 +11,133 @@ defs: |
           | .["https://" + (if ($mainRegistry == "docker.io") then "index.docker.io/v1/" else $mainRegistry end)]
           | .auth | @base64d;
 
-expect: |
-  # Ensure that default/legacy service accounts are always referenced in the correct fashion in the non-error case
-
-  assumeThat(.error == null) | .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "stackrox")
-  assumeThat(.error == null) | .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "collector-stackrox")
-
-  assumeThat(.error == null) | .serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "stackrox")
-  assumeThat(.error == null) | [.serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "collector-stackrox")] | assertThat(length == 0)
-  assumeThat(.error == null) | .serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "stackrox")
-  assumeThat(.error == null) | [.serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "collector-stackrox")] | assertThat(length == 0)
-
-  # Ensure that newly created secrets are always referenced in the correct fashion in the non-error case.
-  assumeThat(.error == null) | .serviceaccounts["collector"] | [.imagePullSecrets[] |
-    select(.name == "secured-cluster-services-main" or .name == "secured-cluster-services-collector")] |
-    assertThat(length == 2)
-  assumeThat(.error == null) | .serviceaccounts["sensor"] | .imagePullSecrets[] |
-    select(.name == "secured-cluster-services-main")
-  assumeThat(.error == null) | .serviceaccounts["admission-control"] | .imagePullSecrets[] |
-    select(.name == "secured-cluster-services-main")
-
 tests:
-- name: "with no IPS creation"
-  expect: |
-    .secrets?["secured-cluster-services-main"]? | assertThat(. == null)
-    .secrets?["secured-cluster-services-collector"]? | assertThat(. == null)
-  tests:
-  - name: "with default settings of allowNone=true"
-  - name: "with allowNone=false"
-    set:
-      imagePullSecrets.allowNone: false
+  - name: without existing legacy secrets
     tests:
-    - name: "should fail with no extra secrets"
-      expectError: true
-    - name: "should succeed with useExisting"
-      expect: |
-        .serviceaccounts[] | [.imagePullSecrets[] | select(.name == "extra-secret1" or .name == "extra-secret2")]
-          | assertThat(length == 2)
-      tests:
-      - name: as JSON list
-        set:
-          imagePullSecrets.useExisting: ["extra-secret1", "extra-secret2"]
-
-      - name: as semicolon-delimited list string
-        set:
-          imagePullSecrets.useExisting: "extra-secret1; extra-secret2 "
-
-- name: "with IPS creation"
-  set:
-    imagePullSecrets.allowNone: false
-
-  expect: |
-    .secrets["secured-cluster-services-main"] | assertThat(. != null)
-    .secrets["secured-cluster-services-collector"] | assertThat(. != null)
-    .serviceaccounts[] | [.imagePullSecrets[] | select(.name == "secured-cluster-services-main")] | assertThat(length == 1)
-    .serviceaccounts.collector | [.imagePullSecrets[] | select(.name == "secured-cluster-services-collector")]
-      | assertThat(length == 1)
-  tests:
-  - name: "with username and password specified"
+      - name: "service accounts do not reference secrets by default"
+        expect: |
+          .serviceaccounts["sensor"] | .imagePullSecrets | assertThat(. == null)
+          .serviceaccounts["collector"] | .imagePullSecrets | assertThat(. == null)
+          .serviceaccounts["admission-control"] | .imagePullSecrets | assertThat(. == null)
+  - name: "with existing legacy secrets"
     values:
-      imagePullSecrets:
-        username: foo
-        password: bar
+      meta:
+        useLookup: false
+        useFakeLookup: true
+        fakeLookupResources:
+          v1/Secret/stackrox:
+            data:
+              foo: bar
+          v1/Secret/stackrox-scanner:
+            data:
+              foo: bar
+          v1/Secret/collector-stackrox:
+            data:
+              foo: bar
     expect: |
-      authForMain | assertThat(. == "foo:bar")
-      authForCollector | assertThat(. == "foo:bar")
+      # Ensure that default/legacy service accounts are always referenced in the correct fashion in the non-error case
+
+      assumeThat(.error == null) | .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "stackrox")
+      assumeThat(.error == null) | .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "collector-stackrox")
+
+      assumeThat(.error == null) | .serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "stackrox")
+      assumeThat(.error == null) | [.serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "collector-stackrox")] | assertThat(length == 0)
+      assumeThat(.error == null) | .serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "stackrox")
+      assumeThat(.error == null) | [.serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "collector-stackrox")] | assertThat(length == 0)
     tests:
-    - name: "with default registry"
-    - name: "with custom default registry"
-      set:
-        image.registry: my.registry.io
-    - name: "with custom main registry"
-      set:
-        image.main.registry: my.registry.io
-    - name: "with custom collector registry"
-      set:
-        image.collector.registry: my.collector-registry.io
-    - name: "with docker registry"
-      set:
-        image.registry: docker.io/stackrox
-  - name: "with empty password"
-    values:
-      imagePullSecrets:
-        username: foo
-        password: ""
-    expect: |
-      authForMain | assertThat(. == "foo:")
-      authForCollector | assertThat(. == "foo:")
+      - name: IPS are referenced in the correct fashion
+        values:
+          imagePullSecrets:
+            username: "adent"
+            password: "vogon-poetry"
+        expect: |
+          .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "secured-cluster-services-main")
+          .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "secured-cluster-services-collector")
+          .serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "secured-cluster-services-main")
+          .serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "secured-cluster-services-main")
+      - name: "IPS are not created"
+        expect: |
+          .secrets?["secured-cluster-services-main"]? | assertThat(. == null)
+          .secrets?["secured-cluster-services-collector"]? | assertThat(. == null)
+        tests:
+          - name: "with default settings of allowNone=true"
+          - name: "with allowNone=false"
+            set:
+              imagePullSecrets.allowNone: false
+            tests:
+              - name: "should fail with no extra secrets"
+                expectError: true
+              - name: "should succeed with useExisting"
+                expect: |
+                  .serviceaccounts[] | [.imagePullSecrets[] | select(.name == "extra-secret1" or .name == "extra-secret2")]
+                    | assertThat(length == 2)
+                tests:
+                  - name: as JSON list
+                    set:
+                      imagePullSecrets.useExisting:
+                        ["extra-secret1", "extra-secret2"]
 
-- name: "default IPS are referenced in service accounts"
-  expect: |
-    .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "stackrox")
-    .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "collector-stackrox")
+                  - name: as semicolon-delimited list string
+                    set:
+                      imagePullSecrets.useExisting: "extra-secret1; extra-secret2 "
 
-    .serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "stackrox")
-    [.serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "collector-stackrox")] | assertThat(length == 0)
-    .serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "stackrox")
-    [.serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "collector-stackrox")] | assertThat(length == 0)
+      - name: "IPS are created"
+        set:
+          imagePullSecrets.allowNone: false
 
-- name: "additional IPS are referenced in service accounts"
-  values:
-    imagePullSecrets:
-      useExisting: custom-ips
-  expect: |
-    .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "custom-ips")
-    .serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "custom-ips")
-    .serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "custom-ips")
+        expect: |
+          .secrets["secured-cluster-services-main"] | assertThat(. != null)
+          .secrets["secured-cluster-services-collector"] | assertThat(. != null)
+          .serviceaccounts[] | [.imagePullSecrets[] | select(.name == "secured-cluster-services-main")] | assertThat(length == 1)
+          .serviceaccounts.collector | [.imagePullSecrets[] | select(.name == "secured-cluster-services-collector")]
+            | assertThat(length == 1)
+        tests:
+          - name: "with username and password specified"
+            values:
+              imagePullSecrets:
+                username: foo
+                password: bar
+            expect: |
+              authForMain | assertThat(. == "foo:bar")
+              authForCollector | assertThat(. == "foo:bar")
+            tests:
+              - name: "with default registry"
+              - name: "with custom default registry"
+                set:
+                  image.registry: my.registry.io
+              - name: "with custom main registry"
+                set:
+                  image.main.registry: my.registry.io
+              - name: "with custom collector registry"
+                set:
+                  image.collector.registry: my.collector-registry.io
+              - name: "with docker registry"
+                set:
+                  image.registry: docker.io/stackrox
+          - name: "with empty password"
+            values:
+              imagePullSecrets:
+                username: foo
+                password: ""
+            expect: |
+              authForMain | assertThat(. == "foo:")
+              authForCollector | assertThat(. == "foo:")
+
+      - name: "default IPS are referenced in service accounts"
+        expect: |
+          .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "stackrox")
+          .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "collector-stackrox")
+
+          .serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "stackrox")
+          [.serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "collector-stackrox")] | assertThat(length == 0)
+          .serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "stackrox")
+          [.serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "collector-stackrox")] | assertThat(length == 0)
+
+      - name: "additional IPS are referenced in service accounts"
+        values:
+          imagePullSecrets:
+            useExisting: custom-ips
+        expect: |
+          .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "custom-ips")
+          .serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "custom-ips")
+          .serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "custom-ips")

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-slim.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-slim.test.yaml
@@ -3,6 +3,17 @@ server:
   - openshift-4.1.0
   availableSchemas:
   - openshift-4.1.0
+values:
+  meta:
+    useLookup: false
+    useFakeLookup: true
+    fakeLookupResources:
+      v1/Secret/stackrox:
+        data:
+          foo: bar
+      v1/Secret/stackrox-scanner:
+        data:
+          foo: bar
 tests:
 - name: "scanner with default settings in slim mode"
   set:
@@ -65,13 +76,12 @@ tests:
     .networkpolicys["scanner"].spec.ingress | assertThat(length == 2)
     .networkpolicys["scanner"].spec.ingress[1] | .from[0].podSelector.matchLabels.app | assertThat(. == "sensor")
 
-- name: "scanner slim service account can access image pull secrets"
+- name: "scanner slim service account can access image pull secrets when they are present"
   set:
     scanner.disable: false
     scanner.mode: "slim"
   expect: |
     .serviceaccounts["scanner"] | assertThat(. != null)
-    .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "secured-cluster-services-main")
     .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "stackrox")
     .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "stackrox-scanner")
   tests:
@@ -83,17 +93,20 @@ tests:
       .serviceaccounts["scanner"] | .imagePullSecrets | assertThat(length == 3)
       .secrets["secured-cluster-services-main"] | assertThat(. != null)
   - name: "no secret is created"
-    expect: .secrets["secured-cluster-services-main"] | assertThat(. == null)
+    expect: |
+      .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "stackrox")
+      .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "stackrox-scanner")
+      .secrets["secured-cluster-services-main"] | assertThat(. == null)
     tests:
     - name: "when allowNone is true"
       set:
         imagePullSecrets.allowNone: true
-      expect: .serviceaccounts["scanner"] | .imagePullSecrets | assertThat(length == 3)
+      expect: .serviceaccounts["scanner"] | .imagePullSecrets | assertThat(length == 2)
     - name: "when using existing secrets"
       set:
         imagePullSecrets.useExisting: "existing-secret1; existing-secret2"
       expect: |
-        .serviceaccounts["scanner"] | .imagePullSecrets | assertThat(length == 5)
+        .serviceaccounts["scanner"] | .imagePullSecrets | assertThat(length == 4)
         .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "existing-secret1")
         .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "existing-secret2")
 


### PR DESCRIPTION
## Description

Within the Secured Cluster Services Helm Chart we are letting service accounts reference image pull secrets irregardless of their existence on the cluster. This is benign but creating noisy error log messages. See https://issues.redhat.com/browse/ROX-9156 for details.

This PR consists of two parts. The first one does two things:
1. it uses the `safeLookup` function for checking if the default secret names (contained in `$defaultSecretNames`) actually exist before adding it to the list of to-be-referenced image pull secrets.
2. it removes the unconditional addition of `$secretResourceName` to the list of to-be-referenced image pull secrets.

The second part takes care of fixing the helmtest based tests for the chart. In order to be able to verify the new behaviour (and to keep the changes to the helmtests conscise) we need a way to simulate a functioning `safeLookup`. Hence I introduced new internal configuration settings for the Helm chart:
```
meta:
  useFakeLookup: # bool
   fakeLookupResources: # map with resource object names as keys (in the form `apiVersion/kind/name`)
```

With this in place the helmtest tests can configure the test environment to contain certain objects (e.g. a `stackrox` secret) which then causes the respective references to be added to the service accounts. The affected tests had to be reorganized somewhat so that one part is executed where these fake resources are in scope, and a different branch is executed where these fake resources are absent.

**For obtaining a clearer overview of what changed in the tests I recommend to use the diff split view with spaces hidden.**

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
