### PR TITLE
Dashrews/rox 12398 backup test eof (WIP)

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -443,6 +443,9 @@ db_backup_and_restore_test() {
     require_environment "API_ENDPOINT"
     require_environment "ROX_PASSWORD"
 
+    # Ensure central is ready for requests after any previous tests
+    wait_for_api
+
     local output_dir="$1"
     info "Backing up to ${output_dir}"
     mkdir -p "$output_dir"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -440,6 +440,9 @@ db_backup_and_restore_test() {
         die "missing args. usage: db_backup_and_restore_test <output dir>"
     fi
 
+    require_environment "API_ENDPOINT"
+    require_environment "ROX_PASSWORD"
+
     local output_dir="$1"
     info "Backing up to ${output_dir}"
     mkdir -p "$output_dir"


### PR DESCRIPTION
## Description

This seems like a timing issue.  When the steps before the backup were running, an action was performed that would cause central to restart.  That was on purpose and controlled.  That can leave us with a timing issue if that is still cycling through as the backup/restore test is completed.  So I added a `wait_for_api` in the restore test.  That should help in these cases and cause no harm.  However, I cannot get the test to fail in the same way and it doesn't seem to happen particularly often.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
