### PR TITLE
dashrews/ROX-13182 clean up central logging when central-db is bounced

### DIFF
--- a/pkg/postgres/pgutils/error.go
+++ b/pkg/postgres/pgutils/error.go
@@ -47,8 +47,8 @@ var transientPGCodes = set.NewFrozenStringSet(
 	"58030", // io_error
 )
 
-// isTransientError specifies if the passed error is transient and should be retried
-func isTransientError(err error) bool {
+// IsTransientError specifies if the passed error is transient and should be retried
+func IsTransientError(err error) bool {
 	if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
 		return transientPGCodes.Contains(pgErr.Code)
 	}

--- a/pkg/postgres/pgutils/retry.go
+++ b/pkg/postgres/pgutils/retry.go
@@ -40,7 +40,7 @@ func Retry2[T any](fn func() (T, error)) (T, error) {
 // that fails with transient errors
 func Retry3[T any, U any](fn func() (T, U, error)) (T, U, error) {
 	// Run query immediately
-	if val1, val2, err := fn(); err == nil || !isTransientError(err) {
+	if val1, val2, err := fn(); err == nil || !IsTransientError(err) {
 		if err != nil && err != pgx.ErrNoRows {
 			log.Debugf("UNEXPECTED: found permanent error: %+v", err)
 		}
@@ -65,7 +65,7 @@ func Retry3[T any, U any](fn func() (T, U, error)) (T, U, error) {
 			var ret1 T
 			var ret2 U
 			ret1, ret2, err = fn()
-			if err == nil || !isTransientError(err) {
+			if err == nil || !IsTransientError(err) {
 				if err != nil && err != pgx.ErrNoRows {
 					log.Debugf("UNEXPECTED: found permanent error: %+v", err)
 				}

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -602,7 +602,9 @@ func retryableRunSearchRequestForSchema(ctx context.Context, query *query, schem
 
 	rows, err := tracedQuery(ctx, db, queryStr, query.Data...)
 	if err != nil {
-		debug.PrintStack()
+		if !pgutils.IsTransientError(err) {
+			debug.PrintStack()
+		}
 		log.Errorf("Query issue: %s %+v: %v", queryStr, redactedQueryData(query), err)
 		return nil, err
 	}
@@ -707,7 +709,9 @@ func RunCountRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1.
 		var count int
 		row := tracedQueryRow(ctx, db, queryStr, query.Data...)
 		if err := row.Scan(&count); err != nil {
-			debug.PrintStack()
+			if !pgutils.IsTransientError(err) {
+				debug.PrintStack()
+			}
 			log.Errorf("Query issue: %s %+v: %v", queryStr, redactedQueryData(query), err)
 			return 0, err
 		}

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -604,6 +604,8 @@ func retryableRunSearchRequestForSchema(ctx context.Context, query *query, schem
 	if err != nil {
 		if !pgutils.IsTransientError(err) {
 			debug.PrintStack()
+		} else {
+			log.Debugf("%s", debug.Stack())
 		}
 		log.Errorf("Query issue: %s %+v: %v", queryStr, redactedQueryData(query), err)
 		return nil, err
@@ -711,6 +713,8 @@ func RunCountRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1.
 		if err := row.Scan(&count); err != nil {
 			if !pgutils.IsTransientError(err) {
 				debug.PrintStack()
+			} else {
+				log.Debugf("%s", debug.Stack())
 			}
 			log.Errorf("Query issue: %s %+v: %v", queryStr, redactedQueryData(query), err)
 			return 0, err


### PR DESCRIPTION
## Description

The ticket was initially written to cover a lot of things when central-db is bounced.  Since then it was updated to focus on the extraneous logging.  The issue here was that the searcher drops a `debug.PrintStack()` anytime there is an error.  Even if it is an error we are retrying.  I updated to not dump the stack trace in the event we are dealing with a transient error we are going to retry.  We will still dump the stack trace in the event it is a non-retryable error.  Additionally the retry code was already dumping the stack trace if it reached max retries, so no need to change that.

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran locally with the UI open. bounce central-db and execute queries or sit on the dashboard to ensure the stacktrace was not being printed out for retryable things such as the database being down.  Before the change, all of these were accompanied with a stack trace:
```
pkg/search/postgres: 2022/10/24 15:11:30.487307 common.go:715: Error: Query issue: select count(*) from clusters []: FATAL: terminating connection due to administrator command (SQLSTATE 57P01)
pkg/search/postgres: 2022/10/24 15:11:30.487414 common.go:608: Error: Query issue: select alerts.Id from alerts where ((alerts.State = $1) or (alerts.State = $2)) order by alerts.Time desc [0 3]: FATAL: terminating connection due to administrator command (SQLSTATE 57P01)
pkg/search/postgres: 2022/10/24 15:11:30.487510 common.go:608: Error: Query issue: select alerts.Id from alerts where ((alerts.State = $1) or (alerts.State = $2)) order by alerts.Time desc [0 3]: FATAL: terminating connection due to administrator command (SQLSTATE 57P01)
pkg/search/postgres: 2022/10/24 15:11:30.487926 common.go:715: Error: Query issue: select count(*) from deployments []: FATAL: terminating connection due to administrator command (SQLSTATE 57P01)
pkg/search/postgres: 2022/10/24 15:11:30.488167 common.go:715: Error: Query issue: select count(*) from images []: FATAL: terminating connection due to administrator command (SQLSTATE 57P01)
pkg/search/postgres: 2022/10/24 15:11:30.488758 common.go:715: Error: Query issue: select count(*) from nodes []: FATAL: terminating connection due to administrator command (SQLSTATE 57P01)
```

whereas this error still logged the stacktrace because it is a go based error and not a retryable sql error
`pkg/search/postgres: 2022/10/24 15:11:32.308578 common.go:608: Error: Query issue: select process_indicators.Id from process_indicators where process_indicators.DeploymentId = $1 [09f510a4-640a-4564-83d4-f0c777cec644]: context canceled`

Now those just report the error and no stacktrace.
