### PR TITLE
ROX-12858: Evaluate usages of query.Data in logs and remove on releases to avoid logging secrets

### DIFF
--- a/scripts/check-log-query-data.sh
+++ b/scripts/check-log-query-data.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+regex="log\.(Error|Debug|Info|Warn|Panic|Fatal)f*\(.*(query.Data).*\)"
+
+tmpfile="$(mktemp)"
+function delete_tmpfile() {
+	rm -f "$tmpfile"
+}
+trap delete_tmpfile EXIT
+
+git grep -inE "$regex" >"$tmpfile"
+
+if [[ ! -s "$tmpfile" ]]; then
+	exit 0
+fi
+
+echo >&2 "Found references to query.Data in log statements in the following files:"
+cat >&2 "$tmpfile"
+
+exit 1

--- a/scripts/ci/jobs/check-log-query-data.sh
+++ b/scripts/ci/jobs/check-log-query-data.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+source "$SCRIPTS_ROOT/scripts/lib.sh"
+
+set -euo pipefail
+
+echo 'Ensure that query.Data is never logged directly in release builds as it could potentially leak sensitive data'
+echo "Fix by using redactedQueryData(query) instead. This will ensure it only gets logged in debug builds"
+
+"$SCRIPTS_ROOT/scripts/check-log-query-data.sh"


### PR DESCRIPTION
## Description

See title for details.

Additionally add a check that will be run in PR and merge CI jobs to check that no one logs query.Data. It might be overkill, but it won't hurt.

## Checklist
- [x] Investigated and inspected CI test results
~[ ] Unit test and regression tests added~
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~
~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Tested manually on a debug build and saw that logs were generated. To test on release, will need to merge first and wait for nightly build.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
