### PR TITLE
CI: Explain the slack/log disconnect

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1271,7 +1271,7 @@ __EOM__
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "*Commit:* <\($commit_url)|\($commit_msg)>\n*Repo:* \($repo)\n*Author:* \($author_name), \($slack_mention)\n*Log:* \($log_url)"
+                "text": "*Commit:* <\($commit_url)|\($commit_msg)>\n*Repo:* \($repo)\n*Author:* \($author_name), \($slack_mention)\n*Log:* \($log_url) (it can take *minutes* for this log to be available :turtle:)"
             }
         },
         {


### PR DESCRIPTION
## Description

The fact that the slack message appears before the log is ready can be confusing. A longer term enhancement might be to send these with a delay: https://api.slack.com/messaging/scheduling.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient