### PR TITLE
Reduce the batch size for image and node postgres migration

### DIFF
--- a/central/cve/cluster/datastore/store/postgres/gen.go
+++ b/central/cve/cluster/datastore/store/postgres/gen.go
@@ -2,4 +2,4 @@ package postgres
 
 //go:generate pg-table-bindings-wrapper --type=storage.ClusterCVE --table=cluster_cves --search-category CLUSTER_VULNERABILITIES --search-scope CLUSTER_VULNERABILITIES,CLUSTER_VULN_EDGE,CLUSTERS
 // To regenerate migration, add:
-// --migration-seq 9 --migrate-from dackbox
+// --migration-seq 9 --migrate-from dackbox --migration-batch 500

--- a/central/image/datastore/store/postgres/gen.go
+++ b/central/image/datastore/store/postgres/gen.go
@@ -2,4 +2,4 @@ package postgres
 
 //go:generate pg-table-bindings-wrapper --type=storage.Image --search-category IMAGES --schema-only --search-scope IMAGE_VULNERABILITIES,COMPONENT_VULN_EDGE,IMAGE_COMPONENTS,IMAGE_COMPONENT_EDGE,IMAGE_VULN_EDGE,IMAGES,DEPLOYMENTS,NAMESPACES,CLUSTERS
 // To regenerate migration, add:
-// --migration-seq 4 --migrate-from dackbox
+// --migration-seq 4 --migrate-from dackbox --migration-batch 500

--- a/central/image/datastore/store/postgres/store.go
+++ b/central/image/datastore/store/postgres/store.go
@@ -44,7 +44,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 500
 )
 
 var (

--- a/central/node/datastore/store/postgres/gen.go
+++ b/central/node/datastore/store/postgres/gen.go
@@ -2,4 +2,4 @@ package postgres
 
 //go:generate pg-table-bindings-wrapper --type=storage.Node --search-category NODES --references=storage.Cluster --schema-only --search-scope NODE_VULNERABILITIES,NODE_COMPONENT_CVE_EDGE,NODE_COMPONENTS,NODE_COMPONENT_EDGE,NODES,CLUSTERS
 // To regenerate migration:
-// --migration-seq 35 --migrate-from dackbox
+// --migration-seq 35 --migrate-from dackbox --migration-batch 500

--- a/central/node/datastore/store/postgres/store.go
+++ b/central/node/datastore/store/postgres/store.go
@@ -40,7 +40,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 500
 )
 
 var (

--- a/migrator/migrations/n_04_to_n_05_postgres_images/migration.go
+++ b/migrator/migrations/n_04_to_n_05_postgres_images/migration.go
@@ -34,7 +34,7 @@ var (
 			return nil
 		},
 	}
-	batchSize = 1000
+	batchSize = 500
 	schema    = pkgSchema.ImagesSchema
 	log       = loghelper.LogWrapper{}
 )

--- a/migrator/migrations/n_04_to_n_05_postgres_images/postgres/store.go
+++ b/migrator/migrations/n_04_to_n_05_postgres_images/postgres/store.go
@@ -36,7 +36,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 500
 )
 
 // New returns a new Store instance using the provided sql instance.

--- a/migrator/migrations/n_09_to_n_10_postgres_cluster_cves/migration.go
+++ b/migrator/migrations/n_09_to_n_10_postgres_cluster_cves/migration.go
@@ -34,7 +34,7 @@ var (
 			return nil
 		},
 	}
-	batchSize = 10000
+	batchSize = 500
 	schema    = pkgSchema.ClusterCvesSchema
 	log       = loghelper.LogWrapper{}
 )

--- a/migrator/migrations/n_09_to_n_10_postgres_cluster_cves/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_09_to_n_10_postgres_cluster_cves/postgres/postgres_plugin.go
@@ -30,7 +30,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 500
 
 	cursorBatchSize = 50
 )

--- a/migrator/migrations/n_35_to_n_36_postgres_nodes/migration.go
+++ b/migrator/migrations/n_35_to_n_36_postgres_nodes/migration.go
@@ -34,7 +34,7 @@ var (
 			return nil
 		},
 	}
-	batchSize = 10000
+	batchSize = 500
 	log       = loghelper.LogWrapper{}
 )
 

--- a/migrator/migrations/n_35_to_n_36_postgres_nodes/postgres/store_impl.go
+++ b/migrator/migrations/n_35_to_n_36_postgres_nodes/postgres/store_impl.go
@@ -34,7 +34,7 @@ const (
 	// using copyFrom, we may not even want to batch.  It would probably be simpler
 	// to deal with failures if we just sent it all.  Something to think about as we
 	// proceed and move into more e2e and larger performance testing
-	batchSize = 10000
+	batchSize = 500
 )
 
 var (

--- a/tools/generate-helpers/pg-table-bindings/migration.go
+++ b/tools/generate-helpers/pg-table-bindings/migration.go
@@ -12,4 +12,5 @@ type MigrationOptions struct {
 	MigrateSequence int
 	Dir             string
 	SingletonStore  bool
+	BatchSize       int
 }

--- a/tools/generate-helpers/pg-table-bindings/migration.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/migration.go.tpl
@@ -52,7 +52,7 @@ var (
 			return nil
 		},
 	}
-	batchSize	 = 10000
+	batchSize	 = {{.Migration.BatchSize}}
 	schema		= {{template "schemaVar" .Schema}}
 	log		   = loghelper.LogWrapper{}
 )


### PR DESCRIPTION
## Description

Image and node objects can be very large. Ops on them impact multiple stores at a time. Reduce the batch size on image and node stores to reduce possibility of timeouts.
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
