### PR TITLE
Write first draft of integration tests for collections table

### DIFF
--- a/ui/apps/platform/cypress/helpers/collections.js
+++ b/ui/apps/platform/cypress/helpers/collections.js
@@ -1,0 +1,42 @@
+import navSelectors from '../selectors/navigation';
+
+import { visitFromLeftNavExpandable } from './nav';
+import { visit } from './visit';
+
+// visit
+
+const basePath = '/main/collections';
+
+export const collectionsAlias = 'collections';
+export const collectionsCountAlias = 'collections/count';
+
+const routeConfigForCollections = {
+    routeMatcherMap: {
+        [collectionsAlias]: {
+            method: 'GET',
+            url: '/v1/collections',
+        },
+        [collectionsCountAlias]: {
+            method: 'GET',
+            url: '/v1/collections/count',
+        },
+    },
+};
+
+export function visitCollections(staticResponseMap) {
+    visit(basePath, routeConfigForCollections, staticResponseMap);
+
+    cy.get('h1:contains("Collections")');
+    cy.get(`${navSelectors.navExpandable}:contains("Platform Configuration")`);
+    cy.get(`${navSelectors.nestedNavLinks}:contains("Collections")`).should(
+        'have.class',
+        'pf-m-current'
+    );
+}
+
+export function visitCollectionsFromLeftNav() {
+    visitFromLeftNavExpandable('Platform Configuration', 'Collections', routeConfigForCollections);
+
+    cy.get('h1:contains("Collections")');
+    cy.location('pathname').should('eq', basePath);
+}

--- a/ui/apps/platform/cypress/integration/collections/collectionsTable.test.js
+++ b/ui/apps/platform/cypress/integration/collections/collectionsTable.test.js
@@ -1,0 +1,35 @@
+import withAuth from '../../helpers/basicAuth';
+import { visitCollections, visitCollectionsFromLeftNav } from '../../helpers/collections';
+import { hasFeatureFlag } from '../../helpers/features';
+
+describe('Collections table', () => {
+    withAuth();
+
+    before(function beforeHook() {
+        if (!hasFeatureFlag('ROX_OBJECT_COLLECTIONS')) {
+            this.skip();
+        }
+    });
+
+    it('should visit via link in left nav', () => {
+        visitCollectionsFromLeftNav();
+    });
+
+    it('should visit via page address', () => {
+        visitCollections();
+    });
+
+    it('should have table column headings', () => {
+        visitCollections();
+
+        cy.get('th:contains("Collection")');
+        cy.get('th:contains("Description")');
+        cy.get('th:contains("In use")');
+    });
+
+    it('should have button to create collection if role has READ_WRITE_ACCESS', () => {
+        visitCollections();
+
+        cy.get('button:contains("Create collection")');
+    });
+});


### PR DESCRIPTION
## Description

### Overview

Dave and Brad, in case you want to read about cypress data structures:
* `RouteMatcher`: https://docs.cypress.io/api/commands/intercept#Matching-with-RouteMatcher
    For example, `{ method: 'GET', url: '/v1/collections' }`
* `StaticResponse`: https://docs.cypress.io/api/commands/intercept#StaticResponse-objects
    For example, response body: `{ body: { collections: […] } }`
    For example, fixture file: `{ fixture: 'collections/collectionsWhatever.json' }`

Here are conventions-in-progress for ACS integration tests:
* `whateverAlias`
    for REST endpoint: delete **/v1/** and usually omit search query
    for GraphQL endpoints: delete **/api/graphql?opname=**
* `routeMatcherMap` object has alias for key and RouteMatcher object for value 
* `staticResponseMap` object has alias for key and StaticResponse object for value 

### Changed files

1. Add cypress/helpers/collections.js
    * Export `whateverAlias` in case tests need to call functions with `staticResponseMap` argument for mock responses.
    * Encapsulate `basePath` and request `url` values in helpers file.
    * Encapsulate baseline assertions like heading text so tests have 3 opportunities to wait if central or UI slows down:
        * Generic requests encapsulated by `visit` function.
        * Container requests.
        * Page rendering.

2. Add cypress/integration/collections/collectionsTable.test.js
    * Write tests for Admin role (pending existence of a Collection resource and helper functions for mock permissions).

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed