### PR TITLE
ROX-13126: Use mock response for both systemHealth vulnDefinitions integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/systemHealth.js
+++ b/ui/apps/platform/cypress/helpers/systemHealth.js
@@ -13,6 +13,8 @@ export function setClock(currentDatetime) {
 
 // visit
 
+export const integrationHealthVulnDefinitionsAlias = 'integrationhealth/vulndefinitions';
+
 const routeMatcherMap = {
     'integrationhealth/imageintegrations': {
         method: 'GET',
@@ -42,7 +44,7 @@ const routeMatcherMap = {
         method: 'GET',
         url: api.clusters.list,
     },
-    'integrationhealth/vulndefinitions': {
+    [integrationHealthVulnDefinitionsAlias]: {
         method: 'GET',
         url: api.integrationHealth.vulnDefinitions,
     },

--- a/ui/apps/platform/cypress/integration/systemHealth/vulnDefinitions.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/vulnDefinitions.test.js
@@ -1,14 +1,26 @@
 import { selectors } from '../../constants/SystemHealth';
 import withAuth from '../../helpers/basicAuth';
-import { setClock, visitSystemHealth } from '../../helpers/systemHealth';
+import {
+    integrationHealthVulnDefinitionsAlias,
+    setClock,
+    visitSystemHealth,
+} from '../../helpers/systemHealth';
 
 const nbsp = '\u00A0';
 
-describe('System Health Vulnerability Definitions without fixture', () => {
+describe('System Health Vulnerability Definitions', () => {
     withAuth();
 
     it('should have widget and up to date text', () => {
-        visitSystemHealth();
+        const currentDatetime = new Date('2020-12-10T02:04:59.377369440Z'); // exactly 23 hours after last updated
+        const lastUpdatedTimestamp = '2020-12-09T03:04:59.377369440Z';
+
+        const staticResponseMap = {
+            [integrationHealthVulnDefinitionsAlias]: { body: { lastUpdatedTimestamp } },
+        };
+
+        setClock(currentDatetime); // call before visit
+        visitSystemHealth(staticResponseMap);
 
         const { vulnDefinitions } = selectors;
         cy.get(vulnDefinitions.header).should('have.text', 'Vulnerability Definitions');
@@ -17,19 +29,17 @@ describe('System Health Vulnerability Definitions without fixture', () => {
             `Vulnerability definitions are up${nbsp}to${nbsp}date`
         );
     });
-});
-
-describe('System Health Vulnerability Definitions with fixture', () => {
-    withAuth();
 
     it('should have widget and out of date text and time', () => {
         const currentDatetime = new Date('2020-12-10T03:04:59.377369440Z'); // exactly 24 hours after last updated
         const lastUpdatedTimestamp = '2020-12-09T03:04:59.377369440Z';
 
+        const staticResponseMap = {
+            [integrationHealthVulnDefinitionsAlias]: { body: { lastUpdatedTimestamp } },
+        };
+
         setClock(currentDatetime); // call before visit
-        visitSystemHealth({
-            'integrationhealth/vulndefinitions': { body: { lastUpdatedTimestamp } },
-        });
+        visitSystemHealth(staticResponseMap);
 
         const { vulnDefinitions } = selectors;
         cy.get(vulnDefinitions.header).should('have.text', 'Vulnerability Definitions');


### PR DESCRIPTION
## Description

### Test failure

System Health Vulnerability Definitions without fixture should have widget and up to date text

> Timed out retrying after 4000ms: expected '<div.leading-normal.px-2.text-center>' to have text 'Vulnerability definitions are up to date', but the text was 'Vulnerability definitions are out of date'

![systemHealth-vulnDefinitions](https://user-images.githubusercontent.com/11862657/196245889-0f8faf6d-01e1-4d41-a40e-f3886116c3f6.png)

1. 1581053722954305536 from master build for 3287 on 2022-10-14
2. 1581991825684566016 from master build for 3420 on 2022-10-17
3. 1582000238493700096 from master build for 3407 on 2022-10-17
4. 1581099497335820288 from branch build for 3441 on 2022-10-17

### Analysis

This has been an intermittent failure in the past. We decided if it occurs again to implement the following solution.

### Solution

Use mock response for both **out of date** and **up to date** tests.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed