### PR TITLE
ROX-12502 Add re-sync feature flag

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -48,4 +48,7 @@ var (
 
 	// ProcessesListeningOnPort enables the NetworkFlow code to also update the processes that are listening on ports
 	ProcessesListeningOnPort = registerFeature("Enable Processes Listening on Port", "ROX_PROCESSES_LISTENING_ON_PORT", false)
+
+	// ResyncDisabled disables the resync behavior of the kubernetes listeners in sensor
+	ResyncDisabled = registerFeature("Disable the re-sync", "ROX_RESYNC_DISABLED", false)
 )


### PR DESCRIPTION
## Description

Adds a feature flag to disable the re-sync behavior of the kubernetes listeners in sensor

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

N/A
