### PR TITLE
Fix license usage in upgrade tests

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -140,11 +140,6 @@ function launch_central {
 
     add_args "--offline=$OFFLINE_MODE"
 
-    if [[ -n "$ROX_LICENSE_KEY" ]]; then
-      add_args "--license"
-      add_maybe_file_arg "${ROX_LICENSE_KEY}"
-    fi
-
     if [[ -n "$SCANNER_IMAGE" ]]; then
         add_args "--scanner-image=$SCANNER_IMAGE"
     fi

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -39,8 +39,6 @@ test_upgrade() {
     export OUTPUT_FORMAT="helm"
     export STORAGE="pvc"
     export CLUSTER_TYPE_FOR_TEST=K8S
-    require_environment "LONGTERM_LICENSE"
-    export ROX_LICENSE_KEY="${LONGTERM_LICENSE}"
 
     if is_CI; then
         export ROXCTL_IMAGE_REPO="quay.io/$QUAY_REPO/roxctl"


### PR DESCRIPTION
## Description

Fix upgrade test issue which was reyling on using the `ROX_LICENSE_KEY` environment variable, which in turn added the roxctl arg `--license`, which is now deprecated.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- see CI `gke-upgrade-tests` should be successful.
