### PR TITLE
Dashrews/ROX-13131 network flow walk needs cluster

### DIFF
--- a/central/networkgraph/flow/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store_test.go
@@ -134,6 +134,29 @@ func (s *NetworkflowStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Len(foundNetworkFlows, 1)
 
+	pred := func(props *storage.NetworkFlowProperties) bool {
+		return true
+	}
+	flowPredicate := func(flow *storage.NetworkFlow) bool {
+		return true
+	}
+	foundNetworkFlows, _, err = store2.GetMatchingFlows(ctx, pred, nil)
+	s.NoError(err)
+	s.Len(foundNetworkFlows, 1)
+
+	err = store2.RemoveMatchingFlows(ctx, pred, flowPredicate)
+	s.NoError(err)
+
+	// Store 2 flows should be removed.
+	foundNetworkFlows, _, err = store2.GetAllFlows(ctx, nil)
+	s.NoError(err)
+	s.Len(foundNetworkFlows, 0)
+
+	// Store 1 flows should remain
+	foundNetworkFlows, _, err = store.GetAllFlows(ctx, nil)
+	s.NoError(err)
+	s.Len(foundNetworkFlows, flowCount)
+
 	// Clean up
 	Destroy(ctx, pool)
 }

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store_test.go
@@ -48,6 +48,7 @@ func getTimestamp(seconds int64) *types.Timestamp {
 func (s *NetworkflowStoreSuite) TestStore() {
 	ctx := context.Background()
 	clusterID := "22"
+	secondCluster := "43"
 
 	source := pgtest.GetConnectionString(s.T())
 	config, err := pgxpool.ParseConfig(source)
@@ -60,6 +61,7 @@ func (s *NetworkflowStoreSuite) TestStore() {
 	gormDB := pgtest.OpenGormDB(s.T(), source)
 	defer pgtest.CloseGormDB(s.T(), gormDB)
 	store := CreateTableAndNewStore(ctx, pool, gormDB, clusterID)
+	store2 := CreateTableAndNewStore(ctx, pool, gormDB, secondCluster)
 
 	networkFlow := &storage.NetworkFlow{
 		Props: &storage.NetworkFlowProperties{
@@ -118,6 +120,19 @@ func (s *NetworkflowStoreSuite) TestStore() {
 	foundNetworkFlows, _, err = store.GetAllFlows(ctx, nil)
 	s.NoError(err)
 	s.Len(foundNetworkFlows, flowCount)
+
+	// Make sure store for second cluster does not find any flows
+	foundNetworkFlows, _, err = store2.GetAllFlows(ctx, nil)
+	s.NoError(err)
+	s.Len(foundNetworkFlows, 0)
+
+	// Add a flow to the second cluster
+	networkFlow.ClusterId = secondCluster
+	s.NoError(store2.UpsertFlows(ctx, []*storage.NetworkFlow{networkFlow}, zeroTs))
+
+	foundNetworkFlows, _, err = store2.GetAllFlows(ctx, nil)
+	s.NoError(err)
+	s.Len(foundNetworkFlows, 1)
 
 	// Clean up
 	Destroy(ctx, pool)


### PR DESCRIPTION
## Description

The stores for network flows are based on cluster.  Meaning each cluster has its own instance of the store.  The walkStmt did not have the cluster ID as a query criteria.  It needs to have that added, otherwise each store when utilizing the walkStmt would see all flows for all clusters instead of only all flows for its cluster.  This should reduce the number of flows returned and allow the query to utilize at least one index when it is executed.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Added UT.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
