### PR TITLE
Add more CI labels to dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -32,7 +32,6 @@ updates:
       - "ci-eks-tests"
       - "ci-no-api-tests"
       - "ci-no-ui-tests"
-      - "ci-openshift-4-tests"
       - "dependencies"
     reviewers:
       - "stackrox/backend-dep-updaters"
@@ -42,6 +41,12 @@ updates:
     schedule:
       interval: 'daily'
     open-pull-requests-limit: 3
+    labels:
+      - "ci-aks-tests"
+      - "ci-all-qa-tests"
+      - "ci-postgres-tests"
+      - "ci-eks-tests"
+      - "dependencies"
     reviewers:
       - "stackrox/backend-dep-updaters"
     ignore:
@@ -81,6 +86,12 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 1
+    labels:
+    - "ci-aks-tests"
+    - "ci-all-qa-tests"
+    - "ci-postgres-tests"
+    - "ci-eks-tests"
+    - "dependencies"
     reviewers:
     - "stackrox/backend-dep-updaters"
 
@@ -90,5 +101,11 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 1
+    labels:
+    - "ci-aks-tests"
+    - "ci-all-qa-tests"
+    - "ci-postgres-tests"
+    - "ci-eks-tests"
+    - "dependencies"
     reviewers:
     - "stackrox/backend-dep-updaters"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -54,6 +54,8 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
+    labels:
+    - "dependencies"
     reviewers:
       - "stackrox/backend-dep-updaters"
 
@@ -63,6 +65,8 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
+    labels:
+    - "dependencies"
     reviewers:
       - "stackrox/backend-dep-updaters"
 
@@ -72,6 +76,8 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 1
+    labels:
+    - "dependencies"
     reviewers:
     - "stackrox/backend-dep-updaters"
 

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -27,9 +27,7 @@ updates:
       interval: 'daily'
     open-pull-requests-limit: 1
     labels:
-      - "ci-aks-tests"
       - "ci-all-qa-tests"
-      - "ci-eks-tests"
       - "ci-no-api-tests"
       - "ci-no-ui-tests"
       - "dependencies"
@@ -42,10 +40,7 @@ updates:
       interval: 'daily'
     open-pull-requests-limit: 3
     labels:
-      - "ci-aks-tests"
       - "ci-all-qa-tests"
-      - "ci-postgres-tests"
-      - "ci-eks-tests"
       - "dependencies"
     reviewers:
       - "stackrox/backend-dep-updaters"
@@ -87,10 +82,7 @@ updates:
       day: 'wednesday'
     open-pull-requests-limit: 1
     labels:
-    - "ci-aks-tests"
     - "ci-all-qa-tests"
-    - "ci-postgres-tests"
-    - "ci-eks-tests"
     - "dependencies"
     reviewers:
     - "stackrox/backend-dep-updaters"
@@ -102,10 +94,7 @@ updates:
       day: 'wednesday'
     open-pull-requests-limit: 1
     labels:
-    - "ci-aks-tests"
     - "ci-all-qa-tests"
-    - "ci-postgres-tests"
-    - "ci-eks-tests"
     - "dependencies"
     reviewers:
     - "stackrox/backend-dep-updaters"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,8 +35,6 @@ ci-postgres-tests:
 - pkg/search/postgres/**/*
 - tools/generate-helpers/pg-table-bindings/**/*
 - tools/generate-helpers/pg-table-bindings-wrapper
-ci-upgrade-tests:
-- pkg/defaults/policies/**/*
 ci-all-qa-tests:
 - COLLECTOR_VERSION
 - SCANNER_VERSION


### PR DESCRIPTION
## Description

Add more CI labels to dependabot PRs so that our CI runs more comprehensive tests for dependencies updates.
Because PRs like #3426 may break some things that won't be visible in just BAT tests or come up on other *KS platforms.

I don't know if docker updates are still working, but will not investigate this time.

## Checklist
- [x] Investigated and inspected CI test results

Won't do any of these:

- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* CI will do the testing.