### PR TITLE
Convert test containers from x86 arch to multi-arch

### DIFF
--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -143,7 +143,7 @@ tasks.withType(Test) {
 }
 
 test {
-    timeout = Duration.ofHours(3)
+    timeout = Duration.ofHours(7)
     testLogging.showStandardStreams = true
 
     // This ensures that repeated invocations of tests actually run the tests.

--- a/qa-tests-backend/src/main/groovy/sampleScripts/reproAdmissionControllerTestFailure.groovy
+++ b/qa-tests-backend/src/main/groovy/sampleScripts/reproAdmissionControllerTestFailure.groovy
@@ -48,7 +48,7 @@ def killAllChaosMonkey = new ChaosMonkey(client, 0, 1L)
 
 def deployment = new Deployment()
         .setName("random-busybox")
-        .setImage("quay.io/rhacs-eng/qa:busybox-1-30")
+        .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-30")
         .addLabel("app", "random-busybox")
 assert client.createDeploymentNoWait(deployment)
 

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -62,7 +62,7 @@ class AdmissionControllerTest extends BaseSpecification {
 
     static final private Deployment MISC_DEPLOYMENT = new Deployment()
         .setName("random-busybox")
-        .setImage("quay.io/rhacs-eng/qa:busybox-1-30")
+        .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-30")
         .addLabel("app", "random-busybox")
 
     def setupSpec() {
@@ -293,7 +293,7 @@ class AdmissionControllerTest extends BaseSpecification {
         and:
         "Create the deployment with a harmless image"
         def modDeployment = deployment.clone()
-        modDeployment.image = "quay.io/rhacs-eng/qa:busybox-1-28"
+        modDeployment.image = "quay.io/rhacs-eng/qa-multi-arch:busybox-1-28"
         def created = orchestrator.createDeploymentNoWait(modDeployment)
         assert created
 

--- a/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
@@ -26,8 +26,8 @@ class AttemptedAlertsTest extends BaseSpecification {
             (DEP_NAMES[1]): createDeployment(DEP_NAMES[1], "nginx:latest"),
             (DEP_NAMES[2]): createDeployment(DEP_NAMES[2], "nginx:latest"),
             (DEP_NAMES[3]): createDeployment(DEP_NAMES[3], "nginx:latest"),
-            (DEP_NAMES[4]): createDeployment(DEP_NAMES[4], "quay.io/rhacs-eng/qa:nginx-1-14-alpine"),
-            (DEP_NAMES[5]): createDeployment(DEP_NAMES[5], "quay.io/rhacs-eng/qa:nginx-1-14-alpine"),
+            (DEP_NAMES[4]): createDeployment(DEP_NAMES[4], "quay.io/rhacs-eng/qa-multi-arch:nginx-1-14-alpine"),
+            (DEP_NAMES[5]): createDeployment(DEP_NAMES[5], "quay.io/rhacs-eng/qa-multi-arch:nginx-1-14-alpine"),
     ]
 
     static final private String LATEST_TAG_POLICY_NAME = "Latest tag"

--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -830,7 +830,7 @@ class ComplianceTest extends BaseSpecification {
         "create Deployment that forces checks to fail"
         Deployment deployment = new Deployment()
                 .setName("compliance-deployment")
-                .setImage("quay.io/rhacs-eng/qa:nginx-1-15-4-alpine")
+                .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-15-4-alpine")
                 .addPort(80, "UDP")
                 .setCommand(["/bin/sh", "-c",])
                 .setArgs(["dd if=/dev/zero of=/dev/null & yes"])

--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -25,7 +25,7 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
     static final private Deployment DEP_EXTERNALCONNECTION =
             createAndRegisterDeployment()
                     .setName(EXT_CONN_DEPLOYMENT_NAME)
-                    .setImage("quay.io/rhacs-eng/qa:nginx-1.19-alpine")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1.19-alpine")
                     .addLabel("app", EXT_CONN_DEPLOYMENT_NAME)
                     .setCommand(["/bin/sh", "-c",])
                     .setArgs(["while sleep ${NetworkGraphUtil.NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS / 10}; " +

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -34,7 +34,7 @@ class ImageScanningTest extends BaseSpecification {
     static final private String RHEL7_IMAGE =
             "richxsl/rhel7@sha256:8f3aae325d2074d2dc328cb532d6e7aeb0c588e15ddf847347038fe0566364d6"
     static final private String GCR_IMAGE   = "us.gcr.io/stackrox-ci/qa/registry-image:0.2"
-    static final private String NGINX_IMAGE = "quay.io/rhacs-eng/qa:nginx-1-12-1"
+    static final private String NGINX_IMAGE = "quay.io/rhacs-eng/qa-multi-arch:nginx-1-12-1"
     static final private String OCI_IMAGE   = "quay.io/rhacs-eng/qa:oci-manifest"
     static final private String AR_IMAGE    = "us-west1-docker.pkg.dev/stackrox-ci/artifact-registry-test1/nginx:1.17"
     static final private String CENTOS_IMAGE = "quay.io/rhacs-eng/qa:centos7-base"

--- a/qa-tests-backend/src/test/groovy/K8sEventDetectionTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sEventDetectionTest.groovy
@@ -18,7 +18,7 @@ class K8sEventDetectionTest extends BaseSpecification {
 
     static private registerDeployment(String name, boolean privileged) {
         DEPLOYMENTS.add(
-            new Deployment().setName(name).setImage("quay.io/rhacs-eng/qa:nginx-1.14-alpine").addLabel("app", name).
+            new Deployment().setName(name).setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-14-alpine").addLabel("app", name).
                 setPrivilegedFlag(privileged)
         )
         return name

--- a/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
@@ -110,7 +110,7 @@ class K8sRbacTest extends BaseSpecification {
                 .setName(DEPLOYMENT_NAME)
                 .setNamespace(Constants.ORCHESTRATOR_NAMESPACE)
                 .setServiceAccountName(SERVICE_ACCOUNT_NAME)
-                .setImage("quay.io/rhacs-eng/qa:nginx-1-15-4-alpine")
+                .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-15-4-alpine")
                 .setSkipReplicaWait(true)
         orchestrator.createDeployment(deployment)
         assert Services.waitForDeployment(deployment)

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -20,7 +20,7 @@ class NetworkBaselineTest extends BaseSpecification {
     static final private String DEFERRED_BASELINED_CLIENT_DEP_NAME = "net-bl-client-deferred-baselined"
     static final private String DEFERRED_POST_LOCK_DEP_NAME = "net-bl-client-post-lock"
 
-    static final private String NGINX_IMAGE = "quay.io/rhacs-eng/qa:nginx-1.19-alpine"
+    static final private String NGINX_IMAGE = "quay.io/rhacs-eng/qa-multi-arch:nginx-1.19-alpine"
 
     // The baseline generation duration must be changed from the default for this test to succeed.
     static final private int EXPECTED_BASELINE_DURATION_SECONDS = 240

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -106,7 +106,7 @@ class NetworkFlowTest extends BaseSpecification {
                     .addLabel("app", NOCONNECTIONSOURCE),
             new Deployment()
                     .setName(SHORTCONSISTENTSOURCE)
-                    .setImage("quay.io/rhacs-eng/qa:nginx-1.15.4-alpine")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-15-4-alpine")
                     .addLabel("app", SHORTCONSISTENTSOURCE)
                     .setCommand(["/bin/sh", "-c",])
                     .setArgs(["while sleep ${NetworkGraphUtil.NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS}; " +
@@ -114,7 +114,7 @@ class NetworkFlowTest extends BaseSpecification {
                                       "done" as String,]),
             new Deployment()
                     .setName(SINGLECONNECTIONSOURCE)
-                    .setImage("quay.io/rhacs-eng/qa:nginx-1.15.4-alpine")
+                    .setImage("quay.io/rhacs-eng/qa:nginx-1-15-4-alpine")
                     .addLabel("app", SINGLECONNECTIONSOURCE)
                     .setCommand(["/bin/sh", "-c",])
                     .setArgs(["wget -S -T 2 http://${NGINXCONNECTIONTARGET} && " +
@@ -150,7 +150,7 @@ class NetworkFlowTest extends BaseSpecification {
                                       "done" as String,]),
             new Deployment()
                     .setName(EXTERNALDESTINATION)
-                    .setImage("quay.io/rhacs-eng/qa:nginx-1.15.4-alpine")
+                    .setImage("quay.io/rhacs-eng/qa:nginx-1-15-4-alpine")
                     .addLabel("app", EXTERNALDESTINATION)
                     .setCommand(["/bin/sh", "-c",])
                     .setArgs(["while sleep ${NetworkGraphUtil.NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS}; " +
@@ -514,7 +514,7 @@ class NetworkFlowTest extends BaseSpecification {
         "create a new deployment that talks to A via the LB IP"
         def newDeployment = new Deployment()
                 .setName("talk-to-lb-ip")
-                .setImage("quay.io/rhacs-eng/qa:nginx-1.15.4-alpine")
+                .setImage("quay.io/rhacs-eng/qa:nginx-1-15-4-alpine")
                 .addLabel("app", "talk-to-lb-ip")
                 .setCommand(["/bin/sh", "-c",])
                 .setArgs(["while sleep 5; do wget -S -T 2 http://"+deploymentIP+"; done"])

--- a/qa-tests-backend/src/test/groovy/PaginationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PaginationTest.groovy
@@ -33,25 +33,25 @@ class PaginationTest extends BaseSpecification {
                     .addSecretName("p2", SECRETS[1]),
             new Deployment()
                     .setName("pagination3")
-                    .setImage("quay.io/rhacs-eng/qa:busybox-1-30")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-30")
                     .addLabel("app", "pagination3")
                     .setCommand(["sleep", "600"])
                     .addSecretName("p3", SECRETS[2]),
             new Deployment()
                     .setName("pagination4")
-                    .setImage("quay.io/rhacs-eng/qa:busybox-1-29")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-29")
                     .addLabel("app", "pagination4")
                     .setCommand(["sleep", "600"])
                     .addSecretName("p4", SECRETS[3]),
             new Deployment()
                     .setName("pagination5")
-                    .setImage("quay.io/rhacs-eng/qa:busybox-1-28")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-28")
                     .addLabel("app", "pagination5")
                     .setCommand(["sleep", "600"])
                     .addSecretName("p5", SECRETS[4]),
             new Deployment()
                     .setName("pagination6")
-                    .setImage("quay.io/rhacs-eng/qa:busybox-1-27")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-27")
                     .addLabel("app", "pagination6")
                     .setCommand(["sleep", "600"])
                     .addSecretName("p6", SECRETS[5]),

--- a/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
@@ -105,7 +105,7 @@ class PolicyConfigurationTest extends BaseSpecification {
                     .setName(DEPLOYMENT_RBAC)
                     .setNamespace(Constants.ORCHESTRATOR_NAMESPACE)
                     .setServiceAccountName(SERVICE_ACCOUNT_NAME)
-                    .setImage("quay.io/rhacs-eng/qa:nginx-1-15-4-alpine")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-15-4-alpine")
                     .setSkipReplicaWait(true),
     ]
 

--- a/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
@@ -26,7 +26,7 @@ class ProcessVisualizationTest extends BaseSpecification {
     static final private List<Deployment> DEPLOYMENTS = [
             new Deployment()
                 .setName (NGINXDEPLOYMENT)
-                .setImage ("quay.io/rhacs-eng/qa:nginx-1.14-alpine")
+                .setImage ("quay.io/rhacs-eng/qa:nginx-1-14-alpine")
                 .addLabel ( "app", "test" ),
             new Deployment()
                 .setName (STRUTSDEPLOYMENT)

--- a/qa-tests-backend/src/test/groovy/RoutesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RoutesTest.groovy
@@ -11,7 +11,7 @@ class RoutesTest extends BaseSpecification {
 
     static final private SERVER_DEP = new Deployment()
         .setName("server")
-        .setImage("quay.io/rhacs-eng/qa:nginx-1.19-alpine")
+        .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1.19-alpine")
         .addLabel("app", "server")
         .addPort(80)
         .setExposeAsService(true)

--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -188,7 +188,7 @@ class TLSChallengeTest extends BaseSpecification {
         loadBalancerDeployment.setNamespace(PROXY_NAMESPACE)
                 .setName("nginx-loadbalancer")
                 .setExposeAsService(true)
-                .setImage("quay.io/rhacs-eng/qa:nginx-1-17-1")
+                .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-17-1")
                 .addVolumeFromConfigMap(nginxConfigMap, "/etc/nginx/conf.d/")
                 .addVolumeFromSecret(tlsConfSecret, "/run/secrets/tls/")
                 .setTargetPort(8443)


### PR DESCRIPTION
## Description

Containers used during testing are x86 and will fail when testing ppc64le or s390x.  Instead use a container repo with multi-arch versions of these containers.
