### PR TITLE
Dashrews/ROX-13100 process indicator pruning performance batches

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -603,30 +603,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -601,12 +602,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -604,6 +604,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -613,14 +614,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/activecomponent/datastore/internal/store/postgres/store_test.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *ActiveComponentsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, activeComponent.GetId()))
 
 	var activeComponents []*storage.ActiveComponent
-	for i := 0; i < 200; i++ {
+	var activeComponentIds []string
+	for i := 0; i < 12000; i++ {
 		activeComponent := &storage.ActiveComponent{}
 		s.NoError(testutils.FullInit(activeComponent, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		activeComponents = append(activeComponents, activeComponent)
+		activeComponentIds = append(activeComponentIds, activeComponent.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, activeComponents))
 
 	activeComponentCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, activeComponentCount)
+	s.Equal(12000, activeComponentCount)
+
+	s.NoError(store.DeleteMany(ctx, activeComponentIds))
+
+	activeComponentCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, activeComponentCount)
 }

--- a/central/activecomponent/datastore/internal/store/postgres/store_test.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ActiveComponentsStoreSuite) TestStore() {
 
 	var activeComponents []*storage.ActiveComponent
 	var activeComponentIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		activeComponent := &storage.ActiveComponent{}
 		s.NoError(testutils.FullInit(activeComponent, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		activeComponents = append(activeComponents, activeComponent)
@@ -112,7 +112,7 @@ func (s *ActiveComponentsStoreSuite) TestStore() {
 
 	activeComponentCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, activeComponentCount)
+	s.Equal(200, activeComponentCount)
 
 	s.NoError(store.DeleteMany(ctx, activeComponentIds))
 

--- a/central/activecomponent/datastore/internal/store/postgres/store_test.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ActiveComponentsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, activeComponent.GetId()))
 
 	var activeComponents []*storage.ActiveComponent
-	var activeComponentIds []string
+	var activeComponentIDs []string
 	for i := 0; i < 200; i++ {
 		activeComponent := &storage.ActiveComponent{}
 		s.NoError(testutils.FullInit(activeComponent, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		activeComponents = append(activeComponents, activeComponent)
-		activeComponentIds = append(activeComponentIds, activeComponent.GetId())
+		activeComponentIDs = append(activeComponentIDs, activeComponent.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, activeComponents))
@@ -114,7 +114,7 @@ func (s *ActiveComponentsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, activeComponentCount)
 
-	s.NoError(store.DeleteMany(ctx, activeComponentIds))
+	s.NoError(store.DeleteMany(ctx, activeComponentIDs))
 
 	activeComponentCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -662,12 +663,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -664,30 +664,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -665,6 +665,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -674,14 +675,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/alert/datastore/internal/store/postgres/store_test.go
+++ b/central/alert/datastore/internal/store/postgres/store_test.go
@@ -103,7 +103,7 @@ func (s *AlertsStoreSuite) TestStore() {
 
 	var alerts []*storage.Alert
 	var alertIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		alert := &storage.Alert{}
 		s.NoError(testutils.FullInit(alert, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		alerts = append(alerts, alert)
@@ -114,7 +114,7 @@ func (s *AlertsStoreSuite) TestStore() {
 
 	alertCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, alertCount)
+	s.Equal(200, alertCount)
 
 	s.NoError(store.DeleteMany(ctx, alertIds))
 

--- a/central/alert/datastore/internal/store/postgres/store_test.go
+++ b/central/alert/datastore/internal/store/postgres/store_test.go
@@ -102,12 +102,12 @@ func (s *AlertsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, alert.GetId()))
 
 	var alerts []*storage.Alert
-	var alertIds []string
+	var alertIDs []string
 	for i := 0; i < 200; i++ {
 		alert := &storage.Alert{}
 		s.NoError(testutils.FullInit(alert, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		alerts = append(alerts, alert)
-		alertIds = append(alertIds, alert.GetId())
+		alertIDs = append(alertIDs, alert.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, alerts))
@@ -116,7 +116,7 @@ func (s *AlertsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, alertCount)
 
-	s.NoError(store.DeleteMany(ctx, alertIds))
+	s.NoError(store.DeleteMany(ctx, alertIDs))
 
 	alertCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/alert/datastore/internal/store/postgres/store_test.go
+++ b/central/alert/datastore/internal/store/postgres/store_test.go
@@ -102,17 +102,25 @@ func (s *AlertsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, alert.GetId()))
 
 	var alerts []*storage.Alert
-	for i := 0; i < 200; i++ {
+	var alertIds []string
+	for i := 0; i < 12000; i++ {
 		alert := &storage.Alert{}
 		s.NoError(testutils.FullInit(alert, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		alerts = append(alerts, alert)
+		alertIds = append(alertIds, alert.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, alerts))
 
 	alertCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, alertCount)
+	s.Equal(12000, alertCount)
+
+	s.NoError(store.DeleteMany(ctx, alertIds))
+
+	alertCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, alertCount)
 }
 
 func (s *AlertsStoreSuite) TestSACUpsert() {

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -429,30 +429,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -427,12 +428,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -430,6 +430,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -439,14 +440,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/apitoken/datastore/internal/store/postgres/store_test.go
+++ b/central/apitoken/datastore/internal/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *ApiTokensStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, tokenMetadata.GetId()), sac.ErrResourceAccessDenied)
 
 	var tokenMetadatas []*storage.TokenMetadata
-	for i := 0; i < 200; i++ {
+	var tokenMetadataIds []string
+	for i := 0; i < 12000; i++ {
 		tokenMetadata := &storage.TokenMetadata{}
 		s.NoError(testutils.FullInit(tokenMetadata, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		tokenMetadatas = append(tokenMetadatas, tokenMetadata)
+		tokenMetadataIds = append(tokenMetadataIds, tokenMetadata.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, tokenMetadatas))
 
 	tokenMetadataCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, tokenMetadataCount)
+	s.Equal(12000, tokenMetadataCount)
+
+	s.NoError(store.DeleteMany(ctx, tokenMetadataIds))
+
+	tokenMetadataCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, tokenMetadataCount)
 }

--- a/central/apitoken/datastore/internal/store/postgres/store_test.go
+++ b/central/apitoken/datastore/internal/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ApiTokensStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, tokenMetadata.GetId()), sac.ErrResourceAccessDenied)
 
 	var tokenMetadatas []*storage.TokenMetadata
-	var tokenMetadataIds []string
+	var tokenMetadataIDs []string
 	for i := 0; i < 200; i++ {
 		tokenMetadata := &storage.TokenMetadata{}
 		s.NoError(testutils.FullInit(tokenMetadata, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		tokenMetadatas = append(tokenMetadatas, tokenMetadata)
-		tokenMetadataIds = append(tokenMetadataIds, tokenMetadata.GetId())
+		tokenMetadataIDs = append(tokenMetadataIDs, tokenMetadata.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, tokenMetadatas))
@@ -114,7 +114,7 @@ func (s *ApiTokensStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, tokenMetadataCount)
 
-	s.NoError(store.DeleteMany(ctx, tokenMetadataIds))
+	s.NoError(store.DeleteMany(ctx, tokenMetadataIDs))
 
 	tokenMetadataCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/apitoken/datastore/internal/store/postgres/store_test.go
+++ b/central/apitoken/datastore/internal/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ApiTokensStoreSuite) TestStore() {
 
 	var tokenMetadatas []*storage.TokenMetadata
 	var tokenMetadataIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		tokenMetadata := &storage.TokenMetadata{}
 		s.NoError(testutils.FullInit(tokenMetadata, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		tokenMetadatas = append(tokenMetadatas, tokenMetadata)
@@ -112,7 +112,7 @@ func (s *ApiTokensStoreSuite) TestStore() {
 
 	tokenMetadataCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, tokenMetadataCount)
+	s.Equal(200, tokenMetadataCount)
 
 	s.NoError(store.DeleteMany(ctx, tokenMetadataIds))
 

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -443,12 +444,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -446,6 +446,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -455,14 +456,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -445,30 +445,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/authprovider/datastore/internal/store/postgres/store_test.go
+++ b/central/authprovider/datastore/internal/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *AuthProvidersStoreSuite) TestStore() {
 
 	var authProviders []*storage.AuthProvider
 	var authProviderIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		authProvider := &storage.AuthProvider{}
 		s.NoError(testutils.FullInit(authProvider, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		authProviders = append(authProviders, authProvider)
@@ -115,7 +115,7 @@ func (s *AuthProvidersStoreSuite) TestStore() {
 
 	authProviderCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, authProviderCount)
+	s.Equal(200, authProviderCount)
 
 	s.NoError(store.DeleteMany(ctx, authProviderIds))
 

--- a/central/authprovider/datastore/internal/store/postgres/store_test.go
+++ b/central/authprovider/datastore/internal/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *AuthProvidersStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, authProvider.GetId()), sac.ErrResourceAccessDenied)
 
 	var authProviders []*storage.AuthProvider
-	var authProviderIds []string
+	var authProviderIDs []string
 	for i := 0; i < 200; i++ {
 		authProvider := &storage.AuthProvider{}
 		s.NoError(testutils.FullInit(authProvider, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		authProviders = append(authProviders, authProvider)
-		authProviderIds = append(authProviderIds, authProvider.GetId())
+		authProviderIDs = append(authProviderIDs, authProvider.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, authProviders))
@@ -117,7 +117,7 @@ func (s *AuthProvidersStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, authProviderCount)
 
-	s.NoError(store.DeleteMany(ctx, authProviderIds))
+	s.NoError(store.DeleteMany(ctx, authProviderIDs))
 
 	authProviderCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/authprovider/datastore/internal/store/postgres/store_test.go
+++ b/central/authprovider/datastore/internal/store/postgres/store_test.go
@@ -100,10 +100,12 @@ func (s *AuthProvidersStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, authProvider.GetId()), sac.ErrResourceAccessDenied)
 
 	var authProviders []*storage.AuthProvider
-	for i := 0; i < 200; i++ {
+	var authProviderIds []string
+	for i := 0; i < 12000; i++ {
 		authProvider := &storage.AuthProvider{}
 		s.NoError(testutils.FullInit(authProvider, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		authProviders = append(authProviders, authProvider)
+		authProviderIds = append(authProviderIds, authProvider.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, authProviders))
@@ -113,5 +115,11 @@ func (s *AuthProvidersStoreSuite) TestStore() {
 
 	authProviderCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, authProviderCount)
+	s.Equal(12000, authProviderCount)
+
+	s.NoError(store.DeleteMany(ctx, authProviderIds))
+
+	authProviderCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, authProviderCount)
 }

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -423,30 +423,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -424,6 +424,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -433,14 +434,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -421,12 +422,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/cluster/store/cluster/postgres/store_test.go
+++ b/central/cluster/store/cluster/postgres/store_test.go
@@ -103,7 +103,7 @@ func (s *ClustersStoreSuite) TestStore() {
 
 	var clusters []*storage.Cluster
 	var clusterIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		cluster := &storage.Cluster{}
 		s.NoError(testutils.FullInit(cluster, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		clusters = append(clusters, cluster)
@@ -114,7 +114,7 @@ func (s *ClustersStoreSuite) TestStore() {
 
 	clusterCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, clusterCount)
+	s.Equal(200, clusterCount)
 
 	s.NoError(store.DeleteMany(ctx, clusterIds))
 

--- a/central/cluster/store/cluster/postgres/store_test.go
+++ b/central/cluster/store/cluster/postgres/store_test.go
@@ -102,17 +102,25 @@ func (s *ClustersStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, cluster.GetId()))
 
 	var clusters []*storage.Cluster
-	for i := 0; i < 200; i++ {
+	var clusterIds []string
+	for i := 0; i < 12000; i++ {
 		cluster := &storage.Cluster{}
 		s.NoError(testutils.FullInit(cluster, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		clusters = append(clusters, cluster)
+		clusterIds = append(clusterIds, cluster.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, clusters))
 
 	clusterCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, clusterCount)
+	s.Equal(12000, clusterCount)
+
+	s.NoError(store.DeleteMany(ctx, clusterIds))
+
+	clusterCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, clusterCount)
 }
 
 func (s *ClustersStoreSuite) TestSACUpsert() {

--- a/central/cluster/store/cluster/postgres/store_test.go
+++ b/central/cluster/store/cluster/postgres/store_test.go
@@ -102,12 +102,12 @@ func (s *ClustersStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, cluster.GetId()))
 
 	var clusters []*storage.Cluster
-	var clusterIds []string
+	var clusterIDs []string
 	for i := 0; i < 200; i++ {
 		cluster := &storage.Cluster{}
 		s.NoError(testutils.FullInit(cluster, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		clusters = append(clusters, cluster)
-		clusterIds = append(clusterIds, cluster.GetId())
+		clusterIDs = append(clusterIDs, cluster.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, clusters))
@@ -116,7 +116,7 @@ func (s *ClustersStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, clusterCount)
 
-	s.NoError(store.DeleteMany(ctx, clusterIds))
+	s.NoError(store.DeleteMany(ctx, clusterIDs))
 
 	clusterCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -538,30 +538,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -536,12 +537,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -539,6 +539,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -548,14 +549,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/cluster/store/clusterhealth/postgres/store_test.go
+++ b/central/cluster/store/clusterhealth/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *ClusterHealthStatusesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, clusterHealthStatus.GetId()))
 
 	var clusterHealthStatuss []*storage.ClusterHealthStatus
-	for i := 0; i < 200; i++ {
+	var clusterHealthStatusIds []string
+	for i := 0; i < 12000; i++ {
 		clusterHealthStatus := &storage.ClusterHealthStatus{}
 		s.NoError(testutils.FullInit(clusterHealthStatus, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		clusterHealthStatuss = append(clusterHealthStatuss, clusterHealthStatus)
+		clusterHealthStatusIds = append(clusterHealthStatusIds, clusterHealthStatus.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, clusterHealthStatuss))
 
 	clusterHealthStatusCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, clusterHealthStatusCount)
+	s.Equal(12000, clusterHealthStatusCount)
+
+	s.NoError(store.DeleteMany(ctx, clusterHealthStatusIds))
+
+	clusterHealthStatusCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, clusterHealthStatusCount)
 }

--- a/central/cluster/store/clusterhealth/postgres/store_test.go
+++ b/central/cluster/store/clusterhealth/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ClusterHealthStatusesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, clusterHealthStatus.GetId()))
 
 	var clusterHealthStatuss []*storage.ClusterHealthStatus
-	var clusterHealthStatusIds []string
+	var clusterHealthStatusIDs []string
 	for i := 0; i < 200; i++ {
 		clusterHealthStatus := &storage.ClusterHealthStatus{}
 		s.NoError(testutils.FullInit(clusterHealthStatus, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		clusterHealthStatuss = append(clusterHealthStatuss, clusterHealthStatus)
-		clusterHealthStatusIds = append(clusterHealthStatusIds, clusterHealthStatus.GetId())
+		clusterHealthStatusIDs = append(clusterHealthStatusIDs, clusterHealthStatus.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, clusterHealthStatuss))
@@ -114,7 +114,7 @@ func (s *ClusterHealthStatusesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, clusterHealthStatusCount)
 
-	s.NoError(store.DeleteMany(ctx, clusterHealthStatusIds))
+	s.NoError(store.DeleteMany(ctx, clusterHealthStatusIDs))
 
 	clusterHealthStatusCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/cluster/store/clusterhealth/postgres/store_test.go
+++ b/central/cluster/store/clusterhealth/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ClusterHealthStatusesStoreSuite) TestStore() {
 
 	var clusterHealthStatuss []*storage.ClusterHealthStatus
 	var clusterHealthStatusIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		clusterHealthStatus := &storage.ClusterHealthStatus{}
 		s.NoError(testutils.FullInit(clusterHealthStatus, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		clusterHealthStatuss = append(clusterHealthStatuss, clusterHealthStatus)
@@ -112,7 +112,7 @@ func (s *ClusterHealthStatusesStoreSuite) TestStore() {
 
 	clusterHealthStatusCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, clusterHealthStatusCount)
+	s.Equal(200, clusterHealthStatusCount)
 
 	s.NoError(store.DeleteMany(ctx, clusterHealthStatusIds))
 

--- a/central/clustercveedge/datastore/store/postgres/store.go
+++ b/central/clustercveedge/datastore/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
 )

--- a/central/clustercveedge/datastore/store/postgres/store.go
+++ b/central/clustercveedge/datastore/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 )

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -426,6 +426,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -435,14 +436,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -425,30 +425,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -32,10 +32,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -32,7 +32,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -35,6 +35,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -423,12 +424,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/clusterinit/store/postgres/store_test.go
+++ b/central/clusterinit/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ClusterInitBundlesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, initBundleMeta.GetId()), sac.ErrResourceAccessDenied)
 
 	var initBundleMetas []*storage.InitBundleMeta
-	var initBundleMetaIds []string
+	var initBundleMetaIDs []string
 	for i := 0; i < 200; i++ {
 		initBundleMeta := &storage.InitBundleMeta{}
 		s.NoError(testutils.FullInit(initBundleMeta, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		initBundleMetas = append(initBundleMetas, initBundleMeta)
-		initBundleMetaIds = append(initBundleMetaIds, initBundleMeta.GetId())
+		initBundleMetaIDs = append(initBundleMetaIDs, initBundleMeta.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, initBundleMetas))
@@ -114,7 +114,7 @@ func (s *ClusterInitBundlesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, initBundleMetaCount)
 
-	s.NoError(store.DeleteMany(ctx, initBundleMetaIds))
+	s.NoError(store.DeleteMany(ctx, initBundleMetaIDs))
 
 	initBundleMetaCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/clusterinit/store/postgres/store_test.go
+++ b/central/clusterinit/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *ClusterInitBundlesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, initBundleMeta.GetId()), sac.ErrResourceAccessDenied)
 
 	var initBundleMetas []*storage.InitBundleMeta
-	for i := 0; i < 200; i++ {
+	var initBundleMetaIds []string
+	for i := 0; i < 12000; i++ {
 		initBundleMeta := &storage.InitBundleMeta{}
 		s.NoError(testutils.FullInit(initBundleMeta, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		initBundleMetas = append(initBundleMetas, initBundleMeta)
+		initBundleMetaIds = append(initBundleMetaIds, initBundleMeta.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, initBundleMetas))
 
 	initBundleMetaCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, initBundleMetaCount)
+	s.Equal(12000, initBundleMetaCount)
+
+	s.NoError(store.DeleteMany(ctx, initBundleMetaIds))
+
+	initBundleMetaCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, initBundleMetaCount)
 }

--- a/central/clusterinit/store/postgres/store_test.go
+++ b/central/clusterinit/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ClusterInitBundlesStoreSuite) TestStore() {
 
 	var initBundleMetas []*storage.InitBundleMeta
 	var initBundleMetaIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		initBundleMeta := &storage.InitBundleMeta{}
 		s.NoError(testutils.FullInit(initBundleMeta, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		initBundleMetas = append(initBundleMetas, initBundleMeta)
@@ -112,7 +112,7 @@ func (s *ClusterInitBundlesStoreSuite) TestStore() {
 
 	initBundleMetaCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, initBundleMetaCount)
+	s.Equal(200, initBundleMetaCount)
 
 	s.NoError(store.DeleteMany(ctx, initBundleMetaIds))
 

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -508,30 +508,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -506,12 +507,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -509,6 +509,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -518,14 +519,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/compliance/datastore/internal/store/postgres/domain/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store_test.go
@@ -100,15 +100,23 @@ func (s *ComplianceDomainsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, complianceDomain.GetId()))
 
 	var complianceDomains []*storage.ComplianceDomain
-	for i := 0; i < 200; i++ {
+	var complianceDomainIds []string
+	for i := 0; i < 12000; i++ {
 		complianceDomain := &storage.ComplianceDomain{}
 		s.NoError(testutils.FullInit(complianceDomain, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceDomains = append(complianceDomains, complianceDomain)
+		complianceDomainIds = append(complianceDomainIds, complianceDomain.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceDomains))
 
 	complianceDomainCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, complianceDomainCount)
+	s.Equal(12000, complianceDomainCount)
+
+	s.NoError(store.DeleteMany(ctx, complianceDomainIds))
+
+	complianceDomainCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, complianceDomainCount)
 }

--- a/central/compliance/datastore/internal/store/postgres/domain/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store_test.go
@@ -101,7 +101,7 @@ func (s *ComplianceDomainsStoreSuite) TestStore() {
 
 	var complianceDomains []*storage.ComplianceDomain
 	var complianceDomainIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		complianceDomain := &storage.ComplianceDomain{}
 		s.NoError(testutils.FullInit(complianceDomain, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceDomains = append(complianceDomains, complianceDomain)
@@ -112,7 +112,7 @@ func (s *ComplianceDomainsStoreSuite) TestStore() {
 
 	complianceDomainCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, complianceDomainCount)
+	s.Equal(200, complianceDomainCount)
 
 	s.NoError(store.DeleteMany(ctx, complianceDomainIds))
 

--- a/central/compliance/datastore/internal/store/postgres/domain/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store_test.go
@@ -100,12 +100,12 @@ func (s *ComplianceDomainsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, complianceDomain.GetId()))
 
 	var complianceDomains []*storage.ComplianceDomain
-	var complianceDomainIds []string
+	var complianceDomainIDs []string
 	for i := 0; i < 200; i++ {
 		complianceDomain := &storage.ComplianceDomain{}
 		s.NoError(testutils.FullInit(complianceDomain, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceDomains = append(complianceDomains, complianceDomain)
-		complianceDomainIds = append(complianceDomainIds, complianceDomain.GetId())
+		complianceDomainIDs = append(complianceDomainIDs, complianceDomain.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceDomains))
@@ -114,7 +114,7 @@ func (s *ComplianceDomainsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceDomainCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceDomainIds))
+	s.NoError(store.DeleteMany(ctx, complianceDomainIDs))
 
 	complianceDomainCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -532,12 +533,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -535,6 +535,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -544,14 +545,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -534,30 +534,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
@@ -102,12 +102,12 @@ func (s *ComplianceRunMetadataStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, complianceRunMetadata.GetRunId()))
 
 	var complianceRunMetadatas []*storage.ComplianceRunMetadata
-	var complianceRunMetadataIds []string
+	var complianceRunMetadataIDs []string
 	for i := 0; i < 200; i++ {
 		complianceRunMetadata := &storage.ComplianceRunMetadata{}
 		s.NoError(testutils.FullInit(complianceRunMetadata, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceRunMetadatas = append(complianceRunMetadatas, complianceRunMetadata)
-		complianceRunMetadataIds = append(complianceRunMetadataIds, complianceRunMetadata.GetRunId())
+		complianceRunMetadataIDs = append(complianceRunMetadataIDs, complianceRunMetadata.GetRunId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceRunMetadatas))
@@ -116,7 +116,7 @@ func (s *ComplianceRunMetadataStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceRunMetadataCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceRunMetadataIds))
+	s.NoError(store.DeleteMany(ctx, complianceRunMetadataIDs))
 
 	complianceRunMetadataCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
@@ -103,7 +103,7 @@ func (s *ComplianceRunMetadataStoreSuite) TestStore() {
 
 	var complianceRunMetadatas []*storage.ComplianceRunMetadata
 	var complianceRunMetadataIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		complianceRunMetadata := &storage.ComplianceRunMetadata{}
 		s.NoError(testutils.FullInit(complianceRunMetadata, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceRunMetadatas = append(complianceRunMetadatas, complianceRunMetadata)
@@ -114,7 +114,7 @@ func (s *ComplianceRunMetadataStoreSuite) TestStore() {
 
 	complianceRunMetadataCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, complianceRunMetadataCount)
+	s.Equal(200, complianceRunMetadataCount)
 
 	s.NoError(store.DeleteMany(ctx, complianceRunMetadataIds))
 

--- a/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
@@ -102,17 +102,25 @@ func (s *ComplianceRunMetadataStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, complianceRunMetadata.GetRunId()))
 
 	var complianceRunMetadatas []*storage.ComplianceRunMetadata
-	for i := 0; i < 200; i++ {
+	var complianceRunMetadataIds []string
+	for i := 0; i < 12000; i++ {
 		complianceRunMetadata := &storage.ComplianceRunMetadata{}
 		s.NoError(testutils.FullInit(complianceRunMetadata, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceRunMetadatas = append(complianceRunMetadatas, complianceRunMetadata)
+		complianceRunMetadataIds = append(complianceRunMetadataIds, complianceRunMetadata.GetRunId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceRunMetadatas))
 
 	complianceRunMetadataCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, complianceRunMetadataCount)
+	s.Equal(12000, complianceRunMetadataCount)
+
+	s.NoError(store.DeleteMany(ctx, complianceRunMetadataIds))
+
+	complianceRunMetadataCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, complianceRunMetadataCount)
 }
 
 func (s *ComplianceRunMetadataStoreSuite) TestSACUpsert() {

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -532,12 +533,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -535,6 +535,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -544,14 +545,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -534,30 +534,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/compliance/datastore/internal/store/postgres/results/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store_test.go
@@ -102,12 +102,12 @@ func (s *ComplianceRunResultsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, complianceRunResults.GetRunMetadata().GetRunId()))
 
 	var complianceRunResultss []*storage.ComplianceRunResults
-	var complianceRunResultsIds []string
+	var complianceRunResultsIDs []string
 	for i := 0; i < 200; i++ {
 		complianceRunResults := &storage.ComplianceRunResults{}
 		s.NoError(testutils.FullInit(complianceRunResults, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceRunResultss = append(complianceRunResultss, complianceRunResults)
-		complianceRunResultsIds = append(complianceRunResultsIds, complianceRunResults.GetRunMetadata().GetRunId())
+		complianceRunResultsIDs = append(complianceRunResultsIDs, complianceRunResults.GetRunMetadata().GetRunId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceRunResultss))
@@ -116,7 +116,7 @@ func (s *ComplianceRunResultsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceRunResultsCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceRunResultsIds))
+	s.NoError(store.DeleteMany(ctx, complianceRunResultsIDs))
 
 	complianceRunResultsCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/compliance/datastore/internal/store/postgres/results/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store_test.go
@@ -103,7 +103,7 @@ func (s *ComplianceRunResultsStoreSuite) TestStore() {
 
 	var complianceRunResultss []*storage.ComplianceRunResults
 	var complianceRunResultsIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		complianceRunResults := &storage.ComplianceRunResults{}
 		s.NoError(testutils.FullInit(complianceRunResults, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceRunResultss = append(complianceRunResultss, complianceRunResults)
@@ -114,7 +114,7 @@ func (s *ComplianceRunResultsStoreSuite) TestStore() {
 
 	complianceRunResultsCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, complianceRunResultsCount)
+	s.Equal(200, complianceRunResultsCount)
 
 	s.NoError(store.DeleteMany(ctx, complianceRunResultsIds))
 

--- a/central/compliance/datastore/internal/store/postgres/results/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store_test.go
@@ -102,17 +102,25 @@ func (s *ComplianceRunResultsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, complianceRunResults.GetRunMetadata().GetRunId()))
 
 	var complianceRunResultss []*storage.ComplianceRunResults
-	for i := 0; i < 200; i++ {
+	var complianceRunResultsIds []string
+	for i := 0; i < 12000; i++ {
 		complianceRunResults := &storage.ComplianceRunResults{}
 		s.NoError(testutils.FullInit(complianceRunResults, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceRunResultss = append(complianceRunResultss, complianceRunResults)
+		complianceRunResultsIds = append(complianceRunResultsIds, complianceRunResults.GetRunMetadata().GetRunId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceRunResultss))
 
 	complianceRunResultsCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, complianceRunResultsCount)
+	s.Equal(12000, complianceRunResultsCount)
+
+	s.NoError(store.DeleteMany(ctx, complianceRunResultsIds))
+
+	complianceRunResultsCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, complianceRunResultsCount)
 }
 
 func (s *ComplianceRunResultsStoreSuite) TestSACUpsert() {

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -475,6 +475,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -484,14 +485,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -472,12 +473,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -474,30 +474,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/compliance/datastore/internal/store/postgres/strings/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store_test.go
@@ -101,7 +101,7 @@ func (s *ComplianceStringsStoreSuite) TestStore() {
 
 	var complianceStringss []*storage.ComplianceStrings
 	var complianceStringsIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		complianceStrings := &storage.ComplianceStrings{}
 		s.NoError(testutils.FullInit(complianceStrings, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceStringss = append(complianceStringss, complianceStrings)
@@ -112,7 +112,7 @@ func (s *ComplianceStringsStoreSuite) TestStore() {
 
 	complianceStringsCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, complianceStringsCount)
+	s.Equal(200, complianceStringsCount)
 
 	s.NoError(store.DeleteMany(ctx, complianceStringsIds))
 

--- a/central/compliance/datastore/internal/store/postgres/strings/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store_test.go
@@ -100,15 +100,23 @@ func (s *ComplianceStringsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, complianceStrings.GetId()))
 
 	var complianceStringss []*storage.ComplianceStrings
-	for i := 0; i < 200; i++ {
+	var complianceStringsIds []string
+	for i := 0; i < 12000; i++ {
 		complianceStrings := &storage.ComplianceStrings{}
 		s.NoError(testutils.FullInit(complianceStrings, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceStringss = append(complianceStringss, complianceStrings)
+		complianceStringsIds = append(complianceStringsIds, complianceStrings.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceStringss))
 
 	complianceStringsCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, complianceStringsCount)
+	s.Equal(12000, complianceStringsCount)
+
+	s.NoError(store.DeleteMany(ctx, complianceStringsIds))
+
+	complianceStringsCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, complianceStringsCount)
 }

--- a/central/compliance/datastore/internal/store/postgres/strings/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store_test.go
@@ -100,12 +100,12 @@ func (s *ComplianceStringsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, complianceStrings.GetId()))
 
 	var complianceStringss []*storage.ComplianceStrings
-	var complianceStringsIds []string
+	var complianceStringsIDs []string
 	for i := 0; i < 200; i++ {
 		complianceStrings := &storage.ComplianceStrings{}
 		s.NoError(testutils.FullInit(complianceStrings, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceStringss = append(complianceStringss, complianceStrings)
-		complianceStringsIds = append(complianceStringsIds, complianceStrings.GetId())
+		complianceStringsIDs = append(complianceStringsIDs, complianceStrings.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceStringss))
@@ -114,7 +114,7 @@ func (s *ComplianceStringsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceStringsCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceStringsIds))
+	s.NoError(store.DeleteMany(ctx, complianceStringsIDs))
 
 	complianceStringsCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -429,30 +429,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -427,12 +428,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -430,6 +430,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -439,14 +440,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/complianceoperator/checkresults/store/postgres/store_test.go
+++ b/central/complianceoperator/checkresults/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ComplianceOperatorCheckResultsStoreSuite) TestStore() {
 
 	var complianceOperatorCheckResults []*storage.ComplianceOperatorCheckResult
 	var complianceOperatorCheckResultIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		complianceOperatorCheckResult := &storage.ComplianceOperatorCheckResult{}
 		s.NoError(testutils.FullInit(complianceOperatorCheckResult, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceOperatorCheckResults = append(complianceOperatorCheckResults, complianceOperatorCheckResult)
@@ -112,7 +112,7 @@ func (s *ComplianceOperatorCheckResultsStoreSuite) TestStore() {
 
 	complianceOperatorCheckResultCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, complianceOperatorCheckResultCount)
+	s.Equal(200, complianceOperatorCheckResultCount)
 
 	s.NoError(store.DeleteMany(ctx, complianceOperatorCheckResultIds))
 

--- a/central/complianceoperator/checkresults/store/postgres/store_test.go
+++ b/central/complianceoperator/checkresults/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ComplianceOperatorCheckResultsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, complianceOperatorCheckResult.GetId()), sac.ErrResourceAccessDenied)
 
 	var complianceOperatorCheckResults []*storage.ComplianceOperatorCheckResult
-	var complianceOperatorCheckResultIds []string
+	var complianceOperatorCheckResultIDs []string
 	for i := 0; i < 200; i++ {
 		complianceOperatorCheckResult := &storage.ComplianceOperatorCheckResult{}
 		s.NoError(testutils.FullInit(complianceOperatorCheckResult, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceOperatorCheckResults = append(complianceOperatorCheckResults, complianceOperatorCheckResult)
-		complianceOperatorCheckResultIds = append(complianceOperatorCheckResultIds, complianceOperatorCheckResult.GetId())
+		complianceOperatorCheckResultIDs = append(complianceOperatorCheckResultIDs, complianceOperatorCheckResult.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceOperatorCheckResults))
@@ -114,7 +114,7 @@ func (s *ComplianceOperatorCheckResultsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorCheckResultCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorCheckResultIds))
+	s.NoError(store.DeleteMany(ctx, complianceOperatorCheckResultIDs))
 
 	complianceOperatorCheckResultCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/complianceoperator/checkresults/store/postgres/store_test.go
+++ b/central/complianceoperator/checkresults/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *ComplianceOperatorCheckResultsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, complianceOperatorCheckResult.GetId()), sac.ErrResourceAccessDenied)
 
 	var complianceOperatorCheckResults []*storage.ComplianceOperatorCheckResult
-	for i := 0; i < 200; i++ {
+	var complianceOperatorCheckResultIds []string
+	for i := 0; i < 12000; i++ {
 		complianceOperatorCheckResult := &storage.ComplianceOperatorCheckResult{}
 		s.NoError(testutils.FullInit(complianceOperatorCheckResult, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceOperatorCheckResults = append(complianceOperatorCheckResults, complianceOperatorCheckResult)
+		complianceOperatorCheckResultIds = append(complianceOperatorCheckResultIds, complianceOperatorCheckResult.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceOperatorCheckResults))
 
 	complianceOperatorCheckResultCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, complianceOperatorCheckResultCount)
+	s.Equal(12000, complianceOperatorCheckResultCount)
+
+	s.NoError(store.DeleteMany(ctx, complianceOperatorCheckResultIds))
+
+	complianceOperatorCheckResultCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, complianceOperatorCheckResultCount)
 }

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -429,30 +429,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -427,12 +428,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -430,6 +430,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -439,14 +440,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/complianceoperator/profiles/store/postgres/store_test.go
+++ b/central/complianceoperator/profiles/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *ComplianceOperatorProfilesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, complianceOperatorProfile.GetId()), sac.ErrResourceAccessDenied)
 
 	var complianceOperatorProfiles []*storage.ComplianceOperatorProfile
-	for i := 0; i < 200; i++ {
+	var complianceOperatorProfileIds []string
+	for i := 0; i < 12000; i++ {
 		complianceOperatorProfile := &storage.ComplianceOperatorProfile{}
 		s.NoError(testutils.FullInit(complianceOperatorProfile, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceOperatorProfiles = append(complianceOperatorProfiles, complianceOperatorProfile)
+		complianceOperatorProfileIds = append(complianceOperatorProfileIds, complianceOperatorProfile.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceOperatorProfiles))
 
 	complianceOperatorProfileCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, complianceOperatorProfileCount)
+	s.Equal(12000, complianceOperatorProfileCount)
+
+	s.NoError(store.DeleteMany(ctx, complianceOperatorProfileIds))
+
+	complianceOperatorProfileCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, complianceOperatorProfileCount)
 }

--- a/central/complianceoperator/profiles/store/postgres/store_test.go
+++ b/central/complianceoperator/profiles/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ComplianceOperatorProfilesStoreSuite) TestStore() {
 
 	var complianceOperatorProfiles []*storage.ComplianceOperatorProfile
 	var complianceOperatorProfileIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		complianceOperatorProfile := &storage.ComplianceOperatorProfile{}
 		s.NoError(testutils.FullInit(complianceOperatorProfile, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceOperatorProfiles = append(complianceOperatorProfiles, complianceOperatorProfile)
@@ -112,7 +112,7 @@ func (s *ComplianceOperatorProfilesStoreSuite) TestStore() {
 
 	complianceOperatorProfileCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, complianceOperatorProfileCount)
+	s.Equal(200, complianceOperatorProfileCount)
 
 	s.NoError(store.DeleteMany(ctx, complianceOperatorProfileIds))
 

--- a/central/complianceoperator/profiles/store/postgres/store_test.go
+++ b/central/complianceoperator/profiles/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ComplianceOperatorProfilesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, complianceOperatorProfile.GetId()), sac.ErrResourceAccessDenied)
 
 	var complianceOperatorProfiles []*storage.ComplianceOperatorProfile
-	var complianceOperatorProfileIds []string
+	var complianceOperatorProfileIDs []string
 	for i := 0; i < 200; i++ {
 		complianceOperatorProfile := &storage.ComplianceOperatorProfile{}
 		s.NoError(testutils.FullInit(complianceOperatorProfile, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceOperatorProfiles = append(complianceOperatorProfiles, complianceOperatorProfile)
-		complianceOperatorProfileIds = append(complianceOperatorProfileIds, complianceOperatorProfile.GetId())
+		complianceOperatorProfileIDs = append(complianceOperatorProfileIDs, complianceOperatorProfile.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceOperatorProfiles))
@@ -114,7 +114,7 @@ func (s *ComplianceOperatorProfilesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorProfileCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorProfileIds))
+	s.NoError(store.DeleteMany(ctx, complianceOperatorProfileIDs))
 
 	complianceOperatorProfileCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -429,30 +429,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -427,12 +428,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -430,6 +430,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -439,14 +440,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/complianceoperator/rules/store/postgres/store_test.go
+++ b/central/complianceoperator/rules/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ComplianceOperatorRulesStoreSuite) TestStore() {
 
 	var complianceOperatorRules []*storage.ComplianceOperatorRule
 	var complianceOperatorRuleIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		complianceOperatorRule := &storage.ComplianceOperatorRule{}
 		s.NoError(testutils.FullInit(complianceOperatorRule, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceOperatorRules = append(complianceOperatorRules, complianceOperatorRule)
@@ -112,7 +112,7 @@ func (s *ComplianceOperatorRulesStoreSuite) TestStore() {
 
 	complianceOperatorRuleCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, complianceOperatorRuleCount)
+	s.Equal(200, complianceOperatorRuleCount)
 
 	s.NoError(store.DeleteMany(ctx, complianceOperatorRuleIds))
 

--- a/central/complianceoperator/rules/store/postgres/store_test.go
+++ b/central/complianceoperator/rules/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *ComplianceOperatorRulesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, complianceOperatorRule.GetId()), sac.ErrResourceAccessDenied)
 
 	var complianceOperatorRules []*storage.ComplianceOperatorRule
-	for i := 0; i < 200; i++ {
+	var complianceOperatorRuleIds []string
+	for i := 0; i < 12000; i++ {
 		complianceOperatorRule := &storage.ComplianceOperatorRule{}
 		s.NoError(testutils.FullInit(complianceOperatorRule, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceOperatorRules = append(complianceOperatorRules, complianceOperatorRule)
+		complianceOperatorRuleIds = append(complianceOperatorRuleIds, complianceOperatorRule.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceOperatorRules))
 
 	complianceOperatorRuleCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, complianceOperatorRuleCount)
+	s.Equal(12000, complianceOperatorRuleCount)
+
+	s.NoError(store.DeleteMany(ctx, complianceOperatorRuleIds))
+
+	complianceOperatorRuleCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, complianceOperatorRuleCount)
 }

--- a/central/complianceoperator/rules/store/postgres/store_test.go
+++ b/central/complianceoperator/rules/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ComplianceOperatorRulesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, complianceOperatorRule.GetId()), sac.ErrResourceAccessDenied)
 
 	var complianceOperatorRules []*storage.ComplianceOperatorRule
-	var complianceOperatorRuleIds []string
+	var complianceOperatorRuleIDs []string
 	for i := 0; i < 200; i++ {
 		complianceOperatorRule := &storage.ComplianceOperatorRule{}
 		s.NoError(testutils.FullInit(complianceOperatorRule, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceOperatorRules = append(complianceOperatorRules, complianceOperatorRule)
-		complianceOperatorRuleIds = append(complianceOperatorRuleIds, complianceOperatorRule.GetId())
+		complianceOperatorRuleIDs = append(complianceOperatorRuleIDs, complianceOperatorRule.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceOperatorRules))
@@ -114,7 +114,7 @@ func (s *ComplianceOperatorRulesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorRuleCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorRuleIds))
+	s.NoError(store.DeleteMany(ctx, complianceOperatorRuleIDs))
 
 	complianceOperatorRuleCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -429,30 +429,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -427,12 +428,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -430,6 +430,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -439,14 +440,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/complianceoperator/scans/store/postgres/store_test.go
+++ b/central/complianceoperator/scans/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *ComplianceOperatorScansStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, complianceOperatorScan.GetId()), sac.ErrResourceAccessDenied)
 
 	var complianceOperatorScans []*storage.ComplianceOperatorScan
-	for i := 0; i < 200; i++ {
+	var complianceOperatorScanIds []string
+	for i := 0; i < 12000; i++ {
 		complianceOperatorScan := &storage.ComplianceOperatorScan{}
 		s.NoError(testutils.FullInit(complianceOperatorScan, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceOperatorScans = append(complianceOperatorScans, complianceOperatorScan)
+		complianceOperatorScanIds = append(complianceOperatorScanIds, complianceOperatorScan.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceOperatorScans))
 
 	complianceOperatorScanCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, complianceOperatorScanCount)
+	s.Equal(12000, complianceOperatorScanCount)
+
+	s.NoError(store.DeleteMany(ctx, complianceOperatorScanIds))
+
+	complianceOperatorScanCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, complianceOperatorScanCount)
 }

--- a/central/complianceoperator/scans/store/postgres/store_test.go
+++ b/central/complianceoperator/scans/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ComplianceOperatorScansStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, complianceOperatorScan.GetId()), sac.ErrResourceAccessDenied)
 
 	var complianceOperatorScans []*storage.ComplianceOperatorScan
-	var complianceOperatorScanIds []string
+	var complianceOperatorScanIDs []string
 	for i := 0; i < 200; i++ {
 		complianceOperatorScan := &storage.ComplianceOperatorScan{}
 		s.NoError(testutils.FullInit(complianceOperatorScan, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceOperatorScans = append(complianceOperatorScans, complianceOperatorScan)
-		complianceOperatorScanIds = append(complianceOperatorScanIds, complianceOperatorScan.GetId())
+		complianceOperatorScanIDs = append(complianceOperatorScanIDs, complianceOperatorScan.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceOperatorScans))
@@ -114,7 +114,7 @@ func (s *ComplianceOperatorScansStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorScanCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorScanIds))
+	s.NoError(store.DeleteMany(ctx, complianceOperatorScanIDs))
 
 	complianceOperatorScanCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/complianceoperator/scans/store/postgres/store_test.go
+++ b/central/complianceoperator/scans/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ComplianceOperatorScansStoreSuite) TestStore() {
 
 	var complianceOperatorScans []*storage.ComplianceOperatorScan
 	var complianceOperatorScanIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		complianceOperatorScan := &storage.ComplianceOperatorScan{}
 		s.NoError(testutils.FullInit(complianceOperatorScan, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceOperatorScans = append(complianceOperatorScans, complianceOperatorScan)
@@ -112,7 +112,7 @@ func (s *ComplianceOperatorScansStoreSuite) TestStore() {
 
 	complianceOperatorScanCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, complianceOperatorScanCount)
+	s.Equal(200, complianceOperatorScanCount)
 
 	s.NoError(store.DeleteMany(ctx, complianceOperatorScanIds))
 

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -429,30 +429,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -427,12 +428,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -430,6 +430,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -439,14 +440,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/complianceoperator/scansettingbinding/store/postgres/store_test.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ComplianceOperatorScanSettingBindingsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, complianceOperatorScanSettingBinding.GetId()), sac.ErrResourceAccessDenied)
 
 	var complianceOperatorScanSettingBindings []*storage.ComplianceOperatorScanSettingBinding
-	var complianceOperatorScanSettingBindingIds []string
+	var complianceOperatorScanSettingBindingIDs []string
 	for i := 0; i < 200; i++ {
 		complianceOperatorScanSettingBinding := &storage.ComplianceOperatorScanSettingBinding{}
 		s.NoError(testutils.FullInit(complianceOperatorScanSettingBinding, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceOperatorScanSettingBindings = append(complianceOperatorScanSettingBindings, complianceOperatorScanSettingBinding)
-		complianceOperatorScanSettingBindingIds = append(complianceOperatorScanSettingBindingIds, complianceOperatorScanSettingBinding.GetId())
+		complianceOperatorScanSettingBindingIDs = append(complianceOperatorScanSettingBindingIDs, complianceOperatorScanSettingBinding.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceOperatorScanSettingBindings))
@@ -114,7 +114,7 @@ func (s *ComplianceOperatorScanSettingBindingsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorScanSettingBindingCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorScanSettingBindingIds))
+	s.NoError(store.DeleteMany(ctx, complianceOperatorScanSettingBindingIDs))
 
 	complianceOperatorScanSettingBindingCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/complianceoperator/scansettingbinding/store/postgres/store_test.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ComplianceOperatorScanSettingBindingsStoreSuite) TestStore() {
 
 	var complianceOperatorScanSettingBindings []*storage.ComplianceOperatorScanSettingBinding
 	var complianceOperatorScanSettingBindingIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		complianceOperatorScanSettingBinding := &storage.ComplianceOperatorScanSettingBinding{}
 		s.NoError(testutils.FullInit(complianceOperatorScanSettingBinding, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceOperatorScanSettingBindings = append(complianceOperatorScanSettingBindings, complianceOperatorScanSettingBinding)
@@ -112,7 +112,7 @@ func (s *ComplianceOperatorScanSettingBindingsStoreSuite) TestStore() {
 
 	complianceOperatorScanSettingBindingCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, complianceOperatorScanSettingBindingCount)
+	s.Equal(200, complianceOperatorScanSettingBindingCount)
 
 	s.NoError(store.DeleteMany(ctx, complianceOperatorScanSettingBindingIds))
 

--- a/central/complianceoperator/scansettingbinding/store/postgres/store_test.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *ComplianceOperatorScanSettingBindingsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, complianceOperatorScanSettingBinding.GetId()), sac.ErrResourceAccessDenied)
 
 	var complianceOperatorScanSettingBindings []*storage.ComplianceOperatorScanSettingBinding
-	for i := 0; i < 200; i++ {
+	var complianceOperatorScanSettingBindingIds []string
+	for i := 0; i < 12000; i++ {
 		complianceOperatorScanSettingBinding := &storage.ComplianceOperatorScanSettingBinding{}
 		s.NoError(testutils.FullInit(complianceOperatorScanSettingBinding, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		complianceOperatorScanSettingBindings = append(complianceOperatorScanSettingBindings, complianceOperatorScanSettingBinding)
+		complianceOperatorScanSettingBindingIds = append(complianceOperatorScanSettingBindingIds, complianceOperatorScanSettingBinding.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, complianceOperatorScanSettingBindings))
 
 	complianceOperatorScanSettingBindingCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, complianceOperatorScanSettingBindingCount)
+	s.Equal(12000, complianceOperatorScanSettingBindingCount)
+
+	s.NoError(store.DeleteMany(ctx, complianceOperatorScanSettingBindingIds))
+
+	complianceOperatorScanSettingBindingCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, complianceOperatorScanSettingBindingCount)
 }

--- a/central/componentcveedge/datastore/store/postgres/store.go
+++ b/central/componentcveedge/datastore/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
 )

--- a/central/componentcveedge/datastore/store/postgres/store.go
+++ b/central/componentcveedge/datastore/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 )

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -551,12 +552,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -553,30 +553,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -554,6 +554,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -563,14 +564,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/cve/cluster/datastore/store/postgres/store_test.go
+++ b/central/cve/cluster/datastore/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ClusterCvesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, clusterCVE.GetId()))
 
 	var clusterCVEs []*storage.ClusterCVE
-	var clusterCVEIds []string
+	var clusterCVEIDs []string
 	for i := 0; i < 200; i++ {
 		clusterCVE := &storage.ClusterCVE{}
 		s.NoError(testutils.FullInit(clusterCVE, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		clusterCVEs = append(clusterCVEs, clusterCVE)
-		clusterCVEIds = append(clusterCVEIds, clusterCVE.GetId())
+		clusterCVEIDs = append(clusterCVEIDs, clusterCVE.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, clusterCVEs))
@@ -114,7 +114,7 @@ func (s *ClusterCvesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, clusterCVECount)
 
-	s.NoError(store.DeleteMany(ctx, clusterCVEIds))
+	s.NoError(store.DeleteMany(ctx, clusterCVEIDs))
 
 	clusterCVECount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/cve/cluster/datastore/store/postgres/store_test.go
+++ b/central/cve/cluster/datastore/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *ClusterCvesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, clusterCVE.GetId()))
 
 	var clusterCVEs []*storage.ClusterCVE
-	for i := 0; i < 200; i++ {
+	var clusterCVEIds []string
+	for i := 0; i < 12000; i++ {
 		clusterCVE := &storage.ClusterCVE{}
 		s.NoError(testutils.FullInit(clusterCVE, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		clusterCVEs = append(clusterCVEs, clusterCVE)
+		clusterCVEIds = append(clusterCVEIds, clusterCVE.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, clusterCVEs))
 
 	clusterCVECount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, clusterCVECount)
+	s.Equal(12000, clusterCVECount)
+
+	s.NoError(store.DeleteMany(ctx, clusterCVEIds))
+
+	clusterCVECount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, clusterCVECount)
 }

--- a/central/cve/cluster/datastore/store/postgres/store_test.go
+++ b/central/cve/cluster/datastore/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ClusterCvesStoreSuite) TestStore() {
 
 	var clusterCVEs []*storage.ClusterCVE
 	var clusterCVEIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		clusterCVE := &storage.ClusterCVE{}
 		s.NoError(testutils.FullInit(clusterCVE, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		clusterCVEs = append(clusterCVEs, clusterCVE)
@@ -112,7 +112,7 @@ func (s *ClusterCvesStoreSuite) TestStore() {
 
 	clusterCVECount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, clusterCVECount)
+	s.Equal(200, clusterCVECount)
 
 	s.NoError(store.DeleteMany(ctx, clusterCVEIds))
 

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -551,12 +552,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -553,30 +553,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -554,6 +554,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -563,14 +564,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/cve/image/datastore/store/postgres/store_test.go
+++ b/central/cve/image/datastore/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ImageCvesStoreSuite) TestStore() {
 
 	var imageCVEs []*storage.ImageCVE
 	var imageCVEIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		imageCVE := &storage.ImageCVE{}
 		s.NoError(testutils.FullInit(imageCVE, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		imageCVEs = append(imageCVEs, imageCVE)
@@ -112,7 +112,7 @@ func (s *ImageCvesStoreSuite) TestStore() {
 
 	imageCVECount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, imageCVECount)
+	s.Equal(200, imageCVECount)
 
 	s.NoError(store.DeleteMany(ctx, imageCVEIds))
 

--- a/central/cve/image/datastore/store/postgres/store_test.go
+++ b/central/cve/image/datastore/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ImageCvesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, imageCVE.GetId()))
 
 	var imageCVEs []*storage.ImageCVE
-	var imageCVEIds []string
+	var imageCVEIDs []string
 	for i := 0; i < 200; i++ {
 		imageCVE := &storage.ImageCVE{}
 		s.NoError(testutils.FullInit(imageCVE, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		imageCVEs = append(imageCVEs, imageCVE)
-		imageCVEIds = append(imageCVEIds, imageCVE.GetId())
+		imageCVEIDs = append(imageCVEIDs, imageCVE.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, imageCVEs))
@@ -114,7 +114,7 @@ func (s *ImageCvesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, imageCVECount)
 
-	s.NoError(store.DeleteMany(ctx, imageCVEIds))
+	s.NoError(store.DeleteMany(ctx, imageCVEIDs))
 
 	imageCVECount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/cve/image/datastore/store/postgres/store_test.go
+++ b/central/cve/image/datastore/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *ImageCvesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, imageCVE.GetId()))
 
 	var imageCVEs []*storage.ImageCVE
-	for i := 0; i < 200; i++ {
+	var imageCVEIds []string
+	for i := 0; i < 12000; i++ {
 		imageCVE := &storage.ImageCVE{}
 		s.NoError(testutils.FullInit(imageCVE, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		imageCVEs = append(imageCVEs, imageCVE)
+		imageCVEIds = append(imageCVEIds, imageCVE.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, imageCVEs))
 
 	imageCVECount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, imageCVECount)
+	s.Equal(12000, imageCVECount)
+
+	s.NoError(store.DeleteMany(ctx, imageCVEIds))
+
+	imageCVECount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, imageCVECount)
 }

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -551,12 +552,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -553,30 +553,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -554,6 +554,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -563,14 +564,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/cve/node/datastore/store/postgres/store_test.go
+++ b/central/cve/node/datastore/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *NodeCvesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, nodeCVE.GetId()))
 
 	var nodeCVEs []*storage.NodeCVE
-	var nodeCVEIds []string
+	var nodeCVEIDs []string
 	for i := 0; i < 200; i++ {
 		nodeCVE := &storage.NodeCVE{}
 		s.NoError(testutils.FullInit(nodeCVE, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		nodeCVEs = append(nodeCVEs, nodeCVE)
-		nodeCVEIds = append(nodeCVEIds, nodeCVE.GetId())
+		nodeCVEIDs = append(nodeCVEIDs, nodeCVE.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, nodeCVEs))
@@ -114,7 +114,7 @@ func (s *NodeCvesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, nodeCVECount)
 
-	s.NoError(store.DeleteMany(ctx, nodeCVEIds))
+	s.NoError(store.DeleteMany(ctx, nodeCVEIDs))
 
 	nodeCVECount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/cve/node/datastore/store/postgres/store_test.go
+++ b/central/cve/node/datastore/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *NodeCvesStoreSuite) TestStore() {
 
 	var nodeCVEs []*storage.NodeCVE
 	var nodeCVEIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		nodeCVE := &storage.NodeCVE{}
 		s.NoError(testutils.FullInit(nodeCVE, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		nodeCVEs = append(nodeCVEs, nodeCVE)
@@ -112,7 +112,7 @@ func (s *NodeCvesStoreSuite) TestStore() {
 
 	nodeCVECount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, nodeCVECount)
+	s.Equal(200, nodeCVECount)
 
 	s.NoError(store.DeleteMany(ctx, nodeCVEIds))
 

--- a/central/cve/node/datastore/store/postgres/store_test.go
+++ b/central/cve/node/datastore/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *NodeCvesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, nodeCVE.GetId()))
 
 	var nodeCVEs []*storage.NodeCVE
-	for i := 0; i < 200; i++ {
+	var nodeCVEIds []string
+	for i := 0; i < 12000; i++ {
 		nodeCVE := &storage.NodeCVE{}
 		s.NoError(testutils.FullInit(nodeCVE, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		nodeCVEs = append(nodeCVEs, nodeCVE)
+		nodeCVEIds = append(nodeCVEIds, nodeCVE.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, nodeCVEs))
 
 	nodeCVECount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, nodeCVECount)
+	s.Equal(12000, nodeCVECount)
+
+	s.NoError(store.DeleteMany(ctx, nodeCVEIds))
+
+	nodeCVECount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, nodeCVECount)
 }

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -1208,30 +1208,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -1206,12 +1207,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -1209,6 +1209,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -1218,14 +1219,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/deployment/store/postgres/store_test.go
+++ b/central/deployment/store/postgres/store_test.go
@@ -103,7 +103,7 @@ func (s *DeploymentsStoreSuite) TestStore() {
 
 	var deployments []*storage.Deployment
 	var deploymentIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		deployment := &storage.Deployment{}
 		s.NoError(testutils.FullInit(deployment, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		deployments = append(deployments, deployment)
@@ -114,7 +114,7 @@ func (s *DeploymentsStoreSuite) TestStore() {
 
 	deploymentCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, deploymentCount)
+	s.Equal(200, deploymentCount)
 
 	s.NoError(store.DeleteMany(ctx, deploymentIds))
 

--- a/central/deployment/store/postgres/store_test.go
+++ b/central/deployment/store/postgres/store_test.go
@@ -102,17 +102,25 @@ func (s *DeploymentsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, deployment.GetId()))
 
 	var deployments []*storage.Deployment
-	for i := 0; i < 200; i++ {
+	var deploymentIds []string
+	for i := 0; i < 12000; i++ {
 		deployment := &storage.Deployment{}
 		s.NoError(testutils.FullInit(deployment, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		deployments = append(deployments, deployment)
+		deploymentIds = append(deploymentIds, deployment.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, deployments))
 
 	deploymentCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, deploymentCount)
+	s.Equal(12000, deploymentCount)
+
+	s.NoError(store.DeleteMany(ctx, deploymentIds))
+
+	deploymentCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, deploymentCount)
 }
 
 func (s *DeploymentsStoreSuite) TestSACUpsert() {

--- a/central/deployment/store/postgres/store_test.go
+++ b/central/deployment/store/postgres/store_test.go
@@ -102,12 +102,12 @@ func (s *DeploymentsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, deployment.GetId()))
 
 	var deployments []*storage.Deployment
-	var deploymentIds []string
+	var deploymentIDs []string
 	for i := 0; i < 200; i++ {
 		deployment := &storage.Deployment{}
 		s.NoError(testutils.FullInit(deployment, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		deployments = append(deployments, deployment)
-		deploymentIds = append(deploymentIds, deployment.GetId())
+		deploymentIDs = append(deploymentIDs, deployment.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, deployments))
@@ -116,7 +116,7 @@ func (s *DeploymentsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, deploymentCount)
 
-	s.NoError(store.DeleteMany(ctx, deploymentIds))
+	s.NoError(store.DeleteMany(ctx, deploymentIDs))
 
 	deploymentCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -438,12 +439,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -440,30 +440,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -441,6 +441,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -450,14 +451,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/externalbackups/internal/store/postgres/store_test.go
+++ b/central/externalbackups/internal/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ExternalBackupsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, externalBackup.GetId()), sac.ErrResourceAccessDenied)
 
 	var externalBackups []*storage.ExternalBackup
-	var externalBackupIds []string
+	var externalBackupIDs []string
 	for i := 0; i < 200; i++ {
 		externalBackup := &storage.ExternalBackup{}
 		s.NoError(testutils.FullInit(externalBackup, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		externalBackups = append(externalBackups, externalBackup)
-		externalBackupIds = append(externalBackupIds, externalBackup.GetId())
+		externalBackupIDs = append(externalBackupIDs, externalBackup.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, externalBackups))
@@ -117,7 +117,7 @@ func (s *ExternalBackupsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, externalBackupCount)
 
-	s.NoError(store.DeleteMany(ctx, externalBackupIds))
+	s.NoError(store.DeleteMany(ctx, externalBackupIDs))
 
 	externalBackupCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/externalbackups/internal/store/postgres/store_test.go
+++ b/central/externalbackups/internal/store/postgres/store_test.go
@@ -100,10 +100,12 @@ func (s *ExternalBackupsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, externalBackup.GetId()), sac.ErrResourceAccessDenied)
 
 	var externalBackups []*storage.ExternalBackup
-	for i := 0; i < 200; i++ {
+	var externalBackupIds []string
+	for i := 0; i < 12000; i++ {
 		externalBackup := &storage.ExternalBackup{}
 		s.NoError(testutils.FullInit(externalBackup, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		externalBackups = append(externalBackups, externalBackup)
+		externalBackupIds = append(externalBackupIds, externalBackup.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, externalBackups))
@@ -113,5 +115,11 @@ func (s *ExternalBackupsStoreSuite) TestStore() {
 
 	externalBackupCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, externalBackupCount)
+	s.Equal(12000, externalBackupCount)
+
+	s.NoError(store.DeleteMany(ctx, externalBackupIds))
+
+	externalBackupCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, externalBackupCount)
 }

--- a/central/externalbackups/internal/store/postgres/store_test.go
+++ b/central/externalbackups/internal/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ExternalBackupsStoreSuite) TestStore() {
 
 	var externalBackups []*storage.ExternalBackup
 	var externalBackupIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		externalBackup := &storage.ExternalBackup{}
 		s.NoError(testutils.FullInit(externalBackup, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		externalBackups = append(externalBackups, externalBackup)
@@ -115,7 +115,7 @@ func (s *ExternalBackupsStoreSuite) TestStore() {
 
 	externalBackupCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, externalBackupCount)
+	s.Equal(200, externalBackupCount)
 
 	s.NoError(store.DeleteMany(ctx, externalBackupIds))
 

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -438,12 +439,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -440,30 +440,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -441,6 +441,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -450,14 +451,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/group/datastore/internal/store/postgres/store_test.go
+++ b/central/group/datastore/internal/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *GroupsStoreSuite) TestStore() {
 
 	var groups []*storage.Group
 	var groupIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		group := &storage.Group{}
 		s.NoError(testutils.FullInit(group, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		groups = append(groups, group)
@@ -115,7 +115,7 @@ func (s *GroupsStoreSuite) TestStore() {
 
 	groupCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, groupCount)
+	s.Equal(200, groupCount)
 
 	s.NoError(store.DeleteMany(ctx, groupIds))
 

--- a/central/group/datastore/internal/store/postgres/store_test.go
+++ b/central/group/datastore/internal/store/postgres/store_test.go
@@ -100,10 +100,12 @@ func (s *GroupsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, group.GetProps().GetId()), sac.ErrResourceAccessDenied)
 
 	var groups []*storage.Group
-	for i := 0; i < 200; i++ {
+	var groupIds []string
+	for i := 0; i < 12000; i++ {
 		group := &storage.Group{}
 		s.NoError(testutils.FullInit(group, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		groups = append(groups, group)
+		groupIds = append(groupIds, group.GetProps().GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, groups))
@@ -113,5 +115,11 @@ func (s *GroupsStoreSuite) TestStore() {
 
 	groupCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, groupCount)
+	s.Equal(12000, groupCount)
+
+	s.NoError(store.DeleteMany(ctx, groupIds))
+
+	groupCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, groupCount)
 }

--- a/central/group/datastore/internal/store/postgres/store_test.go
+++ b/central/group/datastore/internal/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *GroupsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, group.GetProps().GetId()), sac.ErrResourceAccessDenied)
 
 	var groups []*storage.Group
-	var groupIds []string
+	var groupIDs []string
 	for i := 0; i < 200; i++ {
 		group := &storage.Group{}
 		s.NoError(testutils.FullInit(group, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		groups = append(groups, group)
-		groupIds = append(groupIds, group.GetProps().GetId())
+		groupIDs = append(groupIDs, group.GetProps().GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, groups))
@@ -117,7 +117,7 @@ func (s *GroupsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, groupCount)
 
-	s.NoError(store.DeleteMany(ctx, groupIds))
+	s.NoError(store.DeleteMany(ctx, groupIDs))
 
 	groupCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -541,12 +542,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -543,30 +543,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -544,6 +544,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -553,14 +554,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/imagecomponent/datastore/store/postgres/store_test.go
+++ b/central/imagecomponent/datastore/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *ImageComponentsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, imageComponent.GetId()))
 
 	var imageComponents []*storage.ImageComponent
-	for i := 0; i < 200; i++ {
+	var imageComponentIds []string
+	for i := 0; i < 12000; i++ {
 		imageComponent := &storage.ImageComponent{}
 		s.NoError(testutils.FullInit(imageComponent, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		imageComponents = append(imageComponents, imageComponent)
+		imageComponentIds = append(imageComponentIds, imageComponent.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, imageComponents))
 
 	imageComponentCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, imageComponentCount)
+	s.Equal(12000, imageComponentCount)
+
+	s.NoError(store.DeleteMany(ctx, imageComponentIds))
+
+	imageComponentCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, imageComponentCount)
 }

--- a/central/imagecomponent/datastore/store/postgres/store_test.go
+++ b/central/imagecomponent/datastore/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ImageComponentsStoreSuite) TestStore() {
 
 	var imageComponents []*storage.ImageComponent
 	var imageComponentIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		imageComponent := &storage.ImageComponent{}
 		s.NoError(testutils.FullInit(imageComponent, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		imageComponents = append(imageComponents, imageComponent)
@@ -112,7 +112,7 @@ func (s *ImageComponentsStoreSuite) TestStore() {
 
 	imageComponentCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, imageComponentCount)
+	s.Equal(200, imageComponentCount)
 
 	s.NoError(store.DeleteMany(ctx, imageComponentIds))
 

--- a/central/imagecomponent/datastore/store/postgres/store_test.go
+++ b/central/imagecomponent/datastore/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ImageComponentsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, imageComponent.GetId()))
 
 	var imageComponents []*storage.ImageComponent
-	var imageComponentIds []string
+	var imageComponentIDs []string
 	for i := 0; i < 200; i++ {
 		imageComponent := &storage.ImageComponent{}
 		s.NoError(testutils.FullInit(imageComponent, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		imageComponents = append(imageComponents, imageComponent)
-		imageComponentIds = append(imageComponentIds, imageComponent.GetId())
+		imageComponentIDs = append(imageComponentIDs, imageComponent.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, imageComponents))
@@ -114,7 +114,7 @@ func (s *ImageComponentsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, imageComponentCount)
 
-	s.NoError(store.DeleteMany(ctx, imageComponentIds))
+	s.NoError(store.DeleteMany(ctx, imageComponentIDs))
 
 	imageComponentCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
 )

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 )

--- a/central/imagecveedge/datastore/postgres/store.go
+++ b/central/imagecveedge/datastore/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
 )

--- a/central/imagecveedge/datastore/postgres/store.go
+++ b/central/imagecveedge/datastore/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 )

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -474,12 +475,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -477,6 +477,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -486,14 +487,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -476,30 +476,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/imageintegration/store/postgres/store_test.go
+++ b/central/imageintegration/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ImageIntegrationsStoreSuite) TestStore() {
 
 	var imageIntegrations []*storage.ImageIntegration
 	var imageIntegrationIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		imageIntegration := &storage.ImageIntegration{}
 		s.NoError(testutils.FullInit(imageIntegration, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		imageIntegrations = append(imageIntegrations, imageIntegration)
@@ -115,7 +115,7 @@ func (s *ImageIntegrationsStoreSuite) TestStore() {
 
 	imageIntegrationCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, imageIntegrationCount)
+	s.Equal(200, imageIntegrationCount)
 
 	s.NoError(store.DeleteMany(ctx, imageIntegrationIds))
 

--- a/central/imageintegration/store/postgres/store_test.go
+++ b/central/imageintegration/store/postgres/store_test.go
@@ -100,10 +100,12 @@ func (s *ImageIntegrationsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, imageIntegration.GetId()), sac.ErrResourceAccessDenied)
 
 	var imageIntegrations []*storage.ImageIntegration
-	for i := 0; i < 200; i++ {
+	var imageIntegrationIds []string
+	for i := 0; i < 12000; i++ {
 		imageIntegration := &storage.ImageIntegration{}
 		s.NoError(testutils.FullInit(imageIntegration, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		imageIntegrations = append(imageIntegrations, imageIntegration)
+		imageIntegrationIds = append(imageIntegrationIds, imageIntegration.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, imageIntegrations))
@@ -113,5 +115,11 @@ func (s *ImageIntegrationsStoreSuite) TestStore() {
 
 	imageIntegrationCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, imageIntegrationCount)
+	s.Equal(12000, imageIntegrationCount)
+
+	s.NoError(store.DeleteMany(ctx, imageIntegrationIds))
+
+	imageIntegrationCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, imageIntegrationCount)
 }

--- a/central/imageintegration/store/postgres/store_test.go
+++ b/central/imageintegration/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ImageIntegrationsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, imageIntegration.GetId()), sac.ErrResourceAccessDenied)
 
 	var imageIntegrations []*storage.ImageIntegration
-	var imageIntegrationIds []string
+	var imageIntegrationIDs []string
 	for i := 0; i < 200; i++ {
 		imageIntegration := &storage.ImageIntegration{}
 		s.NoError(testutils.FullInit(imageIntegration, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		imageIntegrations = append(imageIntegrations, imageIntegration)
-		imageIntegrationIds = append(imageIntegrationIds, imageIntegration.GetId())
+		imageIntegrationIDs = append(imageIntegrationIDs, imageIntegration.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, imageIntegrations))
@@ -117,7 +117,7 @@ func (s *ImageIntegrationsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, imageIntegrationCount)
 
-	s.NoError(store.DeleteMany(ctx, imageIntegrationIds))
+	s.NoError(store.DeleteMany(ctx, imageIntegrationIDs))
 
 	imageIntegrationCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -426,6 +426,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -435,14 +436,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -425,30 +425,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -32,10 +32,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -32,7 +32,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -35,6 +35,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -423,12 +424,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/integrationhealth/store/postgres/store_test.go
+++ b/central/integrationhealth/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *IntegrationHealthsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, integrationHealth.GetId()), sac.ErrResourceAccessDenied)
 
 	var integrationHealths []*storage.IntegrationHealth
-	for i := 0; i < 200; i++ {
+	var integrationHealthIds []string
+	for i := 0; i < 12000; i++ {
 		integrationHealth := &storage.IntegrationHealth{}
 		s.NoError(testutils.FullInit(integrationHealth, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		integrationHealths = append(integrationHealths, integrationHealth)
+		integrationHealthIds = append(integrationHealthIds, integrationHealth.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, integrationHealths))
 
 	integrationHealthCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, integrationHealthCount)
+	s.Equal(12000, integrationHealthCount)
+
+	s.NoError(store.DeleteMany(ctx, integrationHealthIds))
+
+	integrationHealthCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, integrationHealthCount)
 }

--- a/central/integrationhealth/store/postgres/store_test.go
+++ b/central/integrationhealth/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *IntegrationHealthsStoreSuite) TestStore() {
 
 	var integrationHealths []*storage.IntegrationHealth
 	var integrationHealthIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		integrationHealth := &storage.IntegrationHealth{}
 		s.NoError(testutils.FullInit(integrationHealth, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		integrationHealths = append(integrationHealths, integrationHealth)
@@ -112,7 +112,7 @@ func (s *IntegrationHealthsStoreSuite) TestStore() {
 
 	integrationHealthCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, integrationHealthCount)
+	s.Equal(200, integrationHealthCount)
 
 	s.NoError(store.DeleteMany(ctx, integrationHealthIds))
 

--- a/central/integrationhealth/store/postgres/store_test.go
+++ b/central/integrationhealth/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *IntegrationHealthsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, integrationHealth.GetId()), sac.ErrResourceAccessDenied)
 
 	var integrationHealths []*storage.IntegrationHealth
-	var integrationHealthIds []string
+	var integrationHealthIDs []string
 	for i := 0; i < 200; i++ {
 		integrationHealth := &storage.IntegrationHealth{}
 		s.NoError(testutils.FullInit(integrationHealth, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		integrationHealths = append(integrationHealths, integrationHealth)
-		integrationHealthIds = append(integrationHealthIds, integrationHealth.GetId())
+		integrationHealthIDs = append(integrationHealthIDs, integrationHealth.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, integrationHealths))
@@ -114,7 +114,7 @@ func (s *IntegrationHealthsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, integrationHealthCount)
 
-	s.NoError(store.DeleteMany(ctx, integrationHealthIds))
+	s.NoError(store.DeleteMany(ctx, integrationHealthIDs))
 
 	integrationHealthCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -438,12 +439,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -440,30 +440,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -441,6 +441,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -450,14 +451,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/logimbue/store/postgres/store_test.go
+++ b/central/logimbue/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *LogImbuesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, logImbue.GetId()), sac.ErrResourceAccessDenied)
 
 	var logImbues []*storage.LogImbue
-	var logImbueIds []string
+	var logImbueIDs []string
 	for i := 0; i < 200; i++ {
 		logImbue := &storage.LogImbue{}
 		s.NoError(testutils.FullInit(logImbue, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		logImbues = append(logImbues, logImbue)
-		logImbueIds = append(logImbueIds, logImbue.GetId())
+		logImbueIDs = append(logImbueIDs, logImbue.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, logImbues))
@@ -117,7 +117,7 @@ func (s *LogImbuesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, logImbueCount)
 
-	s.NoError(store.DeleteMany(ctx, logImbueIds))
+	s.NoError(store.DeleteMany(ctx, logImbueIDs))
 
 	logImbueCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/logimbue/store/postgres/store_test.go
+++ b/central/logimbue/store/postgres/store_test.go
@@ -100,10 +100,12 @@ func (s *LogImbuesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, logImbue.GetId()), sac.ErrResourceAccessDenied)
 
 	var logImbues []*storage.LogImbue
-	for i := 0; i < 200; i++ {
+	var logImbueIds []string
+	for i := 0; i < 12000; i++ {
 		logImbue := &storage.LogImbue{}
 		s.NoError(testutils.FullInit(logImbue, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		logImbues = append(logImbues, logImbue)
+		logImbueIds = append(logImbueIds, logImbue.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, logImbues))
@@ -113,5 +115,11 @@ func (s *LogImbuesStoreSuite) TestStore() {
 
 	logImbueCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, logImbueCount)
+	s.Equal(12000, logImbueCount)
+
+	s.NoError(store.DeleteMany(ctx, logImbueIds))
+
+	logImbueCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, logImbueCount)
 }

--- a/central/logimbue/store/postgres/store_test.go
+++ b/central/logimbue/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *LogImbuesStoreSuite) TestStore() {
 
 	var logImbues []*storage.LogImbue
 	var logImbueIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		logImbue := &storage.LogImbue{}
 		s.NoError(testutils.FullInit(logImbue, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		logImbues = append(logImbues, logImbue)
@@ -115,7 +115,7 @@ func (s *LogImbuesStoreSuite) TestStore() {
 
 	logImbueCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, logImbueCount)
+	s.Equal(200, logImbueCount)
 
 	s.NoError(store.DeleteMany(ctx, logImbueIds))
 

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -542,12 +543,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -544,30 +544,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -545,6 +545,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -554,14 +555,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/namespace/store/postgres/store_test.go
+++ b/central/namespace/store/postgres/store_test.go
@@ -102,12 +102,12 @@ func (s *NamespacesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, namespaceMetadata.GetId()))
 
 	var namespaceMetadatas []*storage.NamespaceMetadata
-	var namespaceMetadataIds []string
+	var namespaceMetadataIDs []string
 	for i := 0; i < 200; i++ {
 		namespaceMetadata := &storage.NamespaceMetadata{}
 		s.NoError(testutils.FullInit(namespaceMetadata, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		namespaceMetadatas = append(namespaceMetadatas, namespaceMetadata)
-		namespaceMetadataIds = append(namespaceMetadataIds, namespaceMetadata.GetId())
+		namespaceMetadataIDs = append(namespaceMetadataIDs, namespaceMetadata.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, namespaceMetadatas))
@@ -116,7 +116,7 @@ func (s *NamespacesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, namespaceMetadataCount)
 
-	s.NoError(store.DeleteMany(ctx, namespaceMetadataIds))
+	s.NoError(store.DeleteMany(ctx, namespaceMetadataIDs))
 
 	namespaceMetadataCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/namespace/store/postgres/store_test.go
+++ b/central/namespace/store/postgres/store_test.go
@@ -102,17 +102,25 @@ func (s *NamespacesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, namespaceMetadata.GetId()))
 
 	var namespaceMetadatas []*storage.NamespaceMetadata
-	for i := 0; i < 200; i++ {
+	var namespaceMetadataIds []string
+	for i := 0; i < 12000; i++ {
 		namespaceMetadata := &storage.NamespaceMetadata{}
 		s.NoError(testutils.FullInit(namespaceMetadata, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		namespaceMetadatas = append(namespaceMetadatas, namespaceMetadata)
+		namespaceMetadataIds = append(namespaceMetadataIds, namespaceMetadata.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, namespaceMetadatas))
 
 	namespaceMetadataCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, namespaceMetadataCount)
+	s.Equal(12000, namespaceMetadataCount)
+
+	s.NoError(store.DeleteMany(ctx, namespaceMetadataIds))
+
+	namespaceMetadataCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, namespaceMetadataCount)
 }
 
 func (s *NamespacesStoreSuite) TestSACUpsert() {

--- a/central/namespace/store/postgres/store_test.go
+++ b/central/namespace/store/postgres/store_test.go
@@ -103,7 +103,7 @@ func (s *NamespacesStoreSuite) TestStore() {
 
 	var namespaceMetadatas []*storage.NamespaceMetadata
 	var namespaceMetadataIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		namespaceMetadata := &storage.NamespaceMetadata{}
 		s.NoError(testutils.FullInit(namespaceMetadata, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		namespaceMetadatas = append(namespaceMetadatas, namespaceMetadata)
@@ -114,7 +114,7 @@ func (s *NamespacesStoreSuite) TestStore() {
 
 	namespaceMetadataCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, namespaceMetadataCount)
+	s.Equal(200, namespaceMetadataCount)
 
 	s.NoError(store.DeleteMany(ctx, namespaceMetadataIds))
 

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -527,12 +528,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -530,6 +530,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -539,14 +540,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -529,30 +529,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/networkbaseline/store/postgres/store_test.go
+++ b/central/networkbaseline/store/postgres/store_test.go
@@ -102,12 +102,12 @@ func (s *NetworkBaselinesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, networkBaseline.GetDeploymentId()))
 
 	var networkBaselines []*storage.NetworkBaseline
-	var networkBaselineIds []string
+	var networkBaselineIDs []string
 	for i := 0; i < 200; i++ {
 		networkBaseline := &storage.NetworkBaseline{}
 		s.NoError(testutils.FullInit(networkBaseline, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkBaselines = append(networkBaselines, networkBaseline)
-		networkBaselineIds = append(networkBaselineIds, networkBaseline.GetDeploymentId())
+		networkBaselineIDs = append(networkBaselineIDs, networkBaseline.GetDeploymentId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, networkBaselines))
@@ -116,7 +116,7 @@ func (s *NetworkBaselinesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, networkBaselineCount)
 
-	s.NoError(store.DeleteMany(ctx, networkBaselineIds))
+	s.NoError(store.DeleteMany(ctx, networkBaselineIDs))
 
 	networkBaselineCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/networkbaseline/store/postgres/store_test.go
+++ b/central/networkbaseline/store/postgres/store_test.go
@@ -102,17 +102,25 @@ func (s *NetworkBaselinesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, networkBaseline.GetDeploymentId()))
 
 	var networkBaselines []*storage.NetworkBaseline
-	for i := 0; i < 200; i++ {
+	var networkBaselineIds []string
+	for i := 0; i < 12000; i++ {
 		networkBaseline := &storage.NetworkBaseline{}
 		s.NoError(testutils.FullInit(networkBaseline, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkBaselines = append(networkBaselines, networkBaseline)
+		networkBaselineIds = append(networkBaselineIds, networkBaseline.GetDeploymentId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, networkBaselines))
 
 	networkBaselineCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, networkBaselineCount)
+	s.Equal(12000, networkBaselineCount)
+
+	s.NoError(store.DeleteMany(ctx, networkBaselineIds))
+
+	networkBaselineCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, networkBaselineCount)
 }
 
 func (s *NetworkBaselinesStoreSuite) TestSACUpsert() {

--- a/central/networkbaseline/store/postgres/store_test.go
+++ b/central/networkbaseline/store/postgres/store_test.go
@@ -103,7 +103,7 @@ func (s *NetworkBaselinesStoreSuite) TestStore() {
 
 	var networkBaselines []*storage.NetworkBaseline
 	var networkBaselineIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		networkBaseline := &storage.NetworkBaseline{}
 		s.NoError(testutils.FullInit(networkBaseline, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkBaselines = append(networkBaselines, networkBaseline)
@@ -114,7 +114,7 @@ func (s *NetworkBaselinesStoreSuite) TestStore() {
 
 	networkBaselineCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, networkBaselineCount)
+	s.Equal(200, networkBaselineCount)
 
 	s.NoError(store.DeleteMany(ctx, networkBaselineIds))
 

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -429,30 +429,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -427,12 +428,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -430,6 +430,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -439,14 +440,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/networkgraph/config/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *NetworkGraphConfigsStoreSuite) TestStore() {
 
 	var networkGraphConfigs []*storage.NetworkGraphConfig
 	var networkGraphConfigIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		networkGraphConfig := &storage.NetworkGraphConfig{}
 		s.NoError(testutils.FullInit(networkGraphConfig, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkGraphConfigs = append(networkGraphConfigs, networkGraphConfig)
@@ -112,7 +112,7 @@ func (s *NetworkGraphConfigsStoreSuite) TestStore() {
 
 	networkGraphConfigCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, networkGraphConfigCount)
+	s.Equal(200, networkGraphConfigCount)
 
 	s.NoError(store.DeleteMany(ctx, networkGraphConfigIds))
 

--- a/central/networkgraph/config/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *NetworkGraphConfigsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, networkGraphConfig.GetId()), sac.ErrResourceAccessDenied)
 
 	var networkGraphConfigs []*storage.NetworkGraphConfig
-	var networkGraphConfigIds []string
+	var networkGraphConfigIDs []string
 	for i := 0; i < 200; i++ {
 		networkGraphConfig := &storage.NetworkGraphConfig{}
 		s.NoError(testutils.FullInit(networkGraphConfig, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkGraphConfigs = append(networkGraphConfigs, networkGraphConfig)
-		networkGraphConfigIds = append(networkGraphConfigIds, networkGraphConfig.GetId())
+		networkGraphConfigIDs = append(networkGraphConfigIDs, networkGraphConfig.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, networkGraphConfigs))
@@ -114,7 +114,7 @@ func (s *NetworkGraphConfigsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, networkGraphConfigCount)
 
-	s.NoError(store.DeleteMany(ctx, networkGraphConfigIds))
+	s.NoError(store.DeleteMany(ctx, networkGraphConfigIDs))
 
 	networkGraphConfigCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/networkgraph/config/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *NetworkGraphConfigsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, networkGraphConfig.GetId()), sac.ErrResourceAccessDenied)
 
 	var networkGraphConfigs []*storage.NetworkGraphConfig
-	for i := 0; i < 200; i++ {
+	var networkGraphConfigIds []string
+	for i := 0; i < 12000; i++ {
 		networkGraphConfig := &storage.NetworkGraphConfig{}
 		s.NoError(testutils.FullInit(networkGraphConfig, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkGraphConfigs = append(networkGraphConfigs, networkGraphConfig)
+		networkGraphConfigIds = append(networkGraphConfigIds, networkGraphConfig.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, networkGraphConfigs))
 
 	networkGraphConfigCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, networkGraphConfigCount)
+	s.Equal(12000, networkGraphConfigCount)
+
+	s.NoError(store.DeleteMany(ctx, networkGraphConfigIds))
+
+	networkGraphConfigCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, networkGraphConfigCount)
 }

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -32,10 +32,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -457,6 +457,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -466,14 +467,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -32,7 +32,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -35,6 +35,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -454,12 +455,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -456,30 +456,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *NetworkEntitiesStoreSuite) TestStore() {
 
 	var networkEntitys []*storage.NetworkEntity
 	var networkEntityIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		networkEntity := &storage.NetworkEntity{}
 		s.NoError(testutils.FullInit(networkEntity, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkEntitys = append(networkEntitys, networkEntity)
@@ -112,7 +112,7 @@ func (s *NetworkEntitiesStoreSuite) TestStore() {
 
 	networkEntityCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, networkEntityCount)
+	s.Equal(200, networkEntityCount)
 
 	s.NoError(store.DeleteMany(ctx, networkEntityIds))
 

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *NetworkEntitiesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, networkEntity.GetInfo().GetId()), sac.ErrResourceAccessDenied)
 
 	var networkEntitys []*storage.NetworkEntity
-	var networkEntityIds []string
+	var networkEntityIDs []string
 	for i := 0; i < 200; i++ {
 		networkEntity := &storage.NetworkEntity{}
 		s.NoError(testutils.FullInit(networkEntity, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkEntitys = append(networkEntitys, networkEntity)
-		networkEntityIds = append(networkEntityIds, networkEntity.GetInfo().GetId())
+		networkEntityIDs = append(networkEntityIDs, networkEntity.GetInfo().GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, networkEntitys))
@@ -114,7 +114,7 @@ func (s *NetworkEntitiesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, networkEntityCount)
 
-	s.NoError(store.DeleteMany(ctx, networkEntityIds))
+	s.NoError(store.DeleteMany(ctx, networkEntityIDs))
 
 	networkEntityCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *NetworkEntitiesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, networkEntity.GetInfo().GetId()), sac.ErrResourceAccessDenied)
 
 	var networkEntitys []*storage.NetworkEntity
-	for i := 0; i < 200; i++ {
+	var networkEntityIds []string
+	for i := 0; i < 12000; i++ {
 		networkEntity := &storage.NetworkEntity{}
 		s.NoError(testutils.FullInit(networkEntity, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkEntitys = append(networkEntitys, networkEntity)
+		networkEntityIds = append(networkEntityIds, networkEntity.GetInfo().GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, networkEntitys))
 
 	networkEntityCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, networkEntityCount)
+	s.Equal(12000, networkEntityCount)
+
+	s.NoError(store.DeleteMany(ctx, networkEntityIds))
+
+	networkEntityCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, networkEntityCount)
 }

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -527,12 +528,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -530,6 +530,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -539,14 +540,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -529,30 +529,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/networkpolicies/datastore/internal/store/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store_test.go
@@ -103,7 +103,7 @@ func (s *NetworkpoliciesStoreSuite) TestStore() {
 
 	var networkPolicys []*storage.NetworkPolicy
 	var networkPolicyIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		networkPolicy := &storage.NetworkPolicy{}
 		s.NoError(testutils.FullInit(networkPolicy, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkPolicys = append(networkPolicys, networkPolicy)
@@ -114,7 +114,7 @@ func (s *NetworkpoliciesStoreSuite) TestStore() {
 
 	networkPolicyCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, networkPolicyCount)
+	s.Equal(200, networkPolicyCount)
 
 	s.NoError(store.DeleteMany(ctx, networkPolicyIds))
 

--- a/central/networkpolicies/datastore/internal/store/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store_test.go
@@ -102,12 +102,12 @@ func (s *NetworkpoliciesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, networkPolicy.GetId()))
 
 	var networkPolicys []*storage.NetworkPolicy
-	var networkPolicyIds []string
+	var networkPolicyIDs []string
 	for i := 0; i < 200; i++ {
 		networkPolicy := &storage.NetworkPolicy{}
 		s.NoError(testutils.FullInit(networkPolicy, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkPolicys = append(networkPolicys, networkPolicy)
-		networkPolicyIds = append(networkPolicyIds, networkPolicy.GetId())
+		networkPolicyIDs = append(networkPolicyIDs, networkPolicy.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, networkPolicys))
@@ -116,7 +116,7 @@ func (s *NetworkpoliciesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, networkPolicyCount)
 
-	s.NoError(store.DeleteMany(ctx, networkPolicyIds))
+	s.NoError(store.DeleteMany(ctx, networkPolicyIDs))
 
 	networkPolicyCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/networkpolicies/datastore/internal/store/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store_test.go
@@ -102,17 +102,25 @@ func (s *NetworkpoliciesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, networkPolicy.GetId()))
 
 	var networkPolicys []*storage.NetworkPolicy
-	for i := 0; i < 200; i++ {
+	var networkPolicyIds []string
+	for i := 0; i < 12000; i++ {
 		networkPolicy := &storage.NetworkPolicy{}
 		s.NoError(testutils.FullInit(networkPolicy, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkPolicys = append(networkPolicys, networkPolicy)
+		networkPolicyIds = append(networkPolicyIds, networkPolicy.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, networkPolicys))
 
 	networkPolicyCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, networkPolicyCount)
+	s.Equal(12000, networkPolicyCount)
+
+	s.NoError(store.DeleteMany(ctx, networkPolicyIds))
+
+	networkPolicyCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, networkPolicyCount)
 }
 
 func (s *NetworkpoliciesStoreSuite) TestSACUpsert() {

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -475,6 +475,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -484,14 +485,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -472,12 +473,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -474,30 +474,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *NetworkpoliciesundodeploymentsStoreSuite) TestStore() {
 
 	var networkPolicyApplicationUndoDeploymentRecords []*storage.NetworkPolicyApplicationUndoDeploymentRecord
 	var networkPolicyApplicationUndoDeploymentRecordIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		networkPolicyApplicationUndoDeploymentRecord := &storage.NetworkPolicyApplicationUndoDeploymentRecord{}
 		s.NoError(testutils.FullInit(networkPolicyApplicationUndoDeploymentRecord, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkPolicyApplicationUndoDeploymentRecords = append(networkPolicyApplicationUndoDeploymentRecords, networkPolicyApplicationUndoDeploymentRecord)
@@ -112,7 +112,7 @@ func (s *NetworkpoliciesundodeploymentsStoreSuite) TestStore() {
 
 	networkPolicyApplicationUndoDeploymentRecordCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, networkPolicyApplicationUndoDeploymentRecordCount)
+	s.Equal(200, networkPolicyApplicationUndoDeploymentRecordCount)
 
 	s.NoError(store.DeleteMany(ctx, networkPolicyApplicationUndoDeploymentRecordIds))
 

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *NetworkpoliciesundodeploymentsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, networkPolicyApplicationUndoDeploymentRecord.GetDeploymentId()))
 
 	var networkPolicyApplicationUndoDeploymentRecords []*storage.NetworkPolicyApplicationUndoDeploymentRecord
-	var networkPolicyApplicationUndoDeploymentRecordIds []string
+	var networkPolicyApplicationUndoDeploymentRecordIDs []string
 	for i := 0; i < 200; i++ {
 		networkPolicyApplicationUndoDeploymentRecord := &storage.NetworkPolicyApplicationUndoDeploymentRecord{}
 		s.NoError(testutils.FullInit(networkPolicyApplicationUndoDeploymentRecord, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkPolicyApplicationUndoDeploymentRecords = append(networkPolicyApplicationUndoDeploymentRecords, networkPolicyApplicationUndoDeploymentRecord)
-		networkPolicyApplicationUndoDeploymentRecordIds = append(networkPolicyApplicationUndoDeploymentRecordIds, networkPolicyApplicationUndoDeploymentRecord.GetDeploymentId())
+		networkPolicyApplicationUndoDeploymentRecordIDs = append(networkPolicyApplicationUndoDeploymentRecordIDs, networkPolicyApplicationUndoDeploymentRecord.GetDeploymentId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, networkPolicyApplicationUndoDeploymentRecords))
@@ -114,7 +114,7 @@ func (s *NetworkpoliciesundodeploymentsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, networkPolicyApplicationUndoDeploymentRecordCount)
 
-	s.NoError(store.DeleteMany(ctx, networkPolicyApplicationUndoDeploymentRecordIds))
+	s.NoError(store.DeleteMany(ctx, networkPolicyApplicationUndoDeploymentRecordIDs))
 
 	networkPolicyApplicationUndoDeploymentRecordCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *NetworkpoliciesundodeploymentsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, networkPolicyApplicationUndoDeploymentRecord.GetDeploymentId()))
 
 	var networkPolicyApplicationUndoDeploymentRecords []*storage.NetworkPolicyApplicationUndoDeploymentRecord
-	for i := 0; i < 200; i++ {
+	var networkPolicyApplicationUndoDeploymentRecordIds []string
+	for i := 0; i < 12000; i++ {
 		networkPolicyApplicationUndoDeploymentRecord := &storage.NetworkPolicyApplicationUndoDeploymentRecord{}
 		s.NoError(testutils.FullInit(networkPolicyApplicationUndoDeploymentRecord, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkPolicyApplicationUndoDeploymentRecords = append(networkPolicyApplicationUndoDeploymentRecords, networkPolicyApplicationUndoDeploymentRecord)
+		networkPolicyApplicationUndoDeploymentRecordIds = append(networkPolicyApplicationUndoDeploymentRecordIds, networkPolicyApplicationUndoDeploymentRecord.GetDeploymentId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, networkPolicyApplicationUndoDeploymentRecords))
 
 	networkPolicyApplicationUndoDeploymentRecordCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, networkPolicyApplicationUndoDeploymentRecordCount)
+	s.Equal(12000, networkPolicyApplicationUndoDeploymentRecordCount)
+
+	s.NoError(store.DeleteMany(ctx, networkPolicyApplicationUndoDeploymentRecordIds))
+
+	networkPolicyApplicationUndoDeploymentRecordCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, networkPolicyApplicationUndoDeploymentRecordCount)
 }

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -475,6 +475,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -484,14 +485,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -472,12 +473,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -474,30 +474,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *NetworkpolicyapplicationundorecordsStoreSuite) TestStore() {
 
 	var networkPolicyApplicationUndoRecords []*storage.NetworkPolicyApplicationUndoRecord
 	var networkPolicyApplicationUndoRecordIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		networkPolicyApplicationUndoRecord := &storage.NetworkPolicyApplicationUndoRecord{}
 		s.NoError(testutils.FullInit(networkPolicyApplicationUndoRecord, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkPolicyApplicationUndoRecords = append(networkPolicyApplicationUndoRecords, networkPolicyApplicationUndoRecord)
@@ -112,7 +112,7 @@ func (s *NetworkpolicyapplicationundorecordsStoreSuite) TestStore() {
 
 	networkPolicyApplicationUndoRecordCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, networkPolicyApplicationUndoRecordCount)
+	s.Equal(200, networkPolicyApplicationUndoRecordCount)
 
 	s.NoError(store.DeleteMany(ctx, networkPolicyApplicationUndoRecordIds))
 

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *NetworkpolicyapplicationundorecordsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, networkPolicyApplicationUndoRecord.GetClusterId()))
 
 	var networkPolicyApplicationUndoRecords []*storage.NetworkPolicyApplicationUndoRecord
-	for i := 0; i < 200; i++ {
+	var networkPolicyApplicationUndoRecordIds []string
+	for i := 0; i < 12000; i++ {
 		networkPolicyApplicationUndoRecord := &storage.NetworkPolicyApplicationUndoRecord{}
 		s.NoError(testutils.FullInit(networkPolicyApplicationUndoRecord, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkPolicyApplicationUndoRecords = append(networkPolicyApplicationUndoRecords, networkPolicyApplicationUndoRecord)
+		networkPolicyApplicationUndoRecordIds = append(networkPolicyApplicationUndoRecordIds, networkPolicyApplicationUndoRecord.GetClusterId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, networkPolicyApplicationUndoRecords))
 
 	networkPolicyApplicationUndoRecordCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, networkPolicyApplicationUndoRecordCount)
+	s.Equal(12000, networkPolicyApplicationUndoRecordCount)
+
+	s.NoError(store.DeleteMany(ctx, networkPolicyApplicationUndoRecordIds))
+
+	networkPolicyApplicationUndoRecordCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, networkPolicyApplicationUndoRecordCount)
 }

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *NetworkpolicyapplicationundorecordsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, networkPolicyApplicationUndoRecord.GetClusterId()))
 
 	var networkPolicyApplicationUndoRecords []*storage.NetworkPolicyApplicationUndoRecord
-	var networkPolicyApplicationUndoRecordIds []string
+	var networkPolicyApplicationUndoRecordIDs []string
 	for i := 0; i < 200; i++ {
 		networkPolicyApplicationUndoRecord := &storage.NetworkPolicyApplicationUndoRecord{}
 		s.NoError(testutils.FullInit(networkPolicyApplicationUndoRecord, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkPolicyApplicationUndoRecords = append(networkPolicyApplicationUndoRecords, networkPolicyApplicationUndoRecord)
-		networkPolicyApplicationUndoRecordIds = append(networkPolicyApplicationUndoRecordIds, networkPolicyApplicationUndoRecord.GetClusterId())
+		networkPolicyApplicationUndoRecordIDs = append(networkPolicyApplicationUndoRecordIDs, networkPolicyApplicationUndoRecord.GetClusterId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, networkPolicyApplicationUndoRecords))
@@ -114,7 +114,7 @@ func (s *NetworkpolicyapplicationundorecordsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, networkPolicyApplicationUndoRecordCount)
 
-	s.NoError(store.DeleteMany(ctx, networkPolicyApplicationUndoRecordIds))
+	s.NoError(store.DeleteMany(ctx, networkPolicyApplicationUndoRecordIDs))
 
 	networkPolicyApplicationUndoRecordCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -538,30 +538,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -536,12 +537,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -539,6 +539,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -548,14 +549,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/nodecomponent/datastore/store/postgres/store_test.go
+++ b/central/nodecomponent/datastore/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *NodeComponentsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, nodeComponent.GetId()))
 
 	var nodeComponents []*storage.NodeComponent
-	for i := 0; i < 200; i++ {
+	var nodeComponentIds []string
+	for i := 0; i < 12000; i++ {
 		nodeComponent := &storage.NodeComponent{}
 		s.NoError(testutils.FullInit(nodeComponent, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		nodeComponents = append(nodeComponents, nodeComponent)
+		nodeComponentIds = append(nodeComponentIds, nodeComponent.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, nodeComponents))
 
 	nodeComponentCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, nodeComponentCount)
+	s.Equal(12000, nodeComponentCount)
+
+	s.NoError(store.DeleteMany(ctx, nodeComponentIds))
+
+	nodeComponentCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, nodeComponentCount)
 }

--- a/central/nodecomponent/datastore/store/postgres/store_test.go
+++ b/central/nodecomponent/datastore/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *NodeComponentsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, nodeComponent.GetId()))
 
 	var nodeComponents []*storage.NodeComponent
-	var nodeComponentIds []string
+	var nodeComponentIDs []string
 	for i := 0; i < 200; i++ {
 		nodeComponent := &storage.NodeComponent{}
 		s.NoError(testutils.FullInit(nodeComponent, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		nodeComponents = append(nodeComponents, nodeComponent)
-		nodeComponentIds = append(nodeComponentIds, nodeComponent.GetId())
+		nodeComponentIDs = append(nodeComponentIDs, nodeComponent.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, nodeComponents))
@@ -114,7 +114,7 @@ func (s *NodeComponentsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, nodeComponentCount)
 
-	s.NoError(store.DeleteMany(ctx, nodeComponentIds))
+	s.NoError(store.DeleteMany(ctx, nodeComponentIDs))
 
 	nodeComponentCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/nodecomponent/datastore/store/postgres/store_test.go
+++ b/central/nodecomponent/datastore/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *NodeComponentsStoreSuite) TestStore() {
 
 	var nodeComponents []*storage.NodeComponent
 	var nodeComponentIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		nodeComponent := &storage.NodeComponent{}
 		s.NoError(testutils.FullInit(nodeComponent, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		nodeComponents = append(nodeComponents, nodeComponent)
@@ -112,7 +112,7 @@ func (s *NodeComponentsStoreSuite) TestStore() {
 
 	nodeComponentCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, nodeComponentCount)
+	s.Equal(200, nodeComponentCount)
 
 	s.NoError(store.DeleteMany(ctx, nodeComponentIds))
 

--- a/central/nodecomponentcveedge/datastore/store/postgres/store.go
+++ b/central/nodecomponentcveedge/datastore/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
 )

--- a/central/nodecomponentcveedge/datastore/store/postgres/store.go
+++ b/central/nodecomponentcveedge/datastore/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 )

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
 )

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 )

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -443,12 +444,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -446,6 +446,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -455,14 +456,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -445,30 +445,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/notifier/datastore/internal/store/postgres/store_test.go
+++ b/central/notifier/datastore/internal/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *NotifiersStoreSuite) TestStore() {
 
 	var notifiers []*storage.Notifier
 	var notifierIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		notifier := &storage.Notifier{}
 		s.NoError(testutils.FullInit(notifier, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		notifiers = append(notifiers, notifier)
@@ -115,7 +115,7 @@ func (s *NotifiersStoreSuite) TestStore() {
 
 	notifierCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, notifierCount)
+	s.Equal(200, notifierCount)
 
 	s.NoError(store.DeleteMany(ctx, notifierIds))
 

--- a/central/notifier/datastore/internal/store/postgres/store_test.go
+++ b/central/notifier/datastore/internal/store/postgres/store_test.go
@@ -100,10 +100,12 @@ func (s *NotifiersStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, notifier.GetId()), sac.ErrResourceAccessDenied)
 
 	var notifiers []*storage.Notifier
-	for i := 0; i < 200; i++ {
+	var notifierIds []string
+	for i := 0; i < 12000; i++ {
 		notifier := &storage.Notifier{}
 		s.NoError(testutils.FullInit(notifier, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		notifiers = append(notifiers, notifier)
+		notifierIds = append(notifierIds, notifier.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, notifiers))
@@ -113,5 +115,11 @@ func (s *NotifiersStoreSuite) TestStore() {
 
 	notifierCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, notifierCount)
+	s.Equal(12000, notifierCount)
+
+	s.NoError(store.DeleteMany(ctx, notifierIds))
+
+	notifierCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, notifierCount)
 }

--- a/central/notifier/datastore/internal/store/postgres/store_test.go
+++ b/central/notifier/datastore/internal/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *NotifiersStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, notifier.GetId()), sac.ErrResourceAccessDenied)
 
 	var notifiers []*storage.Notifier
-	var notifierIds []string
+	var notifierIDs []string
 	for i := 0; i < 200; i++ {
 		notifier := &storage.Notifier{}
 		s.NoError(testutils.FullInit(notifier, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		notifiers = append(notifiers, notifier)
-		notifierIds = append(notifierIds, notifier.GetId())
+		notifierIDs = append(notifierIDs, notifier.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, notifiers))
@@ -117,7 +117,7 @@ func (s *NotifiersStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, notifierCount)
 
-	s.NoError(store.DeleteMany(ctx, notifierIds))
+	s.NoError(store.DeleteMany(ctx, notifierIDs))
 
 	notifierCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -619,30 +619,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -620,6 +620,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -629,14 +630,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -617,12 +618,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/pod/store/postgres/store_test.go
+++ b/central/pod/store/postgres/store_test.go
@@ -103,7 +103,7 @@ func (s *PodsStoreSuite) TestStore() {
 
 	var pods []*storage.Pod
 	var podIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		pod := &storage.Pod{}
 		s.NoError(testutils.FullInit(pod, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		pods = append(pods, pod)
@@ -114,7 +114,7 @@ func (s *PodsStoreSuite) TestStore() {
 
 	podCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, podCount)
+	s.Equal(200, podCount)
 
 	s.NoError(store.DeleteMany(ctx, podIds))
 

--- a/central/pod/store/postgres/store_test.go
+++ b/central/pod/store/postgres/store_test.go
@@ -102,17 +102,25 @@ func (s *PodsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, pod.GetId()))
 
 	var pods []*storage.Pod
-	for i := 0; i < 200; i++ {
+	var podIds []string
+	for i := 0; i < 12000; i++ {
 		pod := &storage.Pod{}
 		s.NoError(testutils.FullInit(pod, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		pods = append(pods, pod)
+		podIds = append(podIds, pod.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, pods))
 
 	podCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, podCount)
+	s.Equal(12000, podCount)
+
+	s.NoError(store.DeleteMany(ctx, podIds))
+
+	podCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, podCount)
 }
 
 func (s *PodsStoreSuite) TestSACUpsert() {

--- a/central/pod/store/postgres/store_test.go
+++ b/central/pod/store/postgres/store_test.go
@@ -102,12 +102,12 @@ func (s *PodsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, pod.GetId()))
 
 	var pods []*storage.Pod
-	var podIds []string
+	var podIDs []string
 	for i := 0; i < 200; i++ {
 		pod := &storage.Pod{}
 		s.NoError(testutils.FullInit(pod, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		pods = append(pods, pod)
-		podIds = append(podIds, pod.GetId())
+		podIDs = append(podIDs, pod.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, pods))
@@ -116,7 +116,7 @@ func (s *PodsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, podCount)
 
-	s.NoError(store.DeleteMany(ctx, podIds))
+	s.NoError(store.DeleteMany(ctx, podIDs))
 
 	podCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (
@@ -598,7 +598,7 @@ func CreateTableAndNewStore(ctx context.Context, db *pgxpool.Pool, gormDB *gorm.
 	return New(db)
 }
 
-//// Stubs for satisfying legacy interfaces
+// // Stubs for satisfying legacy interfaces
 func (s *storeImpl) RenamePolicyCategory(request *v1.RenamePolicyCategoryRequest) error {
 	return errors.New("unimplemented")
 }

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -522,6 +522,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -531,14 +532,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -598,7 +598,7 @@ func CreateTableAndNewStore(ctx context.Context, db *pgxpool.Pool, gormDB *gorm.
 	return New(db)
 }
 
-// // Stubs for satisfying legacy interfaces
+//// Stubs for satisfying legacy interfaces
 func (s *storeImpl) RenamePolicyCategory(request *v1.RenamePolicyCategoryRequest) error {
 	return errors.New("unimplemented")
 }

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -521,30 +521,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/policy/store/postgres/store_test.go
+++ b/central/policy/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *PoliciesStoreSuite) TestStore() {
 
 	var policys []*storage.Policy
 	var policyIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		policy := &storage.Policy{}
 		s.NoError(testutils.FullInit(policy, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		policys = append(policys, policy)
@@ -115,7 +115,7 @@ func (s *PoliciesStoreSuite) TestStore() {
 
 	policyCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, policyCount)
+	s.Equal(200, policyCount)
 
 	s.NoError(store.DeleteMany(ctx, policyIds))
 

--- a/central/policy/store/postgres/store_test.go
+++ b/central/policy/store/postgres/store_test.go
@@ -100,10 +100,12 @@ func (s *PoliciesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, policy.GetId()), sac.ErrResourceAccessDenied)
 
 	var policys []*storage.Policy
-	for i := 0; i < 200; i++ {
+	var policyIds []string
+	for i := 0; i < 12000; i++ {
 		policy := &storage.Policy{}
 		s.NoError(testutils.FullInit(policy, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		policys = append(policys, policy)
+		policyIds = append(policyIds, policy.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, policys))
@@ -113,5 +115,11 @@ func (s *PoliciesStoreSuite) TestStore() {
 
 	policyCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, policyCount)
+	s.Equal(12000, policyCount)
+
+	s.NoError(store.DeleteMany(ctx, policyIds))
+
+	policyCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, policyCount)
 }

--- a/central/policy/store/postgres/store_test.go
+++ b/central/policy/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *PoliciesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, policy.GetId()), sac.ErrResourceAccessDenied)
 
 	var policys []*storage.Policy
-	var policyIds []string
+	var policyIDs []string
 	for i := 0; i < 200; i++ {
 		policy := &storage.Policy{}
 		s.NoError(testutils.FullInit(policy, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		policys = append(policys, policy)
-		policyIds = append(policyIds, policy.GetId())
+		policyIDs = append(policyIDs, policy.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, policys))
@@ -117,7 +117,7 @@ func (s *PoliciesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, policyCount)
 
-	s.NoError(store.DeleteMany(ctx, policyIds))
+	s.NoError(store.DeleteMany(ctx, policyIDs))
 
 	policyCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -461,6 +461,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -470,14 +471,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -458,12 +459,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -460,30 +460,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/policycategory/store/postgres/store_test.go
+++ b/central/policycategory/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *PolicyCategoriesStoreSuite) TestStore() {
 
 	var policyCategorys []*storage.PolicyCategory
 	var policyCategoryIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		policyCategory := &storage.PolicyCategory{}
 		s.NoError(testutils.FullInit(policyCategory, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		policyCategorys = append(policyCategorys, policyCategory)
@@ -112,7 +112,7 @@ func (s *PolicyCategoriesStoreSuite) TestStore() {
 
 	policyCategoryCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, policyCategoryCount)
+	s.Equal(200, policyCategoryCount)
 
 	s.NoError(store.DeleteMany(ctx, policyCategoryIds))
 

--- a/central/policycategory/store/postgres/store_test.go
+++ b/central/policycategory/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *PolicyCategoriesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, policyCategory.GetId()), sac.ErrResourceAccessDenied)
 
 	var policyCategorys []*storage.PolicyCategory
-	for i := 0; i < 200; i++ {
+	var policyCategoryIds []string
+	for i := 0; i < 12000; i++ {
 		policyCategory := &storage.PolicyCategory{}
 		s.NoError(testutils.FullInit(policyCategory, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		policyCategorys = append(policyCategorys, policyCategory)
+		policyCategoryIds = append(policyCategoryIds, policyCategory.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, policyCategorys))
 
 	policyCategoryCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, policyCategoryCount)
+	s.Equal(12000, policyCategoryCount)
+
+	s.NoError(store.DeleteMany(ctx, policyCategoryIds))
+
+	policyCategoryCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, policyCategoryCount)
 }

--- a/central/policycategory/store/postgres/store_test.go
+++ b/central/policycategory/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *PolicyCategoriesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, policyCategory.GetId()), sac.ErrResourceAccessDenied)
 
 	var policyCategorys []*storage.PolicyCategory
-	var policyCategoryIds []string
+	var policyCategoryIDs []string
 	for i := 0; i < 200; i++ {
 		policyCategory := &storage.PolicyCategory{}
 		s.NoError(testutils.FullInit(policyCategory, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		policyCategorys = append(policyCategorys, policyCategory)
-		policyCategoryIds = append(policyCategoryIds, policyCategory.GetId())
+		policyCategoryIDs = append(policyCategoryIDs, policyCategory.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, policyCategorys))
@@ -114,7 +114,7 @@ func (s *PolicyCategoriesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, policyCategoryCount)
 
-	s.NoError(store.DeleteMany(ctx, policyCategoryIds))
+	s.NoError(store.DeleteMany(ctx, policyCategoryIDs))
 
 	policyCategoryCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -532,12 +533,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -535,6 +535,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -544,14 +545,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -534,30 +534,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/processbaseline/store/postgres/store_test.go
+++ b/central/processbaseline/store/postgres/store_test.go
@@ -102,12 +102,12 @@ func (s *ProcessBaselinesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, processBaseline.GetId()))
 
 	var processBaselines []*storage.ProcessBaseline
-	var processBaselineIds []string
+	var processBaselineIDs []string
 	for i := 0; i < 200; i++ {
 		processBaseline := &storage.ProcessBaseline{}
 		s.NoError(testutils.FullInit(processBaseline, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		processBaselines = append(processBaselines, processBaseline)
-		processBaselineIds = append(processBaselineIds, processBaseline.GetId())
+		processBaselineIDs = append(processBaselineIDs, processBaseline.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, processBaselines))
@@ -116,7 +116,7 @@ func (s *ProcessBaselinesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, processBaselineCount)
 
-	s.NoError(store.DeleteMany(ctx, processBaselineIds))
+	s.NoError(store.DeleteMany(ctx, processBaselineIDs))
 
 	processBaselineCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/processbaseline/store/postgres/store_test.go
+++ b/central/processbaseline/store/postgres/store_test.go
@@ -103,7 +103,7 @@ func (s *ProcessBaselinesStoreSuite) TestStore() {
 
 	var processBaselines []*storage.ProcessBaseline
 	var processBaselineIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		processBaseline := &storage.ProcessBaseline{}
 		s.NoError(testutils.FullInit(processBaseline, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		processBaselines = append(processBaselines, processBaseline)
@@ -114,7 +114,7 @@ func (s *ProcessBaselinesStoreSuite) TestStore() {
 
 	processBaselineCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, processBaselineCount)
+	s.Equal(200, processBaselineCount)
 
 	s.NoError(store.DeleteMany(ctx, processBaselineIds))
 

--- a/central/processbaseline/store/postgres/store_test.go
+++ b/central/processbaseline/store/postgres/store_test.go
@@ -102,17 +102,25 @@ func (s *ProcessBaselinesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, processBaseline.GetId()))
 
 	var processBaselines []*storage.ProcessBaseline
-	for i := 0; i < 200; i++ {
+	var processBaselineIds []string
+	for i := 0; i < 12000; i++ {
 		processBaseline := &storage.ProcessBaseline{}
 		s.NoError(testutils.FullInit(processBaseline, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		processBaselines = append(processBaselines, processBaseline)
+		processBaselineIds = append(processBaselineIds, processBaseline.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, processBaselines))
 
 	processBaselineCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, processBaselineCount)
+	s.Equal(12000, processBaselineCount)
+
+	s.NoError(store.DeleteMany(ctx, processBaselineIds))
+
+	processBaselineCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, processBaselineCount)
 }
 
 func (s *ProcessBaselinesStoreSuite) TestSACUpsert() {

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -527,12 +528,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -530,6 +530,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -539,14 +540,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -529,30 +529,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
@@ -102,17 +102,25 @@ func (s *ProcessBaselineResultsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, processBaselineResults.GetDeploymentId()))
 
 	var processBaselineResultss []*storage.ProcessBaselineResults
-	for i := 0; i < 200; i++ {
+	var processBaselineResultsIds []string
+	for i := 0; i < 12000; i++ {
 		processBaselineResults := &storage.ProcessBaselineResults{}
 		s.NoError(testutils.FullInit(processBaselineResults, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		processBaselineResultss = append(processBaselineResultss, processBaselineResults)
+		processBaselineResultsIds = append(processBaselineResultsIds, processBaselineResults.GetDeploymentId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, processBaselineResultss))
 
 	processBaselineResultsCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, processBaselineResultsCount)
+	s.Equal(12000, processBaselineResultsCount)
+
+	s.NoError(store.DeleteMany(ctx, processBaselineResultsIds))
+
+	processBaselineResultsCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, processBaselineResultsCount)
 }
 
 func (s *ProcessBaselineResultsStoreSuite) TestSACUpsert() {

--- a/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
@@ -102,12 +102,12 @@ func (s *ProcessBaselineResultsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, processBaselineResults.GetDeploymentId()))
 
 	var processBaselineResultss []*storage.ProcessBaselineResults
-	var processBaselineResultsIds []string
+	var processBaselineResultsIDs []string
 	for i := 0; i < 200; i++ {
 		processBaselineResults := &storage.ProcessBaselineResults{}
 		s.NoError(testutils.FullInit(processBaselineResults, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		processBaselineResultss = append(processBaselineResultss, processBaselineResults)
-		processBaselineResultsIds = append(processBaselineResultsIds, processBaselineResults.GetDeploymentId())
+		processBaselineResultsIDs = append(processBaselineResultsIDs, processBaselineResults.GetDeploymentId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, processBaselineResultss))
@@ -116,7 +116,7 @@ func (s *ProcessBaselineResultsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, processBaselineResultsCount)
 
-	s.NoError(store.DeleteMany(ctx, processBaselineResultsIds))
+	s.NoError(store.DeleteMany(ctx, processBaselineResultsIDs))
 
 	processBaselineResultsCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
@@ -103,7 +103,7 @@ func (s *ProcessBaselineResultsStoreSuite) TestStore() {
 
 	var processBaselineResultss []*storage.ProcessBaselineResults
 	var processBaselineResultsIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		processBaselineResults := &storage.ProcessBaselineResults{}
 		s.NoError(testutils.FullInit(processBaselineResults, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		processBaselineResultss = append(processBaselineResultss, processBaselineResults)
@@ -114,7 +114,7 @@ func (s *ProcessBaselineResultsStoreSuite) TestStore() {
 
 	processBaselineResultsCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, processBaselineResultsCount)
+	s.Equal(200, processBaselineResultsCount)
 
 	s.NoError(store.DeleteMany(ctx, processBaselineResultsIds))
 

--- a/central/processindicator/datastore/datastore_impl.go
+++ b/central/processindicator/datastore/datastore_impl.go
@@ -129,6 +129,7 @@ func (ds *datastoreImpl) RemoveProcessIndicators(ctx context.Context, ids []stri
 		return sac.ErrResourceAccessDenied
 	}
 
+	log.Infof("SHREWS -- RemoveProcessIndicators -- len = %d", len(ids))
 	return ds.removeIndicators(ctx, ids)
 }
 

--- a/central/processindicator/datastore/datastore_impl.go
+++ b/central/processindicator/datastore/datastore_impl.go
@@ -129,7 +129,6 @@ func (ds *datastoreImpl) RemoveProcessIndicators(ctx context.Context, ids []stri
 		return sac.ErrResourceAccessDenied
 	}
 
-	log.Infof("SHREWS -- RemoveProcessIndicators -- len = %d", len(ids))
 	return ds.removeIndicators(ctx, ids)
 }
 

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -572,12 +573,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -575,6 +575,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -584,14 +585,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -574,30 +574,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/processindicator/store/postgres/store_test.go
+++ b/central/processindicator/store/postgres/store_test.go
@@ -103,7 +103,7 @@ func (s *ProcessIndicatorsStoreSuite) TestStore() {
 
 	var processIndicators []*storage.ProcessIndicator
 	var processIndicatorIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		processIndicator := &storage.ProcessIndicator{}
 		s.NoError(testutils.FullInit(processIndicator, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		processIndicators = append(processIndicators, processIndicator)
@@ -114,7 +114,7 @@ func (s *ProcessIndicatorsStoreSuite) TestStore() {
 
 	processIndicatorCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, processIndicatorCount)
+	s.Equal(200, processIndicatorCount)
 
 	s.NoError(store.DeleteMany(ctx, processIndicatorIds))
 

--- a/central/processindicator/store/postgres/store_test.go
+++ b/central/processindicator/store/postgres/store_test.go
@@ -102,12 +102,12 @@ func (s *ProcessIndicatorsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, processIndicator.GetId()))
 
 	var processIndicators []*storage.ProcessIndicator
-	var processIndicatorIds []string
+	var processIndicatorIDs []string
 	for i := 0; i < 200; i++ {
 		processIndicator := &storage.ProcessIndicator{}
 		s.NoError(testutils.FullInit(processIndicator, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		processIndicators = append(processIndicators, processIndicator)
-		processIndicatorIds = append(processIndicatorIds, processIndicator.GetId())
+		processIndicatorIDs = append(processIndicatorIDs, processIndicator.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, processIndicators))
@@ -116,7 +116,7 @@ func (s *ProcessIndicatorsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, processIndicatorCount)
 
-	s.NoError(store.DeleteMany(ctx, processIndicatorIds))
+	s.NoError(store.DeleteMany(ctx, processIndicatorIDs))
 
 	processIndicatorCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/processindicator/store/postgres/store_test.go
+++ b/central/processindicator/store/postgres/store_test.go
@@ -102,17 +102,25 @@ func (s *ProcessIndicatorsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, processIndicator.GetId()))
 
 	var processIndicators []*storage.ProcessIndicator
-	for i := 0; i < 200; i++ {
+	var processIndicatorIds []string
+	for i := 0; i < 12000; i++ {
 		processIndicator := &storage.ProcessIndicator{}
 		s.NoError(testutils.FullInit(processIndicator, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		processIndicators = append(processIndicators, processIndicator)
+		processIndicatorIds = append(processIndicatorIds, processIndicator.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, processIndicators))
 
 	processIndicatorCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, processIndicatorCount)
+	s.Equal(12000, processIndicatorCount)
+
+	s.NoError(store.DeleteMany(ctx, processIndicatorIds))
+
+	processIndicatorCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, processIndicatorCount)
 }
 
 func (s *ProcessIndicatorsStoreSuite) TestSACUpsert() {

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -552,12 +553,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -555,6 +555,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -564,14 +565,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -554,30 +554,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/rbac/k8srole/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srole/internal/store/postgres/store_test.go
@@ -102,12 +102,12 @@ func (s *K8sRolesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, k8SRole.GetId()))
 
 	var k8SRoles []*storage.K8SRole
-	var k8SRoleIds []string
+	var k8SRoleIDs []string
 	for i := 0; i < 200; i++ {
 		k8SRole := &storage.K8SRole{}
 		s.NoError(testutils.FullInit(k8SRole, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		k8SRoles = append(k8SRoles, k8SRole)
-		k8SRoleIds = append(k8SRoleIds, k8SRole.GetId())
+		k8SRoleIDs = append(k8SRoleIDs, k8SRole.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, k8SRoles))
@@ -116,7 +116,7 @@ func (s *K8sRolesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, k8SRoleCount)
 
-	s.NoError(store.DeleteMany(ctx, k8SRoleIds))
+	s.NoError(store.DeleteMany(ctx, k8SRoleIDs))
 
 	k8SRoleCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/rbac/k8srole/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srole/internal/store/postgres/store_test.go
@@ -102,17 +102,25 @@ func (s *K8sRolesStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, k8SRole.GetId()))
 
 	var k8SRoles []*storage.K8SRole
-	for i := 0; i < 200; i++ {
+	var k8SRoleIds []string
+	for i := 0; i < 12000; i++ {
 		k8SRole := &storage.K8SRole{}
 		s.NoError(testutils.FullInit(k8SRole, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		k8SRoles = append(k8SRoles, k8SRole)
+		k8SRoleIds = append(k8SRoleIds, k8SRole.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, k8SRoles))
 
 	k8SRoleCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, k8SRoleCount)
+	s.Equal(12000, k8SRoleCount)
+
+	s.NoError(store.DeleteMany(ctx, k8SRoleIds))
+
+	k8SRoleCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, k8SRoleCount)
 }
 
 func (s *K8sRolesStoreSuite) TestSACUpsert() {

--- a/central/rbac/k8srole/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srole/internal/store/postgres/store_test.go
@@ -103,7 +103,7 @@ func (s *K8sRolesStoreSuite) TestStore() {
 
 	var k8SRoles []*storage.K8SRole
 	var k8SRoleIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		k8SRole := &storage.K8SRole{}
 		s.NoError(testutils.FullInit(k8SRole, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		k8SRoles = append(k8SRoles, k8SRole)
@@ -114,7 +114,7 @@ func (s *K8sRolesStoreSuite) TestStore() {
 
 	k8SRoleCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, k8SRoleCount)
+	s.Equal(200, k8SRoleCount)
 
 	s.NoError(store.DeleteMany(ctx, k8SRoleIds))
 

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -645,6 +645,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -654,14 +655,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -642,12 +643,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -644,30 +644,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
@@ -102,12 +102,12 @@ func (s *RoleBindingsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, k8SRoleBinding.GetId()))
 
 	var k8SRoleBindings []*storage.K8SRoleBinding
-	var k8SRoleBindingIds []string
+	var k8SRoleBindingIDs []string
 	for i := 0; i < 200; i++ {
 		k8SRoleBinding := &storage.K8SRoleBinding{}
 		s.NoError(testutils.FullInit(k8SRoleBinding, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		k8SRoleBindings = append(k8SRoleBindings, k8SRoleBinding)
-		k8SRoleBindingIds = append(k8SRoleBindingIds, k8SRoleBinding.GetId())
+		k8SRoleBindingIDs = append(k8SRoleBindingIDs, k8SRoleBinding.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, k8SRoleBindings))
@@ -116,7 +116,7 @@ func (s *RoleBindingsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, k8SRoleBindingCount)
 
-	s.NoError(store.DeleteMany(ctx, k8SRoleBindingIds))
+	s.NoError(store.DeleteMany(ctx, k8SRoleBindingIDs))
 
 	k8SRoleBindingCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
@@ -102,17 +102,25 @@ func (s *RoleBindingsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, k8SRoleBinding.GetId()))
 
 	var k8SRoleBindings []*storage.K8SRoleBinding
-	for i := 0; i < 200; i++ {
+	var k8SRoleBindingIds []string
+	for i := 0; i < 12000; i++ {
 		k8SRoleBinding := &storage.K8SRoleBinding{}
 		s.NoError(testutils.FullInit(k8SRoleBinding, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		k8SRoleBindings = append(k8SRoleBindings, k8SRoleBinding)
+		k8SRoleBindingIds = append(k8SRoleBindingIds, k8SRoleBinding.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, k8SRoleBindings))
 
 	k8SRoleBindingCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, k8SRoleBindingCount)
+	s.Equal(12000, k8SRoleBindingCount)
+
+	s.NoError(store.DeleteMany(ctx, k8SRoleBindingIds))
+
+	k8SRoleBindingCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, k8SRoleBindingCount)
 }
 
 func (s *RoleBindingsStoreSuite) TestSACUpsert() {

--- a/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
@@ -103,7 +103,7 @@ func (s *RoleBindingsStoreSuite) TestStore() {
 
 	var k8SRoleBindings []*storage.K8SRoleBinding
 	var k8SRoleBindingIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		k8SRoleBinding := &storage.K8SRoleBinding{}
 		s.NoError(testutils.FullInit(k8SRoleBinding, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		k8SRoleBindings = append(k8SRoleBindings, k8SRoleBinding)
@@ -114,7 +114,7 @@ func (s *RoleBindingsStoreSuite) TestStore() {
 
 	k8SRoleBindingCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, k8SRoleBindingCount)
+	s.Equal(200, k8SRoleBindingCount)
 
 	s.NoError(store.DeleteMany(ctx, k8SRoleBindingIds))
 

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -463,12 +464,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -465,30 +465,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -466,6 +466,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -475,14 +476,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/reportconfigurations/store/postgres/store_test.go
+++ b/central/reportconfigurations/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ReportConfigurationsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, reportConfiguration.GetId()), sac.ErrResourceAccessDenied)
 
 	var reportConfigurations []*storage.ReportConfiguration
-	var reportConfigurationIds []string
+	var reportConfigurationIDs []string
 	for i := 0; i < 200; i++ {
 		reportConfiguration := &storage.ReportConfiguration{}
 		s.NoError(testutils.FullInit(reportConfiguration, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		reportConfigurations = append(reportConfigurations, reportConfiguration)
-		reportConfigurationIds = append(reportConfigurationIds, reportConfiguration.GetId())
+		reportConfigurationIDs = append(reportConfigurationIDs, reportConfiguration.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, reportConfigurations))
@@ -114,7 +114,7 @@ func (s *ReportConfigurationsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, reportConfigurationCount)
 
-	s.NoError(store.DeleteMany(ctx, reportConfigurationIds))
+	s.NoError(store.DeleteMany(ctx, reportConfigurationIDs))
 
 	reportConfigurationCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/reportconfigurations/store/postgres/store_test.go
+++ b/central/reportconfigurations/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ReportConfigurationsStoreSuite) TestStore() {
 
 	var reportConfigurations []*storage.ReportConfiguration
 	var reportConfigurationIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		reportConfiguration := &storage.ReportConfiguration{}
 		s.NoError(testutils.FullInit(reportConfiguration, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		reportConfigurations = append(reportConfigurations, reportConfiguration)
@@ -112,7 +112,7 @@ func (s *ReportConfigurationsStoreSuite) TestStore() {
 
 	reportConfigurationCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, reportConfigurationCount)
+	s.Equal(200, reportConfigurationCount)
 
 	s.NoError(store.DeleteMany(ctx, reportConfigurationIds))
 

--- a/central/reportconfigurations/store/postgres/store_test.go
+++ b/central/reportconfigurations/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *ReportConfigurationsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, reportConfiguration.GetId()), sac.ErrResourceAccessDenied)
 
 	var reportConfigurations []*storage.ReportConfiguration
-	for i := 0; i < 200; i++ {
+	var reportConfigurationIds []string
+	for i := 0; i < 12000; i++ {
 		reportConfiguration := &storage.ReportConfiguration{}
 		s.NoError(testutils.FullInit(reportConfiguration, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		reportConfigurations = append(reportConfigurations, reportConfiguration)
+		reportConfigurationIds = append(reportConfigurationIds, reportConfiguration.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, reportConfigurations))
 
 	reportConfigurationCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, reportConfigurationCount)
+	s.Equal(12000, reportConfigurationCount)
+
+	s.NoError(store.DeleteMany(ctx, reportConfigurationIds))
+
+	reportConfigurationCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, reportConfigurationCount)
 }

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -548,12 +549,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -551,6 +551,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -560,14 +561,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -550,30 +550,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/resourcecollection/datastore/store/postgres/store_test.go
+++ b/central/resourcecollection/datastore/store/postgres/store_test.go
@@ -101,13 +101,13 @@ func (s *CollectionsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, resourceCollection.GetId()), sac.ErrResourceAccessDenied)
 
 	var resourceCollections []*storage.ResourceCollection
-	var resourceCollectionIds []string
+	var resourceCollectionIDs []string
 	for i := 0; i < 200; i++ {
 		resourceCollection := &storage.ResourceCollection{}
 		s.NoError(testutils.FullInit(resourceCollection, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		resourceCollection.EmbeddedCollections = nil
 		resourceCollections = append(resourceCollections, resourceCollection)
-		resourceCollectionIds = append(resourceCollectionIds, resourceCollection.GetId())
+		resourceCollectionIDs = append(resourceCollectionIDs, resourceCollection.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, resourceCollections))
@@ -116,7 +116,7 @@ func (s *CollectionsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, resourceCollectionCount)
 
-	s.NoError(store.DeleteMany(ctx, resourceCollectionIds))
+	s.NoError(store.DeleteMany(ctx, resourceCollectionIDs))
 
 	resourceCollectionCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/resourcecollection/datastore/store/postgres/store_test.go
+++ b/central/resourcecollection/datastore/store/postgres/store_test.go
@@ -102,7 +102,7 @@ func (s *CollectionsStoreSuite) TestStore() {
 
 	var resourceCollections []*storage.ResourceCollection
 	var resourceCollectionIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		resourceCollection := &storage.ResourceCollection{}
 		s.NoError(testutils.FullInit(resourceCollection, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		resourceCollection.EmbeddedCollections = nil
@@ -114,7 +114,7 @@ func (s *CollectionsStoreSuite) TestStore() {
 
 	resourceCollectionCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, resourceCollectionCount)
+	s.Equal(200, resourceCollectionCount)
 
 	s.NoError(store.DeleteMany(ctx, resourceCollectionIds))
 

--- a/central/resourcecollection/datastore/store/postgres/store_test.go
+++ b/central/resourcecollection/datastore/store/postgres/store_test.go
@@ -101,16 +101,24 @@ func (s *CollectionsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, resourceCollection.GetId()), sac.ErrResourceAccessDenied)
 
 	var resourceCollections []*storage.ResourceCollection
-	for i := 0; i < 200; i++ {
+	var resourceCollectionIds []string
+	for i := 0; i < 12000; i++ {
 		resourceCollection := &storage.ResourceCollection{}
 		s.NoError(testutils.FullInit(resourceCollection, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		resourceCollection.EmbeddedCollections = nil
 		resourceCollections = append(resourceCollections, resourceCollection)
+		resourceCollectionIds = append(resourceCollectionIds, resourceCollection.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, resourceCollections))
 
 	resourceCollectionCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, resourceCollectionCount)
+	s.Equal(12000, resourceCollectionCount)
+
+	s.NoError(store.DeleteMany(ctx, resourceCollectionIds))
+
+	resourceCollectionCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, resourceCollectionCount)
 }

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -540,6 +540,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -549,14 +550,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -537,12 +538,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -539,30 +539,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/risk/datastore/internal/store/postgres/store_test.go
+++ b/central/risk/datastore/internal/store/postgres/store_test.go
@@ -103,7 +103,7 @@ func (s *RisksStoreSuite) TestStore() {
 
 	var risks []*storage.Risk
 	var riskIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		risk := &storage.Risk{}
 		s.NoError(testutils.FullInit(risk, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		risks = append(risks, risk)
@@ -114,7 +114,7 @@ func (s *RisksStoreSuite) TestStore() {
 
 	riskCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, riskCount)
+	s.Equal(200, riskCount)
 
 	s.NoError(store.DeleteMany(ctx, riskIds))
 

--- a/central/risk/datastore/internal/store/postgres/store_test.go
+++ b/central/risk/datastore/internal/store/postgres/store_test.go
@@ -102,17 +102,25 @@ func (s *RisksStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, risk.GetId()))
 
 	var risks []*storage.Risk
-	for i := 0; i < 200; i++ {
+	var riskIds []string
+	for i := 0; i < 12000; i++ {
 		risk := &storage.Risk{}
 		s.NoError(testutils.FullInit(risk, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		risks = append(risks, risk)
+		riskIds = append(riskIds, risk.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, risks))
 
 	riskCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, riskCount)
+	s.Equal(12000, riskCount)
+
+	s.NoError(store.DeleteMany(ctx, riskIds))
+
+	riskCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, riskCount)
 }
 
 func (s *RisksStoreSuite) TestSACUpsert() {

--- a/central/risk/datastore/internal/store/postgres/store_test.go
+++ b/central/risk/datastore/internal/store/postgres/store_test.go
@@ -102,12 +102,12 @@ func (s *RisksStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, risk.GetId()))
 
 	var risks []*storage.Risk
-	var riskIds []string
+	var riskIDs []string
 	for i := 0; i < 200; i++ {
 		risk := &storage.Risk{}
 		s.NoError(testutils.FullInit(risk, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		risks = append(risks, risk)
-		riskIds = append(riskIds, risk.GetId())
+		riskIDs = append(riskIDs, risk.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, risks))
@@ -116,7 +116,7 @@ func (s *RisksStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, riskCount)
 
-	s.NoError(store.DeleteMany(ctx, riskIds))
+	s.NoError(store.DeleteMany(ctx, riskIDs))
 
 	riskCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -435,6 +435,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -444,14 +445,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -432,12 +433,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -434,30 +434,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/role/store/permissionset/postgres/store_test.go
+++ b/central/role/store/permissionset/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *PermissionSetsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, permissionSet.GetId()), sac.ErrResourceAccessDenied)
 
 	var permissionSets []*storage.PermissionSet
-	var permissionSetIds []string
+	var permissionSetIDs []string
 	for i := 0; i < 200; i++ {
 		permissionSet := &storage.PermissionSet{}
 		s.NoError(testutils.FullInit(permissionSet, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		permissionSets = append(permissionSets, permissionSet)
-		permissionSetIds = append(permissionSetIds, permissionSet.GetId())
+		permissionSetIDs = append(permissionSetIDs, permissionSet.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, permissionSets))
@@ -114,7 +114,7 @@ func (s *PermissionSetsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, permissionSetCount)
 
-	s.NoError(store.DeleteMany(ctx, permissionSetIds))
+	s.NoError(store.DeleteMany(ctx, permissionSetIDs))
 
 	permissionSetCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/role/store/permissionset/postgres/store_test.go
+++ b/central/role/store/permissionset/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *PermissionSetsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, permissionSet.GetId()), sac.ErrResourceAccessDenied)
 
 	var permissionSets []*storage.PermissionSet
-	for i := 0; i < 200; i++ {
+	var permissionSetIds []string
+	for i := 0; i < 12000; i++ {
 		permissionSet := &storage.PermissionSet{}
 		s.NoError(testutils.FullInit(permissionSet, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		permissionSets = append(permissionSets, permissionSet)
+		permissionSetIds = append(permissionSetIds, permissionSet.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, permissionSets))
 
 	permissionSetCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, permissionSetCount)
+	s.Equal(12000, permissionSetCount)
+
+	s.NoError(store.DeleteMany(ctx, permissionSetIds))
+
+	permissionSetCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, permissionSetCount)
 }

--- a/central/role/store/permissionset/postgres/store_test.go
+++ b/central/role/store/permissionset/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *PermissionSetsStoreSuite) TestStore() {
 
 	var permissionSets []*storage.PermissionSet
 	var permissionSetIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		permissionSet := &storage.PermissionSet{}
 		s.NoError(testutils.FullInit(permissionSet, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		permissionSets = append(permissionSets, permissionSet)
@@ -112,7 +112,7 @@ func (s *PermissionSetsStoreSuite) TestStore() {
 
 	permissionSetCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, permissionSetCount)
+	s.Equal(200, permissionSetCount)
 
 	s.NoError(store.DeleteMany(ctx, permissionSetIds))
 

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -429,30 +429,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -427,12 +428,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -430,6 +430,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -439,14 +440,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/role/store/role/postgres/store_test.go
+++ b/central/role/store/role/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *RolesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, role.GetName()), sac.ErrResourceAccessDenied)
 
 	var roles []*storage.Role
-	for i := 0; i < 200; i++ {
+	var roleIds []string
+	for i := 0; i < 12000; i++ {
 		role := &storage.Role{}
 		s.NoError(testutils.FullInit(role, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		roles = append(roles, role)
+		roleIds = append(roleIds, role.GetName())
 	}
 
 	s.NoError(store.UpsertMany(ctx, roles))
 
 	roleCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, roleCount)
+	s.Equal(12000, roleCount)
+
+	s.NoError(store.DeleteMany(ctx, roleIds))
+
+	roleCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, roleCount)
 }

--- a/central/role/store/role/postgres/store_test.go
+++ b/central/role/store/role/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *RolesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, role.GetName()), sac.ErrResourceAccessDenied)
 
 	var roles []*storage.Role
-	var roleIds []string
+	var roleIDs []string
 	for i := 0; i < 200; i++ {
 		role := &storage.Role{}
 		s.NoError(testutils.FullInit(role, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		roles = append(roles, role)
-		roleIds = append(roleIds, role.GetName())
+		roleIDs = append(roleIDs, role.GetName())
 	}
 
 	s.NoError(store.UpsertMany(ctx, roles))
@@ -114,7 +114,7 @@ func (s *RolesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, roleCount)
 
-	s.NoError(store.DeleteMany(ctx, roleIds))
+	s.NoError(store.DeleteMany(ctx, roleIDs))
 
 	roleCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/role/store/role/postgres/store_test.go
+++ b/central/role/store/role/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *RolesStoreSuite) TestStore() {
 
 	var roles []*storage.Role
 	var roleIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		role := &storage.Role{}
 		s.NoError(testutils.FullInit(role, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		roles = append(roles, role)
@@ -112,7 +112,7 @@ func (s *RolesStoreSuite) TestStore() {
 
 	roleCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, roleCount)
+	s.Equal(200, roleCount)
 
 	s.NoError(store.DeleteMany(ctx, roleIds))
 

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -435,6 +435,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -444,14 +445,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -432,12 +433,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -434,30 +434,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/role/store/simpleaccessscope/postgres/store_test.go
+++ b/central/role/store/simpleaccessscope/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *SimpleAccessScopesStoreSuite) TestStore() {
 
 	var simpleAccessScopes []*storage.SimpleAccessScope
 	var simpleAccessScopeIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		simpleAccessScope := &storage.SimpleAccessScope{}
 		s.NoError(testutils.FullInit(simpleAccessScope, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		simpleAccessScopes = append(simpleAccessScopes, simpleAccessScope)
@@ -112,7 +112,7 @@ func (s *SimpleAccessScopesStoreSuite) TestStore() {
 
 	simpleAccessScopeCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, simpleAccessScopeCount)
+	s.Equal(200, simpleAccessScopeCount)
 
 	s.NoError(store.DeleteMany(ctx, simpleAccessScopeIds))
 

--- a/central/role/store/simpleaccessscope/postgres/store_test.go
+++ b/central/role/store/simpleaccessscope/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *SimpleAccessScopesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, simpleAccessScope.GetId()), sac.ErrResourceAccessDenied)
 
 	var simpleAccessScopes []*storage.SimpleAccessScope
-	var simpleAccessScopeIds []string
+	var simpleAccessScopeIDs []string
 	for i := 0; i < 200; i++ {
 		simpleAccessScope := &storage.SimpleAccessScope{}
 		s.NoError(testutils.FullInit(simpleAccessScope, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		simpleAccessScopes = append(simpleAccessScopes, simpleAccessScope)
-		simpleAccessScopeIds = append(simpleAccessScopeIds, simpleAccessScope.GetId())
+		simpleAccessScopeIDs = append(simpleAccessScopeIDs, simpleAccessScope.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, simpleAccessScopes))
@@ -114,7 +114,7 @@ func (s *SimpleAccessScopesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, simpleAccessScopeCount)
 
-	s.NoError(store.DeleteMany(ctx, simpleAccessScopeIds))
+	s.NoError(store.DeleteMany(ctx, simpleAccessScopeIDs))
 
 	simpleAccessScopeCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/role/store/simpleaccessscope/postgres/store_test.go
+++ b/central/role/store/simpleaccessscope/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *SimpleAccessScopesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, simpleAccessScope.GetId()), sac.ErrResourceAccessDenied)
 
 	var simpleAccessScopes []*storage.SimpleAccessScope
-	for i := 0; i < 200; i++ {
+	var simpleAccessScopeIds []string
+	for i := 0; i < 12000; i++ {
 		simpleAccessScope := &storage.SimpleAccessScope{}
 		s.NoError(testutils.FullInit(simpleAccessScope, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		simpleAccessScopes = append(simpleAccessScopes, simpleAccessScope)
+		simpleAccessScopeIds = append(simpleAccessScopeIds, simpleAccessScope.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, simpleAccessScopes))
 
 	simpleAccessScopeCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, simpleAccessScopeCount)
+	s.Equal(12000, simpleAccessScopeCount)
+
+	s.NoError(store.DeleteMany(ctx, simpleAccessScopeIds))
+
+	simpleAccessScopeCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, simpleAccessScopeCount)
 }

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -714,30 +714,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -712,12 +713,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -715,6 +715,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -724,14 +725,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/secret/internal/store/postgres/store_test.go
+++ b/central/secret/internal/store/postgres/store_test.go
@@ -103,7 +103,7 @@ func (s *SecretsStoreSuite) TestStore() {
 
 	var secrets []*storage.Secret
 	var secretIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		secret := &storage.Secret{}
 		s.NoError(testutils.FullInit(secret, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		secrets = append(secrets, secret)
@@ -114,7 +114,7 @@ func (s *SecretsStoreSuite) TestStore() {
 
 	secretCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, secretCount)
+	s.Equal(200, secretCount)
 
 	s.NoError(store.DeleteMany(ctx, secretIds))
 

--- a/central/secret/internal/store/postgres/store_test.go
+++ b/central/secret/internal/store/postgres/store_test.go
@@ -102,12 +102,12 @@ func (s *SecretsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, secret.GetId()))
 
 	var secrets []*storage.Secret
-	var secretIds []string
+	var secretIDs []string
 	for i := 0; i < 200; i++ {
 		secret := &storage.Secret{}
 		s.NoError(testutils.FullInit(secret, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		secrets = append(secrets, secret)
-		secretIds = append(secretIds, secret.GetId())
+		secretIDs = append(secretIDs, secret.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, secrets))
@@ -116,7 +116,7 @@ func (s *SecretsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, secretCount)
 
-	s.NoError(store.DeleteMany(ctx, secretIds))
+	s.NoError(store.DeleteMany(ctx, secretIDs))
 
 	secretCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/secret/internal/store/postgres/store_test.go
+++ b/central/secret/internal/store/postgres/store_test.go
@@ -102,17 +102,25 @@ func (s *SecretsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, secret.GetId()))
 
 	var secrets []*storage.Secret
-	for i := 0; i < 200; i++ {
+	var secretIds []string
+	for i := 0; i < 12000; i++ {
 		secret := &storage.Secret{}
 		s.NoError(testutils.FullInit(secret, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		secrets = append(secrets, secret)
+		secretIds = append(secretIds, secret.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, secrets))
 
 	secretCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, secretCount)
+	s.Equal(12000, secretCount)
+
+	s.NoError(store.DeleteMany(ctx, secretIds))
+
+	secretCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, secretCount)
 }
 
 func (s *SecretsStoreSuite) TestSACUpsert() {

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -38,7 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -35,10 +35,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -550,6 +550,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -559,14 +560,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -549,30 +549,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -38,6 +38,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -547,12 +548,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/serviceaccount/internal/store/postgres/store_test.go
+++ b/central/serviceaccount/internal/store/postgres/store_test.go
@@ -103,7 +103,7 @@ func (s *ServiceAccountsStoreSuite) TestStore() {
 
 	var serviceAccounts []*storage.ServiceAccount
 	var serviceAccountIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		serviceAccount := &storage.ServiceAccount{}
 		s.NoError(testutils.FullInit(serviceAccount, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		serviceAccounts = append(serviceAccounts, serviceAccount)
@@ -114,7 +114,7 @@ func (s *ServiceAccountsStoreSuite) TestStore() {
 
 	serviceAccountCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, serviceAccountCount)
+	s.Equal(200, serviceAccountCount)
 
 	s.NoError(store.DeleteMany(ctx, serviceAccountIds))
 

--- a/central/serviceaccount/internal/store/postgres/store_test.go
+++ b/central/serviceaccount/internal/store/postgres/store_test.go
@@ -102,17 +102,25 @@ func (s *ServiceAccountsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, serviceAccount.GetId()))
 
 	var serviceAccounts []*storage.ServiceAccount
-	for i := 0; i < 200; i++ {
+	var serviceAccountIds []string
+	for i := 0; i < 12000; i++ {
 		serviceAccount := &storage.ServiceAccount{}
 		s.NoError(testutils.FullInit(serviceAccount, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		serviceAccounts = append(serviceAccounts, serviceAccount)
+		serviceAccountIds = append(serviceAccountIds, serviceAccount.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, serviceAccounts))
 
 	serviceAccountCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, serviceAccountCount)
+	s.Equal(12000, serviceAccountCount)
+
+	s.NoError(store.DeleteMany(ctx, serviceAccountIds))
+
+	serviceAccountCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, serviceAccountCount)
 }
 
 func (s *ServiceAccountsStoreSuite) TestSACUpsert() {

--- a/central/serviceaccount/internal/store/postgres/store_test.go
+++ b/central/serviceaccount/internal/store/postgres/store_test.go
@@ -102,12 +102,12 @@ func (s *ServiceAccountsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, serviceAccount.GetId()))
 
 	var serviceAccounts []*storage.ServiceAccount
-	var serviceAccountIds []string
+	var serviceAccountIDs []string
 	for i := 0; i < 200; i++ {
 		serviceAccount := &storage.ServiceAccount{}
 		s.NoError(testutils.FullInit(serviceAccount, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		serviceAccounts = append(serviceAccounts, serviceAccount)
-		serviceAccountIds = append(serviceAccountIds, serviceAccount.GetId())
+		serviceAccountIDs = append(serviceAccountIDs, serviceAccount.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, serviceAccounts))
@@ -116,7 +116,7 @@ func (s *ServiceAccountsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, serviceAccountCount)
 
-	s.NoError(store.DeleteMany(ctx, serviceAccountIds))
+	s.NoError(store.DeleteMany(ctx, serviceAccountIDs))
 
 	serviceAccountCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -438,12 +439,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -440,30 +440,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -441,6 +441,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -450,14 +451,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/serviceidentities/internal/store/postgres/store_test.go
+++ b/central/serviceidentities/internal/store/postgres/store_test.go
@@ -100,10 +100,12 @@ func (s *ServiceIdentitiesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, serviceIdentity.GetSerialStr()), sac.ErrResourceAccessDenied)
 
 	var serviceIdentitys []*storage.ServiceIdentity
-	for i := 0; i < 200; i++ {
+	var serviceIdentityIds []string
+	for i := 0; i < 12000; i++ {
 		serviceIdentity := &storage.ServiceIdentity{}
 		s.NoError(testutils.FullInit(serviceIdentity, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		serviceIdentitys = append(serviceIdentitys, serviceIdentity)
+		serviceIdentityIds = append(serviceIdentityIds, serviceIdentity.GetSerialStr())
 	}
 
 	s.NoError(store.UpsertMany(ctx, serviceIdentitys))
@@ -113,5 +115,11 @@ func (s *ServiceIdentitiesStoreSuite) TestStore() {
 
 	serviceIdentityCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, serviceIdentityCount)
+	s.Equal(12000, serviceIdentityCount)
+
+	s.NoError(store.DeleteMany(ctx, serviceIdentityIds))
+
+	serviceIdentityCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, serviceIdentityCount)
 }

--- a/central/serviceidentities/internal/store/postgres/store_test.go
+++ b/central/serviceidentities/internal/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *ServiceIdentitiesStoreSuite) TestStore() {
 
 	var serviceIdentitys []*storage.ServiceIdentity
 	var serviceIdentityIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		serviceIdentity := &storage.ServiceIdentity{}
 		s.NoError(testutils.FullInit(serviceIdentity, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		serviceIdentitys = append(serviceIdentitys, serviceIdentity)
@@ -115,7 +115,7 @@ func (s *ServiceIdentitiesStoreSuite) TestStore() {
 
 	serviceIdentityCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, serviceIdentityCount)
+	s.Equal(200, serviceIdentityCount)
 
 	s.NoError(store.DeleteMany(ctx, serviceIdentityIds))
 

--- a/central/serviceidentities/internal/store/postgres/store_test.go
+++ b/central/serviceidentities/internal/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *ServiceIdentitiesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, serviceIdentity.GetSerialStr()), sac.ErrResourceAccessDenied)
 
 	var serviceIdentitys []*storage.ServiceIdentity
-	var serviceIdentityIds []string
+	var serviceIdentityIDs []string
 	for i := 0; i < 200; i++ {
 		serviceIdentity := &storage.ServiceIdentity{}
 		s.NoError(testutils.FullInit(serviceIdentity, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		serviceIdentitys = append(serviceIdentitys, serviceIdentity)
-		serviceIdentityIds = append(serviceIdentityIds, serviceIdentity.GetSerialStr())
+		serviceIdentityIDs = append(serviceIdentityIDs, serviceIdentity.GetSerialStr())
 	}
 
 	s.NoError(store.UpsertMany(ctx, serviceIdentitys))
@@ -117,7 +117,7 @@ func (s *ServiceIdentitiesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, serviceIdentityCount)
 
-	s.NoError(store.DeleteMany(ctx, serviceIdentityIds))
+	s.NoError(store.DeleteMany(ctx, serviceIdentityIDs))
 
 	serviceIdentityCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -435,6 +435,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -444,14 +445,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -432,12 +433,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -434,30 +434,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/signatureintegration/store/postgres/store_test.go
+++ b/central/signatureintegration/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *SignatureIntegrationsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, signatureIntegration.GetId()), sac.ErrResourceAccessDenied)
 
 	var signatureIntegrations []*storage.SignatureIntegration
-	for i := 0; i < 200; i++ {
+	var signatureIntegrationIds []string
+	for i := 0; i < 12000; i++ {
 		signatureIntegration := &storage.SignatureIntegration{}
 		s.NoError(testutils.FullInit(signatureIntegration, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		signatureIntegrations = append(signatureIntegrations, signatureIntegration)
+		signatureIntegrationIds = append(signatureIntegrationIds, signatureIntegration.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, signatureIntegrations))
 
 	signatureIntegrationCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, signatureIntegrationCount)
+	s.Equal(12000, signatureIntegrationCount)
+
+	s.NoError(store.DeleteMany(ctx, signatureIntegrationIds))
+
+	signatureIntegrationCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, signatureIntegrationCount)
 }

--- a/central/signatureintegration/store/postgres/store_test.go
+++ b/central/signatureintegration/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *SignatureIntegrationsStoreSuite) TestStore() {
 
 	var signatureIntegrations []*storage.SignatureIntegration
 	var signatureIntegrationIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		signatureIntegration := &storage.SignatureIntegration{}
 		s.NoError(testutils.FullInit(signatureIntegration, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		signatureIntegrations = append(signatureIntegrations, signatureIntegration)
@@ -112,7 +112,7 @@ func (s *SignatureIntegrationsStoreSuite) TestStore() {
 
 	signatureIntegrationCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, signatureIntegrationCount)
+	s.Equal(200, signatureIntegrationCount)
 
 	s.NoError(store.DeleteMany(ctx, signatureIntegrationIds))
 

--- a/central/signatureintegration/store/postgres/store_test.go
+++ b/central/signatureintegration/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *SignatureIntegrationsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, signatureIntegration.GetId()), sac.ErrResourceAccessDenied)
 
 	var signatureIntegrations []*storage.SignatureIntegration
-	var signatureIntegrationIds []string
+	var signatureIntegrationIDs []string
 	for i := 0; i < 200; i++ {
 		signatureIntegration := &storage.SignatureIntegration{}
 		s.NoError(testutils.FullInit(signatureIntegration, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		signatureIntegrations = append(signatureIntegrations, signatureIntegration)
-		signatureIntegrationIds = append(signatureIntegrationIds, signatureIntegration.GetId())
+		signatureIntegrationIDs = append(signatureIntegrationIDs, signatureIntegration.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, signatureIntegrations))
@@ -114,7 +114,7 @@ func (s *SignatureIntegrationsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, signatureIntegrationCount)
 
-	s.NoError(store.DeleteMany(ctx, signatureIntegrationIds))
+	s.NoError(store.DeleteMany(ctx, signatureIntegrationIDs))
 
 	signatureIntegrationCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -650,6 +650,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -659,14 +660,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -649,30 +649,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -32,10 +32,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -32,7 +32,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -35,7 +35,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -35,6 +35,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -647,12 +648,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *VulnerabilityRequestsStoreSuite) TestStore() {
 
 	var vulnerabilityRequests []*storage.VulnerabilityRequest
 	var vulnerabilityRequestIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		vulnerabilityRequest := &storage.VulnerabilityRequest{}
 		s.NoError(testutils.FullInit(vulnerabilityRequest, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		vulnerabilityRequests = append(vulnerabilityRequests, vulnerabilityRequest)
@@ -112,7 +112,7 @@ func (s *VulnerabilityRequestsStoreSuite) TestStore() {
 
 	vulnerabilityRequestCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, vulnerabilityRequestCount)
+	s.Equal(200, vulnerabilityRequestCount)
 
 	s.NoError(store.DeleteMany(ctx, vulnerabilityRequestIds))
 

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *VulnerabilityRequestsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, vulnerabilityRequest.GetId()), sac.ErrResourceAccessDenied)
 
 	var vulnerabilityRequests []*storage.VulnerabilityRequest
-	for i := 0; i < 200; i++ {
+	var vulnerabilityRequestIds []string
+	for i := 0; i < 12000; i++ {
 		vulnerabilityRequest := &storage.VulnerabilityRequest{}
 		s.NoError(testutils.FullInit(vulnerabilityRequest, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		vulnerabilityRequests = append(vulnerabilityRequests, vulnerabilityRequest)
+		vulnerabilityRequestIds = append(vulnerabilityRequestIds, vulnerabilityRequest.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, vulnerabilityRequests))
 
 	vulnerabilityRequestCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, vulnerabilityRequestCount)
+	s.Equal(12000, vulnerabilityRequestCount)
+
+	s.NoError(store.DeleteMany(ctx, vulnerabilityRequestIds))
+
+	vulnerabilityRequestCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, vulnerabilityRequestCount)
 }

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *VulnerabilityRequestsStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, vulnerabilityRequest.GetId()), sac.ErrResourceAccessDenied)
 
 	var vulnerabilityRequests []*storage.VulnerabilityRequest
-	var vulnerabilityRequestIds []string
+	var vulnerabilityRequestIDs []string
 	for i := 0; i < 200; i++ {
 		vulnerabilityRequest := &storage.VulnerabilityRequest{}
 		s.NoError(testutils.FullInit(vulnerabilityRequest, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		vulnerabilityRequests = append(vulnerabilityRequests, vulnerabilityRequest)
-		vulnerabilityRequestIds = append(vulnerabilityRequestIds, vulnerabilityRequest.GetId())
+		vulnerabilityRequestIDs = append(vulnerabilityRequestIDs, vulnerabilityRequest.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, vulnerabilityRequests))
@@ -114,7 +114,7 @@ func (s *VulnerabilityRequestsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, vulnerabilityRequestCount)
 
-	s.NoError(store.DeleteMany(ctx, vulnerabilityRequestIds))
+	s.NoError(store.DeleteMany(ctx, vulnerabilityRequestIDs))
 
 	vulnerabilityRequestCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -429,30 +429,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -427,12 +428,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -33,7 +33,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -430,6 +430,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -439,14 +440,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -33,10 +33,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/central/watchedimage/datastore/internal/store/postgres/store_test.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *WatchedImagesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, watchedImage.GetName()), sac.ErrResourceAccessDenied)
 
 	var watchedImages []*storage.WatchedImage
-	var watchedImageIds []string
+	var watchedImageIDs []string
 	for i := 0; i < 200; i++ {
 		watchedImage := &storage.WatchedImage{}
 		s.NoError(testutils.FullInit(watchedImage, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		watchedImages = append(watchedImages, watchedImage)
-		watchedImageIds = append(watchedImageIds, watchedImage.GetName())
+		watchedImageIDs = append(watchedImageIDs, watchedImage.GetName())
 	}
 
 	s.NoError(store.UpsertMany(ctx, watchedImages))
@@ -114,7 +114,7 @@ func (s *WatchedImagesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, watchedImageCount)
 
-	s.NoError(store.DeleteMany(ctx, watchedImageIds))
+	s.NoError(store.DeleteMany(ctx, watchedImageIDs))
 
 	watchedImageCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/watchedimage/datastore/internal/store/postgres/store_test.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *WatchedImagesStoreSuite) TestStore() {
 	s.ErrorIs(store.Delete(withNoAccessCtx, watchedImage.GetName()), sac.ErrResourceAccessDenied)
 
 	var watchedImages []*storage.WatchedImage
-	for i := 0; i < 200; i++ {
+	var watchedImageIds []string
+	for i := 0; i < 12000; i++ {
 		watchedImage := &storage.WatchedImage{}
 		s.NoError(testutils.FullInit(watchedImage, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		watchedImages = append(watchedImages, watchedImage)
+		watchedImageIds = append(watchedImageIds, watchedImage.GetName())
 	}
 
 	s.NoError(store.UpsertMany(ctx, watchedImages))
 
 	watchedImageCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, watchedImageCount)
+	s.Equal(12000, watchedImageCount)
+
+	s.NoError(store.DeleteMany(ctx, watchedImageIds))
+
+	watchedImageCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, watchedImageCount)
 }

--- a/central/watchedimage/datastore/internal/store/postgres/store_test.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *WatchedImagesStoreSuite) TestStore() {
 
 	var watchedImages []*storage.WatchedImage
 	var watchedImageIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		watchedImage := &storage.WatchedImage{}
 		s.NoError(testutils.FullInit(watchedImage, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		watchedImages = append(watchedImages, watchedImage)
@@ -112,7 +112,7 @@ func (s *WatchedImagesStoreSuite) TestStore() {
 
 	watchedImageCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, watchedImageCount)
+	s.Equal(200, watchedImageCount)
 
 	s.NoError(store.DeleteMany(ctx, watchedImageIds))
 

--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
@@ -291,6 +291,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -300,14 +301,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
@@ -290,30 +290,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -288,12 +289,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -409,12 +410,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
@@ -412,6 +412,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -421,14 +422,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
@@ -411,30 +411,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
@@ -1075,30 +1075,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
@@ -1076,6 +1076,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -1085,14 +1086,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -1073,12 +1074,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
@@ -532,6 +532,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -541,14 +542,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -529,12 +530,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
@@ -531,30 +531,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -364,12 +365,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
@@ -367,6 +367,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -376,14 +377,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
@@ -366,30 +366,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
@@ -381,30 +381,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -379,12 +380,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_08_to_n_09_postgres_auth_providers/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
@@ -416,30 +416,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -414,12 +415,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
@@ -417,6 +417,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -426,14 +427,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -364,12 +365,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
@@ -367,6 +367,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -376,14 +377,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
@@ -366,30 +366,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
@@ -387,6 +387,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -396,14 +397,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
@@ -386,30 +386,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -384,12 +385,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -364,12 +365,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
@@ -367,6 +367,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -376,14 +377,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
@@ -366,30 +366,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -364,12 +365,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
@@ -367,6 +367,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -376,14 +377,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
@@ -366,30 +366,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -364,12 +365,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
@@ -367,6 +367,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -376,14 +377,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
@@ -366,30 +366,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -364,12 +365,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
@@ -367,6 +367,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -376,14 +377,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
@@ -366,30 +366,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -364,12 +365,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
@@ -367,6 +367,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -376,14 +377,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
@@ -366,30 +366,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
@@ -402,6 +402,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -411,14 +412,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -399,12 +400,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
@@ -401,30 +401,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
@@ -402,6 +402,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -411,14 +412,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -399,12 +400,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
@@ -401,30 +401,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -364,12 +365,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
@@ -367,6 +367,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -376,14 +377,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
@@ -366,30 +366,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -374,12 +375,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
@@ -377,6 +377,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -386,14 +387,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_22_to_n_23_postgres_external_backups/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
@@ -407,6 +407,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -416,14 +417,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
@@ -406,30 +406,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -404,12 +405,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -364,12 +365,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
@@ -367,6 +367,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -376,14 +377,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
@@ -366,30 +366,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
@@ -422,6 +422,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -431,14 +432,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
@@ -421,30 +421,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -419,12 +420,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -394,12 +395,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
@@ -396,30 +396,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
@@ -397,6 +397,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -406,14 +407,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
@@ -392,6 +392,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -401,14 +402,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
@@ -391,30 +391,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -389,12 +390,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -364,12 +365,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
@@ -367,6 +367,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -376,14 +377,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
@@ -366,30 +366,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -394,12 +395,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
@@ -396,30 +396,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
@@ -397,6 +397,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -406,14 +407,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -364,12 +365,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
@@ -367,6 +367,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -376,14 +377,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
@@ -366,30 +366,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -364,12 +365,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
@@ -367,6 +367,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -376,14 +377,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
@@ -366,30 +366,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
@@ -381,30 +381,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -379,12 +380,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_36_to_n_37_postgres_notifiers/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -369,12 +370,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
@@ -371,30 +371,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
@@ -372,6 +372,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -381,14 +382,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_37_to_n_38_postgres_permission_sets/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
@@ -486,30 +486,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -484,12 +485,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
@@ -487,6 +487,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -496,14 +497,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
@@ -451,30 +451,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
@@ -452,6 +452,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -461,14 +462,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (
@@ -524,7 +524,7 @@ func CreateTableAndNewStore(ctx context.Context, db *pgxpool.Pool, gormDB *gorm.
 	return New(db)
 }
 
-//// Stubs for satisfying legacy interfaces
+// // Stubs for satisfying legacy interfaces
 func (s *storeImpl) RenamePolicyCategory(request *v1.RenamePolicyCategoryRequest) error {
 	return errors.New("unimplemented")
 }

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
@@ -524,7 +524,7 @@ func CreateTableAndNewStore(ctx context.Context, db *pgxpool.Pool, gormDB *gorm.
 	return New(db)
 }
 
-// // Stubs for satisfying legacy interfaces
+//// Stubs for satisfying legacy interfaces
 func (s *storeImpl) RenamePolicyCategory(request *v1.RenamePolicyCategoryRequest) error {
 	return errors.New("unimplemented")
 }

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -449,12 +450,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure
@@ -503,7 +524,7 @@ func CreateTableAndNewStore(ctx context.Context, db *pgxpool.Pool, gormDB *gorm.
 	return New(db)
 }
 
-//// Stubs for satisfying legacy interfaces
+// // Stubs for satisfying legacy interfaces
 func (s *storeImpl) RenamePolicyCategory(request *v1.RenamePolicyCategoryRequest) error {
 	return errors.New("unimplemented")
 }

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -394,12 +395,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
@@ -396,30 +396,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
@@ -397,6 +397,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -406,14 +407,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
@@ -402,6 +402,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -411,14 +412,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -399,12 +400,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
@@ -401,30 +401,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
@@ -442,6 +442,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -451,14 +452,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
@@ -441,30 +441,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_42_to_n_43_postgres_process_indicators/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -394,12 +395,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
@@ -396,30 +396,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
@@ -397,6 +397,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -406,14 +407,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
@@ -407,6 +407,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -416,14 +417,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
@@ -406,30 +406,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -404,12 +405,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -509,12 +510,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
@@ -511,30 +511,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
@@ -512,6 +512,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -521,14 +522,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -364,12 +365,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
@@ -367,6 +367,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -376,14 +377,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
@@ -366,30 +366,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_46_to_n_47_postgres_roles/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
@@ -581,30 +581,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
@@ -582,6 +582,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -591,14 +592,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -579,12 +580,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
@@ -416,30 +416,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -414,12 +415,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
@@ -417,6 +417,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -426,14 +427,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -374,12 +375,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
@@ -377,6 +377,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -386,14 +387,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_50_to_n_51_postgres_service_identities/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -369,12 +370,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
@@ -371,30 +371,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
@@ -372,6 +372,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -381,14 +382,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -369,12 +370,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
@@ -371,30 +371,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
@@ -372,6 +372,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -381,14 +382,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
@@ -585,6 +585,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -594,14 +595,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -582,12 +583,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
@@ -584,30 +584,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -364,12 +365,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
@@ -367,6 +367,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -376,14 +377,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
@@ -366,30 +366,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
@@ -392,6 +392,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -401,14 +402,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
@@ -391,30 +391,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	var sacQueryFilter *v1.Query
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -389,12 +390,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
@@ -32,7 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
@@ -29,7 +29,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
@@ -32,6 +32,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -374,12 +375,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	var sacQueryFilter *v1.Query
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
@@ -377,6 +377,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -386,14 +387,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_56_to_n_57_postgres_groups/postgres/postgres_plugin.go
@@ -29,10 +29,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -675,12 +676,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -678,6 +678,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -687,14 +688,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -677,30 +677,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *TestMultiKeyStructsStoreSuite) TestStore() {
 
 	var testMultiKeyStructs []*storage.TestMultiKeyStruct
 	var testMultiKeyStructIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		testMultiKeyStruct := &storage.TestMultiKeyStruct{}
 		s.NoError(testutils.FullInit(testMultiKeyStruct, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testMultiKeyStructs = append(testMultiKeyStructs, testMultiKeyStruct)
@@ -112,7 +112,7 @@ func (s *TestMultiKeyStructsStoreSuite) TestStore() {
 
 	testMultiKeyStructCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, testMultiKeyStructCount)
+	s.Equal(200, testMultiKeyStructCount)
 
 	s.NoError(store.DeleteMany(ctx, testMultiKeyStructIds))
 

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
@@ -100,15 +100,23 @@ func (s *TestMultiKeyStructsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, testMultiKeyStruct.GetKey1(), testMultiKeyStruct.GetKey2()))
 
 	var testMultiKeyStructs []*storage.TestMultiKeyStruct
-	for i := 0; i < 200; i++ {
+	var testMultiKeyStructIds []string
+	for i := 0; i < 12000; i++ {
 		testMultiKeyStruct := &storage.TestMultiKeyStruct{}
 		s.NoError(testutils.FullInit(testMultiKeyStruct, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testMultiKeyStructs = append(testMultiKeyStructs, testMultiKeyStruct)
+		testMultiKeyStructIds = append(testMultiKeyStructIds, testMultiKeyStruct.GetKey1(), testMultiKeyStruct.GetKey2())
 	}
 
 	s.NoError(store.UpsertMany(ctx, testMultiKeyStructs))
 
 	testMultiKeyStructCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, testMultiKeyStructCount)
+	s.Equal(12000, testMultiKeyStructCount)
+
+	s.NoError(store.DeleteMany(ctx, testMultiKeyStructIds))
+
+	testMultiKeyStructCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, testMultiKeyStructCount)
 }

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *TestMultiKeyStructsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, testMultiKeyStruct.GetKey1(), testMultiKeyStruct.GetKey2()))
 
 	var testMultiKeyStructs []*storage.TestMultiKeyStruct
-	var testMultiKeyStructIds []string
+	var testMultiKeyStructIDs []string
 	for i := 0; i < 200; i++ {
 		testMultiKeyStruct := &storage.TestMultiKeyStruct{}
 		s.NoError(testutils.FullInit(testMultiKeyStruct, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testMultiKeyStructs = append(testMultiKeyStructs, testMultiKeyStruct)
-		testMultiKeyStructIds = append(testMultiKeyStructIds, testMultiKeyStruct.GetKey1(), testMultiKeyStruct.GetKey2())
+		testMultiKeyStructIDs = append(testMultiKeyStructIDs, testMultiKeyStruct.GetKey1(), testMultiKeyStruct.GetKey2())
 	}
 
 	s.NoError(store.UpsertMany(ctx, testMultiKeyStructs))
@@ -114,7 +114,7 @@ func (s *TestMultiKeyStructsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, testMultiKeyStructCount)
 
-	s.NoError(store.DeleteMany(ctx, testMultiKeyStructIds))
+	s.NoError(store.DeleteMany(ctx, testMultiKeyStructIDs))
 
 	testMultiKeyStructCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -55,7 +55,7 @@ const (
         // using copyFrom, we may not even want to batch.  It would probably be simpler
         // to deal with failures if we just sent it all.  Something to think about as we
         // proceed and move into more e2e and larger performance testing
-        batchSize = 5000
+        batchSize = 10000
 
         cursorBatchSize = 50
 

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -58,6 +58,10 @@ const (
         batchSize = 10000
 
         cursorBatchSize = 50
+
+    {{- if not .JoinTable }}
+        deleteBatchSize = 25000
+    {{- end }}
 )
 
 var (
@@ -893,12 +897,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []{{$singlePK.Type}}) er
     {{- end }}
     {{- end }}{{/* if not $inMigration */}}
 
-    q := search.ConjunctionQuery(
-    sacQueryFilter,
-        search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-    )
+    // Batch the deletes
+    batchSize := deleteBatchSize
+    for {
+        if len(ids) == 0 {
+            break
+        }
 
-    return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+        if len(ids) < batchSize {
+            batchSize = len(ids)
+        }
+
+        idBatch := ids[0:batchSize]
+        q := search.ConjunctionQuery(
+        sacQueryFilter,
+            search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+        )
+
+        if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+            return err
+        }
+
+        // Move the slice forward to start the next batch
+        ids = ids[batchSize:]
+    }
+
+    return nil
 }
 {{- end }}
 {{- end }}

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -898,30 +898,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []{{$singlePK.Type}}) er
     {{- end }}{{/* if not $inMigration */}}
 
     // Batch the deletes
-    batchSize := deleteBatchSize
+    localBatchSize := deleteBatchSize
     numRecordsToDelete := len(ids)
     for {
         if len(ids) == 0 {
             break
         }
 
-        if len(ids) < batchSize {
-            batchSize = len(ids)
+        if len(ids) < localBatchSize {
+            localBatchSize = len(ids)
         }
 
-        idBatch := ids[:batchSize]
+        idBatch := ids[:localBatchSize]
         q := search.ConjunctionQuery(
         sacQueryFilter,
             search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
         )
 
         if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-            log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete - len(ids), numRecordsToDelete)
-            return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete - len(ids), numRecordsToDelete)
+            err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete - len(ids), numRecordsToDelete)
+            log.Error(err)
+            return err
         }
 
         // Move the slice forward to start the next batch
-        ids = ids[batchSize:]
+        ids = ids[localBatchSize:]
     }
 
     return nil

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -60,7 +60,7 @@ const (
         cursorBatchSize = 50
 
     {{- if not .JoinTable }}
-        deleteBatchSize = 25000
+        deleteBatchSize = 10000
     {{- end }}
 )
 

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -899,6 +899,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []{{$singlePK.Type}}) er
 
     // Batch the deletes
     batchSize := deleteBatchSize
+    numRecordsToDelete := len(ids)
     for {
         if len(ids) == 0 {
             break
@@ -908,14 +909,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []{{$singlePK.Type}}) er
             batchSize = len(ids)
         }
 
-        idBatch := ids[0:batchSize]
+        idBatch := ids[:batchSize]
         q := search.ConjunctionQuery(
         sacQueryFilter,
             search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
         )
 
         if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-            return err
+            log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete - len(ids), numRecordsToDelete)
+            return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete - len(ids), numRecordsToDelete)
         }
 
         // Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -55,12 +55,12 @@ const (
         // using copyFrom, we may not even want to batch.  It would probably be simpler
         // to deal with failures if we just sent it all.  Something to think about as we
         // proceed and move into more e2e and larger performance testing
-        batchSize = 10000
+        batchSize = 5000
 
         cursorBatchSize = 50
 
     {{- if not .JoinTable }}
-        deleteBatchSize = 10000
+        deleteBatchSize = 5000
     {{- end }}
 )
 

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -133,7 +133,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
         {{$name}}.{{.EmbeddedFK}} = nil
         {{- end}}
         {{$name}}s = append({{.TrimmedType|lowerCamelCase}}s, {{.TrimmedType|lowerCamelCase}})
-	    {{$name}}Ids = append({{$name}}Ids, {{template "paramList" $}})
+        {{$name}}Ids = append({{$name}}Ids, {{template "paramList" $}})
     }
 
 	s.NoError(store.UpsertMany(ctx, {{.TrimmedType|lowerCamelCase}}s))
@@ -148,7 +148,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
     s.NoError(err)
     s.Equal(200, {{.TrimmedType|lowerCamelCase}}Count)
 
-	s.NoError(store.DeleteMany(ctx, {{$name}}Ids))
+    s.NoError(store.DeleteMany(ctx, {{$name}}Ids))
 
     {{.TrimmedType|lowerCamelCase}}Count, err = store.Count(ctx)
     s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -126,7 +126,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 
 	var {{$name}}s []*{{.Type}}
 	var {{$name}}Ids []string
-    for i := 0; i < 12000; i++ {
+    for i := 0; i < 200; i++ {
         {{$name}} := &{{.Type}}{}
         s.NoError(testutils.FullInit({{$name}}, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
         {{- if .Cycle}}
@@ -146,7 +146,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 
     {{.TrimmedType|lowerCamelCase}}Count, err = store.Count(ctx)
     s.NoError(err)
-    s.Equal(12000, {{.TrimmedType|lowerCamelCase}}Count)
+    s.Equal(200, {{.TrimmedType|lowerCamelCase}}Count)
 
 	s.NoError(store.DeleteMany(ctx, {{$name}}Ids))
 

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -125,7 +125,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 	{{- end }}
 
 	var {{$name}}s []*{{.Type}}
-	var {{$name}}Ids []string
+	var {{$name}}IDs []string
     for i := 0; i < 200; i++ {
         {{$name}} := &{{.Type}}{}
         s.NoError(testutils.FullInit({{$name}}, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
@@ -133,7 +133,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
         {{$name}}.{{.EmbeddedFK}} = nil
         {{- end}}
         {{$name}}s = append({{.TrimmedType|lowerCamelCase}}s, {{.TrimmedType|lowerCamelCase}})
-        {{$name}}Ids = append({{$name}}Ids, {{template "paramList" $}})
+        {{$name}}IDs = append({{$name}}IDs, {{template "paramList" $}})
     }
 
 	s.NoError(store.UpsertMany(ctx, {{.TrimmedType|lowerCamelCase}}s))
@@ -148,7 +148,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
     s.NoError(err)
     s.Equal(200, {{.TrimmedType|lowerCamelCase}}Count)
 
-    s.NoError(store.DeleteMany(ctx, {{$name}}Ids))
+    s.NoError(store.DeleteMany(ctx, {{$name}}IDs))
 
     {{.TrimmedType|lowerCamelCase}}Count, err = store.Count(ctx)
     s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -133,7 +133,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
         {{$name}}.{{.EmbeddedFK}} = nil
         {{- end}}
         {{$name}}s = append({{.TrimmedType|lowerCamelCase}}s, {{.TrimmedType|lowerCamelCase}})
-		{{$name}}Ids = append({{$name}}Ids, {{template "paramList" $}})
+	    {{$name}}Ids = append({{$name}}Ids, {{template "paramList" $}})
     }
 
 	s.NoError(store.UpsertMany(ctx, {{.TrimmedType|lowerCamelCase}}s))
@@ -150,9 +150,9 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 
 	s.NoError(store.DeleteMany(ctx, {{$name}}Ids))
 
-	{{.TrimmedType|lowerCamelCase}}Count, err = store.Count(ctx)
-	s.NoError(err)
-	s.Equal(0, {{.TrimmedType|lowerCamelCase}}Count)
+    {{.TrimmedType|lowerCamelCase}}Count, err = store.Count(ctx)
+    s.NoError(err)
+    s.Equal(0, {{.TrimmedType|lowerCamelCase}}Count)
     {{- end }}
 }
 

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -125,13 +125,15 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 	{{- end }}
 
 	var {{$name}}s []*{{.Type}}
-    for i := 0; i < 200; i++ {
+	var {{$name}}Ids []string
+    for i := 0; i < 12000; i++ {
         {{$name}} := &{{.Type}}{}
         s.NoError(testutils.FullInit({{$name}}, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
         {{- if .Cycle}}
         {{$name}}.{{.EmbeddedFK}} = nil
         {{- end}}
         {{$name}}s = append({{.TrimmedType|lowerCamelCase}}s, {{.TrimmedType|lowerCamelCase}})
+		{{$name}}Ids = append({{$name}}Ids, {{template "paramList" $}})
     }
 
 	s.NoError(store.UpsertMany(ctx, {{.TrimmedType|lowerCamelCase}}s))
@@ -144,7 +146,13 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 
     {{.TrimmedType|lowerCamelCase}}Count, err = store.Count(ctx)
     s.NoError(err)
-    s.Equal(200, {{.TrimmedType|lowerCamelCase}}Count)
+    s.Equal(12000, {{.TrimmedType|lowerCamelCase}}Count)
+
+	s.NoError(store.DeleteMany(ctx, {{$name}}Ids))
+
+	{{.TrimmedType|lowerCamelCase}}Count, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, {{.TrimmedType|lowerCamelCase}}Count)
     {{- end }}
 }
 

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -569,30 +569,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -570,6 +570,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -579,14 +580,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -567,12 +568,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
@@ -100,12 +100,12 @@ func (s *TestSingleKeyStructsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, testSingleKeyStruct.GetKey()))
 
 	var testSingleKeyStructs []*storage.TestSingleKeyStruct
-	var testSingleKeyStructIds []string
+	var testSingleKeyStructIDs []string
 	for i := 0; i < 200; i++ {
 		testSingleKeyStruct := &storage.TestSingleKeyStruct{}
 		s.NoError(testutils.FullInit(testSingleKeyStruct, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testSingleKeyStructs = append(testSingleKeyStructs, testSingleKeyStruct)
-		testSingleKeyStructIds = append(testSingleKeyStructIds, testSingleKeyStruct.GetKey())
+		testSingleKeyStructIDs = append(testSingleKeyStructIDs, testSingleKeyStruct.GetKey())
 	}
 
 	s.NoError(store.UpsertMany(ctx, testSingleKeyStructs))
@@ -117,7 +117,7 @@ func (s *TestSingleKeyStructsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, testSingleKeyStructCount)
 
-	s.NoError(store.DeleteMany(ctx, testSingleKeyStructIds))
+	s.NoError(store.DeleteMany(ctx, testSingleKeyStructIDs))
 
 	testSingleKeyStructCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
@@ -101,7 +101,7 @@ func (s *TestSingleKeyStructsStoreSuite) TestStore() {
 
 	var testSingleKeyStructs []*storage.TestSingleKeyStruct
 	var testSingleKeyStructIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		testSingleKeyStruct := &storage.TestSingleKeyStruct{}
 		s.NoError(testutils.FullInit(testSingleKeyStruct, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testSingleKeyStructs = append(testSingleKeyStructs, testSingleKeyStruct)
@@ -115,7 +115,7 @@ func (s *TestSingleKeyStructsStoreSuite) TestStore() {
 
 	testSingleKeyStructCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, testSingleKeyStructCount)
+	s.Equal(200, testSingleKeyStructCount)
 
 	s.NoError(store.DeleteMany(ctx, testSingleKeyStructIds))
 

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
@@ -100,10 +100,12 @@ func (s *TestSingleKeyStructsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, testSingleKeyStruct.GetKey()))
 
 	var testSingleKeyStructs []*storage.TestSingleKeyStruct
-	for i := 0; i < 200; i++ {
+	var testSingleKeyStructIds []string
+	for i := 0; i < 12000; i++ {
 		testSingleKeyStruct := &storage.TestSingleKeyStruct{}
 		s.NoError(testutils.FullInit(testSingleKeyStruct, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testSingleKeyStructs = append(testSingleKeyStructs, testSingleKeyStruct)
+		testSingleKeyStructIds = append(testSingleKeyStructIds, testSingleKeyStruct.GetKey())
 	}
 
 	s.NoError(store.UpsertMany(ctx, testSingleKeyStructs))
@@ -113,5 +115,11 @@ func (s *TestSingleKeyStructsStoreSuite) TestStore() {
 
 	testSingleKeyStructCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, testSingleKeyStructCount)
+	s.Equal(12000, testSingleKeyStructCount)
+
+	s.NoError(store.DeleteMany(ctx, testSingleKeyStructIds))
+
+	testSingleKeyStructCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, testSingleKeyStructCount)
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -514,6 +514,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -523,14 +524,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -513,30 +513,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -511,12 +512,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
@@ -100,15 +100,23 @@ func (s *TestChild1StoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, testChild1.GetId()))
 
 	var testChild1s []*storage.TestChild1
-	for i := 0; i < 200; i++ {
+	var testChild1Ids []string
+	for i := 0; i < 12000; i++ {
 		testChild1 := &storage.TestChild1{}
 		s.NoError(testutils.FullInit(testChild1, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testChild1s = append(testChild1s, testChild1)
+		testChild1Ids = append(testChild1Ids, testChild1.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, testChild1s))
 
 	testChild1Count, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, testChild1Count)
+	s.Equal(12000, testChild1Count)
+
+	s.NoError(store.DeleteMany(ctx, testChild1Ids))
+
+	testChild1Count, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, testChild1Count)
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
@@ -101,7 +101,7 @@ func (s *TestChild1StoreSuite) TestStore() {
 
 	var testChild1s []*storage.TestChild1
 	var testChild1Ids []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		testChild1 := &storage.TestChild1{}
 		s.NoError(testutils.FullInit(testChild1, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testChild1s = append(testChild1s, testChild1)
@@ -112,7 +112,7 @@ func (s *TestChild1StoreSuite) TestStore() {
 
 	testChild1Count, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, testChild1Count)
+	s.Equal(200, testChild1Count)
 
 	s.NoError(store.DeleteMany(ctx, testChild1Ids))
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
@@ -100,12 +100,12 @@ func (s *TestChild1StoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, testChild1.GetId()))
 
 	var testChild1s []*storage.TestChild1
-	var testChild1Ids []string
+	var testChild1IDs []string
 	for i := 0; i < 200; i++ {
 		testChild1 := &storage.TestChild1{}
 		s.NoError(testutils.FullInit(testChild1, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testChild1s = append(testChild1s, testChild1)
-		testChild1Ids = append(testChild1Ids, testChild1.GetId())
+		testChild1IDs = append(testChild1IDs, testChild1.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, testChild1s))
@@ -114,7 +114,7 @@ func (s *TestChild1StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, testChild1Count)
 
-	s.NoError(store.DeleteMany(ctx, testChild1Ids))
+	s.NoError(store.DeleteMany(ctx, testChild1IDs))
 
 	testChild1Count, err = store.Count(ctx)
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -516,12 +517,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -519,6 +519,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -528,14 +529,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -518,30 +518,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -524,6 +524,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -533,14 +534,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -521,12 +522,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -523,30 +523,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -524,6 +524,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -533,14 +534,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -521,12 +522,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -523,30 +523,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -514,6 +514,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -523,14 +524,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -513,30 +513,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -511,12 +512,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
@@ -100,12 +100,12 @@ func (s *TestG3GrandChild1StoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, testG3GrandChild1.GetId()))
 
 	var testG3GrandChild1s []*storage.TestG3GrandChild1
-	var testG3GrandChild1Ids []string
+	var testG3GrandChild1IDs []string
 	for i := 0; i < 200; i++ {
 		testG3GrandChild1 := &storage.TestG3GrandChild1{}
 		s.NoError(testutils.FullInit(testG3GrandChild1, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testG3GrandChild1s = append(testG3GrandChild1s, testG3GrandChild1)
-		testG3GrandChild1Ids = append(testG3GrandChild1Ids, testG3GrandChild1.GetId())
+		testG3GrandChild1IDs = append(testG3GrandChild1IDs, testG3GrandChild1.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, testG3GrandChild1s))
@@ -114,7 +114,7 @@ func (s *TestG3GrandChild1StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, testG3GrandChild1Count)
 
-	s.NoError(store.DeleteMany(ctx, testG3GrandChild1Ids))
+	s.NoError(store.DeleteMany(ctx, testG3GrandChild1IDs))
 
 	testG3GrandChild1Count, err = store.Count(ctx)
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
@@ -100,15 +100,23 @@ func (s *TestG3GrandChild1StoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, testG3GrandChild1.GetId()))
 
 	var testG3GrandChild1s []*storage.TestG3GrandChild1
-	for i := 0; i < 200; i++ {
+	var testG3GrandChild1Ids []string
+	for i := 0; i < 12000; i++ {
 		testG3GrandChild1 := &storage.TestG3GrandChild1{}
 		s.NoError(testutils.FullInit(testG3GrandChild1, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testG3GrandChild1s = append(testG3GrandChild1s, testG3GrandChild1)
+		testG3GrandChild1Ids = append(testG3GrandChild1Ids, testG3GrandChild1.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, testG3GrandChild1s))
 
 	testG3GrandChild1Count, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, testG3GrandChild1Count)
+	s.Equal(12000, testG3GrandChild1Count)
+
+	s.NoError(store.DeleteMany(ctx, testG3GrandChild1Ids))
+
+	testG3GrandChild1Count, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, testG3GrandChild1Count)
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
@@ -101,7 +101,7 @@ func (s *TestG3GrandChild1StoreSuite) TestStore() {
 
 	var testG3GrandChild1s []*storage.TestG3GrandChild1
 	var testG3GrandChild1Ids []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		testG3GrandChild1 := &storage.TestG3GrandChild1{}
 		s.NoError(testutils.FullInit(testG3GrandChild1, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testG3GrandChild1s = append(testG3GrandChild1s, testG3GrandChild1)
@@ -112,7 +112,7 @@ func (s *TestG3GrandChild1StoreSuite) TestStore() {
 
 	testG3GrandChild1Count, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, testG3GrandChild1Count)
+	s.Equal(200, testG3GrandChild1Count)
 
 	s.NoError(store.DeleteMany(ctx, testG3GrandChild1Ids))
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -514,6 +514,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -523,14 +524,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -513,30 +513,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -511,12 +512,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
@@ -100,15 +100,23 @@ func (s *TestGGrandChild1StoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, testGGrandChild1.GetId()))
 
 	var testGGrandChild1s []*storage.TestGGrandChild1
-	for i := 0; i < 200; i++ {
+	var testGGrandChild1Ids []string
+	for i := 0; i < 12000; i++ {
 		testGGrandChild1 := &storage.TestGGrandChild1{}
 		s.NoError(testutils.FullInit(testGGrandChild1, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testGGrandChild1s = append(testGGrandChild1s, testGGrandChild1)
+		testGGrandChild1Ids = append(testGGrandChild1Ids, testGGrandChild1.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, testGGrandChild1s))
 
 	testGGrandChild1Count, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, testGGrandChild1Count)
+	s.Equal(12000, testGGrandChild1Count)
+
+	s.NoError(store.DeleteMany(ctx, testGGrandChild1Ids))
+
+	testGGrandChild1Count, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, testGGrandChild1Count)
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
@@ -100,12 +100,12 @@ func (s *TestGGrandChild1StoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, testGGrandChild1.GetId()))
 
 	var testGGrandChild1s []*storage.TestGGrandChild1
-	var testGGrandChild1Ids []string
+	var testGGrandChild1IDs []string
 	for i := 0; i < 200; i++ {
 		testGGrandChild1 := &storage.TestGGrandChild1{}
 		s.NoError(testutils.FullInit(testGGrandChild1, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testGGrandChild1s = append(testGGrandChild1s, testGGrandChild1)
-		testGGrandChild1Ids = append(testGGrandChild1Ids, testGGrandChild1.GetId())
+		testGGrandChild1IDs = append(testGGrandChild1IDs, testGGrandChild1.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, testGGrandChild1s))
@@ -114,7 +114,7 @@ func (s *TestGGrandChild1StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, testGGrandChild1Count)
 
-	s.NoError(store.DeleteMany(ctx, testGGrandChild1Ids))
+	s.NoError(store.DeleteMany(ctx, testGGrandChild1IDs))
 
 	testGGrandChild1Count, err = store.Count(ctx)
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
@@ -101,7 +101,7 @@ func (s *TestGGrandChild1StoreSuite) TestStore() {
 
 	var testGGrandChild1s []*storage.TestGGrandChild1
 	var testGGrandChild1Ids []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		testGGrandChild1 := &storage.TestGGrandChild1{}
 		s.NoError(testutils.FullInit(testGGrandChild1, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testGGrandChild1s = append(testGGrandChild1s, testGGrandChild1)
@@ -112,7 +112,7 @@ func (s *TestGGrandChild1StoreSuite) TestStore() {
 
 	testGGrandChild1Count, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, testGGrandChild1Count)
+	s.Equal(200, testGGrandChild1Count)
 
 	s.NoError(store.DeleteMany(ctx, testGGrandChild1Ids))
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -524,6 +524,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -533,14 +534,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -521,12 +522,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -523,30 +523,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -688,30 +688,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -689,6 +689,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -698,14 +699,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -686,12 +687,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
@@ -100,15 +100,23 @@ func (s *TestGrandparentsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, testGrandparent.GetId()))
 
 	var testGrandparents []*storage.TestGrandparent
-	for i := 0; i < 200; i++ {
+	var testGrandparentIds []string
+	for i := 0; i < 12000; i++ {
 		testGrandparent := &storage.TestGrandparent{}
 		s.NoError(testutils.FullInit(testGrandparent, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testGrandparents = append(testGrandparents, testGrandparent)
+		testGrandparentIds = append(testGrandparentIds, testGrandparent.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, testGrandparents))
 
 	testGrandparentCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, testGrandparentCount)
+	s.Equal(12000, testGrandparentCount)
+
+	s.NoError(store.DeleteMany(ctx, testGrandparentIds))
+
+	testGrandparentCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, testGrandparentCount)
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
@@ -101,7 +101,7 @@ func (s *TestGrandparentsStoreSuite) TestStore() {
 
 	var testGrandparents []*storage.TestGrandparent
 	var testGrandparentIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		testGrandparent := &storage.TestGrandparent{}
 		s.NoError(testutils.FullInit(testGrandparent, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testGrandparents = append(testGrandparents, testGrandparent)
@@ -112,7 +112,7 @@ func (s *TestGrandparentsStoreSuite) TestStore() {
 
 	testGrandparentCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, testGrandparentCount)
+	s.Equal(200, testGrandparentCount)
 
 	s.NoError(store.DeleteMany(ctx, testGrandparentIds))
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
@@ -100,12 +100,12 @@ func (s *TestGrandparentsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, testGrandparent.GetId()))
 
 	var testGrandparents []*storage.TestGrandparent
-	var testGrandparentIds []string
+	var testGrandparentIDs []string
 	for i := 0; i < 200; i++ {
 		testGrandparent := &storage.TestGrandparent{}
 		s.NoError(testutils.FullInit(testGrandparent, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testGrandparents = append(testGrandparents, testGrandparent)
-		testGrandparentIds = append(testGrandparentIds, testGrandparent.GetId())
+		testGrandparentIDs = append(testGrandparentIDs, testGrandparent.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, testGrandparents))
@@ -114,7 +114,7 @@ func (s *TestGrandparentsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, testGrandparentCount)
 
-	s.NoError(store.DeleteMany(ctx, testGrandparentIds))
+	s.NoError(store.DeleteMany(ctx, testGrandparentIDs))
 
 	testGrandparentCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -599,6 +599,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -608,14 +609,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -598,30 +598,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -596,12 +597,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -516,12 +517,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -519,6 +519,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -528,14 +529,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -518,30 +518,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -516,12 +517,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -519,6 +519,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -528,14 +529,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -518,30 +518,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -516,12 +517,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -519,6 +519,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -528,14 +529,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -518,30 +518,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -37,7 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 25000
+	deleteBatchSize = 10000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -37,6 +37,7 @@ const (
 	batchSize = 10000
 
 	cursorBatchSize = 50
+	deleteBatchSize = 25000
 )
 
 var (
@@ -516,12 +517,32 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 		return err
 	}
 
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
+	// Batch the deletes
+	batchSize := deleteBatchSize
+	for {
+		if len(ids) == 0 {
+			break
+		}
 
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+		if len(ids) < batchSize {
+			batchSize = len(ids)
+		}
+
+		idBatch := ids[0:batchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[batchSize:]
+	}
+
+	return nil
 }
 
 // Walk iterates over all of the objects in the store and applies the closure

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -34,10 +34,10 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 5000
 
 	cursorBatchSize = 50
-	deleteBatchSize = 10000
+	deleteBatchSize = 5000
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 5000
+	batchSize = 10000
 
 	cursorBatchSize = 50
 	deleteBatchSize = 5000

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -519,6 +519,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 
 	// Batch the deletes
 	batchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
@@ -528,14 +529,15 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 			batchSize = len(ids)
 		}
 
-		idBatch := ids[0:batchSize]
+		idBatch := ids[:batchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			return err
+			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
 		}
 
 		// Move the slice forward to start the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -518,30 +518,31 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 	}
 
 	// Batch the deletes
-	batchSize := deleteBatchSize
+	localBatchSize := deleteBatchSize
 	numRecordsToDelete := len(ids)
 	for {
 		if len(ids) == 0 {
 			break
 		}
 
-		if len(ids) < batchSize {
-			batchSize = len(ids)
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
 		}
 
-		idBatch := ids[:batchSize]
+		idBatch := ids[:localBatchSize]
 		q := search.ConjunctionQuery(
 			sacQueryFilter,
 			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
 		)
 
 		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			log.Errorf("unable to delete all the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
 		}
 
 		// Move the slice forward to start the next batch
-		ids = ids[batchSize:]
+		ids = ids[localBatchSize:]
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store_test.go
@@ -100,12 +100,12 @@ func (s *TestShortCircuitsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, testShortCircuit.GetId()))
 
 	var testShortCircuits []*storage.TestShortCircuit
-	var testShortCircuitIds []string
+	var testShortCircuitIDs []string
 	for i := 0; i < 200; i++ {
 		testShortCircuit := &storage.TestShortCircuit{}
 		s.NoError(testutils.FullInit(testShortCircuit, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testShortCircuits = append(testShortCircuits, testShortCircuit)
-		testShortCircuitIds = append(testShortCircuitIds, testShortCircuit.GetId())
+		testShortCircuitIDs = append(testShortCircuitIDs, testShortCircuit.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, testShortCircuits))
@@ -114,7 +114,7 @@ func (s *TestShortCircuitsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, testShortCircuitCount)
 
-	s.NoError(store.DeleteMany(ctx, testShortCircuitIds))
+	s.NoError(store.DeleteMany(ctx, testShortCircuitIDs))
 
 	testShortCircuitCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store_test.go
@@ -101,7 +101,7 @@ func (s *TestShortCircuitsStoreSuite) TestStore() {
 
 	var testShortCircuits []*storage.TestShortCircuit
 	var testShortCircuitIds []string
-	for i := 0; i < 12000; i++ {
+	for i := 0; i < 200; i++ {
 		testShortCircuit := &storage.TestShortCircuit{}
 		s.NoError(testutils.FullInit(testShortCircuit, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testShortCircuits = append(testShortCircuits, testShortCircuit)
@@ -112,7 +112,7 @@ func (s *TestShortCircuitsStoreSuite) TestStore() {
 
 	testShortCircuitCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(12000, testShortCircuitCount)
+	s.Equal(200, testShortCircuitCount)
 
 	s.NoError(store.DeleteMany(ctx, testShortCircuitIds))
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store_test.go
@@ -100,15 +100,23 @@ func (s *TestShortCircuitsStoreSuite) TestStore() {
 	s.NoError(store.Delete(withNoAccessCtx, testShortCircuit.GetId()))
 
 	var testShortCircuits []*storage.TestShortCircuit
-	for i := 0; i < 200; i++ {
+	var testShortCircuitIds []string
+	for i := 0; i < 12000; i++ {
 		testShortCircuit := &storage.TestShortCircuit{}
 		s.NoError(testutils.FullInit(testShortCircuit, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		testShortCircuits = append(testShortCircuits, testShortCircuit)
+		testShortCircuitIds = append(testShortCircuitIds, testShortCircuit.GetId())
 	}
 
 	s.NoError(store.UpsertMany(ctx, testShortCircuits))
 
 	testShortCircuitCount, err = store.Count(ctx)
 	s.NoError(err)
-	s.Equal(200, testShortCircuitCount)
+	s.Equal(12000, testShortCircuitCount)
+
+	s.NoError(store.DeleteMany(ctx, testShortCircuitIds))
+
+	testShortCircuitCount, err = store.Count(ctx)
+	s.NoError(err)
+	s.Equal(0, testShortCircuitCount)
 }


### PR DESCRIPTION
## Description

`store.go.tpl` and `store_test.go.tpl` are really the only changes.  Everything else was generated from those.

In some performance testing I would notice many occurrences of 
`delete from process_indicators where process_indicators.Id = ANY($1::text[])` timing out during pruning.  I took a look and tried to do this work with SQL, but that too would run into timeouts from time to time due to the volume of data in process indicators.  So the simplest path for now is to batch the deletes so they are more likely to succeed.  Later we may want to investigate utilizing partitions on some of these larger tables to help with the pruning jobs.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Lots of scale test type testing.  Set it up like this:
```
stackrox $ ./scale/dev/cluster.sh some-test-cluster

stackrox $ MAIN_IMAGE_TAG=some_image_tag ROX_POSTGRES_DATASTORE=true ./scale/dev/launch_central.sh
# Edit central config to extend the limit to 16 CPUs and 64Gi RAM
$ kubectl edit -n stackrox deploy/central
# Configure postgres compatible UI and postgres query tracing
$ kubectl -n stackrox set env deploy/central ROX_FRONTEND_VM_UPDATES=true
$ kubectl -n stackrox set env deploy/central ROX_POSTGRES_QUERY_TRACER=true
$ kubectl -n stackrox set env deploy/central ROX_POSTGRES_QUERY_TRACER_GRAPHQL_THRESHOLD=50ms
$ kubectl -n stackrox set env deploy/central ROX_POSTGRES_QUERY_TRACER_QUERY_THRESHOLD=1ms 

stackrox $ pushd scale/dev;  MAIN_IMAGE_TAG=some_image_tag ./run-many.sh 10-sensors 10; popd
```
Ran for a couple of hours and then check the central-db log to see if there were timeout errors.  Followed that up with a bounce of central to ensure it reprocessed everything and checked the logs of central-db again for timeout errors.  

Also added some UT.

