### PR TITLE
ROX-13112: Fix a race condition in setting the sensor hash

### DIFF
--- a/sensor/common/detector/deduper.go
+++ b/sensor/common/detector/deduper.go
@@ -1,7 +1,6 @@
 package detector
 
 import (
-	hashstructure "github.com/mitchellh/hashstructure/v2"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
@@ -27,26 +26,14 @@ func (d *deduper) reset() {
 }
 
 func (d *deduper) addDeployment(deployment *storage.Deployment) {
-	hashValue, err := hashstructure.Hash(deployment, hashstructure.FormatV2, &hashstructure.HashOptions{})
-	if err != nil {
-		log.Errorf("error calculating hash of deployment %q: %v", deployment.GetName(), err)
-		return
-	}
-
 	d.hashLock.Lock()
 	defer d.hashLock.Unlock()
 
-	d.hash[deployment.GetId()] = hashValue
-	deployment.Hash = hashValue
+	d.hash[deployment.GetId()] = deployment.GetHash()
 }
 
 func (d *deduper) needsProcessing(deployment *storage.Deployment) bool {
-	// if removal then remove from hash and send empty alerts
-	hashValue, err := hashstructure.Hash(deployment, hashstructure.FormatV2, &hashstructure.HashOptions{})
-	if err != nil {
-		log.Errorf("error calculating hash of deployment %q: %v", deployment.GetName(), err)
-		return true
-	}
+	hashValue := deployment.GetHash()
 
 	var noUpdate bool
 	concurrency.WithRLock(&d.hashLock, func() {
@@ -61,7 +48,6 @@ func (d *deduper) needsProcessing(deployment *storage.Deployment) bool {
 	defer d.hashLock.Unlock()
 
 	d.hash[deployment.GetId()] = hashValue
-	deployment.Hash = hashValue
 	return true
 }
 

--- a/sensor/kubernetes/listener/resources/convert.go
+++ b/sensor/kubernetes/listener/resources/convert.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"sort"
 
+	"github.com/mitchellh/hashstructure/v2"
 	openshift_appsv1 "github.com/openshift/api/apps/v1"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -549,4 +550,16 @@ func (w *deploymentWrap) Clone() *deploymentWrap {
 	}
 
 	return ret
+}
+
+func (w *deploymentWrap) updateHash() error {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	hashValue, err := hashstructure.Hash(w.GetDeployment(), hashstructure.FormatV2, &hashstructure.HashOptions{})
+	if err != nil {
+		return errors.Wrap(err, "calculating deployment hash")
+	}
+	w.Hash = hashValue
+	return nil
 }

--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -181,6 +181,9 @@ func (d *deploymentHandler) processWithType(obj, oldObj interface{}, action cent
 		d.endpointManager.OnDeploymentRemove(deploymentWrap)
 		d.processFilter.Delete(deploymentWrap.GetId())
 	}
+	if err := deploymentWrap.updateHash(); err != nil {
+		log.Errorf("UNEXPECTED: could not calculate hash of deployment %s: %v", deploymentWrap.GetId(), err)
+	}
 	d.detector.ProcessDeployment(deploymentWrap.GetDeployment(), action)
 	events = d.appendIntegrationsOnCredentials(action, deploymentWrap.GetContainers(), events)
 	events = append(events, deploymentWrap.toEvent(action))


### PR DESCRIPTION
## Description

The recent change of setting the sensor hash led to a race condition in the deduper (see https://issues.redhat.com/browse/ROX-13112). Another disadvantage is that it is non-obvious that the hash is computed and populated on all paths before sending out a deployment event. To improve this, set the hash in the same place where other mutations to the deployment object happen.
 
## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- CI