### PR TITLE
ROX-12712: Address scanner OOMs in OpenShift e2e tests

### DIFF
--- a/deploy/common/ci-values.yaml
+++ b/deploy/common/ci-values.yaml
@@ -1,14 +1,6 @@
-# Reduced resource overrides for the stackrox-central-services Helm chart in CI.
+# Change resource overrides for the stackrox-central-services Helm chart in CI.
 
 scanner:
   replicas: 1
   autoscaling:
     disable: true
-
-  resources:
-    requests:
-      memory: "1000Mi"
-      cpu: "500m"
-    limits:
-      memory: "2500Mi"
-      cpu: "2000m"

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -84,6 +84,9 @@ function roxcurl() {
 deploy_earlier_central() {
     info "Deploying: $EARLIER_TAG..."
 
+    # Change the scanner patch to address scanner OOMs - copying from the main branch
+    cp "$TEST_ROOT/deploy/common/scanner-patch.yaml" deploy/common/scanner-patch.yaml
+
     mkdir -p "bin/$TEST_HOST_PLATFORM"
     if is_CI; then
         gsutil cp "gs://stackrox-ci/roxctl-$EARLIER_TAG" "bin/$TEST_HOST_PLATFORM/roxctl"

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -84,9 +84,6 @@ function roxcurl() {
 deploy_earlier_central() {
     info "Deploying: $EARLIER_TAG..."
 
-    # Change the scanner patch to address scanner OOMs - copying from the main branch
-    cp "$TEST_ROOT/deploy/common/scanner-patch.yaml" deploy/common/scanner-patch.yaml
-
     mkdir -p "bin/$TEST_HOST_PLATFORM"
     if is_CI; then
         gsutil cp "gs://stackrox-ci/roxctl-$EARLIER_TAG" "bin/$TEST_HOST_PLATFORM/roxctl"


### PR DESCRIPTION
## Description

As per https://github.com/stackrox/stackrox/pull/751, don't alter scanner requests/limits in CI. This PR makes the same change for helm based installs which is used in openshift e2e tests.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient