### PR TITLE
Consolidate set uses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/coreos/go-oidc/v3 v3.4.0
 	github.com/coreos/go-systemd/v22 v22.4.0
 	github.com/dave/jennifer v1.6.0
-	github.com/deckarep/golang-set v1.8.0
 	github.com/dexidp/dex v0.0.0-20220607113954-3836196af2e7
 	github.com/docker/distribution v2.8.1+incompatible
 	// If this is updated, be sure to check the version of github.com/opencontainers/runc used.

--- a/go.sum
+++ b/go.sum
@@ -543,8 +543,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
-github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsPppp4=
-github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
 github.com/denis-tingajkin/go-header v0.3.1/go.mod h1:sq/2IxMhaZX+RRcgHfCRx/m0M5na0fBt4/CRe7Lrji0=
 github.com/denisenkom/go-mssqldb v0.9.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=

--- a/pkg/secret/convert/convert.go
+++ b/pkg/secret/convert/convert.go
@@ -1,18 +1,17 @@
 package convert
 
 import (
-	mapset "github.com/deckarep/golang-set"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/set"
 )
 
 // SecretToSecretList converts a secret to list secret
 func SecretToSecretList(s *storage.Secret) *storage.ListSecret {
-	typeSet := mapset.NewSet()
+	typeSet := set.NewSet[storage.SecretType]()
 	var typeSlice []storage.SecretType
 	for _, f := range s.GetFiles() {
-		if !typeSet.Contains(f.GetType()) {
-			typeSlice = append(typeSlice, f.GetType())
-			typeSet.Add(f.GetType())
+		if ty := f.GetType(); typeSet.Add(ty) {
+			typeSlice = append(typeSlice, ty)
 		}
 	}
 	if len(typeSlice) == 0 {


### PR DESCRIPTION
## Description

Use our `pkg/set` package everywhere, getting rid of two usages of a third-party set library (nothing wrong with that library, but our `pkg/set` is not going away as we rely on the interface - a.o.t. allowing us to `range` over the set directly - way too much).

(Actually, one thing that bugs me about the library. The sets are by default thread-safe. I think that's a fallacy - except for in rare circumstances, you don't get concurrency-correct code by simply using thread-safe data structures, the entire algorithm has to be designed around the possibility of concurrent insertions/updates).

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- CI