### PR TITLE
shellcheck fixes for expand-db.sh

### DIFF
--- a/local/expand-db.sh
+++ b/local/expand-db.sh
@@ -11,7 +11,7 @@ fi
 
 rm -rf "${DIR}/database-restore"
 mkdir -p "${DIR}/database-restore"
-unzip -d "${DIR}/database-restore/expanded" $1
+unzip -d "${DIR}/database-restore/expanded" "$1"
 mkdir -p "${DIR}/database-restore/expanded/rocksdb"
 tar -xvf "${DIR}/database-restore/expanded/rocks.db" -C "${DIR}/database-restore/expanded/rocksdb"
 mkdir -p "${DIR}/database-restore/full/rocksdb"

--- a/scripts/style/shellcheck_skip.txt
+++ b/scripts/style/shellcheck_skip.txt
@@ -30,7 +30,6 @@ image/templates/sensor/kubernetes/sensor.sh
 image/templates/sensor/openshift/delete-sensor.sh
 image/templates/sensor/openshift/sensor.sh
 licenses/generate-license-wrapper.sh
-local/expand-db.sh
 operator/hack/common.sh
 operator/hack/olm-operator-install.sh
 operator/hack/olm-operator-upgrade.sh


### PR DESCRIPTION
## Description

Shell checks were ignored for file: local/expand-db.sh file, this PR fixes the warnings provided by shellcheck (#3544)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

executed command "make shell-style"