### PR TITLE
ROX-13225: Add nil checks for impact metrics

### DIFF
--- a/central/cve/converter/utils/convert_utils.go
+++ b/central/cve/converter/utils/convert_utils.go
@@ -124,7 +124,7 @@ func NvdCVEToEmbeddedCVE(nvdCVE *schema.NVDCVEFeedJSON10DefCVEItem, ct CVEType) 
 		return nil, errors.Errorf("unknown CVE type: %d", ct)
 	}
 
-	if nvdCVE.Impact != nil {
+	if nvdCVE.Impact != nil && nvdCVE.Impact.BaseMetricV2 != nil {
 		cvssv2, err := nvdCvssv2ToProtoCvssv2(nvdCVE.Impact.BaseMetricV2)
 		if err != nil {
 			return nil, err
@@ -132,7 +132,9 @@ func NvdCVEToEmbeddedCVE(nvdCVE *schema.NVDCVEFeedJSON10DefCVEItem, ct CVEType) 
 		cve.CvssV2 = cvssv2
 		cve.Cvss = cvssv2.Score
 		cve.ScoreVersion = storage.EmbeddedVulnerability_V2
+	}
 
+	if nvdCVE.Impact != nil && nvdCVE.Impact.BaseMetricV3 != nil {
 		cvssv3, err := nvdCvssv3ToProtoCvssv3(nvdCVE.Impact.BaseMetricV3)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Description

This PR fixes panic problem by checking for nil pointers.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~


## Testing Performed

1. Deployed image build on broken instance
2. CI tests

