### PR TITLE
Delete work-around function from vulnmanagement clusterCves integration test

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusterCvesListPages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusterCvesListPages.test.js
@@ -13,17 +13,6 @@ import {
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
 
-// After the problem has been fixed, remove the function argument below.
-function getCountAndNounFromClustersLinkResults(resultsFromRegExp) {
-    const relatedEntitiesCount = resultsFromRegExp[1];
-    const relatedEntitiesNoun = relatedEntitiesCount === 1 ? 'CLUSTER' : 'CLUSTERS';
-    return {
-        panelHeaderText: '0 clusters', // workaround for bug
-        relatedEntitiesCount,
-        relatedEntitiesNoun,
-    };
-}
-
 const entitiesKey = 'cluster-cves';
 
 describe('Vulnerability Management Cluster (Platform) CVEs', () => {
@@ -101,16 +90,7 @@ describe('Vulnerability Management Cluster (Platform) CVEs', () => {
 
     // Some tests might fail in local deployment.
 
-    it('should display links for clusters', function () {
-        if (hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
-            this.skip();
-        }
-        verifySecondaryEntities(
-            entitiesKey,
-            'clusters',
-            8,
-            /^\d+ clusters?$/,
-            getCountAndNounFromClustersLinkResults
-        );
+    it('should display links for clusters', () => {
+        verifySecondaryEntities(entitiesKey, 'clusters', 8, /^\d+ clusters?$/);
     });
 });


### PR DESCRIPTION
## Description

### Test failure

Follow up after #3414

Vulnerability Management Cluster (Platform) CVEs should display links for clusters

> Timed out retrying after 4000ms: Expected to find element: `[data-testid="side-panel"] [data-testid="panel-header"]:contains(0 clusters)`

<img width="1280" alt="clusterCves-side" src="https://user-images.githubusercontent.com/11862657/195888317-b46091d0-06e8-468e-8a12-0d6f6b4e0a7a.png">

Side panel (above) has **1 cluster** text (with uppercase style) which is consistent with list (below) which has **1 cluster** link.

<img width="1280" alt="clusterCves-list" src="https://user-images.githubusercontent.com/11862657/195888376-3d4f0e2f-74b0-4a84-853c-ae588fa1253b.png">

Brad, I downloaded clusterCvesListPages.test.mp4 file from videos folder to be able to drag the timeline to the preceding frame (second image) immediately preceding the (first) image of the failure in the screenshots folder.

### Analysis

I added work-around function when side panel incorrectly displayed **0 clusters**.

After the problem was solved, the test started failing consistently.

### Solution

Delete function definition and optional argument, so `verifySecondaryEntities` calls the default function to get the count and noun from link results.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed