### PR TITLE
CI: Cleanup dangling processes

### DIFF
--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -77,6 +77,7 @@ class GKECluster:
             time.sleep(60)
 
         if self.refresh_token_cmd is not None:
+            print("Terminating GKE token refresh")
             try:
                 popen_graceful_kill(self.refresh_token_cmd)
             except Exception as err:

--- a/image/fetch-stackrox-data.sh
+++ b/image/fetch-stackrox-data.sh
@@ -22,4 +22,3 @@ fetch_stackrox_data() {
 }
 
 fetch_stackrox_data
-

--- a/image/fetch-stackrox-data.sh
+++ b/image/fetch-stackrox-data.sh
@@ -22,3 +22,4 @@ fetch_stackrox_data() {
 }
 
 fetch_stackrox_data
+

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -240,16 +240,14 @@ refresh_gke_token() {
     # refresh token every 15m
     local pid
     while true; do
-        # background sleep & wait so that it will exit on TERM from parent
-        sleep 900 &
+        sleep 3600 &
         pid="$!"
         kill_sleep() {
-            echo "refresh_gke_token() interrupted, killing the background sleep"
+            echo "refresh_gke_token() terminated, killing the background sleep ($pid)"
             kill "$pid"
         }
-        # kill sleep on INT from OpenShift CI or it will hang
-        trap kill_sleep SIGINT
-        wait $pid
+        trap kill_sleep SIGINT SIGTERM
+        wait "$pid"
 
         info "Refreshing the GKE auth token"
         gcloud config config-helper --force-auth-refresh >/dev/null

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -240,7 +240,7 @@ refresh_gke_token() {
     # refresh token every 15m
     local pid
     while true; do
-        sleep 3600 &
+        sleep 900 &
         pid="$!"
         kill_sleep() {
             echo "refresh_gke_token() terminated, killing the background sleep ($pid)"

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -240,7 +240,7 @@ refresh_gke_token() {
     # refresh token every 15m
     while true; do
         # sleep & wait so that it will exit on TERM
-        sleep 900 &
+        sleep 3600 &
         wait $!
         info "Refreshing the GKE auth token"
         gcloud config config-helper --force-auth-refresh >/dev/null

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -39,6 +39,20 @@ ci_exit_trap() {
         info "Holding this job for debug"
         sleep 60
     done
+
+    info "Process state at exit:"
+    ps -e -O ppid
+
+    local pid
+    for psline in $(ps -e -O ppid); do
+        if [[ "$psline" =~ ^$$ ]]; then
+            echo "Skipping self: $psline"
+            continue
+        fi
+        echo "A candidate to kill: $psline"
+        pid="$(echo "$psline" | cut -d' ' -f1)"
+        echo "Would like to kill $pid"
+    done
 }
 
 create_exit_trap() {

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -48,26 +48,29 @@ ci_exit_trap() {
         # trim leading whitespace
         psline="$(echo "$psline" | xargs)"
         if [[ "$psline" =~ ^PID ]]; then
-            echo "Skipping header: $psline"
+            # Ignoring header
             continue
         fi
         this_pid="$$"
         if [[ "$psline" =~ ^$this_pid ]]; then
-            echo "Skipping self: $psline"
+            echo "Ignoring self: $psline"
             continue
         fi
         # shellcheck disable=SC1087
         if [[ "$psline" =~ [[:space:]]$this_pid[[:space:]] ]]; then
-            echo "Skipping child: $psline"
+            echo "Ignoring child: $psline"
             continue
         fi
         if [[ "$psline" =~ entrypoint|defunct ]]; then
-            echo "Skipping ci-operator entrypoint and defunct processes: $psline"
+            echo "Ignoring ci-operator entrypoint or defunct process: $psline"
             continue
         fi
         echo "A candidate to kill: $psline"
         pid="$(echo "$psline" | cut -d' ' -f1)"
-        echo "Would like to kill $pid"
+        echo "Will kill $pid"
+        kill "$pid" || {
+            echo "Error killing $pid"
+        }
     done
 }
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -40,9 +40,13 @@ ci_exit_trap() {
         sleep 60
     done
 
-    #handle_dangling_processes
+    handle_dangling_processes
 }
 
+# handle_dangling_processes() - The OpenShift CI ci-operator will not complete a
+# test job if there are processes remaining that were started by the job. While
+# processes _should_ be cleaned up by their creators it is common that some are
+# not, so this exists as a fail safe.
 handle_dangling_processes() {
     info "Process state at exit:"
     ps -e -O ppid
@@ -76,7 +80,6 @@ handle_dangling_processes() {
             echo "Error killing $pid"
         }
     done
-
 }
 
 create_exit_trap() {

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -40,6 +40,10 @@ ci_exit_trap() {
         sleep 60
     done
 
+    #handle_dangling_processes
+}
+
+handle_dangling_processes() {
     info "Process state at exit:"
     ps -e -O ppid
 
@@ -72,6 +76,7 @@ ci_exit_trap() {
             echo "Error killing $pid"
         }
     done
+
 }
 
 create_exit_trap() {

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -44,7 +44,13 @@ ci_exit_trap() {
     ps -e -O ppid
 
     local pid
-    for psline in $(ps -e -O ppid); do
+    ps -e -O ppid | while read -r psline; do
+        # trim leading whitespace
+        psline="$(echo "$psline" | xargs)"
+        if [[ "$psline" =~ ^PID ]]; then
+            echo "Skipping header: $psline"
+            continue
+        fi
         if [[ "$psline" =~ ^$$ ]]; then
             echo "Skipping self: $psline"
             continue


### PR DESCRIPTION
## Description

This PR kills processes that tests have left running. These 'dangling' processes cause ci-operator to hang. Which causes timeouts and delayed access to logs.

For example, in the case of a recent gke-upgrade-tests failure when the test is complete there is a sleep left running. This can be seen from the openshift CI console and logs:
```
$ ps -e -O ppid
    PID    PPID S TTY          TIME COMMAND
      1       0 S ?        00:00:01 /tmp/entrypoint-wrapper/entrypoint-wrapper /tools/entrypoint
     20       1 S ?        00:00:00 /tools/entrypoint
   1151       1 S ?        00:00:00 /usr/bin/coreutils --coreutils-prog-shebang=sleep /usr/bin/sleep 3600
   2228       1 Z ?        00:00:00 [kubectl] <defunct>
```
This sleep is from the GKE token refresh process (typically it is 900 but changed to 3600 here to force the issue). The refresh process is terminated by the cluster teardown() but leaves the sleep running. That is easy enough to fix (and is on this PR by trapping the SIGTERM) but it would be useful to have a general purpose process cleaner on exit to avoid playing whackamole with these problems (e.g. another recent case: https://github.com/stackrox/stackrox/pull/3406).

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient. In the first three test cases we expect the test to fail as it still has the `--license` bug.
- [x] general purpose cleaner kills the sleep and terminates the test in a timely manner. [result](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/3440/pull-ci-stackrox-stackrox-master-gke-upgrade-tests/1581115615148511232). 
- [x] killing the sleep when the wait is interrupted also should do the same. [result](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/3440/pull-ci-stackrox-stackrox-master-gke-upgrade-tests/1581316679466487808)
- [x] with both. [result](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/3440/pull-ci-stackrox-stackrox-master-gke-upgrade-tests/1581332802316537856)
- [x] rebase for a green run
