### PR TITLE
ROX-13184: Adding filter for deployments in the namespace side panel

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceDeployments.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceDeployments.tsx
@@ -24,16 +24,15 @@ const deployments = [
 ];
 
 function NamespaceDeployments() {
-    const [value, setValue] = React.useState('');
+    const [searchValue, setSearchValue] = React.useState('');
     const { page, perPage, onSetPage, onPerPageSelect } = usePagination();
 
     const onChange = (newValue: string) => {
-        setValue(newValue);
+        setSearchValue(newValue);
     };
 
-    // @TODO: This will be replaced by filtering on the backend through the API
     const filteredDeployments = deployments.filter((deployment) => {
-        return deployment.name.includes(value);
+        return deployment.name.includes(searchValue);
     });
 
     return (
@@ -66,7 +65,7 @@ function NamespaceDeployments() {
                 <StackItem>
                     <SearchInput
                         placeholder="Find by deployment name"
-                        value={value}
+                        value={searchValue}
                         onChange={onChange}
                         onClear={() => onChange('')}
                     />

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceDeployments.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceDeployments.tsx
@@ -4,6 +4,7 @@ import {
     Flex,
     FlexItem,
     Pagination,
+    SearchInput,
     Stack,
     StackItem,
     Text,
@@ -23,7 +24,17 @@ const deployments = [
 ];
 
 function NamespaceDeployments() {
+    const [value, setValue] = React.useState('');
     const { page, perPage, onSetPage, onPerPageSelect } = usePagination();
+
+    const onChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    // @TODO: This will be replaced by filtering on the backend through the API
+    const filteredDeployments = deployments.filter((deployment) => {
+        return deployment.name.includes(value);
+    });
 
     return (
         <div className="pf-u-h-100 pf-u-p-md">
@@ -53,6 +64,14 @@ function NamespaceDeployments() {
                     </Flex>
                 </StackItem>
                 <StackItem>
+                    <SearchInput
+                        placeholder="Find by deployment name"
+                        value={value}
+                        onChange={onChange}
+                        onClear={() => onChange('')}
+                    />
+                </StackItem>
+                <StackItem>
                     <TableComposable aria-label="Simple table" variant="compact">
                         <Thead>
                             <Tr>
@@ -61,7 +80,7 @@ function NamespaceDeployments() {
                             </Tr>
                         </Thead>
                         <Tbody>
-                            {deployments.map((deployment) => (
+                            {filteredDeployments.map((deployment) => (
                                 <Tr key={deployment.name}>
                                     <Td dataLabel={columnNames.DEPLOYMENT}>
                                         <Button variant="link" isInline>


### PR DESCRIPTION
## Description

This PR adds a search input for filtering deployments in the namespace side panel. This is an iterative addition for the deployments tab of the namespace side panel. 

Additional sub-tasks for the deployments tab of the namespace side panel can be found here: https://issues.redhat.com/browse/ROX-12907

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Screenshots

<img width="1552" alt="Screen Shot 2022-10-18 at 2 26 21 PM" src="https://user-images.githubusercontent.com/4805485/196548067-ad53a533-adf1-467b-b893-d6f0c914cc05.png">
<img width="1552" alt="Screen Shot 2022-10-18 at 2 26 25 PM" src="https://user-images.githubusercontent.com/4805485/196548077-1131f8e1-fe5b-4d34-948e-7c0972e696ce.png">

