### PR TITLE
ROX-13021: Do not highlight SAC fields in queries to Postgres

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -351,7 +351,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -370,7 +370,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -397,7 +397,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ActiveComponen
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -434,7 +434,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -457,7 +457,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -480,7 +480,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -515,7 +515,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Activ
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -567,7 +567,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +597,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/alert/datastore/datastore_sac_test.go
+++ b/central/alert/datastore/datastore_sac_test.go
@@ -431,27 +431,37 @@ var alertScopedSACSearchTestCases = map[string]alertSACSearchResult{
 
 var alertUnrestrictedSACSearchTestCases = map[string]alertSACSearchResult{
 	"full read access should see all alerts": {
-		// SAC search fields are not injected in query when running unscoped search
-		// Therefore results cannot be dispatched per cluster and namespace
 		scopeKey: testutils.UnrestrictedReadCtx,
 		resultCounts: map[string]map[string]int{
-			"": {"": 19},
+			testconsts.Cluster1: {
+				testconsts.NamespaceA: 8,
+				testconsts.NamespaceB: 5,
+			},
+			testconsts.Cluster2: {
+				testconsts.NamespaceB: 3,
+				testconsts.NamespaceC: 2,
+			},
+			"prod cluster": {"stackrox": 1},
 		},
 	},
 	"full read-write access should see all alerts": {
-		// SAC search fields are not injected in query when running unscoped search
-		// Therefore results cannot be dispatched per cluster and namespace
 		scopeKey: testutils.UnrestrictedReadWriteCtx,
 		resultCounts: map[string]map[string]int{
-			"": {"": 19},
+			testconsts.Cluster1: {
+				testconsts.NamespaceA: 8,
+				testconsts.NamespaceB: 5,
+			},
+			testconsts.Cluster2: {
+				testconsts.NamespaceB: 3,
+				testconsts.NamespaceC: 2,
+			},
+			"prod cluster": {"stackrox": 1},
 		},
 	},
 }
 
 var alertUnrestrictedSACObjectSearchTestCases = map[string]alertSACSearchResult{
 	"full read access should see all alerts": {
-		// SAC search fields are not injected in query when running unscoped search
-		// Therefore results cannot be dispatched per cluster and namespace
 		scopeKey: testutils.UnrestrictedReadCtx,
 		resultCounts: map[string]map[string]int{
 			testconsts.Cluster1: {
@@ -466,8 +476,6 @@ var alertUnrestrictedSACObjectSearchTestCases = map[string]alertSACSearchResult{
 		},
 	},
 	"full read-write access should see all alerts": {
-		// SAC search fields are not injected in query when running unscoped search
-		// Therefore results cannot be dispatched per cluster and namespace
 		scopeKey: testutils.UnrestrictedReadWriteCtx,
 		resultCounts: map[string]map[string]int{
 			testconsts.Cluster1: {
@@ -487,7 +495,14 @@ func (s *alertDatastoreSACTestSuite) runSearchTest(testparams alertSACSearchResu
 	ctx := s.testContexts[testparams.scopeKey]
 	searchResults, err := s.datastore.Search(ctx, nil)
 	s.NoError(err)
-	resultCounts := testutils.CountResultsPerClusterAndNamespace(s.T(), searchResults, s.optionsMap)
+	results := make([]sac.NamespaceScopedObject, 0, len(searchResults))
+	for _, r := range searchResults {
+		obj, found, err := s.datastore.GetAlert(s.testContexts[testutils.UnrestrictedReadCtx], r.ID)
+		if found && err == nil {
+			results = append(results, obj)
+		}
+	}
+	resultCounts := testutils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), results)
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, testparams.resultCounts, resultCounts)
 }
 
@@ -524,7 +539,7 @@ func (s *alertDatastoreSACTestSuite) TestAlertScopedCount() {
 }
 
 func (s *alertDatastoreSACTestSuite) TestAlertUnrestrictedCount() {
-	for name, c := range alertUnrestrictedSACSearchTestCases {
+	for name, c := range alertUnrestrictedSACObjectSearchTestCases {
 		s.Run(name, func() {
 			s.runCountTest(c)
 		})
@@ -548,7 +563,7 @@ func (s *alertDatastoreSACTestSuite) TestAlertScopedCountAlerts() {
 }
 
 func (s *alertDatastoreSACTestSuite) TestAlertUnrestrictedCountAlerts() {
-	for name, c := range alertUnrestrictedSACSearchTestCases {
+	for name, c := range alertUnrestrictedSACObjectSearchTestCases {
 		s.Run(name, func() {
 			s.runCountAlertsTest(c)
 		})
@@ -559,7 +574,14 @@ func (s *alertDatastoreSACTestSuite) runSearchAlertsTest(testparams alertSACSear
 	ctx := s.testContexts[testparams.scopeKey]
 	searchResults, err := s.datastore.SearchAlerts(ctx, nil)
 	s.NoError(err)
-	resultsDistribution := testutils.CountSearchResultsPerClusterAndNamespace(s.T(), searchResults, s.optionsMap)
+	results := make([]sac.NamespaceScopedObject, 0, len(searchResults))
+	for _, r := range searchResults {
+		obj, found, err := s.datastore.GetAlert(s.testContexts[testutils.UnrestrictedReadCtx], r.GetId())
+		if found && err == nil {
+			results = append(results, obj)
+		}
+	}
+	resultsDistribution := testutils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), results)
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, testparams.resultCounts, resultsDistribution)
 }
 

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -412,7 +412,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -431,7 +431,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -458,7 +458,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Alert, bool, e
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -495,7 +495,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -518,7 +518,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -541,7 +541,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -576,7 +576,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Alert
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -628,7 +628,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -658,7 +658,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -705,7 +705,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Alert) error)
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -171,7 +171,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -190,7 +190,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -217,7 +217,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Cluster, bool,
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -254,7 +254,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -277,7 +277,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -300,7 +300,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +335,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -387,7 +387,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -417,7 +417,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -464,7 +464,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Cluster) erro
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -286,7 +286,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -305,7 +305,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -332,7 +332,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ClusterHealthS
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -369,7 +369,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -392,7 +392,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -415,7 +415,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -450,7 +450,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -502,7 +502,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -532,7 +532,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/clustercveedge/datastore/store/postgres/store.go
+++ b/central/clustercveedge/datastore/store/postgres/store.go
@@ -81,7 +81,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -100,7 +100,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -127,7 +127,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ClusterCVEEdge
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -164,7 +164,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -251,7 +251,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -256,7 +256,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -275,7 +275,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -302,7 +302,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceDoma
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -339,7 +339,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -362,7 +362,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -385,7 +385,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -420,7 +420,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -472,7 +472,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -502,7 +502,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -282,7 +282,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -301,7 +301,7 @@ func (s *storeImpl) Exists(ctx context.Context, runId string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -328,7 +328,7 @@ func (s *storeImpl) Get(ctx context.Context, runId string) (*storage.ComplianceR
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -365,7 +365,7 @@ func (s *storeImpl) Delete(ctx context.Context, runId string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -388,7 +388,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -411,7 +411,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -446,7 +446,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -498,7 +498,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -528,7 +528,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -575,7 +575,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceRun
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -282,7 +282,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -301,7 +301,7 @@ func (s *storeImpl) Exists(ctx context.Context, runMetadataRunId string) (bool, 
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -328,7 +328,7 @@ func (s *storeImpl) Get(ctx context.Context, runMetadataRunId string) (*storage.
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -365,7 +365,7 @@ func (s *storeImpl) Delete(ctx context.Context, runMetadataRunId string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -388,7 +388,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -411,7 +411,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -446,7 +446,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -498,7 +498,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -528,7 +528,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -575,7 +575,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ComplianceRun
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -255,7 +255,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -274,7 +274,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -301,7 +301,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComplianceStri
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -338,7 +338,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -361,7 +361,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -384,7 +384,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +419,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compl
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -468,7 +468,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/componentcveedge/datastore/store/postgres/store.go
+++ b/central/componentcveedge/datastore/store/postgres/store.go
@@ -81,7 +81,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -100,7 +100,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -127,7 +127,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ComponentCVEEd
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -164,7 +164,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Compo
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -251,7 +251,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -301,7 +301,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -320,7 +320,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -347,7 +347,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ClusterCVE, bo
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -384,7 +384,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -407,7 +407,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -430,7 +430,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +465,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Clust
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -517,7 +517,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -547,7 +547,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -301,7 +301,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -320,7 +320,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -347,7 +347,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ImageCVE, bool
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -384,7 +384,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -407,7 +407,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -430,7 +430,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +465,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -517,7 +517,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -547,7 +547,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -301,7 +301,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -320,7 +320,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -347,7 +347,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NodeCVE, bool,
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -384,7 +384,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -407,7 +407,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -430,7 +430,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +465,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -517,7 +517,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -547,7 +547,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/deployment/datastoretest/datastore_sac_test.go
+++ b/central/deployment/datastoretest/datastore_sac_test.go
@@ -567,7 +567,7 @@ func (s *deploymentDatastoreSACSuite) TestScopedCount() {
 
 func (s *deploymentDatastoreSACSuite) TestUnrestrictedCount() {
 	s.setupSearchTest()
-	for name, c := range testutils.GenericUnrestrictedSACSearchTestCases(s.T()) {
+	for name, c := range testutils.GenericUnrestrictedRawSACSearchTestCases(s.T()) {
 		s.Run(name, func() {
 			s.runTestCount(c)
 		})
@@ -593,7 +593,7 @@ func (s *deploymentDatastoreSACSuite) TestScopedCountDeployments() {
 
 func (s *deploymentDatastoreSACSuite) TestUnrestrictedCountDeployments() {
 	s.setupSearchTest()
-	for name, c := range testutils.GenericUnrestrictedSACSearchTestCases(s.T()) {
+	for name, c := range testutils.GenericUnrestrictedRawSACSearchTestCases(s.T()) {
 		s.Run(name, func() {
 			s.runTestCountDeployments(c)
 		})

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -956,7 +956,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -975,7 +975,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -1002,7 +1002,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Deployment, bo
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1039,7 +1039,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -1062,7 +1062,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -1085,7 +1085,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -1120,7 +1120,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Deplo
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1172,7 +1172,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -1202,7 +1202,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -1249,7 +1249,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Deployment) e
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -291,7 +291,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -310,7 +310,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -337,7 +337,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ImageComponent
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -374,7 +374,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -397,7 +397,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -420,7 +420,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -455,7 +455,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -507,7 +507,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -537,7 +537,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/imagecomponent/datastoretest/datastore_sac_test.go
+++ b/central/imagecomponent/datastoretest/datastore_sac_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestCVEDataStoreSAC(t *testing.T) {
+func TestImageComponentDataStoreSAC(t *testing.T) {
 	suite.Run(t, new(cveDataStoreSACTestSuite))
 }
 

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -81,7 +81,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -100,7 +100,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -127,7 +127,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ImageComponent
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -164,7 +164,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -251,7 +251,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}

--- a/central/imagecveedge/datastore/postgres/store.go
+++ b/central/imagecveedge/datastore/postgres/store.go
@@ -81,7 +81,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -100,7 +100,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -127,7 +127,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ImageCVEEdge, 
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -164,7 +164,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -251,7 +251,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -292,7 +292,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -311,7 +311,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -338,7 +338,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NamespaceMetad
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -375,7 +375,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -398,7 +398,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -421,7 +421,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +456,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Names
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -508,7 +508,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -538,7 +538,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -585,7 +585,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NamespaceMeta
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -277,7 +277,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -296,7 +296,7 @@ func (s *storeImpl) Exists(ctx context.Context, deploymentId string) (bool, erro
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -323,7 +323,7 @@ func (s *storeImpl) Get(ctx context.Context, deploymentId string) (*storage.Netw
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -360,7 +360,7 @@ func (s *storeImpl) Delete(ctx context.Context, deploymentId string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -383,7 +383,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -406,7 +406,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -441,7 +441,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -493,7 +493,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -523,7 +523,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -570,7 +570,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkBaseli
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -277,7 +277,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -296,7 +296,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -323,7 +323,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NetworkPolicy,
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -360,7 +360,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -383,7 +383,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -406,7 +406,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -441,7 +441,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -493,7 +493,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -523,7 +523,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -570,7 +570,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkPolicy
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -255,7 +255,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -274,7 +274,7 @@ func (s *storeImpl) Exists(ctx context.Context, deploymentId string) (bool, erro
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -301,7 +301,7 @@ func (s *storeImpl) Get(ctx context.Context, deploymentId string) (*storage.Netw
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -338,7 +338,7 @@ func (s *storeImpl) Delete(ctx context.Context, deploymentId string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -361,7 +361,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -384,7 +384,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +419,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -468,7 +468,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -255,7 +255,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -274,7 +274,7 @@ func (s *storeImpl) Exists(ctx context.Context, clusterId string) (bool, error) 
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -301,7 +301,7 @@ func (s *storeImpl) Get(ctx context.Context, clusterId string) (*storage.Network
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -338,7 +338,7 @@ func (s *storeImpl) Delete(ctx context.Context, clusterId string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -361,7 +361,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -384,7 +384,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +419,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Netwo
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -468,7 +468,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -286,7 +286,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -305,7 +305,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -332,7 +332,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NodeComponent,
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -369,7 +369,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -392,7 +392,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -415,7 +415,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -450,7 +450,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -502,7 +502,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -532,7 +532,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/nodecomponentcveedge/datastore/store/postgres/store.go
+++ b/central/nodecomponentcveedge/datastore/store/postgres/store.go
@@ -81,7 +81,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -100,7 +100,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -127,7 +127,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NodeComponentC
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -164,7 +164,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -251,7 +251,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -81,7 +81,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -100,7 +100,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -127,7 +127,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.NodeComponentE
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -164,7 +164,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.NodeC
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -251,7 +251,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}

--- a/central/pod/datastore/datastore_sac_test.go
+++ b/central/pod/datastore/datastore_sac_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/blevesearch/bleve"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/central/globalindex"
-	"github.com/stackrox/rox/central/pod/mappings"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/fixtures"
@@ -177,7 +176,14 @@ func (s *podDatastoreSACSuite) runSearchTest(c testutils.SACSearchTestCase) {
 	ctx := s.testContexts[c.ScopeKey]
 	results, err := s.datastore.Search(ctx, nil)
 	s.Require().NoError(err)
-	resultCounts := testutils.CountResultsPerClusterAndNamespace(s.T(), results, mappings.OptionsMap)
+	resultObjects := make([]sac.NamespaceScopedObject, 0, len(results))
+	for _, r := range results {
+		obj, found, err := s.datastore.GetPod(s.testContexts[testutils.UnrestrictedReadCtx], r.ID)
+		if found && err == nil {
+			resultObjects = append(resultObjects, obj)
+		}
+	}
+	resultCounts := testutils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), resultObjects)
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
 }
 
@@ -190,7 +196,7 @@ func (s *podDatastoreSACSuite) TestScopedSearch() {
 }
 
 func (s *podDatastoreSACSuite) TestUnrestrictedSearch() {
-	for name, c := range testutils.GenericUnrestrictedSACSearchTestCases(s.T()) {
+	for name, c := range testutils.GenericUnrestrictedRawSACSearchTestCases(s.T()) {
 		s.Run(name, func() {
 			s.runSearchTest(c)
 		})

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -367,7 +367,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -386,7 +386,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -413,7 +413,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Pod, bool, err
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -450,7 +450,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -473,7 +473,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -496,7 +496,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -531,7 +531,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Pod, 
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -583,7 +583,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -613,7 +613,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -660,7 +660,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Pod) error) e
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/processbaseline/datastore/datastore_sac_test.go
+++ b/central/processbaseline/datastore/datastore_sac_test.go
@@ -233,7 +233,15 @@ func (s *processBaselineSACTestSuite) runSearchTest(c testutils.SACSearchTestCas
 	ctx := s.testContexts[c.ScopeKey]
 	results, err := s.datastore.Search(ctx, nil)
 	s.Require().NoError(err)
-	resultCounts := testutils.CountResultsPerClusterAndNamespace(s.T(), results, s.optionsMap)
+	resultObjects := make([]sac.NamespaceScopedObject, 0, len(results))
+	for _, r := range results {
+		key, err := IDToKey(r.ID)
+		if err != nil {
+			continue
+		}
+		resultObjects = append(resultObjects, key)
+	}
+	resultCounts := testutils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), resultObjects)
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
 }
 
@@ -246,7 +254,7 @@ func (s *processBaselineSACTestSuite) TestScopedSearch() {
 }
 
 func (s *processBaselineSACTestSuite) TestUnrestrictedSearch() {
-	for name, c := range testutils.GenericUnrestrictedSACSearchTestCases(s.T()) {
+	for name, c := range testutils.GenericUnrestrictedRawSACSearchTestCases(s.T()) {
 		s.Run(name, func() {
 			s.runSearchTest(c)
 		})

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -282,7 +282,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -301,7 +301,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -328,7 +328,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ProcessBaselin
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -365,7 +365,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -388,7 +388,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -411,7 +411,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -446,7 +446,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -498,7 +498,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -528,7 +528,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -575,7 +575,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ProcessBaseli
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -277,7 +277,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -296,7 +296,7 @@ func (s *storeImpl) Exists(ctx context.Context, deploymentId string) (bool, erro
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -323,7 +323,7 @@ func (s *storeImpl) Get(ctx context.Context, deploymentId string) (*storage.Proc
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -360,7 +360,7 @@ func (s *storeImpl) Delete(ctx context.Context, deploymentId string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -383,7 +383,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -406,7 +406,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -441,7 +441,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -493,7 +493,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -523,7 +523,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -570,7 +570,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ProcessBaseli
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/processindicator/datastore/datastore_sac_test.go
+++ b/central/processindicator/datastore/datastore_sac_test.go
@@ -183,7 +183,7 @@ func (s *processIndicatorDatastoreSACSuite) TestScopedSearch() {
 }
 
 func (s *processIndicatorDatastoreSACSuite) TestUnrestrictedSearch() {
-	for name, c := range sacTestUtils.GenericUnrestrictedSACSearchTestCases(s.T()) {
+	for name, c := range sacTestUtils.GenericUnrestrictedRawSACSearchTestCases(s.T()) {
 		s.Run(name, func() {
 			s.runSearchTest(c)
 		})
@@ -222,6 +222,13 @@ func (s *processIndicatorDatastoreSACSuite) runSearchTest(c sacTestUtils.SACSear
 	ctx := s.testContexts[c.ScopeKey]
 	results, err := s.datastore.Search(ctx, nil)
 	s.Require().NoError(err)
-	resultCounts := sacTestUtils.CountResultsPerClusterAndNamespace(s.T(), results, s.optionsMap)
+	resultObjects := make([]sac.NamespaceScopedObject, 0, len(results))
+	for _, r := range results {
+		obj, found, err := s.datastore.GetProcessIndicator(s.testContexts[sacTestUtils.UnrestrictedReadCtx], r.ID)
+		if found && err == nil {
+			resultObjects = append(resultObjects, obj)
+		}
+	}
+	resultCounts := sacTestUtils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), resultObjects)
 	sacTestUtils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
 }

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -322,7 +322,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -341,7 +341,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -368,7 +368,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ProcessIndicat
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -405,7 +405,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -428,7 +428,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -451,7 +451,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -486,7 +486,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Proce
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -538,7 +538,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -568,7 +568,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -615,7 +615,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ProcessIndica
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/rbac/k8srole/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srole/datastore/datastore_sac_test.go
@@ -187,7 +187,14 @@ func (s *k8sRoleSACSuite) runSearchTest(c testutils.SACSearchTestCase) {
 	ctx := s.testContexts[c.ScopeKey]
 	results, err := s.datastore.Search(ctx, nil)
 	s.Require().NoError(err)
-	resultCounts := testutils.CountResultsPerClusterAndNamespace(s.T(), results, s.optionsMap)
+	resultObjects := make([]sac.NamespaceScopedObject, 0, len(results))
+	for _, r := range results {
+		obj, found, err := s.datastore.GetRole(s.testContexts[testutils.UnrestrictedReadCtx], r.ID)
+		if found && err == nil {
+			resultObjects = append(resultObjects, obj)
+		}
+	}
+	resultCounts := testutils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), resultObjects)
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
 }
 
@@ -200,7 +207,7 @@ func (s *k8sRoleSACSuite) TestScopedSearch() {
 }
 
 func (s *k8sRoleSACSuite) TestUnrestrictedSearch() {
-	for name, c := range testutils.GenericUnrestrictedSACSearchTestCases(s.T()) {
+	for name, c := range testutils.GenericUnrestrictedRawSACSearchTestCases(s.T()) {
 		s.Run(name, func() {
 			s.runSearchTest(c)
 		})

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -302,7 +302,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -321,7 +321,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -348,7 +348,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.K8SRole, bool,
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -385,7 +385,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -408,7 +408,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -431,7 +431,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +466,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -518,7 +518,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -548,7 +548,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -595,7 +595,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.K8SRole) erro
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
@@ -188,7 +188,14 @@ func (s *k8sRoleBindingSACSuite) runSearchTest(c testutils.SACSearchTestCase) {
 	ctx := s.testContexts[c.ScopeKey]
 	results, err := s.datastore.Search(ctx, nil)
 	s.Require().NoError(err)
-	resultCounts := testutils.CountResultsPerClusterAndNamespace(s.T(), results, s.optionsMap)
+	resultObjects := make([]sac.NamespaceScopedObject, 0, len(results))
+	for _, r := range results {
+		obj, found, err := s.datastore.GetRoleBinding(s.testContexts[testutils.UnrestrictedReadCtx], r.ID)
+		if found && err == nil {
+			resultObjects = append(resultObjects, obj)
+		}
+	}
+	resultCounts := testutils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), resultObjects)
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
 }
 
@@ -201,7 +208,7 @@ func (s *k8sRoleBindingSACSuite) TestScopedSearch() {
 }
 
 func (s *k8sRoleBindingSACSuite) TestUnrestrictedSearch() {
-	for name, c := range testutils.GenericUnrestrictedSACSearchTestCases(s.T()) {
+	for name, c := range testutils.GenericUnrestrictedRawSACSearchTestCases(s.T()) {
 		s.Run(name, func() {
 			s.runSearchTest(c)
 		})

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -392,7 +392,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -411,7 +411,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -438,7 +438,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.K8SRoleBinding
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -475,7 +475,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -498,7 +498,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -521,7 +521,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -556,7 +556,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.K8SRo
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -608,7 +608,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -638,7 +638,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -685,7 +685,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.K8SRoleBindin
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/risk/datastore/datastore_sac_test.go
+++ b/central/risk/datastore/datastore_sac_test.go
@@ -220,7 +220,18 @@ func (s *riskDatastoreSACSuite) runSearchTest(c testutils.SACSearchTestCase) {
 	ctx := s.testContexts[c.ScopeKey]
 	results, err := s.datastore.Search(ctx, nil)
 	s.Require().NoError(err)
-	resultCounts := testutils.CountResultsPerClusterAndNamespace(s.T(), results, s.optionsMap)
+	resultObjects := make([]sac.NamespaceScopedObject, 0, len(results))
+	for _, r := range results {
+		subjectType, subjectID, err := GetIDParts(r.ID)
+		if err != nil {
+			continue
+		}
+		obj, found, err := s.datastore.GetRisk(s.testContexts[testutils.UnrestrictedReadCtx], subjectID, subjectType)
+		if found && err == nil {
+			resultObjects = append(resultObjects, obj.GetSubject())
+		}
+	}
+	resultCounts := testutils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), resultObjects)
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
 }
 
@@ -233,7 +244,7 @@ func (s *riskDatastoreSACSuite) TestScopedSearch() {
 }
 
 func (s *riskDatastoreSACSuite) TestUnrestrictedSearch() {
-	for name, c := range testutils.GenericUnrestrictedSACSearchTestCases(s.T()) {
+	for name, c := range testutils.GenericUnrestrictedRawSACSearchTestCases(s.T()) {
 		s.Run(name, func() {
 			s.runSearchTest(c)
 		})

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -287,7 +287,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -306,7 +306,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -333,7 +333,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Risk, bool, er
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -370,7 +370,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -393,7 +393,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -416,7 +416,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -451,7 +451,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Risk,
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -503,7 +503,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -533,7 +533,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -580,7 +580,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Risk) error) 
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/secret/datastore/datastore_sac_test.go
+++ b/central/secret/datastore/datastore_sac_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/central/globalindex"
 	"github.com/stackrox/rox/central/role/resources"
-	"github.com/stackrox/rox/central/secret/mappings"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
@@ -286,25 +285,6 @@ var secretScopedSACSearchTestCases = map[string]secretSACSearchResult{
 	},
 }
 
-var secretUnrestrictedSACSearchTestCases = map[string]secretSACSearchResult{
-	"full read access should see all secrets": {
-		// SAC search fields are not injected in query when running unscoped search
-		// Therefore results cannot be dispatched per cluster and namespace
-		scopeKey: testutils.UnrestrictedReadCtx,
-		resultCounts: map[string]map[string]int{
-			"": {"": 18},
-		},
-	},
-	"full read-write access should see all secrets": {
-		// SAC search fields are not injected in query when running unscoped search
-		// Therefore results cannot be dispatched per cluster and namespace
-		scopeKey: testutils.UnrestrictedReadWriteCtx,
-		resultCounts: map[string]map[string]int{
-			"": {"": 18},
-		},
-	},
-}
-
 var secretUnrestrictedSACObjectSearchTestCases = map[string]secretSACSearchResult{
 	"full read access should see all secrets": {
 		scopeKey: testutils.UnrestrictedReadCtx,
@@ -351,7 +331,7 @@ func (s *secretDatastoreSACTestSuite) TestSecretScopedCount() {
 }
 
 func (s *secretDatastoreSACTestSuite) TestSecretUnrestrictedCount() {
-	for name, c := range secretUnrestrictedSACSearchTestCases {
+	for name, c := range secretUnrestrictedSACObjectSearchTestCases {
 		s.Run(name, func() {
 			s.runCountTest(c)
 		})
@@ -375,7 +355,7 @@ func (s *secretDatastoreSACTestSuite) TestSecretScopedCountSecrets() {
 }
 
 func (s *secretDatastoreSACTestSuite) TestSecretUnrestrictedCountSecrets() {
-	for name, c := range secretUnrestrictedSACSearchTestCases {
+	for name, c := range secretUnrestrictedSACObjectSearchTestCases {
 		s.Run(name, func() {
 			s.runCountSecretsTest(c)
 		})
@@ -386,7 +366,14 @@ func (s *secretDatastoreSACTestSuite) runSearchTest(testParams secretSACSearchRe
 	ctx := s.testContexts[testParams.scopeKey]
 	searchResults, err := s.datastore.Search(ctx, nil)
 	s.NoError(err)
-	resultCounts := testutils.CountResultsPerClusterAndNamespace(s.T(), searchResults, mappings.OptionsMap)
+	results := make([]sac.NamespaceScopedObject, 0, len(searchResults))
+	for _, r := range searchResults {
+		obj, found, err := s.datastore.GetSecret(s.testContexts[testutils.UnrestrictedReadCtx], r.ID)
+		if found && err == nil {
+			results = append(results, obj)
+		}
+	}
+	resultCounts := testutils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), results)
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, testParams.resultCounts, resultCounts)
 }
 
@@ -399,7 +386,7 @@ func (s *secretDatastoreSACTestSuite) TestSecretScopedSearch() {
 }
 
 func (s *secretDatastoreSACTestSuite) TestSecretUnrestrictedSearch() {
-	for name, c := range secretUnrestrictedSACSearchTestCases {
+	for name, c := range secretUnrestrictedSACObjectSearchTestCases {
 		s.Run(name, func() {
 			s.runSearchTest(c)
 		})
@@ -410,7 +397,14 @@ func (s *secretDatastoreSACTestSuite) runSearchSecretsTest(testParams secretSACS
 	ctx := s.testContexts[testParams.scopeKey]
 	searchResults, err := s.datastore.SearchSecrets(ctx, nil)
 	s.NoError(err)
-	resultDistribution := testutils.CountSearchResultsPerClusterAndNamespace(s.T(), searchResults, mappings.OptionsMap)
+	results := make([]sac.NamespaceScopedObject, 0, len(searchResults))
+	for _, r := range searchResults {
+		obj, found, err := s.datastore.GetSecret(s.testContexts[testutils.UnrestrictedReadCtx], r.GetId())
+		if found && err == nil {
+			results = append(results, obj)
+		}
+	}
+	resultDistribution := testutils.CountSearchResultObjectsPerClusterAndNamespace(s.T(), results)
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, testParams.resultCounts, resultDistribution)
 }
 
@@ -423,7 +417,7 @@ func (s *secretDatastoreSACTestSuite) TestSecretScopedSearchSecrets() {
 }
 
 func (s *secretDatastoreSACTestSuite) TestSecretUnrestrictedSearchSecrets() {
-	for name, c := range secretUnrestrictedSACSearchTestCases {
+	for name, c := range secretUnrestrictedSACObjectSearchTestCases {
 		s.Run(name, func() {
 			s.runSearchSecretsTest(c)
 		})

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -462,7 +462,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -481,7 +481,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -508,7 +508,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Secret, bool, 
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -545,7 +545,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -568,7 +568,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -591,7 +591,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -626,7 +626,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Secre
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -678,7 +678,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -708,7 +708,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -755,7 +755,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Secret) error
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -297,7 +297,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -316,7 +316,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -343,7 +343,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ServiceAccount
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -380,7 +380,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -403,7 +403,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -426,7 +426,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -461,7 +461,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Servi
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -513,7 +513,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -543,7 +543,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -590,7 +590,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ServiceAccoun
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/pkg/sac/query_helper.go
+++ b/pkg/sac/query_helper.go
@@ -84,7 +84,13 @@ func buildClusterNamespaceLevelSACQueryFilter(root *effectiveaccessscope.ScopeTr
 			continue
 		}
 		if clusterAccessScope.State == effectiveaccessscope.Included {
-			clusterQuery := search.ConjunctionQuery(getClusterMatchQuery(clusterID, verbose), getAnyNamespaceMatchQuery())
+			var clusterQuery *v1.Query
+			if verbose {
+				clusterQuery = search.ConjunctionQuery(getClusterMatchQuery(clusterID, verbose),
+					getAnyNamespaceMatchQuery())
+			} else {
+				clusterQuery = getClusterMatchQuery(clusterID, verbose)
+			}
 			clusterFilters = append(clusterFilters, clusterQuery)
 		} else if clusterAccessScope.State == effectiveaccessscope.Partial {
 			clusterQuery := getClusterMatchQuery(clusterID, verbose)

--- a/pkg/sac/query_helper_test.go
+++ b/pkg/sac/query_helper_test.go
@@ -65,12 +65,12 @@ func TestClusterScopeFilterGeneration(topLevelTest *testing.T) {
 		{
 			description:    "Scope tree with one fully included cluster tree generates a Match query filter",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterTreeFullyIncluded,
-			expected:       clusterMatch(planetArrakis),
+			expected:       clusterVerboseMatch(topLevelTest, planetArrakis),
 		},
 		{
 			description:    "Scope tree with one fully included cluster node generates a Match query filter",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterRootFullyIncluded,
-			expected:       clusterMatch(planetArrakis),
+			expected:       clusterVerboseMatch(topLevelTest, planetArrakis),
 		},
 		{
 			description:    "Scope tree with only partial cluster nodes generates a MatchNone query filter",
@@ -80,12 +80,15 @@ func TestClusterScopeFilterGeneration(topLevelTest *testing.T) {
 		{
 			description:    "Scope tree with one included cluster tree and partial clusters generate only a Match for the included cluster",
 			scopeGenerator: effectiveaccessscope.TestTreeClusterNamespaceFullClusterMixIncluded,
-			expected:       clusterMatch(planetArrakis),
+			expected:       clusterVerboseMatch(topLevelTest, planetArrakis),
 		},
 		{
 			description:    "Scope tree with multiple included cluster trees generates a Disjunction of Match for the included clusters",
 			scopeGenerator: effectiveaccessscope.TestTreeTwoClustersFullyIncluded,
-			expected:       search.DisjunctionQuery(clusterMatch(planetArrakis), clusterMatch(planetEarth)),
+			expected: search.DisjunctionQuery(
+				clusterVerboseMatch(topLevelTest, planetArrakis),
+				clusterVerboseMatch(topLevelTest, planetEarth),
+			),
 		},
 	}
 
@@ -139,35 +142,47 @@ func TestNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 		{
 			description:    "Generated query filter for fully included cluster subtree is simple cluster match",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterTreeFullyIncluded,
-			expected:       search.ConjunctionQuery(clusterMatch(planetArrakis), getAnyNamespaceMatchQuery()),
+			expected: search.ConjunctionQuery(
+				clusterVerboseMatch(topLevelTest, planetArrakis),
+				getAnyNamespaceMatchQuery(),
+			),
 		},
 		{
 			description:    "Generated query filter for included cluster node is simple cluster match",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterRootFullyIncluded,
-			expected:       search.ConjunctionQuery(clusterMatch(planetArrakis), getAnyNamespaceMatchQuery()),
+			expected: search.ConjunctionQuery(
+				clusterVerboseMatch(topLevelTest, planetArrakis),
+				getAnyNamespaceMatchQuery(),
+			),
 		},
 		{
 			description:    "Generated query filter for single included namespace is the conjunction of the cluster and namespace matches",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterNamespacePairOnlyIncluded,
-			expected:       search.ConjunctionQuery(clusterMatch(planetArrakis), namespaceMatch(nsAtreides)),
+			expected: search.ConjunctionQuery(
+				clusterVerboseMatch(topLevelTest, planetArrakis),
+				namespaceVerboseMatch(topLevelTest, nsAtreides),
+			),
 		},
 		{
 			description:    "Generated query filter for two namespaces in the same cluster is the conjunction of the cluster and the disjunction of the namespaces",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterTwoNamespacesIncluded,
 			expected: search.ConjunctionQuery(
-				clusterMatch(planetArrakis),
-				search.DisjunctionQuery(namespaceMatch(nsAtreides), namespaceMatch(nsHarkonnen)),
+				clusterVerboseMatch(topLevelTest, planetArrakis),
+				search.DisjunctionQuery(
+					namespaceVerboseMatch(topLevelTest, nsAtreides),
+					namespaceVerboseMatch(topLevelTest, nsHarkonnen),
+				),
 			),
 		},
 		{
 			description:    "Generated query filter for multiple namespaces in the same cluster is the conjunction of the cluster and the disjunction of the namespaces",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterMultipleNamespacesIncluded,
 			expected: search.ConjunctionQuery(
-				clusterMatch(planetEarth),
+				clusterVerboseMatch(topLevelTest, planetEarth),
 				search.DisjunctionQuery(
-					namespaceMatch(nsSkunkWorks),
-					namespaceMatch(nsFraunhofer),
-					namespaceMatch(nsCERN),
+					namespaceVerboseMatch(topLevelTest, nsSkunkWorks),
+					namespaceVerboseMatch(topLevelTest, nsFraunhofer),
+					namespaceVerboseMatch(topLevelTest, nsCERN),
 				),
 			),
 		},
@@ -175,31 +190,47 @@ func TestNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 			description:    "Genreated query filter for multiple cluster-namespace pairs is the disjunction of each cluster-namespace query",
 			scopeGenerator: effectiveaccessscope.TestTreeTwoClusterNamespacePairsIncluded,
 			expected: search.DisjunctionQuery(
-				search.ConjunctionQuery(clusterMatch(planetEarth), namespaceMatch(nsSkunkWorks)),
-				search.ConjunctionQuery(clusterMatch(planetArrakis), namespaceMatch(nsSpacingGuild)),
+				search.ConjunctionQuery(
+					clusterVerboseMatch(topLevelTest, planetEarth),
+					namespaceVerboseMatch(topLevelTest, nsSkunkWorks),
+				),
+				search.ConjunctionQuery(
+					clusterVerboseMatch(topLevelTest, planetArrakis),
+					namespaceVerboseMatch(topLevelTest, nsSpacingGuild),
+				),
 			),
 		},
 		{
 			description:    "Generated query filter for a mix of cluster-namespace combination is the disjunction of the cluster queries",
 			scopeGenerator: effectiveaccessscope.TestTreeClusterNamespaceMixIncluded,
 			expected: search.DisjunctionQuery(
-				search.ConjunctionQuery(clusterMatch(planetArrakis), namespaceMatch(nsSpacingGuild)),
 				search.ConjunctionQuery(
-					clusterMatch(planetEarth),
-					search.DisjunctionQuery(namespaceMatch(nsSkunkWorks), namespaceMatch(nsJPL))),
+					clusterVerboseMatch(topLevelTest, planetArrakis),
+					namespaceVerboseMatch(topLevelTest, nsSpacingGuild),
+				),
+				search.ConjunctionQuery(
+					clusterVerboseMatch(topLevelTest, planetEarth),
+					search.DisjunctionQuery(
+						namespaceVerboseMatch(topLevelTest, nsSkunkWorks),
+						namespaceVerboseMatch(topLevelTest, nsJPL),
+					),
+				),
 			),
 		},
 		{
 			description:    "Generated query filter for a full and a partial cluster is the disjunction of the full cluster match and the partial cluster tree",
 			scopeGenerator: effectiveaccessscope.TestTreeClusterNamespaceFullClusterMixIncluded,
 			expected: search.DisjunctionQuery(
-				search.ConjunctionQuery(clusterMatch(planetArrakis), getAnyNamespaceMatchQuery()),
 				search.ConjunctionQuery(
-					clusterMatch(planetEarth),
+					clusterVerboseMatch(topLevelTest, planetArrakis),
+					getAnyNamespaceMatchQuery(),
+				),
+				search.ConjunctionQuery(
+					clusterVerboseMatch(topLevelTest, planetEarth),
 					search.DisjunctionQuery(
-						namespaceMatch(nsSkunkWorks),
-						namespaceMatch(nsFraunhofer),
-						namespaceMatch(nsCERN),
+						namespaceVerboseMatch(topLevelTest, nsSkunkWorks),
+						namespaceVerboseMatch(topLevelTest, nsFraunhofer),
+						namespaceVerboseMatch(topLevelTest, nsCERN),
 					),
 				),
 			),
@@ -208,16 +239,25 @@ func TestNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 			description:    "Generated query filter for a minimal scope tree matches exactly the tree structure",
 			scopeGenerator: effectiveaccessscope.TestTreeMinimalPartialTree,
 			expected: search.ConjunctionQuery(
-				clusterMatch(planetArrakis),
-				search.DisjunctionQuery(namespaceMatch(nsAtreides), namespaceMatch(nsHarkonnen)),
+				clusterVerboseMatch(topLevelTest, planetArrakis),
+				search.DisjunctionQuery(
+					namespaceVerboseMatch(topLevelTest, nsAtreides),
+					namespaceVerboseMatch(topLevelTest, nsHarkonnen),
+				),
 			),
 		},
 		{
 			description:    "Generated query filter for two fully included cluster tree is the disjunction of the cluster ID matches",
 			scopeGenerator: effectiveaccessscope.TestTreeTwoClustersFullyIncluded,
 			expected: search.DisjunctionQuery(
-				search.ConjunctionQuery(clusterMatch(planetArrakis), getAnyNamespaceMatchQuery()),
-				search.ConjunctionQuery(clusterMatch(planetEarth), getAnyNamespaceMatchQuery()),
+				search.ConjunctionQuery(
+					clusterVerboseMatch(topLevelTest, planetArrakis),
+					getAnyNamespaceMatchQuery(),
+				),
+				search.ConjunctionQuery(
+					clusterVerboseMatch(topLevelTest, planetEarth),
+					getAnyNamespaceMatchQuery(),
+				),
 			),
 		},
 	}
@@ -272,12 +312,12 @@ func TestNonVerboseClusterScopeFilterGeneration(topLevelTest *testing.T) {
 		{
 			description:    "Scope tree with one fully included cluster tree generates a Match query filter",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterTreeFullyIncluded,
-			expected:       clusterNonVerboseMatch(planetArrakis),
+			expected:       clusterNonVerboseMatch(topLevelTest, planetArrakis),
 		},
 		{
 			description:    "Scope tree with one fully included cluster node generates a Match query filter",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterRootFullyIncluded,
-			expected:       clusterNonVerboseMatch(planetArrakis),
+			expected:       clusterNonVerboseMatch(topLevelTest, planetArrakis),
 		},
 		{
 			description:    "Scope tree with only partial cluster nodes generates a MatchNone query filter",
@@ -287,14 +327,14 @@ func TestNonVerboseClusterScopeFilterGeneration(topLevelTest *testing.T) {
 		{
 			description:    "Scope tree with one included cluster tree and partial clusters generate only a Match for the included cluster",
 			scopeGenerator: effectiveaccessscope.TestTreeClusterNamespaceFullClusterMixIncluded,
-			expected:       clusterNonVerboseMatch(planetArrakis),
+			expected:       clusterNonVerboseMatch(topLevelTest, planetArrakis),
 		},
 		{
 			description:    "Scope tree with multiple included cluster trees generates a Disjunction of Match for the included clusters",
 			scopeGenerator: effectiveaccessscope.TestTreeTwoClustersFullyIncluded,
 			expected: search.DisjunctionQuery(
-				clusterNonVerboseMatch(planetArrakis),
-				clusterNonVerboseMatch(planetEarth)),
+				clusterNonVerboseMatch(topLevelTest, planetArrakis),
+				clusterNonVerboseMatch(topLevelTest, planetEarth)),
 		},
 	}
 
@@ -348,29 +388,29 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 		{
 			description:    "Generated query filter for fully included cluster subtree is simple cluster match",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterTreeFullyIncluded,
-			expected:       clusterNonVerboseMatch(planetArrakis),
+			expected:       clusterNonVerboseMatch(topLevelTest, planetArrakis),
 		},
 		{
 			description:    "Generated query filter for included cluster node is simple cluster match",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterRootFullyIncluded,
-			expected:       clusterNonVerboseMatch(planetArrakis),
+			expected:       clusterNonVerboseMatch(topLevelTest, planetArrakis),
 		},
 		{
 			description:    "Generated query filter for single included namespace is the conjunction of the cluster and namespace matches",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterNamespacePairOnlyIncluded,
 			expected: search.ConjunctionQuery(
-				clusterNonVerboseMatch(planetArrakis),
-				namespaceNonVerboseMatch(nsAtreides),
+				clusterNonVerboseMatch(topLevelTest, planetArrakis),
+				namespaceNonVerboseMatch(topLevelTest, nsAtreides),
 			),
 		},
 		{
 			description:    "Generated query filter for two namespaces in the same cluster is the conjunction of the cluster and the disjunction of the namespaces",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterTwoNamespacesIncluded,
 			expected: search.ConjunctionQuery(
-				clusterNonVerboseMatch(planetArrakis),
+				clusterNonVerboseMatch(topLevelTest, planetArrakis),
 				search.DisjunctionQuery(
-					namespaceNonVerboseMatch(nsAtreides),
-					namespaceNonVerboseMatch(nsHarkonnen),
+					namespaceNonVerboseMatch(topLevelTest, nsAtreides),
+					namespaceNonVerboseMatch(topLevelTest, nsHarkonnen),
 				),
 			),
 		},
@@ -378,11 +418,11 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 			description:    "Generated query filter for multiple namespaces in the same cluster is the conjunction of the cluster and the disjunction of the namespaces",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterMultipleNamespacesIncluded,
 			expected: search.ConjunctionQuery(
-				clusterNonVerboseMatch(planetEarth),
+				clusterNonVerboseMatch(topLevelTest, planetEarth),
 				search.DisjunctionQuery(
-					namespaceNonVerboseMatch(nsSkunkWorks),
-					namespaceNonVerboseMatch(nsFraunhofer),
-					namespaceNonVerboseMatch(nsCERN),
+					namespaceNonVerboseMatch(topLevelTest, nsSkunkWorks),
+					namespaceNonVerboseMatch(topLevelTest, nsFraunhofer),
+					namespaceNonVerboseMatch(topLevelTest, nsCERN),
 				),
 			),
 		},
@@ -391,12 +431,12 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 			scopeGenerator: effectiveaccessscope.TestTreeTwoClusterNamespacePairsIncluded,
 			expected: search.DisjunctionQuery(
 				search.ConjunctionQuery(
-					clusterNonVerboseMatch(planetEarth),
-					namespaceNonVerboseMatch(nsSkunkWorks),
+					clusterNonVerboseMatch(topLevelTest, planetEarth),
+					namespaceNonVerboseMatch(topLevelTest, nsSkunkWorks),
 				),
 				search.ConjunctionQuery(
-					clusterNonVerboseMatch(planetArrakis),
-					namespaceNonVerboseMatch(nsSpacingGuild),
+					clusterNonVerboseMatch(topLevelTest, planetArrakis),
+					namespaceNonVerboseMatch(topLevelTest, nsSpacingGuild),
 				),
 			),
 		},
@@ -405,14 +445,14 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 			scopeGenerator: effectiveaccessscope.TestTreeClusterNamespaceMixIncluded,
 			expected: search.DisjunctionQuery(
 				search.ConjunctionQuery(
-					clusterNonVerboseMatch(planetArrakis),
-					namespaceNonVerboseMatch(nsSpacingGuild),
+					clusterNonVerboseMatch(topLevelTest, planetArrakis),
+					namespaceNonVerboseMatch(topLevelTest, nsSpacingGuild),
 				),
 				search.ConjunctionQuery(
-					clusterNonVerboseMatch(planetEarth),
+					clusterNonVerboseMatch(topLevelTest, planetEarth),
 					search.DisjunctionQuery(
-						namespaceNonVerboseMatch(nsSkunkWorks),
-						namespaceNonVerboseMatch(nsJPL)),
+						namespaceNonVerboseMatch(topLevelTest, nsSkunkWorks),
+						namespaceNonVerboseMatch(topLevelTest, nsJPL)),
 				),
 			),
 		},
@@ -420,13 +460,13 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 			description:    "Generated query filter for a full and a partial cluster is the disjunction of the full cluster match and the partial cluster tree",
 			scopeGenerator: effectiveaccessscope.TestTreeClusterNamespaceFullClusterMixIncluded,
 			expected: search.DisjunctionQuery(
-				clusterNonVerboseMatch(planetArrakis),
+				clusterNonVerboseMatch(topLevelTest, planetArrakis),
 				search.ConjunctionQuery(
-					clusterNonVerboseMatch(planetEarth),
+					clusterNonVerboseMatch(topLevelTest, planetEarth),
 					search.DisjunctionQuery(
-						namespaceNonVerboseMatch(nsSkunkWorks),
-						namespaceNonVerboseMatch(nsFraunhofer),
-						namespaceNonVerboseMatch(nsCERN),
+						namespaceNonVerboseMatch(topLevelTest, nsSkunkWorks),
+						namespaceNonVerboseMatch(topLevelTest, nsFraunhofer),
+						namespaceNonVerboseMatch(topLevelTest, nsCERN),
 					),
 				),
 			),
@@ -435,10 +475,10 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 			description:    "Generated query filter for a minimal scope tree matches exactly the tree structure",
 			scopeGenerator: effectiveaccessscope.TestTreeMinimalPartialTree,
 			expected: search.ConjunctionQuery(
-				clusterNonVerboseMatch(planetArrakis),
+				clusterNonVerboseMatch(topLevelTest, planetArrakis),
 				search.DisjunctionQuery(
-					namespaceNonVerboseMatch(nsAtreides),
-					namespaceNonVerboseMatch(nsHarkonnen),
+					namespaceNonVerboseMatch(topLevelTest, nsAtreides),
+					namespaceNonVerboseMatch(topLevelTest, nsHarkonnen),
 				),
 			),
 		},
@@ -446,8 +486,8 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 			description:    "Generated query filter for two fully included cluster tree is the disjunction of the cluster ID matches",
 			scopeGenerator: effectiveaccessscope.TestTreeTwoClustersFullyIncluded,
 			expected: search.DisjunctionQuery(
-				clusterNonVerboseMatch(planetArrakis),
-				clusterNonVerboseMatch(planetEarth),
+				clusterNonVerboseMatch(topLevelTest, planetArrakis),
+				clusterNonVerboseMatch(topLevelTest, planetEarth),
 			),
 		},
 	}
@@ -465,20 +505,4 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 			}
 		})
 	}
-}
-
-func clusterMatch(clusterID string) *v1.Query {
-	return search.NewQueryBuilder().AddExactMatches(search.ClusterID, clusterID).MarkHighlighted(search.ClusterID).ProtoQuery()
-}
-
-func namespaceMatch(namespace string) *v1.Query {
-	return search.NewQueryBuilder().AddExactMatches(search.Namespace, namespace).MarkHighlighted(search.Namespace).ProtoQuery()
-}
-
-func clusterNonVerboseMatch(clusterID string) *v1.Query {
-	return search.NewQueryBuilder().AddExactMatches(search.ClusterID, clusterID).ProtoQuery()
-}
-
-func namespaceNonVerboseMatch(namespace string) *v1.Query {
-	return search.NewQueryBuilder().AddExactMatches(search.Namespace, namespace).ProtoQuery()
 }

--- a/pkg/sac/query_helper_test.go
+++ b/pkg/sac/query_helper_test.go
@@ -237,10 +237,248 @@ func TestNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 	}
 }
 
+func TestNonVerboseClusterScopeFilterGeneration(topLevelTest *testing.T) {
+	testCases := []testCase{
+		{
+			description:    "nil ScopeTree generates a MatchNone query filter",
+			scopeGenerator: effectiveaccessscope.TestTreeNil,
+			expected:       getMatchNoneQuery(),
+		},
+		{
+			description:    "DenyAllAccessScope generates a MatchNone query filter",
+			scopeGenerator: effectiveaccessscope.TestTreeDenyAllEffectiveAccessScope,
+			expected:       getMatchNoneQuery(),
+		},
+		{
+			description:    "UnrestrictedEffectiveAccessScope generates an empty (nil) query filter",
+			scopeGenerator: effectiveaccessscope.TestTreeUnrestrictedEffectiveAccessScope,
+			expected:       nil,
+		},
+		{
+			description:    "All excluded scope tree generates a MatchNone query filter",
+			scopeGenerator: effectiveaccessscope.TestTreeAllExcluded,
+			expected:       getMatchNoneQuery(),
+		},
+		{
+			description:    "Invalid scope tree with excluded root generates a MatchNone query filter",
+			scopeGenerator: effectiveaccessscope.TestTreeInvalidExcludedRootPartialBranch,
+			expected:       getMatchNoneQuery(),
+		},
+		{
+			description:    "Invalid scope tree with partial root and no cluster nodes generates a MatchNone query filter",
+			scopeGenerator: effectiveaccessscope.TestTreeInvalidPartialRootWithoutChildren,
+			expected:       getMatchNoneQuery(),
+		},
+		{
+			description:    "Scope tree with one fully included cluster tree generates a Match query filter",
+			scopeGenerator: effectiveaccessscope.TestTreeOneClusterTreeFullyIncluded,
+			expected:       clusterNonVerboseMatch(planetArrakis),
+		},
+		{
+			description:    "Scope tree with one fully included cluster node generates a Match query filter",
+			scopeGenerator: effectiveaccessscope.TestTreeOneClusterRootFullyIncluded,
+			expected:       clusterNonVerboseMatch(planetArrakis),
+		},
+		{
+			description:    "Scope tree with only partial cluster nodes generates a MatchNone query filter",
+			scopeGenerator: effectiveaccessscope.TestTreeClusterNamespaceMixIncluded,
+			expected:       getMatchNoneQuery(),
+		},
+		{
+			description:    "Scope tree with one included cluster tree and partial clusters generate only a Match for the included cluster",
+			scopeGenerator: effectiveaccessscope.TestTreeClusterNamespaceFullClusterMixIncluded,
+			expected:       clusterNonVerboseMatch(planetArrakis),
+		},
+		{
+			description:    "Scope tree with multiple included cluster trees generates a Disjunction of Match for the included clusters",
+			scopeGenerator: effectiveaccessscope.TestTreeTwoClustersFullyIncluded,
+			expected: search.DisjunctionQuery(
+				clusterNonVerboseMatch(planetArrakis),
+				clusterNonVerboseMatch(planetEarth)),
+		},
+	}
+
+	for _, tc := range testCases {
+		topLevelTest.Run(tc.description, func(t *testing.T) {
+			eas := tc.scopeGenerator(t)
+			filter, err := BuildNonVerboseClusterLevelSACQueryFilter(eas)
+			assert.True(t, tc.hasError == (err != nil))
+			correctFilter := isSameQuery(tc.expected, filter)
+			assert.Truef(t, correctFilter, "mismatch between queries")
+			if !correctFilter {
+				// Expose the mismatch in the test output
+				assert.Equal(t, tc.expected, filter)
+			}
+		})
+	}
+}
+
+func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
+	testCases := []testCase{
+		{
+			description:    "Generated query filter for nil scope tree is MatchNone",
+			scopeGenerator: effectiveaccessscope.TestTreeNil,
+			expected:       getMatchNoneQuery(),
+		},
+		{
+			description:    "Generated query filter for DenyAllEffectiveAccessScope is MatchNone",
+			scopeGenerator: effectiveaccessscope.TestTreeDenyAllEffectiveAccessScope,
+			expected:       getMatchNoneQuery(),
+		},
+		{
+			description:    "Generated query filter for UnrestrictedEffectiveAccessScope is nil",
+			scopeGenerator: effectiveaccessscope.TestTreeUnrestrictedEffectiveAccessScope,
+			expected:       nil,
+		},
+		{
+			description:    "Generated query filter for all excluded subtree is MatchNone",
+			scopeGenerator: effectiveaccessscope.TestTreeAllExcluded,
+			expected:       getMatchNoneQuery(),
+		},
+		{
+			description:    "Generated query filter for invalid tree with excluded root is MatchNone",
+			scopeGenerator: effectiveaccessscope.TestTreeInvalidExcludedRootPartialBranch,
+			expected:       getMatchNoneQuery(),
+		},
+		{
+			description:    "Generated query filter for invalid tree with partial root but no cluster children is MatchNone",
+			scopeGenerator: effectiveaccessscope.TestTreeInvalidPartialRootWithoutChildren,
+			expected:       getMatchNoneQuery(),
+		},
+		{
+			description:    "Generated query filter for fully included cluster subtree is simple cluster match",
+			scopeGenerator: effectiveaccessscope.TestTreeOneClusterTreeFullyIncluded,
+			expected:       clusterNonVerboseMatch(planetArrakis),
+		},
+		{
+			description:    "Generated query filter for included cluster node is simple cluster match",
+			scopeGenerator: effectiveaccessscope.TestTreeOneClusterRootFullyIncluded,
+			expected:       clusterNonVerboseMatch(planetArrakis),
+		},
+		{
+			description:    "Generated query filter for single included namespace is the conjunction of the cluster and namespace matches",
+			scopeGenerator: effectiveaccessscope.TestTreeOneClusterNamespacePairOnlyIncluded,
+			expected: search.ConjunctionQuery(
+				clusterNonVerboseMatch(planetArrakis),
+				namespaceNonVerboseMatch(nsAtreides),
+			),
+		},
+		{
+			description:    "Generated query filter for two namespaces in the same cluster is the conjunction of the cluster and the disjunction of the namespaces",
+			scopeGenerator: effectiveaccessscope.TestTreeOneClusterTwoNamespacesIncluded,
+			expected: search.ConjunctionQuery(
+				clusterNonVerboseMatch(planetArrakis),
+				search.DisjunctionQuery(
+					namespaceNonVerboseMatch(nsAtreides),
+					namespaceNonVerboseMatch(nsHarkonnen),
+				),
+			),
+		},
+		{
+			description:    "Generated query filter for multiple namespaces in the same cluster is the conjunction of the cluster and the disjunction of the namespaces",
+			scopeGenerator: effectiveaccessscope.TestTreeOneClusterMultipleNamespacesIncluded,
+			expected: search.ConjunctionQuery(
+				clusterNonVerboseMatch(planetEarth),
+				search.DisjunctionQuery(
+					namespaceNonVerboseMatch(nsSkunkWorks),
+					namespaceNonVerboseMatch(nsFraunhofer),
+					namespaceNonVerboseMatch(nsCERN),
+				),
+			),
+		},
+		{
+			description:    "Genreated query filter for multiple cluster-namespace pairs is the disjunction of each cluster-namespace query",
+			scopeGenerator: effectiveaccessscope.TestTreeTwoClusterNamespacePairsIncluded,
+			expected: search.DisjunctionQuery(
+				search.ConjunctionQuery(
+					clusterNonVerboseMatch(planetEarth),
+					namespaceNonVerboseMatch(nsSkunkWorks),
+				),
+				search.ConjunctionQuery(
+					clusterNonVerboseMatch(planetArrakis),
+					namespaceNonVerboseMatch(nsSpacingGuild),
+				),
+			),
+		},
+		{
+			description:    "Generated query filter for a mix of cluster-namespace combination is the disjunction of the cluster queries",
+			scopeGenerator: effectiveaccessscope.TestTreeClusterNamespaceMixIncluded,
+			expected: search.DisjunctionQuery(
+				search.ConjunctionQuery(
+					clusterNonVerboseMatch(planetArrakis),
+					namespaceNonVerboseMatch(nsSpacingGuild),
+				),
+				search.ConjunctionQuery(
+					clusterNonVerboseMatch(planetEarth),
+					search.DisjunctionQuery(
+						namespaceNonVerboseMatch(nsSkunkWorks),
+						namespaceNonVerboseMatch(nsJPL)),
+				),
+			),
+		},
+		{
+			description:    "Generated query filter for a full and a partial cluster is the disjunction of the full cluster match and the partial cluster tree",
+			scopeGenerator: effectiveaccessscope.TestTreeClusterNamespaceFullClusterMixIncluded,
+			expected: search.DisjunctionQuery(
+				clusterNonVerboseMatch(planetArrakis),
+				search.ConjunctionQuery(
+					clusterNonVerboseMatch(planetEarth),
+					search.DisjunctionQuery(
+						namespaceNonVerboseMatch(nsSkunkWorks),
+						namespaceNonVerboseMatch(nsFraunhofer),
+						namespaceNonVerboseMatch(nsCERN),
+					),
+				),
+			),
+		},
+		{
+			description:    "Generated query filter for a minimal scope tree matches exactly the tree structure",
+			scopeGenerator: effectiveaccessscope.TestTreeMinimalPartialTree,
+			expected: search.ConjunctionQuery(
+				clusterNonVerboseMatch(planetArrakis),
+				search.DisjunctionQuery(
+					namespaceNonVerboseMatch(nsAtreides),
+					namespaceNonVerboseMatch(nsHarkonnen),
+				),
+			),
+		},
+		{
+			description:    "Generated query filter for two fully included cluster tree is the disjunction of the cluster ID matches",
+			scopeGenerator: effectiveaccessscope.TestTreeTwoClustersFullyIncluded,
+			expected: search.DisjunctionQuery(
+				clusterNonVerboseMatch(planetArrakis),
+				clusterNonVerboseMatch(planetEarth),
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		topLevelTest.Run(tc.description, func(t *testing.T) {
+			eas := tc.scopeGenerator(t)
+			filter, err := BuildNonVerboseClusterNamespaceLevelSACQueryFilter(eas)
+			assert.True(t, tc.hasError == (err != nil))
+			correctFilter := isSameQuery(tc.expected, filter)
+			assert.Truef(t, correctFilter, "mismatch between queries")
+			if !correctFilter {
+				// Expose the mismatch in the test output
+				assert.Equal(t, tc.expected, filter)
+			}
+		})
+	}
+}
+
 func clusterMatch(clusterID string) *v1.Query {
 	return search.NewQueryBuilder().AddExactMatches(search.ClusterID, clusterID).MarkHighlighted(search.ClusterID).ProtoQuery()
 }
 
 func namespaceMatch(namespace string) *v1.Query {
 	return search.NewQueryBuilder().AddExactMatches(search.Namespace, namespace).MarkHighlighted(search.Namespace).ProtoQuery()
+}
+
+func clusterNonVerboseMatch(clusterID string) *v1.Query {
+	return search.NewQueryBuilder().AddExactMatches(search.ClusterID, clusterID).ProtoQuery()
+}
+
+func namespaceNonVerboseMatch(namespace string) *v1.Query {
+	return search.NewQueryBuilder().AddExactMatches(search.Namespace, namespace).ProtoQuery()
 }

--- a/pkg/sac/search_helper.go
+++ b/pkg/sac/search_helper.go
@@ -226,12 +226,12 @@ func (h *pgSearchHelper) enrichQueryWithSACFilter(effectiveAccessScope *effectiv
 	// Build SAC filter
 	switch h.resourceMD.GetScope() {
 	case permissions.NamespaceScope:
-		sacQueryFilter, err = BuildClusterNamespaceLevelSACQueryFilter(effectiveAccessScope)
+		sacQueryFilter, err = BuildNonVerboseClusterNamespaceLevelSACQueryFilter(effectiveAccessScope)
 		if err != nil {
 			return nil, err
 		}
 	case permissions.ClusterScope:
-		sacQueryFilter, err = BuildClusterLevelSACQueryFilter(effectiveAccessScope)
+		sacQueryFilter, err = BuildNonVerboseClusterLevelSACQueryFilter(effectiveAccessScope)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sac/search_helper_test.go
+++ b/pkg/sac/search_helper_test.go
@@ -174,7 +174,7 @@ func TestSACQueryEnricherForClusterResource(t *testing.T) {
 			description:           "Cluster-level scope tree and nil query result in cluster match query enrichment",
 			scope:                 effectiveaccessscope.TestTreeOneClusterRootFullyIncluded(t),
 			query:                 nil,
-			expectedEnrichedQuery: search.ConjunctionQuery(nil, clusterVerboseMatch(t, clusterIDArrakis)),
+			expectedEnrichedQuery: search.ConjunctionQuery(nil, clusterNonVerboseMatch(t, clusterIDArrakis)),
 		},
 		{
 			description: "Cluster-level multi-cluster scope tree and nil query result in multi-cluster match query enrichment",
@@ -182,8 +182,8 @@ func TestSACQueryEnricherForClusterResource(t *testing.T) {
 			query:       nil,
 			expectedEnrichedQuery: search.ConjunctionQuery(nil,
 				search.DisjunctionQuery(
-					clusterVerboseMatch(t, clusterIDArrakis),
-					clusterVerboseMatch(t, clusterIDEarth),
+					clusterNonVerboseMatch(t, clusterIDArrakis),
+					clusterNonVerboseMatch(t, clusterIDEarth),
 				)),
 		},
 		{
@@ -348,8 +348,8 @@ func TestSACQueryEnricherForClusterResource(t *testing.T) {
 								Pagination: paginationWithOffsetLimitAndSort,
 							},
 							search.DisjunctionQuery(
-								clusterVerboseMatch(t, clusterIDArrakis),
-								clusterVerboseMatch(t, clusterIDEarth),
+								clusterNonVerboseMatch(t, clusterIDArrakis),
+								clusterNonVerboseMatch(t, clusterIDEarth),
 							),
 						},
 					},
@@ -397,10 +397,7 @@ func TestSACQueryEnricherForNamespaceResource(t *testing.T) {
 			scope:       effectiveaccessscope.TestTreeOneClusterRootFullyIncluded(t),
 			query:       nil,
 			expectedEnrichedQuery: search.ConjunctionQuery(nil,
-				search.ConjunctionQuery(
-					clusterVerboseMatch(t, clusterIDArrakis),
-					getAnyNamespaceMatchQuery(),
-				),
+				clusterNonVerboseMatch(t, clusterIDArrakis),
 			),
 		},
 		{
@@ -409,14 +406,8 @@ func TestSACQueryEnricherForNamespaceResource(t *testing.T) {
 			query:       nil,
 			expectedEnrichedQuery: search.ConjunctionQuery(nil,
 				search.DisjunctionQuery(
-					search.ConjunctionQuery(
-						clusterVerboseMatch(t, clusterIDArrakis),
-						getAnyNamespaceMatchQuery(),
-					),
-					search.ConjunctionQuery(
-						clusterVerboseMatch(t, clusterIDEarth),
-						getAnyNamespaceMatchQuery(),
-					),
+					clusterNonVerboseMatch(t, clusterIDArrakis),
+					clusterNonVerboseMatch(t, clusterIDEarth),
 				)),
 		},
 		{
@@ -426,8 +417,8 @@ func TestSACQueryEnricherForNamespaceResource(t *testing.T) {
 			expectedEnrichedQuery: search.ConjunctionQuery(
 				nil,
 				search.ConjunctionQuery(
-					clusterVerboseMatch(t, clusterIDArrakis),
-					namespaceVerboseMatch(t, namespaceAtreides),
+					clusterNonVerboseMatch(t, clusterIDArrakis),
+					namespaceNonVerboseMatch(t, namespaceAtreides),
 				),
 			),
 		},
@@ -587,14 +578,8 @@ func TestSACQueryEnricherForNamespaceResource(t *testing.T) {
 								Pagination: paginationWithOffsetLimitAndSort,
 							},
 							search.DisjunctionQuery(
-								search.ConjunctionQuery(
-									clusterVerboseMatch(t, clusterIDArrakis),
-									getAnyNamespaceMatchQuery(),
-								),
-								search.ConjunctionQuery(
-									clusterVerboseMatch(t, clusterIDEarth),
-									getAnyNamespaceMatchQuery(),
-								),
+								clusterNonVerboseMatch(t, clusterIDArrakis),
+								clusterNonVerboseMatch(t, clusterIDEarth),
 							),
 						},
 					},
@@ -639,8 +624,14 @@ func TestSACQueryEnricherForNamespaceResource(t *testing.T) {
 								Pagination: paginationWithOffsetLimitAndSort,
 							},
 							search.DisjunctionQuery(
-								search.ConjunctionQuery(clusterMatch(planetEarth), namespaceMatch(nsSkunkWorks)),
-								search.ConjunctionQuery(clusterMatch(planetArrakis), namespaceMatch(nsSpacingGuild)),
+								search.ConjunctionQuery(
+									clusterNonVerboseMatch(t, planetEarth),
+									namespaceNonVerboseMatch(t, nsSkunkWorks),
+								),
+								search.ConjunctionQuery(
+									clusterNonVerboseMatch(t, planetArrakis),
+									namespaceNonVerboseMatch(t, nsSpacingGuild),
+								),
 							),
 						},
 					},

--- a/pkg/sac/testutils/search_test_cases.go
+++ b/pkg/sac/testutils/search_test_cases.go
@@ -151,25 +151,6 @@ func GenericScopedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase 
 	}
 }
 
-// GenericUnrestrictedSACSearchTestCases returns a generic set of SACSearchTestCase.
-// It is appropriate to use when the store contains 27 objects.
-func GenericUnrestrictedSACSearchTestCases(_ *testing.T) map[string]SACSearchTestCase {
-	return map[string]SACSearchTestCase{
-		"global read access should see all objects": {
-			ScopeKey: UnrestrictedReadCtx,
-			Results: map[string]map[string]int{
-				"": {"": 27},
-			},
-		},
-		"global read-write access should see all objects": {
-			ScopeKey: UnrestrictedReadWriteCtx,
-			Results: map[string]map[string]int{
-				"": {"": 27},
-			},
-		},
-	}
-}
-
 // GenericUnrestrictedRawSACSearchTestCases returns a generic set of SACSearchTestCase.
 // It is appropriate to use when the store contains:
 // 9 objects scoped to Cluster1, 3 to each Namespace A / B / C.

--- a/pkg/sac/testutils/testresult_distribution.go
+++ b/pkg/sac/testutils/testresult_distribution.go
@@ -3,9 +3,7 @@ package testutils
 import (
 	"testing"
 
-	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/sac"
-	searchPkg "github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -26,34 +24,6 @@ func ValidateSACSearchResultDistribution(s *suite.Suite, expected, obtained map[
 	}
 }
 
-// CountResultsPerClusterAndNamespace builds a result distribution map from the search output of a test,
-// counting the results per cluster and namespace.
-func CountResultsPerClusterAndNamespace(_ *testing.T, searchResults []searchPkg.Result, optionsMap searchPkg.OptionsMap) map[string]map[string]int {
-	resultDistribution := make(map[string]map[string]int, 0)
-	clusterIDField, _ := optionsMap.Get(searchPkg.ClusterID.String())
-	namespaceField, _ := optionsMap.Get(searchPkg.Namespace.String())
-	for _, result := range searchResults {
-		var clusterID string
-		var namespace string
-		for k, v := range result.Matches {
-			if k == clusterIDField.GetFieldPath() {
-				clusterID = v[0]
-			}
-			if k == namespaceField.GetFieldPath() {
-				namespace = v[0]
-			}
-		}
-		if _, clusterIDExists := resultDistribution[clusterID]; !clusterIDExists {
-			resultDistribution[clusterID] = make(map[string]int, 0)
-		}
-		if _, namespaceExists := resultDistribution[clusterID][namespace]; !namespaceExists {
-			resultDistribution[clusterID][namespace] = 0
-		}
-		resultDistribution[clusterID][namespace]++
-	}
-	return resultDistribution
-}
-
 // AggregateCounts returns the aggregated result count of an expected test result distribution map
 func AggregateCounts(_ *testing.T, resultDistribution map[string]map[string]int) int {
 	sum := 0
@@ -63,38 +33,6 @@ func AggregateCounts(_ *testing.T, resultDistribution map[string]map[string]int)
 		}
 	}
 	return sum
-}
-
-// CountSearchResultsPerClusterAndNamespace builds a result distribution map from the search output of a test,
-// counting the results per cluster and namespace.
-func CountSearchResultsPerClusterAndNamespace(_ *testing.T, results []*v1.SearchResult, optionsMap searchPkg.OptionsMap) map[string]map[string]int {
-	resultDistribution := make(map[string]map[string]int, 0)
-	clusterIDField, _ := optionsMap.Get(searchPkg.ClusterID.String())
-	namespaceField, _ := optionsMap.Get(searchPkg.Namespace.String())
-	for _, result := range results {
-		var clusterID string
-		var namespace string
-		for k, v := range result.GetFieldToMatches() {
-			if k == clusterIDField.GetFieldPath() {
-				if v != nil && len(v.Values) > 0 {
-					clusterID = v.Values[0]
-				}
-			}
-			if k == namespaceField.GetFieldPath() {
-				if v != nil && len(v.Values) > 0 {
-					namespace = v.Values[0]
-				}
-			}
-		}
-		if _, clusterIDExists := resultDistribution[clusterID]; !clusterIDExists {
-			resultDistribution[clusterID] = make(map[string]int, 0)
-		}
-		if _, namespaceExists := resultDistribution[clusterID][namespace]; !namespaceExists {
-			resultDistribution[clusterID][namespace] = 0
-		}
-		resultDistribution[clusterID][namespace]++
-	}
-	return resultDistribution
 }
 
 // CountSearchResultObjectsPerClusterAndNamespace builds a result distribution map from the search output of a test,

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -422,7 +422,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -441,7 +441,7 @@ func (s *storeImpl) Exists(ctx context.Context, key1 string, key2 string) (bool,
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -469,7 +469,7 @@ func (s *storeImpl) Get(ctx context.Context, key1 string, key2 string) (*storage
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -507,7 +507,7 @@ func (s *storeImpl) Delete(ctx context.Context, key1 string, key2 string) error 
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -531,7 +531,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -554,7 +554,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -589,7 +589,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestM
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -641,7 +641,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -671,7 +671,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -440,9 +440,9 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 		return 0, err
 	}
     {{- if .Obj.IsClusterScope }}
-    sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
     {{- else}}
-    sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
     {{- end }}
 
 	if err != nil {
@@ -478,9 +478,9 @@ func (s *storeImpl) Exists(ctx context.Context, {{template "paramList" $pks}}) (
 		return false, err
 	}
     {{- if .Obj.IsClusterScope }}
-    sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
     {{- else}}
-    sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
     {{- end }}
 	if err != nil {
 		return false, err
@@ -529,9 +529,9 @@ func (s *storeImpl) Get(ctx context.Context, {{template "paramList" $pks}}) (*{{
         return nil, false, err
 	}
     {{- if .Obj.IsClusterScope }}
-    sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
     {{- else}}
-    sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
     {{- end }}
 	if err != nil {
         return nil, false, err
@@ -611,9 +611,9 @@ func (s *storeImpl) Delete(ctx context.Context, {{template "paramList" $pks}}) e
 		return err
 	}
     {{- if .Obj.IsClusterScope }}
-    sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
     {{- else}}
-    sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
     {{- end }}
 	if err != nil {
 		return err
@@ -664,9 +664,9 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 		return err
 	}
     {{- if .Obj.IsClusterScope }}
-    sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
     {{- else}}
-    sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
     {{- end }}
 	if err != nil {
 		return err
@@ -708,9 +708,9 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]{{$singlePK.Type}}, error) {
 		return nil, err
 	}
     {{- if .Obj.IsClusterScope }}
-    sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
     {{- else}}
-    sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
     {{- end }}
 	if err != nil {
 		return nil, err
@@ -763,9 +763,9 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []{{$singlePK.Type}}) ([]*{
         return nil, nil, err
 	}
     {{- if .Obj.IsClusterScope }}
-    sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
     {{- else}}
-    sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
     {{- end }}
 	if err != nil {
         return nil, nil, err
@@ -835,9 +835,9 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*{{.Type
         return nil, err
 	}
     {{- if .Obj.IsClusterScope }}
-    sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
     {{- else}}
-    sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
     {{- end }}
 	if err != nil {
         return nil, err
@@ -887,9 +887,9 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []{{$singlePK.Type}}) er
         return err
     }
     {{- if .Obj.IsClusterScope }}
-    sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
     {{- else}}
-    sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
     {{- end }}
     if err != nil {
         return err
@@ -953,9 +953,9 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *{{.Type}}) error) err
         return err
     }
     {{- if .Obj.IsClusterScope }}
-    sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
     {{- else}}
-    sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+    sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
     {{- end }}
     if err != nil {
         return err

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -307,7 +307,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -326,7 +326,7 @@ func (s *storeImpl) Exists(ctx context.Context, key string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -353,7 +353,7 @@ func (s *storeImpl) Get(ctx context.Context, key string) (*storage.TestSingleKey
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -400,7 +400,7 @@ func (s *storeImpl) Delete(ctx context.Context, key string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -423,7 +423,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -446,7 +446,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -481,7 +481,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestS
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -533,7 +533,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -563,7 +563,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -261,7 +261,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -280,7 +280,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -307,7 +307,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestChild1, bo
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -344,7 +344,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -367,7 +367,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -390,7 +390,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -425,7 +425,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestC
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -477,7 +477,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -507,7 +507,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -266,7 +266,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -285,7 +285,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -312,7 +312,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestChild1P4, 
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -349,7 +349,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -372,7 +372,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -395,7 +395,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +430,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestC
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -482,7 +482,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -512,7 +512,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -271,7 +271,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -290,7 +290,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -317,7 +317,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestChild2, bo
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -354,7 +354,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -377,7 +377,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -400,7 +400,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +435,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestC
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -487,7 +487,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -517,7 +517,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -271,7 +271,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -290,7 +290,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -317,7 +317,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestG2GrandChi
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -354,7 +354,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -377,7 +377,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -400,7 +400,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +435,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -487,7 +487,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -517,7 +517,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -261,7 +261,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -280,7 +280,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -307,7 +307,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestG3GrandChi
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -344,7 +344,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -367,7 +367,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -390,7 +390,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -425,7 +425,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -477,7 +477,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -507,7 +507,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -261,7 +261,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -280,7 +280,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -307,7 +307,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestGGrandChil
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -344,7 +344,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -367,7 +367,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -390,7 +390,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -425,7 +425,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -477,7 +477,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -507,7 +507,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -271,7 +271,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -290,7 +290,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -317,7 +317,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestGrandChild
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -354,7 +354,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -377,7 +377,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -400,7 +400,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +435,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -487,7 +487,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -517,7 +517,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -436,7 +436,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -455,7 +455,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -482,7 +482,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestGrandparen
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -519,7 +519,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -542,7 +542,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -565,7 +565,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -600,7 +600,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestG
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -652,7 +652,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -682,7 +682,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -346,7 +346,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -365,7 +365,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -392,7 +392,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestParent1, b
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -429,7 +429,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -452,7 +452,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -475,7 +475,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -510,7 +510,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -562,7 +562,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -592,7 +592,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -266,7 +266,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -285,7 +285,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -312,7 +312,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestParent2, b
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -349,7 +349,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -372,7 +372,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -395,7 +395,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +430,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -482,7 +482,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -512,7 +512,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -266,7 +266,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -285,7 +285,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -312,7 +312,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestParent3, b
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -349,7 +349,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -372,7 +372,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -395,7 +395,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +430,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -482,7 +482,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -512,7 +512,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -266,7 +266,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -285,7 +285,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -312,7 +312,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestParent4, b
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -349,7 +349,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -372,7 +372,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -395,7 +395,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +430,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestP
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -482,7 +482,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -512,7 +512,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -266,7 +266,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 
 	if err != nil {
 		return 0, err
@@ -285,7 +285,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return false, err
 	}
@@ -312,7 +312,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.TestShortCircu
 	if err != nil {
 		return nil, false, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, false, err
 	}
@@ -349,7 +349,7 @@ func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -372,7 +372,7 @@ func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}
@@ -395,7 +395,7 @@ func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +430,7 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.TestS
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -482,7 +482,7 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	if err != nil {
 		return nil, err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}
@@ -512,7 +512,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	if err != nil {
 		return err
 	}
-	sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

In the early implementation of the postgres SAC search helper, the SAC fields were highlighted in the generated query.
At the time, it did help count and validate the results of SAC search test cases.
In the dackbox, however, these extra select fields tend to break some search queries.
As the validation of search cases can be done otherwise, the SAC filter generation should not highlight the SAC fields anymore.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI is sufficient