### PR TITLE
ROX-13266: Use new CVE list

### DIFF
--- a/central/cve/fetcher/fetch_utils.go
+++ b/central/cve/fetcher/fetch_utils.go
@@ -19,10 +19,10 @@ import (
 const (
 	fetchDelay            = 2 * time.Hour
 	preloadedCVEsBasePath = "/stackrox/static-data"
-	k8sCVEsURL            = "https://definitions.stackrox.io/cve3/k8s/cve-list.json"
-	k8sCVEsChecksumURL    = "https://definitions.stackrox.io/cve3/k8s/checksum"
-	istioCVEsURL          = "https://definitions.stackrox.io/cve3/istio/cve-list.json"
-	istioCVEsChecksumURL  = "https://definitions.stackrox.io/cve3/istio/checksum"
+	k8sCVEsURL            = "https://definitions.stackrox.io/cve2/k8s/cve-list.json"
+	k8sCVEsChecksumURL    = "https://definitions.stackrox.io/cve2/k8s/checksum"
+	istioCVEsURL          = "https://definitions.stackrox.io/cve2/istio/cve-list.json"
+	istioCVEsChecksumURL  = "https://definitions.stackrox.io/cve2/istio/checksum"
 	commonCveDir          = "cve"
 	k8sCVEsDir            = "k8s"
 	istioCVEsDir          = "istio"

--- a/central/cve/fetcher/fetch_utils.go
+++ b/central/cve/fetcher/fetch_utils.go
@@ -19,10 +19,10 @@ import (
 const (
 	fetchDelay            = 2 * time.Hour
 	preloadedCVEsBasePath = "/stackrox/static-data"
-	k8sCVEsURL            = "https://definitions.stackrox.io/cve/k8s/cve-list.json"
-	k8sCVEsChecksumURL    = "https://definitions.stackrox.io/cve/k8s/checksum"
-	istioCVEsURL          = "https://definitions.stackrox.io/cve/istio/cve-list.json"
-	istioCVEsChecksumURL  = "https://definitions.stackrox.io/cve/istio/checksum"
+	k8sCVEsURL            = "https://definitions.stackrox.io/cve3/k8s/cve-list.json"
+	k8sCVEsChecksumURL    = "https://definitions.stackrox.io/cve3/k8s/checksum"
+	istioCVEsURL          = "https://definitions.stackrox.io/cve3/istio/cve-list.json"
+	istioCVEsChecksumURL  = "https://definitions.stackrox.io/cve3/istio/checksum"
 	commonCveDir          = "cve"
 	k8sCVEsDir            = "k8s"
 	istioCVEsDir          = "istio"

--- a/image/fetch-stackrox-data.sh
+++ b/image/fetch-stackrox-data.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 
 fetch_stackrox_data() {
     mkdir -p /stackrox-data/cve/istio
-    wget -O /stackrox-data/cve/istio/checksum "https://definitions.stackrox.io/cve/istio/checksum"
-    wget -O /stackrox-data/cve/istio/cve-list.json "https://definitions.stackrox.io/cve/istio/cve-list.json"
+    wget -O /stackrox-data/cve/istio/checksum "https://definitions.stackrox.io/cve3/istio/checksum"
+    wget -O /stackrox-data/cve/istio/cve-list.json "https://definitions.stackrox.io/cve3/istio/cve-list.json"
 
     mkdir -p /tmp/external-networks
     local latest_prefix

--- a/image/fetch-stackrox-data.sh
+++ b/image/fetch-stackrox-data.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 
 fetch_stackrox_data() {
     mkdir -p /stackrox-data/cve/istio
-    wget -O /stackrox-data/cve/istio/checksum "https://definitions.stackrox.io/cve3/istio/checksum"
-    wget -O /stackrox-data/cve/istio/cve-list.json "https://definitions.stackrox.io/cve3/istio/cve-list.json"
+    wget -O /stackrox-data/cve/istio/checksum "https://definitions.stackrox.io/cve2/istio/checksum"
+    wget -O /stackrox-data/cve/istio/cve-list.json "https://definitions.stackrox.io/cve2/istio/cve-list.json"
 
     mkdir -p /tmp/external-networks
     local latest_prefix


### PR DESCRIPTION
## Description

This PR changes the URL to the CVE list file generated by the CVE pusher. The new CVE list file will contain CVE definitions without V2.

**Open questions**

- ~Where https://definitions.stackrox.io/cve2/openshift/cve-list.json is used?~ - Got answer from Ross, that we are not using it anymore.
- ~Do we have to update Docs if links to files are provided somewhere?~ - `definitions.stackrox.io` is mentioned in a few places, and that we are fetching data from there. But direct links to `cve-list.json` are not provided. I think we don't have to update the docs.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~ - I have checked docs. I didn't find anywhere that we are mentioning `cve-list.json`.

## Testing Performed

1. Checked that files exist under the following URLs:
- https://definitions.stackrox.io/cve2/istio/cve-list.json
- https://definitions.stackrox.io/cve2/istio/checksum
- https://definitions.stackrox.io/cve2/k8s/cve-list.json
- https://definitions.stackrox.io/cve2/k8s/checksum

2. CI pipeline
