### PR TITLE
ROX-12976: fix for 3.72.x: cherry-pick finish-release to avoid auto-trigger on release publish

### DIFF
--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -1,30 +1,133 @@
 name: Finish Release
 on:
-  release:
-    types: [released]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version (A.B.C[-N])
+        required: true
+        default: 0.0.0-test
+        type: string
+      dry-run:
+        description: Dry-run
+        required: false
+        default: true
+        type: boolean
 
 env:
-  slack_channel: C03KSV3N6N8 #test-release-automation
+  main_branch: ${{ github.event.repository.default_branch }}
+  script_url: /repos/${{ github.repository }}/contents/.github/workflows/scripts/common.sh?ref=${{ github.ref_name }}
+  DRY_RUN: ${{ fromJSON('["true", "false"]')[github.event.inputs.dry-run != true] }}
+  ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
+  GH_TOKEN: ${{ github.token }}
+  GH_NO_UPDATE_NOTIFIER: 1
+
+run-name: >-
+  ${{
+    format('Finish release {0}{1}',
+      inputs.version,
+      fromJSON('[" (dry-run)", ""]')[inputs.dry-run != true]
+    )
+  }}
+
+# Ensure that only a single release automation workflow can run at a time.
+concurrency: Release automation
 
 jobs:
-  notify:
-    name: Notify about ${{github.event.release.title}}
+  properties:
+    runs-on: ubuntu-latest
+    outputs:
+      slack-channel: ${{ fromJSON(format('["{0}","{1}"]', steps.fetch.outputs.dry-slack-channel, steps.fetch.outputs.slack-channel))[github.event.inputs.dry-run != 'true'] }}
+    steps:
+      - name: Read workflow properties file
+        id: fetch
+        env:
+          PROPERTIES_URL: /repos/${{ github.repository }}/contents/.github/properties?ref=${{ github.ref_name }}
+        run: gh api -H "$ACCEPT_RAW" "$PROPERTIES_URL" >> "$GITHUB_OUTPUT"
+
+  run-parameters:
+    if: github.event_name == 'workflow_dispatch'
+    name: Run parameters
     runs-on: ubuntu-latest
     steps:
+      - run: |
+          [ "$DRY_RUN" = "true" ] && echo "::warning::This is a dry run"
+          {
+            echo "Event: ${{ github.event_name }}"
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo '```'
+              echo "${{ toJSON(inputs) }}"
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  variables:
+    if: github.event_name == 'workflow_dispatch'
+    name: Setup variables
+    uses: ./.github/workflows/variables.yml
+    with:
+      version: ${{ inputs.version }}
+
+  publish-release:
+    name: Tag Release ${{ needs.variables.outputs.release-patch }}
+    runs-on: ubuntu-latest
+    needs: [variables, properties]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.variables.outputs.branch }}
+          token: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "${{ github.event.sender.login }}"
+          git config user.email noreply@github.com
+
+      - name: Tag release branch with "${{ needs.variables.outputs.release-patch }}"
+        id: tag
+        env:
+          GH_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          gh api -H "$ACCEPT_RAW" "${{ env.script_url }}" | bash -s -- \
+            tag-rc \
+            "${{ needs.variables.outputs.release-patch }}"
+
+      - name: Create GitHub Release
+        id: release
+        if: env.DRY_RUN == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
+            draft-release-notes \
+            "${{ needs.variables.outputs.release-patch }}" \
+            "${{ needs.variables.outputs.branch }}" \
+            "RELEASE_NOTES_GENERATED.md"
+          URL=$(gh release create "${{ needs.variables.outputs.release-patch }}" \
+            --notes-file RELEASE_NOTES_GENERATED.md \
+            --repo "${{ github.repository }}" \
+            --target "${{ needs.variables.outputs.branch }}")
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - run: |
+          echo "Created GitHub release [${{ needs.variables.outputs.release-patch }}](${{ steps.release.outputs.url }})" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Post to Slack
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@v1.19.0
+        uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: ${{env.slack_channel}}
+          channel-id: ${{ needs.properties.outputs.slack-channel }}
           payload: >-
             { "blocks": [
 
             { "type": "section", "text": { "type": "mrkdwn", "text":
-            ":white_check_mark: *<${{github.event.release.url}} | ${{github.event.release.name}}> has been published on GitHub.*" }},
+            ":${{ fromJSON('["desert", "white_check_mark"]')[github.event.inputs.dry-run != 'true'] }}:
+            *<${{ steps.release.outputs.url }} | ${{ inputs.version }}> has been published on GitHub.*" }},
 
             { "type": "section", "text": { "type": "mrkdwn", "text":
             ":arrow_right: Look for a CI generated PR created in `stackrox/release-artifacts` repository
-            and confirm that members of the `@release-publishers` Slack group got notified about
-            it.\n\n":arrow_right: Let's trigger the downstream release!" }}
+            and confirm that members of the @release-publishers Slack group got notified about
+            it.\n\n:arrow_right: Let's trigger the downstream release!" }}
             ]}

--- a/.github/workflows/variables.yml
+++ b/.github/workflows/variables.yml
@@ -48,39 +48,39 @@ jobs:
       next-rc: ${{steps.parse.outputs.next-rc}}
       dash-name: ${{steps.parse.outputs.dash-name}}
     steps:
-      - id: parse
-        env:
-          SCRIPT: |
-            import re
-            import sys
-
-            EXPR = r'(?P<release>\d+\.\d+)\.(?P<patch>\d+)(-(?P<name>\w+(-\w+)*))?(-rc\.(?P<rc>\d+))?$'
-
-            m = re.match(EXPR, sys.argv[1])
-            if not m:
-                exit(1)
-
-            rc = int(m.group('rc') or 1)
-            name = m.group('name') or ''
-            dash_name = f'-{name}' if name else ''
-
-            print(f'''
-            ::set-output name=release::{m.group('release')}
-            ::set-output name=patch::{m.group('patch')}
-            ::set-output name=name::{name}
-            ::set-output name=dash-name::{dash_name}
-            ::set-output name=rc::{rc}
-            ::set-output name=next-rc::{rc+1}
-            ''')
+      - name: Parse version
+        id: parse
+        shell: python
+        # Allowed versions examples:
+        # 1.2.3
+        # 1.2.3-rc.4
+        # 1.2.3-alnum
+        # 1.2.3-alnum-alnum
+        # 1.2.3-alnum-rc.4
         run: |
-          set -u
-          # Allowed versions examples:
-          # 1.2.3
-          # 1.2.3-rc.4
-          # 1.2.3-alnum
-          # 1.2.3-alnum-alnum
-          # 1.2.3-alnum-rc.4
-          if ! python3 - "${{inputs.version}}" <<<"$SCRIPT"; then
-            echo "::error::Cannot parse ${{inputs.version}}: should be in a form of \`X.X.X[-name][-rc.X]\`, where \`X\` is a decimal number."
-            exit 1
-          fi
+          import os
+          import re
+          import sys
+
+          EXPR = r'(?P<release>\d+\.\d+)\.(?P<patch>\d+)(-(?P<name>\w+(-\w+)*))?(-rc\.(?P<rc>\d+))?$'
+
+          version = '${{ inputs.version }}'
+          m = re.match(EXPR, version)
+          if not m:
+              print(f'::error::Cannot parse "{version}": should be in a form of `X.X.X[-name][-rc.X]`, where `X` is a decimal number.')
+              exit(1)
+
+          rc = int(m.group('rc') or 1)
+          name = m.group('name') or ''
+
+          data = {
+              'release': m.group('release'),
+              'patch': m.group('patch'),
+              'name': name,
+              'dash-name': f'-{name}' if name else '',
+              'rc': rc,
+              'next-rc': rc+1
+          }
+
+          with open(os.environ.get('GITHUB_OUTPUT'), mode='a') as f:
+              print('\n'.join(f'{k}={v}' for k,v in data.items()), file=f)


### PR DESCRIPTION
## Description

Cherry-picking the finish-release (and variables) workflows from the master branch. 
This is to remove the trigger on a new release, which previously triggered the finish-release workflow from the release branch after the release engineer had created a new release. Though having no side effects, the Slack message it did send lead to some confusion.

The variables workflow may not be strictly necessary to be updated, but I did it as it is a direct dependency of the finish-release workflow. The common.sh and other scripts are taken from master, so we don't need to update them to the release branch.

## Checklist
- ~[ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

No testing required.
