### PR TITLE
Fixed shellcheck lint for get-lb-ip.sh

### DIFF
--- a/scripts/k8s/get-lb-ip.sh
+++ b/scripts/k8s/get-lb-ip.sh
@@ -6,4 +6,4 @@ until [ -n "${LB_IP}" ]; do
     sleep 1
 done
 
-echo $LB_IP
+echo "$LB_IP"

--- a/scripts/style/shellcheck_skip.txt
+++ b/scripts/style/shellcheck_skip.txt
@@ -69,7 +69,6 @@ scripts/connect-ui.sh
 scripts/ensure_image.sh
 scripts/grab-data-from-central.sh
 scripts/k8s/cleanup.sh
-scripts/k8s/get-lb-ip.sh
 scripts/k8s/kill-pod.sh
 scripts/k8s/local-port-forward.sh
 scripts/mergeswag.sh


### PR DESCRIPTION
## Description

Shell checks were ignored for file: k8s/get-lb-ip.sh file, this PR fixes the warnings provided by shellcheck (#3544)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

executed command "make shell-style"