### PR TITLE
ROX-12906: Adding deployment network policies tab

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { Button, SelectOption, Stack, StackItem } from '@patternfly/react-core';
+import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor';
+
+import download from 'utils/download';
+import SelectSingle from 'Components/SelectSingle';
+import { useTheme } from 'Containers/ThemeProvider';
+import { MoonIcon, SunIcon } from '@patternfly/react-icons';
+
+type NetworkPolicy = {
+    name: string;
+    yaml: string;
+};
+
+type NetworkPoliciesProps = {
+    networkPolicies: NetworkPolicy[];
+};
+
+const downloadYAMLHandler = (fileContent: string) => () => {
+    download('network-policy.yml', fileContent, 'yml');
+};
+
+function NetworkPolicies({ networkPolicies }: NetworkPoliciesProps): React.ReactElement {
+    const { isDarkMode } = useTheme();
+    const [customDarkMode, setCustomDarkMode] = React.useState(isDarkMode);
+    const [selectedNetworkPolicy, setSelectedNetworkPolicy] = React.useState<
+        NetworkPolicy | undefined
+    >(networkPolicies[0]);
+
+    function onToggleDarkMode() {
+        setCustomDarkMode((prevValue) => !prevValue);
+    }
+
+    function handleSelectedNetworkPolicy(_, value: string) {
+        const newlySelectedNetworkPolicy = networkPolicies.find(
+            (networkPolicy) => networkPolicy.name === value
+        );
+        setSelectedNetworkPolicy(newlySelectedNetworkPolicy);
+    }
+
+    const customControl = (
+        <CodeEditorControl
+            icon={customDarkMode ? <SunIcon /> : <MoonIcon />}
+            aria-label="Toggle dark mode"
+            toolTipText={customDarkMode ? 'Toggle to light mode' : 'Toggle to dark mode'}
+            onClick={onToggleDarkMode}
+            isVisible
+        />
+    );
+
+    return (
+        <Stack hasGutter>
+            <StackItem>
+                <SelectSingle
+                    id="search-filter-attributes-select"
+                    value={selectedNetworkPolicy?.name || ''}
+                    handleSelect={handleSelectedNetworkPolicy}
+                    placeholderText="Select a network policy"
+                >
+                    {networkPolicies.map((networkPolicy) => {
+                        return (
+                            <SelectOption key={networkPolicy.name} value={networkPolicy.name}>
+                                {networkPolicy.name}
+                            </SelectOption>
+                        );
+                    })}
+                </SelectSingle>
+            </StackItem>
+            {selectedNetworkPolicy && (
+                <StackItem>
+                    <div className="pf-u-h-100">
+                        <CodeEditor
+                            isDarkTheme={customDarkMode}
+                            customControls={customControl}
+                            isCopyEnabled
+                            isLineNumbersVisible
+                            isReadOnly
+                            code={selectedNetworkPolicy.yaml}
+                            language={Language.yaml}
+                            height="300px"
+                        />
+                    </div>
+                </StackItem>
+            )}
+            {selectedNetworkPolicy && (
+                <StackItem>
+                    <Button onClick={downloadYAMLHandler(selectedNetworkPolicy.yaml)}>
+                        Export YAML
+                    </Button>
+                </StackItem>
+            )}
+        </Stack>
+    );
+}
+
+export default NetworkPolicies;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentNetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentNetworkPolicies.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import NetworkPolicies from '../common/NetworkPolicies';
 
-function NamespaceNetworkPolicies() {
+function DeploymentNetworkPolicies() {
     // @TODO: We will eventually do an API call to fetch the network policies based on the
     // network policy ids for the selected node
     const networkPolicies = [
@@ -20,7 +20,12 @@ metadata:
 kind: NetworkPolicy
 metadata:
   name: ''
-  namespace: test-service-registry`,
+  namespace: test-service-registry
+  annotations:
+    email: support@stackrox.com
+    meta.helm.sh/release-name: stackrox-secured-cluster-services
+    meta.helm.sh/release-namespace: stackrox
+    owner: stackrox`,
         },
     ];
 
@@ -31,4 +36,4 @@ metadata:
     );
 }
 
-export default NamespaceNetworkPolicies;
+export default DeploymentNetworkPolicies;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -14,6 +14,7 @@ import {
 
 import useTabs from 'hooks/patternfly/useTabs';
 import DeploymentDetails from './DeploymentDetails';
+import DeploymentNetworkPolicies from './DeploymentNetworkPolicies';
 
 function DeploymentSideBar() {
     const { activeKeyTab, onSelectTab } = useTabs({
@@ -50,32 +51,40 @@ function DeploymentSideBar() {
                         title={<TabTitleText>Details</TabTitleText>}
                     />
                     <Tab
-                        eventKey="Flows"
-                        tabContentId="Flows"
-                        title={<TabTitleText>Flows</TabTitleText>}
+                        eventKey="Traffic"
+                        tabContentId="Traffic"
+                        title={<TabTitleText>Traffic</TabTitleText>}
                     />
                     <Tab
-                        eventKey="Baseline"
-                        tabContentId="Baseline"
-                        title={<TabTitleText>Baseline</TabTitleText>}
+                        eventKey="Baselines"
+                        tabContentId="Baselines"
+                        title={<TabTitleText>Baselines</TabTitleText>}
                     />
                     <Tab
-                        eventKey="Policies"
-                        tabContentId="Policies"
-                        title={<TabTitleText>Policies</TabTitleText>}
+                        eventKey="Network policies"
+                        tabContentId="Network policies"
+                        title={<TabTitleText>Network policies</TabTitleText>}
                     />
                 </Tabs>
                 <TabContent eventKey="Details" id="Details" hidden={activeKeyTab !== 'Details'}>
                     <DeploymentDetails />
                 </TabContent>
-                <TabContent eventKey="Flows" id="Flows" hidden={activeKeyTab !== 'Flows'}>
-                    <div className="pf-u-h-100 pf-u-p-md">TODO: Add Flows</div>
+                <TabContent eventKey="Traffic" id="Traffic" hidden={activeKeyTab !== 'Traffic'}>
+                    <div className="pf-u-h-100 pf-u-p-md">TODO: Add Traffic</div>
                 </TabContent>
-                <TabContent eventKey="Baseline" id="Baseline" hidden={activeKeyTab !== 'Baseline'}>
-                    <div className="pf-u-h-100 pf-u-p-md">TODO: Add Baseline</div>
+                <TabContent
+                    eventKey="Baselines"
+                    id="Baselines"
+                    hidden={activeKeyTab !== 'Baselines'}
+                >
+                    <div className="pf-u-h-100 pf-u-p-md">TODO: Add Baselines</div>
                 </TabContent>
-                <TabContent eventKey="Policies" id="Policies" hidden={activeKeyTab !== 'Policies'}>
-                    <div className="pf-u-h-100 pf-u-p-md">TODO: Add Policies</div>
+                <TabContent
+                    eventKey="Network policies"
+                    id="Network policies"
+                    hidden={activeKeyTab !== 'Network policies'}
+                >
+                    <DeploymentNetworkPolicies />
                 </TabContent>
             </FlexItem>
         </Flex>

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -67,6 +67,7 @@ function NamespaceSideBar() {
                     eventKey="Network policies"
                     id="Network policies"
                     hidden={activeKeyTab !== 'Network policies'}
+                    className="pf-u-h-100"
                 >
                     <NamespaceNetworkPolicies />
                 </TabContent>


### PR DESCRIPTION
## Description

This PR does the following:
1. Creates a `DeploymentNetworkPolicies` component that will show the network policies for a specific deployment in the network policies tab
2. Abstracts away the common logic used between the `DeploymentNetworkPolicies` and `NamespaceNetworkPolicies` components into another component called NetworkPolicies.

NOTE: This is an iterative addition to the deployment side panel

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

<img width="1552" alt="Screen Shot 2022-10-19 at 11 23 48 AM" src="https://user-images.githubusercontent.com/4805485/196774450-04b404ae-d6da-4786-9aa9-59ad6991861f.png">
<img width="1552" alt="Screen Shot 2022-10-19 at 11 23 53 AM" src="https://user-images.githubusercontent.com/4805485/196774453-e7fb305d-1677-4f0a-a033-4136f8cc8074.png">


