### PR TITLE
Impl name and description fields for collection form.

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -23,8 +23,10 @@ import {
     Flex,
     FlexItem,
     Form,
+    FormGroup,
     Label,
     Text,
+    TextInput,
     Title,
 } from '@patternfly/react-core';
 import { CaretDownIcon } from '@patternfly/react-icons';
@@ -112,7 +114,7 @@ function CollectionForm({
     const [isDeleting, setIsDeleting] = useState(false);
     const { toasts, addToast, removeToast } = useToasts();
 
-    const { values, isValid, errors, setFieldValue } = useFormik({
+    const { values, isValid, errors, handleChange, handleBlur, setFieldValue } = useFormik({
         initialValues: initialData,
         onSubmit: () => {},
         validationSchema: yup.object({
@@ -134,7 +136,7 @@ function CollectionForm({
         toggleDrawer(useInlineDrawer);
     }, [toggleDrawer, useInlineDrawer]);
 
-    const pageTitle = action.type === 'create' ? 'Create collection' : initialData.name;
+    const pageTitle = action.type === 'create' ? 'Create collection' : values.name;
 
     function onEditCollection(id: string) {
         history.push({
@@ -293,9 +295,38 @@ function CollectionForm({
                                 spaceItems={{ default: 'spaceItemsMd' }}
                                 direction={{ default: 'column' }}
                             >
-                                <div className="pf-u-background-color-100 pf-u-p-lg">
+                                <Flex
+                                    className="pf-u-background-color-100 pf-u-p-lg"
+                                    direction={{ default: 'column' }}
+                                    spaceItems={{ default: 'spaceItemsMd' }}
+                                >
                                     <Title headingLevel="h2">Collection details</Title>
-                                </div>
+                                    <Flex>
+                                        <FlexItem flex={{ default: 'flex_1' }}>
+                                            <FormGroup label="Name" isRequired>
+                                                <TextInput
+                                                    id="name"
+                                                    name="name"
+                                                    value={values.name}
+                                                    validated={errors.name ? 'error' : 'default'}
+                                                    onChange={(_, e) => handleChange(e)}
+                                                    onBlur={handleBlur}
+                                                />
+                                            </FormGroup>
+                                        </FlexItem>
+                                        <FlexItem flex={{ default: 'flex_2' }}>
+                                            <FormGroup label="Description">
+                                                <TextInput
+                                                    id="description"
+                                                    name="description"
+                                                    value={values.description}
+                                                    onChange={(_, e) => handleChange(e)}
+                                                    onBlur={handleBlur}
+                                                />
+                                            </FormGroup>
+                                        </FlexItem>
+                                    </Flex>
+                                </Flex>
 
                                 <Flex
                                     className="pf-u-background-color-100 pf-u-p-lg"

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -301,9 +301,9 @@ function CollectionForm({
                                     spaceItems={{ default: 'spaceItemsMd' }}
                                 >
                                     <Title headingLevel="h2">Collection details</Title>
-                                    <Flex>
+                                    <Flex direction={{ default: 'column', lg: 'row' }}>
                                         <FlexItem flex={{ default: 'flex_1' }}>
-                                            <FormGroup label="Name" isRequired>
+                                            <FormGroup label="Name" fieldId="name" isRequired>
                                                 <TextInput
                                                     id="name"
                                                     name="name"
@@ -315,7 +315,7 @@ function CollectionForm({
                                             </FormGroup>
                                         </FlexItem>
                                         <FlexItem flex={{ default: 'flex_2' }}>
-                                            <FormGroup label="Description">
+                                            <FormGroup label="Description" fieldId="description">
                                                 <TextInput
                                                     id="description"
                                                     name="description"


### PR DESCRIPTION
## Description

Adds name and description fields to the collection form.

## Checklist
- [ ] Investigated and inspected CI test results

If any of these don't apply, please comment below.

## Testing Performed

Visit the collection page and click "Create collection" to view the empty name and description fields. For validation, the name field requires only a non-empty string and the description field is left unrestricted. The validation state will appear onBlur for the name field (in the future it will appear onSubmit as well, if the user skips the field entirely.)
<img width="1353" alt="image" src="https://user-images.githubusercontent.com/1292638/196965808-8ba304a7-ad68-4341-8aed-abd835aab152.png">
<img width="1353" alt="image" src="https://user-images.githubusercontent.com/1292638/196966114-03e73c30-a141-490b-af9a-19aeccf44652.png">

Visit the collection page and click the name of an existing collection. The name and description fields should be populated with the correct data. Changing the value of the name field will update the title at the top of the page.
<img width="1353" alt="image" src="https://user-images.githubusercontent.com/1292638/196966407-0b1de927-bbbb-4d79-9197-efdcc32daf55.png">
<img width="1353" alt="image" src="https://user-images.githubusercontent.com/1292638/196966643-d46f2ca4-2f59-4438-a265-68d49acc07a5.png">
<img width="1353" alt="image" src="https://user-images.githubusercontent.com/1292638/196966505-6a2e4dcc-122a-48cf-8b22-6675d25344ab.png">

Mobile view:
﻿<img width="300" alt="image" src="https://user-images.githubusercontent.com/1292638/198041259-0ad9056d-860d-404b-86ef-cebe0987f65e.png">





