### PR TITLE
Add field IDs to name and label selector components

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
@@ -3,6 +3,7 @@ import { Select, ValidatedOptions } from '@patternfly/react-core';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 
 export type AutoCompleteSelectProps = {
+    id: string;
     selectedOption: string;
     className?: string;
     typeAheadAriaLabel?: string;
@@ -12,6 +13,7 @@ export type AutoCompleteSelectProps = {
 
 /* TODO Implement autocompletion */
 export function AutoCompleteSelect({
+    id,
     selectedOption,
     className = '',
     typeAheadAriaLabel,
@@ -28,6 +30,7 @@ export function AutoCompleteSelect({
     return (
         <>
             <Select
+                toggleId={id}
                 validated={validated}
                 typeAheadAriaLabel={typeAheadAriaLabel}
                 className={className}

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
@@ -127,7 +127,7 @@ function ByLabelSelector({
                                 >
                                     <AutoCompleteSelect
                                         id={`${entityType}-label-key-${ruleIndex}`}
-                                        typeAheadAriaLabel={`Select a value for the ${entityType.toLowerCase()} label key`}
+                                        typeAheadAriaLabel={`Select label key for ${entityType} rule ${ruleIndex} of ${scopedResourceSelector.rules.length}`}
                                         selectedOption={rule.key}
                                         onChange={(fieldValue: string) =>
                                             onChangeLabelKey(
@@ -168,7 +168,13 @@ function ByLabelSelector({
                                             <Flex key={keyFor(valueIndex)}>
                                                 <AutoCompleteSelect
                                                     id={`${entityType}-label-value-${ruleIndex}-${valueIndex}`}
-                                                    typeAheadAriaLabel={`Select a value for the ${entityType.toLowerCase()} label value`}
+                                                    typeAheadAriaLabel={`Select label value ${
+                                                        valueIndex + 1
+                                                    } of ${
+                                                        rule.values.length
+                                                    } for ${entityType} rule ${ruleIndex + 1} of ${
+                                                        scopedResourceSelector.rules.length
+                                                    }`}
                                                     className="pf-u-flex-grow-1 pf-u-w-auto"
                                                     selectedOption={value}
                                                     onChange={(fieldValue: string) =>

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
@@ -120,11 +120,13 @@ function ByLabelSelector({
                         <Flex>
                             <Flex className="pf-u-flex-grow-1 pf-u-mb-md">
                                 <FormGroup
+                                    fieldId={`${entityType}-label-key-${ruleIndex}`}
                                     className="pf-u-flex-grow-1"
                                     label={ruleIndex === 0 ? 'Label key' : ''}
                                     isRequired
                                 >
                                     <AutoCompleteSelect
+                                        id={`${entityType}-label-key-${ruleIndex}`}
                                         typeAheadAriaLabel={`Select a value for the ${entityType.toLowerCase()} label key`}
                                         selectedOption={rule.key}
                                         onChange={(fieldValue: string) =>
@@ -145,6 +147,7 @@ function ByLabelSelector({
                                 </FlexItem>
                             </Flex>
                             <FormGroup
+                                fieldId={`${entityType}-label-value-${ruleIndex}`}
                                 className="pf-u-flex-grow-1"
                                 label={ruleIndex === 0 ? 'Label value(s)' : ''}
                                 isRequired
@@ -164,6 +167,7 @@ function ByLabelSelector({
                                         return (
                                             <Flex key={keyFor(valueIndex)}>
                                                 <AutoCompleteSelect
+                                                    id={`${entityType}-label-value-${ruleIndex}-${valueIndex}`}
                                                     typeAheadAriaLabel={`Select a value for the ${entityType.toLowerCase()} label value`}
                                                     className="pf-u-flex-grow-1 pf-u-w-auto"
                                                     selectedOption={value}

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
@@ -127,7 +127,9 @@ function ByLabelSelector({
                                 >
                                     <AutoCompleteSelect
                                         id={`${entityType}-label-key-${ruleIndex}`}
-                                        typeAheadAriaLabel={`Select label key for ${entityType} rule ${ruleIndex} of ${scopedResourceSelector.rules.length}`}
+                                        typeAheadAriaLabel={`Select label key for ${entityType.toLowerCase()} rule ${
+                                            ruleIndex + 1
+                                        } of ${scopedResourceSelector.rules.length}`}
                                         selectedOption={rule.key}
                                         onChange={(fieldValue: string) =>
                                             onChangeLabelKey(
@@ -172,9 +174,9 @@ function ByLabelSelector({
                                                         valueIndex + 1
                                                     } of ${
                                                         rule.values.length
-                                                    } for ${entityType} rule ${ruleIndex + 1} of ${
-                                                        scopedResourceSelector.rules.length
-                                                    }`}
+                                                    } for ${entityType.toLowerCase()} rule ${
+                                                        ruleIndex + 1
+                                                    } of ${scopedResourceSelector.rules.length}`}
                                                     className="pf-u-flex-grow-1 pf-u-w-auto"
                                                     selectedOption={value}
                                                     onChange={(fieldValue: string) =>

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -57,11 +57,12 @@ function ByNameSelector({
     }
 
     return (
-        <FormGroup label={`${entityType} name`} isRequired>
+        <FormGroup fieldId={`${entityType}-name-value`} label={`${entityType} name`} isRequired>
             <Flex spaceItems={{ default: 'spaceItemsSm' }} direction={{ default: 'column' }}>
                 {scopedResourceSelector.rule.values.map((value, index) => (
                     <Flex key={keyFor(index)}>
                         <AutoCompleteSelect
+                            id={`${entityType}-name-value-${index}`}
                             typeAheadAriaLabel={`Select a value for the ${entityType.toLowerCase()} name`}
                             className="pf-u-flex-grow-1 pf-u-w-auto"
                             selectedOption={value}

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -63,7 +63,9 @@ function ByNameSelector({
                     <Flex key={keyFor(index)}>
                         <AutoCompleteSelect
                             id={`${entityType}-name-value-${index}`}
-                            typeAheadAriaLabel={`Select a value for the ${entityType.toLowerCase()} name`}
+                            typeAheadAriaLabel={`Select value ${index + 1} of ${
+                                scopedResourceSelector.rule.values.length
+                            } for the ${entityType.toLowerCase()} name`}
                             className="pf-u-flex-grow-1 pf-u-w-auto"
                             selectedOption={value}
                             onChange={onChangeValue(scopedResourceSelector, index)}

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
@@ -60,7 +60,7 @@ describe('Collection RuleSelector component', () => {
         expect(resourceSelector.field).toBe('Deployment');
         expect(resourceSelector.rule.values).toEqual(['']);
 
-        const typeAheadInput = screen.getByLabelText('Select a value for the deployment name');
+        const typeAheadInput = screen.getByLabelText('Select value 1 of 1 for the deployment name');
         await user.type(typeAheadInput, 'visa-processor{Enter}');
 
         expect(resourceSelector.field).toBe('Deployment');
@@ -76,12 +76,12 @@ describe('Collection RuleSelector component', () => {
 
         // Add a couple more values
         await user.type(
-            screen.getAllByLabelText('Select a value for the deployment name')[1],
+            screen.getByLabelText('Select value 2 of 2 for the deployment name'),
             'mastercard-processor{Enter}'
         );
         await user.click(screen.getByText('Add value'));
         await user.type(
-            screen.getAllByLabelText('Select a value for the deployment name')[2],
+            screen.getByLabelText('Select value 3 of 3 for the deployment name'),
             'discover-processor{Enter}'
         );
 
@@ -126,11 +126,11 @@ describe('Collection RuleSelector component', () => {
         expect(resourceSelector.rules[0].values).toEqual(['']);
 
         await user.type(
-            screen.getByLabelText('Select a value for the deployment label key'),
+            screen.getByLabelText('Select label key for deployment rule 1 of 1'),
             'kubernetes.io/metadata.name{Enter}'
         );
         await user.type(
-            screen.getByLabelText('Select a value for the deployment label value'),
+            screen.getByLabelText('Select label value 1 of 1 for deployment rule 1 of 1'),
             'visa-processor{Enter}'
         );
         expect(resourceSelector.rules[0].key).toEqual('kubernetes.io/metadata.name');
@@ -144,12 +144,12 @@ describe('Collection RuleSelector component', () => {
         expect(resourceSelector.rules[0].values).toEqual(['visa-processor', '']);
 
         await user.type(
-            screen.getAllByLabelText('Select a value for the deployment label value')[1],
+            screen.getByLabelText('Select label value 2 of 2 for deployment rule 1 of 1'),
             'mastercard-processor{Enter}'
         );
         await user.click(screen.getByText('Add value'));
         await user.type(
-            screen.getAllByLabelText('Select a value for the deployment label value')[2],
+            screen.getByLabelText('Select label value 3 of 3 for deployment rule 1 of 1'),
             'discover-processor{Enter}'
         );
 
@@ -163,22 +163,22 @@ describe('Collection RuleSelector component', () => {
         await user.click(screen.getByText('Add label rule'));
 
         await user.type(
-            screen.getAllByLabelText('Select a value for the deployment label key')[1],
+            screen.getByLabelText('Select label key for deployment rule 2 of 2'),
             'kubernetes.io/metadata.release{Enter}'
         );
         await user.type(
-            screen.getAllByLabelText('Select a value for the deployment label value')[3],
+            screen.getByLabelText('Select label value 1 of 1 for deployment rule 2 of 2'),
             // typo
             'stabl{Enter}'
         );
         await user.click(screen.getAllByText('Add value')[1]);
         await user.type(
-            screen.getAllByLabelText('Select a value for the deployment label value')[4],
+            screen.getByLabelText('Select label value 2 of 2 for deployment rule 2 of 2'),
             'beta{Enter}'
         );
         // test editing typo
         await user.type(
-            screen.getAllByLabelText('Select a value for the deployment label value')[3],
+            screen.getByLabelText('Select label value 1 of 2 for deployment rule 2 of 2'),
             'e{Enter}'
         );
 


### PR DESCRIPTION
## Description

This adds `fieldId` (`for` attribute) to form labels and `id` to form input fields.

Since most of the form labels have multiple inputs there are two approaches we can take here:

1. Associate the form label with the _last_ field input, dynamically, so that we get a clean `for`<->`id` mapping between labels and inputs to enable focusing the input element when a label is clicked. This might be somewhat convenient for the user at the expense of ignoring all fields that are not that last field associated with the input. I'm also not sure if this is semantically valid, since the label would only be tied to a single field (in reality is the label references multiple fields). This is even more of a problem since the label key and value labels reference multiple inputs across multiple rules.

2. Assign the form labels and field inputs their own unique ids that make sense given the context. This approach appends an index to each label for clear separation. We lose the ability to click a label to focus an input in all cases except for "Label key", but we gain clear programmatic control of accessing fields in the form.

Name rules will have:
```
# single name rule
for=Entity-name-value
id=Entity-name-value-0
id=Entity-name-value-1
id=Entity-name-value-2
...
```
And label rules will have:
```
# first label rule
for=Entity-label-key-0
id=Entity-label-key-0
for=Entity-label-value-0
id=Entity-label-value-0-0
id=Entity-label-value-0-1

# second label rule
for=Entity-label-key-1
id=Entity-label-key-1
for=Entity-label-value-1
id=Entity-label-value-1-0
id=Entity-label-value-1-1
...
```

I'm honestly not sure which is better for accessibility. The second option doesn't tie form fields and labels together at all, which may or may not be worse than the first option that ties one, but not all, fields to a label.

Another note is that the PatternFly `<Select>` does not give us full control over what the underlying `<input>` element's id is. The component is hard coded to use the passed `toggleId` and append the text `-select-typeahead` to it. The rendered HTML looks like the following when `Namespace-label-key-0` is passed as the `toggleId`.
```html
<div class="pf-c-select__toggle pf-m-typeahead">
  <div class="pf-c-select__toggle-wrapper">
    <input class="pf-c-form-control pf-c-select__toggle-typeahead" id="Namespace-label-key-0-select-typeahead" aria-label="" placeholder="" type="text" autocomplete="off" value="kubernetes.io/metadata.name">
  </div>

  <button id="Namespace-label-key-0" aria-labelledby=" Namespace-label-key-0" aria-expanded="false" aria-haspopup="listbox" type="button" class="pf-c-button pf-c-select__toggle-button pf-m-plain" aria-label="Options menu" tabindex="-1">
    <svg fill="currentColor" height="1em" width="1em" viewBox="0 0 320 512" aria-hidden="true" role="img" class="pf-c-select__toggle-arrow" style="vertical-align: -0.125em;"><path d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"></path></svg>
  </button>
</div>
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual viewing of HTML output.
