### PR TITLE
Use multi arch nginx 1.14 alpine

### DIFF
--- a/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
@@ -26,8 +26,8 @@ class AttemptedAlertsTest extends BaseSpecification {
             (DEP_NAMES[1]): createDeployment(DEP_NAMES[1], "nginx:latest"),
             (DEP_NAMES[2]): createDeployment(DEP_NAMES[2], "nginx:latest"),
             (DEP_NAMES[3]): createDeployment(DEP_NAMES[3], "nginx:latest"),
-            (DEP_NAMES[4]): createDeployment(DEP_NAMES[4], "quay.io/rhacs-eng/qa:nginx-1-14-alpine"),
-            (DEP_NAMES[5]): createDeployment(DEP_NAMES[5], "quay.io/rhacs-eng/qa:nginx-1-14-alpine"),
+            (DEP_NAMES[4]): createDeployment(DEP_NAMES[4], "quay.io/rhacs-eng/qa-multi-arch:nginx-1-14-alpine"),
+            (DEP_NAMES[5]): createDeployment(DEP_NAMES[5], "quay.io/rhacs-eng/qa-multi-arch:nginx-1-14-alpine"),
     ]
 
     static final private String LATEST_TAG_POLICY_NAME = "Latest tag"

--- a/qa-tests-backend/src/test/groovy/K8sEventDetectionTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sEventDetectionTest.groovy
@@ -18,7 +18,7 @@ class K8sEventDetectionTest extends BaseSpecification {
 
     static private registerDeployment(String name, boolean privileged) {
         DEPLOYMENTS.add(
-            new Deployment().setName(name).setImage("quay.io/rhacs-eng/qa:nginx-1.14-alpine").addLabel("app", name).
+            new Deployment().setName(name).setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1.14-alpine").addLabel("app", name).
                 setPrivilegedFlag(privileged)
         )
         return name

--- a/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
@@ -26,7 +26,7 @@ class ProcessVisualizationTest extends BaseSpecification {
     static final private List<Deployment> DEPLOYMENTS = [
             new Deployment()
                 .setName (NGINXDEPLOYMENT)
-                .setImage ("quay.io/rhacs-eng/qa:nginx-1.14-alpine")
+                .setImage ("quay.io/rhacs-eng/qa-multi-arch:nginx-1.14-alpine")
                 .addLabel ( "app", "test" ),
             new Deployment()
                 .setName (STRUTSDEPLOYMENT)


### PR DESCRIPTION
## Description

Use the multi-arch version of nginx 1.14 alpine added to quay.io/rhacs-eng-multi-arch form public dockerhub location https://hub.docker.com/layers/library/nginx/1.14.2-alpine/images/sha256-64a66a550c84638d9c9c18246af57783058a7cb4f0896fb9feafaeb1e311e910?context=explore

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
