### PR TITLE
ROX-13181: Fix more production config to central db

### DIFF
--- a/image/postgres/Dockerfile.envsubst
+++ b/image/postgres/Dockerfile.envsubst
@@ -3,7 +3,7 @@ ARG BASE_IMAGE=ubi8/ubi
 ARG BASE_TAG=8.6
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
-#WORKDIR /bundle
+
 ADD bundle.tar.gz /bundle
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
@@ -19,6 +19,7 @@ ENV ROX_IMAGE_FLAVOR=${ROX_IMAGE_FLAVOR}
 
 ENV PG_MAJOR=13
 ENV PATH="$PATH:/usr/pgsql-$PG_MAJOR/bin/"
+ENV LANG en_US.utf8
 
 COPY signatures/RPM-GPG-KEY-PGDG-13 /
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
@@ -40,6 +41,9 @@ RUN groupadd -g 70 postgres && \
     chown postgres:postgres /usr/local/bin/docker-entrypoint.sh && \
     chmod +x /usr/local/bin/docker-entrypoint.sh && \
     mkdir /docker-entrypoint-initdb.d
+
+# Use SIGINT to bring down with Fast Shutdown mode
+STOPSIGNAL SIGINT
 
 USER postgres:postgres
 

--- a/image/postgres/Dockerfile.envsubst
+++ b/image/postgres/Dockerfile.envsubst
@@ -19,7 +19,7 @@ ENV ROX_IMAGE_FLAVOR=${ROX_IMAGE_FLAVOR}
 
 ENV PG_MAJOR=13
 ENV PATH="$PATH:/usr/pgsql-$PG_MAJOR/bin/"
-ENV LANG en_US.utf8
+ENV LANG=en_US.utf8
 
 COPY signatures/RPM-GPG-KEY-PGDG-13 /
 COPY scripts/docker-entrypoint.sh /usr/local/bin/

--- a/image/postgres/scripts/init-entrypoint.sh
+++ b/image/postgres/scripts/init-entrypoint.sh
@@ -4,5 +4,5 @@ set -Eeo pipefail
 
 # Initialize DB if it does not exist
 if [ ! -s "$PGDATA/PG_VERSION" ]; then
-  initdb --auth-host=scram-sha-256 --auth-local=scram-sha-256 --pwfile /run/secrets/stackrox.io/secrets/password
+  initdb --auth-host=scram-sha-256 --auth-local=scram-sha-256 --pwfile /run/secrets/stackrox.io/secrets/password --data-checksums
 fi


### PR DESCRIPTION
## Description

Fix data checksum, encoding for central db config.
Change central db to fast shutdown which make more sense to production database.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed
Encoding: 
```
Checked pod 
-[ RECORD 1 ]-----+---------------
Name              | central_active
Owner             | postgres
Encoding          | UTF8
Collate           | en_US.utf8
Ctype             | en_US.utf8
```
Fast shutdown mode:
```
Access privileges |
2022-10-18 21:55:25.358 UTC [1] LOG:  database system is ready to accept connections
2022-10-18 21:55:54.355 UTC [1] LOG:  received fast shutdown request
2022-10-18 21:55:54.357 UTC [1] LOG:  aborting any active transactions
```
Data checksum:
```
[postgres@central-db-8655b78fbc-84gfb /]$ pg_controldata |grep checksum
Data page checksum version:           1
```



In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
