### PR TITLE
ROX-13079: collections store test failures fix

### DIFF
--- a/central/resourcecollection/datastore/store/postgres/store_test.go
+++ b/central/resourcecollection/datastore/store/postgres/store_test.go
@@ -60,6 +60,7 @@ func (s *CollectionsStoreSuite) TestStore() {
 
 	resourceCollection := &storage.ResourceCollection{}
 	s.NoError(testutils.FullInit(resourceCollection, testutils.SimpleInitializer(), testutils.JSONFieldsFilter))
+	resourceCollection.EmbeddedCollections[0].Id = resourceCollection.Id
 
 	foundResourceCollection, exists, err := store.Get(ctx, resourceCollection.GetId())
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -69,6 +69,9 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 
 	{{$name}} := &{{.Type}}{}
 	s.NoError(testutils.FullInit({{$name}}, testutils.SimpleInitializer(), testutils.JSONFieldsFilter))
+	{{- if .Cycle}}
+	{{$name}}.{{.EmbeddedFK}} = {{$name}}.{{.ReferencedField}}
+	{{- end}}
 
 	found{{.TrimmedType|upperCamelCase}}, exists, err := store.Get(ctx, {{template "paramList" $}})
 	s.NoError(err)


### PR DESCRIPTION
## Description

Seems like the `testutils.FullInit(...)` function doesn't always fill out the fields the same way every time. Applying the same fix that resolved the same issue this created further down in that same file.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Was able to reproduce the issue locally. Made these changes and have not been able to repro the problem in ~20 runs.
