### PR TITLE
ROX-13185: Adding deployments table to namespace side panel

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -18,6 +18,7 @@ import stylesComponentFactory from './components/stylesComponentFactory';
 import defaultLayoutFactory from './layouts/defaultLayoutFactory';
 import defaultComponentFactory from './components/defaultComponentFactory';
 import DeploymentSideBar from './deployment/DeploymentSideBar';
+import NamespaceSideBar from './namespace/NamespaceSideBar';
 
 const model: Model = {
     graph: {
@@ -113,7 +114,7 @@ const TopologyComponent = () => {
         <TopologyView
             sideBar={
                 <TopologySideBar resizable onClose={() => setSelectedObj(null)}>
-                    {selectedObj?.type === 'group' && <div>Group</div>}
+                    {selectedObj?.type === 'group' && <NamespaceSideBar />}
                     {selectedObj?.type === 'node' && <DeploymentSideBar />}
                 </TopologySideBar>
             }

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -22,7 +22,7 @@ function DeploymentSideBar() {
 
     return (
         <Flex direction={{ default: 'column' }} flex={{ default: 'flex_1' }} className="pf-u-h-100">
-            <Flex direction={{ default: 'row' }} className="pf-u-p-md">
+            <Flex direction={{ default: 'row' }} className="pf-u-p-md pf-u-mb-0">
                 <FlexItem>
                     <Badge style={{ backgroundColor: 'rgb(0,102,205)' }}>D</Badge>
                 </FlexItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceDeployments.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceDeployments.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {
+    Button,
+    Flex,
+    FlexItem,
+    Pagination,
+    Stack,
+    StackItem,
+    Text,
+    TextContent,
+} from '@patternfly/react-core';
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import usePagination from 'hooks/patternfly/usePagination';
+
+const columnNames = {
+    DEPLOYMENT: 'Deployment',
+    ACTIVE_TRAFFIC: 'Active traffic',
+};
+
+const deployments = [
+    { name: 'Sensor', numFlows: '1' },
+    { name: 'Central', numFlows: '1' },
+];
+
+function NamespaceDeployments() {
+    const { page, perPage, onSetPage, onPerPageSelect } = usePagination();
+
+    return (
+        <div className="pf-u-h-100 pf-u-p-md">
+            <Stack hasGutter>
+                <StackItem>
+                    <Flex
+                        direction={{ default: 'row' }}
+                        alignItems={{ default: 'alignItemsCenter' }}
+                    >
+                        <FlexItem flex={{ default: 'flex_1' }}>
+                            <TextContent>
+                                <Text component="h2">6 results found</Text>
+                            </TextContent>
+                        </FlexItem>
+                        <FlexItem>
+                            <Pagination
+                                perPageComponent="button"
+                                itemCount={deployments.length}
+                                perPage={perPage}
+                                page={page}
+                                onSetPage={onSetPage}
+                                widgetId="networkgraph-namespace-deployments-pagination"
+                                onPerPageSelect={onPerPageSelect}
+                                isCompact
+                            />
+                        </FlexItem>
+                    </Flex>
+                </StackItem>
+                <StackItem>
+                    <TableComposable aria-label="Simple table" variant="compact">
+                        <Thead>
+                            <Tr>
+                                <Th>{columnNames.DEPLOYMENT}</Th>
+                                <Th>{columnNames.ACTIVE_TRAFFIC}</Th>
+                            </Tr>
+                        </Thead>
+                        <Tbody>
+                            {deployments.map((deployment) => (
+                                <Tr key={deployment.name}>
+                                    <Td dataLabel={columnNames.DEPLOYMENT}>
+                                        <Button variant="link" isInline>
+                                            {deployment.name}
+                                        </Button>
+                                    </Td>
+                                    <Td dataLabel={columnNames.ACTIVE_TRAFFIC}>
+                                        {deployment.numFlows} flows
+                                    </Td>
+                                </Tr>
+                            ))}
+                        </Tbody>
+                    </TableComposable>
+                </StackItem>
+            </Stack>
+        </div>
+    );
+}
+
+export default NamespaceDeployments;

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import {
+    Badge,
+    Flex,
+    FlexItem,
+    Tab,
+    TabContent,
+    Tabs,
+    TabTitleText,
+    Text,
+    TextContent,
+    TextVariants,
+} from '@patternfly/react-core';
+
+import useTabs from 'hooks/patternfly/useTabs';
+import NamespaceDeployments from './NamespaceDeployments';
+
+function NamespaceSideBar() {
+    const { activeKeyTab, onSelectTab } = useTabs({
+        defaultTab: 'Deployments',
+    });
+
+    return (
+        <Flex direction={{ default: 'column' }} flex={{ default: 'flex_1' }} className="pf-u-h-100">
+            <Flex direction={{ default: 'row' }} className="pf-u-p-md pf-u-mb-0">
+                <FlexItem>
+                    <Badge style={{ backgroundColor: 'rgb(32,79,23)' }}>NS</Badge>
+                </FlexItem>
+                <FlexItem>
+                    <TextContent>
+                        <Text component={TextVariants.h1} className="pf-u-font-size-xl">
+                            stackrox
+                        </Text>
+                    </TextContent>
+                    <TextContent>
+                        <Text
+                            component={TextVariants.h2}
+                            className="pf-u-font-size-sm pf-u-color-200"
+                        >
+                            in &quot;remote&quot;
+                        </Text>
+                    </TextContent>
+                </FlexItem>
+            </Flex>
+            <FlexItem flex={{ default: 'flex_1' }}>
+                <Tabs activeKey={activeKeyTab} onSelect={onSelectTab}>
+                    <Tab
+                        eventKey="Deployments"
+                        tabContentId="Deployments"
+                        title={<TabTitleText>Deployments</TabTitleText>}
+                    />
+                    <Tab
+                        eventKey="Network policies"
+                        tabContentId="Network policies"
+                        title={<TabTitleText>Network policies</TabTitleText>}
+                    />
+                </Tabs>
+                <TabContent
+                    eventKey="Deployments"
+                    id="Deployments"
+                    hidden={activeKeyTab !== 'Deployments'}
+                >
+                    <NamespaceDeployments />
+                </TabContent>
+                <TabContent
+                    eventKey="Network policies"
+                    id="Network policies"
+                    hidden={activeKeyTab !== 'Network policies'}
+                >
+                    <div className="pf-u-h-100 pf-u-p-md">TODO: Add Network policies</div>
+                </TabContent>
+            </FlexItem>
+        </Flex>
+    );
+}
+
+export default NamespaceSideBar;


### PR DESCRIPTION
## Description

Adding the namespace side panel with the deployments table. This is an iterative addition for the deployments tab of the namespace side panel

Additional sub-tasks for the deployments tab of the namespace side panel can be found here: https://issues.redhat.com/browse/ROX-12907

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Screenshots

<img width="1552" alt="Screen Shot 2022-10-18 at 2 00 21 PM" src="https://user-images.githubusercontent.com/4805485/196544953-71d680f2-a5cb-4343-935b-836c6c6c633a.png">


