### PR TITLE
Use gogo Unmarshal

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -413,7 +412,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ActiveComponen
 	}
 
 	var msg storage.ActiveComponent
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -542,7 +541,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Activ
 	resultsByID := make(map[string]*storage.ActiveComponent)
 	for _, data := range rows {
 		msg := &storage.ActiveComponent{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -594,7 +593,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ActiveComponent
 	for _, data := range rows {
 		msg := &storage.ActiveComponent{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -641,7 +640,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ActiveCompone
 		}
 		for _, data := range rows {
 			var msg storage.ActiveComponent
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -474,7 +473,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Alert, bool, e
 	}
 
 	var msg storage.Alert
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -603,7 +602,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Alert
 	resultsByID := make(map[string]*storage.Alert)
 	for _, data := range rows {
 		msg := &storage.Alert{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -655,7 +654,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.Alert
 	for _, data := range rows {
 		msg := &storage.Alert{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -714,7 +713,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Alert) error)
 		}
 		for _, data := range rows {
 			var msg storage.Alert
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -300,7 +299,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TokenMetadata,
 	}
 
 	var msg storage.TokenMetadata
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -406,7 +405,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Token
 	resultsByID := make(map[string]*storage.TokenMetadata)
 	for _, data := range rows {
 		msg := &storage.TokenMetadata{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -463,7 +462,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TokenMetadata
 		}
 		for _, data := range rows {
 			var msg storage.TokenMetadata
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -306,7 +305,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.AuthProvider, 
 	}
 
 	var msg storage.AuthProvider
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -422,7 +421,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.AuthP
 	resultsByID := make(map[string]*storage.AuthProvider)
 	for _, data := range rows {
 		msg := &storage.AuthProvider{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -479,7 +478,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.AuthProvider)
 		}
 		for _, data := range rows {
 			var msg storage.AuthProvider
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -233,7 +232,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Cluster, bool,
 	}
 
 	var msg storage.Cluster
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -362,7 +361,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 	resultsByID := make(map[string]*storage.Cluster)
 	for _, data := range rows {
 		msg := &storage.Cluster{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -414,7 +413,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.Cluster
 	for _, data := range rows {
 		msg := &storage.Cluster{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -473,7 +472,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Cluster) erro
 		}
 		for _, data := range rows {
 			var msg storage.Cluster
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -348,7 +347,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ClusterHealthS
 	}
 
 	var msg storage.ClusterHealthStatus
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -477,7 +476,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 	resultsByID := make(map[string]*storage.ClusterHealthStatus)
 	for _, data := range rows {
 		msg := &storage.ClusterHealthStatus{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -529,7 +528,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ClusterHealthStatus
 	for _, data := range rows {
 		msg := &storage.ClusterHealthStatus{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -576,7 +575,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ClusterHealth
 		}
 		for _, data := range rows {
 			var msg storage.ClusterHealthStatus
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/clustercveedge/datastore/store/postgres/store.go
+++ b/central/clustercveedge/datastore/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
@@ -144,7 +143,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ClusterCVEEdge
 	}
 
 	var msg storage.ClusterCVEEdge
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -227,7 +226,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 	resultsByID := make(map[string]*storage.ClusterCVEEdge)
 	for _, data := range rows {
 		msg := &storage.ClusterCVEEdge{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -279,7 +278,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ClusterCVEEdge
 	for _, data := range rows {
 		msg := &storage.ClusterCVEEdge{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -302,7 +301,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ClusterCVEEdg
 		}
 		for _, data := range rows {
 			var msg storage.ClusterCVEEdge
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -296,7 +295,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.InitBundleMeta
 	}
 
 	var msg storage.InitBundleMeta
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -402,7 +401,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.InitB
 	resultsByID := make(map[string]*storage.InitBundleMeta)
 	for _, data := range rows {
 		msg := &storage.InitBundleMeta{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -458,7 +457,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.InitBundleMet
 		}
 		for _, data := range rows {
 			var msg storage.InitBundleMeta
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -318,7 +317,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceDoma
 	}
 
 	var msg storage.ComplianceDomain
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -447,7 +446,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceDomain)
 	for _, data := range rows {
 		msg := &storage.ComplianceDomain{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -499,7 +498,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ComplianceDomain
 	for _, data := range rows {
 		msg := &storage.ComplianceDomain{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -546,7 +545,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceDom
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceDomain
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -344,7 +343,7 @@ func (s *storeImpl) Get(ctx context.Context, runId string) (*storage.ComplianceR
 	}
 
 	var msg storage.ComplianceRunMetadata
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -473,7 +472,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceRunMetadata)
 	for _, data := range rows {
 		msg := &storage.ComplianceRunMetadata{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetRunId()] = msg
@@ -525,7 +524,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ComplianceRunMetadata
 	for _, data := range rows {
 		msg := &storage.ComplianceRunMetadata{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -584,7 +583,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceRun
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceRunMetadata
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -344,7 +343,7 @@ func (s *storeImpl) Get(ctx context.Context, runMetadataRunId string) (*storage.
 	}
 
 	var msg storage.ComplianceRunResults
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -473,7 +472,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceRunResults)
 	for _, data := range rows {
 		msg := &storage.ComplianceRunResults{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetRunMetadata().GetRunId()] = msg
@@ -525,7 +524,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ComplianceRunResults
 	for _, data := range rows {
 		msg := &storage.ComplianceRunResults{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -584,7 +583,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceRun
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceRunResults
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -317,7 +316,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceStri
 	}
 
 	var msg storage.ComplianceStrings
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -446,7 +445,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceStrings)
 	for _, data := range rows {
 		msg := &storage.ComplianceStrings{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -504,7 +503,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceStr
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceStrings
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -300,7 +299,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceOper
 	}
 
 	var msg storage.ComplianceOperatorCheckResult
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -406,7 +405,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceOperatorCheckResult)
 	for _, data := range rows {
 		msg := &storage.ComplianceOperatorCheckResult{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -463,7 +462,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceOpe
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceOperatorCheckResult
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -300,7 +299,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceOper
 	}
 
 	var msg storage.ComplianceOperatorProfile
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -406,7 +405,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceOperatorProfile)
 	for _, data := range rows {
 		msg := &storage.ComplianceOperatorProfile{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -463,7 +462,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceOpe
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceOperatorProfile
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -300,7 +299,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceOper
 	}
 
 	var msg storage.ComplianceOperatorRule
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -406,7 +405,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceOperatorRule)
 	for _, data := range rows {
 		msg := &storage.ComplianceOperatorRule{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -463,7 +462,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceOpe
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceOperatorRule
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -300,7 +299,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceOper
 	}
 
 	var msg storage.ComplianceOperatorScan
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -406,7 +405,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceOperatorScan)
 	for _, data := range rows {
 		msg := &storage.ComplianceOperatorScan{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -463,7 +462,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceOpe
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceOperatorScan
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -300,7 +299,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceOper
 	}
 
 	var msg storage.ComplianceOperatorScanSettingBinding
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -406,7 +405,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceOperatorScanSettingBinding)
 	for _, data := range rows {
 		msg := &storage.ComplianceOperatorScanSettingBinding{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -463,7 +462,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceOpe
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceOperatorScanSettingBinding
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/componentcveedge/datastore/store/postgres/store.go
+++ b/central/componentcveedge/datastore/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
@@ -144,7 +143,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComponentCVEEd
 	}
 
 	var msg storage.ComponentCVEEdge
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -227,7 +226,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compo
 	resultsByID := make(map[string]*storage.ComponentCVEEdge)
 	for _, data := range rows {
 		msg := &storage.ComponentCVEEdge{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -279,7 +278,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ComponentCVEEdge
 	for _, data := range rows {
 		msg := &storage.ComponentCVEEdge{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -302,7 +301,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComponentCVEE
 		}
 		for _, data := range rows {
 			var msg storage.ComponentCVEEdge
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/config/store/postgres/store.go
+++ b/central/config/store/postgres/store.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/central/metrics"
@@ -138,7 +137,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.Config, bool, er
 	}
 
 	var msg storage.Config
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -363,7 +362,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ClusterCVE, bo
 	}
 
 	var msg storage.ClusterCVE
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -492,7 +491,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 	resultsByID := make(map[string]*storage.ClusterCVE)
 	for _, data := range rows {
 		msg := &storage.ClusterCVE{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -544,7 +543,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ClusterCVE
 	for _, data := range rows {
 		msg := &storage.ClusterCVE{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -591,7 +590,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ClusterCVE) e
 		}
 		for _, data := range rows {
 			var msg storage.ClusterCVE
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -363,7 +362,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ImageCVE, bool
 	}
 
 	var msg storage.ImageCVE
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -492,7 +491,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 	resultsByID := make(map[string]*storage.ImageCVE)
 	for _, data := range rows {
 		msg := &storage.ImageCVE{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -544,7 +543,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ImageCVE
 	for _, data := range rows {
 		msg := &storage.ImageCVE{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -591,7 +590,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ImageCVE) err
 		}
 		for _, data := range rows {
 			var msg storage.ImageCVE
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -363,7 +362,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NodeCVE, bool,
 	}
 
 	var msg storage.NodeCVE
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -492,7 +491,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 	resultsByID := make(map[string]*storage.NodeCVE)
 	for _, data := range rows {
 		msg := &storage.NodeCVE{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -544,7 +543,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.NodeCVE
 	for _, data := range rows {
 		msg := &storage.NodeCVE{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -591,7 +590,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NodeCVE) erro
 		}
 		for _, data := range rows {
 			var msg storage.NodeCVE
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -1018,7 +1017,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Deployment, bo
 	}
 
 	var msg storage.Deployment
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -1147,7 +1146,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Deplo
 	resultsByID := make(map[string]*storage.Deployment)
 	for _, data := range rows {
 		msg := &storage.Deployment{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -1199,7 +1198,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.Deployment
 	for _, data := range rows {
 		msg := &storage.Deployment{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -1258,7 +1257,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Deployment) e
 		}
 		for _, data := range rows {
 			var msg storage.Deployment
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -301,7 +300,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ExternalBackup
 	}
 
 	var msg storage.ExternalBackup
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -417,7 +416,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Exter
 	resultsByID := make(map[string]*storage.ExternalBackup)
 	for _, data := range rows {
 		msg := &storage.ExternalBackup{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -474,7 +473,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ExternalBacku
 		}
 		for _, data := range rows {
 			var msg storage.ExternalBackup
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -301,7 +300,7 @@ func (s *storeImpl) Get(ctx context.Context, propsId string) (*storage.Group, bo
 	}
 
 	var msg storage.Group
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -417,7 +416,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Group
 	resultsByID := make(map[string]*storage.Group)
 	for _, data := range rows {
 		msg := &storage.Group{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetProps().GetId()] = msg
@@ -474,7 +473,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Group) error)
 		}
 		for _, data := range rows {
 			var msg storage.Group
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -353,7 +352,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ImageComponent
 	}
 
 	var msg storage.ImageComponent
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -482,7 +481,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 	resultsByID := make(map[string]*storage.ImageComponent)
 	for _, data := range rows {
 		msg := &storage.ImageComponent{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -534,7 +533,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ImageComponent
 	for _, data := range rows {
 		msg := &storage.ImageComponent{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -581,7 +580,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ImageComponen
 		}
 		for _, data := range rows {
 			var msg storage.ImageComponent
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
@@ -144,7 +143,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ImageComponent
 	}
 
 	var msg storage.ImageComponentEdge
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -227,7 +226,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 	resultsByID := make(map[string]*storage.ImageComponentEdge)
 	for _, data := range rows {
 		msg := &storage.ImageComponentEdge{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -279,7 +278,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ImageComponentEdge
 	for _, data := range rows {
 		msg := &storage.ImageComponentEdge{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -302,7 +301,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ImageComponen
 		}
 		for _, data := range rows {
 			var msg storage.ImageComponentEdge
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/imagecveedge/datastore/postgres/store.go
+++ b/central/imagecveedge/datastore/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
@@ -144,7 +143,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ImageCVEEdge, 
 	}
 
 	var msg storage.ImageCVEEdge
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -227,7 +226,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 	resultsByID := make(map[string]*storage.ImageCVEEdge)
 	for _, data := range rows {
 		msg := &storage.ImageCVEEdge{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -279,7 +278,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ImageCVEEdge
 	for _, data := range rows {
 		msg := &storage.ImageCVEEdge{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -302,7 +301,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ImageCVEEdge)
 		}
 		for _, data := range rows {
 			var msg storage.ImageCVEEdge
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -312,7 +311,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ImageIntegrati
 	}
 
 	var msg storage.ImageIntegration
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -428,7 +427,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 	resultsByID := make(map[string]*storage.ImageIntegration)
 	for _, data := range rows {
 		msg := &storage.ImageIntegration{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -472,7 +471,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ImageIntegration
 	for _, data := range rows {
 		msg := &storage.ImageIntegration{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -518,7 +517,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ImageIntegrat
 		}
 		for _, data := range rows {
 			var msg storage.ImageIntegration
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/installation/store/postgres/store.go
+++ b/central/installation/store/postgres/store.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/central/metrics"
@@ -138,7 +137,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.InstallationInfo
 	}
 
 	var msg storage.InstallationInfo
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -296,7 +295,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.IntegrationHea
 	}
 
 	var msg storage.IntegrationHealth
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -402,7 +401,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Integ
 	resultsByID := make(map[string]*storage.IntegrationHealth)
 	for _, data := range rows {
 		msg := &storage.IntegrationHealth{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -458,7 +457,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.IntegrationHe
 		}
 		for _, data := range rows {
 			var msg storage.IntegrationHealth
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -301,7 +300,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.LogImbue, bool
 	}
 
 	var msg storage.LogImbue
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -417,7 +416,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.LogIm
 	resultsByID := make(map[string]*storage.LogImbue)
 	for _, data := range rows {
 		msg := &storage.LogImbue{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -474,7 +473,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.LogImbue) err
 		}
 		for _, data := range rows {
 			var msg storage.LogImbue
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -354,7 +353,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NamespaceMetad
 	}
 
 	var msg storage.NamespaceMetadata
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -483,7 +482,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Names
 	resultsByID := make(map[string]*storage.NamespaceMetadata)
 	for _, data := range rows {
 		msg := &storage.NamespaceMetadata{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -535,7 +534,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.NamespaceMetadata
 	for _, data := range rows {
 		msg := &storage.NamespaceMetadata{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -594,7 +593,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NamespaceMeta
 		}
 		for _, data := range rows {
 			var msg storage.NamespaceMetadata
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -339,7 +338,7 @@ func (s *storeImpl) Get(ctx context.Context, deploymentId string) (*storage.Netw
 	}
 
 	var msg storage.NetworkBaseline
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -468,7 +467,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	resultsByID := make(map[string]*storage.NetworkBaseline)
 	for _, data := range rows {
 		msg := &storage.NetworkBaseline{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetDeploymentId()] = msg
@@ -520,7 +519,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.NetworkBaseline
 	for _, data := range rows {
 		msg := &storage.NetworkBaseline{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -579,7 +578,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkBaseli
 		}
 		for _, data := range rows {
 			var msg storage.NetworkBaseline
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -300,7 +299,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NetworkGraphCo
 	}
 
 	var msg storage.NetworkGraphConfig
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -406,7 +405,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	resultsByID := make(map[string]*storage.NetworkGraphConfig)
 	for _, data := range rows {
 		msg := &storage.NetworkGraphConfig{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -463,7 +462,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkGraphC
 		}
 		for _, data := range rows {
 			var msg storage.NetworkGraphConfig
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -302,7 +301,7 @@ func (s *storeImpl) Get(ctx context.Context, infoId string) (*storage.NetworkEnt
 	}
 
 	var msg storage.NetworkEntity
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -408,7 +407,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	resultsByID := make(map[string]*storage.NetworkEntity)
 	for _, data := range rows {
 		msg := &storage.NetworkEntity{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetInfo().GetId()] = msg
@@ -452,7 +451,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.NetworkEntity
 	for _, data := range rows {
 		msg := &storage.NetworkEntity{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -497,7 +496,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkEntity
 		}
 		for _, data := range rows {
 			var msg storage.NetworkEntity
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -339,7 +338,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NetworkPolicy,
 	}
 
 	var msg storage.NetworkPolicy
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -468,7 +467,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	resultsByID := make(map[string]*storage.NetworkPolicy)
 	for _, data := range rows {
 		msg := &storage.NetworkPolicy{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -520,7 +519,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.NetworkPolicy
 	for _, data := range rows {
 		msg := &storage.NetworkPolicy{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -579,7 +578,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkPolicy
 		}
 		for _, data := range rows {
 			var msg storage.NetworkPolicy
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -317,7 +316,7 @@ func (s *storeImpl) Get(ctx context.Context, deploymentId string) (*storage.Netw
 	}
 
 	var msg storage.NetworkPolicyApplicationUndoDeploymentRecord
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -446,7 +445,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	resultsByID := make(map[string]*storage.NetworkPolicyApplicationUndoDeploymentRecord)
 	for _, data := range rows {
 		msg := &storage.NetworkPolicyApplicationUndoDeploymentRecord{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetDeploymentId()] = msg
@@ -504,7 +503,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkPolicy
 		}
 		for _, data := range rows {
 			var msg storage.NetworkPolicyApplicationUndoDeploymentRecord
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -317,7 +316,7 @@ func (s *storeImpl) Get(ctx context.Context, clusterId string) (*storage.Network
 	}
 
 	var msg storage.NetworkPolicyApplicationUndoRecord
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -446,7 +445,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	resultsByID := make(map[string]*storage.NetworkPolicyApplicationUndoRecord)
 	for _, data := range rows {
 		msg := &storage.NetworkPolicyApplicationUndoRecord{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetClusterId()] = msg
@@ -504,7 +503,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkPolicy
 		}
 		for _, data := range rows {
 			var msg storage.NetworkPolicyApplicationUndoRecord
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -348,7 +347,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NodeComponent,
 	}
 
 	var msg storage.NodeComponent
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -477,7 +476,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 	resultsByID := make(map[string]*storage.NodeComponent)
 	for _, data := range rows {
 		msg := &storage.NodeComponent{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -529,7 +528,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.NodeComponent
 	for _, data := range rows {
 		msg := &storage.NodeComponent{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -576,7 +575,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NodeComponent
 		}
 		for _, data := range rows {
 			var msg storage.NodeComponent
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/nodecomponentcveedge/datastore/store/postgres/store.go
+++ b/central/nodecomponentcveedge/datastore/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
@@ -144,7 +143,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NodeComponentC
 	}
 
 	var msg storage.NodeComponentCVEEdge
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -227,7 +226,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 	resultsByID := make(map[string]*storage.NodeComponentCVEEdge)
 	for _, data := range rows {
 		msg := &storage.NodeComponentCVEEdge{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -279,7 +278,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.NodeComponentCVEEdge
 	for _, data := range rows {
 		msg := &storage.NodeComponentCVEEdge{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -302,7 +301,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NodeComponent
 		}
 		for _, data := range rows {
 			var msg storage.NodeComponentCVEEdge
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
@@ -144,7 +143,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NodeComponentE
 	}
 
 	var msg storage.NodeComponentEdge
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -227,7 +226,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 	resultsByID := make(map[string]*storage.NodeComponentEdge)
 	for _, data := range rows {
 		msg := &storage.NodeComponentEdge{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -279,7 +278,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.NodeComponentEdge
 	for _, data := range rows {
 		msg := &storage.NodeComponentEdge{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -302,7 +301,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NodeComponent
 		}
 		for _, data := range rows {
 			var msg storage.NodeComponentEdge
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -306,7 +305,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Notifier, bool
 	}
 
 	var msg storage.Notifier
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -422,7 +421,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Notif
 	resultsByID := make(map[string]*storage.Notifier)
 	for _, data := range rows {
 		msg := &storage.Notifier{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -479,7 +478,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Notifier) err
 		}
 		for _, data := range rows {
 			var msg storage.Notifier
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -429,7 +428,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Pod, bool, err
 	}
 
 	var msg storage.Pod
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -558,7 +557,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Pod, 
 	resultsByID := make(map[string]*storage.Pod)
 	for _, data := range rows {
 		msg := &storage.Pod{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -610,7 +609,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.Pod
 	for _, data := range rows {
 		msg := &storage.Pod{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -669,7 +668,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Pod) error) e
 		}
 		for _, data := range rows {
 			var msg storage.Pod
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -357,7 +356,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Policy, bool, 
 	}
 
 	var msg storage.Policy
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -473,7 +472,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Polic
 	resultsByID := make(map[string]*storage.Policy)
 	for _, data := range rows {
 		msg := &storage.Policy{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -517,7 +516,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.Policy
 	for _, data := range rows {
 		msg := &storage.Policy{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -563,7 +562,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Policy) error
 		}
 		for _, data := range rows {
 			var msg storage.Policy
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -306,7 +305,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.PolicyCategory
 	}
 
 	var msg storage.PolicyCategory
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -412,7 +411,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Polic
 	resultsByID := make(map[string]*storage.PolicyCategory)
 	for _, data := range rows {
 		msg := &storage.PolicyCategory{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -456,7 +455,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.PolicyCategory
 	for _, data := range rows {
 		msg := &storage.PolicyCategory{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -502,7 +501,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PolicyCategor
 		}
 		for _, data := range rows {
 			var msg storage.PolicyCategory
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -344,7 +343,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ProcessBaselin
 	}
 
 	var msg storage.ProcessBaseline
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -473,7 +472,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 	resultsByID := make(map[string]*storage.ProcessBaseline)
 	for _, data := range rows {
 		msg := &storage.ProcessBaseline{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -525,7 +524,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ProcessBaseline
 	for _, data := range rows {
 		msg := &storage.ProcessBaseline{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -584,7 +583,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ProcessBaseli
 		}
 		for _, data := range rows {
 			var msg storage.ProcessBaseline
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -339,7 +338,7 @@ func (s *storeImpl) Get(ctx context.Context, deploymentId string) (*storage.Proc
 	}
 
 	var msg storage.ProcessBaselineResults
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -468,7 +467,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 	resultsByID := make(map[string]*storage.ProcessBaselineResults)
 	for _, data := range rows {
 		msg := &storage.ProcessBaselineResults{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetDeploymentId()] = msg
@@ -520,7 +519,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ProcessBaselineResults
 	for _, data := range rows {
 		msg := &storage.ProcessBaselineResults{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -579,7 +578,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ProcessBaseli
 		}
 		for _, data := range rows {
 			var msg storage.ProcessBaselineResults
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -384,7 +383,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ProcessIndicat
 	}
 
 	var msg storage.ProcessIndicator
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -513,7 +512,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 	resultsByID := make(map[string]*storage.ProcessIndicator)
 	for _, data := range rows {
 		msg := &storage.ProcessIndicator{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -565,7 +564,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ProcessIndicator
 	for _, data := range rows {
 		msg := &storage.ProcessIndicator{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -624,7 +623,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ProcessIndica
 		}
 		for _, data := range rows {
 			var msg storage.ProcessIndicator
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -364,7 +363,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.K8SRole, bool,
 	}
 
 	var msg storage.K8SRole
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -493,7 +492,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 	resultsByID := make(map[string]*storage.K8SRole)
 	for _, data := range rows {
 		msg := &storage.K8SRole{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -545,7 +544,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.K8SRole
 	for _, data := range rows {
 		msg := &storage.K8SRole{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -604,7 +603,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.K8SRole) erro
 		}
 		for _, data := range rows {
 			var msg storage.K8SRole
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -454,7 +453,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.K8SRoleBinding
 	}
 
 	var msg storage.K8SRoleBinding
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -583,7 +582,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 	resultsByID := make(map[string]*storage.K8SRoleBinding)
 	for _, data := range rows {
 		msg := &storage.K8SRoleBinding{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -635,7 +634,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.K8SRoleBinding
 	for _, data := range rows {
 		msg := &storage.K8SRoleBinding{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -694,7 +693,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.K8SRoleBindin
 		}
 		for _, data := range rows {
 			var msg storage.K8SRoleBinding
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -311,7 +310,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ReportConfigur
 	}
 
 	var msg storage.ReportConfiguration
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -417,7 +416,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Repor
 	resultsByID := make(map[string]*storage.ReportConfiguration)
 	for _, data := range rows {
 		msg := &storage.ReportConfiguration{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -461,7 +460,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ReportConfiguration
 	for _, data := range rows {
 		msg := &storage.ReportConfiguration{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -507,7 +506,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ReportConfigu
 		}
 		for _, data := range rows {
 			var msg storage.ReportConfiguration
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -396,7 +395,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ResourceCollec
 	}
 
 	var msg storage.ResourceCollection
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -502,7 +501,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Resou
 	resultsByID := make(map[string]*storage.ResourceCollection)
 	for _, data := range rows {
 		msg := &storage.ResourceCollection{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -546,7 +545,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ResourceCollection
 	for _, data := range rows {
 		msg := &storage.ResourceCollection{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -592,7 +591,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ResourceColle
 		}
 		for _, data := range rows {
 			var msg storage.ResourceCollection
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -349,7 +348,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Risk, bool, er
 	}
 
 	var msg storage.Risk
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -478,7 +477,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Risk,
 	resultsByID := make(map[string]*storage.Risk)
 	for _, data := range rows {
 		msg := &storage.Risk{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -530,7 +529,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.Risk
 	for _, data := range rows {
 		msg := &storage.Risk{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -589,7 +588,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Risk) error) 
 		}
 		for _, data := range rows {
 			var msg storage.Risk
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -305,7 +304,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.PermissionSet,
 	}
 
 	var msg storage.PermissionSet
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -411,7 +410,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Permi
 	resultsByID := make(map[string]*storage.PermissionSet)
 	for _, data := range rows {
 		msg := &storage.PermissionSet{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -468,7 +467,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PermissionSet
 		}
 		for _, data := range rows {
 			var msg storage.PermissionSet
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -300,7 +299,7 @@ func (s *storeImpl) Get(ctx context.Context, name string) (*storage.Role, bool, 
 	}
 
 	var msg storage.Role
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -406,7 +405,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Role,
 	resultsByID := make(map[string]*storage.Role)
 	for _, data := range rows {
 		msg := &storage.Role{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetName()] = msg
@@ -463,7 +462,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Role) error) 
 		}
 		for _, data := range rows {
 			var msg storage.Role
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -305,7 +304,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.SimpleAccessSc
 	}
 
 	var msg storage.SimpleAccessScope
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -411,7 +410,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Simpl
 	resultsByID := make(map[string]*storage.SimpleAccessScope)
 	for _, data := range rows {
 		msg := &storage.SimpleAccessScope{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -468,7 +467,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.SimpleAccessS
 		}
 		for _, data := range rows {
 			var msg storage.SimpleAccessScope
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -524,7 +523,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Secret, bool, 
 	}
 
 	var msg storage.Secret
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -653,7 +652,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Secre
 	resultsByID := make(map[string]*storage.Secret)
 	for _, data := range rows {
 		msg := &storage.Secret{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -705,7 +704,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.Secret
 	for _, data := range rows {
 		msg := &storage.Secret{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -764,7 +763,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Secret) error
 		}
 		for _, data := range rows {
 			var msg storage.Secret
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/sensorupgradeconfig/datastore/internal/store/postgres/store.go
+++ b/central/sensorupgradeconfig/datastore/internal/store/postgres/store.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/central/metrics"
@@ -138,7 +137,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.SensorUpgradeCon
 	}
 
 	var msg storage.SensorUpgradeConfig
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -359,7 +358,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ServiceAccount
 	}
 
 	var msg storage.ServiceAccount
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -488,7 +487,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Servi
 	resultsByID := make(map[string]*storage.ServiceAccount)
 	for _, data := range rows {
 		msg := &storage.ServiceAccount{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -540,7 +539,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ServiceAccount
 	for _, data := range rows {
 		msg := &storage.ServiceAccount{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -599,7 +598,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ServiceAccoun
 		}
 		for _, data := range rows {
 			var msg storage.ServiceAccount
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -301,7 +300,7 @@ func (s *storeImpl) Get(ctx context.Context, serialStr string) (*storage.Service
 	}
 
 	var msg storage.ServiceIdentity
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -417,7 +416,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Servi
 	resultsByID := make(map[string]*storage.ServiceIdentity)
 	for _, data := range rows {
 		msg := &storage.ServiceIdentity{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetSerialStr()] = msg
@@ -474,7 +473,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ServiceIdenti
 		}
 		for _, data := range rows {
 			var msg storage.ServiceIdentity
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -305,7 +304,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.SignatureInteg
 	}
 
 	var msg storage.SignatureIntegration
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -411,7 +410,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Signa
 	resultsByID := make(map[string]*storage.SignatureIntegration)
 	for _, data := range rows {
 		msg := &storage.SignatureIntegration{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -468,7 +467,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.SignatureInte
 		}
 		for _, data := range rows {
 			var msg storage.SignatureIntegration
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -495,7 +494,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.VulnerabilityR
 	}
 
 	var msg storage.VulnerabilityRequest
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -601,7 +600,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Vulne
 	resultsByID := make(map[string]*storage.VulnerabilityRequest)
 	for _, data := range rows {
 		msg := &storage.VulnerabilityRequest{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -645,7 +644,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.VulnerabilityRequest
 	for _, data := range rows {
 		msg := &storage.VulnerabilityRequest{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -690,7 +689,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Vulnerability
 		}
 		for _, data := range rows {
 			var msg storage.VulnerabilityRequest
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -300,7 +299,7 @@ func (s *storeImpl) Get(ctx context.Context, name string) (*storage.WatchedImage
 	}
 
 	var msg storage.WatchedImage
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -406,7 +405,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Watch
 	resultsByID := make(map[string]*storage.WatchedImage)
 	for _, data := range rows {
 		msg := &storage.WatchedImage{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetName()] = msg
@@ -463,7 +462,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.WatchedImage)
 		}
 		for _, data := range rows {
 			var msg storage.WatchedImage
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -171,7 +170,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Cluster, bool,
 	}
 
 	var msg storage.Cluster
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -254,7 +253,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 	resultsByID := make(map[string]*storage.Cluster)
 	for _, data := range rows {
 		msg := &storage.Cluster{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -292,7 +291,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.Cluster
 	for _, data := range rows {
 		msg := &storage.Cluster{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -328,7 +327,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Cluster) erro
 		}
 		for _, data := range rows {
 			var msg storage.Cluster
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -292,7 +291,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NamespaceMetad
 	}
 
 	var msg storage.NamespaceMetadata
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -375,7 +374,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Names
 	resultsByID := make(map[string]*storage.NamespaceMetadata)
 	for _, data := range rows {
 		msg := &storage.NamespaceMetadata{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -413,7 +412,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.NamespaceMetadata
 	for _, data := range rows {
 		msg := &storage.NamespaceMetadata{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -449,7 +448,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NamespaceMeta
 		}
 		for _, data := range rows {
 			var msg storage.NamespaceMetadata
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -956,7 +955,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Deployment, bo
 	}
 
 	var msg storage.Deployment
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -1039,7 +1038,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Deplo
 	resultsByID := make(map[string]*storage.Deployment)
 	for _, data := range rows {
 		msg := &storage.Deployment{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -1077,7 +1076,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.Deployment
 	for _, data := range rows {
 		msg := &storage.Deployment{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -1113,7 +1112,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Deployment) e
 		}
 		for _, data := range rows {
 			var msg storage.Deployment
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -412,7 +411,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Alert, bool, e
 	}
 
 	var msg storage.Alert
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -495,7 +494,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Alert
 	resultsByID := make(map[string]*storage.Alert)
 	for _, data := range rows {
 		msg := &storage.Alert{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -533,7 +532,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.Alert
 	for _, data := range rows {
 		msg := &storage.Alert{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -569,7 +568,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Alert) error)
 		}
 		for _, data := range rows {
 			var msg storage.Alert
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -266,7 +265,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TokenMetadata,
 	}
 
 	var msg storage.TokenMetadata
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -349,7 +348,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Token
 	resultsByID := make(map[string]*storage.TokenMetadata)
 	for _, data := range rows {
 		msg := &storage.TokenMetadata{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -396,7 +395,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TokenMetadata
 		}
 		for _, data := range rows {
 			var msg storage.TokenMetadata
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -272,7 +271,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.AuthProvider, 
 	}
 
 	var msg storage.AuthProvider
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -364,7 +363,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.AuthP
 	resultsByID := make(map[string]*storage.AuthProvider)
 	for _, data := range rows {
 		msg := &storage.AuthProvider{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -411,7 +410,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.AuthProvider)
 		}
 		for _, data := range rows {
 			var msg storage.AuthProvider
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -297,7 +296,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ClusterHealthS
 	}
 
 	var msg storage.ClusterHealthStatus
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -380,7 +379,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 	resultsByID := make(map[string]*storage.ClusterHealthStatus)
 	for _, data := range rows {
 		msg := &storage.ClusterHealthStatus{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -418,7 +417,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ClusterHealthStatus
 	for _, data := range rows {
 		msg := &storage.ClusterHealthStatus{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -454,7 +453,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ClusterHealth
 		}
 		for _, data := range rows {
 			var msg storage.ClusterHealthStatus
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -266,7 +265,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.InitBundleMeta
 	}
 
 	var msg storage.InitBundleMeta
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -349,7 +348,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.InitB
 	resultsByID := make(map[string]*storage.InitBundleMeta)
 	for _, data := range rows {
 		msg := &storage.InitBundleMeta{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -396,7 +395,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.InitBundleMet
 		}
 		for _, data := range rows {
 			var msg storage.InitBundleMeta
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -267,7 +266,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceDoma
 	}
 
 	var msg storage.ComplianceDomain
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -350,7 +349,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceDomain)
 	for _, data := range rows {
 		msg := &storage.ComplianceDomain{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -388,7 +387,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ComplianceDomain
 	for _, data := range rows {
 		msg := &storage.ComplianceDomain{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -424,7 +423,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceDom
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceDomain
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -266,7 +265,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceOper
 	}
 
 	var msg storage.ComplianceOperatorCheckResult
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -349,7 +348,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceOperatorCheckResult)
 	for _, data := range rows {
 		msg := &storage.ComplianceOperatorCheckResult{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -396,7 +395,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceOpe
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceOperatorCheckResult
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -266,7 +265,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceOper
 	}
 
 	var msg storage.ComplianceOperatorProfile
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -349,7 +348,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceOperatorProfile)
 	for _, data := range rows {
 		msg := &storage.ComplianceOperatorProfile{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -396,7 +395,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceOpe
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceOperatorProfile
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -266,7 +265,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceOper
 	}
 
 	var msg storage.ComplianceOperatorRule
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -349,7 +348,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceOperatorRule)
 	for _, data := range rows {
 		msg := &storage.ComplianceOperatorRule{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -396,7 +395,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceOpe
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceOperatorRule
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -266,7 +265,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceOper
 	}
 
 	var msg storage.ComplianceOperatorScanSettingBinding
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -349,7 +348,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceOperatorScanSettingBinding)
 	for _, data := range rows {
 		msg := &storage.ComplianceOperatorScanSettingBinding{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -396,7 +395,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceOpe
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceOperatorScanSettingBinding
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -266,7 +265,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceOper
 	}
 
 	var msg storage.ComplianceOperatorScan
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -349,7 +348,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceOperatorScan)
 	for _, data := range rows {
 		msg := &storage.ComplianceOperatorScan{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -396,7 +395,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceOpe
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceOperatorScan
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -282,7 +281,7 @@ func (s *storeImpl) Get(ctx context.Context, runId string) (*storage.ComplianceR
 	}
 
 	var msg storage.ComplianceRunMetadata
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -365,7 +364,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceRunMetadata)
 	for _, data := range rows {
 		msg := &storage.ComplianceRunMetadata{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetRunId()] = msg
@@ -403,7 +402,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ComplianceRunMetadata
 	for _, data := range rows {
 		msg := &storage.ComplianceRunMetadata{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -439,7 +438,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceRun
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceRunMetadata
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -282,7 +281,7 @@ func (s *storeImpl) Get(ctx context.Context, runMetadataRunId string) (*storage.
 	}
 
 	var msg storage.ComplianceRunResults
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -365,7 +364,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceRunResults)
 	for _, data := range rows {
 		msg := &storage.ComplianceRunResults{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetRunMetadata().GetRunId()] = msg
@@ -403,7 +402,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ComplianceRunResults
 	for _, data := range rows {
 		msg := &storage.ComplianceRunResults{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -439,7 +438,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceRun
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceRunResults
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -266,7 +265,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceStri
 	}
 
 	var msg storage.ComplianceStrings
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -349,7 +348,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	resultsByID := make(map[string]*storage.ComplianceStrings)
 	for _, data := range rows {
 		msg := &storage.ComplianceStrings{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -396,7 +395,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceStr
 		}
 		for _, data := range rows {
 			var msg storage.ComplianceStrings
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_21_to_n_22_postgres_configs/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_21_to_n_22_postgres_configs/postgres/postgres_plugin.go
@@ -4,7 +4,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/generated/storage"
@@ -119,7 +118,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.Config, bool, er
 	}
 
 	var msg storage.Config
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -267,7 +266,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ExternalBackup
 	}
 
 	var msg storage.ExternalBackup
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -359,7 +358,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Exter
 	resultsByID := make(map[string]*storage.ExternalBackup)
 	for _, data := range rows {
 		msg := &storage.ExternalBackup{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -406,7 +405,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ExternalBacku
 		}
 		for _, data := range rows {
 			var msg storage.ExternalBackup
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -278,7 +277,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ImageIntegrati
 	}
 
 	var msg storage.ImageIntegration
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -370,7 +369,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 	resultsByID := make(map[string]*storage.ImageIntegration)
 	for _, data := range rows {
 		msg := &storage.ImageIntegration{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -408,7 +407,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ImageIntegration
 	for _, data := range rows {
 		msg := &storage.ImageIntegration{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -444,7 +443,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ImageIntegrat
 		}
 		for _, data := range rows {
 			var msg storage.ImageIntegration
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_24_to_n_25_postgres_installation_infos/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_24_to_n_25_postgres_installation_infos/postgres/postgres_plugin.go
@@ -4,7 +4,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/generated/storage"
@@ -119,7 +118,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.InstallationInfo
 	}
 
 	var msg storage.InstallationInfo
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -266,7 +265,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.IntegrationHea
 	}
 
 	var msg storage.IntegrationHealth
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -349,7 +348,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Integ
 	resultsByID := make(map[string]*storage.IntegrationHealth)
 	for _, data := range rows {
 		msg := &storage.IntegrationHealth{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -396,7 +395,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.IntegrationHe
 		}
 		for _, data := range rows {
 			var msg storage.IntegrationHealth
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -302,7 +301,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.K8SRole, bool,
 	}
 
 	var msg storage.K8SRole
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -385,7 +384,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 	resultsByID := make(map[string]*storage.K8SRole)
 	for _, data := range rows {
 		msg := &storage.K8SRole{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -423,7 +422,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.K8SRole
 	for _, data := range rows {
 		msg := &storage.K8SRole{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -459,7 +458,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.K8SRole) erro
 		}
 		for _, data := range rows {
 			var msg storage.K8SRole
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -277,7 +276,7 @@ func (s *storeImpl) Get(ctx context.Context, deploymentId string) (*storage.Netw
 	}
 
 	var msg storage.NetworkBaseline
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -360,7 +359,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	resultsByID := make(map[string]*storage.NetworkBaseline)
 	for _, data := range rows {
 		msg := &storage.NetworkBaseline{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetDeploymentId()] = msg
@@ -398,7 +397,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.NetworkBaseline
 	for _, data := range rows {
 		msg := &storage.NetworkBaseline{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -434,7 +433,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkBaseli
 		}
 		for _, data := range rows {
 			var msg storage.NetworkBaseline
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -272,7 +271,7 @@ func (s *storeImpl) Get(ctx context.Context, infoId string) (*storage.NetworkEnt
 	}
 
 	var msg storage.NetworkEntity
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -355,7 +354,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	resultsByID := make(map[string]*storage.NetworkEntity)
 	for _, data := range rows {
 		msg := &storage.NetworkEntity{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetInfo().GetId()] = msg
@@ -393,7 +392,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.NetworkEntity
 	for _, data := range rows {
 		msg := &storage.NetworkEntity{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -429,7 +428,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkEntity
 		}
 		for _, data := range rows {
 			var msg storage.NetworkEntity
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -266,7 +265,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NetworkGraphCo
 	}
 
 	var msg storage.NetworkGraphConfig
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -349,7 +348,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	resultsByID := make(map[string]*storage.NetworkGraphConfig)
 	for _, data := range rows {
 		msg := &storage.NetworkGraphConfig{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -396,7 +395,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkGraphC
 		}
 		for _, data := range rows {
 			var msg storage.NetworkGraphConfig
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -277,7 +276,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NetworkPolicy,
 	}
 
 	var msg storage.NetworkPolicy
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -360,7 +359,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	resultsByID := make(map[string]*storage.NetworkPolicy)
 	for _, data := range rows {
 		msg := &storage.NetworkPolicy{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -398,7 +397,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.NetworkPolicy
 	for _, data := range rows {
 		msg := &storage.NetworkPolicy{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -434,7 +433,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkPolicy
 		}
 		for _, data := range rows {
 			var msg storage.NetworkPolicy
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -266,7 +265,7 @@ func (s *storeImpl) Get(ctx context.Context, deploymentId string) (*storage.Netw
 	}
 
 	var msg storage.NetworkPolicyApplicationUndoDeploymentRecord
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -349,7 +348,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	resultsByID := make(map[string]*storage.NetworkPolicyApplicationUndoDeploymentRecord)
 	for _, data := range rows {
 		msg := &storage.NetworkPolicyApplicationUndoDeploymentRecord{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetDeploymentId()] = msg
@@ -396,7 +395,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkPolicy
 		}
 		for _, data := range rows {
 			var msg storage.NetworkPolicyApplicationUndoDeploymentRecord
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -266,7 +265,7 @@ func (s *storeImpl) Get(ctx context.Context, clusterId string) (*storage.Network
 	}
 
 	var msg storage.NetworkPolicyApplicationUndoRecord
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -349,7 +348,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	resultsByID := make(map[string]*storage.NetworkPolicyApplicationUndoRecord)
 	for _, data := range rows {
 		msg := &storage.NetworkPolicyApplicationUndoRecord{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetClusterId()] = msg
@@ -396,7 +395,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkPolicy
 		}
 		for _, data := range rows {
 			var msg storage.NetworkPolicyApplicationUndoRecord
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -272,7 +271,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Notifier, bool
 	}
 
 	var msg storage.Notifier
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -364,7 +363,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Notif
 	resultsByID := make(map[string]*storage.Notifier)
 	for _, data := range rows {
 		msg := &storage.Notifier{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -411,7 +410,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Notifier) err
 		}
 		for _, data := range rows {
 			var msg storage.Notifier
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -271,7 +270,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.PermissionSet,
 	}
 
 	var msg storage.PermissionSet
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -354,7 +353,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Permi
 	resultsByID := make(map[string]*storage.PermissionSet)
 	for _, data := range rows {
 		msg := &storage.PermissionSet{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -401,7 +400,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PermissionSet
 		}
 		for _, data := range rows {
 			var msg storage.PermissionSet
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -367,7 +366,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Pod, bool, err
 	}
 
 	var msg storage.Pod
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -450,7 +449,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Pod, 
 	resultsByID := make(map[string]*storage.Pod)
 	for _, data := range rows {
 		msg := &storage.Pod{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -488,7 +487,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.Pod
 	for _, data := range rows {
 		msg := &storage.Pod{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -524,7 +523,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Pod) error) e
 		}
 		for _, data := range rows {
 			var msg storage.Pod
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -323,7 +322,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Policy, bool, 
 	}
 
 	var msg storage.Policy
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -415,7 +414,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Polic
 	resultsByID := make(map[string]*storage.Policy)
 	for _, data := range rows {
 		msg := &storage.Policy{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -453,7 +452,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.Policy
 	for _, data := range rows {
 		msg := &storage.Policy{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -489,7 +488,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Policy) error
 		}
 		for _, data := range rows {
 			var msg storage.Policy
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -277,7 +276,7 @@ func (s *storeImpl) Get(ctx context.Context, deploymentId string) (*storage.Proc
 	}
 
 	var msg storage.ProcessBaselineResults
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -360,7 +359,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 	resultsByID := make(map[string]*storage.ProcessBaselineResults)
 	for _, data := range rows {
 		msg := &storage.ProcessBaselineResults{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetDeploymentId()] = msg
@@ -398,7 +397,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ProcessBaselineResults
 	for _, data := range rows {
 		msg := &storage.ProcessBaselineResults{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -434,7 +433,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ProcessBaseli
 		}
 		for _, data := range rows {
 			var msg storage.ProcessBaselineResults
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -282,7 +281,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ProcessBaselin
 	}
 
 	var msg storage.ProcessBaseline
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -365,7 +364,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 	resultsByID := make(map[string]*storage.ProcessBaseline)
 	for _, data := range rows {
 		msg := &storage.ProcessBaseline{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -403,7 +402,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ProcessBaseline
 	for _, data := range rows {
 		msg := &storage.ProcessBaseline{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -439,7 +438,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ProcessBaseli
 		}
 		for _, data := range rows {
 			var msg storage.ProcessBaseline
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -322,7 +321,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ProcessIndicat
 	}
 
 	var msg storage.ProcessIndicator
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -405,7 +404,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 	resultsByID := make(map[string]*storage.ProcessIndicator)
 	for _, data := range rows {
 		msg := &storage.ProcessIndicator{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -443,7 +442,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ProcessIndicator
 	for _, data := range rows {
 		msg := &storage.ProcessIndicator{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -479,7 +478,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ProcessIndica
 		}
 		for _, data := range rows {
 			var msg storage.ProcessIndicator
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -277,7 +276,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ReportConfigur
 	}
 
 	var msg storage.ReportConfiguration
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -360,7 +359,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Repor
 	resultsByID := make(map[string]*storage.ReportConfiguration)
 	for _, data := range rows {
 		msg := &storage.ReportConfiguration{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -398,7 +397,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ReportConfiguration
 	for _, data := range rows {
 		msg := &storage.ReportConfiguration{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -434,7 +433,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ReportConfigu
 		}
 		for _, data := range rows {
 			var msg storage.ReportConfiguration
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -287,7 +286,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Risk, bool, er
 	}
 
 	var msg storage.Risk
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -370,7 +369,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Risk,
 	resultsByID := make(map[string]*storage.Risk)
 	for _, data := range rows {
 		msg := &storage.Risk{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -408,7 +407,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.Risk
 	for _, data := range rows {
 		msg := &storage.Risk{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -444,7 +443,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Risk) error) 
 		}
 		for _, data := range rows {
 			var msg storage.Risk
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -392,7 +391,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.K8SRoleBinding
 	}
 
 	var msg storage.K8SRoleBinding
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -475,7 +474,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 	resultsByID := make(map[string]*storage.K8SRoleBinding)
 	for _, data := range rows {
 		msg := &storage.K8SRoleBinding{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -513,7 +512,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.K8SRoleBinding
 	for _, data := range rows {
 		msg := &storage.K8SRoleBinding{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -549,7 +548,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.K8SRoleBindin
 		}
 		for _, data := range rows {
 			var msg storage.K8SRoleBinding
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -266,7 +265,7 @@ func (s *storeImpl) Get(ctx context.Context, name string) (*storage.Role, bool, 
 	}
 
 	var msg storage.Role
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -349,7 +348,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Role,
 	resultsByID := make(map[string]*storage.Role)
 	for _, data := range rows {
 		msg := &storage.Role{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetName()] = msg
@@ -396,7 +395,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Role) error) 
 		}
 		for _, data := range rows {
 			var msg storage.Role
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -462,7 +461,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Secret, bool, 
 	}
 
 	var msg storage.Secret
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -545,7 +544,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Secre
 	resultsByID := make(map[string]*storage.Secret)
 	for _, data := range rows {
 		msg := &storage.Secret{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -583,7 +582,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.Secret
 	for _, data := range rows {
 		msg := &storage.Secret{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -619,7 +618,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Secret) error
 		}
 		for _, data := range rows {
 			var msg storage.Secret
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_48_to_n_49_postgres_sensor_upgrade_configs/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_48_to_n_49_postgres_sensor_upgrade_configs/postgres/postgres_plugin.go
@@ -4,7 +4,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/generated/storage"
@@ -119,7 +118,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.SensorUpgradeCon
 	}
 
 	var msg storage.SensorUpgradeConfig
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -297,7 +296,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ServiceAccount
 	}
 
 	var msg storage.ServiceAccount
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -380,7 +379,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Servi
 	resultsByID := make(map[string]*storage.ServiceAccount)
 	for _, data := range rows {
 		msg := &storage.ServiceAccount{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -418,7 +417,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.ServiceAccount
 	for _, data := range rows {
 		msg := &storage.ServiceAccount{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -454,7 +453,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ServiceAccoun
 		}
 		for _, data := range rows {
 			var msg storage.ServiceAccount
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -267,7 +266,7 @@ func (s *storeImpl) Get(ctx context.Context, serialStr string) (*storage.Service
 	}
 
 	var msg storage.ServiceIdentity
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -359,7 +358,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Servi
 	resultsByID := make(map[string]*storage.ServiceIdentity)
 	for _, data := range rows {
 		msg := &storage.ServiceIdentity{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetSerialStr()] = msg
@@ -406,7 +405,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ServiceIdenti
 		}
 		for _, data := range rows {
 			var msg storage.ServiceIdentity
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -271,7 +270,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.SignatureInteg
 	}
 
 	var msg storage.SignatureIntegration
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -354,7 +353,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Signa
 	resultsByID := make(map[string]*storage.SignatureIntegration)
 	for _, data := range rows {
 		msg := &storage.SignatureIntegration{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -401,7 +400,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.SignatureInte
 		}
 		for _, data := range rows {
 			var msg storage.SignatureIntegration
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -271,7 +270,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.SimpleAccessSc
 	}
 
 	var msg storage.SimpleAccessScope
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -354,7 +353,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Simpl
 	resultsByID := make(map[string]*storage.SimpleAccessScope)
 	for _, data := range rows {
 		msg := &storage.SimpleAccessScope{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -401,7 +400,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.SimpleAccessS
 		}
 		for _, data := range rows {
 			var msg storage.SimpleAccessScope
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -465,7 +464,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.VulnerabilityR
 	}
 
 	var msg storage.VulnerabilityRequest
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -548,7 +547,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Vulne
 	resultsByID := make(map[string]*storage.VulnerabilityRequest)
 	for _, data := range rows {
 		msg := &storage.VulnerabilityRequest{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -586,7 +585,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.VulnerabilityRequest
 	for _, data := range rows {
 		msg := &storage.VulnerabilityRequest{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -622,7 +621,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Vulnerability
 		}
 		for _, data := range rows {
 			var msg storage.VulnerabilityRequest
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -266,7 +265,7 @@ func (s *storeImpl) Get(ctx context.Context, name string) (*storage.WatchedImage
 	}
 
 	var msg storage.WatchedImage
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -349,7 +348,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Watch
 	resultsByID := make(map[string]*storage.WatchedImage)
 	for _, data := range rows {
 		msg := &storage.WatchedImage{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetName()] = msg
@@ -396,7 +395,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.WatchedImage)
 		}
 		for _, data := range rows {
 			var msg storage.WatchedImage
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -272,7 +271,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.PolicyCategory
 	}
 
 	var msg storage.PolicyCategory
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -355,7 +354,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Polic
 	resultsByID := make(map[string]*storage.PolicyCategory)
 	for _, data := range rows {
 		msg := &storage.PolicyCategory{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -393,7 +392,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.PolicyCategory
 	for _, data := range rows {
 		msg := &storage.PolicyCategory{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -429,7 +428,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PolicyCategor
 		}
 		for _, data := range rows {
 			var msg storage.PolicyCategory
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -267,7 +266,7 @@ func (s *storeImpl) Get(ctx context.Context, propsId string) (*storage.Group, bo
 	}
 
 	var msg storage.Group
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -359,7 +358,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Group
 	resultsByID := make(map[string]*storage.Group)
 	for _, data := range rows {
 		msg := &storage.Group{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetProps().GetId()] = msg
@@ -406,7 +405,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Group) error)
 		}
 		for _, data := range rows {
 			var msg storage.Group
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -486,7 +485,7 @@ func (s *storeImpl) Get(ctx context.Context, key1 string, key2 string) (*storage
 	}
 
 	var msg storage.TestMultiKeyStruct
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -616,7 +615,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestM
 	resultsByID := make(map[string]*storage.TestMultiKeyStruct)
 	for _, data := range rows {
 		msg := &storage.TestMultiKeyStruct{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetKey1()] = msg
@@ -668,7 +667,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.TestMultiKeyStruct
 	for _, data := range rows {
 		msg := &storage.TestMultiKeyStruct{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -715,7 +714,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TestMultiKeyS
 		}
 		for _, data := range rows {
 			var msg storage.TestMultiKeyStruct
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/singleton.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/singleton.go.tpl
@@ -14,7 +14,6 @@ import (
     "strings"
     "time"
 
-    "github.com/gogo/protobuf/proto"
     "github.com/jackc/pgx/v4"
     "github.com/jackc/pgx/v4/pgxpool"
     "github.com/pkg/errors"
@@ -173,7 +172,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*{{.Type}}, bool, error) 
 	}
 
 	var msg {{.Type}}
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
         return nil, false, err
 	}
 	return &msg, true, nil

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -25,7 +25,6 @@ import (
     "strings"
     "time"
 
-    "github.com/gogo/protobuf/proto"
     "github.com/hashicorp/go-multierror"
     "github.com/jackc/pgx/v4"
     "github.com/jackc/pgx/v4/pgxpool"
@@ -553,7 +552,7 @@ func (s *storeImpl) Get(ctx context.Context, {{template "paramList" $pks}}) (*{{
 	}
 
 	var msg {{.Type}}
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
         return nil, false, err
 	}
 	return &msg, true, nil
@@ -792,7 +791,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []{{$singlePK.Type}}) ([]*{
 	resultsByID := make(map[{{$singlePK.Type}}]*{{.Type}})
     for _, data := range rows {
 		msg := &{{.Type}}{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 		    return nil, nil, err
 		}
 		resultsByID[{{$singlePK.Getter "msg"}}] = msg
@@ -864,7 +863,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*{{.Type
 	var results []*{{.Type}}
     for _, data := range rows {
 		msg := &{{.Type}}{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 		    return nil, err
 		}
 		results = append(results, msg)
@@ -964,7 +963,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *{{.Type}}) error) err
 		}
 		for _, data := range rows {
 			var msg {{.Type}}
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -369,7 +368,7 @@ func (s *storeImpl) Get(ctx context.Context, key string) (*storage.TestSingleKey
 	}
 
 	var msg storage.TestSingleKeyStruct
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -508,7 +507,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestS
 	resultsByID := make(map[string]*storage.TestSingleKeyStruct)
 	for _, data := range rows {
 		msg := &storage.TestSingleKeyStruct{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetKey()] = msg
@@ -560,7 +559,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.TestSingleKeyStruct
 	for _, data := range rows {
 		msg := &storage.TestSingleKeyStruct{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -607,7 +606,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TestSingleKey
 		}
 		for _, data := range rows {
 			var msg storage.TestSingleKeyStruct
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -323,7 +322,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestChild1, bo
 	}
 
 	var msg storage.TestChild1
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -452,7 +451,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestC
 	resultsByID := make(map[string]*storage.TestChild1)
 	for _, data := range rows {
 		msg := &storage.TestChild1{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -504,7 +503,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.TestChild1
 	for _, data := range rows {
 		msg := &storage.TestChild1{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -551,7 +550,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TestChild1) e
 		}
 		for _, data := range rows {
 			var msg storage.TestChild1
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -328,7 +327,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestChild1P4, 
 	}
 
 	var msg storage.TestChild1P4
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -457,7 +456,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestC
 	resultsByID := make(map[string]*storage.TestChild1P4)
 	for _, data := range rows {
 		msg := &storage.TestChild1P4{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -509,7 +508,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.TestChild1P4
 	for _, data := range rows {
 		msg := &storage.TestChild1P4{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -556,7 +555,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TestChild1P4)
 		}
 		for _, data := range rows {
 			var msg storage.TestChild1P4
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -333,7 +332,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestChild2, bo
 	}
 
 	var msg storage.TestChild2
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -462,7 +461,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestC
 	resultsByID := make(map[string]*storage.TestChild2)
 	for _, data := range rows {
 		msg := &storage.TestChild2{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -514,7 +513,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.TestChild2
 	for _, data := range rows {
 		msg := &storage.TestChild2{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -561,7 +560,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TestChild2) e
 		}
 		for _, data := range rows {
 			var msg storage.TestChild2
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -333,7 +332,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestG2GrandChi
 	}
 
 	var msg storage.TestG2GrandChild1
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -462,7 +461,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 	resultsByID := make(map[string]*storage.TestG2GrandChild1)
 	for _, data := range rows {
 		msg := &storage.TestG2GrandChild1{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -514,7 +513,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.TestG2GrandChild1
 	for _, data := range rows {
 		msg := &storage.TestG2GrandChild1{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -561,7 +560,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TestG2GrandCh
 		}
 		for _, data := range rows {
 			var msg storage.TestG2GrandChild1
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -323,7 +322,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestG3GrandChi
 	}
 
 	var msg storage.TestG3GrandChild1
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -452,7 +451,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 	resultsByID := make(map[string]*storage.TestG3GrandChild1)
 	for _, data := range rows {
 		msg := &storage.TestG3GrandChild1{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -504,7 +503,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.TestG3GrandChild1
 	for _, data := range rows {
 		msg := &storage.TestG3GrandChild1{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -551,7 +550,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TestG3GrandCh
 		}
 		for _, data := range rows {
 			var msg storage.TestG3GrandChild1
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -323,7 +322,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestGGrandChil
 	}
 
 	var msg storage.TestGGrandChild1
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -452,7 +451,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 	resultsByID := make(map[string]*storage.TestGGrandChild1)
 	for _, data := range rows {
 		msg := &storage.TestGGrandChild1{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -504,7 +503,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.TestGGrandChild1
 	for _, data := range rows {
 		msg := &storage.TestGGrandChild1{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -551,7 +550,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TestGGrandChi
 		}
 		for _, data := range rows {
 			var msg storage.TestGGrandChild1
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -333,7 +332,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestGrandChild
 	}
 
 	var msg storage.TestGrandChild1
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -462,7 +461,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 	resultsByID := make(map[string]*storage.TestGrandChild1)
 	for _, data := range rows {
 		msg := &storage.TestGrandChild1{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -514,7 +513,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.TestGrandChild1
 	for _, data := range rows {
 		msg := &storage.TestGrandChild1{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -561,7 +560,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TestGrandChil
 		}
 		for _, data := range rows {
 			var msg storage.TestGrandChild1
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -498,7 +497,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestGrandparen
 	}
 
 	var msg storage.TestGrandparent
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -627,7 +626,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 	resultsByID := make(map[string]*storage.TestGrandparent)
 	for _, data := range rows {
 		msg := &storage.TestGrandparent{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -679,7 +678,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.TestGrandparent
 	for _, data := range rows {
 		msg := &storage.TestGrandparent{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -726,7 +725,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TestGrandpare
 		}
 		for _, data := range rows {
 			var msg storage.TestGrandparent
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -408,7 +407,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestParent1, b
 	}
 
 	var msg storage.TestParent1
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -537,7 +536,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 	resultsByID := make(map[string]*storage.TestParent1)
 	for _, data := range rows {
 		msg := &storage.TestParent1{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -589,7 +588,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.TestParent1
 	for _, data := range rows {
 		msg := &storage.TestParent1{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -636,7 +635,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TestParent1) 
 		}
 		for _, data := range rows {
 			var msg storage.TestParent1
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -328,7 +327,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestParent2, b
 	}
 
 	var msg storage.TestParent2
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -457,7 +456,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 	resultsByID := make(map[string]*storage.TestParent2)
 	for _, data := range rows {
 		msg := &storage.TestParent2{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -509,7 +508,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.TestParent2
 	for _, data := range rows {
 		msg := &storage.TestParent2{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -556,7 +555,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TestParent2) 
 		}
 		for _, data := range rows {
 			var msg storage.TestParent2
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -328,7 +327,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestParent3, b
 	}
 
 	var msg storage.TestParent3
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -457,7 +456,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 	resultsByID := make(map[string]*storage.TestParent3)
 	for _, data := range rows {
 		msg := &storage.TestParent3{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -509,7 +508,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.TestParent3
 	for _, data := range rows {
 		msg := &storage.TestParent3{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -556,7 +555,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TestParent3) 
 		}
 		for _, data := range rows {
 			var msg storage.TestParent3
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -328,7 +327,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestParent4, b
 	}
 
 	var msg storage.TestParent4
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -457,7 +456,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 	resultsByID := make(map[string]*storage.TestParent4)
 	for _, data := range rows {
 		msg := &storage.TestParent4{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -509,7 +508,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.TestParent4
 	for _, data := range rows {
 		msg := &storage.TestParent4{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -556,7 +555,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TestParent4) 
 		}
 		for _, data := range rows {
 			var msg storage.TestParent4
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -328,7 +327,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestShortCircu
 	}
 
 	var msg storage.TestShortCircuit
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -457,7 +456,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestS
 	resultsByID := make(map[string]*storage.TestShortCircuit)
 	for _, data := range rows {
 		msg := &storage.TestShortCircuit{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, nil, err
 		}
 		resultsByID[msg.GetId()] = msg
@@ -509,7 +508,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	var results []*storage.TestShortCircuit
 	for _, data := range rows {
 		msg := &storage.TestShortCircuit{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		results = append(results, msg)
@@ -556,7 +555,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TestShortCirc
 		}
 		for _, data := range rows {
 			var msg storage.TestShortCircuit
-			if err := proto.Unmarshal(data, &msg); err != nil {
+			if err := msg.Unmarshal(data); err != nil {
 				return err
 			}
 			if err := fn(&msg); err != nil {


### PR DESCRIPTION
## Description

Use `object.Unmarshal` instead of `proto.Unmarshal` to speedup marshaling and reduce number of allocs.

```
BenchmarkUnmarshal
BenchmarkUnmarshal/proto.Unmarshal
BenchmarkUnmarshal/proto.Unmarshal-8         	  333862	      3035 ns/op	    2424 B/op	      42 allocs/op
BenchmarkUnmarshal/out.Unmarshal
BenchmarkUnmarshal/out.Unmarshal-8           	  430071	      2874 ns/op	    2028 B/op	      24 allocs/op
PASS
```

## Testing Performed

CI
