### PR TITLE
Make gRPC service structs forward-compatible

### DIFF
--- a/central/alert/service/service_impl.go
+++ b/central/alert/service/service_impl.go
@@ -75,6 +75,8 @@ var (
 
 // serviceImpl is a thin facade over a domain layer that handles CRUD use cases on Alert objects from API clients.
 type serviceImpl struct {
+	v1.UnimplementedAlertServiceServer
+
 	dataStore         datastore.DataStore
 	notifier          notifierProcessor.Processor
 	baselines         baselineDatastore.DataStore

--- a/central/apitoken/service/service_impl.go
+++ b/central/apitoken/service/service_impl.go
@@ -36,6 +36,8 @@ var (
 )
 
 type serviceImpl struct {
+	v1.UnimplementedAPITokenServiceServer
+
 	backend backend.Backend
 	roles   roleDS.DataStore
 }

--- a/central/auth/service/service_impl.go
+++ b/central/auth/service/service_impl.go
@@ -14,7 +14,9 @@ import (
 )
 
 // ClusterService is the struct that manages the cluster API
-type serviceImpl struct{}
+type serviceImpl struct {
+	v1.UnimplementedAuthServiceServer
+}
 
 // RegisterServiceServer registers this service with the given gRPC Server.
 func (s *serviceImpl) RegisterServiceServer(grpcServer *grpc.Server) {

--- a/central/authprovider/service/service_impl.go
+++ b/central/authprovider/service/service_impl.go
@@ -47,6 +47,8 @@ var (
 
 // ClusterService is the struct that manages the cluster API
 type serviceImpl struct {
+	v1.UnimplementedAuthProviderServiceServer
+
 	registry   authproviders.Registry
 	groupStore groupDataStore.DataStore
 }

--- a/central/centralhealth/service/service_impl.go
+++ b/central/centralhealth/service/service_impl.go
@@ -31,7 +31,9 @@ var (
 	capacityMarginFraction = migrations.CapacityMarginFraction + 0.05
 )
 
-type serviceImpl struct{}
+type serviceImpl struct {
+	v1.UnimplementedCentralHealthServiceServer
+}
 
 // RegisterServiceServer registers this service with the given gRPC Server.
 func (s *serviceImpl) RegisterServiceServer(grpcServer *grpc.Server) {

--- a/central/cluster/service/service_impl.go
+++ b/central/cluster/service/service_impl.go
@@ -46,6 +46,8 @@ var (
 
 // ClusterService is the struct that manages the cluster API
 type serviceImpl struct {
+	v1.UnimplementedClustersServiceServer
+
 	datastore          datastore.DataStore
 	riskManager        manager.Manager
 	probeSources       probesources.ProbeSources

--- a/central/clusterinit/service/service_impl.go
+++ b/central/clusterinit/service/service_impl.go
@@ -24,6 +24,8 @@ var (
 var _ v1.ClusterInitServiceServer = (*serviceImpl)(nil)
 
 type serviceImpl struct {
+	v1.UnimplementedClusterInitServiceServer
+
 	backend      backend.Backend
 	clusterStore clusterStore.DataStore
 }

--- a/central/compliance/manager/service/service_impl.go
+++ b/central/compliance/manager/service/service_impl.go
@@ -32,6 +32,8 @@ var (
 )
 
 type service struct {
+	v1.UnimplementedComplianceManagementServiceServer
+
 	manager manager.ComplianceManager
 }
 

--- a/central/compliance/service/service_impl.go
+++ b/central/compliance/service/service_impl.go
@@ -46,6 +46,8 @@ func New(aggregator aggregation.Aggregator, complianceDataStore complianceDS.Dat
 }
 
 type serviceImpl struct {
+	v1.UnimplementedComplianceServiceServer
+
 	aggregator          aggregation.Aggregator
 	complianceDataStore complianceDS.DataStore
 	standardsRepo       standards.Repository

--- a/central/config/service/service.go
+++ b/central/config/service/service.go
@@ -55,6 +55,8 @@ func New(datastore datastore.DataStore) Service {
 }
 
 type serviceImpl struct {
+	v1.UnimplementedConfigServiceServer
+
 	datastore datastore.DataStore
 }
 

--- a/central/credentialexpiry/service/service_impl.go
+++ b/central/credentialexpiry/service/service_impl.go
@@ -34,6 +34,8 @@ var (
 
 // ClusterService is the struct that manages the cluster API
 type serviceImpl struct {
+	v1.UnimplementedCredentialExpiryServiceServer
+
 	imageIntegrations imageIntegrationStore.DataStore
 	scannerConfig     *tls.Config
 }

--- a/central/cve/cluster/service/service_impl.go
+++ b/central/cve/cluster/service/service_impl.go
@@ -32,6 +32,8 @@ var (
 
 // serviceImpl provides APIs for CVEs.
 type serviceImpl struct {
+	v1.UnimplementedClusterCVEServiceServer
+
 	cves datastore.DataStore
 }
 

--- a/central/cve/image/service/service_impl.go
+++ b/central/cve/image/service/service_impl.go
@@ -34,6 +34,8 @@ var (
 
 // serviceImpl provides APIs for CVEs.
 type serviceImpl struct {
+	v1.UnimplementedImageCVEServiceServer
+
 	cves       datastore.DataStore
 	vulnReqMgr vulnReqMgr.Manager
 }

--- a/central/cve/node/service/service_impl.go
+++ b/central/cve/node/service/service_impl.go
@@ -32,6 +32,8 @@ var (
 
 // serviceImpl provides APIs for CVEs.
 type serviceImpl struct {
+	v1.UnimplementedNodeCVEServiceServer
+
 	cves datastore.DataStore
 }
 

--- a/central/cve/service/service_impl.go
+++ b/central/cve/service/service_impl.go
@@ -33,6 +33,8 @@ var (
 
 // serviceImpl provides APIs for CVEs.
 type serviceImpl struct {
+	v1.UnimplementedCVEServiceServer
+
 	cves       datastore.DataStore
 	vulnReqMgr vulnReqMgr.Manager
 }

--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -114,6 +114,8 @@ func New(clusters datastore.DataStore, sensorConnMgr connection.Manager, telemet
 }
 
 type serviceImpl struct {
+	v1.UnimplementedDebugServiceServer
+
 	sensorConnMgr        connection.Manager
 	clusters             datastore.DataStore
 	telemetryGatherer    *gatherers.RoxGatherer

--- a/central/deployment/service/service_impl.go
+++ b/central/deployment/service/service_impl.go
@@ -50,6 +50,8 @@ var (
 
 // serviceImpl provides APIs for deployments.
 type serviceImpl struct {
+	v1.UnimplementedDeploymentServiceServer
+
 	datastore              datastore.DataStore
 	processBaselines       processBaselineStore.DataStore
 	processIndicators      processIndicatorStore.DataStore

--- a/central/detection/service/service_impl.go
+++ b/central/detection/service/service_impl.go
@@ -74,6 +74,8 @@ func init() {
 
 // serviceImpl provides APIs for alerts.
 type serviceImpl struct {
+	apiV1.UnimplementedDetectionServiceServer
+
 	policySet          detection.PolicySet
 	imageEnricher      enricher.ImageEnricher
 	imageDatastore     imageDatastore.DataStore

--- a/central/development/service/service_impl.go
+++ b/central/development/service/service_impl.go
@@ -27,6 +27,8 @@ var (
 )
 
 type serviceImpl struct {
+	central.UnimplementedDevelopmentServiceServer
+
 	sensorConnectionManager connection.Manager
 	client                  http.Client
 }

--- a/central/externalbackups/service/service_impl.go
+++ b/central/externalbackups/service/service_impl.go
@@ -44,6 +44,8 @@ var (
 
 // serviceImpl is the struct that manages the external backups API
 type serviceImpl struct {
+	v1.UnimplementedExternalBackupServiceServer
+
 	manager   manager.Manager
 	reporter  integrationhealth.Reporter
 	dataStore datastore.DataStore

--- a/central/featureflags/service/service_impl.go
+++ b/central/featureflags/service/service_impl.go
@@ -22,7 +22,9 @@ var (
 	})
 )
 
-type serviceImpl struct{}
+type serviceImpl struct {
+	v1.UnimplementedFeatureFlagServiceServer
+}
 
 func (s *serviceImpl) GetFeatureFlags(context.Context, *v1.Empty) (*v1.GetFeatureFlagsResponse, error) {
 	resp := &v1.GetFeatureFlagsResponse{}

--- a/central/globaldb/v2backuprestore/service/service_impl.go
+++ b/central/globaldb/v2backuprestore/service/service_impl.go
@@ -32,6 +32,8 @@ var (
 )
 
 type service struct {
+	v1.UnimplementedDBServiceServer
+
 	mgr manager.Manager
 }
 

--- a/central/group/service/service_impl.go
+++ b/central/group/service/service_impl.go
@@ -35,6 +35,8 @@ var (
 )
 
 type serviceImpl struct {
+	v1.UnimplementedGroupServiceServer
+
 	groups datastore.DataStore
 }
 

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -81,6 +81,8 @@ var (
 
 // serviceImpl provides APIs for alerts.
 type serviceImpl struct {
+	v1.UnimplementedImageServiceServer
+
 	datastore   datastore.DataStore
 	riskManager manager.Manager
 

--- a/central/imageintegration/service/service_impl.go
+++ b/central/imageintegration/service/service_impl.go
@@ -48,6 +48,8 @@ var (
 
 // ImageIntegrationService is the struct that manages the ImageIntegration API
 type serviceImpl struct {
+	v1.UnimplementedImageIntegrationServiceServer
+
 	registryFactory    registries.Factory
 	scannerFactory     scanners.Factory
 	nodeEnricher       enricher.NodeEnricher

--- a/central/integrationhealth/service/service_impl.go
+++ b/central/integrationhealth/service/service_impl.go
@@ -35,6 +35,8 @@ var (
 
 // ImageIntegrationService is the struct that manages the ImageIntegration API
 type serviceImpl struct {
+	v1.UnimplementedIntegrationHealthServiceServer
+
 	datastore            datastore.DataStore
 	vulnDefsInfoProvider scanners.VulnDefsInfoProvider
 }

--- a/central/license/service/service_impl.go
+++ b/central/license/service/service_impl.go
@@ -8,7 +8,9 @@ import (
 	"google.golang.org/grpc"
 )
 
-type service struct{}
+type service struct {
+	v1.UnimplementedLicenseServiceServer
+}
 
 func newService() *service {
 	return &service{}

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -23,6 +23,7 @@ import (
 
 // Service is the struct that manages the Metadata API
 type serviceImpl struct {
+	v1.UnimplementedMetadataServiceServer
 }
 
 // RegisterServiceServer registers this service with the given gRPC Server.

--- a/central/mitre/service/service_impl.go
+++ b/central/mitre/service/service_impl.go
@@ -24,6 +24,8 @@ var (
 )
 
 type serviceImpl struct {
+	v1.UnimplementedMitreAttackServiceServer
+
 	store datastore.MitreAttackReadOnlyDataStore
 }
 

--- a/central/namespace/service/service_impl.go
+++ b/central/namespace/service/service_impl.go
@@ -33,6 +33,8 @@ var (
 )
 
 type serviceImpl struct {
+	v1.UnimplementedNamespaceServiceServer
+
 	datastore       datastore.DataStore
 	deployments     deploymentDataStore.DataStore
 	secrets         secretDataStore.DataStore

--- a/central/networkbaseline/service/service_impl.go
+++ b/central/networkbaseline/service/service_impl.go
@@ -34,6 +34,8 @@ var (
 )
 
 type serviceImpl struct {
+	v1.UnimplementedNetworkBaselineServiceServer
+
 	datastore datastore.ReadOnlyDataStore
 	manager   manager.Manager
 }

--- a/central/networkgraph/service/service_impl.go
+++ b/central/networkgraph/service/service_impl.go
@@ -63,6 +63,8 @@ var (
 
 // serviceImpl provides APIs for alerts.
 type serviceImpl struct {
+	v1.UnimplementedNetworkGraphServiceServer
+
 	clusterFlows   networkFlowDS.ClusterDataStore
 	entities       networkEntityDS.EntityDataStore
 	networkTreeMgr networktree.Manager

--- a/central/networkpolicies/service/service_impl.go
+++ b/central/networkpolicies/service/service_impl.go
@@ -84,6 +84,8 @@ var (
 
 // serviceImpl provides APIs for alerts.
 type serviceImpl struct {
+	v1.UnimplementedNetworkPolicyServiceServer
+
 	sensorConnMgr    connection.Manager
 	clusterStore     clusterDataStore.DataStore
 	deployments      deploymentDataStore.DataStore

--- a/central/node/service/service_impl.go
+++ b/central/node/service/service_impl.go
@@ -28,6 +28,8 @@ var (
 )
 
 type nodeServiceImpl struct {
+	v1.UnimplementedNodeServiceServer
+
 	nodeStore globaldatastore.GlobalDataStore
 }
 

--- a/central/notifier/service/service_impl.go
+++ b/central/notifier/service/service_impl.go
@@ -48,6 +48,8 @@ var (
 
 // ClusterService is the struct that manages the cluster API
 type serviceImpl struct {
+	v1.UnimplementedNotifierServiceServer
+
 	storage   datastore.DataStore
 	processor processor.Processor
 	reporter  integrationhealth.Reporter

--- a/central/ping/service/service_impl.go
+++ b/central/ping/service/service_impl.go
@@ -9,7 +9,9 @@ import (
 	"google.golang.org/grpc"
 )
 
-type serviceImpl struct{}
+type serviceImpl struct {
+	v1.UnimplementedPingServiceServer
+}
 
 // RegisterServiceServer registers this service with the given gRPC Server.
 func (s *serviceImpl) RegisterServiceServer(grpcServer *grpc.Server) {

--- a/central/pod/service/service_impl.go
+++ b/central/pod/service/service_impl.go
@@ -32,6 +32,8 @@ var (
 
 // serviceImpl provides APIs for deployments.
 type serviceImpl struct {
+	v1.UnimplementedPodServiceServer
+
 	datastore datastore.DataStore
 }
 

--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -99,6 +99,8 @@ var (
 
 // serviceImpl provides APIs for alerts.
 type serviceImpl struct {
+	v1.UnimplementedPolicyServiceServer
+
 	policies          datastore.DataStore
 	clusters          clusterDataStore.DataStore
 	deployments       deploymentDataStore.DataStore

--- a/central/policycategory/service/service_impl.go
+++ b/central/policycategory/service/service_impl.go
@@ -48,6 +48,8 @@ var (
 
 // serviceImpl provides APIs for alerts.
 type serviceImpl struct {
+	v1.UnimplementedPolicyCategoryServiceServer
+
 	policyCategoriesDatastore datastore.DataStore
 }
 

--- a/central/probeupload/service/service_impl.go
+++ b/central/probeupload/service/service_impl.go
@@ -37,6 +37,8 @@ var (
 )
 
 type service struct {
+	v1.UnimplementedProbeUploadServiceServer
+
 	mgr manager.Manager
 
 	probeServerHandler http.Handler

--- a/central/processbaseline/service/service_impl.go
+++ b/central/processbaseline/service/service_impl.go
@@ -39,6 +39,8 @@ var (
 )
 
 type serviceImpl struct {
+	v1.UnimplementedProcessBaselineServiceServer
+
 	dataStore         datastore.DataStore
 	reprocessor       reprocessor.Loop
 	connectionManager connection.Manager

--- a/central/processindicator/service/service_impl.go
+++ b/central/processindicator/service/service_impl.go
@@ -37,6 +37,8 @@ var (
 )
 
 type serviceImpl struct {
+	v1.UnimplementedProcessServiceServer
+
 	processIndicators processIndicatorStore.DataStore
 	deployments       deploymentStore.DataStore
 	baselines         baselineStore.DataStore

--- a/central/rbac/service/service_impl.go
+++ b/central/rbac/service/service_impl.go
@@ -38,6 +38,8 @@ var (
 
 // serviceImpl provides APIs for k8s rbac objects.
 type serviceImpl struct {
+	v1.UnimplementedRbacServiceServer
+
 	roles    rolesDataStore.DataStore
 	bindings roleBindingsDataStore.DataStore
 }

--- a/central/reportconfigurations/service/service_impl.go
+++ b/central/reportconfigurations/service/service_impl.go
@@ -46,6 +46,8 @@ var (
 )
 
 type serviceImpl struct {
+	v1.UnimplementedReportConfigurationServiceServer
+
 	manager           manager.Manager
 	reportConfigStore datastore.DataStore
 	notifierStore     notifierDataStore.DataStore

--- a/central/reports/service/service_impl.go
+++ b/central/reports/service/service_impl.go
@@ -32,6 +32,8 @@ var (
 )
 
 type serviceImpl struct {
+	v1.UnimplementedReportServiceServer
+
 	manager           manager.Manager
 	reportConfigStore reportConfigDS.DataStore
 	notifierStore     notifierDataStore.DataStore

--- a/central/resourcecollection/service/service_impl.go
+++ b/central/resourcecollection/service/service_impl.go
@@ -38,6 +38,8 @@ var (
 
 // serviceImpl is the struct that manages the collection API
 type serviceImpl struct {
+	v1.UnimplementedCollectionServiceServer
+
 	datastore datastore.DataStore
 }
 

--- a/central/role/service/service_impl.go
+++ b/central/role/service/service_impl.go
@@ -62,6 +62,8 @@ var (
 )
 
 type serviceImpl struct {
+	v1.UnimplementedRoleServiceServer
+
 	roleDataStore      datastore.DataStore
 	clusterDataStore   clusterDS.DataStore
 	namespaceDataStore namespaceDS.DataStore

--- a/central/search/service/service_impl.go
+++ b/central/search/service/service_impl.go
@@ -125,6 +125,8 @@ var (
 
 // SearchService provides APIs for search.
 type serviceImpl struct {
+	v1.UnimplementedSearchServiceServer
+
 	alerts            alertDataStore.DataStore
 	deployments       deploymentDataStore.DataStore
 	images            imageDataStore.DataStore

--- a/central/secret/service/service_impl.go
+++ b/central/secret/service/service_impl.go
@@ -36,6 +36,8 @@ var (
 
 // serviceImpl provides APIs for alerts.
 type serviceImpl struct {
+	v1.UnimplementedSecretServiceServer
+
 	secrets     datastore.DataStore
 	deployments deploymentDatastore.DataStore
 }

--- a/central/sensor/service/service_impl.go
+++ b/central/sensor/service/service_impl.go
@@ -34,6 +34,8 @@ var (
 )
 
 type serviceImpl struct {
+	central.UnimplementedSensorServiceServer
+
 	manager  connection.Manager
 	pf       pipeline.Factory
 	clusters clusterDataStore.DataStore

--- a/central/sensorupgrade/controlservice/service_impl.go
+++ b/central/sensorupgrade/controlservice/service_impl.go
@@ -25,6 +25,8 @@ var (
 )
 
 type service struct {
+	central.UnimplementedSensorUpgradeControlServiceServer
+
 	connectionManager connection.Manager
 }
 

--- a/central/sensorupgrade/service/service_impl.go
+++ b/central/sensorupgrade/service/service_impl.go
@@ -33,6 +33,8 @@ var (
 )
 
 type service struct {
+	v1.UnimplementedSensorUpgradeServiceServer
+
 	configDataStore datastore.DataStore
 	manager         connection.Manager
 }

--- a/central/serviceaccount/service/service_impl.go
+++ b/central/serviceaccount/service/service_impl.go
@@ -35,6 +35,8 @@ var (
 
 // serviceImpl provides APIs for alerts.
 type serviceImpl struct {
+	v1.UnimplementedServiceAccountServiceServer
+
 	serviceAccounts saDatastore.DataStore
 	bindings        bindingDatastore.DataStore
 	roles           roleDatastore.DataStore

--- a/central/serviceidentities/service/service_impl.go
+++ b/central/serviceidentities/service/service_impl.go
@@ -32,6 +32,8 @@ var (
 
 // IdentityService is the struct that manages the Service Identity API
 type serviceImpl struct {
+	v1.UnimplementedServiceIdentityServiceServer
+
 	dataStore datastore.DataStore
 }
 

--- a/central/signatureintegration/service/service_impl.go
+++ b/central/signatureintegration/service/service_impl.go
@@ -34,6 +34,8 @@ var (
 )
 
 type serviceImpl struct {
+	v1.UnimplementedSignatureIntegrationServiceServer
+
 	datastore        datastore.DataStore
 	reprocessingLoop reprocessor.Loop
 }

--- a/central/summary/service/service_impl.go
+++ b/central/summary/service/service_impl.go
@@ -38,6 +38,8 @@ var (
 
 // SearchService provides APIs for search.
 type serviceImpl struct {
+	v1.UnimplementedSummaryServiceServer
+
 	alerts      alertDataStore.DataStore
 	clusters    clusterDataStore.DataStore
 	deployments deploymentDataStore.DataStore

--- a/central/telemetry/service/service_impl.go
+++ b/central/telemetry/service/service_impl.go
@@ -25,7 +25,9 @@ var (
 	})
 )
 
-type serviceImpl struct{}
+type serviceImpl struct {
+	v1.UnimplementedTelemetryServiceServer
+}
 
 func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
 	return ctx, authorizer.Authorized(ctx, fullMethodName)

--- a/central/user/service/service_impl.go
+++ b/central/user/service/service_impl.go
@@ -29,6 +29,8 @@ var (
 )
 
 type serviceImpl struct {
+	v1.UnimplementedUserServiceServer
+
 	users datastore.DataStore
 }
 

--- a/central/vulnerabilityrequest/service/service_impl.go
+++ b/central/vulnerabilityrequest/service/service_impl.go
@@ -54,6 +54,8 @@ var (
 
 // serviceImpl provides APIs for vulnerability requests.
 type serviceImpl struct {
+	v1.UnimplementedVulnerabilityRequestServiceServer
+
 	datastore datastore.DataStore
 	manager   requestmgr.Manager
 }

--- a/integration-tests/mock-grpc-server/main.go
+++ b/integration-tests/mock-grpc-server/main.go
@@ -31,6 +31,9 @@ var (
 )
 
 type signalServer struct {
+	sensorAPI.UnimplementedSignalServiceServer
+	sensorAPI.UnimplementedNetworkConnectionInfoServiceServer
+
 	db *bolt.DB
 }
 

--- a/roxctl/central/whoami/whoami_test.go
+++ b/roxctl/central/whoami/whoami_test.go
@@ -30,8 +30,8 @@ type centralWhoAmITestSuite struct {
 }
 
 type mockAuthServiceServer struct {
-	v1.AuthServiceServer
-	v1.RoleServiceServer
+	v1.UnimplementedAuthServiceServer
+	v1.UnimplementedRoleServiceServer
 
 	userInfo         *storage.UserInfo
 	resourceToAccess map[string]storage.Access

--- a/roxctl/cluster/delete/delete_test.go
+++ b/roxctl/cluster/delete/delete_test.go
@@ -31,7 +31,8 @@ type clusterDeleteTestSuite struct {
 }
 
 type mockClustersServiceServer struct {
-	v1.ClustersServiceServer
+	v1.UnimplementedClustersServiceServer
+
 	clusters []*storage.Cluster
 }
 

--- a/roxctl/deployment/check/check_test.go
+++ b/roxctl/deployment/check/check_test.go
@@ -210,7 +210,8 @@ var (
 
 // mock for testing implementing v1.DetectionServiceServer
 type mockDetectionServiceServer struct {
-	v1.DetectionServiceServer
+	v1.UnimplementedDetectionServiceServer
+
 	alerts         []*storage.Alert
 	ignoredObjRefs []string
 }

--- a/roxctl/image/check/check_test.go
+++ b/roxctl/image/check/check_test.go
@@ -180,10 +180,9 @@ var (
 
 // mock implementation for v1.DetectionServiceServer
 type mockDetectionServiceServer struct {
+	v1.UnimplementedDetectionServiceServer
+
 	alerts []*storage.Alert
-	// This will allow us to use the struct when registering it via v1.RegisterDetectionServiceServer without the need
-	// to implement all functions of the interface, only the one we require for testing.
-	v1.DetectionServiceServer
 }
 
 func (m *mockDetectionServiceServer) DetectBuildTime(context.Context, *v1.BuildDetectionRequest) (*v1.BuildDetectionResponse, error) {

--- a/roxctl/image/scan/scan_test.go
+++ b/roxctl/image/scan/scan_test.go
@@ -182,7 +182,8 @@ var (
 
 // mock implementation for v1.ImageServiceServer
 type mockImageServiceServer struct {
-	v1.ImageServiceServer
+	v1.UnimplementedImageServiceServer
+
 	components []*storage.EmbeddedImageScanComponent
 }
 

--- a/roxctl/sensor/generate/generate_test.go
+++ b/roxctl/sensor/generate/generate_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 type mockClustersServiceServer struct {
-	v1.ClustersServiceServer
+	v1.UnimplementedClustersServiceServer
 
 	// injected behavior
 	getKernelSupportInjectedFn getKernelSupportFn

--- a/sensor/common/admissioncontroller/management_service.go
+++ b/sensor/common/admissioncontroller/management_service.go
@@ -23,6 +23,8 @@ var (
 )
 
 type managementService struct {
+	sensor.UnimplementedAdmissionControlManagementServiceServer
+
 	settingsStream     concurrency.ReadOnlyValueStream[*sensor.AdmissionControlSettings]
 	sensorEventsStream concurrency.ReadOnlyValueStream[*sensor.AdmCtrlUpdateResourceRequest]
 

--- a/sensor/common/certdistribution/service_impl.go
+++ b/sensor/common/certdistribution/service_impl.go
@@ -42,6 +42,8 @@ var (
 )
 
 type service struct {
+	sensor.UnimplementedCertDistributionServiceServer
+
 	namespace string
 
 	k8sAuthnClient authenticationV1.AuthenticationV1Interface

--- a/sensor/common/compliance/service_impl.go
+++ b/sensor/common/compliance/service_impl.go
@@ -18,6 +18,8 @@ import (
 
 // ComplianceService is the struct that manages the compliance results and audit log events
 type serviceImpl struct {
+	sensor.UnimplementedComplianceServiceServer
+
 	output      chan *compliance.ComplianceReturn
 	auditEvents chan *sensor.AuditEvents
 

--- a/sensor/common/deployment/service_impl.go
+++ b/sensor/common/deployment/service_impl.go
@@ -30,6 +30,8 @@ func NewService(deployments store.DeploymentStore, pods store.PodStore) Service 
 }
 
 type serviceImpl struct {
+	sensor.UnimplementedDeploymentServiceServer
+
 	deployments store.DeploymentStore
 	pods        store.PodStore
 }

--- a/sensor/common/image/service_impl.go
+++ b/sensor/common/image/service_impl.go
@@ -35,6 +35,8 @@ func NewService(imageCache expiringcache.Cache, registryStore *registry.Store) S
 }
 
 type serviceImpl struct {
+	sensor.UnimplementedImageServiceServer
+
 	centralClient v1.ImageServiceClient
 	imageCache    expiringcache.Cache
 	registryStore *registry.Store

--- a/sensor/common/networkflow/service/service_impl.go
+++ b/sensor/common/networkflow/service/service_impl.go
@@ -34,6 +34,8 @@ func NewService(networkFlowManager manager.Manager) Service {
 }
 
 type serviceImpl struct {
+	sensor.UnimplementedNetworkConnectionInfoServiceServer
+
 	manager manager.Manager
 }
 

--- a/sensor/common/signal/signal_service.go
+++ b/sensor/common/signal/signal_service.go
@@ -33,6 +33,8 @@ type Service interface {
 }
 
 type serviceImpl struct {
+	sensorAPI.UnimplementedSignalServiceServer
+
 	queue      chan *v1.Signal
 	indicators chan *central.MsgFromSensor
 

--- a/sensor/debugger/central/communicate_server.go
+++ b/sensor/debugger/central/communicate_server.go
@@ -15,6 +15,8 @@ import (
 
 // FakeService represents a fake central gRPC that reads and sends messages to sensor's connected gRPC stream.
 type FakeService struct {
+	central.UnimplementedSensorServiceServer
+
 	ConnectionStarted concurrency.Signal
 	KillSwitch        concurrency.Signal
 


### PR DESCRIPTION
## Description

gRPC code generation generates `Unimplemented...` structs that return an unimplemented status code for all methods. This struct should be embedded in all gRPC service implementations. While this is not currently enforced, future gRPC code generator versions will make this mandatory (this behavior can be disabled, but it is not recommended; see [here](https://github.com/grpc/grpc-go/issues/3669) for a lengthy discussion on this matter with the clear verdict that gRPC authors see embedding of `Unimplemented..` as something that should always have been required).

Alas, this makes service type assertions ineffective, but that seems to be the pill to swallow.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- CI
