### PR TITLE
ROX-12844: Refactor image enricher with multiple image names

### DIFF
--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -55,7 +55,7 @@ type fakeSigFetcher struct {
 	retryable bool
 }
 
-func (f *fakeSigFetcher) FetchSignatures(ctx context.Context, image *storage.Image,
+func (f *fakeSigFetcher) FetchSignatures(ctx context.Context, image *storage.Image, imageReference string,
 	registry types.Registry) ([]*storage.Signature, error) {
 	if f.fail {
 		err := errors.New("some error")
@@ -226,7 +226,11 @@ func TestEnricherFlow(t *testing.T) {
 				FetchOpt: UseCachesIfPossible,
 			},
 			inMetadataCache: false,
-			image:           &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}},
+			image: &storage.Image{
+				Id:    "id",
+				Name:  &storage.ImageName{Registry: "reg"},
+				Names: []*storage.ImageName{{Registry: "reg"}},
+			},
 
 			fsr: newFakeRegistryScanner(opts{
 				requestedMetadata: true,
@@ -245,8 +249,12 @@ func TestEnricherFlow(t *testing.T) {
 			inMetadataCache:      true,
 			shortCircuitRegistry: false,
 			shortCircuitScanner:  true,
-			image:                &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}},
-			imageGetter:          imageGetterFromImage(&storage.Image{Id: "id", Scan: &storage.ImageScan{}}),
+			image: &storage.Image{
+				Id:    "id",
+				Name:  &storage.ImageName{Registry: "reg"},
+				Names: []*storage.ImageName{{Registry: "reg"}},
+			},
+			imageGetter: imageGetterFromImage(&storage.Image{Id: "id", Scan: &storage.ImageScan{}}),
 
 			fsr: newFakeRegistryScanner(opts{
 				requestedMetadata: false,
@@ -263,7 +271,11 @@ func TestEnricherFlow(t *testing.T) {
 				FetchOpt: ForceRefetch,
 			},
 			inMetadataCache: true,
-			image:           &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}},
+			image: &storage.Image{
+				Id:    "id",
+				Name:  &storage.ImageName{Registry: "reg"},
+				Names: []*storage.ImageName{{Registry: "reg"}},
+			},
 
 			fsr: newFakeRegistryScanner(opts{
 				requestedMetadata: true,
@@ -280,7 +292,10 @@ func TestEnricherFlow(t *testing.T) {
 				FetchOpt: ForceRefetchScansOnly,
 			},
 			inMetadataCache: true,
-			image:           &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}},
+			image: &storage.Image{
+				Id: "id", Name: &storage.ImageName{Registry: "reg"},
+				Names: []*storage.ImageName{{Registry: "reg"}},
+			},
 
 			fsr: newFakeRegistryScanner(opts{
 				requestedMetadata: false,
@@ -323,6 +338,7 @@ func TestEnricherFlow(t *testing.T) {
 				Metadata: &storage.ImageMetadata{},
 				Scan:     &storage.ImageScan{},
 				Name:     &storage.ImageName{Registry: "reg"},
+				Names:    []*storage.ImageName{{Registry: "reg"}},
 			},
 			fsr: newFakeRegistryScanner(opts{
 				requestedMetadata: false,
@@ -344,7 +360,8 @@ func TestEnricherFlow(t *testing.T) {
 				Name: &storage.ImageName{
 					Registry: "reg",
 				},
-				Scan: &storage.ImageScan{},
+				Names: []*storage.ImageName{{Registry: "reg"}},
+				Scan:  &storage.ImageScan{},
 			},
 			fsr: newFakeRegistryScanner(opts{
 				requestedMetadata: true,
@@ -368,6 +385,7 @@ func TestEnricherFlow(t *testing.T) {
 				Metadata: &storage.ImageMetadata{},
 				Scan:     &storage.ImageScan{},
 				Name:     &storage.ImageName{Registry: "reg"},
+				Names:    []*storage.ImageName{{Registry: "reg"}},
 			},
 			imageGetter: imageGetterFromImage(&storage.Image{
 				Id:       "id",
@@ -474,7 +492,8 @@ func TestCVESuppression(t *testing.T) {
 		signatureFetcher:           &fakeSigFetcher{},
 	}
 
-	img := &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}}
+	img := &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"},
+		Names: []*storage.ImageName{{Registry: "reg"}}}
 	results, err := enricherImpl.EnrichImage(emptyCtx, EnrichmentContext{}, img)
 	require.NoError(t, err)
 	assert.True(t, results.ImageUpdated)
@@ -663,7 +682,11 @@ func TestZeroScannerIntegrations(t *testing.T) {
 		emptyImageGetter,
 		mockReporter, emptySignatureIntegrationGetter)
 
-	img := &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}}
+	img := &storage.Image{
+		Id:    "id",
+		Name:  &storage.ImageName{Registry: "reg"},
+		Names: []*storage.ImageName{{Registry: "reg"}},
+	}
 	results, err := enricherImpl.EnrichImage(emptyCtx, EnrichmentContext{}, img)
 	assert.Error(t, err)
 	expectedErrMsg := "image enrichment error: error scanning image:  error: no image scanners are integrated"
@@ -789,7 +812,11 @@ func TestEnrichWithSignature_Success(t *testing.T) {
 		ctx          EnrichmentContext
 	}{
 		"signatures found without pre-existing signatures": {
-			img: &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}},
+			img: &storage.Image{
+				Id:    "id",
+				Name:  &storage.ImageName{Registry: "reg"},
+				Names: []*storage.ImageName{{Registry: "reg"}},
+			},
 			ctx: EnrichmentContext{FetchOpt: ForceRefetchSignaturesOnly},
 			sigFetcher: &fakeSigFetcher{sigs: []*storage.Signature{
 				createSignature("rawsignature", "rawpayload")}},
@@ -802,12 +829,16 @@ func TestEnrichWithSignature_Success(t *testing.T) {
 		"cached values should be respected": {
 			ctx: EnrichmentContext{FetchOpt: UseCachesIfPossible},
 			img: &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}, Signature: &storage.ImageSignature{
-				Signatures: []*storage.Signature{createSignature("rawsignature", "rawpayload")},
-			}},
+				Signatures: []*storage.Signature{createSignature("rawsignature", "rawpayload")}},
+				Names: []*storage.ImageName{{Registry: "reg"}},
+			},
 			expectedSigs: []*storage.Signature{createSignature("rawsignature", "rawpayload")},
 		},
 		"fetched signatures contains duplicate": {
-			img: &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}},
+			img: &storage.Image{
+				Id:    "id",
+				Name:  &storage.ImageName{Registry: "reg"},
+				Names: []*storage.ImageName{{Registry: "reg"}}},
 			ctx: EnrichmentContext{FetchOpt: ForceRefetchSignaturesOnly},
 			sigFetcher: &fakeSigFetcher{sigs: []*storage.Signature{
 				createSignature("rawsignature", "rawpayload"),

--- a/pkg/images/integration/util.go
+++ b/pkg/images/integration/util.go
@@ -1,0 +1,37 @@
+package integration
+
+import (
+	"sort"
+
+	"github.com/stackrox/rox/generated/storage"
+	registryTypes "github.com/stackrox/rox/pkg/registries/types"
+	"github.com/stackrox/rox/pkg/urlfmt"
+)
+
+// GetMatchingImageIntegrations will return all image integrations that match the given image name.
+// In case no matching image integrations are found, an empty array will be returned.
+// The resulting image integrations array will be sorted by the registry's hostname.
+func GetMatchingImageIntegrations(registries []registryTypes.ImageRegistry,
+	imageName *storage.ImageName) []registryTypes.ImageRegistry {
+	var matchingIntegrations []registryTypes.ImageRegistry
+	for _, registry := range registries {
+		if registry.Match(imageName) {
+			matchingIntegrations = append(matchingIntegrations, registry)
+		}
+	}
+
+	sort.Slice(matchingIntegrations, func(i, j int) bool {
+		// Note: the Name of ImageRegistry does not reflect the registry hostname used within the integration but a
+		// name chosen by the creator. Additionally, we have to trim the HTTP prefixes (http:// & https://).
+		if matchingIntegrations[i].Config() == nil {
+			return true
+		}
+		if matchingIntegrations[j].Config() == nil {
+			return false
+		}
+		return urlfmt.TrimHTTPPrefixes(matchingIntegrations[i].Config().RegistryHostname) <
+			urlfmt.TrimHTTPPrefixes(matchingIntegrations[j].Config().RegistryHostname)
+	})
+
+	return matchingIntegrations
+}

--- a/pkg/images/integration/util_test.go
+++ b/pkg/images/integration/util_test.go
@@ -1,0 +1,73 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	imgUtils "github.com/stackrox/rox/pkg/images/utils"
+	registryTypes "github.com/stackrox/rox/pkg/registries/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRegistry struct {
+	registryTypes.ImageRegistry
+	match            bool
+	registryHostName string
+}
+
+func (f *fakeRegistry) Match(_ *storage.ImageName) bool {
+	return f.match
+}
+
+func (f *fakeRegistry) Config() *registryTypes.Config {
+	if f.registryHostName == "" {
+		return nil
+	}
+	return &registryTypes.Config{
+		RegistryHostname: f.registryHostName,
+	}
+}
+
+func TestGetMatchingImageIntegrations(t *testing.T) {
+	imgName, _, err := imgUtils.GenerateImageNameFromString("docker.io/nginx:1.23")
+	require.NoError(t, err)
+
+	cases := map[string]struct {
+		registries         []registryTypes.ImageRegistry
+		expectedRegistries []registryTypes.ImageRegistry
+	}{
+		"no matches for image": {
+			registries: []registryTypes.ImageRegistry{
+				&fakeRegistry{match: false},
+			},
+		},
+		"single matche for image name": {
+			registries: []registryTypes.ImageRegistry{
+				&fakeRegistry{match: true},
+			},
+			expectedRegistries: []registryTypes.ImageRegistry{
+				&fakeRegistry{match: true},
+			},
+		},
+		"multiple matches for image name": {
+			registries: []registryTypes.ImageRegistry{
+				&fakeRegistry{match: true, registryHostName: "docker.io"},
+				&fakeRegistry{match: true},
+				&fakeRegistry{match: true, registryHostName: "hub.docker.io"},
+			},
+			expectedRegistries: []registryTypes.ImageRegistry{
+				&fakeRegistry{match: true},
+				&fakeRegistry{match: true, registryHostName: "docker.io"},
+				&fakeRegistry{match: true, registryHostName: "hub.docker.io"},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			res := GetMatchingImageIntegrations(tc.registries, imgName)
+			assert.Equal(t, tc.expectedRegistries, res)
+		})
+	}
+}

--- a/pkg/signatures/factory.go
+++ b/pkg/signatures/factory.go
@@ -112,11 +112,11 @@ func createVerifiersFromIntegration(integration *storage.SignatureIntegration) [
 // FetchImageSignaturesWithRetries will try and fetch signatures for the given image from the given registry and return them.
 // It will retry on transient errors and return the fetched signatures.
 func FetchImageSignaturesWithRetries(ctx context.Context, fetcher SignatureFetcher, image *storage.Image,
-	imageReference string, registry registryTypes.Registry) ([]*storage.Signature, error) {
+	fullImageName string, registry registryTypes.Registry) ([]*storage.Signature, error) {
 	var fetchedSignatures []*storage.Signature
 	var err error
 	err = retry.WithRetry(func() error {
-		fetchedSignatures, err = fetchAndAppendSignatures(ctx, fetcher, image, imageReference, registry, fetchedSignatures)
+		fetchedSignatures, err = fetchAndAppendSignatures(ctx, fetcher, image, fullImageName, registry, fetchedSignatures)
 		return err
 	},
 		retry.Tries(2),
@@ -129,11 +129,11 @@ func FetchImageSignaturesWithRetries(ctx context.Context, fetcher SignatureFetch
 }
 
 func fetchAndAppendSignatures(ctx context.Context, fetcher SignatureFetcher, image *storage.Image,
-	imageReference string, registry registryTypes.Registry, fetchedSignatures []*storage.Signature) ([]*storage.Signature, error) {
+	fullImageName string, registry registryTypes.Registry, fetchedSignatures []*storage.Signature) ([]*storage.Signature, error) {
 	sigFetchCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	sigs, err := fetcher.FetchSignatures(sigFetchCtx, image, imageReference, registry)
+	sigs, err := fetcher.FetchSignatures(sigFetchCtx, image, fullImageName, registry)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/signatures/factory.go
+++ b/pkg/signatures/factory.go
@@ -26,7 +26,7 @@ type SignatureVerifier interface {
 
 // SignatureFetcher is responsible for fetching raw signatures supporting multiple specific signature formats.
 type SignatureFetcher interface {
-	FetchSignatures(ctx context.Context, image *storage.Image, imageReference string, registry registryTypes.Registry) ([]*storage.Signature, error)
+	FetchSignatures(ctx context.Context, image *storage.Image, fullImageName string, registry registryTypes.Registry) ([]*storage.Signature, error)
 }
 
 // NewSignatureVerifier creates a new signature verifier capable of verifying signatures against the provided config.

--- a/pkg/signatures/public_key_fetcher.go
+++ b/pkg/signatures/public_key_fetcher.go
@@ -52,7 +52,7 @@ func init() {
 // It will return the storage.ImageSignature and an error that indicated whether the fetching should be retried or not.
 // NOTE: No error will be returned when the image has no signature available. All occurring errors will be logged.
 func (c *cosignPublicKeySignatureFetcher) FetchSignatures(ctx context.Context, image *storage.Image,
-	registry registryTypes.Registry) ([]*storage.Signature, error) {
+	imageReference string, registry registryTypes.Registry) ([]*storage.Signature, error) {
 	// Short-circuit for images that do not have V2 metadata associated with them. These would be older images manifest
 	// schemes that are not supported by cosign, like the docker v1 manifest.
 	if image.GetMetadata().GetV2() == nil {
@@ -61,8 +61,7 @@ func (c *cosignPublicKeySignatureFetcher) FetchSignatures(ctx context.Context, i
 
 	// Since cosign makes heavy use of google/go-containerregistry, we need to parse the image's full name as a
 	// name.Reference.
-	imgFullName := image.GetName().GetFullName()
-	imgRef, err := name.ParseReference(imgFullName)
+	imgRef, err := name.ParseReference(imageReference)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +103,7 @@ func (c *cosignPublicKeySignatureFetcher) FetchSignatures(ctx context.Context, i
 		// We skip the invalid base64 signature and log its occurrence.
 		if err != nil {
 			log.Errorf("Error during decoding of raw signature for image %q: %v",
-				imgFullName, err)
+				imageReference, err)
 			continue
 		}
 		// Since we are only focusing on public keys, we are ignoring the certificate / rekor bundles associated with

--- a/pkg/signatures/public_key_fetcher.go
+++ b/pkg/signatures/public_key_fetcher.go
@@ -52,7 +52,7 @@ func init() {
 // It will return the storage.ImageSignature and an error that indicated whether the fetching should be retried or not.
 // NOTE: No error will be returned when the image has no signature available. All occurring errors will be logged.
 func (c *cosignPublicKeySignatureFetcher) FetchSignatures(ctx context.Context, image *storage.Image,
-	imageReference string, registry registryTypes.Registry) ([]*storage.Signature, error) {
+	fullImageName string, registry registryTypes.Registry) ([]*storage.Signature, error) {
 	// Short-circuit for images that do not have V2 metadata associated with them. These would be older images manifest
 	// schemes that are not supported by cosign, like the docker v1 manifest.
 	if image.GetMetadata().GetV2() == nil {
@@ -61,7 +61,7 @@ func (c *cosignPublicKeySignatureFetcher) FetchSignatures(ctx context.Context, i
 
 	// Since cosign makes heavy use of google/go-containerregistry, we need to parse the image's full name as a
 	// name.Reference.
-	imgRef, err := name.ParseReference(imageReference)
+	imgRef, err := name.ParseReference(fullImageName)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (c *cosignPublicKeySignatureFetcher) FetchSignatures(ctx context.Context, i
 		// We skip the invalid base64 signature and log its occurrence.
 		if err != nil {
 			log.Errorf("Error during decoding of raw signature for image %q: %v",
-				imageReference, err)
+				fullImageName, err)
 			continue
 		}
 		// Since we are only focusing on public keys, we are ignoring the certificate / rekor bundles associated with

--- a/pkg/signatures/public_key_fetcher_test.go
+++ b/pkg/signatures/public_key_fetcher_test.go
@@ -165,7 +165,7 @@ func TestPublicKey_FetchSignature_Success(t *testing.T) {
 	}
 	reg := &mockRegistry{cfg: mockConfig}
 
-	res, err := f.FetchSignatures(context.Background(), img, reg)
+	res, err := f.FetchSignatures(context.Background(), img, img.GetName().GetFullName(), reg)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedSignatures, res)
 }
@@ -184,7 +184,7 @@ func TestPublicKey_FetchSignature_Failure(t *testing.T) {
 	cimg.Name.FullName = "fa@wrongreference"
 	img := types.ToImage(cimg)
 	img.Metadata = &storage.ImageMetadata{V2: &storage.V2Metadata{Digest: "something"}}
-	res, err := f.FetchSignatures(context.Background(), img, nil)
+	res, err := f.FetchSignatures(context.Background(), img, img.GetName().GetFullName(), nil)
 	assert.Nil(t, res)
 	require.Error(t, err)
 	assert.False(t, retry.IsRetryable(err))
@@ -203,7 +203,7 @@ func TestPublicKey_FetchSignature_NoSignature(t *testing.T) {
 	reg := &mockRegistry{cfg: &registryTypes.Config{}}
 
 	require.NoError(t, err)
-	result, err := f.FetchSignatures(context.Background(), img, reg)
+	result, err := f.FetchSignatures(context.Background(), img, img.GetName().GetFullName(), reg)
 	assert.NoError(t, err)
 	assert.Nil(t, result)
 }

--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -77,7 +77,7 @@ func EnrichLocalImage(ctx context.Context, centralClient v1.ImageServiceClient, 
 	}
 
 	// Fetch signatures from cluster-local registry.
-	sigs, err := fetchSignaturesWithRetry(ctx, signatures.NewSignatureFetcher(), image,
+	sigs, err := fetchSignaturesWithRetry(ctx, signatures.NewSignatureFetcher(), image, image.GetName().GetFullName(),
 		matchingRegistry)
 	if err != nil {
 		log.Debugf("Failed fetching signatures for image %q: %v", imgName, err)

--- a/sensor/common/scan/scan_test.go
+++ b/sensor/common/scan/scan_test.go
@@ -37,7 +37,7 @@ func (i *fakeImageServiceClient) EnrichLocalImageInternal(ctx context.Context,
 type scanTestSuite struct {
 	suite.Suite
 	fetchSignaturesWithRetry func(ctx context.Context, fetcher signatures.SignatureFetcher, image *storage.Image,
-		registry registryTypes.Registry) ([]*storage.Signature, error)
+		imageRef string, registry registryTypes.Registry) ([]*storage.Signature, error)
 	getMatchingRegistry    func(image *storage.ImageName) (registryTypes.Registry, error)
 	scannerClientSingleton func() *scannerclient.Client
 	scanImg                func(ctx context.Context, image *storage.Image, registry registryTypes.Registry,
@@ -101,7 +101,7 @@ func (suite *scanTestSuite) TestEnrichImageFailures() {
 		scanImg func(ctx context.Context, image *storage.Image,
 			registry registryTypes.Registry, _ *scannerclient.Client) (*scannerV1.GetImageComponentsResponse, error)
 		fetchSignaturesWithRetry func(ctx context.Context, fetcher signatures.SignatureFetcher, image *storage.Image,
-			registry registryTypes.Registry) ([]*storage.Signature, error)
+			imgRef string, registry registryTypes.Registry) ([]*storage.Signature, error)
 		getMatchingRegistry    func(image *storage.ImageName) (registryTypes.Registry, error)
 		fakeImageServiceClient *fakeImageServiceClient
 		enrichmentTriggered    bool
@@ -168,7 +168,7 @@ func (suite *scanTestSuite) TestEnrichImageFailures() {
 
 func (suite *scanTestSuite) TestMetadataBeingSet() {
 	scanImg = successfulScan
-	fetchSignaturesWithRetry = func(_ context.Context, _ signatures.SignatureFetcher, img *storage.Image,
+	fetchSignaturesWithRetry = func(_ context.Context, _ signatures.SignatureFetcher, img *storage.Image, _ string,
 		_ registryTypes.Registry) ([]*storage.Signature, error) {
 		if img.GetMetadata().GetV2() == nil {
 			return nil, errors.New("image metadata missing, not attempting fetch of signatures")
@@ -210,7 +210,7 @@ func successfulScan(_ context.Context, _ *storage.Image,
 	}, nil
 }
 
-func successfulFetchSignatures(_ context.Context, _ signatures.SignatureFetcher, _ *storage.Image,
+func successfulFetchSignatures(_ context.Context, _ signatures.SignatureFetcher, _ *storage.Image, _ string,
 	_ registryTypes.Registry) ([]*storage.Signature, error) {
 	return []*storage.Signature{{
 		Signature: &storage.Signature_Cosign{Cosign: &storage.CosignSignature{
@@ -225,7 +225,7 @@ func failingScan(_ context.Context, _ *storage.Image,
 	return nil, errors.New("failed scanning image")
 }
 
-func failingFetchSignatures(_ context.Context, _ signatures.SignatureFetcher, _ *storage.Image,
+func failingFetchSignatures(_ context.Context, _ signatures.SignatureFetcher, _ *storage.Image, _ string,
 	_ registryTypes.Registry) ([]*storage.Signature, error) {
 	return nil, errors.New("failed fetching signatures")
 }

--- a/sensor/common/scan/scan_test.go
+++ b/sensor/common/scan/scan_test.go
@@ -37,7 +37,7 @@ func (i *fakeImageServiceClient) EnrichLocalImageInternal(ctx context.Context,
 type scanTestSuite struct {
 	suite.Suite
 	fetchSignaturesWithRetry func(ctx context.Context, fetcher signatures.SignatureFetcher, image *storage.Image,
-		imageRef string, registry registryTypes.Registry) ([]*storage.Signature, error)
+		fullImageName string, registry registryTypes.Registry) ([]*storage.Signature, error)
 	getMatchingRegistry    func(image *storage.ImageName) (registryTypes.Registry, error)
 	scannerClientSingleton func() *scannerclient.Client
 	scanImg                func(ctx context.Context, image *storage.Image, registry registryTypes.Registry,
@@ -101,7 +101,7 @@ func (suite *scanTestSuite) TestEnrichImageFailures() {
 		scanImg func(ctx context.Context, image *storage.Image,
 			registry registryTypes.Registry, _ *scannerclient.Client) (*scannerV1.GetImageComponentsResponse, error)
 		fetchSignaturesWithRetry func(ctx context.Context, fetcher signatures.SignatureFetcher, image *storage.Image,
-			imgRef string, registry registryTypes.Registry) ([]*storage.Signature, error)
+			fullImageName string, registry registryTypes.Registry) ([]*storage.Signature, error)
 		getMatchingRegistry    func(image *storage.ImageName) (registryTypes.Registry, error)
 		fakeImageServiceClient *fakeImageServiceClient
 		enrichmentTriggered    bool
@@ -239,7 +239,7 @@ type fakeRegistry struct {
 	fail bool
 }
 
-func (f *fakeRegistry) Metadata(image *storage.Image) (*storage.ImageMetadata, error) {
+func (f *fakeRegistry) Metadata(_ *storage.Image) (*storage.ImageMetadata, error) {
 	if f.fail {
 		return nil, errors.New("failed fetching metadata")
 	}


### PR DESCRIPTION
## Description

This is the third PR in a series of PRs to enable the image enricher to respect multiple image names when fetching signatures.

For additional context of the series of PRs, see the parent's PR context as well as [ROX-12844](https://issues.redhat.com/browse/ROX-12844).

To achieve this, the following has been done:
- Refactor image enricher's `enrichWithSignature` to ensure additional image names are respected.
- Adopt the existing interfaces for fetching signatures to include a image reference from which the signature should be fetched.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

- see CI, unit tests adjusted.
