### PR TITLE
shellcheck fixes for helmdiff.sh

### DIFF
--- a/dev-tools/helmdiff.sh
+++ b/dev-tools/helmdiff.sh
@@ -13,7 +13,7 @@ echo "Generating temporary files in ${TMP_ROOT}"
 
 echo "Rendering from metatemplates to helm charts:"
 for CHART in ${CHARTS}; do
-  $ROXCTL helm output --debug --remove ${CHART} --output-dir="${TMP_ROOT}/${CHART}-new"
+  $ROXCTL helm output --debug --remove "${CHART}" --output-dir="${TMP_ROOT}/${CHART}-new"
 done
 
 REPO_STAT="$(git diff --stat)"
@@ -24,9 +24,9 @@ if [[ -n $REPO_STAT ]]; then
 fi
 git switch master
 for CHART in ${CHARTS}; do
-  $ROXCTL helm output --debug --remove ${CHART} --output-dir="${TMP_ROOT}/${CHART}-old"
+  $ROXCTL helm output --debug --remove "${CHART}" --output-dir="${TMP_ROOT}/${CHART}-old"
 done
-git switch ${WORKING_BRANCH}
+git switch "${WORKING_BRANCH}"
 if [[ -n $REPO_STAT ]]; then
   echo "Restoring uncommitted changes with 'git stash pop'."
   git stash pop
@@ -38,8 +38,8 @@ for VERSION in "old" "new"; do
     -n stackrox \
     --disable-openapi-validation \
     stackrox-central-services \
-    ${TMP_ROOT}/central-services-${VERSION} \
-    > ${TMP_ROOT}/central-services-${VERSION}-installation.yaml
+    "${TMP_ROOT}"/central-services-${VERSION} \
+    > "${TMP_ROOT}"/central-services-${VERSION}-installation.yaml
 done
 
 echo "Rendering a dry run installation of the stackrox-secured-cluster-services helm charts as Kubernetes manifests:"
@@ -53,8 +53,8 @@ for VERSION in "old" "new"; do
     --set serviceTLS.key=c3 \
     --set createSecrets=false \
     stackrox-secured-cluster-services \
-    ${TMP_ROOT}/secured-cluster-services-${VERSION} \
-    > ${TMP_ROOT}/secured-cluster-services-${VERSION}-installation.yaml
+    "${TMP_ROOT}"/secured-cluster-services-${VERSION} \
+    > "${TMP_ROOT}"/secured-cluster-services-${VERSION}-installation.yaml
 done
 
 cat <<EOF

--- a/scripts/style/shellcheck_skip.txt
+++ b/scripts/style/shellcheck_skip.txt
@@ -12,7 +12,6 @@ deploy/openshift/deploy.sh
 deploy/openshift/sensor.sh
 dev-tools/add-host-alias.sh
 dev-tools/enable-hotreload.sh
-dev-tools/helmdiff.sh
 dev-tools/roxctl.sh
 image/assets/docker-auth.sh
 image/central-entrypoint.sh


### PR DESCRIPTION
## Description

Shell checks were ignored for file: dev-tools/helmdiff.sh, this PR fixes the warnings provided by shellcheck (#3544 )

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

Above doesn't apply, logic of script isn't changed

## Testing Performed

executed command "make shell-style"

