### PR TITLE
Move skipped test from auth to separate logout integration test file

### DIFF
--- a/ui/apps/platform/cypress/integration/auth.test.js
+++ b/ui/apps/platform/cypress/integration/auth.test.js
@@ -1,11 +1,9 @@
 import addSeconds from 'date-fns/add_seconds';
 
 import { url as loginUrl, selectors } from '../constants/LoginPage';
-import { selectors as navSelectors } from '../constants/TopNavigation';
 import { url as dashboardURL } from '../constants/DashboardPage';
 
 import * as api from '../constants/apiEndpoints';
-import withAuth from '../helpers/basicAuth'; // used to make logout test less flakey
 
 const AUTHENTICATED = true;
 const UNAUTHENTICATED = false;
@@ -82,25 +80,5 @@ describe('Authentication', () => {
         });
 
         cy.wait('@tokenRefresh');
-    });
-
-    // the logout test has its own describe block, which uses our withAuth() helper function
-    //   to log in with a real auth token
-    //   because after a Cypress upgrade, using a fake token on this test became flakey
-    describe('Logout', () => {
-        withAuth();
-
-        // turning off for now, because of an issue with Cypress
-        // see https://srox.slack.com/archives/C7ERNFL0M/p1596839383218700
-        it.skip('should logout user by request', () => {
-            cy.intercept('POST', api.auth.logout, { body: {} }).as('logout');
-
-            cy.visit(dashboardURL);
-
-            cy.get(navSelectors.menuButton).click();
-            cy.get(navSelectors.menuList.logoutButton).click();
-            cy.wait('@logout');
-            cy.location('pathname').should('eq', loginUrl);
-        });
     });
 });

--- a/ui/apps/platform/cypress/integration/logout.test.js
+++ b/ui/apps/platform/cypress/integration/logout.test.js
@@ -5,9 +5,11 @@ import withAuth from '../helpers/basicAuth';
 import { visitMainDashboard } from '../helpers/main';
 import { interactAndWaitForResponses } from '../helpers/request';
 
+const logoutAlias = 'logout';
+
 const requestConfigForLogout = {
     routeMatcherMap: {
-        logout: {
+        [logoutAlias]: {
             method: 'POST',
             url: api.auth.logout,
         },
@@ -15,7 +17,7 @@ const requestConfigForLogout = {
 };
 
 const staticResponseMapForLogout = {
-    logout: {
+    [logoutAlias]: {
         body: {},
     },
 };

--- a/ui/apps/platform/cypress/integration/logout.test.js
+++ b/ui/apps/platform/cypress/integration/logout.test.js
@@ -1,0 +1,40 @@
+import * as api from '../constants/apiEndpoints';
+import { url as loginUrl } from '../constants/LoginPage';
+import { selectors as navSelectors } from '../constants/TopNavigation';
+import withAuth from '../helpers/basicAuth';
+import { visitMainDashboard } from '../helpers/main';
+import { interactAndWaitForResponses } from '../helpers/request';
+
+const requestConfigForLogout = {
+    routeMatcherMap: {
+        logout: {
+            method: 'POST',
+            url: api.auth.logout,
+        },
+    },
+};
+
+const staticResponseMapForLogout = {
+    logout: {
+        body: {},
+    },
+};
+
+describe('Logout', () => {
+    withAuth();
+
+    it('go to login page after logout on user menu', () => {
+        visitMainDashboard();
+
+        interactAndWaitForResponses(
+            () => {
+                cy.get(navSelectors.menuButton).click();
+                cy.get(navSelectors.menuList.logoutButton).click();
+            },
+            requestConfigForLogout,
+            staticResponseMapForLogout
+        );
+
+        cy.location('pathname').should('eq', loginUrl);
+    });
+});


### PR DESCRIPTION
## Description

One of these tests `'should logout user by request'` is not like the others:
* Its initial state is logged in via `withAuth` helper.
* It uses real user interface interactions.
* It uses real responses except for logout request.

Moving it to its own test file seems likely to solve the timing problems described as reason why it needed to be skipped.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed