### PR TITLE
ROX-12909: wire up active graph to PF topology library data model

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -34,132 +34,6 @@ export const UrlDetailType = {
 export type UrlDetailTypeKey = keyof typeof UrlDetailType;
 export type UrlDetailTypeValue = typeof UrlDetailType[UrlDetailTypeKey];
 
-// TODO: replace this dummy data with real parsed graph data
-const model: Model = {
-    graph: {
-        id: 'g1',
-        type: 'graph',
-        layout: 'ColaNoForce',
-    },
-    nodes: [
-        {
-            id: 'e337f873-64d8-46be-84ed-2a0c38c75fac',
-            label: 'Central',
-            type: 'node',
-            width: 75,
-            height: 75,
-            data: {
-                id: 'e337f873-64d8-46be-84ed-2a0c38c75fac',
-                label: 'Central',
-                type: 'node',
-                width: 75,
-                height: 75,
-                entityType: 'DEPLOYMENT',
-            },
-        },
-        {
-            id: '09134b5d-8c12-41e8-821b-c97a5a1331c9',
-            label: 'Sensor',
-            type: 'node',
-            width: 75,
-            height: 75,
-            data: {
-                id: '09134b5d-8c12-41e8-821b-c97a5a1331c9',
-                label: 'Sensor',
-                type: 'node',
-                width: 75,
-                height: 75,
-                entityType: 'DEPLOYMENT',
-            },
-        },
-        {
-            id: '__MzQuMTIwLjAuMC8xNg',
-            label: 'Google/global | 34.120.0.0/16',
-            type: 'node',
-            width: 75,
-            height: 75,
-            data: {
-                id: '__MzQuMTIwLjAuMC8xNg',
-                label: 'Google/global | 34.120.0.0/16',
-                type: 'node',
-                width: 75,
-                height: 75,
-                entityType: 'CIDR_BLOCK',
-            },
-        },
-        {
-            id: 'afa12424-bde3-4313-b810-bb463cbe8f90',
-            label: 'External entities',
-            type: 'node',
-            width: 75,
-            height: 75,
-            data: {
-                id: 'afa12424-bde3-4313-b810-bb463cbe8f90',
-                label: 'External entities',
-                type: 'node',
-                width: 75,
-                height: 75,
-                entityType: 'EXTERNAL_ENTITIES',
-            },
-        },
-        {
-            id: 'e8dabcb7-f471-414e-a999-fe91be5a28fa',
-            type: 'group',
-            children: [
-                'e337f873-64d8-46be-84ed-2a0c38c75fac',
-                '09134b5d-8c12-41e8-821b-c97a5a1331c9',
-            ],
-            group: true,
-            label: 'stackrox',
-            style: { padding: 15 },
-            data: {
-                collapsible: true,
-                showContextMenu: false,
-                entityType: 'NAMESPACE',
-            },
-        },
-        {
-            id: 'EXTERNAL',
-            type: 'group',
-            children: ['__MzQuMTIwLjAuMC8xNg', 'afa12424-bde3-4313-b810-bb463cbe8f90'],
-            group: true,
-            label: 'External to cluster',
-            style: { padding: 15 },
-            data: {
-                collapsible: true,
-                showContextMenu: false,
-                entityType: 'EXTERNAL',
-            },
-        },
-    ],
-    edges: [
-        {
-            id: 'e1',
-            type: 'edge',
-            source: 'e337f873-64d8-46be-84ed-2a0c38c75fac',
-            target: '09134b5d-8c12-41e8-821b-c97a5a1331c9',
-        },
-        {
-            id: 'e2',
-            type: 'edge',
-            source: '09134b5d-8c12-41e8-821b-c97a5a1331c9',
-            target: 'e337f873-64d8-46be-84ed-2a0c38c75fac',
-        },
-        {
-            id: 'e3',
-            type: 'edge',
-            source: '__MzQuMTIwLjAuMC8xNg',
-            target: 'e337f873-64d8-46be-84ed-2a0c38c75fac',
-        },
-        {
-            id: 'e4',
-            type: 'edge',
-            source: 'afa12424-bde3-4313-b810-bb463cbe8f90',
-            target: 'e337f873-64d8-46be-84ed-2a0c38c75fac',
-        },
-    ],
-};
-
 function findEntityById(
     graphModel: Model,
     id: string,
@@ -202,11 +76,12 @@ function getUrlParamsForEntity(selectEntity: {
 export type NetworkGraphProps = {
     detailType?: UrlDetailTypeValue;
     detailId?: string;
+    model: Model;
 };
 
 export type TopologyComponentProps = NetworkGraphProps;
 
-const TopologyComponent = ({ detailType, detailId }: TopologyComponentProps) => {
+const TopologyComponent = ({ detailType, detailId, model }: TopologyComponentProps) => {
     const selectedEntity = detailId && findEntityById(model, detailId, detailType);
     const history = useHistory();
 
@@ -270,7 +145,7 @@ const TopologyComponent = ({ detailType, detailId }: TopologyComponentProps) => 
     );
 };
 
-const NetworkGraph = React.memo<NetworkGraphProps>(({ detailType, detailId }) => {
+const NetworkGraph = React.memo<NetworkGraphProps>(({ detailType, detailId, model }) => {
     const controller = new Visualization();
     controller.registerLayoutFactory(defaultLayoutFactory);
     controller.registerComponentFactory(defaultComponentFactory);
@@ -279,7 +154,7 @@ const NetworkGraph = React.memo<NetworkGraphProps>(({ detailType, detailId }) =>
     return (
         <div className="pf-ri__topology-demo">
             <VisualizationProvider controller={controller}>
-                <TopologyComponent detailType={detailType} detailId={detailId} />
+                <TopologyComponent detailType={detailType} detailId={detailId} model={model} />
             </VisualizationProvider>
         </div>
     );

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { PageSection, Title, Flex, FlexItem } from '@patternfly/react-core';
 
+import { fetchNetworkFlowGraph } from 'services/NetworkService';
 import PageTitle from 'Components/PageTitle';
 import NetworkGraph from './NetworkGraph';
 
@@ -9,6 +10,10 @@ import './NetworkGraphPage.css';
 
 function NetworkGraphPage() {
     const { detailType, detailId } = useParams();
+
+    // useEffect(() => {
+    //     fetchNetworkFlowGraph()
+    // },[]);
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -16,16 +16,16 @@ function NetworkGraphPage() {
     const [model, setModel] = useState<Model>({
         graph: graphModel,
     });
-    const [epoch, setEpoch] = useState(0);
     const [clusters, setClusters] = useState<Cluster[]>([]);
 
     useEffect(() => {
         fetchClustersAsArray()
             .then((response) => {
                 setClusters(response);
-                setEpoch(1);
             })
-            .catch((err) => console.error(err));
+            .catch(() => {
+                // TODO
+            });
     }, []);
 
     useEffect(() => {
@@ -34,9 +34,10 @@ function NetworkGraphPage() {
                 .then(({ response }) => {
                     const dataModel = transformData(response.nodes);
                     setModel(dataModel);
-                    setEpoch(response.epoch);
                 })
-                .catch((err) => console.error(err));
+                .catch(() => {
+                    // TODO
+                });
         }
     }, [clusters]);
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils.tsx
@@ -23,7 +23,6 @@ export const graphModel = {
 };
 
 export function transformData(nodes: Node[]): Model {
-    console.log(nodes);
     const dataModel = {
         graph: graphModel,
         nodes: [] as NodeModel[],
@@ -70,6 +69,8 @@ export function transformData(nodes: Node[]): Model {
                 type: 'edge',
                 source: entity.id,
                 target: nodes[nodeIdx].entity.id,
+                // TODO: figure out how to conditionally render performantly
+                // visible: false,
             };
             dataModel.edges.push(edge);
         });

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils.tsx
@@ -1,0 +1,77 @@
+import { Model, NodeModel, EdgeModel } from '@patternfly/react-topology';
+
+import { NetworkEntityInfo, Node } from 'types/networkFlow.proto';
+
+export function getLabel(entity: NetworkEntityInfo): string {
+    const { type } = entity;
+    switch (type) {
+        case 'DEPLOYMENT':
+            return entity.deployment.name;
+        case 'INTERNET':
+            return 'Internet';
+        case 'EXTERNAL_SOURCE':
+            return entity.externalSource.name;
+        default:
+            return '';
+    }
+}
+
+export function transformData(nodes: Node[]): Model {
+    const dataModel = {
+        graph: {
+            id: 'stackrox-active-graph',
+            type: 'graph',
+            layout: 'ColaGroups',
+        },
+        nodes: [] as NodeModel[],
+        edges: [] as EdgeModel[],
+    };
+    const groupNodes = {};
+    nodes.forEach(({ entity, outEdges }) => {
+        // creating each node and adding to data model
+        const node = {
+            id: entity.id,
+            type: 'node',
+            width: 75,
+            height: 75,
+            label: getLabel(entity),
+        };
+        dataModel.nodes.push(node);
+
+        // to group deployments into namespaces
+        if (entity.type === 'DEPLOYMENT') {
+            const { namespace } = entity.deployment;
+            if (groupNodes[namespace]) {
+                groupNodes[namespace].children.push(entity.id);
+            } else {
+                groupNodes[namespace] = {
+                    id: namespace,
+                    type: 'group',
+                    children: [entity.id],
+                    group: true,
+                    label: namespace,
+                    style: { padding: 15 },
+                    data: {
+                        collapsible: true,
+                        showContextMenu: false,
+                    },
+                };
+            }
+        }
+
+        // creating edges based off of outEdges per node and adding to data model
+        Object.keys(outEdges).forEach((nodeIdx) => {
+            const edge = {
+                id: `${entity.id} ${nodes[nodeIdx].entity.id as string}`,
+                type: 'edge',
+                source: entity.id,
+                target: nodes[nodeIdx].entity.id,
+            };
+            dataModel.edges.push(edge);
+        });
+    });
+
+    // add group nodes to data model
+    dataModel.nodes.push(...Object.values(groupNodes));
+    return dataModel;
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils.tsx
@@ -2,7 +2,7 @@ import { Model, NodeModel, EdgeModel } from '@patternfly/react-topology';
 
 import { NetworkEntityInfo, Node } from 'types/networkFlow.proto';
 
-export function getLabel(entity: NetworkEntityInfo): string {
+function getLabel(entity: NetworkEntityInfo): string {
     const { type } = entity;
     switch (type) {
         case 'DEPLOYMENT':
@@ -16,17 +16,20 @@ export function getLabel(entity: NetworkEntityInfo): string {
     }
 }
 
+export const graphModel = {
+    id: 'stackrox-active-graph',
+    type: 'graph',
+    layout: 'ColaGroups',
+};
+
 export function transformData(nodes: Node[]): Model {
+    console.log(nodes);
     const dataModel = {
-        graph: {
-            id: 'stackrox-active-graph',
-            type: 'graph',
-            layout: 'ColaGroups',
-        },
+        graph: graphModel,
         nodes: [] as NodeModel[],
         edges: [] as EdgeModel[],
     };
-    const groupNodes = {};
+    const groupNodes = {} as NodeModel;
     nodes.forEach(({ entity, outEdges }) => {
         // creating each node and adding to data model
         const node = {
@@ -35,6 +38,7 @@ export function transformData(nodes: Node[]): Model {
             width: 75,
             height: 75,
             label: getLabel(entity),
+            data: {},
         };
         dataModel.nodes.push(node);
 

--- a/ui/apps/platform/src/types/networkFlow.proto.ts
+++ b/ui/apps/platform/src/types/networkFlow.proto.ts
@@ -38,7 +38,10 @@ export type NetworkEntityScope = {
     clusterId: string;
 };
 
-export type NetworkEntityInfo = DeploymentNetworkEntityInfo | ExternalSourceNetworkEntityInfo;
+export type NetworkEntityInfo =
+    | DeploymentNetworkEntityInfo
+    | ExternalSourceNetworkEntityInfo
+    | InternetNetworkEntityInfo;
 
 export type DeploymentNetworkEntityInfo = {
     deployment: {
@@ -47,6 +50,7 @@ export type DeploymentNetworkEntityInfo = {
         cluster: string; // deprecated
         listenPorts: ListenPort[];
     };
+    type: 'DEPLOYMENT';
 } & BaseNetworkEntityInfo;
 
 export type ListenPort = {
@@ -60,6 +64,11 @@ export type ExternalSourceNetworkEntityInfo = {
         cidr?: string;
         default: boolean; // `default` indicates whether the external source is user-generated or system-generated.
     };
+    type: 'EXTERNAL_SOURCE';
+} & BaseNetworkEntityInfo;
+
+export type InternetNetworkEntityInfo = {
+    type: 'INTERNET';
 } & BaseNetworkEntityInfo;
 
 type BaseNetworkEntityInfo = {
@@ -82,3 +91,26 @@ export type L4Protocol =
     | 'L4_PROTOCOL_RAW'
     | 'L4_PROTOCOL_SCTP'
     | 'L4_PROTOCOL_ANY'; // -1
+
+// network flow graph nodes
+export type Node = {
+    entity: NetworkEntityInfo;
+    internetAccess: boolean;
+    policyIds: string[];
+    nonIsolatedIngress: boolean;
+    nonIsolatedEgress: boolean;
+    queryMatch: boolean;
+    outEdges: Edge[];
+};
+
+export type Edge = {
+    [key: string]: {
+        properties: EdgeProperties[];
+    };
+};
+
+type EdgeProperties = {
+    port: number;
+    protocol: L4Protocol;
+    lastActiveTimestamp: string | null;
+};


### PR DESCRIPTION
getting the new PF topology graph to be hooked up to the network flow graph endpoint. the cluster fetch business logic and epoch refetching logic will probably need to be improved as we come around to it again.

<img width="1502" alt="image" src="https://user-images.githubusercontent.com/10412893/198140837-bb7b2533-61dc-434e-a481-16327d72a918.png">
