### PR TITLE
ROX-9316: Fix missing permissions for diagnostic bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,11 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   The default SCC for sensor is now `restricted[-v2]` or `stackrox-sensor` depending on the settings.
   Both the `runAsUser` and `fsGroup` for the admission-control and sensor deployments are no longer hardcoded to 4000 on Openshift clusters
   to allow using the `restricted` and `restricted-v2` SCCs.
-- The service account "central", which is used by the central deployment, will now include `get and list` access to the pod resource in the namespace
-  where central is deployed to. This fixes an issue when generating diagnostic bundles to now correctly include all logs within the namespace of central.
+- The service account "central", which is used by the central deployment, will now include `get and list` access to the following resources in the namespace where central is deployed to:
+  - "pods"
+  - "events"
+  - "namespaces"
+  This fixes an issue when generating diagnostic bundles to now correctly include all relevant information within the namespace of central.
 
 ## [3.72.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   The default SCC for sensor is now `restricted[-v2]` or `stackrox-sensor` depending on the settings.
   Both the `runAsUser` and `fsGroup` for the admission-control and sensor deployments are no longer hardcoded to 4000 on Openshift clusters
   to allow using the `restricted` and `restricted-v2` SCCs.
-- The service account "central", which is used by the central deployment, will now include `get and list` access to the following resources in the namespace where central is deployed to:
-  - "pods"
-  - "events"
-  - "namespaces"
-  This fixes an issue when generating diagnostic bundles to now correctly include all relevant information within the namespace of central.
+- The service account "central", which is used by the central deployment, will now include `get` and `list` access to the following resources in the namespace where central is deployed to:
+  `pods`, `events`, and `namespaces`. This fixes an issue when generating diagnostic bundles to now correctly include all relevant information within the namespace of central.
 
 ## [3.72.0]
 

--- a/image/templates/helm/stackrox-central/templates/01-central-03-diagnostics-rbac.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-03-diagnostics-rbac.yaml
@@ -19,6 +19,8 @@ rules:
   - "configmaps"
   - "services"
   - "pods"
+  - "events"
+  - "namespaces"
   verbs:
   - get
   - list


### PR DESCRIPTION
## Description

There are a few permissions missing for central's service account to generate a complete diagnostic bundle.
Currently, the following is failed to be retrieved:
- events
- namespace spec

Both are unable to be retrieved due to the missing permissions. This PR fixes this by adding the missing permissions to the service account (similar to what has been done for the pods resource in #3394).

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
- [X] Evaluated and added CHANGELOG entry if required
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~
