### PR TITLE
ROX-13300: Remove certexpiry request from generic wait in integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -80,6 +80,7 @@ export const images = {
 };
 
 export const auth = {
+    availableAuthProviders: '/v1/availableAuthProviders',
     loginAuthProviders: '/v1/login/authproviders',
     authProviders: '/v1/authProviders',
     authStatus: '/v1/auth/status',

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -2,33 +2,45 @@ import * as api from '../constants/apiEndpoints';
 
 import { interceptRequests, waitForResponses } from './request';
 
+// Single source of truth for keys in optional staticResponseMap argument.
+export const availableAuthProvidersAlias = 'availableAuthProviders';
+export const featureFlagsAlias = 'featureflags';
+export const loginAuthProvidersAlias = 'login/authproviders';
+export const myPermissionsAlias = 'mypermissions';
+export const configPublicAlias = 'config/public';
+export const authStatusAlias = 'auth/status';
+
 // generic requests to render the MainPage component
 const requestConfigGeneric = {
     routeMatcherMap: {
-        featureflags: {
+        [availableAuthProvidersAlias]: {
+            method: 'GET',
+            url: api.auth.availableAuthProviders,
+        }, // reducers/auth and sagas/authSagas
+        [featureFlagsAlias]: {
             method: 'GET',
             url: api.featureFlags,
         }, // reducers/featureFlags and sagas/featureFlagSagas
-        mypermissions: {
+        [myPermissionsAlias]: {
             method: 'GET',
             url: api.roles.mypermissions,
         }, // hooks/usePermissions and reducers/roles and sagas/authSagas
-        'config/public': {
+        [availableAuthProvidersAlias]: {
+            method: 'GET',
+            url: api.auth.availableAuthProviders,
+        }, // reducers/auth and sagas/authSagas
+        [configPublicAlias]: {
             method: 'GET',
             url: api.system.configPublic,
         }, // reducers/systemConfig and sagas/systemConfig
-        'auth/status': {
+        [authStatusAlias]: {
             method: 'GET',
             url: api.auth.authStatus,
         }, // sagas/authSagas
-        credentialexpiry_CENTRAL: {
-            method: 'GET',
-            url: api.certExpiry.central,
-        }, // MainPage/CredentialExpiryService
-        credentialexpiry_SCANNER: {
-            method: 'GET',
-            url: api.certExpiry.scanner,
-        }, // MainPage/CredentialExpiryService
+        /*
+         * Intentionally omit credentialexpiry requests for central and scanner,
+         * because they are in parallel with (and possibly even delayed by) page-specific requests.
+         */
     },
 };
 

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -86,7 +86,7 @@ export function visit(pageUrl, requestConfig, staticResponseMap) {
  * @param {{ routeMatcherMap?: Record<string, { method: string, url: string }>, opnameAliasesMap?: Record<string, (request: Object) => boolean>, waitOptions?: { requestTimeout?: number, responseTimeout?: number } }} [requestConfig]
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
-export function visitWithPermissions(
+export function visitWithStaticResponseForPermissions(
     pageUrl,
     staticResponseForPermissions,
     requestConfig,

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -5,8 +5,8 @@ import { interceptRequests, waitForResponses } from './request';
 // Single source of truth for keys in optional staticResponseMap argument.
 export const availableAuthProvidersAlias = 'availableAuthProviders';
 export const featureFlagsAlias = 'featureflags';
-export const myPermissionsAlias = 'mypermissions';
 export const loginAuthProvidersAlias = 'login/authproviders';
+export const myPermissionsAlias = 'mypermissions';
 export const configPublicAlias = 'config/public';
 export const authStatusAlias = 'auth/status';
 
@@ -21,14 +21,14 @@ const requestConfigGeneric = {
             method: 'GET',
             url: api.featureFlags,
         }, // reducers/featureFlags and sagas/featureFlagSagas
-        [myPermissionsAlias]: {
-            method: 'GET',
-            url: api.roles.mypermissions,
-        }, // hooks/usePermissions and reducers/roles and sagas/authSagas
         [loginAuthProvidersAlias]: {
             method: 'GET',
             url: api.auth.loginAuthProviders,
         }, // reducers/auth and sagas/authSagas
+        [myPermissionsAlias]: {
+            method: 'GET',
+            url: api.roles.mypermissions,
+        }, // hooks/usePermissions and reducers/roles and sagas/authSagas
         [configPublicAlias]: {
             method: 'GET',
             url: api.system.configPublic,

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -82,18 +82,18 @@ export function visit(pageUrl, requestConfig, staticResponseMap) {
  * { fixture: 'fixtures/wherever/whatever.json' }
  *
  * @param {string} pageUrl
- * @param {{ body: { resourceToAccess: Record<string, string> } } | { fixture: string }} permissionsStaticResponseMap
+ * @param {{ body: { resourceToAccess: Record<string, string> } } | { fixture: string }} staticResponseForPermissions
  * @param {{ routeMatcherMap?: Record<string, { method: string, url: string }>, opnameAliasesMap?: Record<string, (request: Object) => boolean>, waitOptions?: { requestTimeout?: number, responseTimeout?: number } }} [requestConfig]
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
 export function visitWithPermissions(
     pageUrl,
-    permissionsStaticResponse,
+    staticResponseForPermissions,
     requestConfig,
     staticResponseMap
 ) {
     const staticResponseMapGeneric = {
-        mypermissions: permissionsStaticResponse,
+        [myPermissionsAlias]: staticResponseForPermissions,
     };
     interceptRequests(requestConfigGeneric, staticResponseMapGeneric);
     interceptRequests(requestConfig, staticResponseMap);

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -5,8 +5,8 @@ import { interceptRequests, waitForResponses } from './request';
 // Single source of truth for keys in optional staticResponseMap argument.
 export const availableAuthProvidersAlias = 'availableAuthProviders';
 export const featureFlagsAlias = 'featureflags';
-export const loginAuthProvidersAlias = 'login/authproviders';
 export const myPermissionsAlias = 'mypermissions';
+export const loginAuthProvidersAlias = 'login/authproviders';
 export const configPublicAlias = 'config/public';
 export const authStatusAlias = 'auth/status';
 
@@ -25,9 +25,9 @@ const requestConfigGeneric = {
             method: 'GET',
             url: api.roles.mypermissions,
         }, // hooks/usePermissions and reducers/roles and sagas/authSagas
-        [availableAuthProvidersAlias]: {
+        [loginAuthProvidersAlias]: {
             method: 'GET',
-            url: api.auth.availableAuthProviders,
+            url: api.auth.loginAuthProviders,
         }, // reducers/auth and sagas/authSagas
         [configPublicAlias]: {
             method: 'GET',

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -6,7 +6,7 @@ import {
 import * as api from '../../constants/apiEndpoints';
 import sampleCert from '../../helpers/sampleCert';
 import { generateNameWithDate, getInputByLabel } from '../../helpers/formHelpers';
-import { visit, visitWithPermissions } from '../../helpers/visit';
+import { visit, visitWithStaticResponseForPermissions } from '../../helpers/visit';
 import updateMinimumAccessRoleRequest from '../../fixtures/auth/updateMinimumAccessRole.json';
 
 import withAuth from '../../helpers/basicAuth';
@@ -47,10 +47,10 @@ describe('Access Control Auth providers', () => {
     withAuth();
 
     it('displays alert if no permission', () => {
-        const permissionsStaticResponse = {
+        const staticResponseForPermissions = {
             fixture: 'auth/mypermissionsMinimalAccess.json',
         };
-        visitWithPermissions(authProvidersUrl, permissionsStaticResponse);
+        visitWithStaticResponseForPermissions(authProvidersUrl, staticResponseForPermissions);
 
         cy.get(`${selectors.h1}:contains("${h1}")`);
         cy.get(selectors.navLink).should('not.exist');


### PR DESCRIPTION
## Description

### Test failure

* 1584938569003175936 from master build for 3535 on 2022-10-25

Compliance dashboard page should show the same amount of nodes between the Dashboard and List Page

> Timed out retrying after 10000ms: `cy.wait()` timed out waiting `10000ms` for the 1st request to the route: `credentialexpiry_CENTRAL`. No request ever occurred.

![credentialexpiry](https://user-images.githubusercontent.com/11862657/198045253-d1d13b1c-d1d5-4426-84f7-911ac555ff4b.png)

This is the fourth test in compliance/complianceDashboard.test.js

### Analysis

Compliance dashboard has made its requests before responses to credentialexpiry requests. Because the former are several and slow, they might even delay the latter.

Because `MainPage` renders pair of `CredentialExpiryBanner` elements which make the requests, they are in parallel with page specific requests, not in sequence as prerequisites. Therefore, my bad to include them in `requestConfigGeneric` for visit helpers.

### Solution

Because certexpiration tests independently mock the response to the relevant request without staticResponseMap argument, just delete the route matcher properties.

## Changed files

1. Edit cypress/constants/apiEndpoints
    * Add `availableAuthProviders` property.

2. Edit cypress/helpers/visit.js
    * Add key constants as single source of truth for keys in optional staticResponseMap argument.
    * Add availableAuthProviders and loginAuthProviders route matcher properties. Brad, these requests seem relevant to auth tests. Although on second thought, those tests mock them in a specialized context.
    * Replace credentialexpiray route matcher properties with comment.
    * Rename `visitWithPermissions` as `visitWithStaticResponseForPermissions` function and also `permissionsStaticResponse` with `staticResponseForPermissions` to prevent misunderstanding that argument is a permissions object.

3. Edit cypress/integration/accessControl/accessControlAuthProviders.test.js
    * Ditto bullet point above.

### Residue

1. Now that we know credentialexpiry requests are test-specific instead of generic, improve certexpiration tests in general and test which mocks permissions in specific.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test constants and helpers

## Testing Performed