### PR TITLE
ROX-13165: Removing security overview section and redesigning network security section

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -17,7 +17,7 @@ import {
     TextContent,
     TextVariants,
 } from '@patternfly/react-core';
-import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 
 function DetailSection({ title, children }) {
     const [isExpanded, setIsExpanded] = useState(true);

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -17,7 +17,7 @@ import {
     TextContent,
     TextVariants,
 } from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 
 function DetailSection({ title, children }) {
     const [isExpanded, setIsExpanded] = useState(true);
@@ -48,67 +48,36 @@ function DeploymentDetails() {
         <div className="pf-u-h-100 pf-u-p-md">
             <ul>
                 <li>
-                    <DetailSection title="Security overview">
-                        <DescriptionList columnModifier={{ default: '2Col' }}>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Risk score</DescriptionListTerm>
-                                <DescriptionListDescription>Priority 1</DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Asset value</DescriptionListTerm>
-                                <DescriptionListDescription>High</DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Violations</DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <Flex
-                                        direction={{ default: 'row' }}
-                                        alignItems={{ default: 'alignItemsCenter' }}
-                                    >
-                                        <FlexItem>
-                                            <ExclamationCircleIcon className="pf-u-danger-color-100" />
-                                        </FlexItem>
-                                        <FlexItem>
-                                            <Button variant="link" isInline>
-                                                1 deploy
-                                            </Button>
-                                            ,{' '}
-                                            <Button variant="link" isInline>
-                                                1 runtime
-                                            </Button>
-                                        </FlexItem>
-                                    </Flex>
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Processes</DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <Flex
-                                        direction={{ default: 'row' }}
-                                        alignItems={{ default: 'alignItemsCenter' }}
-                                    >
-                                        <FlexItem>
-                                            <ExclamationCircleIcon className="pf-u-danger-color-100" />
-                                        </FlexItem>
-                                        <FlexItem>
-                                            <Button variant="link" isInline>
-                                                3 anomalous
-                                            </Button>
-                                            ,{' '}
-                                            <Button variant="link" isInline>
-                                                12 running
-                                            </Button>
-                                        </FlexItem>
-                                    </Flex>
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
-                        </DescriptionList>
-                    </DetailSection>
-                </li>
-                <Divider component="li" className="pf-u-mb-sm" />
-                <li>
                     <DetailSection title="Network security">
                         <DescriptionList columnModifier={{ default: '1Col' }}>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Anomalous traffic</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <Flex
+                                        direction={{ default: 'row' }}
+                                        alignItems={{ default: 'alignItemsCenter' }}
+                                    >
+                                        <FlexItem>
+                                            <Label
+                                                variant="outline"
+                                                color="red"
+                                                icon={<InfoCircleIcon />}
+                                            >
+                                                2 external flows
+                                            </Label>
+                                        </FlexItem>
+                                        <FlexItem>
+                                            <Label
+                                                variant="outline"
+                                                color="gold"
+                                                icon={<InfoCircleIcon />}
+                                            >
+                                                3 internal flows
+                                            </Label>
+                                        </FlexItem>
+                                    </Flex>
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
                             <DescriptionListGroup>
                                 <DescriptionListTerm>Network policy rules</DescriptionListTerm>
                                 <DescriptionListDescription>
@@ -117,43 +86,31 @@ function DeploymentDetails() {
                                         alignItems={{ default: 'alignItemsCenter' }}
                                     >
                                         <FlexItem>
-                                            <ExclamationCircleIcon className="pf-u-warning-color-100" />
+                                            <Label
+                                                variant="outline"
+                                                color="gold"
+                                                icon={<InfoCircleIcon />}
+                                            >
+                                                0 egress, allowing 325 flows
+                                            </Label>
                                         </FlexItem>
                                         <FlexItem>
-                                            0 egress,{' '}
-                                            <Button variant="link" isInline>
-                                                1 ingress
-                                            </Button>
+                                            <Label variant="outline" color="blue">
+                                                1 egress
+                                            </Label>
                                         </FlexItem>
                                     </Flex>
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                             <DescriptionListGroup>
-                                <DescriptionListTerm>Flows observed</DescriptionListTerm>
+                                <DescriptionListTerm>Listening ports</DescriptionListTerm>
                                 <DescriptionListDescription>
                                     <Flex
                                         direction={{ default: 'row' }}
                                         alignItems={{ default: 'alignItemsCenter' }}
                                     >
                                         <FlexItem>
-                                            <ExclamationCircleIcon className="pf-u-danger-color-100" />
-                                        </FlexItem>
-                                        <FlexItem>
-                                            <Button variant="link" isInline>
-                                                3 external
-                                            </Button>
-                                            ,{' '}
-                                            <Button variant="link" isInline>
-                                                2 anomalous
-                                            </Button>
-                                            ,{' '}
-                                            <Button variant="link" isInline>
-                                                4 active
-                                            </Button>
-                                            ,{' '}
-                                            <Button variant="link" isInline>
-                                                312 allowed
-                                            </Button>
+                                            <Label variant="outline">TCP: 2020, 2021</Label>
                                         </FlexItem>
                                     </Flex>
                                 </DescriptionListDescription>
@@ -176,17 +133,17 @@ function DeploymentDetails() {
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                     <DescriptionListGroup>
+                                        <DescriptionListTerm>Created</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            12/09/21 | 6:03:23 PM
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                    <DescriptionListGroup>
                                         <DescriptionListTerm>Cluster</DescriptionListTerm>
                                         <DescriptionListDescription>
                                             <Button variant="link" isInline>
                                                 Production
                                             </Button>
-                                        </DescriptionListDescription>
-                                    </DescriptionListGroup>
-                                    <DescriptionListGroup>
-                                        <DescriptionListTerm>Created</DescriptionListTerm>
-                                        <DescriptionListDescription>
-                                            12/09/21 | 6:03:23 PM
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                     <DescriptionListGroup>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -64,11 +64,6 @@ function DeploymentSideBar() {
                         tabContentId="Policies"
                         title={<TabTitleText>Policies</TabTitleText>}
                     />
-                    <Tab
-                        eventKey="Timeline"
-                        tabContentId="Timeline"
-                        title={<TabTitleText>Timeline</TabTitleText>}
-                    />
                 </Tabs>
                 <TabContent eventKey="Details" id="Details" hidden={activeKeyTab !== 'Details'}>
                     <DeploymentDetails />
@@ -81,9 +76,6 @@ function DeploymentSideBar() {
                 </TabContent>
                 <TabContent eventKey="Policies" id="Policies" hidden={activeKeyTab !== 'Policies'}>
                     <div className="pf-u-h-100 pf-u-p-md">TODO: Add Policies</div>
-                </TabContent>
-                <TabContent eventKey="Timeline" id="Timeline" hidden={activeKeyTab !== 'Timeline'}>
-                    <div className="pf-u-h-100 pf-u-p-md">TODO: Add Timeline</div>
                 </TabContent>
             </FlexItem>
         </Flex>


### PR DESCRIPTION
## Description

Making modifications in the DeploymentDetails component based on the updated mocks shown here: https://docs.google.com/presentation/d/1DdKZ0PoLk6yDyV9vFM4Q-HpB0N_lXwJ53G-CYAc56Sc/edit#slide=id.g1669bc43c7d_13_51

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~ Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs)) ~

## Screenshots

<img width="1552" alt="Screen Shot 2022-10-18 at 1 26 18 PM" src="https://user-images.githubusercontent.com/4805485/196537316-d99beba6-51ff-41a4-8f51-ce830a0ccc62.png">
<img width="1552" alt="Screen Shot 2022-10-18 at 1 26 15 PM" src="https://user-images.githubusercontent.com/4805485/196537328-eccb43e1-09fd-4af0-8259-4e62ff1578f2.png">
