### PR TITLE
Add fix for unstable component key and fill out tests

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
@@ -12,6 +12,7 @@ import { TrashIcon } from '@patternfly/react-icons';
 import { FormikErrors } from 'formik';
 import cloneDeep from 'lodash/cloneDeep';
 
+import useIndexKey from 'hooks/useIndexKey';
 import { SelectorEntityType, ScopedResourceSelector, ByLabelResourceSelector } from '../types';
 import { AutoCompleteSelect } from './AutoCompleteSelect';
 
@@ -31,6 +32,7 @@ function ByLabelSelector({
     handleChange,
     validationErrors,
 }: ByLabelSelectorProps) {
+    const { keyFor, invalidateIndexKeys } = useIndexKey();
     function onChangeLabelKey(resourceSelector: ByLabelResourceSelector, ruleIndex, value) {
         const newSelector = cloneDeep(resourceSelector);
         newSelector.rules[ruleIndex].key = value;
@@ -73,10 +75,12 @@ function ByLabelSelector({
 
         if (newSelector.rules[ruleIndex].values.length > 1) {
             newSelector.rules[ruleIndex].values.splice(valueIndex, 1);
+            invalidateIndexKeys();
             handleChange(entityType, newSelector);
         } else if (newSelector.rules.length > 1) {
             // This was the last value, so drop the rule
             newSelector.rules.splice(ruleIndex, 1);
+            invalidateIndexKeys();
             handleChange(entityType, newSelector);
         } else {
             // This was the last value in the last rule, so drop the selector
@@ -93,7 +97,7 @@ function ByLabelSelector({
                         ? ValidatedOptions.error
                         : ValidatedOptions.default;
                 return (
-                    <div key={rule.key}>
+                    <div key={keyFor(ruleIndex)}>
                         {ruleIndex > 0 && (
                             <Flex
                                 className="pf-u-pt-md pf-u-pb-xl"
@@ -121,6 +125,7 @@ function ByLabelSelector({
                                     isRequired
                                 >
                                     <AutoCompleteSelect
+                                        typeAheadAriaLabel={`Select a value for the ${entityType.toLowerCase()} label key`}
                                         selectedOption={rule.key}
                                         onChange={(fieldValue: string) =>
                                             onChangeLabelKey(
@@ -157,8 +162,9 @@ function ByLabelSelector({
                                                 ? ValidatedOptions.error
                                                 : ValidatedOptions.default;
                                         return (
-                                            <Flex key={value}>
+                                            <Flex key={keyFor(valueIndex)}>
                                                 <AutoCompleteSelect
+                                                    typeAheadAriaLabel={`Select a value for the ${entityType.toLowerCase()} label value`}
                                                     className="pf-u-flex-grow-1 pf-u-w-auto"
                                                     selectedOption={value}
                                                     onChange={(fieldValue: string) =>

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -4,6 +4,7 @@ import { TrashIcon } from '@patternfly/react-icons';
 import cloneDeep from 'lodash/cloneDeep';
 
 import { FormikErrors } from 'formik';
+import useIndexKey from 'hooks/useIndexKey';
 import { AutoCompleteSelect } from './AutoCompleteSelect';
 import { ByNameResourceSelector, ScopedResourceSelector, SelectorEntityType } from '../types';
 
@@ -23,6 +24,8 @@ function ByNameSelector({
     handleChange,
     validationErrors,
 }: ByNameSelectorProps) {
+    const { keyFor, invalidateIndexKeys } = useIndexKey();
+
     function onAddValue() {
         const selector = cloneDeep(scopedResourceSelector);
         // Only add a new form row if there are no blank entries
@@ -45,6 +48,7 @@ function ByNameSelector({
 
         if (newSelector.rule.values.length > 1) {
             newSelector.rule.values.splice(valueIndex, 1);
+            invalidateIndexKeys();
             handleChange(entityType, newSelector);
         } else {
             // This was the last value in the rule, so drop the selector
@@ -56,7 +60,7 @@ function ByNameSelector({
         <FormGroup label={`${entityType} name`} isRequired>
             <Flex spaceItems={{ default: 'spaceItemsSm' }} direction={{ default: 'column' }}>
                 {scopedResourceSelector.rule.values.map((value, index) => (
-                    <Flex key={value}>
+                    <Flex key={keyFor(index)}>
                         <AutoCompleteSelect
                             typeAheadAriaLabel={`Select a value for the ${entityType.toLowerCase()} name`}
                             className="pf-u-flex-grow-1 pf-u-w-auto"

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
@@ -1,14 +1,10 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React, { useEffect, useState } from 'react';
 import { render, screen } from '@testing-library/react';
-// import userEvent from '@testing-library/user-event';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 
 import RuleSelector from './RuleSelector';
-import {
-    // ByNameResourceSelector,
-    ScopedResourceSelector,
-} from '../types';
+import { ByLabelResourceSelector, ByNameResourceSelector, ScopedResourceSelector } from '../types';
 
 jest.setTimeout(10000);
 
@@ -44,13 +40,6 @@ describe('Collection RuleSelector component', () => {
         expect(await screen.findByText('All deployments')).toBeInTheDocument();
     });
 
-    // eslint-disable-next-line jest/no-commented-out-tests
-    /*
-        This test is failing due to a console.error thrown when changing an option in one of the dropdowns,
-        which then forces a failure due to our `setupTests` Spy class.
-
-        The logic in the test passes, but the internal React rendering issue causes the test to fail.
-
     it('Should allow users to add name selectors', async () => {
         let resourceSelector: ByNameResourceSelector = {
             field: 'Deployment',
@@ -68,7 +57,6 @@ describe('Collection RuleSelector component', () => {
         await user.click(screen.getByLabelText('Select deployments by name or label'));
         await user.click(screen.getByText('Deployments with names matching'));
 
-        expect(resourceSelector).not.toBeNull();
         expect(resourceSelector.field).toBe('Deployment');
         expect(resourceSelector.rule.values).toEqual(['']);
 
@@ -116,5 +104,98 @@ describe('Collection RuleSelector component', () => {
         expect(screen.getByText('All deployments')).toBeInTheDocument();
     });
 
-    */
+    it('Should allow users to add label key/value selectors', async () => {
+        let resourceSelector: ByLabelResourceSelector = {
+            field: 'Deployment Label',
+            rules: [{ operator: 'OR', key: '', values: [''] }],
+        };
+
+        const user = userEvent.setup();
+
+        function onChange(newSelector) {
+            resourceSelector = newSelector;
+        }
+
+        render(<DeploymentRuleSelector defaultSelector={{}} onChange={onChange} />);
+
+        await user.click(screen.getByLabelText('Select deployments by name or label'));
+        await user.click(screen.getByText('Deployments with labels matching'));
+
+        expect(resourceSelector.field).toBe('Deployment Label');
+        expect(resourceSelector.rules[0].key).toEqual('');
+        expect(resourceSelector.rules[0].values).toEqual(['']);
+
+        await user.type(
+            screen.getByLabelText('Select a value for the deployment label key'),
+            'kubernetes.io/metadata.name{Enter}'
+        );
+        await user.type(
+            screen.getByLabelText('Select a value for the deployment label value'),
+            'visa-processor{Enter}'
+        );
+        expect(resourceSelector.rules[0].key).toEqual('kubernetes.io/metadata.name');
+        expect(resourceSelector.rules[0].values).toEqual(['visa-processor']);
+
+        // Attempt to add multiple blank values
+        await user.click(screen.getByText('Add value'));
+        await user.click(screen.getByText('Add value'));
+
+        // Only a single blank value should be added
+        expect(resourceSelector.rules[0].values).toEqual(['visa-processor', '']);
+
+        await user.type(
+            screen.getAllByLabelText('Select a value for the deployment label value')[1],
+            'mastercard-processor{Enter}'
+        );
+        await user.click(screen.getByText('Add value'));
+        await user.type(
+            screen.getAllByLabelText('Select a value for the deployment label value')[2],
+            'discover-processor{Enter}'
+        );
+
+        expect(resourceSelector.rules[0].values).toEqual([
+            'visa-processor',
+            'mastercard-processor',
+            'discover-processor',
+        ]);
+
+        // Add another label rule and key'values
+        await user.click(screen.getByText('Add label rule'));
+
+        await user.type(
+            screen.getAllByLabelText('Select a value for the deployment label key')[1],
+            'kubernetes.io/metadata.release{Enter}'
+        );
+        await user.type(
+            screen.getAllByLabelText('Select a value for the deployment label value')[3],
+            // typo
+            'stabl{Enter}'
+        );
+        await user.click(screen.getAllByText('Add value')[1]);
+        await user.type(
+            screen.getAllByLabelText('Select a value for the deployment label value')[4],
+            'beta{Enter}'
+        );
+        // test editing typo
+        await user.type(
+            screen.getAllByLabelText('Select a value for the deployment label value')[3],
+            'e{Enter}'
+        );
+
+        expect(resourceSelector).toEqual({
+            field: 'Deployment Label',
+            rules: [
+                {
+                    operator: 'OR',
+                    key: 'kubernetes.io/metadata.name',
+                    values: ['visa-processor', 'mastercard-processor', 'discover-processor'],
+                },
+                {
+                    operator: 'OR',
+                    key: 'kubernetes.io/metadata.release',
+                    values: ['stable', 'beta'],
+                },
+            ],
+        });
+    });
 });

--- a/ui/apps/platform/src/hooks/useIndexKey.tsx
+++ b/ui/apps/platform/src/hooks/useIndexKey.tsx
@@ -27,7 +27,11 @@ type UseIndexKeyReturn = {
  * rendering.
  */
 export default function useIndexKey(): UseIndexKeyReturn {
-    const [prefix, setPrefix] = useState(globalPrefix);
+    const [prefix, setPrefix] = useState(() => {
+        // Increment on initial call to hook, to ensure no two components start from the same index
+        globalPrefix += 1;
+        return globalPrefix;
+    });
     const keyFor = useCallback((index: number) => `${prefix}-useIndexKey-${index}`, [prefix]);
     const invalidateIndexKeys = useCallback(() => {
         globalPrefix += 1;

--- a/ui/apps/platform/src/hooks/useIndexKey.tsx
+++ b/ui/apps/platform/src/hooks/useIndexKey.tsx
@@ -1,0 +1,38 @@
+import { useState, useCallback } from 'react';
+
+// Using a single value at the module scope allows multiple components to use this hook
+// without generating conflicting keys.
+let globalPrefix = 0;
+
+type UseIndexKeyReturn = {
+    /**
+     * Generate a stable key for an array index
+     */
+    keyFor: (index: number) => string;
+    /**
+     * Invalidates all keys in use by this hook, causing React to rerender the entirety
+     * of the list, but keeping render results predictable and correct.
+     */
+    invalidateIndexKeys: () => void;
+};
+
+/**
+ * Hook that allows the usage of `index` values for React component keys in -specific- situations.
+ * This should only be used when the following are true:
+ * 1. There is no stable key to be used instead.
+ * 2. The ordering of the items in the list never changes.
+ *
+ * For the second case, this hook can be used but the `invalidateKeys` function must be called whenever
+ * the list is rearranged, or an item is deleted. This will eschew performance in favor of predictable
+ * rendering.
+ */
+export default function useIndexKey(): UseIndexKeyReturn {
+    const [prefix, setPrefix] = useState(globalPrefix);
+    const keyFor = useCallback((index: number) => `${prefix}-useIndexKey-${index}`, [prefix]);
+    const invalidateIndexKeys = useCallback(() => {
+        globalPrefix += 1;
+        setPrefix(globalPrefix);
+    }, [setPrefix]);
+
+    return { keyFor, invalidateIndexKeys };
+}


### PR DESCRIPTION
## Description

This adds a fix for unstable key values in the collections form. This follows the guidelines linked in the React docs [here](https://robinpokorny.com/blog/index-as-a-key-is-an-anti-pattern#update-exception-from-the-rule).

This solution effectively is using the array index as the key, but appended to a stable, unique value. The downside with this approach is that you need to manually call the `invalidateIndexKeys` function whenever one of the rules from the link above are violated. This resets the stable value, wiping the keys for your array. This sacrifices the performance boost React gets from iterating over a list in favor of ensuring the list will render correctly.

This PR also re-enables the broken test caused by the error, and adds an equivalent test for the ByLabelSelector component.

An [alternative approach](https://github.com/stackrox/stackrox/pull/3492) to this is to add arbitrary unique ids to each item client side. This is more verbose and adds cruft to the data model, but doesn't require us to manually invalidate keys and is a more type-safe approach.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Manual testing according to #3444

UI unit tests are passing
