### PR TITLE
ROX-11009: Re-activate image case in GraphQL pagination test

### DIFF
--- a/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
@@ -58,8 +58,7 @@ class GraphQLResourcePaginationTest extends BaseSpecification {
 
         "node"       | "" | null | ""
 
-        // TODO: re-activate once fixed against postgres
-        //"image"      | "Image:main" | null | "deployments"
+        "image"      | "Image:main" | null | "deployments"
 
         "secret"     | "Secret:scanner-db-password" | null | "deployments"
 

--- a/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
@@ -58,7 +58,7 @@ class GraphQLResourcePaginationTest extends BaseSpecification {
 
         "node"       | "" | null | ""
 
-        "image"      | "Image:main" | null | "deployments"
+        "image"      | "Image Remote:main" | null | "deployments"
 
         "secret"     | "Secret:scanner-db-password" | null | "deployments"
 


### PR DESCRIPTION
## Description

In order to ensure the postgres migration does not bring functional regression, the tests that were disabled in the early phases of the postgres project should be re-enabled.
This change covers one of the disabled tests.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI is sufficient
