### PR TITLE
Replace ambiguous central deployment name in integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -255,7 +255,7 @@ export const basePath = '/main/network';
 
 /*
  * Reach clusters by interaction from another container.
- * For example, click View All button from System Health.
+ * For example, click View Deployment in Network Graph button from Risk.
  */
 export function reachNetworkGraph(interactionCallback, staticResponseMap) {
     interactAndWaitForResponses(interactionCallback, requestConfigToVisitGraph, staticResponseMap);

--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -253,6 +253,17 @@ const requestConfigToVisitGraph = {
 
 export const basePath = '/main/network';
 
+/*
+ * Reach clusters by interaction from another container.
+ * For example, click View All button from System Health.
+ */
+export function reachNetworkGraph(interactionCallback, staticResponseMap) {
+    interactAndWaitForResponses(interactionCallback, requestConfigToVisitGraph, staticResponseMap);
+
+    cy.location('pathname').should('contain', basePath); // contain because pathname might have id
+    cy.get(networkGraphSelectors.networkGraphHeading);
+}
+
 export function visitNetworkGraphFromLeftNav() {
     visitFromLeftNav('Network', requestConfigToVisitGraph);
 

--- a/ui/apps/platform/cypress/integration/networkGraph/network.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/network.test.js
@@ -16,7 +16,6 @@ import {
     visitNetworkGraphWithMockedData,
     visitNetworkGraphWithNamespaceFilter,
 } from '../../helpers/networkGraph';
-import { hasFeatureFlag } from '../../helpers/features';
 
 function uploadYAMLFile(fileName, selector) {
     cy.intercept('POST', api.network.simulate).as('postNetworkPolicySimulate');
@@ -94,12 +93,9 @@ describe('Network page', () => {
         // Stop here because after Policies processed, local deployment differs from CI.
     });
 
-    it('should show the network policy simulator screen after generating network policies', function () {
-        if (hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
-            this.skip();
-        }
+    it('should show the network policy simulator screen after generating network policies', () => {
         visitRiskDeployments();
-        viewRiskDeploymentByName('central');
+        viewRiskDeploymentByName('sensor');
         viewRiskDeploymentInNetworkGraph();
 
         cy.get(networkPageSelectors.networkEntityTabbedOverlay.header).should('be.visible');
@@ -117,16 +113,15 @@ describe('Network page', () => {
 describe('Network Deployment Details', () => {
     withAuth();
 
-    it('should show the deployment name and namespace', function () {
-        if (hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
-            this.skip();
-        }
+    it('should show the deployment name and namespace', () => {
+        const deploymentName = 'sensor';
+
         visitRiskDeployments();
-        viewRiskDeploymentByName('central');
+        viewRiskDeploymentByName(deploymentName);
         viewRiskDeploymentInNetworkGraph();
 
         cy.get(`${selectors.tab.tabs}:contains('Details')`).click();
-        cy.get(`[data-testid="Deployment Name"]:contains('central')`);
+        cy.get(`[data-testid="Deployment Name"]:contains('${deploymentName}')`);
         cy.get(`[data-testid="Namespace"]:contains('stackrox')`);
     });
 });
@@ -171,28 +166,5 @@ describe('Network Policy Simulator', () => {
                 });
             });
         });
-    });
-});
-
-describe('Network Flows Table', () => {
-    withAuth();
-
-    it('should show the proper table column headers for the network flows table', function () {
-        if (hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
-            this.skip();
-        }
-        visitRiskDeployments();
-        viewRiskDeploymentByName('central');
-        viewRiskDeploymentInNetworkGraph();
-
-        cy.get(`${selectors.tab.tabs}:contains('Network Flows')`).click();
-        cy.get(`${selectors.table.th}:contains('Entity')`);
-        cy.get(`${selectors.table.th}:contains('Traffic')`);
-        cy.get(`${selectors.table.th}:contains('Type')`);
-        cy.get(`${selectors.table.th}:contains('Namespace')`);
-        cy.get(`${selectors.table.th}:contains('State')`);
-
-        cy.get(`${selectors.table.th}:contains('Protocol')`);
-        cy.get(`${selectors.table.th}:contains('Port')`);
     });
 });

--- a/ui/apps/platform/cypress/integration/networkGraph/networkFlows.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkFlows.test.js
@@ -51,6 +51,22 @@ describe('Network Baseline Flows', () => {
     });
 
     describe('Active Network Flows', () => {
+        it('should show table column headings', () => {
+            visitNetworkGraphWithNamespaceFilter('stackrox');
+
+            cy.getCytoscape(networkPageSelectors.cytoscapeContainer).then((cytoscape) => {
+                clickOnDeploymentNodeByName(cytoscape, 'central');
+
+                cy.get('th:contains("Entity")');
+                cy.get('th:contains("Traffic")');
+                cy.get('th:contains("Type")');
+                cy.get('th:contains("Namespace")');
+                cy.get('th:contains("State")');
+                cy.get('th:contains("Protocol")');
+                cy.get('th:contains("Port")');
+            });
+        });
+
         it('should show anomalous flows section above the baseline flows', () => {
             visitNetworkGraphWithNamespaceFilter('stackrox');
 

--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -1,5 +1,6 @@
 import { selectors as RiskPageSelectors } from '../../constants/RiskPage';
 import withAuth from '../../helpers/basicAuth';
+import { reachNetworkGraph } from '../../helpers/networkGraph';
 import {
     deploymentswithprocessinfoAlias,
     deploymentscountAlias,
@@ -138,15 +139,12 @@ describe('Risk page', () => {
     });
 
     describe('with actual API', () => {
-        it('should navigate to network page with selected deployment', function () {
-            if (hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
-                this.skip();
-            }
+        it('should navigate to network page with selected deployment', () => {
             visitRiskDeployments();
-            viewRiskDeploymentByName('central');
-            viewRiskDeploymentInNetworkGraph();
-
-            cy.location('pathname').should('match', /^\/main\/network\/[-0-9a-z]+$/);
+            viewRiskDeploymentByName('collector');
+            reachNetworkGraph(() => {
+                viewRiskDeploymentInNetworkGraph();
+            });
         });
 
         const searchPlaceholderText = 'Add one or more resource filters';


### PR DESCRIPTION
## Description

### Test failures

Follow up after #3414

1. Network page should show the network policy simulator screen after generating network policies

    > `cy.click()` can only be called on a single element. Your subject contained 2 elements.

    ![network-risk-central-2](https://user-images.githubusercontent.com/11862657/195943483-63e22161-7aca-4c56-8573-ed4c03a4bf13.png)

2. Network Deployment Details should show the deployment name and namespace 

    > `cy.click()` can only be called on a single element. Your subject contained 2 elements.

3. Network Flows Table should show the proper table column headers for the network flows table

    > `cy.click()` can only be called on a single element. Your subject contained 2 elements.

4. Risk page with actual API should navigate to network page with selected deployment

    > `cy.click()` can only be called on a single element. Your subject contained 2 elements.

    ![risk-deployment-central-2](https://user-images.githubusercontent.com/11862657/195943514-65348da9-d471-4397-9f6b-615aa34a6332.png)

### Analysis

Indeed, not only **central** but **central-db** deployment for postgress.

### Solution

1. Replace `'central'` with `'sensor'` deployment.

2. Replace `'central'` with `'sensor'` deployment.

3. Move test to networkGraph/networkFlows.test.js file which has exact match for `'central'` in cytoscape data instead of partial match in DOM element.

4. Replace only occurrence of `'central'` with `'collector'` deployment like several sibling tests.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Ran edited tests with local deployment
* networkGraph/network.test.js
* networkGraph/networkFlows.test.js
* risk/risk.test.js