### PR TITLE
Configure Goland to use shared indexes

### DIFF
--- a/intellij.yaml
+++ b/intellij.yaml
@@ -1,0 +1,3 @@
+sharedIndex:
+  project:
+    - url: https://stackrox.github.io/goland-indexes/cache/project/stackrox


### PR DESCRIPTION
## Description

I created the repository of [Goland shared indexes](https://www.jetbrains.com/help/go/shared-indexes.html) for stackrox: https://github.com/stackrox/goland-indexes
It's updated weekly by github action.
This PR adds a config file for Goland to set location of shared index. For the first use, Goland may ask for permission to download the file.

See: https://srox.slack.com/archives/C02CFR7GQUS/p1666190259522359