### PR TITLE
ROX-13125: Show error if CVE CSV download in non-Postgres env

### DIFF
--- a/ui/apps/platform/src/Components/ExportButton.js
+++ b/ui/apps/platform/src/Components/ExportButton.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import * as Icon from 'react-feather';
 import onClickOutside from 'react-onclickoutside';
+import { toast } from 'react-toastify';
 
 import downloadCSV from 'services/CSVDownloadService';
 import WorkflowPDFExportButton from 'Components/WorkflowPDFExportButton';
@@ -83,9 +84,13 @@ class ExportButton extends Component {
             }
 
             this.setState({ csvIsDownloading: true });
-            customCsvExportHandler(csvName).finally(() => {
-                this.setState({ toggleWidget: false, csvIsDownloading: false });
-            });
+            customCsvExportHandler(csvName)
+                .catch((err) => {
+                    toast(`An error occurred while trying to export: ${err}`);
+                })
+                .finally(() => {
+                    this.setState({ toggleWidget: false, csvIsDownloading: false });
+                });
         } else {
             // otherwise, use legacy compliance CSV export
             let queryStr = '';

--- a/ui/apps/platform/src/services/DownloadService.js
+++ b/ui/apps/platform/src/services/DownloadService.js
@@ -14,24 +14,34 @@ export function saveFile({ method, url, data, name = '' }) {
         // removing timeout for downloads
         timeout: 0,
     };
-    return axios(options).then((response) => {
-        if (response.data) {
-            const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
-            const matches = filenameRegex.exec(response.headers['content-disposition']);
+    return axios(options)
+        .then((response) => {
+            if (response.data) {
+                const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+                const matches = filenameRegex.exec(response.headers['content-disposition']);
 
-            const file = new Blob([response.data], {
-                type: response.headers['content-type'],
-            });
+                const file = new Blob([response.data], {
+                    type: response.headers['content-type'],
+                });
 
-            if (name && typeof name === 'string') {
-                FileSaver.saveAs(file, name);
-            } else if (matches !== null && matches[1]) {
-                FileSaver.saveAs(file, matches[1].replace(/['"]/g, ''));
+                if (name && typeof name === 'string') {
+                    FileSaver.saveAs(file, name);
+                } else if (matches !== null && matches[1]) {
+                    FileSaver.saveAs(file, matches[1].replace(/['"]/g, ''));
+                } else {
+                    throw new Error('Unable to extract file name');
+                }
             } else {
-                throw new Error('Unable to extract file name');
+                throw new Error('Expected response to contain "data" property');
             }
-        } else {
-            throw new Error('Expected response to contain "data" property');
-        }
-    });
+        })
+        .catch((err) => {
+            // because the responseType of the request is `arraybuffer`,
+            // any error message is also wrapped in an ArrayBuffer data structure
+            // we try to parse that to a string
+            const parsedError = new TextDecoder().decode(err?.response?.data);
+
+            // pass along the parsed error message, unless the parsing returned nothing
+            throw parsedError || err;
+        });
 }


### PR DESCRIPTION
## Description

This is an MVP solution to letting the user know they now have to choose a CVE type (IMAGE_CVE, K8S_CVE, ISTIO_CVE, NODE_CVE, and OPENSHIFT_CVE) in a non-Postgres environment.

**This needs to go into 3.73 because Postgres will not be turned on by default for that version.**

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Manual testing

Go to the CVE list page and try to download a CSV without setting a CVE_TYPE filter.
<img width="1511" alt="Screen Shot 2022-10-25 at 11 23 07 AM" src="https://user-images.githubusercontent.com/715729/197825615-e096239e-6d14-42fb-9041-22108a0c8deb.png">
