### PR TITLE
remove unused env var ROX_RECORDER_DURATION

### DIFF
--- a/pkg/env/recorder.go
+++ b/pkg/env/recorder.go
@@ -1,8 +1,0 @@
-package env
-
-import "time"
-
-var (
-	// RecorderTime will set the duration for which to record the events from Sensor. 0 is the default which means no recording
-	RecorderTime = registerDurationSetting("ROX_RECORDER_DURATION", 0*time.Minute)
-)


### PR DESCRIPTION
## Description

This is no longer used, so why not delete it?

## Checklist
- [x] Investigated and inspected CI test results
- ~[] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI
