### PR TITLE
Use generics in RunGetManyQueryForSchema

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -527,7 +527,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Activ
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ActiveComponent](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -538,12 +538,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Activ
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ActiveComponent)
-	for _, data := range rows {
-		msg := &storage.ActiveComponent{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ActiveComponent, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -583,22 +579,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ActiveComponent](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ActiveComponent
-	for _, data := range rows {
-		msg := &storage.ActiveComponent{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/alert/datastore/internal/store/postgres/bench_test.go
+++ b/central/alert/datastore/internal/store/postgres/bench_test.go
@@ -1,0 +1,50 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/testutils"
+)
+
+func BenchmarkGetMany(b *testing.B) {
+	var alerts []*storage.Alert
+	const alertsNum = 3000
+	for i := 0; i < alertsNum; i++ {
+		alert := &storage.Alert{}
+		err := testutils.FullInit(alert, testutils.UniqueInitializer(), testutils.JSONFieldsFilter)
+		if err != nil {
+			b.Fatal(err)
+		}
+		alerts = append(alerts, alert)
+	}
+
+	var idx []string
+	for _, a := range alerts {
+		idx = append(idx, a.Id)
+	}
+
+	testDB := pgtest.ForT(b)
+	store := New(testDB.Pool)
+
+	ctx := sac.WithAllAccess(context.Background())
+	err := store.UpsertMany(ctx, alerts)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for n := 1; n < alertsNum; n = n * 2 {
+		b.Run(fmt.Sprintf("%d alerts", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _, err := store.GetMany(ctx, idx[:n])
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -588,7 +588,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Alert
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Alert](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -599,12 +599,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Alert
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Alert)
-	for _, data := range rows {
-		msg := &storage.Alert{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Alert, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -644,22 +640,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Alert](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.Alert
-	for _, data := range rows {
-		msg := &storage.Alert{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -391,7 +391,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Token
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TokenMetadata](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -402,12 +402,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Token
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TokenMetadata)
-	for _, data := range rows {
-		msg := &storage.TokenMetadata{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TokenMetadata, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -407,7 +407,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.AuthP
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.AuthProvider](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -418,12 +418,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.AuthP
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.AuthProvider)
-	for _, data := range rows {
-		msg := &storage.AuthProvider{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.AuthProvider, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -347,7 +347,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Cluster](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -358,12 +358,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Cluster)
-	for _, data := range rows {
-		msg := &storage.Cluster{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Cluster, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -403,22 +399,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Cluster](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.Cluster
-	for _, data := range rows {
-		msg := &storage.Cluster{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -462,7 +462,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ClusterHealthStatus](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -473,12 +473,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ClusterHealthStatus)
-	for _, data := range rows {
-		msg := &storage.ClusterHealthStatus{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ClusterHealthStatus, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -518,22 +514,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ClusterHealthStatus](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ClusterHealthStatus
-	for _, data := range rows {
-		msg := &storage.ClusterHealthStatus{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/clustercveedge/datastore/store/postgres/store.go
+++ b/central/clustercveedge/datastore/store/postgres/store.go
@@ -212,7 +212,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ClusterCVEEdge](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -223,12 +223,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ClusterCVEEdge)
-	for _, data := range rows {
-		msg := &storage.ClusterCVEEdge{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ClusterCVEEdge, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -268,22 +264,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ClusterCVEEdge](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ClusterCVEEdge
-	for _, data := range rows {
-		msg := &storage.ClusterCVEEdge{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -387,7 +387,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.InitB
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.InitBundleMeta](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -398,12 +398,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.InitB
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.InitBundleMeta)
-	for _, data := range rows {
-		msg := &storage.InitBundleMeta{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.InitBundleMeta, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -432,7 +432,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceDomain](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -443,12 +443,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceDomain)
-	for _, data := range rows {
-		msg := &storage.ComplianceDomain{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceDomain, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -488,22 +484,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceDomain](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ComplianceDomain
-	for _, data := range rows {
-		msg := &storage.ComplianceDomain{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -458,7 +458,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceRunMetadata](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -469,12 +469,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceRunMetadata)
-	for _, data := range rows {
-		msg := &storage.ComplianceRunMetadata{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceRunMetadata, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetRunId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -514,22 +510,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceRunMetadata](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ComplianceRunMetadata
-	for _, data := range rows {
-		msg := &storage.ComplianceRunMetadata{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -431,7 +431,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceStrings](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -442,12 +442,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceStrings)
-	for _, data := range rows {
-		msg := &storage.ComplianceStrings{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceStrings, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -391,7 +391,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceOperatorCheckResult](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -402,12 +402,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceOperatorCheckResult)
-	for _, data := range rows {
-		msg := &storage.ComplianceOperatorCheckResult{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceOperatorCheckResult, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -391,7 +391,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceOperatorProfile](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -402,12 +402,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceOperatorProfile)
-	for _, data := range rows {
-		msg := &storage.ComplianceOperatorProfile{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceOperatorProfile, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -391,7 +391,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceOperatorRule](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -402,12 +402,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceOperatorRule)
-	for _, data := range rows {
-		msg := &storage.ComplianceOperatorRule{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceOperatorRule, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -391,7 +391,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceOperatorScan](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -402,12 +402,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceOperatorScan)
-	for _, data := range rows {
-		msg := &storage.ComplianceOperatorScan{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceOperatorScan, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -391,7 +391,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceOperatorScanSettingBinding](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -402,12 +402,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceOperatorScanSettingBinding)
-	for _, data := range rows {
-		msg := &storage.ComplianceOperatorScanSettingBinding{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceOperatorScanSettingBinding, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/componentcveedge/datastore/store/postgres/store.go
+++ b/central/componentcveedge/datastore/store/postgres/store.go
@@ -212,7 +212,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComponentCVEEdge](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -223,12 +223,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComponentCVEEdge)
-	for _, data := range rows {
-		msg := &storage.ComponentCVEEdge{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComponentCVEEdge, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -268,22 +264,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComponentCVEEdge](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ComponentCVEEdge
-	for _, data := range rows {
-		msg := &storage.ComponentCVEEdge{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/cve/cluster/datastore/store/postgres/full_store.go
+++ b/central/cve/cluster/datastore/store/postgres/full_store.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	protoTypes "github.com/gogo/protobuf/types"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -273,7 +272,7 @@ func getCVEs(ctx context.Context, tx pgx.Tx, cveIDs []string) (map[string]*stora
 			return nil, err
 		}
 		msg := &storage.ClusterCVE{}
-		if err := proto.Unmarshal(data, msg); err != nil {
+		if err := msg.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		idToCVEMap[msg.GetId()] = msg

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -477,7 +477,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ClusterCVE](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -488,12 +488,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ClusterCVE)
-	for _, data := range rows {
-		msg := &storage.ClusterCVE{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ClusterCVE, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -533,22 +529,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ClusterCVE](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ClusterCVE
-	for _, data := range rows {
-		msg := &storage.ClusterCVE{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -477,7 +477,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ImageCVE](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -488,12 +488,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ImageCVE)
-	for _, data := range rows {
-		msg := &storage.ImageCVE{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ImageCVE, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -533,22 +529,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ImageCVE](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ImageCVE
-	for _, data := range rows {
-		msg := &storage.ImageCVE{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -477,7 +477,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NodeCVE](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -488,12 +488,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NodeCVE)
-	for _, data := range rows {
-		msg := &storage.NodeCVE{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NodeCVE, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -533,22 +529,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NodeCVE](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.NodeCVE
-	for _, data := range rows {
-		msg := &storage.NodeCVE{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -1132,7 +1132,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Deplo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Deployment](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -1143,12 +1143,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Deplo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Deployment)
-	for _, data := range rows {
-		msg := &storage.Deployment{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Deployment, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -1188,22 +1184,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Deployment](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.Deployment
-	for _, data := range rows {
-		msg := &storage.Deployment{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -402,7 +402,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Exter
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ExternalBackup](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -413,12 +413,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Exter
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ExternalBackup)
-	for _, data := range rows {
-		msg := &storage.ExternalBackup{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ExternalBackup, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -402,7 +402,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Group
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Group](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -413,12 +413,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Group
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Group)
-	for _, data := range rows {
-		msg := &storage.Group{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Group, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetProps().GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/image/datastore/store/postgres/store.go
+++ b/central/image/datastore/store/postgres/store.go
@@ -1124,7 +1124,7 @@ func (s *storeImpl) retryableGetManyImageMetadata(ctx context.Context, ids []str
 		search.NewQueryBuilder().AddExactMatches(search.ImageSHA, ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Image](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -1135,12 +1135,8 @@ func (s *storeImpl) retryableGetManyImageMetadata(ctx context.Context, ids []str
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Image)
-	for _, data := range rows {
-		msg := &storage.Image{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Image, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -467,7 +467,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ImageComponent](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -478,12 +478,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ImageComponent)
-	for _, data := range rows {
-		msg := &storage.ImageComponent{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ImageComponent, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -523,22 +519,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ImageComponent](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ImageComponent
-	for _, data := range rows {
-		msg := &storage.ImageComponent{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -212,7 +212,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ImageComponentEdge](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -223,12 +223,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ImageComponentEdge)
-	for _, data := range rows {
-		msg := &storage.ImageComponentEdge{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ImageComponentEdge, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -268,22 +264,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ImageComponentEdge](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ImageComponentEdge
-	for _, data := range rows {
-		msg := &storage.ImageComponentEdge{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/imagecveedge/datastore/postgres/store.go
+++ b/central/imagecveedge/datastore/postgres/store.go
@@ -212,7 +212,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ImageCVEEdge](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -223,12 +223,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ImageCVEEdge)
-	for _, data := range rows {
-		msg := &storage.ImageCVEEdge{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ImageCVEEdge, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -268,22 +264,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ImageCVEEdge](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ImageCVEEdge
-	for _, data := range rows {
-		msg := &storage.ImageCVEEdge{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -413,7 +413,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ImageIntegration](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -424,12 +424,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ImageIntegration)
-	for _, data := range rows {
-		msg := &storage.ImageIntegration{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ImageIntegration, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -461,22 +457,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ImageIntegration](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ImageIntegration
-	for _, data := range rows {
-		msg := &storage.ImageIntegration{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -387,7 +387,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Integ
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.IntegrationHealth](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -398,12 +398,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Integ
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.IntegrationHealth)
-	for _, data := range rows {
-		msg := &storage.IntegrationHealth{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.IntegrationHealth, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -402,7 +402,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.LogIm
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.LogImbue](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -413,12 +413,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.LogIm
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.LogImbue)
-	for _, data := range rows {
-		msg := &storage.LogImbue{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.LogImbue, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -468,7 +468,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Names
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NamespaceMetadata](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -479,12 +479,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Names
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NamespaceMetadata)
-	for _, data := range rows {
-		msg := &storage.NamespaceMetadata{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NamespaceMetadata, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -524,22 +520,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NamespaceMetadata](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.NamespaceMetadata
-	for _, data := range rows {
-		msg := &storage.NamespaceMetadata{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -453,7 +453,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkBaseline](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -464,12 +464,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NetworkBaseline)
-	for _, data := range rows {
-		msg := &storage.NetworkBaseline{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NetworkBaseline, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetDeploymentId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -509,22 +505,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkBaseline](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.NetworkBaseline
-	for _, data := range rows {
-		msg := &storage.NetworkBaseline{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -391,7 +391,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkGraphConfig](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -402,12 +402,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NetworkGraphConfig)
-	for _, data := range rows {
-		msg := &storage.NetworkGraphConfig{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NetworkGraphConfig, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -393,7 +393,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkEntity](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -404,12 +404,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NetworkEntity)
-	for _, data := range rows {
-		msg := &storage.NetworkEntity{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NetworkEntity, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetInfo().GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -441,22 +437,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkEntity](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.NetworkEntity
-	for _, data := range rows {
-		msg := &storage.NetworkEntity{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -453,7 +453,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkPolicy](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -464,12 +464,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NetworkPolicy)
-	for _, data := range rows {
-		msg := &storage.NetworkPolicy{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NetworkPolicy, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -509,22 +505,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkPolicy](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.NetworkPolicy
-	for _, data := range rows {
-		msg := &storage.NetworkPolicy{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -431,7 +431,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkPolicyApplicationUndoDeploymentRecord](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -442,12 +442,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NetworkPolicyApplicationUndoDeploymentRecord)
-	for _, data := range rows {
-		msg := &storage.NetworkPolicyApplicationUndoDeploymentRecord{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NetworkPolicyApplicationUndoDeploymentRecord, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetDeploymentId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -431,7 +431,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkPolicyApplicationUndoRecord](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -442,12 +442,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NetworkPolicyApplicationUndoRecord)
-	for _, data := range rows {
-		msg := &storage.NetworkPolicyApplicationUndoRecord{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NetworkPolicyApplicationUndoRecord, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetClusterId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -462,7 +462,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NodeComponent](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -473,12 +473,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NodeComponent)
-	for _, data := range rows {
-		msg := &storage.NodeComponent{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NodeComponent, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -518,22 +514,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NodeComponent](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.NodeComponent
-	for _, data := range rows {
-		msg := &storage.NodeComponent{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/nodecomponentcveedge/datastore/store/postgres/store.go
+++ b/central/nodecomponentcveedge/datastore/store/postgres/store.go
@@ -212,7 +212,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NodeComponentCVEEdge](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -223,12 +223,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NodeComponentCVEEdge)
-	for _, data := range rows {
-		msg := &storage.NodeComponentCVEEdge{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NodeComponentCVEEdge, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -268,22 +264,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NodeComponentCVEEdge](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.NodeComponentCVEEdge
-	for _, data := range rows {
-		msg := &storage.NodeComponentCVEEdge{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -212,7 +212,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NodeComponentEdge](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -223,12 +223,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NodeComponentEdge)
-	for _, data := range rows {
-		msg := &storage.NodeComponentEdge{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NodeComponentEdge, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -268,22 +264,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NodeComponentEdge](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.NodeComponentEdge
-	for _, data := range rows {
-		msg := &storage.NodeComponentEdge{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -407,7 +407,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Notif
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Notifier](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -418,12 +418,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Notif
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Notifier)
-	for _, data := range rows {
-		msg := &storage.Notifier{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Notifier, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -543,7 +543,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Pod, 
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Pod](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -554,12 +554,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Pod, 
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Pod)
-	for _, data := range rows {
-		msg := &storage.Pod{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Pod, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -599,22 +595,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Pod](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.Pod
-	for _, data := range rows {
-		msg := &storage.Pod{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -458,7 +458,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Polic
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Policy](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -469,12 +469,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Polic
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Policy)
-	for _, data := range rows {
-		msg := &storage.Policy{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Policy, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -506,22 +502,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Policy](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.Policy
-	for _, data := range rows {
-		msg := &storage.Policy{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -397,7 +397,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Polic
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.PolicyCategory](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -408,12 +408,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Polic
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.PolicyCategory)
-	for _, data := range rows {
-		msg := &storage.PolicyCategory{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.PolicyCategory, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -445,22 +441,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.PolicyCategory](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.PolicyCategory
-	for _, data := range rows {
-		msg := &storage.PolicyCategory{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -458,7 +458,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ProcessBaseline](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -469,12 +469,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ProcessBaseline)
-	for _, data := range rows {
-		msg := &storage.ProcessBaseline{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ProcessBaseline, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -514,22 +510,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ProcessBaseline](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ProcessBaseline
-	for _, data := range rows {
-		msg := &storage.ProcessBaseline{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -453,7 +453,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ProcessBaselineResults](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -464,12 +464,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ProcessBaselineResults)
-	for _, data := range rows {
-		msg := &storage.ProcessBaselineResults{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ProcessBaselineResults, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetDeploymentId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -509,22 +505,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ProcessBaselineResults](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ProcessBaselineResults
-	for _, data := range rows {
-		msg := &storage.ProcessBaselineResults{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -498,7 +498,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ProcessIndicator](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -509,12 +509,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ProcessIndicator)
-	for _, data := range rows {
-		msg := &storage.ProcessIndicator{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ProcessIndicator, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -554,22 +550,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ProcessIndicator](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ProcessIndicator
-	for _, data := range rows {
-		msg := &storage.ProcessIndicator{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -478,7 +478,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.K8SRole](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -489,12 +489,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.K8SRole)
-	for _, data := range rows {
-		msg := &storage.K8SRole{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.K8SRole, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -534,22 +530,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.K8SRole](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.K8SRole
-	for _, data := range rows {
-		msg := &storage.K8SRole{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -568,7 +568,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.K8SRoleBinding](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -579,12 +579,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.K8SRoleBinding)
-	for _, data := range rows {
-		msg := &storage.K8SRoleBinding{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.K8SRoleBinding, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -624,22 +620,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.K8SRoleBinding](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.K8SRoleBinding
-	for _, data := range rows {
-		msg := &storage.K8SRoleBinding{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -402,7 +402,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Repor
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ReportConfiguration](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -413,12 +413,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Repor
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ReportConfiguration)
-	for _, data := range rows {
-		msg := &storage.ReportConfiguration{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ReportConfiguration, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -450,22 +446,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ReportConfiguration](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ReportConfiguration
-	for _, data := range rows {
-		msg := &storage.ReportConfiguration{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -487,7 +487,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Resou
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ResourceCollection](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -498,12 +498,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Resou
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ResourceCollection)
-	for _, data := range rows {
-		msg := &storage.ResourceCollection{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ResourceCollection, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -535,22 +531,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ResourceCollection](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ResourceCollection
-	for _, data := range rows {
-		msg := &storage.ResourceCollection{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -463,7 +463,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Risk,
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Risk](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -474,12 +474,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Risk,
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Risk)
-	for _, data := range rows {
-		msg := &storage.Risk{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Risk, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -519,22 +515,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Risk](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.Risk
-	for _, data := range rows {
-		msg := &storage.Risk{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -396,7 +396,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Permi
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.PermissionSet](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -407,12 +407,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Permi
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.PermissionSet)
-	for _, data := range rows {
-		msg := &storage.PermissionSet{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.PermissionSet, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -391,7 +391,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Role,
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Role](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -402,12 +402,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Role,
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Role)
-	for _, data := range rows {
-		msg := &storage.Role{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Role, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetName()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -638,7 +638,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Secre
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Secret](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -649,12 +649,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Secre
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Secret)
-	for _, data := range rows {
-		msg := &storage.Secret{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Secret, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -694,22 +690,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Secret](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.Secret
-	for _, data := range rows {
-		msg := &storage.Secret{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -473,7 +473,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Servi
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ServiceAccount](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -484,12 +484,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Servi
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ServiceAccount)
-	for _, data := range rows {
-		msg := &storage.ServiceAccount{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ServiceAccount, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -529,22 +525,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ServiceAccount](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ServiceAccount
-	for _, data := range rows {
-		msg := &storage.ServiceAccount{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -402,7 +402,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Servi
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ServiceIdentity](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -413,12 +413,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Servi
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ServiceIdentity)
-	for _, data := range rows {
-		msg := &storage.ServiceIdentity{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ServiceIdentity, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetSerialStr()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -396,7 +396,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Signa
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.SignatureIntegration](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -407,12 +407,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Signa
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.SignatureIntegration)
-	for _, data := range rows {
-		msg := &storage.SignatureIntegration{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.SignatureIntegration, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/central/version/postgres/store.go
+++ b/central/version/postgres/store.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/generated/storage"
@@ -128,7 +127,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.Version, bool, e
 	}
 
 	var msg storage.Version
-	if err := proto.Unmarshal(data, &msg); err != nil {
+	if err := msg.Unmarshal(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -586,7 +586,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Vulne
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.VulnerabilityRequest](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -597,12 +597,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Vulne
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.VulnerabilityRequest)
-	for _, data := range rows {
-		msg := &storage.VulnerabilityRequest{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.VulnerabilityRequest, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -634,22 +630,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.VulnerabilityRequest](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.VulnerabilityRequest
-	for _, data := range rows {
-		msg := &storage.VulnerabilityRequest{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -391,7 +391,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Watch
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.WatchedImage](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -402,12 +402,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Watch
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.WatchedImage)
-	for _, data := range rows {
-		msg := &storage.WatchedImage{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.WatchedImage, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetName()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
@@ -239,7 +239,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Cluster](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -250,12 +250,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Cluster)
-	for _, data := range rows {
-		msg := &storage.Cluster{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Cluster, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -281,22 +277,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Cluster](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.Cluster
-	for _, data := range rows {
-		msg := &storage.Cluster{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
@@ -360,7 +360,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Names
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NamespaceMetadata](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -371,12 +371,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Names
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NamespaceMetadata)
-	for _, data := range rows {
-		msg := &storage.NamespaceMetadata{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NamespaceMetadata, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -402,22 +398,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NamespaceMetadata](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.NamespaceMetadata
-	for _, data := range rows {
-		msg := &storage.NamespaceMetadata{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
@@ -1024,7 +1024,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Deplo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Deployment](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -1035,12 +1035,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Deplo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Deployment)
-	for _, data := range rows {
-		msg := &storage.Deployment{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Deployment, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -1066,22 +1062,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Deployment](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.Deployment
-	for _, data := range rows {
-		msg := &storage.Deployment{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
@@ -480,7 +480,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Alert
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Alert](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -491,12 +491,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Alert
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Alert)
-	for _, data := range rows {
-		msg := &storage.Alert{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Alert, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -522,22 +518,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Alert](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.Alert
-	for _, data := range rows {
-		msg := &storage.Alert{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
@@ -334,7 +334,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Token
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TokenMetadata](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -345,12 +345,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Token
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TokenMetadata)
-	for _, data := range rows {
-		msg := &storage.TokenMetadata{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TokenMetadata, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
@@ -349,7 +349,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.AuthP
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.AuthProvider](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -360,12 +360,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.AuthP
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.AuthProvider)
-	for _, data := range rows {
-		msg := &storage.AuthProvider{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.AuthProvider, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_09_to_n_10_postgres_cluster_cves/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_09_to_n_10_postgres_cluster_cves/postgres/postgres_plugin.go
@@ -365,7 +365,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ClusterCVE](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -376,12 +376,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ClusterCVE)
-	for _, data := range rows {
-		msg := &storage.ClusterCVE{}
-		if err := proto.Unmarshal(data, msg); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ClusterCVE, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
@@ -365,7 +365,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ClusterHealthStatus](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -376,12 +376,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ClusterHealthStatus)
-	for _, data := range rows {
-		msg := &storage.ClusterHealthStatus{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ClusterHealthStatus, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -407,22 +403,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ClusterHealthStatus](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ClusterHealthStatus
-	for _, data := range rows {
-		msg := &storage.ClusterHealthStatus{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
@@ -334,7 +334,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.InitB
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.InitBundleMeta](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -345,12 +345,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.InitB
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.InitBundleMeta)
-	for _, data := range rows {
-		msg := &storage.InitBundleMeta{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.InitBundleMeta, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
@@ -335,7 +335,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceDomain](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -346,12 +346,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceDomain)
-	for _, data := range rows {
-		msg := &storage.ComplianceDomain{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceDomain, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -377,22 +373,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceDomain](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ComplianceDomain
-	for _, data := range rows {
-		msg := &storage.ComplianceDomain{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
@@ -334,7 +334,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceOperatorCheckResult](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -345,12 +345,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceOperatorCheckResult)
-	for _, data := range rows {
-		msg := &storage.ComplianceOperatorCheckResult{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceOperatorCheckResult, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
@@ -334,7 +334,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceOperatorProfile](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -345,12 +345,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceOperatorProfile)
-	for _, data := range rows {
-		msg := &storage.ComplianceOperatorProfile{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceOperatorProfile, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
@@ -334,7 +334,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceOperatorRule](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -345,12 +345,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceOperatorRule)
-	for _, data := range rows {
-		msg := &storage.ComplianceOperatorRule{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceOperatorRule, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
@@ -334,7 +334,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceOperatorScanSettingBinding](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -345,12 +345,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceOperatorScanSettingBinding)
-	for _, data := range rows {
-		msg := &storage.ComplianceOperatorScanSettingBinding{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceOperatorScanSettingBinding, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
@@ -334,7 +334,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceOperatorScan](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -345,12 +345,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceOperatorScan)
-	for _, data := range rows {
-		msg := &storage.ComplianceOperatorScan{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceOperatorScan, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
@@ -350,7 +350,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceRunMetadata](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -361,12 +361,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceRunMetadata)
-	for _, data := range rows {
-		msg := &storage.ComplianceRunMetadata{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceRunMetadata, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetRunId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -392,22 +388,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceRunMetadata](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ComplianceRunMetadata
-	for _, data := range rows {
-		msg := &storage.ComplianceRunMetadata{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
@@ -350,7 +350,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceRunResults](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -361,12 +361,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceRunResults)
-	for _, data := range rows {
-		msg := &storage.ComplianceRunResults{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceRunResults, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetRunMetadata().GetRunId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -392,22 +388,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceRunResults](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ComplianceRunResults
-	for _, data := range rows {
-		msg := &storage.ComplianceRunResults{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
@@ -334,7 +334,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ComplianceStrings](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -345,12 +345,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ComplianceStrings)
-	for _, data := range rows {
-		msg := &storage.ComplianceStrings{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ComplianceStrings, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
@@ -344,7 +344,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Exter
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ExternalBackup](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -355,12 +355,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Exter
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ExternalBackup)
-	for _, data := range rows {
-		msg := &storage.ExternalBackup{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ExternalBackup, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
@@ -355,7 +355,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ImageIntegration](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -366,12 +366,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ImageIntegration)
-	for _, data := range rows {
-		msg := &storage.ImageIntegration{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ImageIntegration, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -397,22 +393,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ImageIntegration](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ImageIntegration
-	for _, data := range rows {
-		msg := &storage.ImageIntegration{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
@@ -334,7 +334,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Integ
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.IntegrationHealth](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -345,12 +345,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Integ
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.IntegrationHealth)
-	for _, data := range rows {
-		msg := &storage.IntegrationHealth{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.IntegrationHealth, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
@@ -370,7 +370,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.K8SRole](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -381,12 +381,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.K8SRole)
-	for _, data := range rows {
-		msg := &storage.K8SRole{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.K8SRole, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -412,22 +408,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.K8SRole](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.K8SRole
-	for _, data := range rows {
-		msg := &storage.K8SRole{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_27_to_n_28_postgres_log_imbues/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_27_to_n_28_postgres_log_imbues/postgres/postgres_plugin.go
@@ -328,7 +328,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.LogIm
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.LogImbue](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -339,12 +339,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.LogIm
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.LogImbue)
-	for _, data := range rows {
-		msg := &storage.LogImbue{}
-		if err := proto.Unmarshal(data, msg); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.LogImbue, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
@@ -345,7 +345,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkBaseline](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -356,12 +356,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NetworkBaseline)
-	for _, data := range rows {
-		msg := &storage.NetworkBaseline{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NetworkBaseline, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetDeploymentId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -387,22 +383,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkBaseline](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.NetworkBaseline
-	for _, data := range rows {
-		msg := &storage.NetworkBaseline{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
@@ -340,7 +340,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkEntity](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -351,12 +351,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NetworkEntity)
-	for _, data := range rows {
-		msg := &storage.NetworkEntity{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NetworkEntity, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetInfo().GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -382,22 +378,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkEntity](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.NetworkEntity
-	for _, data := range rows {
-		msg := &storage.NetworkEntity{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
@@ -334,7 +334,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkGraphConfig](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -345,12 +345,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NetworkGraphConfig)
-	for _, data := range rows {
-		msg := &storage.NetworkGraphConfig{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NetworkGraphConfig, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
@@ -345,7 +345,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkPolicy](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -356,12 +356,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NetworkPolicy)
-	for _, data := range rows {
-		msg := &storage.NetworkPolicy{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NetworkPolicy, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -387,22 +383,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkPolicy](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.NetworkPolicy
-	for _, data := range rows {
-		msg := &storage.NetworkPolicy{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
@@ -334,7 +334,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkPolicyApplicationUndoDeploymentRecord](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -345,12 +345,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NetworkPolicyApplicationUndoDeploymentRecord)
-	for _, data := range rows {
-		msg := &storage.NetworkPolicyApplicationUndoDeploymentRecord{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NetworkPolicyApplicationUndoDeploymentRecord, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetDeploymentId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
@@ -334,7 +334,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.NetworkPolicyApplicationUndoRecord](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -345,12 +345,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.NetworkPolicyApplicationUndoRecord)
-	for _, data := range rows {
-		msg := &storage.NetworkPolicyApplicationUndoRecord{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.NetworkPolicyApplicationUndoRecord, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetClusterId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
@@ -349,7 +349,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Notif
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Notifier](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -360,12 +360,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Notif
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Notifier)
-	for _, data := range rows {
-		msg := &storage.Notifier{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Notifier, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
@@ -339,7 +339,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Permi
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.PermissionSet](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -350,12 +350,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Permi
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.PermissionSet)
-	for _, data := range rows {
-		msg := &storage.PermissionSet{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.PermissionSet, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
@@ -400,7 +400,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Polic
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Policy](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -411,12 +411,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Polic
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Policy)
-	for _, data := range rows {
-		msg := &storage.Policy{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Policy, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -442,22 +438,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Policy](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.Policy
-	for _, data := range rows {
-		msg := &storage.Policy{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
@@ -345,7 +345,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ProcessBaselineResults](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -356,12 +356,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ProcessBaselineResults)
-	for _, data := range rows {
-		msg := &storage.ProcessBaselineResults{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ProcessBaselineResults, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetDeploymentId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -387,22 +383,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ProcessBaselineResults](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ProcessBaselineResults
-	for _, data := range rows {
-		msg := &storage.ProcessBaselineResults{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
@@ -350,7 +350,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ProcessBaseline](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -361,12 +361,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ProcessBaseline)
-	for _, data := range rows {
-		msg := &storage.ProcessBaseline{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ProcessBaseline, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -392,22 +388,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ProcessBaseline](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ProcessBaseline
-	for _, data := range rows {
-		msg := &storage.ProcessBaseline{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
@@ -390,7 +390,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ProcessIndicator](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -401,12 +401,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ProcessIndicator)
-	for _, data := range rows {
-		msg := &storage.ProcessIndicator{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ProcessIndicator, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -432,22 +428,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ProcessIndicator](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ProcessIndicator
-	for _, data := range rows {
-		msg := &storage.ProcessIndicator{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
@@ -345,7 +345,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Repor
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ReportConfiguration](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -356,12 +356,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Repor
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ReportConfiguration)
-	for _, data := range rows {
-		msg := &storage.ReportConfiguration{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ReportConfiguration, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -387,22 +383,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ReportConfiguration](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ReportConfiguration
-	for _, data := range rows {
-		msg := &storage.ReportConfiguration{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
@@ -355,7 +355,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Risk,
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Risk](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -366,12 +366,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Risk,
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Risk)
-	for _, data := range rows {
-		msg := &storage.Risk{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Risk, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -397,22 +393,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Risk](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.Risk
-	for _, data := range rows {
-		msg := &storage.Risk{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
@@ -460,7 +460,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.K8SRoleBinding](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -471,12 +471,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.K8SRoleBinding)
-	for _, data := range rows {
-		msg := &storage.K8SRoleBinding{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.K8SRoleBinding, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -502,22 +498,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.K8SRoleBinding](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.K8SRoleBinding
-	for _, data := range rows {
-		msg := &storage.K8SRoleBinding{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
@@ -334,7 +334,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Role,
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Role](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -345,12 +345,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Role,
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Role)
-	for _, data := range rows {
-		msg := &storage.Role{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Role, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetName()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
@@ -530,7 +530,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Secre
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Secret](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -541,12 +541,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Secre
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Secret)
-	for _, data := range rows {
-		msg := &storage.Secret{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Secret, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -572,22 +568,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Secret](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.Secret
-	for _, data := range rows {
-		msg := &storage.Secret{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
@@ -365,7 +365,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Servi
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ServiceAccount](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -376,12 +376,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Servi
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.ServiceAccount)
-	for _, data := range rows {
-		msg := &storage.ServiceAccount{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.ServiceAccount, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -407,22 +403,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.ServiceAccount](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.ServiceAccount
-	for _, data := range rows {
-		msg := &storage.ServiceAccount{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
@@ -339,7 +339,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Signa
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.SignatureIntegration](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -350,12 +350,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Signa
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.SignatureIntegration)
-	for _, data := range rows {
-		msg := &storage.SignatureIntegration{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.SignatureIntegration, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
@@ -339,7 +339,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Simpl
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.SimpleAccessScope](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -350,12 +350,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Simpl
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.SimpleAccessScope)
-	for _, data := range rows {
-		msg := &storage.SimpleAccessScope{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.SimpleAccessScope, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
@@ -533,7 +533,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Vulne
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.VulnerabilityRequest](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -544,12 +544,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Vulne
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.VulnerabilityRequest)
-	for _, data := range rows {
-		msg := &storage.VulnerabilityRequest{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.VulnerabilityRequest, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -575,22 +571,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.VulnerabilityRequest](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.VulnerabilityRequest
-	for _, data := range rows {
-		msg := &storage.VulnerabilityRequest{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
@@ -334,7 +334,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Watch
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.WatchedImage](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -345,12 +345,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Watch
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.WatchedImage)
-	for _, data := range rows {
-		msg := &storage.WatchedImage{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.WatchedImage, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetName()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
@@ -340,7 +340,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Polic
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.PolicyCategory](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -351,12 +351,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Polic
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.PolicyCategory)
-	for _, data := range rows {
-		msg := &storage.PolicyCategory{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.PolicyCategory, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -382,22 +378,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.PolicyCategory](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.PolicyCategory
-	for _, data := range rows {
-		msg := &storage.PolicyCategory{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
@@ -344,7 +344,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Group
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.Group](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -355,12 +355,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Group
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.Group)
-	for _, data := range rows {
-		msg := &storage.Group{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.Group, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetProps().GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -853,7 +853,7 @@ func scanRows[T any, PT unmarshaler[T]](rows pgx.Rows) ([]*T, error) {
 		if err != nil {
 			return nil, err
 		}
-		results = append(results, (*T)(msg))
+		results = append(results, msg)
 	}
 	return results, nil
 }

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -858,13 +858,13 @@ func scanRows[T any, PT unmarshaler[T]](rows pgx.Rows) ([]*T, error) {
 	return results, nil
 }
 
-func unmarshal[T any, PT unmarshaler[T]](row pgx.Row) (PT, error) {
+func unmarshal[T any, PT unmarshaler[T]](row pgx.Row) (*T, error) {
 	var data []byte
 	if err := row.Scan(&data); err != nil {
 		return nil, errors.Wrap(err, "scanning row")
 	}
-	msg := PT(new(T))
-	if err := msg.Unmarshal(data); err != nil {
+	msg := new(T)
+	if err := PT(msg).Unmarshal(data); err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling %T", msg)
 	}
 	return msg, nil

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
@@ -36,6 +37,7 @@ var (
 )
 
 // QueryType describe what type of query to execute
+//
 //go:generate stringer -type=QueryType
 type QueryType int
 
@@ -713,6 +715,11 @@ func RunCountRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1.
 	})
 }
 
+type unmarshaler[T any] interface {
+	proto.Unmarshaler
+	*T
+}
+
 // RunGetQueryForSchema executes a request for just the search against the database
 func RunGetQueryForSchema(ctx context.Context, schema *walker.Schema, q *v1.Query, db *pgxpool.Pool) ([]byte, error) {
 	query, err := standardizeQueryAndPopulatePath(q, schema, GET)
@@ -734,7 +741,7 @@ func RunGetQueryForSchema(ctx context.Context, schema *walker.Schema, q *v1.Quer
 	})
 }
 
-func retryableRunGetManyQueryForSchema(ctx context.Context, query *query, db *pgxpool.Pool) ([][]byte, error) {
+func retryableRunGetManyQueryForSchema[T any, PT unmarshaler[T]](ctx context.Context, query *query, db *pgxpool.Pool) ([]*T, error) {
 	queryStr := query.AsSQL()
 	rows, err := tracedQuery(ctx, db, queryStr, query.Data...)
 	if err != nil {
@@ -742,19 +749,11 @@ func retryableRunGetManyQueryForSchema(ctx context.Context, query *query, db *pg
 	}
 	defer rows.Close()
 
-	var results [][]byte
-	for rows.Next() {
-		var data []byte
-		if err := rows.Scan(&data); err != nil {
-			return nil, err
-		}
-		results = append(results, data)
-	}
-	return results, nil
+	return scanRows[T, PT](rows)
 }
 
-// RunGetManyQueryForSchema executes a request for just the search against the database
-func RunGetManyQueryForSchema(ctx context.Context, schema *walker.Schema, q *v1.Query, db *pgxpool.Pool) ([][]byte, error) {
+// RunGetManyQueryForSchema executes a request for just the search against the database and unmarshal it to given type.
+func RunGetManyQueryForSchema[T any, PT unmarshaler[T]](ctx context.Context, schema *walker.Schema, q *v1.Query, db *pgxpool.Pool) ([]*T, error) {
 	query, err := standardizeQueryAndPopulatePath(q, schema, GET)
 	if err != nil {
 		return nil, err
@@ -763,8 +762,8 @@ func RunGetManyQueryForSchema(ctx context.Context, schema *walker.Schema, q *v1.
 		return nil, emptyQueryErr
 	}
 
-	return pgutils.Retry2(func() ([][]byte, error) {
-		return retryableRunGetManyQueryForSchema(ctx, query, db)
+	return pgutils.Retry2(func() ([]*T, error) {
+		return retryableRunGetManyQueryForSchema[T, PT](ctx, query, db)
 	})
 }
 
@@ -845,4 +844,28 @@ func redactedQueryData(query *query) interface{} {
 	}
 	// Otherwise, allow the logging
 	return query.Data
+}
+
+func scanRows[T any, PT unmarshaler[T]](rows pgx.Rows) ([]*T, error) {
+	var results []*T
+	for rows.Next() {
+		msg, err := unmarshal[T, PT](rows)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, (*T)(msg))
+	}
+	return results, nil
+}
+
+func unmarshal[T any, PT unmarshaler[T]](row pgx.Row) (PT, error) {
+	var data []byte
+	if err := row.Scan(&data); err != nil {
+		return nil, errors.Wrap(err, "scanning row")
+	}
+	msg := PT(new(T))
+	if err := msg.Unmarshal(data); err != nil {
+		return nil, errors.Wrapf(err, "unmarshaling %T", msg)
+	}
+	return msg, nil
 }

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -601,7 +601,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestM
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestMultiKeyStruct](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -612,12 +612,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestM
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TestMultiKeyStruct)
-	for _, data := range rows {
-		msg := &storage.TestMultiKeyStruct{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TestMultiKeyStruct, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetKey1()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -657,22 +653,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestMultiKeyStruct](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.TestMultiKeyStruct
-	for _, data := range rows {
-		msg := &storage.TestMultiKeyStruct{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -777,7 +777,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []{{$singlePK.Type}}) ([]*{
         search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
     )
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[{{.Type}}](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -788,12 +788,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []{{$singlePK.Type}}) ([]*{
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[{{$singlePK.Type}}]*{{.Type}})
-    for _, data := range rows {
-		msg := &{{.Type}}{}
-		if err := msg.Unmarshal(data); err != nil {
-		    return nil, nil, err
-		}
+	resultsByID := make(map[{{$singlePK.Type}}]*{{.Type}}, len(rows))
+    for _, msg := range rows {
 		resultsByID[{{$singlePK.Getter "msg"}}] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -853,22 +849,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*{{.Type
         query,
     )
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[{{.Type}}](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 		    return nil, nil
 		}
 		return nil, err
 	}
-	var results []*{{.Type}}
-    for _, data := range rows {
-		msg := &{{.Type}}{}
-		if err := msg.Unmarshal(data); err != nil {
-		    return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 {{- end }}
 

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -493,7 +493,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestS
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestSingleKeyStruct](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -504,12 +504,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestS
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TestSingleKeyStruct)
-	for _, data := range rows {
-		msg := &storage.TestSingleKeyStruct{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TestSingleKeyStruct, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetKey()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -549,22 +545,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestSingleKeyStruct](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.TestSingleKeyStruct
-	for _, data := range rows {
-		msg := &storage.TestSingleKeyStruct{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -437,7 +437,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestC
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestChild1](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -448,12 +448,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestC
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TestChild1)
-	for _, data := range rows {
-		msg := &storage.TestChild1{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TestChild1, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -493,22 +489,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestChild1](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.TestChild1
-	for _, data := range rows {
-		msg := &storage.TestChild1{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -442,7 +442,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestC
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestChild1P4](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -453,12 +453,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestC
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TestChild1P4)
-	for _, data := range rows {
-		msg := &storage.TestChild1P4{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TestChild1P4, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -498,22 +494,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestChild1P4](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.TestChild1P4
-	for _, data := range rows {
-		msg := &storage.TestChild1P4{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -447,7 +447,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestC
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestChild2](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -458,12 +458,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestC
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TestChild2)
-	for _, data := range rows {
-		msg := &storage.TestChild2{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TestChild2, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -503,22 +499,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestChild2](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.TestChild2
-	for _, data := range rows {
-		msg := &storage.TestChild2{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -447,7 +447,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestG2GrandChild1](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -458,12 +458,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TestG2GrandChild1)
-	for _, data := range rows {
-		msg := &storage.TestG2GrandChild1{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TestG2GrandChild1, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -503,22 +499,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestG2GrandChild1](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.TestG2GrandChild1
-	for _, data := range rows {
-		msg := &storage.TestG2GrandChild1{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -437,7 +437,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestG3GrandChild1](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -448,12 +448,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TestG3GrandChild1)
-	for _, data := range rows {
-		msg := &storage.TestG3GrandChild1{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TestG3GrandChild1, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -493,22 +489,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestG3GrandChild1](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.TestG3GrandChild1
-	for _, data := range rows {
-		msg := &storage.TestG3GrandChild1{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -437,7 +437,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestGGrandChild1](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -448,12 +448,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TestGGrandChild1)
-	for _, data := range rows {
-		msg := &storage.TestGGrandChild1{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TestGGrandChild1, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -493,22 +489,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestGGrandChild1](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.TestGGrandChild1
-	for _, data := range rows {
-		msg := &storage.TestGGrandChild1{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -447,7 +447,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestGrandChild1](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -458,12 +458,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TestGrandChild1)
-	for _, data := range rows {
-		msg := &storage.TestGrandChild1{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TestGrandChild1, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -503,22 +499,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestGrandChild1](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.TestGrandChild1
-	for _, data := range rows {
-		msg := &storage.TestGrandChild1{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -612,7 +612,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestGrandparent](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -623,12 +623,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TestGrandparent)
-	for _, data := range rows {
-		msg := &storage.TestGrandparent{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TestGrandparent, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -668,22 +664,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestGrandparent](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.TestGrandparent
-	for _, data := range rows {
-		msg := &storage.TestGrandparent{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -522,7 +522,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestParent1](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -533,12 +533,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TestParent1)
-	for _, data := range rows {
-		msg := &storage.TestParent1{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TestParent1, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -578,22 +574,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestParent1](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.TestParent1
-	for _, data := range rows {
-		msg := &storage.TestParent1{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -442,7 +442,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestParent2](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -453,12 +453,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TestParent2)
-	for _, data := range rows {
-		msg := &storage.TestParent2{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TestParent2, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -498,22 +494,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestParent2](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.TestParent2
-	for _, data := range rows {
-		msg := &storage.TestParent2{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -442,7 +442,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestParent3](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -453,12 +453,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TestParent3)
-	for _, data := range rows {
-		msg := &storage.TestParent3{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TestParent3, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -498,22 +494,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestParent3](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.TestParent3
-	for _, data := range rows {
-		msg := &storage.TestParent3{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -442,7 +442,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestParent4](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -453,12 +453,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TestParent4)
-	for _, data := range rows {
-		msg := &storage.TestParent4{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TestParent4, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -498,22 +494,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestParent4](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.TestParent4
-	for _, data := range rows {
-		msg := &storage.TestParent4{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -442,7 +442,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestS
 		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestShortCircuit](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			missingIndices := make([]int, 0, len(ids))
@@ -453,12 +453,8 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestS
 		}
 		return nil, nil, err
 	}
-	resultsByID := make(map[string]*storage.TestShortCircuit)
-	for _, data := range rows {
-		msg := &storage.TestShortCircuit{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, nil, err
-		}
+	resultsByID := make(map[string]*storage.TestShortCircuit, len(rows))
+	for _, msg := range rows {
 		resultsByID[msg.GetId()] = msg
 	}
 	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
@@ -498,22 +494,14 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 		query,
 	)
 
-	rows, err := postgres.RunGetManyQueryForSchema(ctx, schema, q, s.db)
+	rows, err := postgres.RunGetManyQueryForSchema[storage.TestShortCircuit](ctx, schema, q, s.db)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var results []*storage.TestShortCircuit
-	for _, data := range rows {
-		msg := &storage.TestShortCircuit{}
-		if err := msg.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, nil
+	return rows, nil
 }
 
 // Delete removes the specified IDs from the store


### PR DESCRIPTION
## Description

After switching to Go 1.18 we can use generics. This will allow us to not parse output from database to `[][]byte` and then unmarshal it to `[]storage.*` but immediately parse to `[]storage.*`. So no intermediate slice will be created and we can save up some memory and allocations. 

Below tests shows comparison with previous commit not master.

```
name                   old time/op    new time/op    delta
GetMany/1_alerts-8        161µs ±11%     157µs ± 4%     ~     (p=0.065 n=19+19)
GetMany/2_alerts-8        196µs ± 8%     196µs ± 4%     ~     (p=0.708 n=19+20)
GetMany/4_alerts-8        238µs ± 7%     237µs ± 5%     ~     (p=0.687 n=19+20)
GetMany/8_alerts-8        338µs ± 7%     310µs ± 8%   -8.16%  (p=0.000 n=19+17)
GetMany/16_alerts-8       559µs ± 4%     470µs ± 6%  -15.79%  (p=0.000 n=18+20)
GetMany/32_alerts-8      1.00ms ±14%    0.79ms ± 4%  -21.21%  (p=0.000 n=19+20)
GetMany/64_alerts-8      2.10ms ±14%    1.71ms ± 5%  -18.51%  (p=0.000 n=17+19)
GetMany/128_alerts-8     4.57ms ±62%    2.93ms ± 7%  -35.88%  (p=0.000 n=20+20)
GetMany/256_alerts-8     7.66ms ± 8%    5.28ms ± 5%  -30.99%  (p=0.000 n=19+20)
GetMany/512_alerts-8     14.2ms ± 9%    10.1ms ± 4%  -28.77%  (p=0.000 n=20+20)
GetMany/1024_alerts-8    27.2ms ±15%    19.1ms ± 4%  -29.99%  (p=0.000 n=19+18)
GetMany/2048_alerts-8    51.9ms ± 5%    37.4ms ± 4%  -27.95%  (p=0.000 n=18+19)

name                   old alloc/op   new alloc/op   delta
GetMany/1_alerts-8       10.4kB ± 0%    10.4kB ± 0%   -0.16%  (p=0.000 n=20+20)
GetMany/2_alerts-8       18.3kB ± 0%    18.3kB ± 0%   -0.39%  (p=0.000 n=20+20)
GetMany/4_alerts-8       34.1kB ± 0%    33.9kB ± 0%   -0.54%  (p=0.000 n=18+20)
GetMany/8_alerts-8       66.4kB ± 0%    66.0kB ± 0%   -0.61%  (p=0.000 n=20+20)
GetMany/16_alerts-8       132kB ± 0%     130kB ± 0%   -1.01%  (p=0.000 n=20+20)
GetMany/32_alerts-8       263kB ± 0%     260kB ± 0%   -1.24%  (p=0.000 n=19+20)
GetMany/64_alerts-8       526kB ± 0%     519kB ± 0%   -1.37%  (p=0.000 n=20+20)
GetMany/128_alerts-8     1.05MB ± 0%    1.04MB ± 0%   -1.43%  (p=0.000 n=20+20)
GetMany/256_alerts-8     2.11MB ± 0%    2.08MB ± 0%   -1.44%  (p=0.000 n=20+19)
GetMany/512_alerts-8     4.21MB ± 0%    4.15MB ± 0%   -1.45%  (p=0.000 n=20+20)
GetMany/1024_alerts-8    8.49MB ± 0%    8.34MB ± 0%   -1.67%  (p=0.000 n=20+19)
GetMany/2048_alerts-8    16.9MB ± 0%    16.6MB ± 0%   -1.45%  (p=0.000 n=20+20)

name                   old allocs/op  new allocs/op  delta
GetMany/1_alerts-8          149 ± 0%       149 ± 0%     ~     (all equal)
GetMany/2_alerts-8          245 ± 0%       244 ± 0%   -0.41%  (p=0.000 n=20+20)
GetMany/4_alerts-8          437 ± 0%       434 ± 0%   -0.69%  (p=0.000 n=20+20)
GetMany/8_alerts-8          821 ± 0%       814 ± 0%   -0.85%  (p=0.000 n=20+20)
GetMany/16_alerts-8       1.59k ± 0%     1.57k ± 0%   -1.01%  (p=0.000 n=20+20)
GetMany/32_alerts-8       3.12k ± 0%     3.08k ± 0%   -1.08%  (p=0.000 n=20+18)
GetMany/64_alerts-8       6.18k ± 0%     6.11k ± 0%   -1.12%  (p=0.000 n=20+20)
GetMany/128_alerts-8      12.3k ± 0%     12.1k ± 0%   -1.09%  (p=0.000 n=20+20)
GetMany/256_alerts-8      24.5k ± 0%     24.2k ± 0%   -1.08%  (p=0.000 n=20+19)
GetMany/512_alerts-8      48.9k ± 0%     48.4k ± 0%   -1.08%  (p=0.000 n=20+19)
GetMany/1024_alerts-8     97.7k ± 0%     96.7k ± 0%   -1.08%  (p=0.000 n=19+20)
GetMany/2048_alerts-8      195k ± 0%      193k ± 0%   -1.08%  (p=0.000 n=20+15)

```

## Testing Performed

CI
