### PR TITLE
CI: Move the upgrade test to 3.69.x

### DIFF
--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -371,9 +371,10 @@ test_upgrade_paths() {
 
     local log_output_dir="$1"
 
-    EARLIER_SHA="9f82d2713cfec4b5c876d8dc0149f6d9cd70d349"
-    EARLIER_TAG="3.63.x-163-g2c4fe1563c"
+    EARLIER_SHA="83963e020fe08e61c9d368a42e4d23bfc22ba8f2"
+    EARLIER_TAG="3.70.x-1-g83963e020f"
     FORCE_ROLLBACK_VERSION="$EARLIER_TAG"
+    export FORCE_ROLLBACK_VERSION
 
     cd "$REPO_FOR_TIME_TRAVEL"
     git checkout "$EARLIER_SHA"
@@ -389,14 +390,14 @@ test_upgrade_paths() {
     kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:$(make --quiet tag)"
     wait_for_api
 
-    validate_upgrade "00-3-63-x-to-current" "central upgrade to 3.63.x -> current" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
+    validate_upgrade "00-3-70-x-to-current" "central upgrade to 3.70.x -> current" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
 
     force_rollback
     wait_for_api
 
     cd "$REPO_FOR_TIME_TRAVEL"
 
-    validate_upgrade "01-current-back-to-3-63-x" "forced rollback to 3.63.x from current" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
+    validate_upgrade "01-current-back-to-3-70-x" "forced rollback to 3.70.x from current" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
 
     cd "$TEST_ROOT"
 

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -379,6 +379,9 @@ test_upgrade_paths() {
     cd "$REPO_FOR_TIME_TRAVEL"
     git checkout "$EARLIER_SHA"
 
+    # required to handle scanner protos
+    go mod tidy
+
     deploy_earlier_central
     wait_for_api
     restore_backup_test

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -371,8 +371,8 @@ test_upgrade_paths() {
 
     local log_output_dir="$1"
 
-    EARLIER_SHA="83963e020fe08e61c9d368a42e4d23bfc22ba8f2"
-    EARLIER_TAG="3.70.x-1-g83963e020f"
+    EARLIER_SHA="870568de0830819aae85f255dbdb7e9c19bd74e7"
+    EARLIER_TAG="3.69.x-1-g870568de08"
     FORCE_ROLLBACK_VERSION="$EARLIER_TAG"
     export FORCE_ROLLBACK_VERSION
 
@@ -393,14 +393,14 @@ test_upgrade_paths() {
     kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:$(make --quiet tag)"
     wait_for_api
 
-    validate_upgrade "00-3-70-x-to-current" "central upgrade to 3.70.x -> current" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
+    validate_upgrade "00-3-69-x-to-current" "central upgrade to 3.69.x -> current" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
 
     force_rollback
     wait_for_api
 
     cd "$REPO_FOR_TIME_TRAVEL"
 
-    validate_upgrade "01-current-back-to-3-70-x" "forced rollback to 3.70.x from current" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
+    validate_upgrade "01-current-back-to-3-69-x" "forced rollback to 3.69.x from current" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
 
     cd "$TEST_ROOT"
 


### PR DESCRIPTION
## Description

Per title. Upgrading from 3.63.x is not very relevant. This also fixes the upgrade-test as it was the `scanImage()` in `3.63.x` Groovy tests that failed most often (once the OOMs were fixed). ~Also excluded a policy in the default policy comparison due to ROX-13265.~

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.
~/test gke-upgrade-tests~ Don't need this now that openshift/release is configured to test on changes to the test 🎉 